### PR TITLE
Remove Deploy into Development Environment on master merger

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,14 +38,6 @@ jobs:
         command: |
           docker login -u $DOCKER_USER -p $DOCKER_PASS
           ./build/run make -j$(nproc) publish BRANCH_NAME=${CIRCLE_BRANCH} AWS_ACCESS_KEY_ID=${AWS_KEY_ID} AWS_SECRET_ACCESS_KEY=${AWS_KEY_SECRET} GIT_API_TOKEN=${GITHUB_UPBOUND_BOT}
-          if [ "${CIRCLE_BRANCH}" == "master" ]; then
-            ./build/run make -j$(nproc) promote BRANCH_NAME=master CHANNEL=master AWS_ACCESS_KEY_ID=${AWS_KEY_ID} AWS_SECRET_ACCESS_KEY=${AWS_KEY_SECRET}
-            crumb="$(curl ${JENKINS_CRUMB_URL} --user ${JENKINS_USER}:${JENKINS_TOKEN})"
-            curl -H ".crumb:${crumb}" -X POST ${JENKINS_DEPLOY_URL} --user ${JENKINS_USER}:${JENKINS_TOKEN} -d "Content-Length:0"
-          fi
-        environment:
-          JENKINS_CRUMB_URL: https://jenkins.upbound.io/crumbIssuer/api/xml\?xpath\=concat\(//crumbRequestField,%22:%22,//crumb\)
-          JENKINS_DEPLOY_URL: https://jenkins.upbound.io/job/upbound/job/cloud/job/dev/job/master/buildWithParameters
 
     - save_cache:
         when: on_success

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -59,15 +59,6 @@ pipeline {
             }
         }
 
-        stage('Deploy') {
-            when {
-                branch 'master'
-            }
-
-            steps {
-                build job: 'upbound/cloud/dev/master', parameters: [string(name: 'action', value: 'up')], quietPeriod: 30
-            }
-        }
     }
 
     post {


### PR DESCRIPTION
### Overview
Initial project scaffolding #13 included a trigger for CICD to start deployment into Development environment on merge into the master branch.

### Change
Remove deployment job trigger.