### PR TITLE
Fixes for walking through build and test flow

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,6 +55,10 @@ This is a rough outline of what a contributor's workflow looks like:
 - Make sure all tests pass, and add any new tests as appropriate.
 - Submit a pull request to the original repository.
 
+## Building
+
+Details about building conductor can be found in [INSTALL.md](INSTALL.md).
+
 ## Coding Style
 
 Conductor projects are written in golang and follows the style guidelines dictated by
@@ -170,4 +174,7 @@ To verify that new artifacts run:
 ```bash
 make build test
 ```
-To locally test new types/controllers please refer to [Local Build](/cluster/local/README.md) instructions.
+
+## Local Build and Test
+
+To learn more about the developer iteration workflow, including how to locally test new types/controllers, please refer to the [Local Build](cluster/local/README.md) instructions.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -22,7 +22,13 @@ The following tools are need on the host:
 
 ## Build
 
-You can build the Conductor binaries and all container images for the host platform by simply running the
+First ensure that you have the build submodule synced and updated:
+
+```
+git submodule sync && git submodule update --init --recursive
+```
+
+You can then build the Conductor binaries and all container images for the host platform by simply running the
 command below. Building in parallel with the `-j` option is recommended.
 
 ```

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Name | Details | API Group | Status
 ### Official Releases
 
 Official releases of Conductor can be found on the [releases page](https://github.com/upbound/conductor/releases).
-Please note that it is **strongly recommended** that you use [official releases](https://github.com/upbound/concuctor/releases) of Conductor, as unreleased versions from the master branch are subject to changes and incompatibilities that will not be supported in the official releases.
+Please note that it is **strongly recommended** that you use [official releases](https://github.com/upbound/conductor/releases) of Conductor, as unreleased versions from the master branch are subject to changes and incompatibilities that will not be supported in the official releases.
 Builds from the master branch can have functionality changed and even removed at any time without compatibility support and without prior notice.
 
 ## Licensing

--- a/cluster/local/README.md
+++ b/cluster/local/README.md
@@ -16,55 +16,58 @@ quickly spin up a Kubernetes cluster.The Local framework is designed to install 
 
 ### Install Kubernetes
 You can choose any Kubernetes flavor of your choice.  The test framework only depends on kubectl being configured.
-The framework also provides scripts to install Kubernetes. There are two scripts to start the cluster:
-- **Minikube** (recommended for MacOS): Run [minikube.sh](/build/local/minikube.sh) to setup a single-node Minikube Kubernetes.
-    - Minikube v0.28.2 and higher is supported. Older minikube versions do not have cephfs or rbd tools installed.ster using kubeadm
+The framework also provides scripts to install Kubernetes.
+
+- **Minikube** (recommended for MacOS): Run [minikube.sh](./minikube.sh) to setup a single-node Minikube Kubernetes.
+  - Minikube v0.28.2 and higher is supported
 
 #### Minikube (recommended for MacOS)
 Starting the cluster on Minikube is as simple as running:
 ```console
-build/local/minikube.sh up
+cluster/local/minikube.sh up
 ```
 
 To copy Conductor image generated from your local build into the Minikube VM, run the following commands after `minikube.sh up` succeeded:
 ```
-build/local/minikube.sh helm-install
+cluster/local/minikube.sh helm-install
 ```
 
 Stopping the cluster and destroying the Minikube VM can be done with:
 ```console
-build/local/minikube.sh clean
+cluster/local/minikube.sh clean
 ```
 
 For complete list of subcommands supported by `minikube.sh`, run:
 ```console
-buld/local/minikube.sh
+cluster/local/minikube.sh
 ```
 
 ## Run Tests
 From the project root do the following:
 #### 1. Build conductor:
-Run `make build`
+```
+make build
+```
 
 #### 2. Start Kubernetes
 ```
-build/local/minikube.sh up
+cluster/local/minikube.sh up
 ```
 
 #### 3. Install Conductor
 ```
-build/local/minikube.sh helm-install
+cluster/local/minikube.sh helm-install
 ```
 
 #### 4. Interact with Conductor
-Create and/or delete external resources CRD's
+Use `kubectl` to create and/or delete external resources CRD's in your Minikube cluster
 
 #### 5. Uninstall Conductor
 ```
-build/local/minikube.sh helm-delete
+cluster/local/minikube.sh helm-delete
 ```  
 
 #### 6. Stop Kubernetes
 ```
-build/local/minikube.sh down
+cluster/local/minikube.sh down
 ```


### PR DESCRIPTION
Fixes for some issues I found while walking through the build and test flow to build conductor and deploy it to minikube.  I'm still seeing the following 2 issues that I need to look into, any hints?

I believe it has to do with `build.vars` and `${BUILD_REGISTRY}` being defined in the `build/*.mk` files, and we aren't including them.  Can you source a `*.mk` file?
```
> ./cluster/local/minikube.sh update
make: *** No rule to make target `build.vars'.  Stop.
Error response from daemon: No such image: upbound/conductor-amd64
open /var/lib/docker/tmp/docker-import-633839604/repositories: no such file or directory
```