### PR TITLE
Add license header to files that are missing it

### DIFF
--- a/pkg/clients/aws/aws.go
+++ b/pkg/clients/aws/aws.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2018 The Conductor Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package aws
 
 import (

--- a/pkg/clients/aws/aws_test.go
+++ b/pkg/clients/aws/aws_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2018 The Conductor Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package aws
 
 import (

--- a/pkg/clients/aws/rds/rds.go
+++ b/pkg/clients/aws/rds/rds.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2018 The Conductor Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package rds
 
 import (

--- a/pkg/clients/aws/rds/rds_test.go
+++ b/pkg/clients/aws/rds/rds_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2018 The Conductor Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package rds
 
 import (

--- a/pkg/clients/aws/rds/rds_testing.go
+++ b/pkg/clients/aws/rds/rds_testing.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2018 The Conductor Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package rds
 
 import "github.com/upbound/conductor/pkg/apis/aws/database/v1alpha1"

--- a/pkg/clients/gcp/gcp_test.go
+++ b/pkg/clients/gcp/gcp_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2018 The Conductor Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package gcp
 
 import (

--- a/pkg/test/envtest.go
+++ b/pkg/test/envtest.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2018 The Conductor Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package test
 
 import (


### PR DESCRIPTION
After this PR, there are no more files returned from the following command:

```
find . -path ./vendor -prune -o -name '*.go' -print | xargs grep -L -F -i 'Copyright'
```