### PR TITLE
azure: only set the connection secret endpoint key when we have an endpoint

### DIFF
--- a/pkg/controller/azure/database/mysqlserver.go
+++ b/pkg/controller/azure/database/mysqlserver.go
@@ -428,9 +428,11 @@ func (r *Reconciler) createOrUpdateConnectionSecret(instance *databasev1alpha1.M
 
 	// fill in all of the connection details on the secret's data
 	connectionSecret.Data = map[string][]byte{
-		coredbv1alpha1.ConnectionSecretEndpointKey: []byte(instance.Status.Endpoint),
 		coredbv1alpha1.ConnectionSecretUserKey:     []byte(fmt.Sprintf("%s@%s", instance.Spec.AdminLoginName, instance.Name)),
 		coredbv1alpha1.ConnectionSecretPasswordKey: []byte(password),
+	}
+	if instance.Status.Endpoint != "" {
+		connectionSecret.Data[coredbv1alpha1.ConnectionSecretEndpointKey] = []byte(instance.Status.Endpoint)
 	}
 
 	if secretExists {


### PR DESCRIPTION
If we set the endpoint key/value in the connection secret before we have a valid value, then apps that consume this secret will go ahead and start running before we have a good value.

Keeping it unset, like this PR now does, will cause the k8s scheduler to keep a consuming pod in the `CreateContainerConfigError` status until the secret is fully set and the pod can run successfully.