### PR TITLE
fix a warning with jenkins when archiving

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -33,7 +33,7 @@ pipeline {
             }
             post {
                 always {
-                    archive "_output/tests/**/*"
+                    archiveArtifacts "_output/tests/**/*"
                     junit "_output/tests/**/*.xml"
                 }
             }


### PR DESCRIPTION
Jenkins is complaining about the following

```
The archive step is deprecated, please use archiveArtifacts instead.
```

This PR uses the newer syntax.