### PR TITLE
Add vendor.check rule to Jenkins build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -23,6 +23,7 @@ pipeline {
 
         stage('Build validation'){
             steps {
+                sh './build/run make vendor.check'
                 sh './build/run make -j$(nproc) build.all'
             }
         }


### PR DESCRIPTION
If we have a vendoring issue, we get an error when helm chart fails to build, but would be nicer if we caught it with vendor.check

> 11:52:27 19:52:27 [31m[FAIL][0m version v0.0.0-176.32fd465.dirty is dirty aborting publish. The following files changed: Gopkg.lock