### PR TITLE
Quiet down gcp log

### DIFF
--- a/pkg/clients/gcp/gcp.go
+++ b/pkg/clients/gcp/gcp.go
@@ -49,7 +49,6 @@ func GetGoogleClient(clientset kubernetes.Interface, namespace string, secretKey
 		creds, err = google.CredentialsFromJSON(context.Background(), gcpSecretData, scopes...)
 		if err == nil {
 			hc = oauth2.NewClient(context.Background(), creds.TokenSource)
-			log.Printf("google client created from secret %s", secretKey.Name)
 		}
 	}
 


### PR DESCRIPTION
Currently, GCP client is rather chatty:
```
2018/11/28 22:11:12 google client created from secret gcp-provider-creds
2018/11/28 22:12:12 google client created from secret gcp-provider-creds
2018/11/28 22:13:12 google client created from secret gcp-provider-creds
2018/11/28 22:14:12 google client created from secret gcp-provider-creds
2018/11/28 22:15:12 google client created from secret gcp-provider-creds
2018/11/28 22:16:12 google client created from secret gcp-provider-creds
```