### PR TITLE
build: deleteDir after every CI run

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -87,6 +87,7 @@ pipeline {
                 sh 'make -j\$(nproc) clean'
                 sh 'make -j\$(nproc) prune PRUNE_HOURS=48 PRUNE_KEEP=48'
                 sh 'docker images'
+                deleteDir()
             }
         }
     }


### PR DESCRIPTION
This should clean the workspace directory after every jenkins run. 