### PR TITLE
Remove crossplane-system ns from provider in gcp demo

### DIFF
--- a/cluster/examples/workloads/wordpress-gcp/provider.yaml
+++ b/cluster/examples/workloads/wordpress-gcp/provider.yaml
@@ -1,9 +1,3 @@
-## Crossplane System Namespace
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: crossplane-system
----
 ## GCP Service Account Credentials
 apiVersion: v1
 data:


### PR DESCRIPTION
Install instructions for crossplay indicate that we should install into --namespace crossplane-system, so we don't want the demo to blow away the install.

