### PR TITLE
Fix to parse only region from aws config file

### DIFF
--- a/cluster/examples/aws-setup-provider/setup.sh
+++ b/cluster/examples/aws-setup-provider/setup.sh
@@ -36,7 +36,7 @@ kubectl cluster-info > /dev/null || echo "KUBECONFIG is not configured properly"
 aws_profile="${aws_profile:-default}"
 
 # if region is not provided, retrieve aws profile region from config
-AWS_REGION=$(awk '/["$aws_profile"]/ {getline; print $3}' ${HOME}/.aws/config)
+AWS_REGION=$(aws configure get region --profile $aws_profile)
 
 # retrieve aws profile credentials, save it under 'default' profile, and base64 encode it
 AWS_CREDS_BASE64=$(cat ${HOME}/.aws/credentials | awk '/["$aws_profile"]/ {getline; print $0}' | awk 'NR==1{print "[default]"}1' | base64 | tr -d "\n")


### PR DESCRIPTION
Signed-off-by: Sayan Chowdhury <sayan.chowdhury2012@gmail.com>

<!--
Thank you for helping to improve Crossplane!

We strongly recommend you look through our contributor guide at https://git.io/fj2m9
if this is your first time opening a Crossplane pull request. You can find us in
https://slack.crossplane.io/messages/dev if you need any help contributing.
-->

### Description of your changes
The `cluster/examples/aws-setup-provider/setup.sh` script fails if the `~/.aws/config` file contains anything more than just region, for example my config file had `region` as well as `output`. This PR would just parse the region value and use it in `provider.yaml`

### How has this code been tested?

By successfully running the `cluster/examples/aws-setup-provider/setup.sh` script.

### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every Crossplane pull request.
-->
I have:
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Ensured this PR contains a neat, self documenting set of commits.
- [ ] Updated any relevant [documentation] and [examples].
- [ ] Reported all new error conditions into the log or as an event, as
  appropriate.

For more about what we believe makes a pull request complete, see our
[definition of done].

[documentation]: https://github.com/crossplane/crossplane/tree/master/docs
[examples]: https://github.com/crossplane/crossplane/tree/master/cluster/examples
[definition of done]: https://github.com/crossplane/crossplane/tree/master/design/one-pager-definition-of-done.md
