### PR TITLE
template stacks: allow authors to specify controller image

### DIFF
--- a/apis/stacks/v1alpha1/stackdefinition.go
+++ b/apis/stacks/v1alpha1/stackdefinition.go
@@ -61,10 +61,16 @@ type BehaviorCRD struct {
 
 // StackResourceEngineConfiguration represents a configuration for a resource engine, such as helm2 or kustomize.
 type StackResourceEngineConfiguration struct {
+	// ControllerImage is the image of the generic controller used to reconcile
+	// the instances of the given CRDs. If empty, it is populated by stack manager
+	// during unpack with default value.
+	// +optional
+	ControllerImage string `json:"controllerImage,omitempty"`
 	// Type is the engine type, such as "helm2" or "kustomize"
 	Type string `json:"type"`
 	// Because different engine configurations could specify conflicting field names,
 	// we want to namespace the engines with engine-specific keys
+	// +optional
 	Kustomize *KustomizeEngineConfiguration `json:"kustomize,omitempty"`
 }
 

--- a/cluster/charts/crossplane-types/crds/stacks.crossplane.io_stackdefinitions.yaml
+++ b/cluster/charts/crossplane-types/crds/stacks.crossplane.io_stackdefinitions.yaml
@@ -40,6 +40,8 @@ spec:
                   type: object
                 engine:
                   properties:
+                    controllerImage:
+                      type: string
                     kustomize:
                       properties:
                         kustomization:

--- a/cluster/charts/crossplane/templates/crds/stacks.crossplane.io_stackdefinitions.yaml
+++ b/cluster/charts/crossplane/templates/crds/stacks.crossplane.io_stackdefinitions.yaml
@@ -40,6 +40,8 @@ spec:
                   type: object
                 engine:
                   properties:
+                    controllerImage:
+                      type: string
                     kustomize:
                       properties:
                         kustomization:

--- a/pkg/stacks/steps.go
+++ b/pkg/stacks/steps.go
@@ -92,7 +92,9 @@ func behaviorStep(sp StackPackager) walker.Step {
 			return errors.New(fmt.Sprintf("Behavior source path cannot be empty, '/', or '.'"))
 		}
 		behavior.Source.Path = cleanPath
-
+		if behavior.Engine.ControllerImage == "" {
+			behavior.Engine.ControllerImage = sp.GetDefaultTmplCtrlImage()
+		}
 		sp.SetBehavior(behavior)
 		return nil
 	}

--- a/pkg/stacks/unpack.go
+++ b/pkg/stacks/unpack.go
@@ -122,6 +122,7 @@ type StackPackager interface {
 
 	GotApp() bool
 	IsNamespaced() bool
+	GetDefaultTmplCtrlImage() string
 
 	AddGroup(string, StackGroup)
 	AddResource(string, StackResource)
@@ -168,8 +169,13 @@ type StackPackage struct {
 	// baseDir is the directory that serves as the base of the stack package (it should be absolute)
 	baseDir string
 
-	// tmplCtrlImage is the Template Controller image to handle template stacks
-	tmplCtrlImage string
+	// defaultTmplCtrlImage is the Template Controller image to handle template stacks
+	defaultTmplCtrlImage string
+}
+
+// GetDefaultTmplCtrlImage returns the default templating controller image path.
+func (sp *StackPackage) GetDefaultTmplCtrlImage() string {
+	return sp.defaultTmplCtrlImage
 }
 
 // Yaml returns a multiple document YAML representation of the Stack Package
@@ -244,7 +250,7 @@ func (sp *StackPackage) createBehaviorController(sd v1alpha1.Behavior) appsv1.De
 				Containers: []corev1.Container{
 					{
 						Name:  controllerContainerName,
-						Image: sp.tmplCtrlImage,
+						Image: sd.Engine.ControllerImage,
 						// the environment variables are known and applied
 						// to containers at a higher level than unpack
 						Command: []string{"/manager"},
@@ -493,14 +499,14 @@ func NewStackPackage(baseDir, tmplCtrlImage string) *StackPackage {
 			TypeMeta:   metav1.TypeMeta{APIVersion: sdv, Kind: sdk},
 			ObjectMeta: metav1.ObjectMeta{},
 		},
-		CRDs:          map[string]apiextensions.CustomResourceDefinition{},
-		CRDPaths:      map[string]string{},
-		Groups:        map[string]StackGroup{},
-		Icons:         map[string]*v1alpha1.IconSpec{},
-		Resources:     map[string]StackResource{},
-		UISchemas:     map[string]string{},
-		baseDir:       baseDir,
-		tmplCtrlImage: tmplCtrlImage,
+		CRDs:                 map[string]apiextensions.CustomResourceDefinition{},
+		CRDPaths:             map[string]string{},
+		Groups:               map[string]StackGroup{},
+		Icons:                map[string]*v1alpha1.IconSpec{},
+		Resources:            map[string]StackResource{},
+		UISchemas:            map[string]string{},
+		baseDir:              baseDir,
+		defaultTmplCtrlImage: tmplCtrlImage,
 	}
 
 	return sp

--- a/pkg/stacks/unpack_test.go
+++ b/pkg/stacks/unpack_test.go
@@ -262,6 +262,7 @@ spec:
       apiVersion: samples.stacks.crossplane.io/v1alpha1
       kind: SampleClaim
     engine:
+      controllerImage: crossplane/ts-controller:0.0.0
       type: helm2
     source:
       image: crossplane/sample-stack-claim-test:helm2


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

We strongly recommend you look through our contributor guide at https://git.io/fj2m9
if this is your first time opening a Crossplane pull request. You can find us in
https://slack.crossplane.io/messages/dev if you need any help contributing.
-->

### Description of your changes

This PR allows template stack authors to pin down the templating controller image they'd like. If not provided, it falls back to the default value on Crossplane helm chart.

Fixes https://github.com/crossplane/crossplane/issues/1291
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

Fixes #
-->

### How has this code been tested?

* Crossplane master with minimal azure with and without `engine.controllerImage`
* This PR with minimal azure with and without `engine.controllerImage`

It's backward compatible.
<!--
Before reviewers can be confident in the correctness of a pull request,
it needs to tested and shown to be correct. In this section, briefly
describe the testing that has already been done or which is planned.
-->

### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every Crossplane pull request.
-->
I have:
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Ensured this PR contains a neat, self documenting set of commits.
- [x] Updated any relevant [documentation] and [examples].
- [x] Reported all new error conditions into the log or as an event, as
  appropriate.

For more about what we believe makes a pull request complete, see our
[definition of done].

[documentation]: https://github.com/crossplane/crossplane/tree/master/docs
[examples]: https://github.com/crossplane/crossplane/tree/master/cluster/examples
[definition of done]: https://github.com/crossplane/crossplane/tree/master/design/one-pager-definition-of-done.md
