### PR TITLE
Fix broken servicenetworking API reference link

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -125,7 +125,7 @@ API Group | Status | Details
 [`container.gcp.crossplane.io/v1alpha1`]: api/crossplane/stack-gcp/container-gcp-crossplane-io-v1alpha1.md
 [`container.gcp.crossplane.io/v1beta1`]: api/crossplane/stack-gcp/container-gcp-crossplane-io-v1beta1.md
 [`database.gcp.crossplane.io/v1beta1`]: api/crossplane/stack-gcp/database-gcp-crossplane-io-v1beta1.md
-[`servicenetworking.gcp.crossplane.io/v1alpha3`]: api/crossplane/stack-gcp/servicenetworking-gcp-crossplane-io-v1alpha3.md
+[`servicenetworking.gcp.crossplane.io/v1beta1`]: api/crossplane/stack-gcp/servicenetworking-gcp-crossplane-io-v1beta1.md
 [`storage.gcp.crossplane.io/v1alpha3`]: api/crossplane/stack-gcp/storage-gcp-crossplane-io-v1alpha3.md
 
 ## Rook Stack


### PR DESCRIPTION
Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

<!--
Thank you for helping to improve Crossplane!

We strongly recommend you look through our contributor guide at https://git.io/fj2m9
if this is your first time opening a Crossplane pull request. You can find us in
https://slack.crossplane.io/messages/dev if you need any help contributing.
-->

### Description of your changes
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

Fixes #
-->

Fixes broken GCP `servicenetworking` link in API Ref doc. Will need backport to `release-0.8` after merge.

### How has this code been tested?
<!--
Before reviewers can be confident in the correctness of a pull request,
it needs to tested and shown to be correct. In this section, briefly
describe the testing that has already been done or which is planned.
-->

n/a

[skip ci]

### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every Crossplane pull request.
-->
I have:
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Ensured this PR contains a neat, self documenting set of commits.
- [x] Updated any relevant [documentation] and [examples].
- [ ] Reported all new error conditions into the log or as an event, as
  appropriate.

For more about what we believe makes a pull request complete, see our
[definition of done].

[documentation]: https://github.com/crossplane/crossplane/tree/master/docs
[examples]: https://github.com/crossplane/crossplane/tree/master/cluster/examples
[definition of done]: https://github.com/crossplane/crossplane/tree/master/design/one-pager-definition-of-done.md
