### PR TITLE
stacks: introduce packageType to app.yaml and Stack spec

### DIFF
--- a/apis/stacks/v1alpha1/types.go
+++ b/apis/stacks/v1alpha1/types.go
@@ -322,9 +322,12 @@ type AppMetadataSpec struct {
 	Source        string            `json:"source,omitempty"`
 	License       string            `json:"license,omitempty"`
 
-	// DependsOn is the list of CRDs that this stack depends on. This data drives the
-	// dependency resolution process.
+	// DependsOn is the list of CRDs that this stack depends on. This data
+	// drives the RBAC generation process.
 	DependsOn []StackInstallSpec `json:"dependsOn,omitempty"`
+
+	// +kubebuilder:validation:Enum=Provider;Stack;Application
+	PackageType string `json:"packageType,omitempty"`
 
 	// +kubebuilder:validation:Enum=Cluster;Namespaced
 	PermissionScope string `json:"permissionScope,omitempty"`

--- a/cluster/charts/crossplane-types/crds/stacks.crossplane.io_stackdefinitions.yaml
+++ b/cluster/charts/crossplane-types/crds/stacks.crossplane.io_stackdefinitions.yaml
@@ -2843,6 +2843,12 @@ spec:
                     type: string
                 type: object
               type: array
+            packageType:
+              enum:
+              - Provider
+              - Stack
+              - Application
+              type: string
             permissionScope:
               enum:
               - Cluster

--- a/cluster/charts/crossplane-types/crds/stacks.crossplane.io_stacks.yaml
+++ b/cluster/charts/crossplane-types/crds/stacks.crossplane.io_stacks.yaml
@@ -2793,6 +2793,12 @@ spec:
                     type: string
                 type: object
               type: array
+            packageType:
+              enum:
+              - Provider
+              - Stack
+              - Application
+              type: string
             permissionScope:
               enum:
               - Cluster

--- a/cluster/charts/crossplane/templates/crds/stacks.crossplane.io_stackdefinitions.yaml
+++ b/cluster/charts/crossplane/templates/crds/stacks.crossplane.io_stackdefinitions.yaml
@@ -2843,6 +2843,12 @@ spec:
                     type: string
                 type: object
               type: array
+            packageType:
+              enum:
+              - Provider
+              - Stack
+              - Application
+              type: string
             permissionScope:
               enum:
               - Cluster

--- a/cluster/charts/crossplane/templates/crds/stacks.crossplane.io_stacks.yaml
+++ b/cluster/charts/crossplane/templates/crds/stacks.crossplane.io_stacks.yaml
@@ -2793,6 +2793,12 @@ spec:
                     type: string
                 type: object
               type: array
+            packageType:
+              enum:
+              - Provider
+              - Stack
+              - Application
+              type: string
             permissionScope:
               enum:
               - Cluster

--- a/design/design-doc-stacks.md
+++ b/design/design-doc-stacks.md
@@ -320,6 +320,14 @@ source: "https://github.com/crossplane/sample-stack"
 # License SPDX name: https://spdx.org/licenses/
 license: Apache-2.0
 
+# Type of package represented. Supported values are:
+#
+# - Provider
+# - Stack
+# - Application
+packageType: Provider
+
+
 # Scope of roles needed by the stack once installed in the control plane,
 # current supported values are:
 #

--- a/pkg/stacks/unpack_test.go
+++ b/pkg/stacks/unpack_test.go
@@ -181,6 +181,7 @@ spec:
   owners:
   - email: bassam@upbound.io
     name: Bassam Tabbara
+  packageType: Application
   permissionScope: Namespaced
   permissions:
     rules:
@@ -332,6 +333,7 @@ spec:
   owners:
   - email: bassam@upbound.io
     name: Bassam Tabbara
+  packageType: Application
   permissionScope: Namespaced
   permissions:
     rules:
@@ -606,6 +608,7 @@ spec:
   owners:
   - email: bassam@upbound.io
     name: Bassam Tabbara
+  packageType: Application
   permissionScope: Namespaced
   permissions:
     rules:
@@ -901,6 +904,7 @@ spec:
   owners:
   - email: bassam@upbound.io
     name: Bassam Tabbara
+  packageType: Provider
   permissionScope: Cluster
   permissions:
     rules:
@@ -968,7 +972,7 @@ var (
 	_ StackPackager = &StackPackage{}
 )
 
-func simpleAppFile(permissionScope string) string {
+func simpleAppFile(permissionScope, packageType string) string {
 	return fmt.Sprintf(`# Human readable title of application.
 title: Sample Crossplane Stack
 
@@ -1013,12 +1017,12 @@ keywords:
 # Links to more information about the application (about page, source code, etc.)
 website: "https://upbound.io"
 source: "https://github.com/crossplane/sample-stack"
-
+packageType: %q
 permissionScope: %q
 
 # License SPDX name: https://spdx.org/licenses/
 license: Apache-2.0
-`, permissionScope)
+`, packageType, permissionScope)
 }
 
 func simpleCRDFile(singular string) string {
@@ -1099,7 +1103,7 @@ func TestUnpack(t *testing.T) {
 				fs := afero.NewMemMapFs()
 				fs.MkdirAll("ext-dir", 0755)
 				afero.WriteFile(fs, "ext-dir/icon.jpg", []byte("mock-icon-data"), 0644)
-				afero.WriteFile(fs, "ext-dir/app.yaml", []byte(simpleAppFile("Namespaced")), 0644)
+				afero.WriteFile(fs, "ext-dir/app.yaml", []byte(simpleAppFile("Namespaced", "Application")), 0644)
 				afero.WriteFile(fs, "ext-dir/install.yaml", []byte(simpleDeploymentInstallFile), 0644)
 				crdDir := "ext-dir/resources/samples.upbound.io/mytype/v1alpha1"
 				fs.MkdirAll(crdDir, 0755)
@@ -1115,7 +1119,7 @@ func TestUnpack(t *testing.T) {
 				fs := afero.NewMemMapFs()
 				fs.MkdirAll("ext-dir", 0755)
 				afero.WriteFile(fs, "ext-dir/icon.jpg", []byte("mock-icon-data"), 0644)
-				afero.WriteFile(fs, "ext-dir/app.yaml", []byte(simpleAppFile("Namespaced")), 0644)
+				afero.WriteFile(fs, "ext-dir/app.yaml", []byte(simpleAppFile("Namespaced", "Application")), 0644)
 				afero.WriteFile(fs, "ext-dir/behavior.yaml", []byte(simpleBehaviorFile), 0644)
 				crdDir := "ext-dir/resources/samples.upbound.io/mytype/v1alpha1"
 				fs.MkdirAll(crdDir, 0755)
@@ -1146,7 +1150,7 @@ func TestUnpack(t *testing.T) {
 				}
 
 				afero.WriteFile(fs, "ext-dir/icon.jpg", []byte("mock-icon-data"), 0644)
-				afero.WriteFile(fs, "ext-dir/app.yaml", []byte(simpleAppFile("Namespaced")), 0644)
+				afero.WriteFile(fs, "ext-dir/app.yaml", []byte(simpleAppFile("Namespaced", "Application")), 0644)
 				afero.WriteFile(fs, "ext-dir/install.yaml", []byte(simpleDeploymentInstallFile), 0644)
 				afero.WriteFile(fs, filepath.Join(groupDir, "group.yaml"), []byte(simpleGroupFile), 0644)
 				afero.WriteFile(fs, filepath.Join(groupDir, "ui-schema.yaml"), []byte(simpleUIFile("group")), 0644)
@@ -1217,7 +1221,7 @@ func TestUnpackCluster(t *testing.T) {
 				}
 
 				afero.WriteFile(fs, "ext-dir/icon.jpg", []byte("mock-icon-data"), 0644)
-				afero.WriteFile(fs, "ext-dir/app.yaml", []byte(simpleAppFile("Cluster")), 0644)
+				afero.WriteFile(fs, "ext-dir/app.yaml", []byte(simpleAppFile("Cluster", "Provider")), 0644)
 				afero.WriteFile(fs, "ext-dir/install.yaml", []byte(simpleDeploymentInstallFile), 0644)
 				afero.WriteFile(fs, filepath.Join(groupDir, "group.yaml"), []byte(simpleGroupFile), 0644)
 				afero.WriteFile(fs, filepath.Join(groupDir, "ui-schema.yaml"), []byte(simpleUIFile("group")), 0644)


### PR DESCRIPTION
### Description of your changes

Adds a new meta descriptor for stacks: `packageType`.

This property can be provided in `app.yaml` and will be represented in the Stack and StackDefinition resources.

This field is another descriptor, like Category or Keyword, but defines the nature of the package as belonging to one of three classes: Provider, Stack, or Application.

### How has this code been tested?
<!--
Before reviewers can be confident in the correctness of a pull request,
it needs to tested and shown to be correct. In this section, briefly
describe the testing that has already been done or which is planned.
-->

### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every Crossplane pull request.
-->
I have:
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Ensured this PR contains a neat, self documenting set of commits.
- [x] Updated any relevant [documentation] and [examples].
- [ ] Reported all new error conditions into the log or as an event, as
  appropriate.

For more about what we believe makes a pull request complete, see our
[definition of done].

[documentation]: https://github.com/crossplane/crossplane/tree/master/docs
[examples]: https://github.com/crossplane/crossplane/tree/master/cluster/examples
[definition of done]: https://github.com/crossplane/crossplane/tree/master/design/one-pager-definition-of-done.md
