### PR TITLE
stacks: multiple namespace support

### DIFF
--- a/cmd/crossplane/main.go
+++ b/cmd/crossplane/main.go
@@ -105,7 +105,7 @@ func main() {
 		kingpin.FatalIfError(mgr.Start(ctrl.SetupSignalHandler()), "Cannot start controller manager")
 
 	case extManageCmd.FullCommand():
-		log := logging.NewLogrLogger(zl.WithName("stack-manager"))
+		log := logging.NewLogrLogger(zl.WithName(stack.LabelValueStackManager))
 		log.Debug("Starting", "sync-period", syncPeriod.String())
 
 		cfg, err := getRestConfig(*extManageTenantKubeconfig)

--- a/cmd/crossplane/main.go
+++ b/cmd/crossplane/main.go
@@ -115,9 +115,7 @@ func main() {
 		kingpin.FatalIfError(err, "Cannot create manager")
 
 		kingpin.FatalIfError(apis.AddToScheme(mgr.GetScheme()), "Cannot add core Crossplane APIs to scheme")
-
 		kingpin.FatalIfError(apiextensionsv1beta1.AddToScheme(mgr.GetScheme()), "Cannot add API extensions to scheme")
-
 		kingpin.FatalIfError(stacks.Setup(mgr, log, *extManageHostControllerNamespace, *extManageTemplatesController), "Cannot add stacks controllers to manager")
 
 		if *extManageTemplatesController != "" {

--- a/cmd/crossplane/main.go
+++ b/cmd/crossplane/main.go
@@ -115,7 +115,9 @@ func main() {
 		kingpin.FatalIfError(err, "Cannot create manager")
 
 		kingpin.FatalIfError(apis.AddToScheme(mgr.GetScheme()), "Cannot add core Crossplane APIs to scheme")
+
 		kingpin.FatalIfError(apiextensionsv1beta1.AddToScheme(mgr.GetScheme()), "Cannot add API extensions to scheme")
+
 		kingpin.FatalIfError(stacks.Setup(mgr, log, *extManageHostControllerNamespace, *extManageTemplatesController), "Cannot add stacks controllers to manager")
 
 		if *extManageTemplatesController != "" {

--- a/go.sum
+++ b/go.sum
@@ -81,8 +81,10 @@ github.com/docker/distribution v2.7.1+incompatible h1:a5mlkVzth6W5A4fOsS3D2EO5BU
 github.com/docker/distribution v2.7.1+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
 github.com/docker/docker v0.7.3-0.20190327010347-be7ac8be2ae0/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/go-units v0.3.3/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
+github.com/docker/spdystream v0.0.0-20160310174837-449fdfce4d96 h1:cenwrSVm+Z7QLSV/BsnenAOcDXdX4cMv4wP0B/5QbPg=
 github.com/docker/spdystream v0.0.0-20160310174837-449fdfce4d96/go.mod h1:Qh8CwZgvJUkLughtfhJv5dyTYa91l1fOUCrgjqmcifM=
 github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815/go.mod h1:WwZ+bS3ebgob9U8Nd0kOddGdZWjyMGR8Wziv+TBNwSE=
+github.com/elazarl/goproxy v0.0.0-20170405201442-c4fc26588b6e h1:p1yVGRW3nmb85p1Sh1ZJSDm4A4iKLS5QNbvUHMgGu/M=
 github.com/elazarl/goproxy v0.0.0-20170405201442-c4fc26588b6e/go.mod h1:/Zj4wYkgs4iZTTu3o/KG3Itv/qCCa8VVMlb3i9OVuzc=
 github.com/emicklei/go-restful v0.0.0-20170410110728-ff4f55a20633/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
 github.com/emicklei/go-restful v2.9.5+incompatible/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
@@ -169,6 +171,7 @@ github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5y
 github.com/golang/protobuf v1.3.2 h1:6nsPYzhq5kReh6QImI3k5qWzO4PEbvbIW2cwSfR/6xs=
 github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
+github.com/google/btree v1.0.0 h1:0udJVsspx3VBr5FwtLhQQtuAsVc79tTq0ocGIPAU6qo=
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/google/go-cmp v0.3.0 h1:crn/baboCvb5fXaQ0IJ1SGTsTVrWpDsCWC8EGETZijY=
@@ -196,6 +199,7 @@ github.com/gophercloud/gophercloud v0.6.0 h1:Xb2lcqZtml1XjgYZxbeayEemq7ASbeTp09m
 github.com/gophercloud/gophercloud v0.6.0/go.mod h1:GICNByuaEBibcjmjvI7QvYJSZEbGkcYwAR7EZK2WMqM=
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/gregjones/httpcache v0.0.0-20170728041850-787624de3eb7/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=
+github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7 h1:pdN6V1QBWetyv/0+wjACpqVH+eVULgEjkurDLq3goeM=
 github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=
 github.com/grpc-ecosystem/go-grpc-middleware v0.0.0-20190222133341-cfaf5686ec79/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgfV/d3M/q6VIi02HzZEHgUlZvzk=
@@ -276,6 +280,7 @@ github.com/modern-go/reflect2 v1.0.1 h1:9f412s+6RmYXLWZSEzVVgPGK7C2PphHj5RJrvfx9
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/munnerz/goautoneg v0.0.0-20120707110453-a547fc61f48d/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
+github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f h1:y5//uYreIhSUg3J1GEMiLbxo1LJaP8RfCpH6pymGZus=
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+o7JKHSa8/e818NopupXU1YMK5fe1lsApnBw=
 github.com/onsi/ginkgo v0.0.0-20170829012221-11459a886d9c/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.4.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
@@ -293,6 +298,7 @@ github.com/opencontainers/go-digest v1.0.0-rc1 h1:WzifXhOVOEOuFYOJAW6aQqW0TooG2i
 github.com/opencontainers/go-digest v1.0.0-rc1/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
+github.com/peterbourgon/diskv v2.0.1+incompatible h1:UBdAOUP5p4RWqPBg048CAvpKN+vxiaj6gdUUzhl4XmI=
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=

--- a/go.sum
+++ b/go.sum
@@ -341,6 +341,7 @@ github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An
 github.com/spf13/viper v1.3.2/go.mod h1:ZiWeW+zYFKm7srdB9IoDzzZXaJaI5eL9QjNiN/DMA2s=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.2.0 h1:Hbg2NidpLE8veEBkEZTL3CvlkUIVzuU9jDplZO54c48=
 github.com/stretchr/objx v0.2.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoHMkEqE=
 github.com/stretchr/testify v0.0.0-20151208002404-e3a8ff8ce365/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=

--- a/pkg/controller/stacks/install/installjob.go
+++ b/pkg/controller/stacks/install/installjob.go
@@ -251,6 +251,9 @@ func (jc *stackInstallJobCompleter) createJobOutputObject(ctx context.Context, o
 			saAnnotationSetter(i.GetServiceAccountAnnotations()),
 		}
 
+		labels := stacks.ParentLabels(i)
+		meta.AddLabels(obj, labels)
+
 		// StackDefinition controllers need the name of the StackDefinition
 		// which, by design, matches the StackInstall
 		if isStackDefinition {
@@ -263,11 +266,6 @@ func (jc *stackInstallJobCompleter) createJobOutputObject(ctx context.Context, o
 		}
 	}
 
-	// TODO(displague) parentlabels can only express a single parent, CRDs
-	// may have multiple contributing "parents"
-	labels := stacks.ParentLabels(i)
-	meta.AddLabels(obj, labels)
-
 	jc.log.Debug(
 		"creating object from job output",
 		"job", job.Name,
@@ -275,7 +273,6 @@ func (jc *stackInstallJobCompleter) createJobOutputObject(ctx context.Context, o
 		"namespace", obj.GetNamespace(),
 		"apiVersion", obj.GetAPIVersion(),
 		"kind", obj.GetKind(),
-		"labels", labels,
 	)
 	if err := jc.client.Create(ctx, obj); err != nil && !kerrors.IsAlreadyExists(err) {
 		return errors.Wrapf(err, "failed to create object %s from job output %s", obj.GetName(), job.Name)

--- a/pkg/controller/stacks/install/installjob.go
+++ b/pkg/controller/stacks/install/installjob.go
@@ -28,7 +28,6 @@ import (
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
-	apiextensions "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -308,16 +307,6 @@ func isStackDefinitionObject(obj stacks.KindlyIdentifier) bool {
 
 	return gvk.Group == v1alpha1.Group && gvk.Version == v1alpha1.Version &&
 		strings.EqualFold(gvk.Kind, v1alpha1.StackDefinitionKind)
-}
-
-func isCRDObject(obj runtime.Object) bool {
-	if obj == nil {
-		return false
-	}
-	gvk := obj.GetObjectKind().GroupVersionKind()
-
-	return apiextensions.SchemeGroupVersion == gvk.GroupVersion() &&
-		strings.EqualFold(gvk.Kind, "CustomResourceDefinition")
 }
 
 func setupStackDefinitionController(obj *unstructured.Unstructured, modifiers ...stackSpecModifier) error {

--- a/pkg/controller/stacks/install/installjob_test.go
+++ b/pkg/controller/stacks/install/installjob_test.go
@@ -1169,9 +1169,7 @@ func TestCreateJobOutputObject(t *testing.T) {
 			obj:            unstructuredObj(crdRaw),
 			want: want{
 				err: nil,
-				obj: unstructuredObj(crdRaw,
-					withUnstructuredObjLabels(wantedParentLabels),
-				),
+				obj: unstructuredObj(crdRaw),
 			},
 		},
 		{

--- a/pkg/controller/stacks/install/installjob_test.go
+++ b/pkg/controller/stacks/install/installjob_test.go
@@ -368,10 +368,6 @@ var (
 	_ jobCompleter = &stackInstallJobCompleter{}
 )
 
-func nsLabel(ns string) string {
-	return fmt.Sprintf(stacks.LabelNamespaceFmt, ns)
-}
-
 // Job modifiers
 type jobModifier func(*batchv1.Job)
 

--- a/pkg/controller/stacks/install/stackinstall.go
+++ b/pkg/controller/stacks/install/stackinstall.go
@@ -298,8 +298,11 @@ func (h *stackInstallHandler) create(ctx context.Context) (reconcile.Result, err
 		// there is no install job created yet, create it now
 		job := h.createInstallJob()
 
-		// remove any stale jobs that would prevent the stack from installing
-		// correctly
+		// if an install job with our name already exists, compare the labels
+		// (specifically parent labels). If they match, adopt this job - we must
+		// have failed to update the jobref on a previous reconciliation.
+		// if the install job does not belong to this stackinstall, block
+		// reconciliation and report it until the problem is resolved.
 		existingJob := &batchv1.Job{ObjectMeta: metav1.ObjectMeta{Name: job.Name, Namespace: job.Namespace}}
 
 		switch err := h.hostKube.Get(ctx, types.NamespacedName{Name: job.Name, Namespace: job.Namespace}, existingJob); {
@@ -412,65 +415,90 @@ func (h *stackInstallHandler) update(ctx context.Context) (reconcile.Result, err
 	return reconcile.Result{}, nil
 }
 
-// delete performs clean up (finalizer) actions when a StackInstall is being deleted.
-// This function ensures that all the resources (e.g., CRDs) that this StackInstall owns
-// are also cleaned up.
+// delete performs clean up (finalizer) actions when a StackInstall is being
+// deleted. This function ensures that all the resources (e.g., CRDs) that this
+// StackInstall owns are also cleaned up.
 func (h *stackInstallHandler) delete(ctx context.Context) (reconcile.Result, error) {
 	labels := stacks.ParentLabels(h.ext)
 
-	// Delete all StackDefintions created by this StackInstall or
-	// ClusterStackInstall
-	if err := h.kube.DeleteAllOf(ctx, &v1alpha1.StackDefinition{}, client.InNamespace(h.ext.GetNamespace()), client.MatchingLabels(labels)); err != nil {
-		return fail(ctx, h.kube, h.ext, err)
-	}
-
-	// Waiting for all StackDefinitions to clear their finalizers and delete
-	// before deleting the Stacks they may co-manage
-	sdList := &v1alpha1.StackDefinitionList{}
-	if err := h.kube.List(ctx, sdList, client.MatchingLabels(labels)); err != nil {
-		return fail(ctx, h.kube, h.ext, err)
-	}
-
-	// Delete all Stacks created by this StackInstall or ClusterStackInstall
-	if err := h.kube.DeleteAllOf(ctx, &v1alpha1.Stack{}, client.InNamespace(h.ext.GetNamespace()), client.MatchingLabels(labels)); err != nil {
-		return fail(ctx, h.kube, h.ext, err)
-	}
-
-	// Waiting for all Stacks to clear their finalizers and delete before
-	// deleting the CRDs that they depend on
-	stackList := &v1alpha1.StackList{}
-	if err := h.kube.List(ctx, stackList, client.MatchingLabels(labels)); err != nil {
-		return fail(ctx, h.kube, h.ext, err)
-	}
-
-	if len(stackList.Items) != 0 {
-		err := errors.New("Stack resources have not been deleted")
-		return fail(ctx, h.kube, h.ext, err)
-	}
-
-	stackControllerNamespace := h.ext.GetNamespace()
-	if h.hostAwareConfig != nil {
-		stackControllerNamespace = h.hostAwareConfig.HostControllerNamespace
-	}
-
-	// Once the Stacks are gone, we can remove install job associated with the StackInstall using hostKube since jobs
-	// were deployed into host Kubernetes cluster.
-	if err := h.hostKube.DeleteAllOf(ctx, &batchv1.Job{}, client.MatchingLabels(labels),
-		client.InNamespace(stackControllerNamespace), client.PropagationPolicy(metav1.DeletePropagationForeground)); err != nil {
-		return fail(ctx, h.kube, h.ext, err)
-	}
-
-	if err := h.deleteOrphanedCRDs(ctx); err != nil {
-		return fail(ctx, h.kube, h.ext, err)
-	}
-
-	// And finally clear the StackInstall's own finalizer
-	meta.RemoveFinalizer(h.ext, installFinalizer)
-	if err := h.kube.Update(ctx, h.ext); err != nil {
-		return fail(ctx, h.kube, h.ext, err)
+	for _, df := range []deleteReq{
+		h.stackDefinitionDeleter(labels),
+		// clear finalizers before deleting the Stacks they may co-manage
+		h.stackDefinitionFinalizerWaiter(labels),
+		h.stackDeleter(labels),
+		// clear finalizers before deleting the CRDs they depend on
+		h.stackFinalizerWaiter(labels),
+		// Once the Stacks are gone, we can remove install job associated with
+		// the StackInstall using hostKube since jobs were deployed into host
+		// Kubernetes cluster.
+		h.installJobDeleter(labels),
+		// Clear out orphaned CRDs and orphaned parent labels on CRDs
+		h.deleteOrphanedCRDs,
+		h.removeCRDParentLabels(labels),
+		// And finally clear the StackInstall's own finalizer
+		h.removeFinalizer,
+	} {
+		if err := df(ctx); err != nil {
+			return fail(ctx, h.kube, h.ext, err)
+		}
 	}
 
 	return reconcile.Result{}, nil
+}
+
+type deleteReq func(context.Context) error
+
+// stackDefinitionDeleter deletes all StackDefintions created by this
+// StackInstall or ClusterStackInstall
+func (h *stackInstallHandler) stackDefinitionDeleter(labels map[string]string) deleteReq {
+	return func(ctx context.Context) error {
+		return h.kube.DeleteAllOf(ctx, &v1alpha1.StackDefinition{}, client.InNamespace(h.ext.GetNamespace()), client.MatchingLabels(labels))
+	}
+}
+
+// stackDefinitionFinalizerWaiter waits for all StackDefinitions to clear their
+// finalizers and delete
+func (h *stackInstallHandler) stackDefinitionFinalizerWaiter(labels map[string]string) deleteReq {
+	return func(ctx context.Context) error {
+		sdList := &v1alpha1.StackDefinitionList{}
+		return h.kube.List(ctx, sdList, client.MatchingLabels(labels))
+	}
+}
+
+// stackDeleter deletes all Stacks created by this StackInstall or ClusterStackInstall
+func (h *stackInstallHandler) stackDeleter(labels map[string]string) deleteReq {
+	return func(ctx context.Context) error {
+		return h.kube.DeleteAllOf(ctx, &v1alpha1.Stack{}, client.InNamespace(h.ext.GetNamespace()), client.MatchingLabels(labels))
+	}
+}
+
+// Waiting for all Stacks to clear their finalizers and delete
+func (h *stackInstallHandler) stackFinalizerWaiter(labels map[string]string) deleteReq {
+	return func(ctx context.Context) error {
+		stackList := &v1alpha1.StackList{}
+		if err := h.kube.List(ctx, stackList, client.MatchingLabels(labels)); err != nil {
+			return err
+		}
+
+		if len(stackList.Items) != 0 {
+			return errors.New("Stack resources have not been deleted")
+		}
+		return nil
+	}
+}
+
+// installJobDeleter deletes the install jobs belonging to the stackinstall
+// found on the host client
+func (h *stackInstallHandler) installJobDeleter(labels map[string]string) deleteReq {
+	return func(ctx context.Context) error {
+		stackControllerNamespace := h.ext.GetNamespace()
+		if h.hostAwareConfig != nil {
+			stackControllerNamespace = h.hostAwareConfig.HostControllerNamespace
+		}
+
+		return h.hostKube.DeleteAllOf(ctx, &batchv1.Job{}, client.MatchingLabels(labels),
+			client.InNamespace(stackControllerNamespace), client.PropagationPolicy(metav1.DeletePropagationForeground))
+	}
 }
 
 // deleteOrphanedCRDs will delete CRDs with managed-by label and NO stack parent
@@ -482,7 +510,7 @@ func (h *stackInstallHandler) delete(ctx context.Context) (reconcile.Result, err
 // whose Stack resources have not yet claimed the CRDs.
 func (h *stackInstallHandler) deleteOrphanedCRDs(ctx context.Context) error {
 	crds := &apiextensionsv1beta1.CustomResourceDefinitionList{}
-	if err := h.kube.List(ctx, crds, client.MatchingLabels{stacks.LabelKubernetesManagedBy: "stack-manager"}); err != nil {
+	if err := h.kube.List(ctx, crds, client.MatchingLabels{stacks.LabelKubernetesManagedBy: stacks.LabelValueStackManager}); err != nil {
 		h.debugWithName("failed to list CRDs")
 		return err
 	}
@@ -500,6 +528,39 @@ func (h *stackInstallHandler) deleteOrphanedCRDs(ctx context.Context) error {
 		}
 	}
 	return nil
+}
+
+// removeCRDParentLabels will remove unused ParentLabels from CRDs, these labels
+// are no longer used on CRDs by Crossplane, replaced with multi parent labels
+func (h *stackInstallHandler) removeCRDParentLabels(labels map[string]string) deleteReq {
+	return func(ctx context.Context) error {
+		crdList := &apiextensionsv1beta1.CustomResourceDefinitionList{}
+		if err := h.kube.List(ctx, crdList, client.MatchingLabels(labels)); err != nil {
+			return err
+		} else if len(crdList.Items) > 0 {
+			crds := crdList.Items
+			for i := range crds {
+				crdLabels := crds[i].GetLabels()
+				crdPatch := client.MergeFrom(crds[i].DeepCopy())
+
+				for label := range labels {
+					delete(crdLabels, label)
+				}
+
+				h.log.Debug("removing parent labels from CRD", "parent", "name", crds[i].GetName())
+				if err := h.kube.Patch(ctx, &crds[i], crdPatch); err != nil {
+					return err
+				}
+			}
+		}
+		return nil
+	}
+}
+
+// removeFinalizer removes the finalizer from the StackInstall resource
+func (h *stackInstallHandler) removeFinalizer(ctx context.Context) error {
+	meta.RemoveFinalizer(h.ext, installFinalizer)
+	return h.kube.Update(ctx, h.ext)
 }
 
 // ************************************************************************************************

--- a/pkg/controller/stacks/install/stackinstall.go
+++ b/pkg/controller/stacks/install/stackinstall.go
@@ -474,8 +474,9 @@ func (h *stackInstallHandler) delete(ctx context.Context) (reconcile.Result, err
 }
 
 // deleteOrphanedCRDs will delete CRDs with managed-by label and NO stack parent
-// labels. we can't predict these names, so fetch all and then filter locally
-// for any crds that still contain the labels
+// labels. we can't predict these names, so fetch all crds from any stackinstall
+// and then locally filter out any crds that still contain labels indicating
+// they are in use.
 //
 // TODO(displague) stackinstall delete and install can race and delete CRDs
 // whose Stack resources have not yet claimed the CRDs.

--- a/pkg/controller/stacks/stack/stack_test.go
+++ b/pkg/controller/stacks/stack/stack_test.go
@@ -815,7 +815,12 @@ func TestProcessRBAC_Cluster(t *testing.T) {
 						Name:      resourceName,
 						Namespace: namespace,
 						OwnerReferences: []metav1.OwnerReference{
-							meta.AsOwner(meta.ReferenceTo(resource(withPermissionScope("Cluster")), v1alpha1.StackGroupVersionKind)),
+							meta.AsOwner(
+								meta.ReferenceTo(resource(
+									withPermissionScope("Cluster")),
+									v1alpha1.StackGroupVersionKind,
+								),
+							),
 						},
 					},
 				},
@@ -1810,38 +1815,78 @@ func Test_crdListFulfilled(t *testing.T) {
 		wantErr error
 	}{
 		{
-			name:    "MissingFromCRDList",
-			args:    args{v1alpha1.CRDList{metav1.TypeMeta{Kind: kind, APIVersion: apiVersion}}, []apiextensionsv1beta1.CustomResourceDefinition{}},
+			name: "MissingFromCRDList",
+			args: args{v1alpha1.CRDList{
+				metav1.TypeMeta{Kind: kind, APIVersion: apiVersion},
+			}, []apiextensionsv1beta1.CustomResourceDefinition{}},
 			wantErr: fmt.Errorf(`Missing CRD with APIVersion %q and Kind %q`, apiVersion, kind),
 		},
 		{
-			name:    "WrongCRDVersion",
-			args:    args{v1alpha1.CRDList{metav1.TypeMeta{Kind: kind, APIVersion: apiVersion}}, []apiextensionsv1beta1.CustomResourceDefinition{crd(withCRDGroupKind(group, kind), withCRDVersion("foo"))}},
+			name: "WrongCRDVersion",
+			args: args{v1alpha1.CRDList{
+				metav1.TypeMeta{Kind: kind, APIVersion: apiVersion},
+			}, []apiextensionsv1beta1.CustomResourceDefinition{
+				crd(
+					withCRDGroupKind(group, kind),
+					withCRDVersion("foo"),
+				)}},
 			wantErr: fmt.Errorf(`Missing CRD with APIVersion %q and Kind %q`, apiVersion, kind),
 		},
 		{
-			name:    "DifferentCRDKind",
-			args:    args{v1alpha1.CRDList{metav1.TypeMeta{Kind: kind, APIVersion: apiVersion}}, []apiextensionsv1beta1.CustomResourceDefinition{crd(withCRDGroupKind(group, "foo"), withCRDVersion(version))}},
+			name: "DifferentCRDKind",
+			args: args{v1alpha1.CRDList{
+				metav1.TypeMeta{Kind: kind, APIVersion: apiVersion},
+			}, []apiextensionsv1beta1.CustomResourceDefinition{
+				crd(
+					withCRDGroupKind(group, "foo"),
+					withCRDVersion(version),
+				)}},
 			wantErr: fmt.Errorf(`Missing CRD with APIVersion %q and Kind %q`, apiVersion, kind),
 		},
 		{
-			name:    "PartialMatch",
-			args:    args{v1alpha1.CRDList{metav1.TypeMeta{Kind: kind, APIVersion: apiVersion}, metav1.TypeMeta{Kind: kind + "z", APIVersion: apiVersion}}, []apiextensionsv1beta1.CustomResourceDefinition{crd(withCRDGroupKind(group, kind), withCRDVersion(version))}},
+			name: "PartialMatch",
+			args: args{v1alpha1.CRDList{
+				metav1.TypeMeta{Kind: kind, APIVersion: apiVersion},
+				metav1.TypeMeta{Kind: kind + "z", APIVersion: apiVersion},
+			}, []apiextensionsv1beta1.CustomResourceDefinition{crd(
+				withCRDGroupKind(group, kind),
+				withCRDVersion(version),
+			)}},
 			wantErr: fmt.Errorf(`Missing CRD with APIVersion %q and Kind %q`, apiVersion, kind+"z"),
 		},
 		{
-			name:    "Success",
-			args:    args{v1alpha1.CRDList{metav1.TypeMeta{Kind: kind, APIVersion: apiVersion}}, []apiextensionsv1beta1.CustomResourceDefinition{crd(withCRDGroupKind(group, kind), withCRDVersion(version))}},
+			name: "Success",
+			args: args{v1alpha1.CRDList{
+				metav1.TypeMeta{Kind: kind, APIVersion: apiVersion},
+			}, []apiextensionsv1beta1.CustomResourceDefinition{crd(
+				withCRDGroupKind(group, kind),
+				withCRDVersion(version),
+			)}},
 			wantErr: nil,
 		},
 		{
-			name:    "SuccessMultiple",
-			args:    args{v1alpha1.CRDList{metav1.TypeMeta{Kind: kind, APIVersion: apiVersion}, metav1.TypeMeta{Kind: kind + "z", APIVersion: apiVersion}}, []apiextensionsv1beta1.CustomResourceDefinition{crd(withCRDGroupKind(group, kind), withCRDVersion(version)), crd(withCRDGroupKind(group, kind+"z"), withCRDVersion(version))}},
+			name: "SuccessMultiple",
+			args: args{v1alpha1.CRDList{
+				metav1.TypeMeta{Kind: kind, APIVersion: apiVersion},
+				metav1.TypeMeta{Kind: kind + "z", APIVersion: apiVersion},
+			}, []apiextensionsv1beta1.CustomResourceDefinition{
+				crd(withCRDGroupKind(group, kind),
+					withCRDVersion(version),
+				),
+				crd(withCRDGroupKind(group, kind+"z"),
+					withCRDVersion(version),
+				)}},
 			wantErr: nil,
 		},
 		{
-			name:    "SuccessWithExtra",
-			args:    args{v1alpha1.CRDList{metav1.TypeMeta{Kind: kind, APIVersion: apiVersion}}, []apiextensionsv1beta1.CustomResourceDefinition{crd(withCRDGroupKind(group, kind), withCRDVersion(version)), crd(withCRDGroupKind(group, kind+"z"), withCRDVersion(version))}},
+			name: "SuccessWithExtra",
+			args: args{v1alpha1.CRDList{metav1.TypeMeta{Kind: kind, APIVersion: apiVersion}}, []apiextensionsv1beta1.CustomResourceDefinition{
+				crd(withCRDGroupKind(group, kind),
+					withCRDVersion(version),
+				),
+				crd(withCRDGroupKind(group, kind+"z"),
+					withCRDVersion(version),
+				)}},
 			wantErr: nil,
 		},
 	}
@@ -1915,7 +1960,12 @@ func Test_stackHandler_crdsFromStack(t *testing.T) {
 					MockList: func(_ context.Context, list runtime.Object, _ ...client.ListOption) error {
 						switch list := list.(type) {
 						case *apiextensionsv1beta1.CustomResourceDefinitionList:
-							list.Items = append(list.Items, crd(withCRDGroupKind(group, kind), withCRDVersion("foo")))
+							list.Items = append(list.Items,
+								crd(
+									withCRDGroupKind(group, kind),
+									withCRDVersion("foo"),
+								),
+							)
 						default:
 							return errors.New("unexpected list for testing")
 						}
@@ -1934,7 +1984,12 @@ func Test_stackHandler_crdsFromStack(t *testing.T) {
 					MockList: func(_ context.Context, list runtime.Object, _ ...client.ListOption) error {
 						switch list := list.(type) {
 						case *apiextensionsv1beta1.CustomResourceDefinitionList:
-							list.Items = append(list.Items, crd(withCRDGroupKind(group, "Differentkind"), withCRDVersion(version)))
+							list.Items = append(list.Items,
+								crd(
+									withCRDGroupKind(group, "Differentkind"),
+									withCRDVersion(version),
+								),
+							)
 						default:
 							return errors.New("unexpected list for testing")
 						}
@@ -1953,7 +2008,11 @@ func Test_stackHandler_crdsFromStack(t *testing.T) {
 					MockList: func(_ context.Context, list runtime.Object, _ ...client.ListOption) error {
 						switch list := list.(type) {
 						case *apiextensionsv1beta1.CustomResourceDefinitionList:
-							list.Items = append(list.Items, crd(withCRDGroupKind(group, kind), withCRDVersion(version)))
+							list.Items = append(list.Items,
+								crd(
+									withCRDGroupKind(group, kind), withCRDVersion(version),
+								),
+							)
 						default:
 							return errors.New("unexpected list for testing")
 						}
@@ -1961,8 +2020,10 @@ func Test_stackHandler_crdsFromStack(t *testing.T) {
 					},
 				},
 			},
-			args:    args{context.TODO()},
-			want:    []apiextensionsv1beta1.CustomResourceDefinition{crd(withCRDGroupKind(group, kind), withCRDVersion(version))},
+			args: args{context.TODO()},
+			want: []apiextensionsv1beta1.CustomResourceDefinition{
+				crd(withCRDGroupKind(group, kind), withCRDVersion(version)),
+			},
 			wantErr: nil,
 		},
 	}
@@ -2025,8 +2086,13 @@ func Test_stackHandler_createNamespaceLabelsCRDHandler(t *testing.T) {
 				},
 			},
 			args: args{
-				ctx:  context.TODO(),
-				crds: []apiextensionsv1beta1.CustomResourceDefinition{crd(withCRDGroupKind(group, kind), withCRDVersion(version), withCRDLabels(map[string]string{stackspkg.LabelKubernetesManagedBy: "stack-manager"}))},
+				ctx: context.TODO(),
+				crds: []apiextensionsv1beta1.CustomResourceDefinition{
+					crd(
+						withCRDGroupKind(group, kind),
+						withCRDVersion(version),
+						withCRDLabels(map[string]string{stackspkg.LabelKubernetesManagedBy: stackspkg.LabelValueStackManager}),
+					)},
 			},
 			want: []apiextensionsv1beta1.CustomResourceDefinition{},
 			wantErr: kerrors.NewNotFound(
@@ -2038,45 +2104,68 @@ func Test_stackHandler_createNamespaceLabelsCRDHandler(t *testing.T) {
 			fields: fields{
 				ext: resource(),
 				clientFunc: func() client.Client {
-					c := crd(withCRDGroupKind(group, kind), withCRDVersion(version))
+					c := crd(withCRDGroupKind(group, kind),
+						withCRDVersion(version))
 					return fake.NewFakeClient(&c)
 				},
 			},
 			args: args{
-				ctx:  context.TODO(),
-				crds: []apiextensionsv1beta1.CustomResourceDefinition{crd(withCRDGroupKind(group, kind), withCRDVersion(version))},
+				ctx: context.TODO(),
+				crds: []apiextensionsv1beta1.CustomResourceDefinition{
+					crd(withCRDGroupKind(group, kind),
+						withCRDVersion(version))},
 			},
-			want: []apiextensionsv1beta1.CustomResourceDefinition{crd(withCRDGroupKind(group, kind), withCRDVersion(version))},
+			want: []apiextensionsv1beta1.CustomResourceDefinition{
+				crd(withCRDGroupKind(group, kind),
+					withCRDVersion(version))},
 		},
 		{
 			name: "ManagedCRD",
 			fields: fields{
 				ext: resource(),
 				clientFunc: func() client.Client {
-					c := crd(withCRDGroupKind(group, kind), withCRDVersion(version), withCRDLabels(map[string]string{stackspkg.LabelKubernetesManagedBy: "stack-manager"}))
+					c := crd(withCRDGroupKind(group, kind),
+						withCRDVersion(version),
+						withCRDLabels(map[string]string{stackspkg.LabelKubernetesManagedBy: stackspkg.LabelValueStackManager}))
 					return fake.NewFakeClient(&c)
 				},
 			},
 			args: args{
-				ctx:  context.TODO(),
-				crds: []apiextensionsv1beta1.CustomResourceDefinition{crd(withCRDGroupKind(group, kind), withCRDVersion(version), withCRDLabels(map[string]string{stackspkg.LabelKubernetesManagedBy: "stack-manager"}))},
+				ctx: context.TODO(),
+				crds: []apiextensionsv1beta1.CustomResourceDefinition{
+					crd(withCRDGroupKind(group, kind),
+						withCRDVersion(version),
+						withCRDLabels(map[string]string{stackspkg.LabelKubernetesManagedBy: stackspkg.LabelValueStackManager}))},
 			},
-			want: []apiextensionsv1beta1.CustomResourceDefinition{crd(withCRDGroupKind(group, kind), withCRDVersion(version), withCRDLabels(map[string]string{stackspkg.LabelKubernetesManagedBy: "stack-manager", nsLabel: "true"}))},
+			want: []apiextensionsv1beta1.CustomResourceDefinition{
+				crd(withCRDGroupKind(group, kind),
+					withCRDVersion(version),
+					withCRDLabels(map[string]string{stackspkg.LabelKubernetesManagedBy: stackspkg.LabelValueStackManager, nsLabel: "true"}))},
 		},
 		{
 			name: "ManagedCRDAlreadyLabeled",
 			fields: fields{
 				ext: resource(),
 				clientFunc: func() client.Client {
-					c := crd(withCRDGroupKind(group, kind), withCRDVersion(version), withCRDLabels(map[string]string{stackspkg.LabelKubernetesManagedBy: "stack-manager", nsLabel: "true"}))
+					c := crd(
+						withCRDGroupKind(group, kind),
+						withCRDVersion(version),
+						withCRDLabels(map[string]string{stackspkg.LabelKubernetesManagedBy: stackspkg.LabelValueStackManager, nsLabel: "true"}))
 					return fake.NewFakeClient(&c)
 				},
 			},
 			args: args{
-				ctx:  context.TODO(),
-				crds: []apiextensionsv1beta1.CustomResourceDefinition{crd(withCRDGroupKind(group, kind), withCRDVersion(version), withCRDLabels(map[string]string{stackspkg.LabelKubernetesManagedBy: "stack-manager", nsLabel: "true"}))},
+				ctx: context.TODO(),
+				crds: []apiextensionsv1beta1.CustomResourceDefinition{
+					crd(
+						withCRDGroupKind(group, kind),
+						withCRDVersion(version),
+						withCRDLabels(map[string]string{stackspkg.LabelKubernetesManagedBy: stackspkg.LabelValueStackManager, nsLabel: "true"}))},
 			},
-			want: []apiextensionsv1beta1.CustomResourceDefinition{crd(withCRDGroupKind(group, kind), withCRDVersion(version), withCRDLabels(map[string]string{stackspkg.LabelKubernetesManagedBy: "stack-manager", nsLabel: "true"}))},
+			want: []apiextensionsv1beta1.CustomResourceDefinition{
+				crd(withCRDGroupKind(group, kind),
+					withCRDVersion(version),
+					withCRDLabels(map[string]string{stackspkg.LabelKubernetesManagedBy: stackspkg.LabelValueStackManager, nsLabel: "true"}))},
 		},
 	}
 	for _, tt := range tests {
@@ -2142,8 +2231,14 @@ func Test_stackHandler_createMultipleParentLabelsCRDHandler(t *testing.T) {
 				},
 			},
 			args: args{
-				ctx:  context.TODO(),
-				crds: []apiextensionsv1beta1.CustomResourceDefinition{crd(withCRDGroupKind(group, kind), withCRDVersion(version), withCRDLabels(map[string]string{stackspkg.LabelKubernetesManagedBy: "stack-manager"}))},
+				ctx: context.TODO(),
+				crds: []apiextensionsv1beta1.CustomResourceDefinition{
+					crd(
+						withCRDGroupKind(group, kind),
+						withCRDVersion(version),
+						withCRDLabels(map[string]string{stackspkg.LabelKubernetesManagedBy: stackspkg.LabelValueStackManager}),
+					),
+				},
 			},
 			want: []apiextensionsv1beta1.CustomResourceDefinition{},
 			wantErr: kerrors.NewNotFound(
@@ -2155,45 +2250,66 @@ func Test_stackHandler_createMultipleParentLabelsCRDHandler(t *testing.T) {
 			fields: fields{
 				ext: resource(),
 				clientFunc: func() client.Client {
-					c := crd(withCRDGroupKind(group, kind), withCRDVersion(version))
+					c := crd(withCRDGroupKind(group, kind),
+						withCRDVersion(version))
 					return fake.NewFakeClient(&c)
 				},
 			},
 			args: args{
-				ctx:  context.TODO(),
-				crds: []apiextensionsv1beta1.CustomResourceDefinition{crd(withCRDGroupKind(group, kind), withCRDVersion(version))},
+				ctx: context.TODO(),
+				crds: []apiextensionsv1beta1.CustomResourceDefinition{
+					crd(withCRDGroupKind(group, kind),
+						withCRDVersion(version))},
 			},
-			want: []apiextensionsv1beta1.CustomResourceDefinition{crd(withCRDGroupKind(group, kind), withCRDVersion(version))},
+			want: []apiextensionsv1beta1.CustomResourceDefinition{
+				crd(withCRDGroupKind(group, kind),
+					withCRDVersion(version))},
 		},
 		{
 			name: "ManagedCRD",
 			fields: fields{
 				ext: resource(),
 				clientFunc: func() client.Client {
-					c := crd(withCRDGroupKind(group, kind), withCRDVersion(version), withCRDLabels(map[string]string{stackspkg.LabelKubernetesManagedBy: "stack-manager"}))
+					c := crd(withCRDGroupKind(group, kind),
+						withCRDVersion(version),
+						withCRDLabels(map[string]string{stackspkg.LabelKubernetesManagedBy: stackspkg.LabelValueStackManager}))
 					return fake.NewFakeClient(&c)
 				},
 			},
 			args: args{
-				ctx:  context.TODO(),
-				crds: []apiextensionsv1beta1.CustomResourceDefinition{crd(withCRDGroupKind(group, kind), withCRDVersion(version), withCRDLabels(map[string]string{stackspkg.LabelKubernetesManagedBy: "stack-manager"}))},
+				ctx: context.TODO(),
+				crds: []apiextensionsv1beta1.CustomResourceDefinition{
+					crd(withCRDGroupKind(group, kind),
+						withCRDVersion(version),
+						withCRDLabels(map[string]string{stackspkg.LabelKubernetesManagedBy: stackspkg.LabelValueStackManager}))},
 			},
-			want: []apiextensionsv1beta1.CustomResourceDefinition{crd(withCRDGroupKind(group, kind), withCRDVersion(version), withCRDLabels(map[string]string{stackspkg.LabelKubernetesManagedBy: "stack-manager", label: "true"}))},
+			want: []apiextensionsv1beta1.CustomResourceDefinition{
+				crd(withCRDGroupKind(group, kind),
+					withCRDVersion(version),
+					withCRDLabels(map[string]string{stackspkg.LabelKubernetesManagedBy: stackspkg.LabelValueStackManager, label: "true"}))},
 		},
 		{
 			name: "ManagedCRDAlreadyLabeled",
 			fields: fields{
 				ext: resource(),
 				clientFunc: func() client.Client {
-					c := crd(withCRDGroupKind(group, kind), withCRDVersion(version), withCRDLabels(map[string]string{stackspkg.LabelKubernetesManagedBy: "stack-manager", label: "true"}))
+					c := crd(withCRDGroupKind(group, kind),
+						withCRDVersion(version),
+						withCRDLabels(map[string]string{stackspkg.LabelKubernetesManagedBy: stackspkg.LabelValueStackManager, label: "true"}))
 					return fake.NewFakeClient(&c)
 				},
 			},
 			args: args{
-				ctx:  context.TODO(),
-				crds: []apiextensionsv1beta1.CustomResourceDefinition{crd(withCRDGroupKind(group, kind), withCRDVersion(version), withCRDLabels(map[string]string{stackspkg.LabelKubernetesManagedBy: "stack-manager", label: "true"}))},
+				ctx: context.TODO(),
+				crds: []apiextensionsv1beta1.CustomResourceDefinition{
+					crd(withCRDGroupKind(group, kind),
+						withCRDVersion(version),
+						withCRDLabels(map[string]string{stackspkg.LabelKubernetesManagedBy: stackspkg.LabelValueStackManager, label: "true"}))},
 			},
-			want: []apiextensionsv1beta1.CustomResourceDefinition{crd(withCRDGroupKind(group, kind), withCRDVersion(version), withCRDLabels(map[string]string{stackspkg.LabelKubernetesManagedBy: "stack-manager", label: "true"}))},
+			want: []apiextensionsv1beta1.CustomResourceDefinition{
+				crd(withCRDGroupKind(group, kind),
+					withCRDVersion(version),
+					withCRDLabels(map[string]string{stackspkg.LabelKubernetesManagedBy: stackspkg.LabelValueStackManager, label: "true"}))},
 		},
 	}
 	for _, tt := range tests {
@@ -2259,8 +2375,10 @@ func Test_stackHandler_createPersonaClusterRolesCRDHandler(t *testing.T) {
 				},
 			},
 			args: args{
-				ctx:  context.TODO(),
-				crds: []apiextensionsv1beta1.CustomResourceDefinition{crd(withCRDGroupKind(group, kind), withCRDVersion(version))},
+				ctx: context.TODO(),
+				crds: []apiextensionsv1beta1.CustomResourceDefinition{
+					crd(withCRDGroupKind(group, kind),
+						withCRDVersion(version))},
 			},
 			want:    nil,
 			wantErr: errors.Wrap(errBoom, "failed to create persona cluster roles"),
@@ -2275,8 +2393,10 @@ func Test_stackHandler_createPersonaClusterRolesCRDHandler(t *testing.T) {
 				},
 			},
 			args: args{
-				ctx:  context.TODO(),
-				crds: []apiextensionsv1beta1.CustomResourceDefinition{crd(withCRDGroupKind(group, kind), withCRDVersion(version))},
+				ctx: context.TODO(),
+				crds: []apiextensionsv1beta1.CustomResourceDefinition{
+					crd(withCRDGroupKind(group, kind),
+						withCRDVersion(version))},
 			},
 			want: []rbac.ClusterRole{clusterRole(name)},
 		},
@@ -2289,8 +2409,11 @@ func Test_stackHandler_createPersonaClusterRolesCRDHandler(t *testing.T) {
 				},
 			},
 			args: args{
-				ctx:  context.TODO(),
-				crds: []apiextensionsv1beta1.CustomResourceDefinition{crd(withCRDGroupKind(group, kind), withCRDVersion(version), withCRDSubresources())},
+				ctx: context.TODO(),
+				crds: []apiextensionsv1beta1.CustomResourceDefinition{
+					crd(withCRDGroupKind(group, kind),
+						withCRDVersion(version),
+						withCRDSubresources())},
 			},
 			want: []rbac.ClusterRole{clusterRole(name, withClusterRoleLabels(map[string]string{
 				"core.crossplane.io/parent-group":                "",
@@ -2312,8 +2435,11 @@ func Test_stackHandler_createPersonaClusterRolesCRDHandler(t *testing.T) {
 				},
 			},
 			args: args{
-				ctx:  context.TODO(),
-				crds: []apiextensionsv1beta1.CustomResourceDefinition{crd(withCRDGroupKind(group, kind), withCRDVersion(version), withCRDScope(apiextensionsv1beta1.ClusterScoped))},
+				ctx: context.TODO(),
+				crds: []apiextensionsv1beta1.CustomResourceDefinition{
+					crd(withCRDGroupKind(group, kind),
+						withCRDVersion(version),
+						withCRDScope(apiextensionsv1beta1.ClusterScoped))},
 			},
 			want: []rbac.ClusterRole{clusterRole(name, withClusterRoleLabels(map[string]string{
 				"core.crossplane.io/parent-group":                  "",
@@ -2408,29 +2534,39 @@ func Test_stackHandler_removeCRDLabels(t *testing.T) {
 			fields: fields{
 				ext: resource(withCRDs(metav1.TypeMeta{Kind: kind, APIVersion: apiVersion})),
 				clientFn: func() client.Client {
-					c := crd(withCRDGroupKind(group, kind), withCRDVersion(version))
+					c := crd(withCRDGroupKind(group, kind),
+						withCRDVersion(version))
 					return fake.NewFakeClient(&c)
 				},
 			},
-			want: []apiextensionsv1beta1.CustomResourceDefinition{crd(withCRDGroupKind(group, kind), withCRDVersion(version))},
+			want: []apiextensionsv1beta1.CustomResourceDefinition{
+				crd(withCRDGroupKind(group, kind),
+					withCRDVersion(version))},
 		},
 		{
 			name: "ManagedWithoutMultiParentLabel",
 			fields: fields{
 				ext: resource(withCRDs(metav1.TypeMeta{Kind: kind, APIVersion: apiVersion})),
 				clientFn: func() client.Client {
-					c := crd(withCRDGroupKind(group, kind), withCRDVersion(version), withCRDLabels(map[string]string{stackspkg.LabelKubernetesManagedBy: "stack-manager"}))
+					c := crd(withCRDGroupKind(group, kind),
+						withCRDVersion(version),
+						withCRDLabels(map[string]string{stackspkg.LabelKubernetesManagedBy: stackspkg.LabelValueStackManager}))
 					return fake.NewFakeClient(&c)
 				},
 			},
-			want: []apiextensionsv1beta1.CustomResourceDefinition{crd(withCRDGroupKind(group, kind), withCRDVersion(version), withCRDLabels(map[string]string{stackspkg.LabelKubernetesManagedBy: "stack-manager"}))},
+			want: []apiextensionsv1beta1.CustomResourceDefinition{
+				crd(withCRDGroupKind(group, kind),
+					withCRDVersion(version),
+					withCRDLabels(map[string]string{stackspkg.LabelKubernetesManagedBy: stackspkg.LabelValueStackManager}))},
 		},
 		{
 			name: "PatchFailed",
 			fields: fields{
 				ext: resource(withCRDs(metav1.TypeMeta{Kind: kind, APIVersion: apiVersion})),
 				clientFn: func() client.Client {
-					c := crd(withCRDGroupKind(group, kind), withCRDVersion(version), withCRDLabels(map[string]string{stackspkg.LabelKubernetesManagedBy: "stack-manager"}))
+					c := crd(withCRDGroupKind(group, kind),
+						withCRDVersion(version),
+						withCRDLabels(map[string]string{stackspkg.LabelKubernetesManagedBy: stackspkg.LabelValueStackManager}))
 					f := fake.NewFakeClient(&c)
 					return &test.MockClient{
 						MockList:  f.List,
@@ -2445,26 +2581,39 @@ func Test_stackHandler_removeCRDLabels(t *testing.T) {
 			fields: fields{
 				ext: resource(withCRDs(metav1.TypeMeta{Kind: kind, APIVersion: apiVersion})),
 				clientFn: func() client.Client {
-					c := crd(withCRDGroupKind(group, kind), withCRDVersion(version), withCRDLabels(map[string]string{stackspkg.LabelKubernetesManagedBy: "stack-manager", label: "true"}))
+					c := crd(withCRDGroupKind(group, kind),
+						withCRDVersion(version),
+						withCRDLabels(map[string]string{stackspkg.LabelKubernetesManagedBy: stackspkg.LabelValueStackManager, label: "true"}))
 					return fake.NewFakeClient(&c)
 				},
 			},
-			want: []apiextensionsv1beta1.CustomResourceDefinition{crd(withCRDGroupKind(group, kind), withCRDVersion(version), withCRDLabels(map[string]string{stackspkg.LabelKubernetesManagedBy: "stack-manager"}))},
+			want: []apiextensionsv1beta1.CustomResourceDefinition{
+				crd(withCRDGroupKind(group, kind),
+					withCRDVersion(version),
+					withCRDLabels(map[string]string{stackspkg.LabelKubernetesManagedBy: stackspkg.LabelValueStackManager}))},
 		},
 		{
 			name: "StacksSharingOneOfTwoCRDs",
 			fields: fields{
 				ext: resource(withCRDs(metav1.TypeMeta{Kind: kind, APIVersion: apiVersion}, metav1.TypeMeta{Kind: kind + "2", APIVersion: apiVersion})),
 				clientFn: func() client.Client {
-					c := crd(withCRDGroupKind(group, kind), withCRDVersion(version), withCRDLabels(map[string]string{stackspkg.LabelKubernetesManagedBy: "stack-manager", label: "true"}))
-					c2 := crd(withCRDGroupKind(group, kind+"2"), withCRDVersion(version), withCRDLabels(map[string]string{stackspkg.LabelKubernetesManagedBy: "stack-manager", label: "true", label + ".stack2": "true"}))
+					c := crd(withCRDGroupKind(group, kind),
+						withCRDVersion(version),
+						withCRDLabels(map[string]string{stackspkg.LabelKubernetesManagedBy: stackspkg.LabelValueStackManager, label: "true"}))
+					c2 := crd(withCRDGroupKind(group, kind+"2"),
+						withCRDVersion(version),
+						withCRDLabels(map[string]string{stackspkg.LabelKubernetesManagedBy: stackspkg.LabelValueStackManager, label: "true", label + ".stack2": "true"}))
 
 					return fake.NewFakeClient(&c, &c2)
 				},
 			},
 			want: []apiextensionsv1beta1.CustomResourceDefinition{
-				crd(withCRDGroupKind(group, kind), withCRDVersion(version), withCRDLabels(map[string]string{stackspkg.LabelKubernetesManagedBy: "stack-manager"})),
-				crd(withCRDGroupKind(group, kind+"2"), withCRDVersion(version), withCRDLabels(map[string]string{stackspkg.LabelKubernetesManagedBy: "stack-manager", label + ".stack2": "true"})),
+				crd(withCRDGroupKind(group, kind),
+					withCRDVersion(version),
+					withCRDLabels(map[string]string{stackspkg.LabelKubernetesManagedBy: stackspkg.LabelValueStackManager})),
+				crd(withCRDGroupKind(group, kind+"2"),
+					withCRDVersion(version),
+					withCRDLabels(map[string]string{stackspkg.LabelKubernetesManagedBy: stackspkg.LabelValueStackManager, label + ".stack2": "true"})),
 			},
 		},
 	}

--- a/pkg/controller/stacks/stack/stack_test.go
+++ b/pkg/controller/stacks/stack/stack_test.go
@@ -19,12 +19,14 @@ package stack
 import (
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/google/go-cmp/cmp"
 	. "github.com/onsi/gomega"
 	"github.com/pkg/errors"
+
 	apps "k8s.io/api/apps/v1"
 	batch "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -56,7 +58,7 @@ const (
 	hostControllerNamespace = "controller-namespace"
 	uid                     = types.UID("definitely-a-uuid")
 	resourceName            = "cool-stack"
-	roleName                = "stack:cool-namespace:cool-stack::system"
+	roleName                = "stack:cool-namespace:cool-stack:0.0.1:system"
 
 	controllerDeploymentName = "cool-stack-controller"
 	controllerContainerName  = "cool-container"
@@ -85,6 +87,14 @@ type deploymentSpecModifier func(*apps.DeploymentSpec)
 
 func withFinalizers(finalizers ...string) resourceModifier {
 	return func(r *v1alpha1.Stack) { r.SetFinalizers(finalizers) }
+}
+
+func withResourceVersion(version string) resourceModifier {
+	return func(r *v1alpha1.Stack) { r.SetResourceVersion(version) }
+}
+
+func withCRDs(crds ...metav1.TypeMeta) resourceModifier {
+	return func(r *v1alpha1.Stack) { r.Spec.CRDs = crds }
 }
 
 func withDeletionTimestamp(t time.Time) resourceModifier {
@@ -177,7 +187,11 @@ func resource(rm ...resourceModifier) *v1alpha1.Stack {
 			UID:        uid,
 			Finalizers: []string{},
 		},
-		Spec: v1alpha1.StackSpec{},
+		Spec: v1alpha1.StackSpec{
+			AppMetadataSpec: v1alpha1.AppMetadataSpec{
+				Version: "0.0.1",
+			},
+		},
 	}
 
 	for _, m := range rm {
@@ -478,6 +492,7 @@ func TestCreate(t *testing.T) {
 					withGVK(v1alpha1.StackGroupVersionKind),
 					withConditions(runtimev1alpha1.Available(), runtimev1alpha1.ReconcileSuccess()),
 					withFinalizers(stacksFinalizer),
+					withResourceVersion("2"),
 				),
 			},
 		},
@@ -493,6 +508,7 @@ func TestCreate(t *testing.T) {
 					withPermissionScope("Cluster"),
 					withConditions(runtimev1alpha1.Available(), runtimev1alpha1.ReconcileSuccess()),
 					withFinalizers(stacksFinalizer),
+					withResourceVersion("2"),
 				),
 			},
 		},
@@ -517,9 +533,6 @@ func TestCreate(t *testing.T) {
 				t.Errorf("create(): -want, +got:\n%s", diff)
 			}
 
-			// NOTE(muvaf): ResourceVersion is not our concern in these tests
-			// but it gets filled up by the client.
-			tt.want.r.ResourceVersion = tt.r.ResourceVersion
 			if diff := cmp.Diff(tt.want.r, tt.r, test.EquateConditions()); diff != "" {
 				t.Errorf("create() resource: -want, +got:\n%s", diff)
 			}
@@ -1688,6 +1701,657 @@ func Test_stackHandler_prepareHostAwarePodSpec(t *testing.T) {
 	}
 }
 
+type crdModifier func(*apiextensionsv1beta1.CustomResourceDefinition)
+
+func withCRDVersion(version string) crdModifier {
+	return func(c *apiextensionsv1beta1.CustomResourceDefinition) {
+		c.Spec.Version = version
+		c.Spec.Versions = append(c.Spec.Versions, apiextensionsv1beta1.CustomResourceDefinitionVersion{Name: version})
+	}
+}
+
+func withCRDScope(scope apiextensionsv1beta1.ResourceScope) crdModifier {
+	return func(c *apiextensionsv1beta1.CustomResourceDefinition) {
+		c.Spec.Scope = scope
+	}
+}
+
+func withCRDLabels(labels map[string]string) crdModifier {
+	return func(c *apiextensionsv1beta1.CustomResourceDefinition) {
+		meta.AddLabels(c, labels)
+	}
+}
+
+func withCRDSubresources() crdModifier {
+	return func(c *apiextensionsv1beta1.CustomResourceDefinition) {
+		c.Spec.Subresources = &apiextensionsv1beta1.CustomResourceSubresources{
+			Status: &apiextensionsv1beta1.CustomResourceSubresourceStatus{},
+			Scale:  &apiextensionsv1beta1.CustomResourceSubresourceScale{},
+		}
+	}
+}
+
+func withCRDGroupKind(group, kind string) crdModifier {
+	singular := strings.ToLower(kind)
+	plural := singular + "s"
+	list := kind + "List"
+
+	return func(c *apiextensionsv1beta1.CustomResourceDefinition) {
+		c.Spec.Group = group
+		c.Spec.Names.Kind = kind
+		c.Spec.Names.Plural = plural
+		c.Spec.Names.ListKind = list
+		c.Spec.Names.Singular = singular
+		c.SetName(plural + "." + group)
+	}
+}
+
+func crd(cm ...crdModifier) apiextensionsv1beta1.CustomResourceDefinition {
+	// basic crd with defaults
+	t := true
+	c := apiextensionsv1beta1.CustomResourceDefinition{
+		Spec: apiextensionsv1beta1.CustomResourceDefinitionSpec{
+			Scope: "Namespaced",
+			Conversion: &apiextensionsv1beta1.CustomResourceConversion{
+				Strategy:                 apiextensionsv1beta1.NoneConverter,
+				WebhookClientConfig:      nil,
+				ConversionReviewVersions: nil,
+			},
+			PreserveUnknownFields: &t,
+		},
+	}
+	for _, m := range cm {
+		m(&c)
+	}
+	return c
+}
+
+type crModifier func(*rbac.ClusterRole)
+
+func withClusterRoleLabels(labels map[string]string) crModifier {
+	return func(cr *rbac.ClusterRole) {
+		meta.AddLabels(cr, labels)
+	}
+}
+
+func withClusterRoleRules(rules []rbac.PolicyRule) crModifier {
+	return func(cr *rbac.ClusterRole) {
+		cr.Rules = append(cr.Rules, rules...)
+
+	}
+}
+
+func clusterRole(name string, crm ...crModifier) rbac.ClusterRole {
+	c := rbac.ClusterRole{}
+	c.SetName(name)
+	for _, m := range crm {
+		m(&c)
+	}
+	return c
+}
+
+func Test_crdListFulfilled(t *testing.T) {
+	type args struct {
+		want v1alpha1.CRDList
+		got  []apiextensionsv1beta1.CustomResourceDefinition
+	}
+
+	const (
+		group      = "samples.upbound.io"
+		version    = "v1alpha1"
+		kind       = "Mytype"
+		plural     = "mytypes"
+		apiVersion = group + "/" + version
+	)
+
+	tests := []struct {
+		name    string
+		args    args
+		wantErr error
+	}{
+		{
+			name:    "MissingFromCRDList",
+			args:    args{v1alpha1.CRDList{metav1.TypeMeta{Kind: kind, APIVersion: apiVersion}}, []apiextensionsv1beta1.CustomResourceDefinition{}},
+			wantErr: fmt.Errorf(`Missing CRD with APIVersion %q and Kind %q`, apiVersion, kind),
+		},
+		{
+			name:    "WrongCRDVersion",
+			args:    args{v1alpha1.CRDList{metav1.TypeMeta{Kind: kind, APIVersion: apiVersion}}, []apiextensionsv1beta1.CustomResourceDefinition{crd(withCRDGroupKind(group, kind), withCRDVersion("foo"))}},
+			wantErr: fmt.Errorf(`Missing CRD with APIVersion %q and Kind %q`, apiVersion, kind),
+		},
+		{
+			name:    "DifferentCRDKind",
+			args:    args{v1alpha1.CRDList{metav1.TypeMeta{Kind: kind, APIVersion: apiVersion}}, []apiextensionsv1beta1.CustomResourceDefinition{crd(withCRDGroupKind(group, "foo"), withCRDVersion(version))}},
+			wantErr: fmt.Errorf(`Missing CRD with APIVersion %q and Kind %q`, apiVersion, kind),
+		},
+		{
+			name:    "PartialMatch",
+			args:    args{v1alpha1.CRDList{metav1.TypeMeta{Kind: kind, APIVersion: apiVersion}, metav1.TypeMeta{Kind: kind + "z", APIVersion: apiVersion}}, []apiextensionsv1beta1.CustomResourceDefinition{crd(withCRDGroupKind(group, kind), withCRDVersion(version))}},
+			wantErr: fmt.Errorf(`Missing CRD with APIVersion %q and Kind %q`, apiVersion, kind+"z"),
+		},
+		{
+			name:    "Success",
+			args:    args{v1alpha1.CRDList{metav1.TypeMeta{Kind: kind, APIVersion: apiVersion}}, []apiextensionsv1beta1.CustomResourceDefinition{crd(withCRDGroupKind(group, kind), withCRDVersion(version))}},
+			wantErr: nil,
+		},
+		{
+			name:    "SuccessMultiple",
+			args:    args{v1alpha1.CRDList{metav1.TypeMeta{Kind: kind, APIVersion: apiVersion}, metav1.TypeMeta{Kind: kind + "z", APIVersion: apiVersion}}, []apiextensionsv1beta1.CustomResourceDefinition{crd(withCRDGroupKind(group, kind), withCRDVersion(version)), crd(withCRDGroupKind(group, kind+"z"), withCRDVersion(version))}},
+			wantErr: nil,
+		},
+		{
+			name:    "SuccessWithExtra",
+			args:    args{v1alpha1.CRDList{metav1.TypeMeta{Kind: kind, APIVersion: apiVersion}}, []apiextensionsv1beta1.CustomResourceDefinition{crd(withCRDGroupKind(group, kind), withCRDVersion(version)), crd(withCRDGroupKind(group, kind+"z"), withCRDVersion(version))}},
+			wantErr: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotErr := crdListFulfilled(tt.args.want, tt.args.got)
+
+			if diff := cmp.Diff(tt.wantErr, gotErr, test.EquateErrors()); diff != "" {
+				t.Fatalf("crdListFulfilled(...): -want error, +got error: %s", diff)
+			}
+		})
+	}
+}
+
+func Test_stackHandler_crdsFromStack(t *testing.T) {
+	type fields struct {
+		kube            client.Client
+		hostKube        client.Client
+		hostAwareConfig *hosted.Config
+		ext             *v1alpha1.Stack
+		log             logging.Logger
+	}
+	type args struct {
+		ctx context.Context
+	}
+
+	const (
+		group      = "samples.upbound.io"
+		version    = "v1alpha1"
+		kind       = "Mytype"
+		plural     = "mytypes"
+		apiVersion = group + "/" + version
+	)
+
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		want    []apiextensionsv1beta1.CustomResourceDefinition
+		wantErr error
+	}{
+		{
+			name: "MissingFromCRDList",
+			fields: fields{
+				ext: resource(withCRDs(metav1.TypeMeta{Kind: kind, APIVersion: apiVersion})),
+				kube: &test.MockClient{
+					MockList: test.NewMockListFn(nil),
+				},
+			},
+			args:    args{context.TODO()},
+			want:    []apiextensionsv1beta1.CustomResourceDefinition{},
+			wantErr: nil,
+		},
+		{
+			name: "ErrorListingCRDs",
+			fields: fields{
+				ext: resource(withCRDs(metav1.TypeMeta{Kind: kind, APIVersion: apiVersion})),
+				kube: &test.MockClient{
+					MockList: test.NewMockListFn(errBoom),
+				},
+			},
+			args:    args{context.TODO()},
+			want:    nil,
+			wantErr: errors.Wrap(errBoom, "CRDs could not be listed"),
+		},
+		{
+			name: "MissingCRDVersion",
+			fields: fields{
+				ext: resource(withCRDs(metav1.TypeMeta{Kind: kind, APIVersion: apiVersion})),
+				kube: &test.MockClient{
+					MockList: func(_ context.Context, list runtime.Object, _ ...client.ListOption) error {
+						switch list := list.(type) {
+						case *apiextensionsv1beta1.CustomResourceDefinitionList:
+							list.Items = append(list.Items, crd(withCRDGroupKind(group, kind), withCRDVersion("foo")))
+						default:
+							return errors.New("unexpected list for testing")
+						}
+						return nil
+					},
+				},
+			},
+			want:    []apiextensionsv1beta1.CustomResourceDefinition{},
+			wantErr: nil,
+		},
+		{
+			name: "MissingCRDKind",
+			fields: fields{
+				ext: resource(withCRDs(metav1.TypeMeta{Kind: kind, APIVersion: apiVersion})),
+				kube: &test.MockClient{
+					MockList: func(_ context.Context, list runtime.Object, _ ...client.ListOption) error {
+						switch list := list.(type) {
+						case *apiextensionsv1beta1.CustomResourceDefinitionList:
+							list.Items = append(list.Items, crd(withCRDGroupKind(group, "Differentkind"), withCRDVersion(version)))
+						default:
+							return errors.New("unexpected list for testing")
+						}
+						return nil
+					},
+				},
+			},
+			want:    []apiextensionsv1beta1.CustomResourceDefinition{},
+			wantErr: nil,
+		},
+		{
+			name: "Success",
+			fields: fields{
+				ext: resource(withCRDs(metav1.TypeMeta{Kind: kind, APIVersion: apiVersion})),
+				kube: &test.MockClient{
+					MockList: func(_ context.Context, list runtime.Object, _ ...client.ListOption) error {
+						switch list := list.(type) {
+						case *apiextensionsv1beta1.CustomResourceDefinitionList:
+							list.Items = append(list.Items, crd(withCRDGroupKind(group, kind), withCRDVersion(version)))
+						default:
+							return errors.New("unexpected list for testing")
+						}
+						return nil
+					},
+				},
+			},
+			args:    args{context.TODO()},
+			want:    []apiextensionsv1beta1.CustomResourceDefinition{crd(withCRDGroupKind(group, kind), withCRDVersion(version))},
+			wantErr: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := &stackHandler{
+				kube:            tt.fields.kube,
+				hostKube:        tt.fields.hostKube,
+				hostAwareConfig: tt.fields.hostAwareConfig,
+				ext:             tt.fields.ext,
+				log:             tt.fields.log,
+			}
+			got, gotErr := h.crdsFromStack(tt.args.ctx)
+
+			if diff := cmp.Diff(tt.wantErr, gotErr, test.EquateErrors()); diff != "" {
+				t.Fatalf("stackHandler.crdsFromStack(...): -want error, +got error: %s", diff)
+			}
+
+			if diff := cmp.Diff(tt.want, got, test.EquateErrors()); diff != "" {
+				t.Fatalf("stackHandler.crdsFromStack(...): -want, +got: %s", diff)
+			}
+		})
+	}
+}
+
+func Test_stackHandler_createNamespaceLabelsCRDHandler(t *testing.T) {
+	type fields struct {
+		clientFunc func() client.Client
+		ext        *v1alpha1.Stack
+	}
+	type args struct {
+		ctx  context.Context
+		crds []apiextensionsv1beta1.CustomResourceDefinition
+	}
+
+	const (
+		group      = "samples.upbound.io"
+		version    = "v1alpha1"
+		kind       = "Mytype"
+		plural     = "mytypes"
+		apiVersion = group + "/" + version
+	)
+
+	var (
+		nsLabel = fmt.Sprintf(stackspkg.LabelNamespaceFmt, namespace)
+	)
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		want    []apiextensionsv1beta1.CustomResourceDefinition
+		wantErr error
+	}{
+		{
+			name: "MissingCRD",
+			fields: fields{
+				ext: resource(),
+				clientFunc: func() client.Client {
+					return fake.NewFakeClient()
+				},
+			},
+			args: args{
+				ctx:  context.TODO(),
+				crds: []apiextensionsv1beta1.CustomResourceDefinition{crd(withCRDGroupKind(group, kind), withCRDVersion(version), withCRDLabels(map[string]string{stackspkg.LabelKubernetesManagedBy: "stack-manager"}))},
+			},
+			want: []apiextensionsv1beta1.CustomResourceDefinition{},
+			wantErr: kerrors.NewNotFound(
+				schema.GroupResource{Group: "apiextensions.k8s.io", Resource: "customresourcedefinitions"},
+				plural+"."+group),
+		},
+		{
+			name: "UnmanagedCRD",
+			fields: fields{
+				ext: resource(),
+				clientFunc: func() client.Client {
+					c := crd(withCRDGroupKind(group, kind), withCRDVersion(version))
+					return fake.NewFakeClient(&c)
+				},
+			},
+			args: args{
+				ctx:  context.TODO(),
+				crds: []apiextensionsv1beta1.CustomResourceDefinition{crd(withCRDGroupKind(group, kind), withCRDVersion(version))},
+			},
+			want: []apiextensionsv1beta1.CustomResourceDefinition{crd(withCRDGroupKind(group, kind), withCRDVersion(version))},
+		},
+		{
+			name: "ManagedCRD",
+			fields: fields{
+				ext: resource(),
+				clientFunc: func() client.Client {
+					c := crd(withCRDGroupKind(group, kind), withCRDVersion(version), withCRDLabels(map[string]string{stackspkg.LabelKubernetesManagedBy: "stack-manager"}))
+					return fake.NewFakeClient(&c)
+				},
+			},
+			args: args{
+				ctx:  context.TODO(),
+				crds: []apiextensionsv1beta1.CustomResourceDefinition{crd(withCRDGroupKind(group, kind), withCRDVersion(version), withCRDLabels(map[string]string{stackspkg.LabelKubernetesManagedBy: "stack-manager"}))},
+			},
+			want: []apiextensionsv1beta1.CustomResourceDefinition{crd(withCRDGroupKind(group, kind), withCRDVersion(version), withCRDLabels(map[string]string{stackspkg.LabelKubernetesManagedBy: "stack-manager", nsLabel: "true"}))},
+		},
+		{
+			name: "ManagedCRDAlreadyLabeled",
+			fields: fields{
+				ext: resource(),
+				clientFunc: func() client.Client {
+					c := crd(withCRDGroupKind(group, kind), withCRDVersion(version), withCRDLabels(map[string]string{stackspkg.LabelKubernetesManagedBy: "stack-manager", nsLabel: "true"}))
+					return fake.NewFakeClient(&c)
+				},
+			},
+			args: args{
+				ctx:  context.TODO(),
+				crds: []apiextensionsv1beta1.CustomResourceDefinition{crd(withCRDGroupKind(group, kind), withCRDVersion(version), withCRDLabels(map[string]string{stackspkg.LabelKubernetesManagedBy: "stack-manager", nsLabel: "true"}))},
+			},
+			want: []apiextensionsv1beta1.CustomResourceDefinition{crd(withCRDGroupKind(group, kind), withCRDVersion(version), withCRDLabels(map[string]string{stackspkg.LabelKubernetesManagedBy: "stack-manager", nsLabel: "true"}))},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+
+			h := &stackHandler{
+				kube: tt.fields.clientFunc(),
+				ext:  tt.fields.ext,
+				log:  logging.NewNopLogger(),
+			}
+			fn := h.createNamespaceLabelsCRDHandler()
+			gotErr := fn(tt.args.ctx, tt.args.crds)
+
+			if diff := cmp.Diff(tt.wantErr, gotErr, test.EquateErrors()); diff != "" {
+				t.Fatalf("stackHandler.createNamespaceLabelsCRDHandler.fn(...): -want error, +got error: %s", diff)
+			}
+
+			if tt.want != nil {
+				for _, wanted := range tt.want {
+					got := &apiextensionsv1beta1.CustomResourceDefinition{}
+					assertKubernetesObject(t, g, got, &wanted, h.kube)
+				}
+			}
+		})
+	}
+}
+
+func Test_stackHandler_createMultipleParentLabelsCRDHandler(t *testing.T) {
+	type fields struct {
+		clientFunc func() client.Client
+		ext        *v1alpha1.Stack
+	}
+	type args struct {
+		ctx  context.Context
+		crds []apiextensionsv1beta1.CustomResourceDefinition
+	}
+
+	const (
+		group      = "samples.upbound.io"
+		version    = "v1alpha1"
+		kind       = "Mytype"
+		plural     = "mytypes"
+		apiVersion = group + "/" + version
+	)
+
+	var (
+		label = fmt.Sprintf(stackspkg.LabelMultiParentFormat, namespace, resourceName)
+	)
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		want    []apiextensionsv1beta1.CustomResourceDefinition
+		wantErr error
+	}{
+		{
+			name: "MissingCRD",
+			fields: fields{
+				ext: resource(),
+				clientFunc: func() client.Client {
+					return fake.NewFakeClient()
+				},
+			},
+			args: args{
+				ctx:  context.TODO(),
+				crds: []apiextensionsv1beta1.CustomResourceDefinition{crd(withCRDGroupKind(group, kind), withCRDVersion(version), withCRDLabels(map[string]string{stackspkg.LabelKubernetesManagedBy: "stack-manager"}))},
+			},
+			want: []apiextensionsv1beta1.CustomResourceDefinition{},
+			wantErr: kerrors.NewNotFound(
+				schema.GroupResource{Group: "apiextensions.k8s.io", Resource: "customresourcedefinitions"},
+				plural+"."+group),
+		},
+		{
+			name: "UnmanagedCRD",
+			fields: fields{
+				ext: resource(),
+				clientFunc: func() client.Client {
+					c := crd(withCRDGroupKind(group, kind), withCRDVersion(version))
+					return fake.NewFakeClient(&c)
+				},
+			},
+			args: args{
+				ctx:  context.TODO(),
+				crds: []apiextensionsv1beta1.CustomResourceDefinition{crd(withCRDGroupKind(group, kind), withCRDVersion(version))},
+			},
+			want: []apiextensionsv1beta1.CustomResourceDefinition{crd(withCRDGroupKind(group, kind), withCRDVersion(version))},
+		},
+		{
+			name: "ManagedCRD",
+			fields: fields{
+				ext: resource(),
+				clientFunc: func() client.Client {
+					c := crd(withCRDGroupKind(group, kind), withCRDVersion(version), withCRDLabels(map[string]string{stackspkg.LabelKubernetesManagedBy: "stack-manager"}))
+					return fake.NewFakeClient(&c)
+				},
+			},
+			args: args{
+				ctx:  context.TODO(),
+				crds: []apiextensionsv1beta1.CustomResourceDefinition{crd(withCRDGroupKind(group, kind), withCRDVersion(version), withCRDLabels(map[string]string{stackspkg.LabelKubernetesManagedBy: "stack-manager"}))},
+			},
+			want: []apiextensionsv1beta1.CustomResourceDefinition{crd(withCRDGroupKind(group, kind), withCRDVersion(version), withCRDLabels(map[string]string{stackspkg.LabelKubernetesManagedBy: "stack-manager", label: "true"}))},
+		},
+		{
+			name: "ManagedCRDAlreadyLabeled",
+			fields: fields{
+				ext: resource(),
+				clientFunc: func() client.Client {
+					c := crd(withCRDGroupKind(group, kind), withCRDVersion(version), withCRDLabels(map[string]string{stackspkg.LabelKubernetesManagedBy: "stack-manager", label: "true"}))
+					return fake.NewFakeClient(&c)
+				},
+			},
+			args: args{
+				ctx:  context.TODO(),
+				crds: []apiextensionsv1beta1.CustomResourceDefinition{crd(withCRDGroupKind(group, kind), withCRDVersion(version), withCRDLabels(map[string]string{stackspkg.LabelKubernetesManagedBy: "stack-manager", label: "true"}))},
+			},
+			want: []apiextensionsv1beta1.CustomResourceDefinition{crd(withCRDGroupKind(group, kind), withCRDVersion(version), withCRDLabels(map[string]string{stackspkg.LabelKubernetesManagedBy: "stack-manager", label: "true"}))},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+
+			h := &stackHandler{
+				kube: tt.fields.clientFunc(),
+				ext:  tt.fields.ext,
+				log:  logging.NewNopLogger(),
+			}
+			fn := h.createMultipleParentLabelsCRDHandler()
+			gotErr := fn(tt.args.ctx, tt.args.crds)
+
+			if diff := cmp.Diff(tt.wantErr, gotErr, test.EquateErrors()); diff != "" {
+				t.Fatalf("stackHandler.createMultipleParentLabelsCRDHandler.fn(...): -want error, +got error: %s", diff)
+			}
+
+			if tt.want != nil {
+				for _, wanted := range tt.want {
+					got := &apiextensionsv1beta1.CustomResourceDefinition{}
+					assertKubernetesObject(t, g, got, &wanted, h.kube)
+				}
+			}
+		})
+	}
+}
+
+func Test_stackHandler_createPersonaClusterRolesCRDHandler(t *testing.T) {
+	type fields struct {
+		clientFunc func() client.Client
+		ext        *v1alpha1.Stack
+	}
+	type args struct {
+		ctx  context.Context
+		crds []apiextensionsv1beta1.CustomResourceDefinition
+	}
+
+	const (
+		group      = "samples.upbound.io"
+		version    = "v1alpha1"
+		kind       = "Mytype"
+		plural     = "mytypes"
+		apiVersion = group + "/" + version
+	)
+
+	var (
+		name = stackspkg.PersonaRoleName(resource(), "view")
+	)
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		want    []rbac.ClusterRole
+		wantErr error
+	}{
+		{
+			name: "CreateFailed",
+			fields: fields{
+				ext: resource(),
+				clientFunc: func() client.Client {
+					return &test.MockClient{MockCreate: test.NewMockCreateFn(errBoom)}
+				},
+			},
+			args: args{
+				ctx:  context.TODO(),
+				crds: []apiextensionsv1beta1.CustomResourceDefinition{crd(withCRDGroupKind(group, kind), withCRDVersion(version))},
+			},
+			want:    nil,
+			wantErr: errors.Wrap(errBoom, "failed to create persona cluster roles"),
+		},
+		{
+			name: "ExistingClusterRole",
+			fields: fields{
+				ext: resource(),
+				clientFunc: func() client.Client {
+					c := clusterRole(name)
+					return fake.NewFakeClient(&c)
+				},
+			},
+			args: args{
+				ctx:  context.TODO(),
+				crds: []apiextensionsv1beta1.CustomResourceDefinition{crd(withCRDGroupKind(group, kind), withCRDVersion(version))},
+			},
+			want: []rbac.ClusterRole{clusterRole(name)},
+		},
+		{
+			name: "WithSubresources",
+			fields: fields{
+				ext: resource(),
+				clientFunc: func() client.Client {
+					return fake.NewFakeClient()
+				},
+			},
+			args: args{
+				ctx:  context.TODO(),
+				crds: []apiextensionsv1beta1.CustomResourceDefinition{crd(withCRDGroupKind(group, kind), withCRDVersion(version), withCRDSubresources())},
+			},
+			want: []rbac.ClusterRole{clusterRole(name, withClusterRoleLabels(map[string]string{
+				"core.crossplane.io/parent-group":                "",
+				"core.crossplane.io/parent-kind":                 "",
+				"core.crossplane.io/parent-name":                 "cool-stack",
+				"core.crossplane.io/parent-namespace":            "cool-namespace",
+				"core.crossplane.io/parent-uid":                  "definitely-a-uuid",
+				"core.crossplane.io/parent-version":              "",
+				"namespace.crossplane.io/cool-namespace":         "true",
+				"rbac.crossplane.io/aggregate-to-namespace-view": "true",
+			}), withClusterRoleRules([]rbac.PolicyRule{{Verbs: []string{"get", "list", "watch"}, APIGroups: []string{group}, Resources: []string{plural, plural + "/status", plural + "/scale"}}}))},
+		},
+		{
+			name: "WithClusterScope",
+			fields: fields{
+				ext: resource(withPermissionScope("Cluster")),
+				clientFunc: func() client.Client {
+					return fake.NewFakeClient()
+				},
+			},
+			args: args{
+				ctx:  context.TODO(),
+				crds: []apiextensionsv1beta1.CustomResourceDefinition{crd(withCRDGroupKind(group, kind), withCRDVersion(version), withCRDScope(apiextensionsv1beta1.ClusterScoped))},
+			},
+			want: []rbac.ClusterRole{clusterRole(name, withClusterRoleLabels(map[string]string{
+				"core.crossplane.io/parent-group":                  "",
+				"core.crossplane.io/parent-kind":                   "",
+				"core.crossplane.io/parent-name":                   "cool-stack",
+				"core.crossplane.io/parent-namespace":              "cool-namespace",
+				"core.crossplane.io/parent-uid":                    "definitely-a-uuid",
+				"core.crossplane.io/parent-version":                "",
+				"rbac.crossplane.io/aggregate-to-environment-view": "true",
+			}), withClusterRoleRules([]rbac.PolicyRule{{Verbs: []string{"get", "list", "watch"}, APIGroups: []string{group}, Resources: []string{plural}}}))},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+
+			h := &stackHandler{
+				kube: tt.fields.clientFunc(),
+				ext:  tt.fields.ext,
+				log:  logging.NewNopLogger(),
+			}
+			fn := h.createPersonaClusterRolesCRDHandler()
+			gotErr := fn(tt.args.ctx, tt.args.crds)
+
+			if diff := cmp.Diff(tt.wantErr, gotErr, test.EquateErrors()); diff != "" {
+				t.Fatalf("stackHandler.createPersonaClusterRolesCRDHandler.fn(...): -want error, +got error: %s", diff)
+			}
+
+			if tt.want != nil {
+				for _, wanted := range tt.want {
+					got := &rbac.ClusterRole{}
+					assertKubernetesObject(t, g, got, &wanted, h.kube)
+				}
+			}
+		})
+	}
+}
+
 func assertKubernetesObject(t *testing.T, g *GomegaWithT, got objectWithGVK, want metav1.Object, kube client.Client) {
 	n := types.NamespacedName{Name: want.GetName(), Namespace: want.GetNamespace()}
 	g.Expect(kube.Get(ctx, n, got)).NotTo(HaveOccurred())
@@ -1700,5 +2364,131 @@ func assertKubernetesObject(t *testing.T, g *GomegaWithT, got objectWithGVK, wan
 
 	if diff := cmp.Diff(want, got, test.EquateConditions()); diff != "" {
 		t.Errorf("-want, +got:\n%s", diff)
+	}
+}
+
+func Test_stackHandler_removeCRDLabels(t *testing.T) {
+	type fields struct {
+		clientFn func() client.Client
+		ext      *v1alpha1.Stack
+	}
+
+	const (
+		group      = "samples.upbound.io"
+		version    = "v1alpha1"
+		kind       = "Mytype"
+		plural     = "mytypes"
+		apiVersion = group + "/" + version
+	)
+
+	var (
+		label = fmt.Sprintf(stackspkg.LabelMultiParentFormat, namespace, resourceName)
+	)
+
+	tests := []struct {
+		name    string
+		fields  fields
+		want    []apiextensionsv1beta1.CustomResourceDefinition
+		wantErr error
+	}{
+		{
+			name: "CouldNotListCRDs",
+			fields: fields{
+				ext: resource(withCRDs(metav1.TypeMeta{Kind: kind, APIVersion: apiVersion})),
+				clientFn: func() client.Client {
+					return &test.MockClient{
+						MockList: test.NewMockListFn(errBoom),
+					}
+				},
+			},
+			wantErr: errors.Wrap(errBoom, "CRDs could not be listed"),
+		},
+		{
+			name: "UnmanagedCRD",
+			fields: fields{
+				ext: resource(withCRDs(metav1.TypeMeta{Kind: kind, APIVersion: apiVersion})),
+				clientFn: func() client.Client {
+					c := crd(withCRDGroupKind(group, kind), withCRDVersion(version))
+					return fake.NewFakeClient(&c)
+				},
+			},
+			want: []apiextensionsv1beta1.CustomResourceDefinition{crd(withCRDGroupKind(group, kind), withCRDVersion(version))},
+		},
+		{
+			name: "ManagedWithoutMultiParentLabel",
+			fields: fields{
+				ext: resource(withCRDs(metav1.TypeMeta{Kind: kind, APIVersion: apiVersion})),
+				clientFn: func() client.Client {
+					c := crd(withCRDGroupKind(group, kind), withCRDVersion(version), withCRDLabels(map[string]string{stackspkg.LabelKubernetesManagedBy: "stack-manager"}))
+					return fake.NewFakeClient(&c)
+				},
+			},
+			want: []apiextensionsv1beta1.CustomResourceDefinition{crd(withCRDGroupKind(group, kind), withCRDVersion(version), withCRDLabels(map[string]string{stackspkg.LabelKubernetesManagedBy: "stack-manager"}))},
+		},
+		{
+			name: "PatchFailed",
+			fields: fields{
+				ext: resource(withCRDs(metav1.TypeMeta{Kind: kind, APIVersion: apiVersion})),
+				clientFn: func() client.Client {
+					c := crd(withCRDGroupKind(group, kind), withCRDVersion(version), withCRDLabels(map[string]string{stackspkg.LabelKubernetesManagedBy: "stack-manager"}))
+					f := fake.NewFakeClient(&c)
+					return &test.MockClient{
+						MockList:  f.List,
+						MockPatch: test.NewMockPatchFn(errBoom),
+					}
+				},
+			},
+			wantErr: errBoom,
+		},
+		{
+			name: "ManagedWithMultiParentLabel",
+			fields: fields{
+				ext: resource(withCRDs(metav1.TypeMeta{Kind: kind, APIVersion: apiVersion})),
+				clientFn: func() client.Client {
+					c := crd(withCRDGroupKind(group, kind), withCRDVersion(version), withCRDLabels(map[string]string{stackspkg.LabelKubernetesManagedBy: "stack-manager", label: "true"}))
+					return fake.NewFakeClient(&c)
+				},
+			},
+			want: []apiextensionsv1beta1.CustomResourceDefinition{crd(withCRDGroupKind(group, kind), withCRDVersion(version), withCRDLabels(map[string]string{stackspkg.LabelKubernetesManagedBy: "stack-manager"}))},
+		},
+		{
+			name: "StacksSharingOneOfTwoCRDs",
+			fields: fields{
+				ext: resource(withCRDs(metav1.TypeMeta{Kind: kind, APIVersion: apiVersion}, metav1.TypeMeta{Kind: kind + "2", APIVersion: apiVersion})),
+				clientFn: func() client.Client {
+					c := crd(withCRDGroupKind(group, kind), withCRDVersion(version), withCRDLabels(map[string]string{stackspkg.LabelKubernetesManagedBy: "stack-manager", label: "true"}))
+					c2 := crd(withCRDGroupKind(group, kind+"2"), withCRDVersion(version), withCRDLabels(map[string]string{stackspkg.LabelKubernetesManagedBy: "stack-manager", label: "true", label + ".stack2": "true"}))
+
+					return fake.NewFakeClient(&c, &c2)
+				},
+			},
+			want: []apiextensionsv1beta1.CustomResourceDefinition{
+				crd(withCRDGroupKind(group, kind), withCRDVersion(version), withCRDLabels(map[string]string{stackspkg.LabelKubernetesManagedBy: "stack-manager"})),
+				crd(withCRDGroupKind(group, kind+"2"), withCRDVersion(version), withCRDLabels(map[string]string{stackspkg.LabelKubernetesManagedBy: "stack-manager", label + ".stack2": "true"})),
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+
+			h := &stackHandler{
+				kube: tt.fields.clientFn(),
+				ext:  tt.fields.ext,
+				log:  logging.NewNopLogger(),
+			}
+			gotErr := h.removeCRDLabels(context.TODO())
+
+			if diff := cmp.Diff(tt.wantErr, gotErr, test.EquateErrors()); diff != "" {
+				t.Errorf("-want error, +got error:\n%s", diff)
+			}
+
+			if tt.want != nil {
+				for _, wanted := range tt.want {
+					got := &apiextensionsv1beta1.CustomResourceDefinition{}
+					assertKubernetesObject(t, g, got, &wanted, h.kube)
+				}
+			}
+		})
 	}
 }

--- a/pkg/stacks/clusterrole.go
+++ b/pkg/stacks/clusterrole.go
@@ -30,7 +30,8 @@ const (
 	LabelAggregateFmt = "rbac.crossplane.io/aggregate-to-%s-%s"
 
 	// namespace.crossplane.io/{namespace}
-	LabelNamespaceFmt = "namespace.crossplane.io/%s"
+	LabelNamespacePrefix = "namespace.crossplane.io/"
+	LabelNamespaceFmt    = LabelNamespacePrefix + "%s"
 
 	LabelScope = "crossplane.io/scope"
 

--- a/pkg/stacks/relationship.go
+++ b/pkg/stacks/relationship.go
@@ -17,6 +17,9 @@ limitations under the License.
 package stacks
 
 import (
+	"strings"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 )
@@ -29,6 +32,10 @@ const (
 	LabelParentNamespace = "core.crossplane.io/parent-namespace"
 	LabelParentName      = "core.crossplane.io/parent-name"
 	LabelParentUID       = "core.crossplane.io/parent-uid"
+
+	LabelMultiParentPrefix   = "parent.stacks.crossplane.io/"
+	LabelMultiParentNSFormat = "parent.stacks.crossplane.io/%s"
+	LabelMultiParentFormat   = LabelMultiParentNSFormat + "-%s"
 )
 
 // KindlyIdentifier implementations provide the means to access the Name,
@@ -54,4 +61,17 @@ func ParentLabels(i KindlyIdentifier) map[string]string {
 		LabelParentUID:       string(i.GetUID()),
 	}
 	return labels
+}
+
+// HasPrefixedLabel checks if any label on an Object starts with any of the
+// provided prefixes
+func HasPrefixedLabel(obj metav1.Object, prefixes ...string) bool {
+	for k := range obj.GetLabels() {
+		for _, prefix := range prefixes {
+			if strings.HasPrefix(k, prefix) {
+				return true
+			}
+		}
+	}
+	return false
 }

--- a/pkg/stacks/unpack.go
+++ b/pkg/stacks/unpack.go
@@ -87,8 +87,8 @@ const (
 	annotationResourceOverview      = "stacks.crossplane.io/resource-overview"
 	annotationResourceOverviewShort = "stacks.crossplane.io/resource-overview-short"
 
-	// Stack CRD Labels
-	labelKubernetesManagedBy = "app.kubernetes.io/managed-by"
+	// LabelKubernetesManagedBy identifies the resource manager
+	LabelKubernetesManagedBy = "app.kubernetes.io/managed-by"
 )
 
 var (
@@ -398,7 +398,7 @@ func (sp *StackPackage) AddCRD(path string, crd *apiextensions.CustomResourceDef
 	if crd.ObjectMeta.Annotations == nil {
 		crd.ObjectMeta.Annotations = map[string]string{}
 	}
-	crd.ObjectMeta.Labels[labelKubernetesManagedBy] = "stack-manager"
+	crd.ObjectMeta.Labels[LabelKubernetesManagedBy] = "stack-manager"
 
 	if sp.IsNamespaced() {
 		crd.ObjectMeta.Labels[LabelScope] = NamespaceScoped

--- a/pkg/stacks/unpack.go
+++ b/pkg/stacks/unpack.go
@@ -89,6 +89,9 @@ const (
 
 	// LabelKubernetesManagedBy identifies the resource manager
 	LabelKubernetesManagedBy = "app.kubernetes.io/managed-by"
+
+	// LabelValueStackManager is the Crossplane Stack Manager managed-by value
+	LabelValueStackManager = "stack-manager"
 )
 
 var (
@@ -398,7 +401,7 @@ func (sp *StackPackage) AddCRD(path string, crd *apiextensions.CustomResourceDef
 	if crd.ObjectMeta.Annotations == nil {
 		crd.ObjectMeta.Annotations = map[string]string{}
 	}
-	crd.ObjectMeta.Labels[LabelKubernetesManagedBy] = "stack-manager"
+	crd.ObjectMeta.Labels[LabelKubernetesManagedBy] = LabelValueStackManager
 
 	if sp.IsNamespaced() {
 		crd.ObjectMeta.Labels[LabelScope] = NamespaceScoped


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

We strongly recommend you look through our contributor guide at https://git.io/fj2m9
if this is your first time opening a Crossplane pull request. You can find us in
https://slack.crossplane.io/messages/dev if you need any help contributing.
-->

### Description of your changes
Fixes #1051 

When the Stack controller reconciles a Stack it will look for the expected CRDs.  If the CRDs are not present, the reconcile will be requeued.

Any of the matching CRDs which contain the `app.kubernetes.io/managed-by: stack-manager` label (which StackInstall controller's `unpack` provides) will receive additional labels:
* `namespace.crossplane.io/{ns}: "true"` an existing label being deferred from unpack to stack reconciliation
* `parent.stacks.crossplane.io/{ns}-{name}: "true"` a new label to support multiple parents of a CRD

When a Stack is installed into a namespace the existing CRDs will gain additional copies of these labels, for each namespace or stack within that namespace.

When a Stack is deleted from a namespace the CRDs will have `parent.stacks.crossplane.io/{ns}-{name}` labels removed by the Stack controller. The `namespace.crossplane.io/{ns}` label will also be removed if there are no remaining `parent.stacks.crossplane.io/{ns}*` labels. 

When a Stack is deleted and a CRD with the `app.kubernetes.io/managed-by: stack-manager` label contains none of the these two types of labels, the CRD will be deleted by the StackInstall controller.

Honoring the existing `namespace.crossplane.io/{ns}: "true"` discoverability labels prevents this PR from deleting existing Stack CRDs.

We may also want to revisit the need for single parent labels which are currently used for detecting and deleting owned resources that cross the namespace/cluster scope boundary.

(Updated comment) Single parent labeling is modified in this PR. CRDs no longer receive these labels on unpack. When a StackInstall is removed, any CRD parent labels referring to that StackInstall are also removed from any matching CRDs.

If two StackInstalls sharing a common CRD are installed and deleted within a reconciliation window a race could have the newly reused CRD deleted before the new Stack can label it.

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

Fixes #
-->

### How has this code been tested?


#### Upgrading Stack-Manager
1. Install the Wordpress and GCP Stack before this version of Stack-Manager is applied.
2. Update Stack Manager to this version.
   * observe existing CRDs are not deleted

#### Multiple Stacks

1. Install this version of the Stack Manager
1. Install Stack GCP into crossplane-system
1. Install Stack Wordpress into two namespaces
   
   * observe CRDs are given the labels mentioned in the description above
   ```
   $ kubectl get crd -o jsonpath='{.metadata.labels}' wordpressinstances.wordpress.samples.stacks.crossplane.io ; echo 
   map[app.kubernetes.io/managed-by:stack-manager crossplane.io/scope:namespace namespace.crossplane.io/default:true namespace.crossplane.io/precipice:true parent.stacks.crossplane.io/default-stack-wordpress:true parent.stacks.crossplane.io/precipice-stack-wordpress:true]
   ```
1. Delete one of these StackInstalls

   * observe CRDs lose the appropriate labels
   ```
   $ kubectl delete stackinstall -n default stack-wordpress
   $ kubectl get crd -o jsonpath='{.metadata.labels}' wordpressinstances.wordpress.samples.stacks.crossplane.io ; echo 
   map[app.kubernetes.io/managed-by:stack-manager crossplane.io/scope:namespace namespace.crossplane.io/precipice:true parent.stacks.crossplane.io/precipice-stack-wordpress:true]
   ```
1. Delete the other StackInstall
   
   * observe that the CRD has been deleted
<!--
Before reviewers can be confident in the correctness of a pull request,
it needs to tested and shown to be correct. In this section, briefly
describe the testing that has already been done or which is planned.
-->

### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every Crossplane pull request.
-->
I have:
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Ensured this PR contains a neat, self documenting set of commits.
- [ ] Updated any relevant [documentation] and [examples].
- [ ] Reported all new error conditions into the log or as an event, as
  appropriate.

For more about what we believe makes a pull request complete, see our
[definition of done].

[documentation]: https://github.com/crossplane/crossplane/tree/master/docs
[examples]: https://github.com/crossplane/crossplane/tree/master/cluster/examples
[definition of done]: https://github.com/crossplane/crossplane/tree/master/design/one-pager-definition-of-done.md
