### PR TITLE
Add support for single stack image

### DIFF
--- a/pkg/controller/stacks/install/installjob_test.go
+++ b/pkg/controller/stacks/install/installjob_test.go
@@ -49,7 +49,6 @@ import (
 const (
 	jobPodName                   = "job-pod-123"
 	podLogOutputMalformed        = `)(&not valid yaml?()!`
-	podLogOutput                 = crdRaw + "\n" + stackRaw
 	stackInstallSource           = "example.host"
 	stackEnvelopeImage           = "crossplane/sample-stack:latest"
 	stackDefinitionEnvelopeImage = "crossplane/sample-stack-wordpress:0.1.0"
@@ -70,372 +69,7 @@ spec:
   scope: Namespaced
   version: v1alpha1
 `
-	stackDefinitionRaw = `---
-apiVersion: stacks.crossplane.io/v1alpha1
-kind: StackDefinition
-metadata:
-  creationTimestamp: null
-spec:
-  behavior:
-    crd:
-      apiVersion: samples.upbound.io/v1alpha1
-      kind: Mytype
-    engine:
-      type: helm3
-    source:
-      image: crossplane/sample-stack:latest
-      path: helm-chart
-  company: Upbound
-  controller:
-    deployment:
-      name: crossplane-sample-stack
-      spec:
-        selector: {}
-        strategy: {}
-        template:
-          metadata:
-            creationTimestamp: null
-          spec:
-            containers:
-            - args:
-              - --resources-dir
-              - /behaviors
-              - --stack-definition-namespace
-              - $(SD_NAMESPACE)
-              - --stack-definition-name
-              - $(SD_NAME)
-              command:
-              - /manager
-              image: crossplane/templating-controller:v0.2.1
-              name: stack-behavior-manager
-              resources: {}
-              volumeMounts:
-              - mountPath: /behaviors
-                name: behaviors
-            initContainers:
-            - command:
-              - cp
-              - -R
-              - helm-chart/.
-              - /behaviors
-              image: crossplane/sample-stack-wordpress:0.1.0
-              name: stack-behavior-copy-to-manager
-              resources: {}
-              volumeMounts:
-              - mountPath: /behaviors
-                name: behaviors
-            restartPolicy: Always
-            volumes:
-            - emptyDir: {}
-              name: behaviors
-  customresourcedefinitions:
-  - apiVersion: samples.upbound.io/v1alpha1
-    kind: Mytype
-  overview: |
-    Markdown describing this sample Crossplane stack project.
-  icons:
-  - base64Data: bW9jay1pY29uLWRh
-    mediatype: image/jpeg
-  keywords:
-  - samples
-  - examples
-  - tutorials
-  license: Apache-2.0
-  maintainers:
-  - email: jared@upbound.io
-    name: Jared Watts
-  owners:
-  - email: bassam@upbound.io
-    name: Bassam Tabbara
-  permissionScope: Namespaced
-  permissions:
-    rules:
-    - apiGroups:
-      - ""
-      resources:
-      - configmaps
-      - events
-      - secrets
-      verbs:
-      - '*'
-    - apiGroups:
-      - samples.upbound.io/v1alpha1
-      resources:
-      - mytypes
-      verbs:
-      - '*'
-  readme: |-
-    ### Readme
-  source: https://github.com/crossplane/sample-stack
-  title: Sample Crossplane Stack
-  version: 0.0.1
-  website: https://upbound.io
-status: {}
-`
 
-	stackDefinitionRawNoControllerImage = `---
-apiVersion: stacks.crossplane.io/v1alpha1
-kind: StackDefinition
-metadata:
-  creationTimestamp: null
-spec:
-  behavior:
-    crd:
-      apiVersion: samples.upbound.io/v1alpha1
-      kind: Mytype
-    engine:
-      type: helm3
-    source:
-      image: crossplane/sample-stack:latest
-      path: helm-chart
-  company: Upbound
-  controller:
-    deployment:
-      name: crossplane-sample-stack
-      spec:
-        selector: {}
-        strategy: {}
-        template:
-          metadata:
-            creationTimestamp: null
-          spec:
-            containers:
-            - args:
-              - --resources-dir
-              - /behaviors
-              - --stack-definition-namespace
-              - $(SD_NAMESPACE)
-              - --stack-definition-name
-              - $(SD_NAME)
-              command:
-              - /manager
-              image: crossplane/templating-controller:v0.2.1
-              name: stack-behavior-manager
-              resources: {}
-              volumeMounts:
-              - mountPath: /behaviors
-                name: behaviors
-            initContainers:
-            - command:
-              - cp
-              - -R
-              - helm-chart/.
-              - /behaviors
-              name: stack-behavior-copy-to-manager
-              resources: {}
-              volumeMounts:
-              - mountPath: /behaviors
-                name: behaviors
-            restartPolicy: Always
-            volumes:
-            - emptyDir: {}
-              name: behaviors
-  customresourcedefinitions:
-  - apiVersion: samples.upbound.io/v1alpha1
-    kind: Mytype
-  overview: |
-    Markdown describing this sample Crossplane stack project.
-  icons:
-  - base64Data: bW9jay1pY29uLWRh
-    mediatype: image/jpeg
-  keywords:
-  - samples
-  - examples
-  - tutorials
-  license: Apache-2.0
-  maintainers:
-  - email: jared@upbound.io
-    name: Jared Watts
-  owners:
-  - email: bassam@upbound.io
-    name: Bassam Tabbara
-  permissionScope: Namespaced
-  permissions:
-    rules:
-    - apiGroups:
-      - ""
-      resources:
-      - configmaps
-      - events
-      - secrets
-      verbs:
-      - '*'
-    - apiGroups:
-      - samples.upbound.io/v1alpha1
-      resources:
-      - mytypes
-      verbs:
-      - '*'
-  readme: |-
-    ### Readme
-  source: https://github.com/crossplane/sample-stack
-  title: Sample Crossplane Stack
-  version: 0.0.1
-  website: https://upbound.io
-status: {}
-`
-
-	stackRaw = `---
-apiVersion: stacks.crossplane.io/v1alpha1
-kind: Stack
-metadata:
-  creationTimestamp: null
-spec:
-  company: Upbound
-  controller:
-    deployment:
-      name: crossplane-sample-stack
-      spec:
-        replicas: 1
-        selector:
-          matchLabels:
-            core.crossplane.io/name: crossplane-sample-stack
-        strategy: {}
-        template:
-          metadata:
-            creationTimestamp: null
-            labels:
-              core.crossplane.io/name: crossplane-sample-stack
-            name: sample-stack-controller
-          spec:
-            containers:
-            - env:
-              - name: POD_NAME
-                valueFrom:
-                  fieldRef:
-                    fieldPath: metadata.name
-              - name: POD_NAMESPACE
-                valueFrom:
-                  fieldRef:
-                    fieldPath: metadata.namespace
-              image: crossplane/sample-stack:latest
-              name: sample-stack-controller
-              resources: {}
-  customresourcedefinitions:
-  - apiVersion: samples.upbound.io/v1alpha1
-    kind: Mytype
-  overview: |
-    Markdown describing this sample Crossplane stack project.
-  icons:
-  - base64Data: bW9jay1pY29uLWRh
-    mediatype: image/jpeg
-  keywords:
-  - samples
-  - examples
-  - tutorials
-  license: Apache-2.0
-  website: https://upbound.io
-  source: https://github.com/crossplane/sample-stack
-  maintainers:
-  - email: jared@upbound.io
-    name: Jared Watts
-  owners:
-  - email: bassam@upbound.io
-    name: Bassam Tabbara
-  permissions:
-    rules:
-    - apiGroups:
-      - ""
-      resources:
-      - configmaps
-      - events
-      - secrets
-      verbs:
-      - '*'
-    - apiGroups:
-      - samples.upbound.io/v1alpha1
-      resources:
-      - mytypes
-      verbs:
-      - '*'
-  permissionScope: Namespaced
-  title: Sample Crossplane Stack
-  version: 0.0.1
-status:
- conditionedStatus: {}
-`
-
-	stackRawNoControllerImage = `---
-apiVersion: stacks.crossplane.io/v1alpha1
-kind: Stack
-metadata:
-  creationTimestamp: null
-spec:
-  company: Upbound
-  controller:
-    deployment:
-      name: crossplane-sample-stack
-      spec:
-        replicas: 1
-        selector:
-          matchLabels:
-            core.crossplane.io/name: crossplane-sample-stack
-        strategy: {}
-        template:
-          metadata:
-            creationTimestamp: null
-            labels:
-              core.crossplane.io/name: crossplane-sample-stack
-            name: sample-stack-controller
-          spec:
-            containers:
-            - env:
-              - name: POD_NAME
-                valueFrom:
-                  fieldRef:
-                    fieldPath: metadata.name
-              - name: POD_NAMESPACE
-                valueFrom:
-                  fieldRef:
-                    fieldPath: metadata.namespace
-              name: sample-stack-controller
-              resources: {}
-  customresourcedefinitions:
-  - apiVersion: samples.upbound.io/v1alpha1
-    kind: Mytype
-  overview: |
-    Markdown describing this sample Crossplane stack project.
-  icons:
-  - base64Data: bW9jay1pY29uLWRh
-    mediatype: image/jpeg
-  keywords:
-  - samples
-  - examples
-  - tutorials
-  license: Apache-2.0
-  website: https://upbound.io
-  source: https://github.com/crossplane/sample-stack
-  maintainers:
-  - email: jared@upbound.io
-    name: Jared Watts
-  owners:
-  - email: bassam@upbound.io
-    name: Bassam Tabbara
-  permissions:
-    rules:
-    - apiGroups:
-      - ""
-      resources:
-      - configmaps
-      - events
-      - secrets
-      verbs:
-      - '*'
-    - apiGroups:
-      - samples.upbound.io/v1alpha1
-      resources:
-      - mytypes
-      verbs:
-      - '*'
-  permissionScope: Namespaced
-  title: Sample Crossplane Stack
-  version: 0.0.1
-status:
- conditionedStatus: {}
-`
-
-	// TODO(displague) use crossplane-runtime.pavement to set the
-	// container envs on stackDefinitionRaw instead of copying it here
 	expectedStackDefinitionRaw = `---
 apiVersion: stacks.crossplane.io/v1alpha1
 kind: StackDefinition
@@ -546,8 +180,208 @@ status: {}
 )
 
 var (
-	_ jobCompleter = &stackInstallJobCompleter{}
+	_            jobCompleter = &stackInstallJobCompleter{}
+	podLogOutput              = crdRaw + "\n" + stackRaw("crossplane/sample-stack:latest")
 )
+
+func stackRaw(controllerImage string) string {
+	tmpl := `---
+apiVersion: stacks.crossplane.io/v1alpha1
+kind: Stack
+metadata:
+  creationTimestamp: null
+spec:
+  company: Upbound
+  controller:
+    deployment:
+      name: crossplane-sample-stack
+      spec:
+        replicas: 1
+        selector:
+          matchLabels:
+            core.crossplane.io/name: crossplane-sample-stack
+        strategy: {}
+        template:
+          metadata:
+            creationTimestamp: null
+            labels:
+              core.crossplane.io/name: crossplane-sample-stack
+            name: sample-stack-controller
+          spec:
+            containers:
+            - env:
+              - name: POD_NAME
+                valueFrom:
+                  fieldRef:
+                    fieldPath: metadata.name
+              - name: POD_NAMESPACE
+                valueFrom:
+                  fieldRef:
+                    fieldPath: metadata.namespace
+              %sname: sample-stack-controller
+              resources: {}
+  customresourcedefinitions:
+  - apiVersion: samples.upbound.io/v1alpha1
+    kind: Mytype
+  overview: |
+    Markdown describing this sample Crossplane stack project.
+  icons:
+  - base64Data: bW9jay1pY29uLWRh
+    mediatype: image/jpeg
+  keywords:
+  - samples
+  - examples
+  - tutorials
+  license: Apache-2.0
+  website: https://upbound.io
+  source: https://github.com/crossplane/sample-stack
+  maintainers:
+  - email: jared@upbound.io
+    name: Jared Watts
+  owners:
+  - email: bassam@upbound.io
+    name: Bassam Tabbara
+  permissions:
+    rules:
+    - apiGroups:
+      - ""
+      resources:
+      - configmaps
+      - events
+      - secrets
+      verbs:
+      - '*'
+    - apiGroups:
+      - samples.upbound.io/v1alpha1
+      resources:
+      - mytypes
+      verbs:
+      - '*'
+  permissionScope: Namespaced
+  title: Sample Crossplane Stack
+  version: 0.0.1
+status:
+ conditionedStatus: {}
+`
+	if controllerImage != "" {
+		// The spaces are used for formatting the next line. This is a quick and dirty way
+		// to optionally insert an additional line into the output.
+		return fmt.Sprintf(tmpl, fmt.Sprintf("image: %s\n              ", controllerImage))
+	}
+
+	return fmt.Sprintf(tmpl, "")
+}
+
+func stackDefinitionRaw(controllerImage string) string {
+	tmpl := `---
+apiVersion: stacks.crossplane.io/v1alpha1
+kind: StackDefinition
+metadata:
+  creationTimestamp: null
+spec:
+  behavior:
+    crd:
+      apiVersion: samples.upbound.io/v1alpha1
+      kind: Mytype
+    engine:
+      type: helm3
+    source:
+      image: crossplane/sample-stack:latest
+      path: helm-chart
+  company: Upbound
+  controller:
+    deployment:
+      name: crossplane-sample-stack
+      spec:
+        selector: {}
+        strategy: {}
+        template:
+          metadata:
+            creationTimestamp: null
+          spec:
+            containers:
+            - args:
+              - --resources-dir
+              - /behaviors
+              - --stack-definition-namespace
+              - $(SD_NAMESPACE)
+              - --stack-definition-name
+              - $(SD_NAME)
+              command:
+              - /manager
+              image: crossplane/templating-controller:v0.2.1
+              name: stack-behavior-manager
+              resources: {}
+              volumeMounts:
+              - mountPath: /behaviors
+                name: behaviors
+            initContainers:
+            - command:
+              - cp
+              - -R
+              - helm-chart/.
+              - /behaviors
+              %sname: stack-behavior-copy-to-manager
+              resources: {}
+              volumeMounts:
+              - mountPath: /behaviors
+                name: behaviors
+            restartPolicy: Always
+            volumes:
+            - emptyDir: {}
+              name: behaviors
+  customresourcedefinitions:
+  - apiVersion: samples.upbound.io/v1alpha1
+    kind: Mytype
+  overview: |
+    Markdown describing this sample Crossplane stack project.
+  icons:
+  - base64Data: bW9jay1pY29uLWRh
+    mediatype: image/jpeg
+  keywords:
+  - samples
+  - examples
+  - tutorials
+  license: Apache-2.0
+  maintainers:
+  - email: jared@upbound.io
+    name: Jared Watts
+  owners:
+  - email: bassam@upbound.io
+    name: Bassam Tabbara
+  permissionScope: Namespaced
+  permissions:
+    rules:
+    - apiGroups:
+      - ""
+      resources:
+      - configmaps
+      - events
+      - secrets
+      verbs:
+      - '*'
+    - apiGroups:
+      - samples.upbound.io/v1alpha1
+      resources:
+      - mytypes
+      verbs:
+      - '*'
+  readme: |-
+    ### Readme
+  source: https://github.com/crossplane/sample-stack
+  title: Sample Crossplane Stack
+  version: 0.0.1
+  website: https://upbound.io
+status: {}
+`
+	if controllerImage != "" {
+		// The spaces are used for formatting the next line. This is a quick and dirty way
+		// to optionally insert an additional line into the output.
+		return fmt.Sprintf(tmpl, fmt.Sprintf("image: %s\n              ", controllerImage))
+	}
+
+	return fmt.Sprintf(tmpl, "")
+}
 
 func nsLabel(ns string) string {
 	return fmt.Sprintf(stacks.LabelNamespaceFmt, ns)
@@ -1333,10 +1167,10 @@ func TestCreateJobOutputObject(t *testing.T) {
 			},
 			stackInstaller: resource(),
 			job:            job(),
-			obj:            unstructuredObj(stackRaw),
+			obj:            unstructuredObj(stackRaw("crossplane/sample-stack:latest")),
 			want: want{
 				err: nil,
-				obj: unstructuredObj(stackRaw,
+				obj: unstructuredObj(stackRaw("crossplane/sample-stack:latest"),
 					withUnstructuredObjLabels(wantedParentLabels),
 					withUnstructuredObjNamespacedName(types.NamespacedName{Namespace: namespace, Name: resourceName}),
 				),
@@ -1352,7 +1186,7 @@ func TestCreateJobOutputObject(t *testing.T) {
 			},
 			stackInstaller: resource(),
 			job:            job(),
-			obj:            unstructuredObj(stackDefinitionRaw),
+			obj:            unstructuredObj(stackDefinitionRaw("crossplane/sample-stack-wordpress:0.1.0")),
 			want: want{
 				err: nil,
 				obj: unstructuredObj(expectedStackDefinitionRaw,
@@ -1371,10 +1205,10 @@ func TestCreateJobOutputObject(t *testing.T) {
 			},
 			stackInstaller: resource(withPackage(stackEnvelopeImage)),
 			job:            job(),
-			obj:            unstructuredObj(stackRawNoControllerImage),
+			obj:            unstructuredObj(stackRaw("")),
 			want: want{
 				err: nil,
-				obj: unstructuredObj(stackRaw,
+				obj: unstructuredObj(stackRaw("crossplane/sample-stack:latest"),
 					withUnstructuredObjLabels(wantedParentLabels),
 					withUnstructuredObjNamespacedName(types.NamespacedName{Namespace: namespace, Name: resourceName}),
 				),
@@ -1390,7 +1224,7 @@ func TestCreateJobOutputObject(t *testing.T) {
 			},
 			stackInstaller: resource(withPackage(stackDefinitionEnvelopeImage)),
 			job:            job(),
-			obj:            unstructuredObj(stackDefinitionRawNoControllerImage),
+			obj:            unstructuredObj(stackDefinitionRaw("")),
 			want: want{
 				err: nil,
 				obj: unstructuredObj(expectedStackDefinitionRaw,
@@ -1409,10 +1243,10 @@ func TestCreateJobOutputObject(t *testing.T) {
 			},
 			stackInstaller: resource(withPackage("thisImageShouldBeIgnored:becauseTheStackSpecifiesAnExplicitImage")),
 			job:            job(),
-			obj:            unstructuredObj(stackRaw),
+			obj:            unstructuredObj(stackRaw("crossplane/sample-stack:latest")),
 			want: want{
 				err: nil,
-				obj: unstructuredObj(stackRaw,
+				obj: unstructuredObj(stackRaw("crossplane/sample-stack:latest"),
 					withUnstructuredObjLabels(wantedParentLabels),
 					withUnstructuredObjNamespacedName(types.NamespacedName{Namespace: namespace, Name: resourceName}),
 				),
@@ -1428,7 +1262,7 @@ func TestCreateJobOutputObject(t *testing.T) {
 			},
 			stackInstaller: resource(withPackage("thisImageShouldBeIgnored:becauseTheStackSpecifiesAnExplicitImage")),
 			job:            job(),
-			obj:            unstructuredObj(stackDefinitionRaw),
+			obj:            unstructuredObj(stackDefinitionRaw("crossplane/sample-stack-wordpress:0.1.0")),
 			want: want{
 				err: nil,
 				obj: unstructuredObj(expectedStackDefinitionRaw,

--- a/pkg/controller/stacks/install/stackinstall_test.go
+++ b/pkg/controller/stacks/install/stackinstall_test.go
@@ -91,6 +91,19 @@ func withStackRecord(stackRecord *corev1.ObjectReference) resourceModifier {
 	return func(r v1alpha1.StackInstaller) { r.SetStackRecord(stackRecord) }
 }
 
+// withPackage allows a test to set a StackInstaller's package
+// Another option would have been to modify the interface to allow this,
+// but it is preferable if we treat the package field as immutable.
+func withPackage(pkg string) resourceModifier {
+	return func(r v1alpha1.StackInstaller) {
+		if si, ok := r.(*v1alpha1.StackInstall); ok {
+			si.Spec.Package = pkg
+		} else if csi, ok := r.(*v1alpha1.ClusterStackInstall); ok {
+			csi.Spec.Package = pkg
+		}
+	}
+}
+
 func withSource(src string) resourceModifier {
 	return func(r v1alpha1.StackInstaller) { r.SetSource(src) }
 }

--- a/pkg/stacks/unpack_test.go
+++ b/pkg/stacks/unpack_test.go
@@ -36,49 +36,7 @@ import (
 )
 
 const (
-	simpleDeploymentInstallFile = `apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: crossplane-sample-stack
-  labels:
-    core.crossplane.io/name: "crossplane-sample-stack"
-spec:
-  selector:
-    matchLabels:
-      core.crossplane.io/name: "crossplane-sample-stack"
-  replicas: 1
-  template:
-    metadata:
-      name: sample-stack-controller
-      labels:
-        core.crossplane.io/name: "crossplane-sample-stack"
-    spec:
-      containers:
-      - name: sample-stack-controller
-        image: crossplane/sample-stack:latest
-        env:
-        - name: POD_NAME
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.name
-        - name: POD_NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
-`
-
-	simpleBehaviorFile = `
-crd:
-  kind: SampleClaim
-  apiVersion: samples.stacks.crossplane.io/v1alpha1
-engine:
-  type: helm2
-reconcile:
-  path: 'resources'
-source:
-  image: crossplane/sample-stack-claim-test:helm2
-  path: /path
-`
+	simpleCrdDir = "ext-dir/resources/samples.upbound.io/mytype/v1alpha1"
 
 	simpleGroupFile = `title: Group Title
 overviewShort: Group Short Overview
@@ -94,288 +52,6 @@ overviewShort: Resource Short Overview
 overview: Resource Overview
 readme: Resource Readme
 category: Resource Category
-`
-
-	expectedSimpleDeploymentStackOutput = `
----
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  annotations:
-    stacks.crossplane.io/icon-data-uri: data:image/jpeg;base64,bW9jay1pY29uLWRhdGE=
-    stacks.crossplane.io/stack-title: Sample Crossplane Stack
-  creationTimestamp: null
-  labels:
-    app.kubernetes.io/managed-by: stack-manager
-    crossplane.io/scope: namespace
-  name: mytypes.samples.upbound.io
-spec:
-  group: samples.upbound.io
-  names:
-    kind: Mytype
-    listKind: MytypeList
-    plural: mytypes
-    singular: mytype
-  scope: Namespaced
-  version: v1alpha1
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: null
-  storedVersions: null
-
----
-apiVersion: stacks.crossplane.io/v1alpha1
-kind: Stack
-metadata:
-  creationTimestamp: null
-spec:
-  category: Category
-  company: Upbound
-  controller:
-    deployment:
-      name: ""
-      spec:
-        replicas: 1
-        selector:
-          matchLabels:
-            core.crossplane.io/name: crossplane-sample-stack
-        strategy: {}
-        template:
-          metadata:
-            creationTimestamp: null
-            labels:
-              core.crossplane.io/name: crossplane-sample-stack
-            name: sample-stack-controller
-          spec:
-            containers:
-            - env:
-              - name: POD_NAME
-                valueFrom:
-                  fieldRef:
-                    fieldPath: metadata.name
-              - name: POD_NAMESPACE
-                valueFrom:
-                  fieldRef:
-                    fieldPath: metadata.namespace
-              image: crossplane/sample-stack:latest
-              name: sample-stack-controller
-              resources: {}
-  customresourcedefinitions:
-  - apiVersion: samples.upbound.io/v1alpha1
-    kind: Mytype
-  dependsOn:
-  - crd: foo.mystack.example.org/v1alpha1
-  - crd: '*.yourstack.example.org/v1alpha2'
-  icons:
-  - base64Data: bW9jay1pY29uLWRhdGE=
-    mediatype: image/jpeg
-  keywords:
-  - samples
-  - examples
-  - tutorials
-  license: Apache-2.0
-  maintainers:
-  - email: jared@upbound.io
-    name: Jared Watts
-  overview: text overview
-  overviewShort: short text overview
-  owners:
-  - email: bassam@upbound.io
-    name: Bassam Tabbara
-  packageType: Application
-  permissionScope: Namespaced
-  permissions:
-    rules:
-    - apiGroups:
-      - ""
-      resources:
-      - configmaps
-      - events
-      - secrets
-      verbs:
-      - '*'
-    - apiGroups:
-      - samples.upbound.io
-      resources:
-      - mytypes
-      verbs:
-      - '*'
-    - apiGroups:
-      - mystack.example.org
-      resources:
-      - foo
-      verbs:
-      - '*'
-    - apiGroups:
-      - yourstack.example.org
-      resources:
-      - '*'
-      verbs:
-      - '*'
-  readme: |
-    Markdown describing this sample Crossplane stack project.
-  source: https://github.com/crossplane/sample-stack
-  title: Sample Crossplane Stack
-  version: 0.0.1
-  website: https://upbound.io
-status:
-  conditionedStatus: {}
-
----
-`
-
-	expectedSimpleBehaviorStackOutput = `
----
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  annotations:
-    stacks.crossplane.io/icon-data-uri: data:image/jpeg;base64,bW9jay1pY29uLWRhdGE=
-    stacks.crossplane.io/stack-title: Sample Crossplane Stack
-  creationTimestamp: null
-  labels:
-    app.kubernetes.io/managed-by: stack-manager
-    crossplane.io/scope: namespace
-  name: mytypes.samples.upbound.io
-spec:
-  group: samples.upbound.io
-  names:
-    kind: Mytype
-    listKind: MytypeList
-    plural: mytypes
-    singular: mytype
-  scope: Namespaced
-  version: v1alpha1
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: null
-  storedVersions: null
-
----
-apiVersion: stacks.crossplane.io/v1alpha1
-kind: StackDefinition
-metadata:
-  creationTimestamp: null
-spec:
-  behavior:
-    crd:
-      apiVersion: samples.stacks.crossplane.io/v1alpha1
-      kind: SampleClaim
-    engine:
-      controllerImage: crossplane/ts-controller:0.0.0
-      type: helm2
-    source:
-      image: crossplane/sample-stack-claim-test:helm2
-      path: /path
-  category: Category
-  company: Upbound
-  controller:
-    deployment:
-      name: ""
-      spec:
-        selector: {}
-        strategy: {}
-        template:
-          metadata:
-            creationTimestamp: null
-          spec:
-            containers:
-            - args:
-              - --resources-dir
-              - /behaviors
-              - --stack-definition-namespace
-              - $(SD_NAMESPACE)
-              - --stack-definition-name
-              - $(SD_NAME)
-              command:
-              - /manager
-              image: crossplane/ts-controller:0.0.0
-              name: stack-behavior-manager
-              resources: {}
-              volumeMounts:
-              - mountPath: /behaviors
-                name: behaviors
-            initContainers:
-            - command:
-              - cp
-              - -R
-              - /path/.
-              - /behaviors
-              image: crossplane/sample-stack-claim-test:helm2
-              name: stack-behavior-copy-to-manager
-              resources: {}
-              volumeMounts:
-              - mountPath: /behaviors
-                name: behaviors
-            restartPolicy: Always
-            volumes:
-            - emptyDir: {}
-              name: behaviors
-  customresourcedefinitions:
-  - apiVersion: samples.upbound.io/v1alpha1
-    kind: Mytype
-  dependsOn:
-  - crd: foo.mystack.example.org/v1alpha1
-  - crd: '*.yourstack.example.org/v1alpha2'
-  icons:
-  - base64Data: bW9jay1pY29uLWRhdGE=
-    mediatype: image/jpeg
-  keywords:
-  - samples
-  - examples
-  - tutorials
-  license: Apache-2.0
-  maintainers:
-  - email: jared@upbound.io
-    name: Jared Watts
-  overview: text overview
-  overviewShort: short text overview
-  owners:
-  - email: bassam@upbound.io
-    name: Bassam Tabbara
-  packageType: Application
-  permissionScope: Namespaced
-  permissions:
-    rules:
-    - apiGroups:
-      - ""
-      resources:
-      - configmaps
-      - events
-      - secrets
-      verbs:
-      - '*'
-    - apiGroups:
-      - samples.upbound.io
-      resources:
-      - mytypes
-      verbs:
-      - '*'
-    - apiGroups:
-      - mystack.example.org
-      resources:
-      - foo
-      verbs:
-      - '*'
-    - apiGroups:
-      - yourstack.example.org
-      resources:
-      - '*'
-      verbs:
-      - '*'
-  readme: |
-    Markdown describing this sample Crossplane stack project.
-  source: https://github.com/crossplane/sample-stack
-  title: Sample Crossplane Stack
-  version: 0.0.1
-  website: https://upbound.io
-status: {}
-
----
 `
 
 	expectedComplexDeploymentStackOutput = `
@@ -976,6 +652,71 @@ var (
 	_ StackPackager = &StackPackage{}
 )
 
+// simpleDeploymentInstallFile allows us to create an install file
+// with different values, without having to have multiple copies
+// of a whole install file
+func simpleDeploymentInstallFile(image string) string {
+	tmpl := `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: crossplane-sample-stack
+  labels:
+    core.crossplane.io/name: "crossplane-sample-stack"
+spec:
+  selector:
+    matchLabels:
+      core.crossplane.io/name: "crossplane-sample-stack"
+  replicas: 1
+  template:
+    metadata:
+      name: sample-stack-controller
+      labels:
+        core.crossplane.io/name: "crossplane-sample-stack"
+    spec:
+      containers:
+      - name: sample-stack-controller
+        %s
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+`
+
+	if image != "" {
+		return fmt.Sprintf(tmpl, fmt.Sprintf("image: %s", image))
+
+	}
+
+	return fmt.Sprintf(tmpl, "")
+}
+
+func simpleBehaviorFile(sourceImage string) string {
+	tmpl := `
+crd:
+  kind: SampleClaim
+  apiVersion: samples.stacks.crossplane.io/v1alpha1
+engine:
+  type: helm2
+reconcile:
+  path: 'resources'
+source:
+  %s
+  path: /path
+`
+
+	if sourceImage != "" {
+		return fmt.Sprintf(tmpl, fmt.Sprintf("image: %s", sourceImage))
+
+	}
+
+	return fmt.Sprintf(tmpl, "")
+}
+
 func simpleAppFile(permissionScope, packageType string, includeVersion bool) string {
 	appFile := `# apiVersion this app.yaml conforms to
 apiVersion: 0.1.0
@@ -1087,6 +828,305 @@ configSections:
 `, name, name)
 }
 
+func expectedSimpleDeploymentStackOutput(controllerImage string) string {
+	tmpl := `
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    stacks.crossplane.io/icon-data-uri: data:image/jpeg;base64,bW9jay1pY29uLWRhdGE=
+    stacks.crossplane.io/stack-title: Sample Crossplane Stack
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/managed-by: stack-manager
+    crossplane.io/scope: namespace
+  name: mytypes.samples.upbound.io
+spec:
+  group: samples.upbound.io
+  names:
+    kind: Mytype
+    listKind: MytypeList
+    plural: mytypes
+    singular: mytype
+  scope: Namespaced
+  version: v1alpha1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null
+
+---
+apiVersion: stacks.crossplane.io/v1alpha1
+kind: Stack
+metadata:
+  creationTimestamp: null
+spec:
+  category: Category
+  company: Upbound
+  controller:
+    deployment:
+      name: ""
+      spec:
+        replicas: 1
+        selector:
+          matchLabels:
+            core.crossplane.io/name: crossplane-sample-stack
+        strategy: {}
+        template:
+          metadata:
+            creationTimestamp: null
+            labels:
+              core.crossplane.io/name: crossplane-sample-stack
+            name: sample-stack-controller
+          spec:
+            containers:
+            - env:
+              - name: POD_NAME
+                valueFrom:
+                  fieldRef:
+                    fieldPath: metadata.name
+              - name: POD_NAMESPACE
+                valueFrom:
+                  fieldRef:
+                    fieldPath: metadata.namespace
+              %sname: sample-stack-controller
+              resources: {}
+  customresourcedefinitions:
+  - apiVersion: samples.upbound.io/v1alpha1
+    kind: Mytype
+  dependsOn:
+  - crd: foo.mystack.example.org/v1alpha1
+  - crd: '*.yourstack.example.org/v1alpha2'
+  icons:
+  - base64Data: bW9jay1pY29uLWRhdGE=
+    mediatype: image/jpeg
+  keywords:
+  - samples
+  - examples
+  - tutorials
+  license: Apache-2.0
+  maintainers:
+  - email: jared@upbound.io
+    name: Jared Watts
+  overview: text overview
+  overviewShort: short text overview
+  owners:
+  - email: bassam@upbound.io
+    name: Bassam Tabbara
+  packageType: Application
+  permissionScope: Namespaced
+  permissions:
+    rules:
+    - apiGroups:
+      - ""
+      resources:
+      - configmaps
+      - events
+      - secrets
+      verbs:
+      - '*'
+    - apiGroups:
+      - samples.upbound.io
+      resources:
+      - mytypes
+      verbs:
+      - '*'
+    - apiGroups:
+      - mystack.example.org
+      resources:
+      - foo
+      verbs:
+      - '*'
+    - apiGroups:
+      - yourstack.example.org
+      resources:
+      - '*'
+      verbs:
+      - '*'
+  readme: |
+    Markdown describing this sample Crossplane stack project.
+  source: https://github.com/crossplane/sample-stack
+  title: Sample Crossplane Stack
+  version: 0.0.1
+  website: https://upbound.io
+status:
+  conditionedStatus: {}
+
+---
+`
+
+	if controllerImage != "" {
+		// The spaces are used for formatting the next line. This is a quick and dirty way
+		// to optionally insert an additional line into the output.
+		return fmt.Sprintf(tmpl, fmt.Sprintf("image: %s\n              ", controllerImage))
+	}
+
+	return fmt.Sprintf(tmpl, "")
+}
+
+func expectedSimpleBehaviorStackOutput(sourceImage string) string {
+	tmpl := `
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    stacks.crossplane.io/icon-data-uri: data:image/jpeg;base64,bW9jay1pY29uLWRhdGE=
+    stacks.crossplane.io/stack-title: Sample Crossplane Stack
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/managed-by: stack-manager
+    crossplane.io/scope: namespace
+  name: mytypes.samples.upbound.io
+spec:
+  group: samples.upbound.io
+  names:
+    kind: Mytype
+    listKind: MytypeList
+    plural: mytypes
+    singular: mytype
+  scope: Namespaced
+  version: v1alpha1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null
+
+---
+apiVersion: stacks.crossplane.io/v1alpha1
+kind: StackDefinition
+metadata:
+  creationTimestamp: null
+spec:
+  behavior:
+    crd:
+      apiVersion: samples.stacks.crossplane.io/v1alpha1
+      kind: SampleClaim
+    engine:
+      controllerImage: crossplane/ts-controller:0.0.0
+      type: helm2
+    source:
+      %spath: /path
+  category: Category
+  company: Upbound
+  controller:
+    deployment:
+      name: ""
+      spec:
+        selector: {}
+        strategy: {}
+        template:
+          metadata:
+            creationTimestamp: null
+          spec:
+            containers:
+            - args:
+              - --resources-dir
+              - /behaviors
+              - --stack-definition-namespace
+              - $(SD_NAMESPACE)
+              - --stack-definition-name
+              - $(SD_NAME)
+              command:
+              - /manager
+              image: crossplane/ts-controller:0.0.0
+              name: stack-behavior-manager
+              resources: {}
+              volumeMounts:
+              - mountPath: /behaviors
+                name: behaviors
+            initContainers:
+            - command:
+              - cp
+              - -R
+              - /path/.
+              - /behaviors
+              %sname: stack-behavior-copy-to-manager
+              resources: {}
+              volumeMounts:
+              - mountPath: /behaviors
+                name: behaviors
+            restartPolicy: Always
+            volumes:
+            - emptyDir: {}
+              name: behaviors
+  customresourcedefinitions:
+  - apiVersion: samples.upbound.io/v1alpha1
+    kind: Mytype
+  dependsOn:
+  - crd: foo.mystack.example.org/v1alpha1
+  - crd: '*.yourstack.example.org/v1alpha2'
+  icons:
+  - base64Data: bW9jay1pY29uLWRhdGE=
+    mediatype: image/jpeg
+  keywords:
+  - samples
+  - examples
+  - tutorials
+  license: Apache-2.0
+  maintainers:
+  - email: jared@upbound.io
+    name: Jared Watts
+  overview: text overview
+  overviewShort: short text overview
+  owners:
+  - email: bassam@upbound.io
+    name: Bassam Tabbara
+  packageType: Application
+  permissionScope: Namespaced
+  permissions:
+    rules:
+    - apiGroups:
+      - ""
+      resources:
+      - configmaps
+      - events
+      - secrets
+      verbs:
+      - '*'
+    - apiGroups:
+      - samples.upbound.io
+      resources:
+      - mytypes
+      verbs:
+      - '*'
+    - apiGroups:
+      - mystack.example.org
+      resources:
+      - foo
+      verbs:
+      - '*'
+    - apiGroups:
+      - yourstack.example.org
+      resources:
+      - '*'
+      verbs:
+      - '*'
+  readme: |
+    Markdown describing this sample Crossplane stack project.
+  source: https://github.com/crossplane/sample-stack
+  title: Sample Crossplane Stack
+  version: 0.0.1
+  website: https://upbound.io
+status: {}
+
+---
+`
+
+	if sourceImage != "" {
+		// The spaces are used for formatting the next line. This is a quick and dirty way
+		// to optionally insert an additional line into the output.
+		return fmt.Sprintf(tmpl, fmt.Sprintf("image: %s\n      ", sourceImage), fmt.Sprintf("image: %s\n              ", sourceImage))
+	}
+
+	return fmt.Sprintf(tmpl, "", "")
+}
+
 func TestUnpack(t *testing.T) {
 	type want struct {
 		output string
@@ -1118,14 +1158,30 @@ func TestUnpack(t *testing.T) {
 				fs.MkdirAll("ext-dir", 0755)
 				afero.WriteFile(fs, "ext-dir/icon.jpg", []byte("mock-icon-data"), 0644)
 				afero.WriteFile(fs, "ext-dir/app.yaml", []byte(simpleAppFile("Namespaced", "Application", true)), 0644)
-				afero.WriteFile(fs, "ext-dir/install.yaml", []byte(simpleDeploymentInstallFile), 0644)
-				crdDir := "ext-dir/resources/samples.upbound.io/mytype/v1alpha1"
+				afero.WriteFile(fs, "ext-dir/install.yaml", []byte(simpleDeploymentInstallFile("crossplane/sample-stack:latest")), 0644)
+				crdDir := simpleCrdDir
 				fs.MkdirAll(crdDir, 0755)
 				afero.WriteFile(fs, filepath.Join(crdDir, "mytype.v1alpha1.crd.yaml"), []byte(simpleCRDFile("mytype")), 0644)
 				return fs
 			}(),
 			root: "ext-dir",
-			want: want{output: expectedSimpleDeploymentStackOutput, err: nil},
+			want: want{output: expectedSimpleDeploymentStackOutput("crossplane/sample-stack:latest"), err: nil},
+		},
+		{
+			name: "SimpleDeploymentStackWithNoVersionShouldHaveNoVersion",
+			fs: func() afero.Fs {
+				fs := afero.NewMemMapFs()
+				fs.MkdirAll("ext-dir", 0755)
+				afero.WriteFile(fs, "ext-dir/icon.jpg", []byte("mock-icon-data"), 0644)
+				afero.WriteFile(fs, "ext-dir/app.yaml", []byte(simpleAppFile("Namespaced", "Application", true)), 0644)
+				afero.WriteFile(fs, "ext-dir/install.yaml", []byte(simpleDeploymentInstallFile("")), 0644)
+				crdDir := simpleCrdDir
+				fs.MkdirAll(crdDir, 0755)
+				afero.WriteFile(fs, filepath.Join(crdDir, "mytype.v1alpha1.crd.yaml"), []byte(simpleCRDFile("mytype")), 0644)
+				return fs
+			}(),
+			root: "ext-dir",
+			want: want{output: expectedSimpleDeploymentStackOutput(""), err: nil},
 		},
 		{
 			name: "ReadVersionFromStackImage",
@@ -1134,14 +1190,14 @@ func TestUnpack(t *testing.T) {
 				fs.MkdirAll("ext-dir", 0755)
 				afero.WriteFile(fs, "ext-dir/icon.jpg", []byte("mock-icon-data"), 0644)
 				afero.WriteFile(fs, "ext-dir/app.yaml", []byte(simpleAppFile("Namespaced", "Application", false)), 0644)
-				afero.WriteFile(fs, "ext-dir/install.yaml", []byte(simpleDeploymentInstallFile), 0644)
-				crdDir := "ext-dir/resources/samples.upbound.io/mytype/v1alpha1"
+				afero.WriteFile(fs, "ext-dir/install.yaml", []byte(simpleDeploymentInstallFile("crossplane/sample-stack:latest")), 0644)
+				crdDir := simpleCrdDir
 				fs.MkdirAll(crdDir, 0755)
 				afero.WriteFile(fs, filepath.Join(crdDir, "mytype.v1alpha1.crd.yaml"), []byte(simpleCRDFile("mytype")), 0644)
 				return fs
 			}(),
 			root:       "ext-dir",
-			want:       want{output: expectedSimpleDeploymentStackOutput, err: nil},
+			want:       want{output: expectedSimpleDeploymentStackOutput("crossplane/sample-stack:latest"), err: nil},
 			stackImage: "crossplane/sample-stack:0.0.1",
 		},
 		{
@@ -1151,14 +1207,30 @@ func TestUnpack(t *testing.T) {
 				fs.MkdirAll("ext-dir", 0755)
 				afero.WriteFile(fs, "ext-dir/icon.jpg", []byte("mock-icon-data"), 0644)
 				afero.WriteFile(fs, "ext-dir/app.yaml", []byte(simpleAppFile("Namespaced", "Application", true)), 0644)
-				afero.WriteFile(fs, "ext-dir/behavior.yaml", []byte(simpleBehaviorFile), 0644)
-				crdDir := "ext-dir/resources/samples.upbound.io/mytype/v1alpha1"
+				afero.WriteFile(fs, "ext-dir/behavior.yaml", []byte(simpleBehaviorFile("crossplane/sample-stack-claim-test:helm2")), 0644)
+				crdDir := simpleCrdDir
 				fs.MkdirAll(crdDir, 0755)
 				afero.WriteFile(fs, filepath.Join(crdDir, "mytype.v1alpha1.crd.yaml"), []byte(simpleCRDFile("mytype")), 0644)
 				return fs
 			}(),
 			root: "ext-dir",
-			want: want{output: expectedSimpleBehaviorStackOutput, err: nil},
+			want: want{output: expectedSimpleBehaviorStackOutput("crossplane/sample-stack-claim-test:helm2"), err: nil},
+		},
+		{
+			name: "SimpleBehaviorStackWithNoVersionShouldHaveNoVersion",
+			fs: func() afero.Fs {
+				fs := afero.NewMemMapFs()
+				fs.MkdirAll("ext-dir", 0755)
+				afero.WriteFile(fs, "ext-dir/icon.jpg", []byte("mock-icon-data"), 0644)
+				afero.WriteFile(fs, "ext-dir/app.yaml", []byte(simpleAppFile("Namespaced", "Application", true)), 0644)
+				afero.WriteFile(fs, "ext-dir/behavior.yaml", []byte(simpleBehaviorFile("")), 0644)
+				crdDir := simpleCrdDir
+				fs.MkdirAll(crdDir, 0755)
+				afero.WriteFile(fs, filepath.Join(crdDir, "mytype.v1alpha1.crd.yaml"), []byte(simpleCRDFile("mytype")), 0644)
+				return fs
+			}(),
+			root: "ext-dir",
+			want: want{output: expectedSimpleBehaviorStackOutput(""), err: nil},
 		},
 		{
 			name: "ComplexDeploymentStack",
@@ -1182,7 +1254,7 @@ func TestUnpack(t *testing.T) {
 
 				afero.WriteFile(fs, "ext-dir/icon.jpg", []byte("mock-icon-data"), 0644)
 				afero.WriteFile(fs, "ext-dir/app.yaml", []byte(simpleAppFile("Namespaced", "Application", true)), 0644)
-				afero.WriteFile(fs, "ext-dir/install.yaml", []byte(simpleDeploymentInstallFile), 0644)
+				afero.WriteFile(fs, "ext-dir/install.yaml", []byte(simpleDeploymentInstallFile("crossplane/sample-stack:latest")), 0644)
 				afero.WriteFile(fs, filepath.Join(groupDir, "group.yaml"), []byte(simpleGroupFile), 0644)
 				afero.WriteFile(fs, filepath.Join(groupDir, "ui-schema.yaml"), []byte(simpleUIFile("group")), 0644)
 				afero.WriteFile(fs, filepath.Join(crdDir, "icon.png"), []byte("mock-icon-data-png"), 0644)
@@ -1256,7 +1328,7 @@ func TestUnpackCluster(t *testing.T) {
 
 				afero.WriteFile(fs, "ext-dir/icon.jpg", []byte("mock-icon-data"), 0644)
 				afero.WriteFile(fs, "ext-dir/app.yaml", []byte(simpleAppFile("Cluster", "Provider", true)), 0644)
-				afero.WriteFile(fs, "ext-dir/install.yaml", []byte(simpleDeploymentInstallFile), 0644)
+				afero.WriteFile(fs, "ext-dir/install.yaml", []byte(simpleDeploymentInstallFile("crossplane/sample-stack:latest")), 0644)
 				afero.WriteFile(fs, filepath.Join(groupDir, "group.yaml"), []byte(simpleGroupFile), 0644)
 				afero.WriteFile(fs, filepath.Join(groupDir, "ui-schema.yaml"), []byte(simpleUIFile("group")), 0644)
 				afero.WriteFile(fs, filepath.Join(crdDir, "icon.png"), []byte("mock-icon-data-png"), 0644)


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

We strongly recommend you look through our contributor guide at https://git.io/fj2m9
if this is your first time opening a Crossplane pull request. You can find us in
https://slack.crossplane.io/messages/dev if you need any help contributing.
-->

### Description of your changes
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

Fixes #
-->

Related to #1308 - see that ticket for more background.

This change adds the ability to omit the container image name for the controller image (in the case of standard stacks) or behavior image (in the case of template stacks). We want to do this to simplify container image management, because we usually use the same container image for both the envelope image and for the controller/behavior image, and it's inconvenient for the envelope image to have a file in it with an explicit reference to the envelope image tag.

The changes are fully backward-compatible.

### How has this code been tested?
<!--
Before reviewers can be confident in the correctness of a pull request,
it needs to tested and shown to be correct. In this section, briefly
describe the testing that has already been done or which is planned.
-->

Unit tests have been added:

* Unpack functionality is tested with the image omitted, to make sure it still functions well
* Stack/StackDefinition object creation is tested with the image omitted from the input, to make sure that the image is injected properly

I have also tested this with a running Crossplane locally:

* With a locally-built version of stack-gcp with the image removed from the `install.yaml`. The Stack showed up with the image in the right place as expected.
* With a locally-built version of stack-minimal-gcp with the image removed from the `behavior.yaml` `source`. The Stack showed up with the image in the right place, as expected.

### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every Crossplane pull request.
-->
I have:
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Ensured this PR contains a neat, self documenting set of commits.
- [ ] Updated any relevant [documentation] and [examples].
- [x] Reported all new error conditions into the log or as an event, as
  appropriate.

For more about what we believe makes a pull request complete, see our
[definition of done].

[documentation]: https://github.com/crossplane/crossplane/tree/master/docs
[examples]: https://github.com/crossplane/crossplane/tree/master/cluster/examples
[definition of done]: https://github.com/crossplane/crossplane/tree/master/design/one-pager-definition-of-done.md
