### PR TITLE
stacks: add core APIGroup restriction option for Stack controller

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/crossplane/crossplane-tools v0.0.0-20200219001116-bb8b2ce46330
 	github.com/docker/distribution v2.7.1+incompatible
 	github.com/ghodss/yaml v1.0.0
+	github.com/go-logr/logr v0.1.0
 	github.com/google/go-cmp v0.3.1
 	github.com/onsi/gomega v1.7.0
 	github.com/opencontainers/go-digest v1.0.0-rc1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -547,6 +547,7 @@ gopkg.in/yaml.v2 v2.2.8 h1:obN1ZagJSUGI0Ek/LBmuj4SNLPfIny3KsKFopxRdj10=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v3 v3.0.0-20190905181640-827449938966 h1:B0J02caTR6tpSJozBJyiAzT6CtBzjclw4pgm9gg8Ys0=
 gopkg.in/yaml.v3 v3.0.0-20190905181640-827449938966/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gotest.tools v2.2.0+incompatible h1:VsBPFP1AI068pPrMxtb/S8Zkgf9xEmTLJjfM+P5UIEo=
 gotest.tools v2.2.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81HFBacw=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190106161140-3f1c8253044a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/pkg/controller/stacks/stack/stack_test.go
+++ b/pkg/controller/stacks/stack/stack_test.go
@@ -205,11 +205,11 @@ func resource(rm ...resourceModifier) *v1alpha1.Stack {
 // mockFactory and mockHandler
 // ************************************************************************************************
 type mockFactory struct {
-	MockNewHandler func(logging.Logger, *v1alpha1.Stack, client.Client, client.Client, *hosted.Config) handler
+	MockNewHandler func(logging.Logger, *v1alpha1.Stack, client.Client, client.Client, *hosted.Config, bool) handler
 }
 
-func (f *mockFactory) newHandler(log logging.Logger, r *v1alpha1.Stack, c client.Client, h client.Client, hc *hosted.Config) handler {
-	return f.MockNewHandler(log, r, c, nil, nil)
+func (f *mockFactory) newHandler(log logging.Logger, r *v1alpha1.Stack, c client.Client, h client.Client, hc *hosted.Config, restrictCore bool) handler {
+	return f.MockNewHandler(log, r, c, nil, nil, restrictCore)
 }
 
 type mockHandler struct {
@@ -338,7 +338,7 @@ func TestReconcile(t *testing.T) {
 					},
 				},
 				factory: &mockFactory{
-					MockNewHandler: func(logging.Logger, *v1alpha1.Stack, client.Client, client.Client, *hosted.Config) handler {
+					MockNewHandler: func(logging.Logger, *v1alpha1.Stack, client.Client, client.Client, *hosted.Config, bool) handler {
 						return &mockHandler{
 							MockSync: func(context.Context) (reconcile.Result, error) {
 								return reconcile.Result{}, nil

--- a/pkg/controller/stacks/stack/stack_test.go
+++ b/pkg/controller/stacks/stack/stack_test.go
@@ -2641,3 +2641,282 @@ func Test_stackHandler_removeCRDLabels(t *testing.T) {
 		})
 	}
 }
+
+func Test_stackHandler_validateStackPermissions(t *testing.T) {
+	everything := []rbac.PolicyRule{{
+		APIGroups: []string{"*"},
+		Resources: []string{"*"},
+		Verbs:     []string{"*"},
+	}}
+
+	mixed := append(stackspkg.StackCoreRBACRules, everything...)
+	tests := []struct {
+		name         string
+		restrictCore bool
+		ext          *v1alpha1.Stack
+		wantErr      error
+	}{
+		{
+			name:         "DefaultPolicy",
+			restrictCore: true,
+			ext:          resource(withPolicyRules(stackspkg.StackCoreRBACRules)),
+			wantErr:      nil,
+		},
+		{
+			name:         "DefaultPolicyWithoutRestrictions",
+			restrictCore: false,
+			ext:          resource(withPolicyRules(stackspkg.StackCoreRBACRules)),
+			wantErr:      nil,
+		},
+		{
+			name:         "EverythingPolicy",
+			restrictCore: true,
+			ext:          resource(withPolicyRules(everything)),
+			wantErr:      errors.New("permissions contain a restricted rule"),
+		},
+		{
+			name:         "EverythingPolicyWithoutRestrictions",
+			restrictCore: false,
+			ext:          resource(withPolicyRules(everything)),
+			wantErr:      nil,
+		},
+		{
+			name:         "MixedPolicy",
+			restrictCore: true,
+			ext:          resource(withPolicyRules(mixed)),
+			wantErr:      errors.New("permissions contain a restricted rule"),
+		},
+		{
+			name:         "MixedPolicyWithoutRestrictions",
+			restrictCore: false,
+			ext:          resource(withPolicyRules(mixed)),
+			wantErr:      nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := &stackHandler{
+				restrictCore: tt.restrictCore,
+				ext:          tt.ext,
+				log:          logging.NewNopLogger(),
+			}
+			gotErr := h.validateStackPermissions()
+
+			if diff := cmp.Diff(tt.wantErr, gotErr, test.EquateErrors()); diff != "" {
+				t.Errorf("-want error, +got error:\n%s", diff)
+			}
+		})
+	}
+}
+
+func Test_policiesEqual(t *testing.T) {
+	tests := []struct {
+		name string
+		a    rbac.PolicyRule
+		b    rbac.PolicyRule
+		want bool
+	}{
+		{
+			name: "EmptyMatch",
+			a:    rbac.PolicyRule{},
+			b:    rbac.PolicyRule{},
+			want: true,
+		},
+		{
+			name: "APIGroups",
+			a:    rbac.PolicyRule{APIGroups: []string{"foo"}},
+			b:    rbac.PolicyRule{APIGroups: []string{"bar"}},
+			want: false,
+		},
+		{
+			name: "Resources",
+			a:    rbac.PolicyRule{Resources: []string{"foo"}},
+			b:    rbac.PolicyRule{Resources: []string{"bar"}},
+			want: false,
+		},
+		{
+			name: "Verbs",
+			a:    rbac.PolicyRule{Verbs: []string{"foo"}},
+			b:    rbac.PolicyRule{Verbs: []string{"bar"}},
+			want: false,
+		},
+		{
+			name: "ResourceNames",
+			a:    rbac.PolicyRule{ResourceNames: []string{"foo"}},
+			b:    rbac.PolicyRule{ResourceNames: []string{"bar"}},
+			want: false,
+		},
+		{
+			name: "NonResourceURLs",
+			a:    rbac.PolicyRule{NonResourceURLs: []string{"foo"}},
+			b:    rbac.PolicyRule{NonResourceURLs: []string{"bar"}},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := policiesEqual(tt.a, tt.b)
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Errorf("policiesEqual(), -want, +got:\n%s", diff)
+			}
+		})
+	}
+}
+
+func Test_isDefaultStackPolicy(t *testing.T) {
+	tests := []struct {
+		name   string
+		policy rbac.PolicyRule
+		want   bool
+	}{
+		{
+			name:   "EmptyPolicy",
+			policy: rbac.PolicyRule{},
+			want:   false,
+		},
+		{
+			name:   "DefaultPolicy",
+			policy: stackspkg.StackCoreRBACRules[0],
+			want:   true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isDefaultStackPolicy(tt.policy)
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Errorf("isDefaultStackPolicy(), -want, +got:\n%s", diff)
+			}
+		})
+	}
+}
+
+func Test_isPermittedAPIGroup(t *testing.T) {
+	tests := []struct {
+		name     string
+		apiGroup string
+		want     bool
+	}{
+		{
+			name:     "DotLess",
+			apiGroup: "",
+			want:     false,
+		},
+		{
+			name:     "k8s.io",
+			apiGroup: "foo.k8s.io",
+			want:     false,
+		},
+		{
+			name:     "Permitted",
+			apiGroup: "foo.stack.example.com",
+			want:     true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isPermittedAPIGroup(tt.apiGroup)
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Errorf("isPermittedAPIGroup(), -want, +got:\n%s", diff)
+			}
+		})
+	}
+}
+
+func Test_isPermittedStackPolicy(t *testing.T) {
+	tests := []struct {
+		name   string
+		policy rbac.PolicyRule
+		want   bool
+	}{
+		{
+			name:   "EmptyPolicy",
+			policy: rbac.PolicyRule{},
+			want:   false,
+		},
+		{
+			name:   "EmptyAPIGroup",
+			policy: rbac.PolicyRule{APIGroups: []string{""}, Resources: []string{"*"}, Verbs: []string{"*"}},
+			want:   false,
+		},
+		{
+			name:   "Everything",
+			policy: rbac.PolicyRule{APIGroups: []string{"*"}, Resources: []string{"*"}, Verbs: []string{"*"}},
+			want:   false,
+		},
+		{
+			name:   "NonResourceURLPolicy",
+			policy: rbac.PolicyRule{NonResourceURLs: []string{"foo"}},
+			want:   false,
+		},
+		{
+			name:   "DefaultPolicy",
+			policy: stackspkg.StackCoreRBACRules[0],
+			want:   true,
+		},
+		{
+			name: "PermittedPolicy",
+			policy: rbac.PolicyRule{
+				APIGroups: []string{"foo.bar", "bar.foo"},
+				Resources: []string{"foo", "bar"},
+				Verbs:     []string{"*"},
+			},
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isPermittedStackPolicy(tt.policy)
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Errorf("isPermittedStackPolicy(), -want, +got:\n%s", diff)
+			}
+		})
+	}
+}
+
+func Test_stringSlicesEqual(t *testing.T) {
+	tests := []struct {
+		name string
+		a    []string
+		b    []string
+		want bool
+	}{
+		{
+			name: "Empty",
+			a:    []string{},
+			b:    []string{},
+			want: true,
+		},
+		{
+			name: "Uneven",
+			a:    []string{"a"},
+			b:    []string{"a", "b"},
+			want: false,
+		},
+		{
+			name: "OrderMatters",
+			a:    []string{"b", "a"},
+			b:    []string{"a", "b"},
+			want: false,
+		},
+		{
+			name: "Mismatched",
+			a:    []string{"b", "a"},
+			b:    []string{"c", "d"},
+			want: false,
+		},
+		{
+			name: "Matched",
+			a:    []string{"a", "b", "c"},
+			b:    []string{"a", "b", "c"},
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := stringSlicesEqual(tt.a, tt.b)
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Errorf("stringSlicesEqual(), -want, +got:\n%s", diff)
+			}
+		})
+	}
+}

--- a/pkg/controller/stacks/stacks.go
+++ b/pkg/controller/stacks/stacks.go
@@ -27,7 +27,7 @@ import (
 )
 
 // Setup Crossplane Stacks controllers.
-func Setup(mgr ctrl.Manager, l logging.Logger, hostControllerNamespace, tsControllerImage string) error {
+func Setup(mgr ctrl.Manager, l logging.Logger, hostControllerNamespace, tsControllerImage string, restrictCore bool) error {
 	if err := install.SetupStackInstall(mgr, l, hostControllerNamespace, tsControllerImage); err != nil {
 		return err
 	}
@@ -39,7 +39,7 @@ func Setup(mgr ctrl.Manager, l logging.Logger, hostControllerNamespace, tsContro
 	if err := persona.Setup(mgr, l); err != nil {
 		return nil
 	}
-	if err := stack.Setup(mgr, l, hostControllerNamespace); err != nil {
+	if err := stack.Setup(mgr, l, hostControllerNamespace, restrictCore); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
### Description of your changes

Fixes #899

I originally wrote this supporting documentation https://gist.github.com/displague/3b6368c7eca459961d018b5a9408f5c8
 into the Stacks design doc as a way to guide this PR.  I have since found that it would be more at home in the Stacks Isolation design doc or the Crossplane.io Stacks docs.  I'm looking for ideas on where to weave this in.

This PR adds the new `stack manage --restrict-core-apigroups` argument which when enabled prevents certain rules signatures from being used in Stack `spec.permissions.rules`:
* restricts `*.k8s.io` as an APIGroup
* restricts dot-less API groups (`""`, `"*"`, `"batch"`, `"api"`, etc)
* restricts `NonResourceURL` use in permission rules

`main.go` needed to be refactored as the cyclomatic complexity finally hit the roof.  Apologies in advance.

The old behavior of failing a StackInstall unpack if an app.yaml `dependsOn` field did not contain an API Group has been removed.  This will allow the use of `pod/v1`, for example, as a dependency so long as `--restrict-core-apigroups` has not been provided.  While `StackInstall` resources were prevented from using the `""` API group, `Stack` resources were not enforcing the same policy.

### How has this code been tested?

Unit tests cover the added logic and stack handler validation.

1. I took the yaml of an already installed Stack (stack-wordpress)
1. removed the status and creation metadata
1. then deleted the resource. 

With a crossplane image built from this branch and with the restricted command line arguments:
1.  I applied the stack-wordpress.yaml unmodified
1.  and waited for that Stack to be successful,
1.  and then repeated the process with bad values
1.  and waited for the Stack to fail reconciliation with the expected error

### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every Crossplane pull request.
-->
I have:
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Ensured this PR contains a neat, self documenting set of commits.
- [ ] Updated any relevant [documentation] and [examples].
- [x] Reported all new error conditions into the log or as an event, as
  appropriate.

For more about what we believe makes a pull request complete, see our
[definition of done].

[documentation]: https://github.com/crossplane/crossplane/tree/master/docs
[examples]: https://github.com/crossplane/crossplane/tree/master/cluster/examples
[definition of done]: https://github.com/crossplane/crossplane/tree/master/design/one-pager-definition-of-done.md
