### PR TITLE
Stacks: Truncate resource names and labels for host-aware environments

### DIFF
--- a/docs/troubleshoot.md
+++ b/docs/troubleshoot.md
@@ -11,6 +11,7 @@ indent: true
 * [Crossplane Logs](#crossplane-logs)
 * [Pausing Crossplane](#pausing-crossplane)
 * [Deleting a Resource Hangs](#deleting-a-resource-hangs)
+* [Host-Aware Resource Debugging](#host-aware-resource-debugging)
 
 ## Using the trace command
 
@@ -131,3 +132,16 @@ For example, for a Workload object (`workloads.compute.crossplane.io`) named
 ```console
 kubectl patch workloads.compute.crossplane.io test-workload -p '{"metadata":{"finalizers": []}}' --type=merge
 ```
+
+## Host-Aware Resource Debugging
+
+Stack resources (including the Stack, service accounts, deployments, and jobs) are usually easy to identify by name. These resource names are based on the name used in the StackInstall or Stack resource.
+
+In some cases, the full name of a Stack resource, which could be up to 253 characters long, can not be represented in the created resources. For example, jobs and deployment names may not exceed 63 characters because these names are turned into resource label values which impose a 63 character limit. Stack created resources whose names would otherwise not be permitted in the Kubernetes API will be truncated with a unique suffix.
+
+When running the Stack Manager in host-aware mode, tenant stack resources created in the host controller namespace generally reuse the Stack names: "{tenant namespace}.{tenant name}".  In order to avoid the name length restrictions, these resources may be truncated at either or both of the namespace segment or over the entire name.  In these cases resource labels, owner references, and annotations should be consulted to identify the responsible Stack.
+
+* [Relationship Labels](https://github.com/crossplane/crossplane/blob/master/design/one-pager-stack-relationship-labels.md)
+* [Owner References](https://kubernetes.io/docs/concepts/workloads/controllers/garbage-collection/#owners-and-dependents)
+* Annotations: `tenant.crossplane.io/{singular}-name` and `tenant.crossplane.io/{singular}-namespace` (_singular_ may be `stackinstall`, `clusterstackinstall` or `stack`)
+

--- a/docs/troubleshoot.md
+++ b/docs/troubleshoot.md
@@ -135,13 +135,78 @@ kubectl patch workloads.compute.crossplane.io test-workload -p '{"metadata":{"fi
 
 ## Host-Aware Resource Debugging
 
-Stack resources (including the Stack, service accounts, deployments, and jobs) are usually easy to identify by name. These resource names are based on the name used in the StackInstall or Stack resource.
+Stack resources (including the Stack, service accounts, deployments, and jobs)
+are usually easy to identify by name. These resource names are based on the name
+used in the StackInstall or Stack resource.
 
-In some cases, the full name of a Stack resource, which could be up to 253 characters long, can not be represented in the created resources. For example, jobs and deployment names may not exceed 63 characters because these names are turned into resource label values which impose a 63 character limit. Stack created resources whose names would otherwise not be permitted in the Kubernetes API will be truncated with a unique suffix.
+In some cases, the full name of a Stack resource, which could be up to 253
+characters long, can not be represented in the created resources. For example,
+jobs and deployment names may not exceed 63 characters because these names are
+turned into resource label values which impose a 63 character limit. Stack
+created resources whose names would otherwise not be permitted in the Kubernetes
+API will be truncated with a unique suffix.
 
-When running the Stack Manager in host-aware mode, tenant stack resources created in the host controller namespace generally reuse the Stack names: "{tenant namespace}.{tenant name}".  In order to avoid the name length restrictions, these resources may be truncated at either or both of the namespace segment or over the entire name.  In these cases resource labels, owner references, and annotations should be consulted to identify the responsible Stack.
+When running the Stack Manager in host-aware mode, tenant stack resources
+created in the host controller namespace generally reuse the Stack names:
+"{tenant namespace}.{tenant name}".  In order to avoid the name length
+restrictions, these resources may be truncated at either or both of the
+namespace segment or over the entire name.  In these cases resource labels,
+owner references, and annotations should be consulted to identify the
+responsible Stack.
 
 * [Relationship Labels](https://github.com/crossplane/crossplane/blob/master/design/one-pager-stack-relationship-labels.md)
 * [Owner References](https://kubernetes.io/docs/concepts/workloads/controllers/garbage-collection/#owners-and-dependents)
-* Annotations: `tenant.crossplane.io/{singular}-name` and `tenant.crossplane.io/{singular}-namespace` (_singular_ may be `stackinstall`, `clusterstackinstall` or `stack`)
+* Annotations: `tenant.crossplane.io/{singular}-name` and
+  `tenant.crossplane.io/{singular}-namespace` (_singular_ may be `stackinstall`,
+  `clusterstackinstall` or `stack`)
 
+### Example
+
+Long resource names may be present on the tenant.
+
+```console
+$ name=stack-with-a-really-long-resource-name-so-long-that-it-will-be-truncated
+$ ns=this-is-just-a-really-long-namespace-name-at-the-character-max
+$ kubectl create ns $ns
+$ kubectl crossplane stack install --namespace $ns crossplane/sample-stack-wordpress:0.1.1 $name
+```
+
+When used as host resource names, the stack namespace and stack are concatenated
+ to form host names, as well as labels.  These resource names and label values
+ must be truncated to fit the 63 character limit on label values.
+
+```console
+$ kubectl --context=crossplane-host -n tenant-controllers get job -o yaml
+apiVersion: v1
+items:
+- apiVersion: batch/v1
+  kind: Job
+  metadata:
+    annotations:
+      tenant.crossplane.io/stackinstall-name: stack-with-a-really-long-resource-name-so-long-that-it-will-be-truncated
+      tenant.crossplane.io/stackinstall-namespace: this-is-just-a-really-long-namespace-name-at-the-character-max
+    creationTimestamp: "2020-03-20T17:06:25Z"
+    labels:
+      core.crossplane.io/parent-group: stacks.crossplane.io
+      core.crossplane.io/parent-kind: StackInstall
+      core.crossplane.io/parent-name: stack-with-a-really-long-resource-name-so-long-that-it-wi-alqdw
+      core.crossplane.io/parent-namespace: this-is-just-a-really-long-namespace-name-at-the-character-max
+      core.crossplane.io/parent-uid: 596705e4-a28e-47c9-a907-d2732f07a85e
+      core.crossplane.io/parent-version: v1alpha1
+    name: this-is-just-a-really-long-namespace-name-at-the-characte-egoav
+    namespace: tenant-controllers
+  spec:
+    backoffLimit: 0
+    completions: 1
+    parallelism: 1
+    selector:
+      matchLabels:
+        controller-uid: 8f290bf2-8c91-494a-a76b-27c2ccb9e0a8
+    template:
+      metadata:
+        creationTimestamp: null
+        labels:
+          controller-uid: 8f290bf2-8c91-494a-a76b-27c2ccb9e0a8
+          job-name: this-is-just-a-really-long-namespace-name-at-the-characte-egoav
+  ...
+```

--- a/pkg/controller/stacks/hosted/config.go
+++ b/pkg/controller/stacks/hosted/config.go
@@ -27,13 +27,15 @@ import (
 )
 
 const (
-	// AnnotationTenantNameFmt with a resource singular applied provides the
+	// AnnotationTenantNameFmt with a CR `singular` name applied provides the
 	// annotation key used to identify tenant resources by name on the host side
+	// Example: tenant.crossplane.io/stackinstall-name
 	AnnotationTenantNameFmt = "tenant.crossplane.io/%s-name"
 
-	// AnnotationTenantNamespaceFmt with a resource singular applied provides
+	// AnnotationTenantNamespaceFmt with a CR `singular` name applied provides
 	// the annotation key used to identify tenant resources by namespace on the
 	// host side
+	// Example: tenant.crossplane.io/stack-namespace
 	AnnotationTenantNamespaceFmt = "tenant.crossplane.io/%s-namespace"
 
 	errMissingOption = "host aware mode activated but %s is not set"
@@ -70,11 +72,13 @@ func NewConfig(hostControllerNamespace, tenantAPIServiceHost, tenantAPIServicePo
 	}, nil
 }
 
-// ObjectReferenceOnHost maps object with given name and namespace into single
-// controller namespace on Host Cluster.
-// The resource name on the host cluster is truncated to label value length
-// because the name may be used in labels defined by an admission controller, as
-// is the case for jobs and deployments.
+// ObjectReferenceOnHost maps objects with a given name and namespace into a
+// single controller namespace on the Host Cluster.
+//
+// The resource name on the host cluster may be truncated from the original
+// tenant name to fit label value length.  The resource name may be used as a
+// label, as is the case for jobs and deployments where the admission controller
+// generates labels based on the resource name.
 func (c *Config) ObjectReferenceOnHost(name, namespace string) corev1.ObjectReference {
 	return corev1.ObjectReference{
 		Name:      truncate.LabelValue(fmt.Sprintf("%s.%s", namespace, name)),
@@ -83,7 +87,13 @@ func (c *Config) ObjectReferenceOnHost(name, namespace string) corev1.ObjectRefe
 }
 
 // ObjectReferenceAnnotationsOnHost returns a map for use as annotations on the
-// host to identify the named tenant resource
+// host to identify the named tenant resource. This annotation is used for
+// reference purposes to define a relationship to a single resource of a
+// specific kind. For example, this could be used to declare the tenant
+// stackinstall resource that is related to a host install job.
+//
+// On a host the original tenant resource name may be truncated away.
+// Annotations provide a way to store the original name without truncation.
 func ObjectReferenceAnnotationsOnHost(singular, name, namespace string) map[string]string {
 	nameLabel := fmt.Sprintf(AnnotationTenantNameFmt, singular)
 	nsLabel := fmt.Sprintf(AnnotationTenantNamespaceFmt, singular)

--- a/pkg/controller/stacks/install/installjob.go
+++ b/pkg/controller/stacks/install/installjob.go
@@ -70,15 +70,17 @@ type prepareInstallJobParams struct {
 	stackManagerPullPolicy corev1.PullPolicy
 	imagePullPolicy        corev1.PullPolicy
 	labels                 map[string]string
+	annotations            map[string]string
 	imagePullSecrets       []corev1.LocalObjectReference
 }
 
 func prepareInstallJob(p prepareInstallJobParams) *batchv1.Job {
 	return &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      p.name,
-			Namespace: p.namespace,
-			Labels:    p.labels,
+			Name:        p.name,
+			Namespace:   p.namespace,
+			Labels:      p.labels,
+			Annotations: p.annotations,
 		},
 		Spec: batchv1.JobSpec{
 			BackoffLimit: &jobBackoff,

--- a/pkg/controller/stacks/install/stackinstall.go
+++ b/pkg/controller/stacks/install/stackinstall.go
@@ -346,7 +346,11 @@ func (h *stackInstallHandler) createInstallJob() *batchv1.Job {
 	namespace := i.GetNamespace()
 
 	if hCfg != nil {
-		annotations = hosted.ObjectReferenceAnnotationsOnHost("stackinstall", name, namespace)
+		singular := "stackinstall"
+		if i.PermissionScope() == string(apiextensionsv1beta1.ClusterScoped) {
+			singular = "clusterstackinstall"
+		}
+		annotations = hosted.ObjectReferenceAnnotationsOnHost(singular, name, namespace)
 
 		// In Hosted Mode, we need to map all install jobs on tenant Kubernetes into a single namespace on host cluster.
 		o := hCfg.ObjectReferenceOnHost(name, namespace)

--- a/pkg/controller/stacks/install/stackinstall.go
+++ b/pkg/controller/stacks/install/stackinstall.go
@@ -336,6 +336,8 @@ func (h *stackInstallHandler) create(ctx context.Context) (reconcile.Result, err
 }
 
 func (h *stackInstallHandler) createInstallJob() *batchv1.Job {
+	var annotations map[string]string
+
 	i := h.ext
 	executorInfo := h.executorInfo
 	hCfg := h.hostAwareConfig
@@ -344,6 +346,8 @@ func (h *stackInstallHandler) createInstallJob() *batchv1.Job {
 	namespace := i.GetNamespace()
 
 	if hCfg != nil {
+		annotations = hosted.ObjectReferenceAnnotationsOnHost("stackinstall", name, namespace)
+
 		// In Hosted Mode, we need to map all install jobs on tenant Kubernetes into a single namespace on host cluster.
 		o := hCfg.ObjectReferenceOnHost(name, namespace)
 		name = o.Name
@@ -368,6 +372,7 @@ func (h *stackInstallHandler) createInstallJob() *batchv1.Job {
 		stackManagerPullPolicy: executorInfo.ImagePullPolicy,
 		imagePullPolicy:        i.GetImagePullPolicy(),
 		labels:                 stacks.ParentLabels(i),
+		annotations:            annotations,
 		imagePullSecrets:       i.GetImagePullSecrets()})
 }
 

--- a/pkg/controller/stacks/install/stackinstall_test.go
+++ b/pkg/controller/stacks/install/stackinstall_test.go
@@ -790,7 +790,7 @@ func Test_stackInstallHandler_deleteOrphanedCRDs(t *testing.T) {
 	var (
 		nsLabel = fmt.Sprintf(stacks.LabelNamespaceFmt, namespace)
 
-		// MultiParentLabels refer to a stack name. while resource() is a
+		// MultiParentLabels refer to a stack name. While resource() is a
 		// stackinstall, it is an object that has a name that matches the stack
 		label = stacks.MultiParentLabel(resource())
 	)

--- a/pkg/controller/stacks/install/stackinstall_test.go
+++ b/pkg/controller/stacks/install/stackinstall_test.go
@@ -788,8 +788,11 @@ func Test_stackInstallHandler_deleteOrphanedCRDs(t *testing.T) {
 	)
 
 	var (
-		label   = fmt.Sprintf(stacks.LabelMultiParentFormat, namespace, resourceName)
 		nsLabel = fmt.Sprintf(stacks.LabelNamespaceFmt, namespace)
+
+		// MultiParentLabels refer to a stack name. while resource() is a
+		// stackinstall, it is an object that has a name that matches the stack
+		label = stacks.MultiParentLabel(resource())
 	)
 	tests := []struct {
 		name     string

--- a/pkg/controller/stacks/stack/stack.go
+++ b/pkg/controller/stacks/stack/stack.go
@@ -724,7 +724,8 @@ func (h *stackHandler) prepareDeployment(d *apps.Deployment) {
 
 	// force the deployment to use stack opinionated names and service account
 	suffix := "-controller"
-	name, _ := truncate.Truncate(h.ext.Name, truncate.LabelValueLength-len(suffix), truncate.DefaultSuffixLength)
+	size := truncate.LabelValueLength - len(suffix)
+	name, _ := truncate.Truncate(h.ext.Name, size, truncate.DefaultSuffixLength)
 	name += suffix
 	matchLabels := map[string]string{"app": name}
 	labels := stacks.ParentLabels(h.ext)

--- a/pkg/controller/stacks/stack/stack.go
+++ b/pkg/controller/stacks/stack/stack.go
@@ -713,24 +713,6 @@ func (h *stackHandler) prepareHostAwareDeployment(d *apps.Deployment, tokenSecre
 
 	return nil
 }
-func (h *stackHandler) prepareHostAwareJob(j *batch.Job, tokenSecret string) error {
-	if h.hostAwareConfig == nil {
-		return errors.New(errHostAwareModeNotEnabled)
-	}
-
-	if err := h.prepareHostAwarePodSpec(tokenSecret, &j.Spec.Template.Spec); err != nil {
-		return err
-	}
-
-	o := h.hostAwareConfig.ObjectReferenceOnHost(j.Name, j.Namespace)
-	j.Name = o.Name
-	j.Namespace = o.Namespace
-
-	a := hosted.ObjectReferenceAnnotationsOnHost("stack", h.ext.GetName(), h.ext.GetNamespace())
-	meta.AddAnnotations(j, a)
-
-	return nil
-}
 
 func (h *stackHandler) prepareDeployment(d *apps.Deployment) {
 	controllerDeployment := h.ext.Spec.Controller.Deployment

--- a/pkg/controller/stacks/stack/stack_test.go
+++ b/pkg/controller/stacks/stack/stack_test.go
@@ -1270,9 +1270,10 @@ func TestProcessDeployment(t *testing.T) {
 				err: nil,
 				d: &apps.Deployment{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      fmt.Sprintf("%s.%s", namespace, controllerDeploymentName),
-						Namespace: hostControllerNamespace,
-						Labels:    stackspkg.ParentLabels(resource(withControllerSpec(defaultControllerSpec()))),
+						Name:        fmt.Sprintf("%s.%s", namespace, controllerDeploymentName),
+						Namespace:   hostControllerNamespace,
+						Labels:      stackspkg.ParentLabels(resource(withControllerSpec(defaultControllerSpec()))),
+						Annotations: hosted.ObjectReferenceAnnotationsOnHost("stack", resourceName, namespace),
 					},
 					Spec: apps.DeploymentSpec{
 						Selector: &metav1.LabelSelector{
@@ -2213,7 +2214,7 @@ func Test_stackHandler_createMultipleParentLabelsCRDHandler(t *testing.T) {
 	)
 
 	var (
-		label = fmt.Sprintf(stackspkg.LabelMultiParentFormat, namespace, resourceName)
+		label = stackspkg.MultiParentLabel(resource())
 	)
 	tests := []struct {
 		name    string
@@ -2508,7 +2509,7 @@ func Test_stackHandler_removeCRDLabels(t *testing.T) {
 	)
 
 	var (
-		label = fmt.Sprintf(stackspkg.LabelMultiParentFormat, namespace, resourceName)
+		label = stackspkg.MultiParentLabel(resource())
 	)
 
 	tests := []struct {

--- a/pkg/controller/stacks/stack/stack_test.go
+++ b/pkg/controller/stacks/stack/stack_test.go
@@ -63,6 +63,7 @@ const (
 	controllerDeploymentName = "cool-stack-controller"
 	controllerContainerName  = "cool-container"
 	controllerImageName      = "cool/controller-image:rad"
+	dashAlphabet             = "-abcdefghijklmnopqrstuvwxyz"
 )
 
 var (
@@ -111,6 +112,13 @@ func withConditions(c ...runtimev1alpha1.Condition) resourceModifier {
 	return func(r *v1alpha1.Stack) { r.Status.SetConditions(c...) }
 }
 
+func withNamespacedName(nsn types.NamespacedName) resourceModifier {
+	return func(r *v1alpha1.Stack) {
+		r.SetNamespace(nsn.Namespace)
+		r.SetName(nsn.Name)
+	}
+}
+
 func withControllerSpec(cs v1alpha1.ControllerSpec) resourceModifier {
 	return func(r *v1alpha1.Stack) { r.Spec.Controller = cs }
 }
@@ -127,6 +135,13 @@ type saModifier func(*corev1.ServiceAccount)
 
 func withTokenSecret(ref corev1.ObjectReference) saModifier {
 	return func(sa *corev1.ServiceAccount) { sa.Secrets = append(sa.Secrets, ref) }
+}
+
+func withSANamespacedName(nsn types.NamespacedName) saModifier {
+	return func(s *corev1.ServiceAccount) {
+		s.SetNamespace(nsn.Namespace)
+		s.SetName(nsn.Name)
+	}
 }
 
 func withDeploymentPullSecrets(secrets ...string) deploymentSpecModifier {
@@ -163,7 +178,8 @@ func sa(sm ...saModifier) *corev1.ServiceAccount {
 	}
 	return s
 }
-func saSecret() *corev1.Secret {
+
+func saSecret(resourceName, namespace string) *corev1.Secret {
 	return &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      resourceName,
@@ -933,7 +949,7 @@ func TestSyncSATokenSecret(t *testing.T) {
 		},
 		{
 			name:           "TokenSecretNotGenerated",
-			initObjs:       []runtime.Object{sa(), saSecret()},
+			initObjs:       []runtime.Object{sa(), saSecret(resourceName, namespace)},
 			clientFunc:     fake.NewFakeClient,
 			hostClientFunc: func() client.Client { return fake.NewFakeClient() },
 			want: want{
@@ -952,7 +968,7 @@ func TestSyncSATokenSecret(t *testing.T) {
 		},
 		{
 			name:       "FailedToCreateSecret",
-			initObjs:   []runtime.Object{sa(withTokenSecret(corev1.ObjectReference{Name: resourceName, Namespace: namespace})), saSecret()},
+			initObjs:   []runtime.Object{sa(withTokenSecret(corev1.ObjectReference{Name: resourceName, Namespace: namespace})), saSecret(resourceName, namespace)},
 			clientFunc: fake.NewFakeClient,
 			hostClientFunc: func() client.Client {
 				return &test.MockClient{
@@ -971,7 +987,7 @@ func TestSyncSATokenSecret(t *testing.T) {
 		},
 		{
 			name:       "Success",
-			initObjs:   []runtime.Object{sa(withTokenSecret(corev1.ObjectReference{Name: resourceName, Namespace: namespace})), saSecret()},
+			initObjs:   []runtime.Object{sa(withTokenSecret(corev1.ObjectReference{Name: resourceName, Namespace: namespace})), saSecret(resourceName, namespace)},
 			clientFunc: fake.NewFakeClient,
 			hostClientFunc: func() client.Client {
 				return fake.NewFakeClient()
@@ -1150,7 +1166,7 @@ func TestProcessDeployment(t *testing.T) {
 		{
 			name:       "HostedError_SyncSATokenFailedToCreateSecret",
 			r:          resource(withControllerSpec(defaultControllerSpec())),
-			initObjs:   []runtime.Object{sa(withTokenSecret(corev1.ObjectReference{Name: resourceName, Namespace: namespace})), saSecret()},
+			initObjs:   []runtime.Object{sa(withTokenSecret(corev1.ObjectReference{Name: resourceName, Namespace: namespace})), saSecret(resourceName, namespace)},
 			clientFunc: fake.NewFakeClient,
 			hostClientFunc: func() client.Client {
 				return &test.MockClient{
@@ -1260,7 +1276,7 @@ func TestProcessDeployment(t *testing.T) {
 		{
 			name:           "SuccessHosted",
 			r:              resource(withControllerSpec(defaultControllerSpec())),
-			initObjs:       []runtime.Object{sa(withTokenSecret(corev1.ObjectReference{Name: resourceName, Namespace: namespace})), saSecret()},
+			initObjs:       []runtime.Object{sa(withTokenSecret(corev1.ObjectReference{Name: resourceName, Namespace: namespace})), saSecret(resourceName, namespace)},
 			clientFunc:     fake.NewFakeClient,
 			hostClientFunc: func() client.Client { return fake.NewFakeClient() },
 			hostawareCfg: &hosted.Config{
@@ -1334,6 +1350,107 @@ func TestProcessDeployment(t *testing.T) {
 				},
 				controllerRef: &corev1.ObjectReference{
 					Name:       fmt.Sprintf("%s.%s", namespace, controllerDeploymentName),
+					Namespace:  hostControllerNamespace,
+					Kind:       "Deployment",
+					APIVersion: "apps/v1",
+				},
+			},
+		},
+		{
+			name: "SuccessHostedTruncated",
+			r: resource(
+				withNamespacedName(types.NamespacedName{
+					Name:      resourceName + dashAlphabet,
+					Namespace: namespace + dashAlphabet,
+				}),
+				withControllerSpec(defaultControllerSpec())),
+			initObjs: []runtime.Object{sa(
+				withSANamespacedName(types.NamespacedName{
+					Name:      resourceName + dashAlphabet,
+					Namespace: namespace + dashAlphabet,
+				}),
+				withTokenSecret(corev1.ObjectReference{
+					Name:      resourceName + dashAlphabet,
+					Namespace: namespace + dashAlphabet,
+				})), saSecret(resourceName+dashAlphabet, namespace+dashAlphabet)},
+			clientFunc:     fake.NewFakeClient,
+			hostClientFunc: func() client.Client { return fake.NewFakeClient() },
+			hostawareCfg: &hosted.Config{
+				HostControllerNamespace: hostControllerNamespace,
+			},
+			want: want{
+				err: nil,
+				d: &apps.Deployment{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "cool-namespace-abcdefghijklmnopqrstuvwxyz.cool-stack-abcd-u7d2t",
+						Namespace: hostControllerNamespace,
+						Labels: stackspkg.ParentLabels(resource(
+							withNamespacedName(types.NamespacedName{
+								Name:      resourceName + dashAlphabet,
+								Namespace: namespace + dashAlphabet,
+							}),
+							withControllerSpec(defaultControllerSpec()))),
+						Annotations: hosted.ObjectReferenceAnnotationsOnHost("stack", resourceName+dashAlphabet, namespace+dashAlphabet),
+					},
+					Spec: apps.DeploymentSpec{
+						Selector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{
+								"app": resourceName + dashAlphabet + "-controller",
+							},
+						},
+						Template: corev1.PodTemplateSpec{
+							ObjectMeta: metav1.ObjectMeta{
+								Labels: map[string]string{
+									"app": resourceName + dashAlphabet + "-controller",
+								},
+								Name: resourceName + dashAlphabet + "-controller",
+							},
+							Spec: corev1.PodSpec{
+								ServiceAccountName:           "",
+								AutomountServiceAccountToken: &disableAutoMount,
+								Containers: []corev1.Container{
+									{
+										Name:  controllerContainerName,
+										Image: controllerImageName,
+										Env: []corev1.EnvVar{
+											{
+												Name:  envK8SServiceHost,
+												Value: "",
+											},
+											{
+												Name:  envK8SServicePort,
+												Value: "",
+											},
+											{
+												Name:  envPodNamespace,
+												Value: namespace + dashAlphabet,
+											},
+										},
+										VolumeMounts: []corev1.VolumeMount{
+											{
+												Name:      saVolumeName,
+												ReadOnly:  true,
+												MountPath: saMountPath,
+											},
+										},
+									},
+								},
+								Volumes: []corev1.Volume{
+									{
+										Name: saVolumeName,
+										VolumeSource: corev1.VolumeSource{
+											Secret: &corev1.SecretVolumeSource{
+												SecretName: "cool-namespace-abcdefghijklmnopqrstuvwxyz.cool-stack-abcd-7u42t",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				controllerRef: &corev1.ObjectReference{
+					Name:       "cool-namespace-abcdefghijklmnopqrstuvwxyz.cool-stack-abcd-u7d2t",
 					Namespace:  hostControllerNamespace,
 					Kind:       "Deployment",
 					APIVersion: "apps/v1",
@@ -1564,52 +1681,6 @@ func TestStackDelete(t *testing.T) {
 
 			if diff := cmp.Diff(tt.want.si, tt.handler.ext, test.EquateConditions()); diff != "" {
 				t.Errorf("delete() -want stackInstall, +got stackInstall:\n%v", diff)
-			}
-		})
-	}
-}
-
-func Test_stackHandler_prepareHostAwareJob(t *testing.T) {
-	type fields struct {
-		kube            client.Client
-		hostKube        client.Client
-		hostAwareConfig *hosted.Config
-		ext             *v1alpha1.Stack
-	}
-	type args struct {
-		tokenSecret string
-		j           *batch.Job
-	}
-	type want struct {
-		err error
-	}
-	cases := map[string]struct {
-		fields
-		args
-		want
-	}{
-		"hostAwareNotEnabled": {
-			fields: fields{},
-			args: args{
-				tokenSecret: resourceName,
-				j:           nil,
-			},
-			want: want{
-				err: errors.New(errHostAwareModeNotEnabled),
-			},
-		},
-	}
-	for name, tc := range cases {
-		t.Run(name, func(t *testing.T) {
-			h := &stackHandler{
-				kube:            tc.fields.kube,
-				hostKube:        tc.fields.hostKube,
-				hostAwareConfig: tc.fields.hostAwareConfig,
-				ext:             tc.fields.ext,
-			}
-			gotErr := h.prepareHostAwareJob(tc.args.j, tc.args.tokenSecret)
-			if diff := cmp.Diff(tc.want.err, gotErr, test.EquateErrors()); diff != "" {
-				t.Fatalf("prepareHostAwareDeployment(...): -want error, +got error: %s", diff)
 			}
 		})
 	}

--- a/pkg/stacks/relationship_test.go
+++ b/pkg/stacks/relationship_test.go
@@ -1,0 +1,310 @@
+/*
+Copyright 2019 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package stacks
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+var (
+	namespace             = "cool-namespace"
+	uidString             = "definitely-a-uuid"
+	resourceName          = "cool-resource"
+	thirtyTwoAs           = strings.Repeat("a", 32)
+	sixtyOneAs            = strings.Repeat("a", 61)
+	sixtyThreeAs          = strings.Repeat("a", 63)
+	truncatedAsAndZ       = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-ukl4i"
+	truncatedSixtyThreeAs = "aaaaaaaaaaaaaaaaaaaaaaaaaa-apyj6"
+)
+
+func resource(namespace, resourceName, uidString string) *corev1.Secret {
+	uid := types.UID(uidString)
+
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      resourceName,
+			UID:       uid,
+		},
+	}
+}
+func TestParentLabels(t *testing.T) {
+	tests := []struct {
+		name string
+		i    KindlyIdentifier
+		want map[string]string
+	}{
+		{
+			name: "Success",
+			i:    resource(namespace, resourceName, uidString),
+			want: map[string]string{
+				LabelParentNamespace: namespace,
+				LabelParentName:      resourceName,
+				LabelParentUID:       uidString,
+				LabelParentGroup:     "",
+				LabelParentKind:      "",
+				LabelParentVersion:   "",
+			},
+		},
+		{
+			name: "Max",
+			i:    resource(sixtyThreeAs, sixtyThreeAs, uidString),
+			want: map[string]string{
+				LabelParentNamespace: sixtyThreeAs,
+				LabelParentName:      sixtyThreeAs,
+				LabelParentUID:       uidString,
+				LabelParentGroup:     "",
+				LabelParentKind:      "",
+				LabelParentVersion:   "",
+			},
+		},
+		{
+			name: "Truncated",
+			i:    resource(sixtyThreeAs+"z", sixtyThreeAs+"z", uidString),
+			want: map[string]string{
+				LabelParentNamespace: truncatedAsAndZ,
+				LabelParentName:      truncatedAsAndZ,
+				LabelParentUID:       uidString,
+				LabelParentGroup:     "",
+				LabelParentKind:      "",
+				LabelParentVersion:   "",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ParentLabels(tt.i)
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Errorf("ParentLabels() -want, +got:\n%v", diff)
+			}
+		})
+	}
+}
+
+func TestMultiParentLabel(t *testing.T) {
+
+	tests := []struct {
+		name        string
+		stackParent metav1.Object
+		want        string
+	}{
+		{
+			name:        "Simple",
+			stackParent: resource(namespace, resourceName, uidString),
+			want:        "parent.stacks.crossplane.io/cool-namespace-cool-resource",
+		},
+		{
+			name:        "NotTruncatedNS",
+			stackParent: resource(thirtyTwoAs, "z", uidString),
+			want:        "parent.stacks.crossplane.io/" + thirtyTwoAs + "-z",
+		},
+		{
+			name:        "TruncatedNS",
+			stackParent: resource(sixtyThreeAs+"z", resourceName, uidString),
+			// notice ukl4i is also the suffix with 64 a's because the sum is
+			// generated from the whole string. In the NS prefix only 27
+			// characters from the original are preserved.
+			want: "parent.stacks.crossplane.io/aaaaaaaaaaaaaaaaaaaaaaaaaa-ukl4i-" + resourceName,
+		},
+		{
+			name:        "NotTruncatedOnNameLength",
+			stackParent: resource("n", sixtyOneAs, uidString),
+			want:        "parent.stacks.crossplane.io/n-" + sixtyOneAs,
+		},
+		{
+			name:        "TruncatedOnNameLength",
+			stackParent: resource("n", sixtyThreeAs, uidString),
+			want:        "parent.stacks.crossplane.io/n-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-k5upc",
+		},
+		{
+			name:        "TruncatedOnNameNotNS",
+			stackParent: resource(thirtyTwoAs, sixtyThreeAs, uidString),
+			want:        "parent.stacks.crossplane.io/" + thirtyTwoAs + "-aaaaaaaaaaaaaaaaaaaaaaaa-ga5cb",
+		},
+		{
+			name:        "DoubleTruncated",
+			stackParent: resource(sixtyThreeAs, sixtyThreeAs, uidString),
+			want:        "parent.stacks.crossplane.io/" + truncatedSixtyThreeAs + "-aaaaaaaaaaaaaaaaaaaaaaaa-4qqns",
+		},
+		{
+			name:        "DoubleTruncatedDifferentNameSameNSPrefix",
+			stackParent: resource(sixtyThreeAs, sixtyThreeAs+"z", uidString),
+			want:        "parent.stacks.crossplane.io/" + truncatedSixtyThreeAs + "-aaaaaaaaaaaaaaaaaaaaaaaa-7fywo",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := MultiParentLabel(tt.stackParent)
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Errorf("MultiParentLabel() -want, +got:\n%v", diff)
+			}
+		})
+	}
+}
+
+func TestHasPrefixedLabel(t *testing.T) {
+	type args struct {
+		obj      metav1.Object
+		prefixes []string
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "NotFound",
+			args: args{
+				obj: func() metav1.Object {
+					r := resource("a", "b", "c")
+					r.SetLabels(map[string]string{"not/close": "foo"})
+					return r
+				}(),
+				prefixes: []string{"test/prefix"},
+			},
+			want: false,
+		},
+
+		{
+			name: "WholePrefix",
+			args: args{
+				obj: func() metav1.Object {
+					r := resource("a", "b", "c")
+					r.SetLabels(map[string]string{"test/prefix": "foo"})
+					return r
+				}(),
+				prefixes: []string{"test/prefix"},
+			},
+			want: true,
+		},
+		{
+			name: "PartialPrefixIgnored",
+			args: args{
+				obj: func() metav1.Object {
+					r := resource("a", "b", "c")
+					r.SetLabels(map[string]string{"test/pre": "foo"})
+					return r
+				}(),
+				prefixes: []string{"test/prefix"},
+			},
+			want: false,
+		},
+		{
+			name: "PrefixFoundWithExtra",
+			args: args{
+				obj: func() metav1.Object {
+					r := resource("a", "b", "c")
+					r.SetLabels(map[string]string{"test/prefix-extra": "foo"})
+					return r
+				}(),
+				prefixes: []string{"test/prefix"},
+			},
+			want: true,
+		},
+		{
+			name: "FoundWithOtherLabels",
+			args: args{
+				obj: func() metav1.Object {
+					r := resource("a", "b", "c")
+					r.SetLabels(map[string]string{
+						"test/prefix": "foo",
+						"test/other":  "bar",
+					})
+					return r
+				}(),
+				prefixes: []string{"test/prefix"},
+			},
+			want: true,
+		},
+		{
+			name: "FoundAllPrefixes",
+			args: args{
+				obj: func() metav1.Object {
+					r := resource("a", "b", "c")
+					r.SetLabels(map[string]string{
+						"test/prefix": "foo",
+						"test/other":  "bar",
+					})
+					return r
+				}(),
+				prefixes: []string{"test/prefix", "test/other"},
+			},
+			want: true,
+		},
+		{
+			name: "FoundSomePrefixes",
+			args: args{
+				obj: func() metav1.Object {
+					r := resource("a", "b", "c")
+					r.SetLabels(map[string]string{"test/prefix": "foo"})
+					return r
+				}(),
+				prefixes: []string{"test/prefix", "test/other"},
+			},
+			want: true,
+		},
+		{
+			name: "NotAnyPrefixesFound",
+			args: args{
+				obj: func() metav1.Object {
+					r := resource("a", "b", "c")
+					r.SetLabels(map[string]string{
+						"test/prefix": "foo",
+						"test/other":  "bar",
+					})
+					return r
+				}(),
+				prefixes: []string{"test/foo", "test/bar"},
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := HasPrefixedLabel(tt.args.obj, tt.args.prefixes...)
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Errorf("HasPrefixedLabel() -want, +got:\n%v", diff)
+			}
+		})
+	}
+}
+
+func TestMultiParentLabelPrefix(t *testing.T) {
+	type args struct {
+		stackParent metav1.Object
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		// TODO: Add test cases.
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := MultiParentLabelPrefix(tt.args.stackParent); got != tt.want {
+				t.Errorf("MultiParentLabelPrefix() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/stacks/relationship_test.go
+++ b/pkg/stacks/relationship_test.go
@@ -121,10 +121,7 @@ func TestMultiParentLabel(t *testing.T) {
 		{
 			name:        "TruncatedNS",
 			stackParent: resource(sixtyThreeAs+"z", resourceName, uidString),
-			// notice ukl4i is also the suffix with 64 a's because the sum is
-			// generated from the whole string. In the NS prefix only 27
-			// characters from the original are preserved.
-			want: "parent.stacks.crossplane.io/aaaaaaaaaaaaaaaaaaaaaaaaaa-ukl4i-" + resourceName,
+			want:        "parent.stacks.crossplane.io/aaaaaaaaaaaaaaaaaaaaaaaaaa-ukl4i-" + resourceName,
 		},
 		{
 			name:        "NotTruncatedOnNameLength",

--- a/pkg/stacks/truncate/truncate.go
+++ b/pkg/stacks/truncate/truncate.go
@@ -23,7 +23,7 @@ import (
 	// sha1 is not cryptographically secure, but that is not a goal. we require
 	// predictable and uniform text transformation. Any checksum function with
 	// even distribution would suffice.
-	"crypto/sha1" // nolint:blacklist
+	"crypto/sha1" // nolint:gosec
 	"encoding/base32"
 	"fmt"
 	"strings"
@@ -51,9 +51,19 @@ const (
 // Truncate replaces the suffixLength number of trailing characters from str
 // with a consistent hash fragment based on that string. The suffix will include
 // a leading hyphen.
+//
 // An error will be returned if the truncation length is less than the
 // suffixLength, or truncation length is greater than sha1Length, or the suffix
 // length is less than 2.
+//
+// Example:
+// If the base32 sum of a digest of "aaaaaaaaaaa" is "ovo", with a suffix length of 4:
+//
+// Truncating this string to a length of 11 would result in "aaaaaaaaaaa"
+// Truncating this string to a length of 8 would result in "aaaa-ovo"
+// Truncating this string to a length of 7 would result in "aaa-ovo"
+// Truncating this string to a length of 5 would result in "a-ovo"
+// Truncating this string to a length of 4 would result in "-ovo"
 func Truncate(str string, length, suffixLength int) (string, error) {
 	if len(str) <= length {
 		return str, nil

--- a/pkg/stacks/truncate/truncate.go
+++ b/pkg/stacks/truncate/truncate.go
@@ -20,6 +20,9 @@ limitations under the License.
 package truncate
 
 import (
+	// sha1 is not cryptographically secure, but that is not a goal. we require
+	// predictable and uniform text transformation. Any checksum function with
+	// even distribution would suffice.
 	"crypto/sha1" // nolint:blacklist
 	"encoding/base32"
 	"fmt"
@@ -68,9 +71,7 @@ func Truncate(str string, length, suffixLength int) (string, error) {
 		return "", fmt.Errorf("truncate suffixLength is less than minimum: %d < 2", suffixLength)
 	}
 
-	// sha1 is not cryptographically secure, but that is not a goal.
-	// we require predictable and uniform text transformation. Any checksum
-	// function with even distribution would suffice.
+	// See the import comment regarding use of sha1
 	// nolint:gosec
 	checksum := sha1.Sum([]byte(str))
 	retained := length - suffixLength

--- a/pkg/stacks/truncate/truncate.go
+++ b/pkg/stacks/truncate/truncate.go
@@ -1,0 +1,105 @@
+/*
+Copyright 2020 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package truncate provides functions for truncating Kubernetes values in a
+// predictable way offering mildly collision safe values usable in
+// deterministic field searches.
+package truncate
+
+import (
+	"crypto/sha1" // nolint:blacklist
+	"encoding/base32"
+	"fmt"
+	"strings"
+)
+
+const (
+	// LabelNameLength is the max length of a name fragment in a label
+	LabelNameLength = 63
+
+	// LabelValueLength is the max length of a label value
+	LabelValueLength = 63
+
+	// ResourceNameLength is the max length of a resource name or a label with
+	// optional prefix and name
+	ResourceNameLength = 253
+
+	// DefaultSuffixLength is the length of combined separator and checksum
+	// characters that will be used as a truncation suffix in Label and Resource
+	// truncation functions
+	DefaultSuffixLength = 6
+
+	sha1Length = 40
+)
+
+// Truncate replaces the suffixLength number of trailing characters from str
+// with a consistent hash fragment based on that string. The suffix will include
+// a leading hyphen.
+// An error will be returned if the truncation length is less than the
+// suffixLength, or truncation length is greater than sha1Length, or the suffix
+// length is less than 2.
+func Truncate(str string, length, suffixLength int) (string, error) {
+	if len(str) <= length {
+		return str, nil
+	}
+
+	if length < suffixLength {
+		return "", fmt.Errorf("truncate length is less than suffixLength: %d < %d", length, suffixLength)
+	}
+
+	if suffixLength > sha1Length {
+		return "", fmt.Errorf("truncate suffixLength exceeds max length: %d > %d", suffixLength, sha1Length)
+	}
+
+	if suffixLength < 2 {
+		return "", fmt.Errorf("truncate suffixLength is less than minimum: %d < 2", suffixLength)
+	}
+
+	// sha1 is not cryptographically secure, but that is not a goal.
+	// we require predictable and uniform text transformation. Any checksum
+	// function with even distribution would suffice.
+	// nolint:gosec
+	checksum := sha1.Sum([]byte(str))
+	retained := length - suffixLength
+
+	// base64 includes "/" which can only occur once in label names
+	b32 := base32.StdEncoding.WithPadding(base32.NoPadding).EncodeToString(checksum[:])
+	separator := "-"
+	suffix := strings.ToLower(b32[0 : suffixLength-len(separator)])
+
+	return fmt.Sprintf("%s%s%s", str[0:retained], separator, suffix), nil
+}
+
+// LabelName predictably truncates the supplied string using label name
+// length restrictions and a uniform distribution suffix based on the string
+func LabelName(str string) string {
+	s, _ := Truncate(str, LabelNameLength, DefaultSuffixLength)
+	return s
+}
+
+// LabelValue predictably truncates the supplied string using label value
+// length restrictions and a uniform distribution suffix based on the string
+func LabelValue(str string) string {
+	s, _ := Truncate(str, LabelValueLength, DefaultSuffixLength)
+	return s
+}
+
+// ResourceName predictably truncates the supplied string using resource name
+// length restrictions and a uniform distribution suffix based on the string
+func ResourceName(str string) string {
+	s, _ := Truncate(str, ResourceNameLength, DefaultSuffixLength)
+	return s
+}

--- a/pkg/stacks/truncate/truncate_test.go
+++ b/pkg/stacks/truncate/truncate_test.go
@@ -1,0 +1,200 @@
+/*
+Copyright 2020 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package truncate provides functions for truncating Kubernetes values in a
+// predictable way offering safe values usable in deterministic field searches.
+package truncate
+
+import (
+	"strings"
+	"testing"
+)
+
+var (
+	str63  = strings.Repeat("1234567890", 6) + "123"
+	str253 = strings.Repeat("1234567890", 25) + "123"
+)
+
+func Test_truncate(t *testing.T) {
+	type args struct {
+		str          string
+		length       int
+		suffixLength int
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    string
+		wantErr bool
+	}{
+		{
+			name:    "StrTooShort",
+			args:    args{str: "a", length: 0, suffixLength: 0},
+			want:    "",
+			wantErr: true,
+		},
+		{
+			name:    "SuffixExceedsStr",
+			args:    args{str: "a", length: 0, suffixLength: 2},
+			want:    "",
+			wantErr: true,
+		},
+		{
+			name:    "SuffixExceedsSum",
+			args:    args{str: strings.Repeat("12345678890", 21), length: 200, suffixLength: 100},
+			want:    "",
+			wantErr: true,
+		},
+		{
+			name:    "SuffixTooShort",
+			args:    args{str: "12345678901", length: 10, suffixLength: 1},
+			want:    "",
+			wantErr: true,
+		},
+		{
+			name:    "StrNotTruncated",
+			args:    args{str: "1234567890", length: 10, suffixLength: 1},
+			want:    "1234567890",
+			wantErr: false,
+		},
+		{
+			name:    "StrTruncated",
+			args:    args{str: "12345678901", length: 10, suffixLength: 5},
+			want:    "12345-ezw4",
+			wantErr: false,
+		},
+		{
+			name:    "AllTruncated",
+			args:    args{str: "1234567890", length: 5, suffixLength: 5},
+			want:    "-agzq",
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := Truncate(tt.args.str, tt.args.length, tt.args.suffixLength)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("truncate() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("truncate() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestLabelName(t *testing.T) {
+	type args struct {
+		str string
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "short",
+			args: args{str: "foo"},
+			want: "foo",
+		},
+		{
+			name: "max",
+			args: args{str: str63},
+			want: str63,
+		},
+		{
+			name: "truncate",
+			args: args{str: str253},
+			want: strings.Repeat("1234567890", 5) + "1234567-ij43w",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := LabelName(tt.args.str); got != tt.want {
+				t.Errorf("LabelName() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestLabelValue(t *testing.T) {
+	type args struct {
+		str string
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "short",
+			args: args{str: "foo"},
+			want: "foo",
+		},
+		{
+			name: "max",
+			args: args{str: str63},
+			want: str63,
+		},
+		{
+			name: "truncate",
+			args: args{str: str253},
+			want: strings.Repeat("1234567890", 5) + "1234567-ij43w",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := LabelValue(tt.args.str); got != tt.want {
+				t.Errorf("LabelValue() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestResourceName(t *testing.T) {
+	type args struct {
+		str string
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "short",
+			args: args{str: "foo"},
+			want: "foo",
+		},
+		{
+			name: "max",
+			args: args{str: str253},
+			want: str253,
+		},
+		{
+			name: "truncate",
+			args: args{str: str253 + "z"},
+			want: strings.Repeat("1234567890", 24) + "1234567-lsbgh",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ResourceName(tt.args.str); got != tt.want {
+				t.Errorf("ResourceName() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/stacks/truncate/truncate_test.go
+++ b/pkg/stacks/truncate/truncate_test.go
@@ -82,6 +82,11 @@ func Test_truncate(t *testing.T) {
 			want:    "-agzq",
 			wantErr: false,
 		},
+		{
+			name: "hosted-stack-ns-example",
+			args: args{str: "cool-namespace-abcdefghijklmnopqrstuvwxyz", length: 32, suffixLength: 5},
+			want: "cool-namespace-abcdefghijkl-lzi4",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -154,6 +159,12 @@ func TestLabelValue(t *testing.T) {
 			name: "truncate",
 			args: args{str: str253},
 			want: strings.Repeat("1234567890", 5) + "1234567-ij43w",
+		},
+
+		{
+			name: "hosted-stack-ns-and-name-example",
+			args: args{str: "cool-namespace-abcdefghijkl-lzi4.cool-stack-abcdefghijklmnopqrstuvwxyz"},
+			want: "cool-namespace-abcdefghijkl-lzi4.cool-stack-abcdefghijklm-h4q4b",
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

We strongly recommend you look through our contributor guide at https://git.io/fj2m9
if this is your first time opening a Crossplane pull request. You can find us in
https://slack.crossplane.io/messages/dev if you need any help contributing.
-->

### Description of your changes

Addresses #1337

There may be other scenarios requiring truncation, but this PR addresses the known problem encountered when creating a tenant `StackInstall` resource with a long name in a long namespace that will be processed by a host.

Resource names in the host environment may not exceed 253 characters. Since these names are based on tenant namespace+name they could easily exceed this limitation.
    
There are also some resources created on the host which invoke admission controller behaviors adding resource labels that match resource names. Because labels values are limited to 63 characters the resource names created on the host should not exceed 63 characters.
    
Because the names have been truncated, annotations have been added on the host to help identify the related tenant resource when debugging.
    
This PR adds a truncation package with helpers for specific use-cases. Truncation is performed in a predictable way to make it possible to find resources by label knowing only the original resource names.  The suffix of the truncation is a subset of a lowercased base32 checksum of a SHA1 digest of the original string.  SHA1's security limitations are not a factor here because this is not being used for security purposes, it is chosen for quick and even distribution in the checksum.
    
The suffix is lowercase because resource names must be lowercase. Base32 was chosen to avoid "/" and a conflicting set of alphabetic characters (upper and lower case are used in base64).

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

Fixes #
-->

### How has this code been tested?
<!--
Before reviewers can be confident in the correctness of a pull request,
it needs to tested and shown to be correct. In this section, briefly
describe the testing that has already been done or which is planned.
-->
```sh
cluster/local/hosted_test.sh
export KUBECONFIG=~/.kube/kind-config-kind

# 63 characters
ns="r23456789012345678901234567890123456789012345678901234567890123"

# 63.63.63 characters
resource="s23456789012345678901234567890123456789012345678901234567890123.t23456789012345678901234567890123456789012345678901234567890123.u23456789012345678901234567890123456789012345678901234567890123.u23456789012345678901234567890123456789012345678901234567890"

kubectl create namespace $ns
kubectl crossplane stack install --namespace $ns --cluster 'crossplane/stack-gcp:master' $resource

kind delete cluster --name local-hosted-test
```

### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every Crossplane pull request.
-->
I have:
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Ensured this PR contains a neat, self documenting set of commits.
- [ ] Updated any relevant [documentation] and [examples].
- [x] Reported all new error conditions into the log or as an event, as
  appropriate.

For more about what we believe makes a pull request complete, see our
[definition of done].

[documentation]: https://github.com/crossplane/crossplane/tree/master/docs
[examples]: https://github.com/crossplane/crossplane/tree/master/cluster/examples
[definition of done]: https://github.com/crossplane/crossplane/tree/master/design/one-pager-definition-of-done.md
