### PR TITLE
[WIP] fix debug logging bug introduced in #1333

### DIFF
--- a/cmd/crossplane/main.go
+++ b/cmd/crossplane/main.go
@@ -59,6 +59,9 @@ func main() {
 	debug := app.Flag("debug", "Run with debug logging.").Short('d').Bool()
 	syncPeriod := app.Flag("sync", "Controller manager sync period duration such as 300ms, 1.5h or 2h45m").Short('s').Default("1h").Duration()
 
+	// populate debug early
+	_, _ = app.Parse(args)
+
 	a := appReq{
 		app:        app,
 		zl:         zap.New(zap.UseDevMode(*debug)),


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

We strongly recommend you look through our contributor guide at https://git.io/fj2m9
if this is your first time opening a Crossplane pull request. You can find us in
https://slack.crossplane.io/messages/dev if you need any help contributing.
-->

### Description of your changes

The boolean `debug` pointer in main.go is not given a value until
kingpin Parse is called. Parse the args early in the process so that early
debug output can be captured in logs.

_WIP_ This PR has only corrected the debug output in the core process. `go run cmd/crossplane/main.go stack manage --debug` is not emitting the expected debug output.

This can be taken as a short term fix preempting any review or decision making about #1349 

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

Fixes #
-->

### How has this code been tested?
<!--
Before reviewers can be confident in the correctness of a pull request,
it needs to tested and shown to be correct. In this section, briefly
describe the testing that has already been done or which is planned.
-->
```
go run cmd/crossplane/main.go --debug
```
I offered various valid and invalid command line arguments on the root and subcommands and received expected responses.

I also brought up a kind environment with stack-gcp and stack-wordpress with this branch.

### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every Crossplane pull request.
-->
I have:
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Ensured this PR contains a neat, self documenting set of commits.
- [ ] Updated any relevant [documentation] and [examples].
- [ ] Reported all new error conditions into the log or as an event, as
  appropriate.

For more about what we believe makes a pull request complete, see our
[definition of done].

[documentation]: https://github.com/crossplane/crossplane/tree/master/docs
[examples]: https://github.com/crossplane/crossplane/tree/master/cluster/examples
[definition of done]: https://github.com/crossplane/crossplane/tree/master/design/one-pager-definition-of-done.md
