### PR TITLE
stacks: sync image pull secrets to the host

### DIFF
--- a/apis/stacks/v1alpha1/types.go
+++ b/apis/stacks/v1alpha1/types.go
@@ -320,12 +320,12 @@ func (si *ClusterStackInstall) GroupVersionKind() schema.GroupVersionKind {
 type StackInstaller interface {
 	metav1.Object
 	runtime.Object
+	schema.ObjectKind
 
 	GetPackage() string
 	GetImagePullPolicy() corev1.PullPolicy
 	GetImagePullSecrets() []corev1.LocalObjectReference
 	GetServiceAccountAnnotations() map[string]string
-	GroupVersionKind() schema.GroupVersionKind
 	ImageWithSource(string) (string, error)
 	InstallJob() *corev1.ObjectReference
 	PermissionScope() string

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/evanphx/json-patch v4.5.0+incompatible
 	github.com/ghodss/yaml v1.0.0
 	github.com/google/go-cmp v0.3.1
+	github.com/google/uuid v1.1.1
 	github.com/onsi/gomega v1.7.0
 	github.com/opencontainers/go-digest v1.0.0-rc1 // indirect
 	github.com/pkg/errors v0.8.1

--- a/pkg/controller/stacks/hosted/config_test.go
+++ b/pkg/controller/stacks/hosted/config_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2020 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package hosted
 
 import (

--- a/pkg/controller/stacks/hosted/sync.go
+++ b/pkg/controller/stacks/hosted/sync.go
@@ -1,0 +1,174 @@
+/*
+Copyright 2020 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hosted
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/google/uuid"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/crossplane/crossplane-runtime/pkg/meta"
+	"github.com/crossplane/crossplane/pkg/stacks"
+	"github.com/crossplane/crossplane/pkg/stacks/truncate"
+)
+
+const (
+	labelForKind     = "host.stacks.crossplane.io/for-kind"
+	labelForAPIGroup = "host.stacks.crossplane.io/for-apiGroup"
+	labelForName     = "host.stacks.crossplane.io/for-name"
+
+	labelSourceKind      = "host.stacks.crossplane.io/source-kind"
+	labelSourceAPIGroup  = "host.stacks.crossplane.io/source-apiGroup"
+	labelSourceName      = "host.stacks.crossplane.io/source-name"
+	labelSourceNamespace = "host.stacks.crossplane.io/source-namespace"
+
+	errSecretNotFoundWithPrefixFmt = "failed to find ImagePullSecret with prefix %q in host resource"
+)
+
+// SyncImagePullSecrets copies imagePullSecrets from the tenant to the host
+// using the supplied secret names and returns the name of the secrets on the
+// host.
+//
+// The secrets are searched on the host using a name prefix based on the tenant
+// secret name. If the secrets are not present they are created with a host
+// owner resource reference for garbage collection.
+func SyncImagePullSecrets(ctx context.Context, tenantKube, hostKube client.Client, tenantNS string, tenantSecretRefs []corev1.LocalObjectReference, hostSecretRefs []corev1.LocalObjectReference, hostObj stacks.KindlyIdentifier) error {
+	gvk := hostObj.GroupVersionKind()
+	v, k := gvk.ToAPIVersionAndKind()
+	name := hostObj.GetName()
+	hostNS := hostObj.GetNamespace()
+
+	ref := &corev1.ObjectReference{
+		APIVersion: v,
+		Kind:       k,
+		Namespace:  hostNS,
+		Name:       name,
+		UID:        hostObj.GetUID(),
+	}
+
+	forLabels := map[string]string{
+		labelForKind:     k,
+		labelForAPIGroup: gvk.Group,
+		labelForName:     truncate.LabelValue(name),
+	}
+	hostSecrets := &corev1.SecretList{}
+
+	if err := hostKube.List(ctx, hostSecrets, client.MatchingLabels(forLabels), client.InNamespace(hostNS)); err != nil {
+		return err
+	}
+
+	if len(tenantSecretRefs) == 0 && len(hostSecrets.Items) > 0 {
+		if err := hostKube.DeleteAllOf(ctx, hostSecrets, client.MatchingLabels(forLabels)); err != nil {
+			return err
+		}
+	}
+
+TENANT:
+	for _, secName := range tenantSecretRefs {
+		sourceLabels := map[string]string{
+			labelSourceKind:      "Secret",
+			labelSourceAPIGroup:  "",
+			labelSourceName:      truncate.LabelValue(secName.Name),
+			labelSourceNamespace: tenantNS,
+		}
+		hostSecPrefix := ImagePullSecretPrefixOnHost(tenantNS, secName.Name)
+
+		for _, hostSec := range hostSecrets.Items {
+			if strings.HasPrefix(hostSec.GetName(), hostSecPrefix) {
+				// Found on host. Verify the next tenantSecret.
+				continue TENANT
+			}
+		}
+
+		hostSecName, err := findImagePullSecretName(hostSecPrefix, hostSecretRefs)
+		if err != nil {
+			return err
+		}
+
+		// Not Found. Fetch the secret from the tenant and create the
+		// secret on the host.
+		_, err = syncImagePullSecret(ctx,
+			tenantKube,
+			hostKube,
+			types.NamespacedName{Namespace: tenantNS, Name: secName.Name},
+			types.NamespacedName{Namespace: hostNS, Name: hostSecName},
+			labels.Merge(forLabels, sourceLabels),
+			ObjectReferenceAnnotationsOnHost("secret", secName.Name, tenantNS),
+			meta.AsOwner(ref))
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// findImagePullSecretName returns the first secret name from a list of secret
+// references to start with the given prefix
+func findImagePullSecretName(hostSecPrefix string, hostSecretRefs []corev1.LocalObjectReference) (string, error) {
+	var hostSecName string
+	for i := range hostSecretRefs {
+		if strings.HasPrefix(hostSecretRefs[i].Name, hostSecPrefix) {
+			hostSecName = hostSecretRefs[i].Name
+			break
+		}
+	}
+
+	if hostSecName == "" {
+		return "", fmt.Errorf(errSecretNotFoundWithPrefixFmt, hostSecPrefix)
+	}
+	return hostSecName, nil
+}
+
+// syncImagePullSecret reads the named tenant secrets from the tenant API and
+// creates a copy on the host with the supplied name, annotations, and labels
+func syncImagePullSecret(ctx context.Context, tenantKube, hostKube client.Client, tenantName, hostName types.NamespacedName, labels, annotations map[string]string, owner metav1.OwnerReference) (*corev1.Secret, error) {
+	sec := &corev1.Secret{}
+
+	if err := tenantKube.Get(ctx, types.NamespacedName{Name: tenantName.Name, Namespace: tenantName.Namespace}, sec); err != nil {
+		return nil, err
+	}
+	hostSec := &corev1.Secret{}
+	hostSec.Data = sec.Data
+	hostSec.Type = sec.Type
+
+	hostSec.SetName(hostName.Name)
+	hostSec.SetNamespace(hostName.Namespace)
+	hostSec.SetLabels(labels)
+	hostSec.SetAnnotations(annotations)
+	hostSec.SetOwnerReferences([]metav1.OwnerReference{owner})
+	if err := hostKube.Create(ctx, hostSec); err != nil {
+		return nil, err
+	}
+	return hostSec, nil
+}
+
+// uuidName produces a string suitable as a resource name using a random UUIDv4
+func uuidName() (string, error) {
+	id, err := uuid.NewRandom()
+	if err != nil {
+		return "", err
+	}
+	return id.String(), nil
+}

--- a/pkg/controller/stacks/hosted/sync_test.go
+++ b/pkg/controller/stacks/hosted/sync_test.go
@@ -1,0 +1,243 @@
+/*
+Copyright 2020 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hosted
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/crossplane/crossplane-runtime/pkg/test"
+	"github.com/crossplane/crossplane/apis/stacks/v1alpha1"
+	"github.com/crossplane/crossplane/pkg/stacks"
+)
+
+const (
+	namespace        = "cool-namespace"
+	tenantSecretName = "foo"
+
+	// hostResource represents the StackInstall Job or Stack Deployment
+	hostResourceName      = "host-foo"
+	hostResourceNamespace = "host-ns"
+	hostResourceUID       = "host-uid"
+)
+
+type resource struct {
+	name, namespace, uid string
+	gvk                  schema.GroupVersionKind
+}
+
+var (
+	testGVK = schema.GroupVersionKind{
+		Group:   "group",
+		Version: "version",
+		Kind:    "Kind",
+	}
+	errBoom = errors.New("boom")
+)
+
+func secret(name, namespace string) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+	}
+}
+
+func testResource(name, namespace, uid string, gvk schema.GroupVersionKind) *resource {
+	return &resource{
+		name:      name,
+		namespace: namespace,
+		uid:       uid,
+		gvk:       gvk,
+	}
+}
+
+func (r *resource) GetName() string {
+	return r.name
+}
+
+func (r *resource) GetNamespace() string {
+	return r.namespace
+}
+
+func (r *resource) GetUID() types.UID {
+	return types.UID(r.uid)
+}
+
+func (r *resource) GroupVersionKind() schema.GroupVersionKind {
+	return r.gvk
+}
+
+func TestSyncImagePullSecrets(t *testing.T) {
+	type args struct {
+		ctx              context.Context
+		tenantKube       client.Client
+		hostKube         client.Client
+		tenantNS         string
+		tenantSecretRefs []corev1.LocalObjectReference
+		hostSecretRefs   []corev1.LocalObjectReference
+		hostObj          stacks.KindlyIdentifier
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr error
+	}{
+		{
+			name: "NoSecrets",
+			args: args{
+				ctx:        context.TODO(),
+				tenantKube: nil,
+				tenantNS:   namespace,
+				hostKube:   fake.NewFakeClient(),
+				hostObj:    &v1alpha1.StackInstall{},
+			},
+			wantErr: nil,
+		},
+		{
+			name: "MissingHostSecretName",
+			args: args{
+				ctx:              context.TODO(),
+				tenantKube:       fake.NewFakeClient(),
+				hostKube:         fake.NewFakeClient(),
+				tenantNS:         namespace,
+				tenantSecretRefs: []corev1.LocalObjectReference{{Name: tenantSecretName}},
+				hostSecretRefs:   []corev1.LocalObjectReference{},
+				hostObj:          &v1alpha1.StackInstall{},
+			},
+			wantErr: fmt.Errorf(errSecretNotFoundWithPrefixFmt, namespace+"."+tenantSecretName),
+		},
+		{
+			name: "TenantSecretNotPresent",
+			args: args{
+				ctx:              context.TODO(),
+				tenantKube:       fake.NewFakeClient(),
+				hostKube:         fake.NewFakeClient(),
+				tenantNS:         namespace,
+				tenantSecretRefs: []corev1.LocalObjectReference{{Name: tenantSecretName}},
+				hostSecretRefs:   []corev1.LocalObjectReference{{Name: namespace + "." + tenantSecretName}},
+				hostObj:          &v1alpha1.StackInstall{},
+			},
+			wantErr: kerrors.NewNotFound(schema.GroupResource{Resource: "secrets"}, tenantSecretName),
+		},
+		{
+			name: "HostSecretNotPresent",
+			args: args{
+				ctx:              context.TODO(),
+				tenantKube:       fake.NewFakeClient(secret(tenantSecretName, namespace)),
+				hostKube:         fake.NewFakeClient(),
+				tenantNS:         namespace,
+				tenantSecretRefs: []corev1.LocalObjectReference{{Name: tenantSecretName}},
+				hostSecretRefs:   []corev1.LocalObjectReference{{Name: namespace + "." + tenantSecretName}},
+				hostObj:          &v1alpha1.StackInstall{},
+			},
+			wantErr: nil,
+		},
+		{
+			name: "HostCreateFails",
+			args: args{
+				ctx:        context.TODO(),
+				tenantKube: fake.NewFakeClient(secret(tenantSecretName, namespace)),
+				hostKube: func() client.Client {
+					fc := fake.NewFakeClient()
+					c := &test.MockClient{
+						MockList:   fc.List,
+						MockCreate: test.NewMockCreateFn(errBoom),
+					}
+					return c
+				}(),
+				tenantNS:         namespace,
+				tenantSecretRefs: []corev1.LocalObjectReference{{Name: tenantSecretName}},
+				hostSecretRefs:   []corev1.LocalObjectReference{{Name: namespace + "." + tenantSecretName}},
+				hostObj:          &v1alpha1.StackInstall{},
+			},
+			wantErr: errBoom,
+		},
+
+		{
+			name: "HostSecretPresentButMislabeled",
+			args: args{
+				ctx:        context.TODO(),
+				tenantKube: fake.NewFakeClient(secret(tenantSecretName, namespace)),
+				hostKube: func() client.Client {
+					sec := secret(namespace+"."+tenantSecretName, hostResourceNamespace)
+
+					fc := fake.NewFakeClient(sec)
+					c := &test.MockClient{
+						MockList:   fc.List,
+						MockCreate: test.NewMockCreateFn(errBoom),
+					}
+					return c
+				}(),
+				tenantNS:         namespace,
+				tenantSecretRefs: []corev1.LocalObjectReference{{Name: tenantSecretName}},
+				hostSecretRefs:   []corev1.LocalObjectReference{{Name: namespace + "." + tenantSecretName}},
+				hostObj:          testResource(hostResourceName, hostResourceNamespace, hostResourceUID, testGVK),
+			},
+			wantErr: errBoom,
+		},
+		{
+			name: "HostSecretPresentAndLabeled",
+			args: args{
+				ctx:        context.TODO(),
+				tenantKube: fake.NewFakeClient(secret(tenantSecretName, namespace)),
+				hostKube: func() client.Client {
+					sec := secret(namespace+"."+tenantSecretName, hostResourceNamespace)
+
+					sec.SetLabels(map[string]string{
+						labelForKind:     testGVK.Kind,
+						labelForAPIGroup: testGVK.Group,
+						labelForName:     hostResourceName,
+					})
+
+					fc := fake.NewFakeClient(sec)
+					c := &test.MockClient{
+						MockList:   fc.List,
+						MockCreate: test.NewMockCreateFn(errBoom),
+					}
+					return c
+				}(),
+				tenantNS:         namespace,
+				tenantSecretRefs: []corev1.LocalObjectReference{{Name: tenantSecretName}},
+				hostSecretRefs:   []corev1.LocalObjectReference{{Name: namespace + "." + tenantSecretName}},
+				hostObj:          testResource(hostResourceName, hostResourceNamespace, hostResourceUID, testGVK),
+			},
+			wantErr: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotErr := SyncImagePullSecrets(tt.args.ctx, tt.args.tenantKube, tt.args.hostKube, tt.args.tenantNS, tt.args.tenantSecretRefs, tt.args.hostSecretRefs, tt.args.hostObj)
+
+			if diff := cmp.Diff(tt.wantErr, gotErr, test.EquateErrors()); diff != "" {
+				t.Errorf("SyncImagePullSecrets() -want error, +got error:\n%s", diff)
+			}
+		})
+	}
+}

--- a/pkg/controller/stacks/install/installjob.go
+++ b/pkg/controller/stacks/install/installjob.go
@@ -60,7 +60,7 @@ type stackInstallJobCompleter struct {
 	log          logging.Logger
 }
 
-type prepareInstallJobParams struct {
+type buildInstallJobParams struct {
 	name                   string
 	namespace              string
 	permissionScope        string
@@ -74,7 +74,7 @@ type prepareInstallJobParams struct {
 	imagePullSecrets       []corev1.LocalObjectReference
 }
 
-func prepareInstallJob(p prepareInstallJobParams) *batchv1.Job {
+func buildInstallJob(p buildInstallJobParams) *batchv1.Job {
 	return &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        p.name,

--- a/pkg/controller/stacks/stack/stack_test.go
+++ b/pkg/controller/stacks/stack/stack_test.go
@@ -1170,7 +1170,8 @@ func TestProcessDeployment(t *testing.T) {
 			clientFunc: fake.NewFakeClient,
 			hostClientFunc: func() client.Client {
 				return &test.MockClient{
-					MockGet: test.NewMockGetFn(nil),
+					MockList: test.NewMockListFn(nil),
+					MockGet:  test.NewMockGetFn(nil),
 					MockCreate: func(ctx context.Context, obj runtime.Object, _ ...client.CreateOption) error {
 						if _, ok := obj.(*corev1.Secret); ok {
 							return errBoom
@@ -1712,7 +1713,7 @@ func Test_stackHandler_prepareHostAwareDeployment(t *testing.T) {
 				d:           nil,
 			},
 			want: want{
-				err: errors.New(errHostAwareModeNotEnabled),
+				err: nil,
 			},
 		},
 	}


### PR DESCRIPTION
### Description of your changes
 When a StackInstall or Stack (controller template) include imagePullSecrets, these secrets must be copied to the host where the install job (for StackInstalls) and the deployment (for Stacks) are run.
    
This PR adds to the preparation of jobs and deployments a process that:
    
* Creates secure, length restricted, alternate names for the tenant secret to use on the host. 
 Predictable secret names could be abused by stacks in other namespaces.
* References those names in the host job or deployment
* Creates the job or deployment (per usual)
* Copies the secrets from the tenant into their host mapped names, using the job or deployment as an owner reference for garbage collection
 

Fixes #1317 

#### Learnings

* `client.Create` sets the `UID` on the object immediately on a successful REST response
* Job and Deployment `spec.template.spec.imagePullSecrets` fields are immutable

### How has this code been tested?

Unit tests walk the `hosted.SyncImagePullSecrets` flow, with the names of local and host secrets being plugged in.

In local testing, using `cluster/local/hosted_test.sh`:
* push the `app-wordpress` image to a private repo (on Docker hub, for example)
* create a `regcred` secret in the tenant: 
  `kubectl create secret docker-registry regcred --docker-server=docker.io --docker-username=displague --docker-password=... --docker-email=marques@example.com`
* create a StackInstall in the tenant that requires this credential as an image pull secret
* watch the Job and Deployment succeed in the `crossplane-host-controller` namespace
* notice that the tenant secret has been copied into two new secrets in the `crossplane-host-controller` namespace
* notice that the `Stack` and `StackInstall` have both successfully reconciled

```
apiVersion: stacks.crossplane.io/v1alpha1
kind: StackInstall
metadata:
  name: "app-wordpress"
  namespace: "default"
spec:
  package: displague/app-wordpress:master
  source: index.docker.io
  imagePullSecrets:
  - name: regcred
  imagePullPolicy: Always
```

### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every Crossplane pull request.
-->
I have:
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Ensured this PR contains a neat, self documenting set of commits.
- [ ] Updated any relevant [documentation] and [examples].
- [ ] Reported all new error conditions into the log or as an event, as
  appropriate.

For more about what we believe makes a pull request complete, see our
[definition of done].

[documentation]: https://github.com/crossplane/crossplane/tree/master/docs
[examples]: https://github.com/crossplane/crossplane/tree/master/cluster/examples
[definition of done]: https://github.com/crossplane/crossplane/tree/master/design/one-pager-definition-of-done.md
