### PR TITLE
AWS DBSubnetGroup Doc updates for v1beta1

### DIFF
--- a/cluster/examples/workloads/kubernetes/wordpress/aws/network-config/dbsubnetgroup.yaml
+++ b/cluster/examples/workloads/kubernetes/wordpress/aws/network-config/dbsubnetgroup.yaml
@@ -1,18 +1,18 @@
 ---
-apiVersion: database.aws.crossplane.io/v1alpha3
+apiVersion: database.aws.crossplane.io/v1beta1
 kind: DBSubnetGroup
 metadata:
   name: sample-dbsubnetgroup
 spec:
-  groupName: my-cool-dbsubnetgroup
-  description: EKS vpc to rds
-  subnetIdRefs:
-    - name: sample-subnet1
-    - name: sample-subnet2
-    - name: sample-subnet3
-  tags:
-    - key: name
-      value: my-cool-dbsubnetgroup
+  forProvider:
+    description: EKS vpc to rds
+    subnetIdRefs:
+      - name: sample-subnet1
+      - name: sample-subnet2
+      - name: sample-subnet3
+    tags:
+      - key: name
+        value: my-cool-dbsubnetgroup
   reclaimPolicy: Delete
   providerRef:
     name: aws-provider


### PR DESCRIPTION
### Description of your changes
Missing doc updates for v1beta1 DBSubnetGroup.

Depends on [move DBSubnetGroup to v1beta1](https://github.com/crossplane/provider-aws/pull/162).

### Checklist
I have:
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Ensured this PR contains a neat, self documenting set of commits.
- [x] Updated any relevant [documentation] and [examples].