### PR TITLE
Do not use default as namespace for KAR templates if not supplied

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/crossplane/crossplane
 go 1.13
 
 require (
-	github.com/crossplane/crossplane-runtime v0.5.1-0.20200319222234-946bbdd9464e
+	github.com/crossplane/crossplane-runtime v0.5.1-0.20200320220925-da385a76bc9b
 	github.com/crossplane/crossplane-tools v0.0.0-20200219001116-bb8b2ce46330
 	github.com/docker/distribution v2.7.1+incompatible
 	github.com/ghodss/yaml v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -65,8 +65,8 @@ github.com/coreos/go-semver v0.3.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3Ee
 github.com/coreos/go-systemd v0.0.0-20180511133405-39ca1b05acc7/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/coreos/pkg v0.0.0-20180108230652-97fdf19511ea/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
 github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwcJI5acqYI6dE=
-github.com/crossplane/crossplane-runtime v0.5.1-0.20200319222234-946bbdd9464e h1:gq6mmtLru2juGVy08Xok+xMTDnRjI+w8/pO0K+GPVvc=
-github.com/crossplane/crossplane-runtime v0.5.1-0.20200319222234-946bbdd9464e/go.mod h1:e12p4X6dbtqd9GOnph78Epd6aezyvmcMM1+6aQy3VzY=
+github.com/crossplane/crossplane-runtime v0.5.1-0.20200320220925-da385a76bc9b h1:KTetfTWGeJ0I11gxHcJRFe1OrgKqzVgmeN1hJazkFYk=
+github.com/crossplane/crossplane-runtime v0.5.1-0.20200320220925-da385a76bc9b/go.mod h1:e12p4X6dbtqd9GOnph78Epd6aezyvmcMM1+6aQy3VzY=
 github.com/crossplane/crossplane-tools v0.0.0-20200219001116-bb8b2ce46330 h1:zxdYGQnQbfyZSnRbKUJ16x5lRzkUTbH+uumVq03ijYo=
 github.com/crossplane/crossplane-tools v0.0.0-20200219001116-bb8b2ce46330/go.mod h1:C735A9X0x0lR8iGVOOxb49Mt70Ua4EM2b7PGaRPBLd4=
 github.com/dave/jennifer v1.3.0 h1:p3tl41zjjCZTNBytMwrUuiAnherNUZktlhPTKoF/sEk=

--- a/pkg/controller/workload/kubernetes/resource/resource.go
+++ b/pkg/controller/workload/kubernetes/resource/resource.go
@@ -172,7 +172,6 @@ func (c *remoteCluster) sync(ctx context.Context, ar *v1alpha1.KubernetesApplica
 	templates := createSecretTemplates(secrets, template.GetNamespace(), ar.GetName())
 	for i := range templates {
 		template := &templates[i]
-		ensureNamespace(template)
 		setRemoteController(ar, template)
 
 		if err := c.secret.sync(ctx, template); err != nil {
@@ -180,7 +179,6 @@ func (c *remoteCluster) sync(ctx context.Context, ar *v1alpha1.KubernetesApplica
 		}
 	}
 
-	ensureNamespace(template)
 	setRemoteController(ar, template)
 
 	status, err := c.unstructured.sync(ctx, template)
@@ -202,7 +200,6 @@ func (c *remoteCluster) delete(ctx context.Context, ar *v1alpha1.KubernetesAppli
 	if err := json.Unmarshal(ar.Spec.Template.Raw, template); err != nil {
 		return v1alpha1.KubernetesApplicationResourceStateFailed, errors.Wrap(err, errUnmarshalTemplate)
 	}
-	ensureNamespace(template)
 	setRemoteController(ar, template)
 
 	if err := c.unstructured.delete(ctx, template); err != nil {
@@ -212,7 +209,6 @@ func (c *remoteCluster) delete(ctx context.Context, ar *v1alpha1.KubernetesAppli
 	templates := createSecretTemplates(secrets, template.GetNamespace(), ar.GetName())
 	for i := range templates {
 		template := &templates[i]
-		ensureNamespace(template)
 		setRemoteController(ar, template)
 
 		if err := c.secret.delete(ctx, template); err != nil {
@@ -564,11 +560,4 @@ func haveSameController(a, b metav1.Object) bool {
 	}
 
 	return a.GetAnnotations()[RemoteControllerUID] == b.GetAnnotations()[RemoteControllerUID]
-}
-
-func ensureNamespace(obj metav1.Object) {
-	if obj.GetNamespace() != "" {
-		return
-	}
-	obj.SetNamespace(corev1.NamespaceDefault)
 }

--- a/pkg/controller/workload/kubernetes/resource/resource_test.go
+++ b/pkg/controller/workload/kubernetes/resource/resource_test.go
@@ -383,8 +383,8 @@ func TestSync(t *testing.T) {
 			syncer: &remoteCluster{
 				unstructured: &mockUnstructuredClient{
 					mockSync: func(_ context.Context, got *unstructured.Unstructured) (*v1alpha1.RemoteStatus, error) {
-						want := template(serviceWithoutNamespace)
-						want.SetNamespace(corev1.NamespaceDefault)
+						want := template(service)
+						want.SetNamespace(namespace)
 						want.SetAnnotations(map[string]string{
 							RemoteControllerNamespace: objectMeta.GetNamespace(),
 							RemoteControllerName:      objectMeta.GetName(),
@@ -402,7 +402,7 @@ func TestSync(t *testing.T) {
 					mockSync: func(_ context.Context, got *corev1.Secret) error {
 						want := secret.DeepCopy()
 						want.SetName(fmt.Sprintf("%s-%s", objectMeta.GetName(), secret.GetName()))
-						want.SetNamespace(corev1.NamespaceDefault)
+						want.SetNamespace(namespace)
 						want.SetAnnotations(map[string]string{
 							RemoteControllerNamespace: objectMeta.GetNamespace(),
 							RemoteControllerName:      objectMeta.GetName(),
@@ -416,7 +416,7 @@ func TestSync(t *testing.T) {
 					},
 				},
 			},
-			ar:        kubeAR(withTemplate(template(serviceWithoutNamespace))),
+			ar:        kubeAR(withTemplate(template(service))),
 			secrets:   []corev1.Secret{*secret},
 			wantState: v1alpha1.KubernetesApplicationResourceStateSubmitted,
 		},
@@ -439,7 +439,7 @@ func TestSync(t *testing.T) {
 					mockSync: func(_ context.Context, got *corev1.Secret) error {
 						want := secretWithExplicitType.DeepCopy()
 						want.SetName(fmt.Sprintf("%s-%s", objectMeta.GetName(), secretWithExplicitType.GetName()))
-						want.SetNamespace(corev1.NamespaceDefault)
+						want.SetNamespace(namespace)
 						want.SetAnnotations(map[string]string{
 							RemoteControllerNamespace: objectMeta.GetNamespace(),
 							RemoteControllerName:      objectMeta.GetName(),
@@ -453,7 +453,7 @@ func TestSync(t *testing.T) {
 					},
 				},
 			},
-			ar:        kubeAR(withTemplate(template(serviceWithoutNamespace))),
+			ar:        kubeAR(withTemplate(template(service))),
 			secrets:   []corev1.Secret{*secretWithExplicitType},
 			wantState: v1alpha1.KubernetesApplicationResourceStateSubmitted,
 		},


### PR DESCRIPTION
Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

<!--
Thank you for helping to improve Crossplane!

We strongly recommend you look through our contributor guide at https://git.io/fj2m9
if this is your first time opening a Crossplane pull request. You can find us in
https://slack.crossplane.io/messages/dev if you need any help contributing.
-->

### Description of your changes
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

Fixes #
-->

This changes the behavior of the `KubernetesApplicationResource` controller to not automatically assume the resources that do not have a `namespace` defined should be created in the `default` namespace. This was causing issues because we updated the patch logic in this controller to actually update the remote resources, but the change caused errors when patching `Namespace` resources that had no namespace supplied (as is customary).

A few summarizing notes:
- If a `Namespace` is included in a template without having the `namespace` field defined, it will be able to be created and patched successfully
- If a `Namespace` is included in a template and **does have** the `namespace` field defined, it **will be** created but will **fail** to be patched (this is probably the most surprising behavior)
- If a cluster-scoped resource that is not a `Namespace` (like a `CustomResourceDefinition`) is included in a template **with or without** having the `namespace` field defined, it will be able to be created and patched successfully
- If a namespace-scoped resource (like a `Service`) is included in a template without having the `namespace` field defined, it will **fail to be created**
- If a namespace-scoped resource (like a `Service`) is included in a template without having the `namespace` field defined, it will **fail to be created**

### How has this code been tested?
<!--
Before reviewers can be confident in the correctness of a pull request,
it needs to tested and shown to be correct. In this section, briefly
describe the testing that has already been done or which is planned.
-->

I created various renditions of the scenarios listed above. One such config, labeled with success / error for each template is included below:

<details>
 <summary>Config:</summary>

```yaml
apiVersion: workload.crossplane.io/v1alpha1
kind: KubernetesApplication
metadata:
  name: helloworld
  namespace: cp-quickstart
  labels:
    app: helloworld
spec:
  resourceSelector:
    matchLabels:
      app: helloworld
  targetSelector:
    matchLabels:
      cluster: helloworld
  resourceTemplates:
# SUCCESSFUL CREATION AND PATCH
    - metadata:
        name: helloworld-deployment
        labels:
          app: helloworld
      spec:
        secrets:
        - name: k8scluster
        template:
          apiVersion: apps/v1
          kind: Deployment
          metadata:
            name: helloworld-deployment
            namespace: helloworld
          spec:
            selector:
              matchLabels:
                app: helloworld
            replicas: 2
            template:
              metadata:
                labels:
                  app: helloworld
              spec:
                containers:
                - name: hello-world
                  image: gcr.io/google-samples/hello-app:1.0
                  ports:
                  - containerPort: 8080
                    protocol: TCP
# FAILED CREATION
    - metadata:
        name: helloworld-service
        labels:
          app: helloworld
      spec:
        template:
          kind: Service
          metadata:
            name: helloworld-service
            # namespace: helloworld <-- this missing causes failure (we do not insert `default` any more)
          spec:
            selector:
              app: helloworld
            ports:
            - port: 80
              targetPort: 8080
            type: LoadBalancer
# SUCCESSFUL CREATION, FAILED PATCH
    - metadata:
        name: helloworld-namespace
        labels:
          app: helloworld
      spec:
        template:
          apiVersion: v1
          kind: Namespace
          metadata:
            name: helloworld
            namespace: hmmm # this causes patch fail
            labels:
              app: helloworld
# SUCCESSFUL CREATION AND PATCH
    - metadata:
        name: helloworld-random
        labels:
          app: helloworld
      spec:
        template:
          apiVersion: apiextensions.k8s.io/v1beta1
          kind: CustomResourceDefinition
          metadata:
            creationTimestamp: null
            name: wordpressinstances.wordpress.apps.crossplane.io
            namespace: hi
          spec:
            preserveUnknownFields: true
            group: wordpress.apps.crossplane.io
            names:
              kind: WordpressInstance
              listKind: WordpressInstanceList
              plural: wordpressinstances
              singular: wordpressinstance
            scope: Namespaced
            subresources:
              status: {}
            validation:
              openAPIV3Schema:
                description: WordpressInstance is the Schema for the wordpressinstances API
                properties:
                  apiVersion:
                    description: 'APIVersion defines the versioned schema of this representation
                      of an object. Servers should convert recognized schemas to the latest
                      internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
                    type: string
                  kind:
                    description: 'Kind is a string value representing the REST resource this
                      object represents. Servers may infer this from the endpoint the client
                      submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
                    type: string
                  metadata:
                    type: object
                  spec:
                    description: WordpressInstanceSpec defines the desired state of WordpressInstance
                    properties:
                      image:
                        description: Image will be used as image of the container that Wordpress
                          runs in. If not specified, the default will be used.
                        type: string
                      provisionPolicy:
                        description: ProvisionPolicy indicates whether Wordpress should be deployed
                          to an existing Kubernetes cluster or to provision a new cluster.
                        enum:
                        - ProvisionNewCluster
                        - UseExistingTarget
                        type: string
                    type: object
                type: object
            version: v1alpha1
            versions:
            - name: v1alpha1
              served: true
              storage: true
          status:
            acceptedNames:
              kind: ""
              plural: ""
            conditions: []
            storedVersions: []
```

</details>

### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every Crossplane pull request.
-->
I have:
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Ensured this PR contains a neat, self documenting set of commits.
- [ ] Updated any relevant [documentation] and [examples].
- [ ] Reported all new error conditions into the log or as an event, as
  appropriate.

For more about what we believe makes a pull request complete, see our
[definition of done].

[documentation]: https://github.com/crossplane/crossplane/tree/master/docs
[examples]: https://github.com/crossplane/crossplane/tree/master/cluster/examples
[definition of done]: https://github.com/crossplane/crossplane/tree/master/design/one-pager-definition-of-done.md
