### PR TITLE
stacks: add stack-manager option to force image pull policy

### DIFF
--- a/cluster/charts/crossplane-controllers/templates/stack-manager-deployment.yaml
+++ b/cluster/charts/crossplane-controllers/templates/stack-manager-deployment.yaml
@@ -40,6 +40,10 @@ spec:
         - {{ .Values.templateStacks.controllerImage | quote }}
         {{- end }}
         {{- end }}
+        {{- if .Values.forceImagePullPolicy }}
+        - --force-image-pull-policy
+        - {{ .Values.forceImagePullPolicy | quote }}
+        {{- end }}
         {{- range $arg := .Values.args }}
         - {{ $arg }}
         {{- end }}

--- a/cluster/charts/crossplane-controllers/values.yaml.tmpl
+++ b/cluster/charts/crossplane-controllers/values.yaml.tmpl
@@ -42,3 +42,5 @@ resourcesStackManager:
   requests:
     cpu: 100m
     memory: 256Mi
+
+forceImagePullPolicy: ""

--- a/cluster/charts/crossplane/README.md
+++ b/cluster/charts/crossplane/README.md
@@ -313,6 +313,7 @@ and their default values.
 | `resourcesStackManager.limits.memory`   | Memory resource limits for StackManager                  | `512Mi`
 | `resourcesStackManager.requests.cpu`    | CPU resource requests for StackManager                   | `100m`
 | `resourcesStackManager.requests.memory` | Memory resource requests for StackManager                | `256Mi`
+| `forceImagePullPolicy`           | Force the named ImagePullPolicy on Stack install and containers | ``
 
 ### Command Line
 

--- a/cluster/charts/crossplane/templates/stack-manager-deployment.yaml
+++ b/cluster/charts/crossplane/templates/stack-manager-deployment.yaml
@@ -40,6 +40,10 @@ spec:
         - {{ .Values.templateStacks.controllerImage | quote }}
         {{- end }}
         {{- end }}
+        {{- if .Values.forceImagePullPolicy }}
+        - --force-image-pull-policy
+        - {{ .Values.forceImagePullPolicy | quote }}
+        {{- end }}
         {{- range $arg := .Values.args }}
         - {{ $arg }}
         {{- end }}

--- a/cluster/charts/crossplane/values.yaml.tmpl
+++ b/cluster/charts/crossplane/values.yaml.tmpl
@@ -52,3 +52,5 @@ resourcesStackManager:
   requests:
     cpu: 100m
     memory: 256Mi
+
+forceImagePullPolicy: ""

--- a/cmd/crossplane/stack/manage/manage.go
+++ b/cmd/crossplane/stack/manage/manage.go
@@ -41,6 +41,7 @@ type Command struct {
 	TemplatingControllerImage string
 	HostControllerNamespace   string
 	TenantKubeConfig          string
+	ForceImagePullPolicy      string
 }
 
 // FromKingpin produces the stack manager command from a Kingpin command.
@@ -52,6 +53,7 @@ func FromKingpin(cmd *kingpin.CmdClause) *Command {
 	cmd.Flag("templating-controller-image", "The image of the template stacks controller").StringVar(&c.TemplatingControllerImage)
 	cmd.Flag("host-controller-namespace", "The namespace on Host Cluster where install and controller jobs/deployments will be created. Setting this will activate host aware mode of Stack Manager").StringVar(&c.HostControllerNamespace)
 	cmd.Flag("tenant-kubeconfig", "The absolute path of the kubeconfig file to Tenant Kubernetes instance (required for host aware mode, ignored otherwise).").ExistingFileVar(&c.TenantKubeConfig)
+	cmd.Flag("force-image-pull-policy", "All containers created by the StackManager in service of StackInstall and Stack resources will use the specified imagePullPolicy").StringVar(&c.ForceImagePullPolicy)
 	return c
 }
 
@@ -81,7 +83,7 @@ func (c *Command) Run(log logging.Logger) error {
 		return errors.Wrap(err, "Cannot add API extensions to scheme")
 	}
 
-	if err := stacks.Setup(mgr, log, c.HostControllerNamespace, c.TemplatingControllerImage, c.RestrictCoreAPIGroups); err != nil {
+	if err := stacks.Setup(mgr, log, c.HostControllerNamespace, c.TemplatingControllerImage, c.RestrictCoreAPIGroups, c.ForceImagePullPolicy); err != nil {
 		return errors.Wrap(err, "Cannot add stacks controllers to manager")
 	}
 

--- a/docs/1_install.md
+++ b/docs/1_install.md
@@ -319,6 +319,7 @@ and their default values.
 | `resourcesStackManager.limits.memory`   | Memory resource limits for StackManager                  | `512Mi`
 | `resourcesStackManager.requests.cpu`    | CPU resource requests for StackManager                   | `100m`
 | `resourcesStackManager.requests.memory` | Memory resource requests for StackManager                | `256Mi`
+| `forceImagePullPolicy`           | Force the named ImagePullPolicy on Stack install and containers | ``
 
 ### Command Line
 

--- a/pkg/controller/stacks/stacks.go
+++ b/pkg/controller/stacks/stacks.go
@@ -27,8 +27,8 @@ import (
 )
 
 // Setup Crossplane Stacks controllers.
-func Setup(mgr ctrl.Manager, l logging.Logger, hostControllerNamespace, tsControllerImage string, restrictCore bool) error {
-	if err := install.SetupStackInstall(mgr, l, hostControllerNamespace, tsControllerImage); err != nil {
+func Setup(mgr ctrl.Manager, l logging.Logger, hostControllerNamespace, tsControllerImage string, restrictCore bool, forceImagePullPolicy string) error {
+	if err := install.SetupStackInstall(mgr, l, hostControllerNamespace, tsControllerImage, forceImagePullPolicy); err != nil {
 		return err
 	}
 
@@ -39,7 +39,7 @@ func Setup(mgr ctrl.Manager, l logging.Logger, hostControllerNamespace, tsContro
 	if err := persona.Setup(mgr, l); err != nil {
 		return nil
 	}
-	if err := stack.Setup(mgr, l, hostControllerNamespace, restrictCore); err != nil {
+	if err := stack.Setup(mgr, l, hostControllerNamespace, restrictCore, forceImagePullPolicy); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
### Description of your changes

In multi-tenant environments, images fetched for one Stack unpack or Stack
controller become available in the node level docker registry. This could
allow other tenants to access those images without the appropriate
imagePullSecrets.

This change introduces a stack-manager parameter: `--force-image-pull-policy`,
which when set to a non-empty string, will override the imagePullPolicy set in
any StackInstall spec (affecting the install job and upack) and will force an
imagePullPolicy for each pod in a Stack deployment.

Fixes #1346

### How has this code been tested?

Unit tests verify that Deployments and Jobs receive the correct pull policy.

This was run in the cluster/local/hosted-test.sh environment with the stack-manager deployment including the `--force-image-pull-policy Always` argument. A StackInstall was created with an `imagePullPolicy: Never` and the resulting Job and Deployment correctly adopted the imagePullPolicy of `Always`.

<!--
Before reviewers can be confident in the correctness of a pull request,
it needs to tested and shown to be correct. In this section, briefly
describe the testing that has already been done or which is planned.
-->

### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every Crossplane pull request.
-->
I have:
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Ensured this PR contains a neat, self documenting set of commits.
- [ ] Updated any relevant [documentation] and [examples].
- [ ] Reported all new error conditions into the log or as an event, as
  appropriate.

For more about what we believe makes a pull request complete, see our
[definition of done].

[documentation]: https://github.com/crossplane/crossplane/tree/master/docs
[examples]: https://github.com/crossplane/crossplane/tree/master/cluster/examples
[definition of done]: https://github.com/crossplane/crossplane/tree/master/design/one-pager-definition-of-done.md
