### PR TITLE
Remove KAR owner UID annotation on remote resources

### DIFF
--- a/pkg/controller/workload/kubernetes/resource/resource.go
+++ b/pkg/controller/workload/kubernetes/resource/resource.go
@@ -559,5 +559,12 @@ func haveSameController(a, b metav1.Object) bool {
 		return false
 	}
 
-	return a.GetAnnotations()[RemoteControllerUID] == b.GetAnnotations()[RemoteControllerUID]
+	// NOTE(hasheddan): we set an annotation for the UID of the remote
+	// controller but do not check that it matches because it would prohibit a
+	// lost KubernetesApplication from re-establishing ownership of its remote
+	// resources.
+	if a.GetAnnotations()[RemoteControllerNamespace] != b.GetAnnotations()[RemoteControllerNamespace] {
+		return false
+	}
+	return a.GetAnnotations()[RemoteControllerName] == b.GetAnnotations()[RemoteControllerName]
 }

--- a/pkg/controller/workload/kubernetes/resource/resource_test.go
+++ b/pkg/controller/workload/kubernetes/resource/resource_test.go
@@ -1686,7 +1686,7 @@ func TestHaveSameController(t *testing.T) {
 			want: false,
 		},
 		{
-			name: "HasDifferentController",
+			name: "HasDifferentUID",
 			a:    service,
 			b: &corev1.Service{
 				ObjectMeta: metav1.ObjectMeta{
@@ -1697,7 +1697,7 @@ func TestHaveSameController(t *testing.T) {
 					},
 				},
 			},
-			want: false,
+			want: true,
 		},
 	}
 


### PR DESCRIPTION
Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

<!--
Thank you for helping to improve Crossplane!

We strongly recommend you look through our contributor guide at https://git.io/fj2m9
if this is your first time opening a Crossplane pull request. You can find us in
https://slack.crossplane.io/messages/dev if you need any help contributing.
-->

### Description of your changes
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

Fixes #
-->

This removes the owner `UID` annotation on remote Kubernetes resources in order to allow a lost `KubernetesApplication` to re-establish control of its remote resources. However, this also means that any`KubernetesApplicationResource` with the same name and namespace of the owner annotations on existing resources in a remote Kubernetes cluster can establish control of them. This is not a huge issue if the original `KubernetesApplicationResource` still exists because the name / namespace conflict would serve as a guard, but in the case that remote resources are orphaned and a user does not wish for a `KubernetesApplication` to ever be able to establish control over them again, they should make sure to remove the owner annotations.

Keeping in draft in case we need further discussion before merge.

### How has this code been tested?
<!--
Before reviewers can be confident in the correctness of a pull request,
it needs to tested and shown to be correct. In this section, briefly
describe the testing that has already been done or which is planned.
-->

Unit tests only right now. Manual testing will be done prior to merge.

### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every Crossplane pull request.
-->
I have:
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Ensured this PR contains a neat, self documenting set of commits.
- [ ] Updated any relevant [documentation] and [examples].
- [ ] Reported all new error conditions into the log or as an event, as
  appropriate.

For more about what we believe makes a pull request complete, see our
[definition of done].

[documentation]: https://github.com/crossplane/crossplane/tree/master/docs
[examples]: https://github.com/crossplane/crossplane/tree/master/cluster/examples
[definition of done]: https://github.com/crossplane/crossplane/tree/master/design/one-pager-definition-of-done.md
