### PR TITLE
Set namespace on resources rendered from OAM containerizedworkload

### DIFF
--- a/pkg/oam/workload/containerized/containerized.go
+++ b/pkg/oam/workload/containerized/containerized.go
@@ -36,6 +36,8 @@ const (
 	errNotContainerizedWorkload = "object is not a containerized workload"
 )
 
+const defaultNamespace = "default"
+
 const labelKey = "containerizedworkload.oam.crossplane.io"
 
 var (
@@ -58,6 +60,11 @@ func Translator(ctx context.Context, w resource.Workload) ([]resource.Object, er
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name: cw.GetName(),
+			// NOTE(hasheddan): we always create the Deployment in the default
+			// namespace because there is not currently a namespace scheduling
+			// mechanism in the Crossplane OAM implementation. It is likely that
+			// this will be addressed in the future by adding a Scope.
+			Namespace: defaultNamespace,
 		},
 		Spec: appsv1.DeploymentSpec{
 			Selector: &metav1.LabelSelector{

--- a/pkg/oam/workload/containerized/containerized_test.go
+++ b/pkg/oam/workload/containerized/containerized_test.go
@@ -65,7 +65,8 @@ func deployment(mod ...deploymentModifier) *appsv1.Deployment {
 			APIVersion: deploymentAPIVersion,
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name: cwName,
+			Name:      cwName,
+			Namespace: defaultNamespace,
 		},
 		Spec: appsv1.DeploymentSpec{
 			Selector: &metav1.LabelSelector{

--- a/pkg/oam/workload/translate.go
+++ b/pkg/oam/workload/translate.go
@@ -112,7 +112,8 @@ func ServiceInjector(ctx context.Context, w resource.Workload, objs []resource.O
 				APIVersion: serviceAPIVersion,
 			},
 			ObjectMeta: metav1.ObjectMeta{
-				Name: d.GetName(),
+				Name:      d.GetName(),
+				Namespace: d.GetNamespace(),
 				Labels: map[string]string{
 					LabelKey: string(w.GetUID()),
 				},

--- a/pkg/oam/workload/translate_test.go
+++ b/pkg/oam/workload/translate_test.go
@@ -80,6 +80,7 @@ func deployment(mod ...deploymentModifier) *appsv1.Deployment {
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:              workloadName,
+			Namespace:         workloadNamespace,
 			CreationTimestamp: metav1.NewTime(time.Date(0, 0, 0, 0, 0, 0, 0, time.Local)),
 		},
 		Spec: appsv1.DeploymentSpec{
@@ -128,7 +129,8 @@ func service(mod ...serviceModifier) *corev1.Service {
 			APIVersion: serviceAPIVersion,
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name: workloadName,
+			Name:      workloadName,
+			Namespace: workloadNamespace,
 			Labels: map[string]string{
 				LabelKey: workloadUID,
 			},


### PR DESCRIPTION
Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

<!--
Thank you for helping to improve Crossplane!

We strongly recommend you look through our contributor guide at https://git.io/fj2m9
if this is your first time opening a Crossplane pull request. You can find us in
https://slack.crossplane.io/messages/dev if you need any help contributing.
-->

### Description of your changes
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

Fixes #
-->

This follows #1361 and sets the `namespace` of the `Deployment` rendered by a `ContainerizedWorkload` to the `namespace` of the `ContainerizedWorkload`. The `Service` is set to the same `namespace` as the `Deployment` for which it is being injected. Note that these are the namespaces for the remote resources, not the `KubernetesApplicationResources` (although they will match).

### How has this code been tested?
<!--
Before reviewers can be confident in the correctness of a pull request,
it needs to tested and shown to be correct. In this section, briefly
describe the testing that has already been done or which is planned.
-->

Tested these changes successfully with https://github.com/crossplane/addon-oam-kubernetes-remote/pull/4 using the following configuration:

<details>
 <summary>App Config</summary>

```yaml
---
apiVersion: core.oam.dev/v1alpha2
kind: TraitDefinition
metadata:
  name: manualscalertraits.core.oam.dev
spec:
  definitionRef:
    name: manualscalertraits.core.oam.dev
---
apiVersion: core.oam.dev/v1alpha2
kind: WorkloadDefinition
metadata:
  name: containerizedworkloads.core.oam.dev
spec:
  definitionRef:
    name: containerizedworkloads.core.oam.dev
---
apiVersion: core.oam.dev/v1alpha2
kind: Component
metadata:
  name: example-component
spec:
  workload:
    apiVersion: core.oam.dev/v1alpha2
    kind: ContainerizedWorkload
    spec:
      containers:
      - name: wordpress
        image: wordpress:4.6.1-apache
        # TODO(negz): Allow environment variables to be set from a secret? OAM
        # doesn't have a concept of Kubernetes secrets, so we will likely need
        # to abstract this somehow.
        ports:
        - containerPort: 80
          name: wordpress
  parameters:
  - name: instance-name
    required: true
    fieldPaths:
    - metadata.name
  - name: image
    fieldPaths:
    - spec.containers[0].image
---
apiVersion: core.oam.dev/v1alpha2
kind: ApplicationConfiguration
metadata:
  name: example-appconfig
spec:
  components:
  - componentName: example-component
    parameterValues:
    - name: instance-name
      value: example-appconfig-workload
    - name: image
      value: wordpress:php7.2
    traits:
    - trait:
        apiVersion: core.oam.dev/v1alpha2
        kind: ManualScalerTrait
        metadata:
          # TODO(negz): This name can be omitted and generated automatically if
          # each trait kind may apply only once to a component/workload.
          name:  example-appconfig-trait
        spec:
          replicaCount: 3
```

</details>

### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every Crossplane pull request.
-->
I have:
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Ensured this PR contains a neat, self documenting set of commits.
- [ ] Updated any relevant [documentation] and [examples].
- [ ] Reported all new error conditions into the log or as an event, as
  appropriate.

For more about what we believe makes a pull request complete, see our
[definition of done].

[documentation]: https://github.com/crossplane/crossplane/tree/master/docs
[examples]: https://github.com/crossplane/crossplane/tree/master/cluster/examples
[definition of done]: https://github.com/crossplane/crossplane/tree/master/design/one-pager-definition-of-done.md
