### PR TITLE
Parse secrets from Deployment rendered for ContainerizedWorkload

### DIFF
--- a/pkg/controller/workload/kubernetes/resource/resource_test.go
+++ b/pkg/controller/workload/kubernetes/resource/resource_test.go
@@ -397,7 +397,6 @@ func TestSync(t *testing.T) {
 							RemoteControllerUID:       string(objectMeta.GetUID()),
 						})
 						if diff := cmp.Diff(want, got); diff != "" {
-							fmt.Println(diff)
 							return nil, errors.Errorf("mockSync: -want, +got: %s", diff)
 						}
 


### PR DESCRIPTION
Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

<!--
Thank you for helping to improve Crossplane!

We strongly recommend you look through our contributor guide at https://git.io/fj2m9
if this is your first time opening a Crossplane pull request. You can find us in
https://slack.crossplane.io/messages/dev if you need any help contributing.
-->

### Description of your changes
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

Fixes #
-->

This PR adds parsing for required secrets in a `Deployment` that is rendered for a `ContainerizedWorkload` when it is wrapped in a `KubernetesApplication`. When a `ContainerizedWorkload` uses the `fromSecret` field and is scheduled to a remote cluster, we must make sure that any required secrets are included on the `KubernetesApplicationResourceTemplate`.

### How has this code been tested?
<!--
Before reviewers can be confident in the correctness of a pull request,
it needs to tested and shown to be correct. In this section, briefly
describe the testing that has already been done or which is planned.
-->

This was tested with `addon-oam-kubernetes-remote` reflected in this PR: https://github.com/crossplane/addon-oam-kubernetes-remote/pull/4

1. Created a `Secret` in default namespace of Crossplane cluster

<details>
 <summary>Secret</summary>

```yaml
apiVersion: v1
data:
  key: dmFsdWU=
kind: Secret
metadata:
  creationTimestamp: "2020-04-02T16:02:54Z"
  name: test
  namespace: default
  resourceVersion: "2252"
  selfLink: /api/v1/namespaces/default/secrets/test
  uid: 4ad0a9bd-78ce-4522-8e43-6d002a543a43
type: Opaque
```

</details>

2. Created the following `ApplicationConfiguration` that utilizes the `fromSecret` field on the `ContainerizedWorkload`
<details>
 <summary>App Config</summary>

```yaml
---
apiVersion: core.oam.dev/v1alpha2
kind: TraitDefinition
metadata:
  name: manualscalertraits.core.oam.dev
spec:
  definitionRef:
    name: manualscalertraits.core.oam.dev
---
apiVersion: core.oam.dev/v1alpha2
kind: WorkloadDefinition
metadata:
  name: containerizedworkloads.core.oam.dev
spec:
  definitionRef:
    name: containerizedworkloads.core.oam.dev
---
apiVersion: core.oam.dev/v1alpha2
kind: Component
metadata:
  name: example-component
spec:
  workload:
    apiVersion: core.oam.dev/v1alpha2
    kind: ContainerizedWorkload
    spec:
      containers:
      - name: wordpress
        image: wordpress:4.6.1-apache
        env:
        - name: TEST_ENV
          fromSecret:
            name: replaceme
            key: replaceme
        ports:
        - containerPort: 80
          name: wordpress
  parameters:
  - name: instance-name
    required: true
    fieldPaths:
    - metadata.name
  - name: image
    fieldPaths:
    - spec.containers[0].image
  - name: env-var
    fieldPaths:
    - spec.containers[0].env[0].fromSecret.name
  - name: env-var-key
    fieldPaths:
    - spec.containers[0].env[0].fromSecret.key
---
apiVersion: core.oam.dev/v1alpha2
kind: ApplicationConfiguration
metadata:
  name: example-appconfig
spec:
  components:
  - componentName: example-component
    parameterValues:
    - name: instance-name
      value: example-appconfig-workload
    - name: image
      value: wordpress:php7.2
    - name: env-var
      value: test
    - name: env-var-key
      value: key
    traits:
    - trait:
        apiVersion: core.oam.dev/v1alpha2
        kind: ManualScalerTrait
        metadata:
          # TODO(negz): This name can be omitted and generated automatically if
          # each trait kind may apply only once to a component/workload.
          name:  example-appconfig-trait
        spec:
          replicaCount: 3
```

</details>

3. This rendered a `KubernetesApplication`

<details>
 <summary>KubernetesApplication</summary>

```yaml
apiVersion: workload.crossplane.io/v1alpha1
kind: KubernetesApplication
metadata:
  creationTimestamp: "2020-04-02T16:05:08Z"
  generation: 4
  labels:
    containerizedworkload.core.oam.dev: f62ec69c-d718-4926-9ada-64cfa1f36a40
  name: example-appconfig-workload
  namespace: default
  ownerReferences:
  - apiVersion: core.oam.dev/v1alpha2
    blockOwnerDeletion: true
    controller: true
    kind: ContainerizedWorkload
    name: example-appconfig-workload
    uid: f62ec69c-d718-4926-9ada-64cfa1f36a40
  resourceVersion: "2725"
  selfLink: /apis/workload.crossplane.io/v1alpha1/namespaces/default/kubernetesapplications/example-appconfig-workload
  uid: 44d69658-6cce-408f-a96a-2705aa7eac1d
spec:
  resourceSelector:
    matchLabels:
      workload.oam.crossplane.io: f62ec69c-d718-4926-9ada-64cfa1f36a40
  resourceTemplates:
  - metadata:
      labels:
        workload.oam.crossplane.io: f62ec69c-d718-4926-9ada-64cfa1f36a40
      name: example-appconfig-workload-deployment
    spec:
      secrets:
      - name: test # this was added to propagate the secret to remote
      template:
        apiVersion: apps/v1
        kind: Deployment
        metadata:
          name: example-appconfig-workload
          namespace: default
        spec:
          replicas: 3
          selector:
            matchLabels:
              containerizedworkload.oam.crossplane.io: f62ec69c-d718-4926-9ada-64cfa1f36a40
          strategy: {}
          template:
            metadata:
              labels:
                containerizedworkload.oam.crossplane.io: f62ec69c-d718-4926-9ada-64cfa1f36a40
            spec:
              containers:
              - env:
                - name: TEST_ENV
                  valueFrom:
                    secretKeyRef:
                      key: key
                      name: example-appconfig-workload-deployment-test # this was updated to appropriate secret name for remote cluster
                image: wordpress:php7.2
                name: wordpress
                ports:
                - containerPort: 80
                  name: wordpress
                resources: {}
        status: {}
  - metadata:
      labels:
        workload.oam.crossplane.io: f62ec69c-d718-4926-9ada-64cfa1f36a40
      name: example-appconfig-workload-service
    spec:
      template:
        apiVersion: v1
        kind: Service
        metadata:
          labels:
            workload.oam.crossplane.io: f62ec69c-d718-4926-9ada-64cfa1f36a40
          name: example-appconfig-workload
          namespace: default
        spec:
          ports:
          - name: example-appconfig-workload
            port: 80
            targetPort: 80
          selector:
            containerizedworkload.oam.crossplane.io: f62ec69c-d718-4926-9ada-64cfa1f36a40
          type: LoadBalancer
        status:
          loadBalancer: {}
  targetRef:
    name: 4b3bbc1a-fd42-4138-a74e-1f26c481f0d3
status:
  conditionedStatus:
    conditions:
    - lastTransitionTime: "2020-04-02T16:05:08Z"
      reason: Successfully reconciled resource
      status: "True"
      type: Synced
  desiredResources: 2
  state: Submitted
  submittedResources: 2
```

</details>

4. This resulted in `KubernetesApplicationResources` being created for the `Service` and `Deployment`, which were successfully submitted to the target cluster

<details>
 <summary>KubernetesApplicationResources</summary>

```
NAME                                    TEMPLATE-KIND   TEMPLATE-NAME                CLUSTER                                STATUS
example-appconfig-workload-deployment   Deployment      example-appconfig-workload   4b3bbc1a-fd42-4138-a74e-1f26c481f0d3   Submitted
example-appconfig-workload-service      Service         example-appconfig-workload   4b3bbc1a-fd42-4138-a74e-1f26c481f0d3   Submitted
```

</details>

5. The resources were successfully provisioned in the cluster (including propagating the secret)

<details>
 <summary>Service and Deployment </summary>
 
```
NAME                         READY   UP-TO-DATE   AVAILABLE   AGE
example-appconfig-workload   3/3     3            3           62m
```

```
NAME                         TYPE           CLUSTER-IP     EXTERNAL-IP      PORT(S)        AGE
example-appconfig-workload   LoadBalancer   10.43.248.86   35.223.212.136   80:32205/TCP   62m
kubernetes                   ClusterIP      10.43.240.1    <none>           443/TCP        67m
```

```
NAME                                         TYPE                                  DATA   AGE
default-token-9vvf2                          kubernetes.io/service-account-token   3      67m
example-appconfig-workload-deployment-test   Opaque                                1      63m
```

</details>

6. I also checked to make sure that the env var was actually set in the containers

<details>
 <summary>Show Env Var</summary>

```
🤖 (examples) kubectl --kubeconfig=remote1.kubeconfig exec -it example-appconfig-workload-68d54d6c47-5qm52 /bin/bash
root@example-appconfig-workload-68d54d6c47-5qm52:/var/www/html# env | grep TEST
TEST_ENV=value

```

</details>

### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every Crossplane pull request.
-->
I have:
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Ensured this PR contains a neat, self documenting set of commits.
- [ ] Updated any relevant [documentation] and [examples].
- [ ] Reported all new error conditions into the log or as an event, as
  appropriate.

For more about what we believe makes a pull request complete, see our
[definition of done].

[documentation]: https://github.com/crossplane/crossplane/tree/master/docs
[examples]: https://github.com/crossplane/crossplane/tree/master/cluster/examples
[definition of done]: https://github.com/crossplane/crossplane/tree/master/design/one-pager-definition-of-done.md
