### PR TITLE
template-stacks: Remove Command field from Deployment that hosts the templating-controller

### DIFF
--- a/pkg/stacks/unpack.go
+++ b/pkg/stacks/unpack.go
@@ -287,9 +287,12 @@ func (sp *StackPackage) createBehaviorController(sd v1alpha1.Behavior) appsv1.De
 					{
 						Name:  controllerContainerName,
 						Image: sd.Engine.ControllerImage,
-						// the environment variables are known and applied
-						// to containers at a higher level than unpack
-						Command: []string{"/manager"},
+						// The Command field is omitted and we are relying on
+						// the controller's image to explicitly define its
+						// entrypoint
+						//
+						// the environment variables are known and applied to
+						// containers at a higher level than unpack
 						Args: []string{
 							"--resources-dir", behaviorMountPoint,
 							"--stack-definition-namespace", "$(" + StackDefinitionNamespaceEnv + ")",

--- a/pkg/stacks/unpack_test.go
+++ b/pkg/stacks/unpack_test.go
@@ -1032,8 +1032,6 @@ spec:
               - $(SD_NAMESPACE)
               - --stack-definition-name
               - $(SD_NAME)
-              command:
-              - /manager
               image: crossplane/ts-controller:0.0.0
               name: stack-behavior-manager
               resources: {}


### PR DESCRIPTION
### Description of your changes

In the latest v0.3.0-rc version of the templating-controller, the entrypoint changed from
the typical kubebuilder `/manager` to a specific `/templating-controller` binary. To be
backwards compatible, the Stack Manager now just omits the Command (entrypoint) from the
deployment that it generates and expects the templating-controller image to have explicitly
defined its entrypoint.

Fixes https://github.com/crossplane/templating-controller/issues/13

### How has this code been tested?

I have tested this change with 2 versions of stack-minimal-azure, one that was using the old templating-controller with a `/manager` entrypoint and one with the new templating-controller that uses a `/templating-controller` entrypoint.  Both were able to install, run the templating-controller, and reconcile an example MinimalAzure instance.

* `crossplane/stack-minimal-azure:v0.4.0-rc-2-g98a4f97` that uses `crossplane/templating-controller:v0.3.0-rc`
* `crossplane/stack-minimal-azure:v0.3.0` that uses ` crossplane/templating-controller:v0.2.1`

### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every Crossplane pull request.
-->
I have:
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Ensured this PR contains a neat, self documenting set of commits.
- [x] Updated any relevant [documentation] and [examples].
- [x] Reported all new error conditions into the log or as an event, as
  appropriate.

For more about what we believe makes a pull request complete, see our
[definition of done].

[documentation]: https://github.com/crossplane/crossplane/tree/master/docs
[examples]: https://github.com/crossplane/crossplane/tree/master/cluster/examples
[definition of done]: https://github.com/crossplane/crossplane/tree/master/design/one-pager-definition-of-done.md
