### PR TITLE
Add categories to all core crossplane CRDs

### DIFF
--- a/apis/cache/v1alpha1/types.go
+++ b/apis/cache/v1alpha1/types.go
@@ -37,6 +37,7 @@ type RedisClusterSpec struct {
 // to a Redis managed resource such as a GCP CloudMemorystore instance or an AWS
 // ReplicationGroup. Despite the name RedisCluster claims may bind to Redis
 // managed resources that are a single node, or not in cluster mode.
+// +kubebuilder:resource:categories={crossplane,claim}
 // +kubebuilder:printcolumn:name="STATUS",type="string",JSONPath=".status.bindingPhase"
 // +kubebuilder:printcolumn:name="CLASS-KIND",type="string",JSONPath=".spec.classRef.kind"
 // +kubebuilder:printcolumn:name="CLASS-NAME",type="string",JSONPath=".spec.classRef.name"

--- a/apis/compute/v1alpha1/types.go
+++ b/apis/compute/v1alpha1/types.go
@@ -35,6 +35,7 @@ type KubernetesClusterSpec struct {
 // A KubernetesCluster is a portable resource claim that may be satisfied by
 // binding to a Kubernetes cluster managed resource such as an AWS EKS cluster
 // or an Azure AKS cluster.
+// +kubebuilder:resource:categories={crossplane,claim}
 // +kubebuilder:printcolumn:name="STATUS",type="string",JSONPath=".status.bindingPhase"
 // +kubebuilder:printcolumn:name="CLASS-KIND",type="string",JSONPath=".spec.classRef.kind"
 // +kubebuilder:printcolumn:name="CLASS-NAME",type="string",JSONPath=".spec.classRef.name"
@@ -70,6 +71,7 @@ type MachineInstanceSpec struct {
 // binding to a machine instance, which may include Virtual Machine managed
 // resources such as an AWS EC2 instance or bare metal managed resources such as
 // a Packet Device.
+// +kubebuilder:resource:categories={crossplane,claim}
 // +kubebuilder:printcolumn:name="STATUS",type="string",JSONPath=".status.bindingPhase"
 // +kubebuilder:printcolumn:name="CLASS-KIND",type="string",JSONPath=".spec.classRef.kind"
 // +kubebuilder:printcolumn:name="CLASS-NAME",type="string",JSONPath=".spec.classRef.name"

--- a/apis/database/v1alpha1/types.go
+++ b/apis/database/v1alpha1/types.go
@@ -36,6 +36,7 @@ type MySQLInstanceSpec struct {
 // A MySQLInstance is a portable resource claim that may be satisfied by binding
 // to a MySQL managed resource such as an AWS RDS instance or a GCP CloudSQL
 // instance.
+// +kubebuilder:resource:categories={crossplane,claim}
 // +kubebuilder:printcolumn:name="STATUS",type="string",JSONPath=".status.bindingPhase"
 // +kubebuilder:printcolumn:name="CLASS-KIND",type="string",JSONPath=".spec.classRef.kind"
 // +kubebuilder:printcolumn:name="CLASS-NAME",type="string",JSONPath=".spec.classRef.name"
@@ -75,6 +76,7 @@ type PostgreSQLInstanceSpec struct {
 // A PostgreSQLInstance is a portable resource claim that may be satisfied by
 // binding to a PostgreSQL managed resource such as an AWS RDS instance or a GCP
 // CloudSQL instance.
+// +kubebuilder:resource:categories={crossplane,claim}
 // +kubebuilder:printcolumn:name="STATUS",type="string",JSONPath=".status.bindingPhase"
 // +kubebuilder:printcolumn:name="CLASS-KIND",type="string",JSONPath=".spec.classRef.kind"
 // +kubebuilder:printcolumn:name="CLASS-NAME",type="string",JSONPath=".spec.classRef.name"
@@ -108,6 +110,7 @@ type NoSQLInstanceSpec struct {
 
 // A NoSQLInstance is a portable resource claim that may be satisfied by binding
 // to a NoSQL managed resource such as an AWS DynamoDB or an Azure CosmosDB instance.
+// +kubebuilder:resource:categories={crossplane,claim}
 // +kubebuilder:printcolumn:name="STATUS",type="string",JSONPath=".status.bindingPhase"
 // +kubebuilder:printcolumn:name="CLASS-KIND",type="string",JSONPath=".spec.classRef.kind"
 // +kubebuilder:printcolumn:name="CLASS-NAME",type="string",JSONPath=".spec.classRef.name"

--- a/apis/kubernetes/v1alpha1/types.go
+++ b/apis/kubernetes/v1alpha1/types.go
@@ -37,7 +37,7 @@ type ProviderSpec struct {
 // A Provider configures a Kubernetes 'provider', i.e. a connection to a particular
 // Kubernetes cluster using the referenced Secret.
 // +kubebuilder:printcolumn:name="SECRET-NAME",type="string",JSONPath=".spec.credentialsSecretRef.name",priority=1
-// +kubebuilder:resource:scope=Cluster
+// +kubebuilder:resource:scope=Cluster,categories=crossplane
 type Provider struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/apis/oam/v1alpha2/core_trait_types.go
+++ b/apis/oam/v1alpha2/core_trait_types.go
@@ -40,6 +40,7 @@ type ManualScalerTraitStatus struct {
 // +kubebuilder:object:root=true
 
 // A ManualScalerTrait determines how many replicas a workload should have.
+// +kubebuilder:resource:categories={crossplane,oam}
 // +kubebuilder:subresource:status
 type ManualScalerTrait struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/apis/oam/v1alpha2/core_types.go
+++ b/apis/oam/v1alpha2/core_types.go
@@ -44,7 +44,7 @@ type WorkloadDefinitionSpec struct {
 // is used to validate the schema of the workload when it is embedded in an OAM
 // Component.
 // +kubebuilder:printcolumn:JSONPath=".spec.definitionRef.name",name=DEFINITION-NAME,type=string
-// +kubebuilder:resource:scope=Cluster
+// +kubebuilder:resource:scope=Cluster,categories={crossplane,oam}
 type WorkloadDefinition struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -81,7 +81,7 @@ type TraitDefinitionSpec struct {
 // to validate the schema of the trait when it is embedded in an OAM
 // ApplicationConfiguration.
 // +kubebuilder:printcolumn:JSONPath=".spec.definitionRef.name",name=DEFINITION-NAME,type=string
-// +kubebuilder:resource:scope=Cluster
+// +kubebuilder:resource:scope=Cluster,categories={crossplane,oam}
 type TraitDefinition struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -115,7 +115,7 @@ type ScopeDefinitionSpec struct {
 // to validate the schema of the scope when it is embedded in an OAM
 // ApplicationConfiguration.
 // +kubebuilder:printcolumn:JSONPath=".spec.definitionRef.name",name=DEFINITION-NAME,type=string
-// +kubebuilder:resource:scope=Cluster
+// +kubebuilder:resource:scope=Cluster,categories={crossplane,oam}
 type ScopeDefinition struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -186,6 +186,7 @@ type ComponentStatus struct {
 // +kubebuilder:object:root=true
 
 // A Component describes how an OAM workload kind may be instantiated.
+// +kubebuilder:resource:categories={crossplane,oam}
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:JSONPath=".spec.workload.kind",name=WORKLOAD-KIND,type=string
 type Component struct {
@@ -291,7 +292,7 @@ type ApplicationConfigurationStatus struct {
 // +kubebuilder:object:root=true
 
 // An ApplicationConfiguration represents an OAM application.
-// +kubebuilder:resource:shortName=appconfig
+// +kubebuilder:resource:shortName=appconfig,categories={crossplane,oam}
 // +kubebuilder:subresource:status
 type ApplicationConfiguration struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/apis/oam/v1alpha2/core_workload_types.go
+++ b/apis/oam/v1alpha2/core_workload_types.go
@@ -384,6 +384,7 @@ type ContainerizedWorkloadStatus struct {
 // +kubebuilder:object:root=true
 
 // A ContainerizedWorkload is a workload that runs OCI containers.
+// +kubebuilder:resource:categories={crossplane,oam}
 // +kubebuilder:subresource:status
 type ContainerizedWorkload struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/apis/stacks/v1alpha1/stackdefinition.go
+++ b/apis/stacks/v1alpha1/stackdefinition.go
@@ -103,6 +103,7 @@ type StackDefinitionStatus struct {
 // +kubebuilder:object:root=true
 
 // StackDefinition is the Schema for the StackDefinitions API
+// +kubebuilder:resource:categories=crossplane
 type StackDefinition struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/apis/stacks/v1alpha1/types.go
+++ b/apis/stacks/v1alpha1/types.go
@@ -34,6 +34,7 @@ import (
 // +kubebuilder:object:root=true
 
 // A StackInstall requests a stack be installed to Crossplane.
+// +kubebuilder:resource:categories=crossplane
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="READY",type="string",JSONPath=".status.conditionedStatus.conditions[?(@.type=='Ready')].status"
 // +kubebuilder:printcolumn:name="SOURCE",type="string",JSONPath=".spec.source"
@@ -342,6 +343,7 @@ type StackInstaller interface {
 // +kubebuilder:object:root=true
 
 // ClusterStackInstall is the CRD type for a request to add a stack to Crossplane.
+// +kubebuilder:resource:categories=crossplane
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="READY",type="string",JSONPath=".status.conditionedStatus.conditions[?(@.type=='Ready')].status"
 // +kubebuilder:printcolumn:name="SOURCE",type="string",JSONPath=".spec.source"
@@ -368,6 +370,7 @@ type ClusterStackInstallList struct {
 // +kubebuilder:object:root=true
 
 // A Stack that has been added to Crossplane.
+// +kubebuilder:resource:categories=crossplane
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="READY",type="string",JSONPath=".status.conditionedStatus.conditions[?(@.type=='Ready')].status"
 // +kubebuilder:printcolumn:name="VERSION",type="string",JSONPath=".spec.version"

--- a/apis/storage/v1alpha1/types.go
+++ b/apis/storage/v1alpha1/types.go
@@ -74,6 +74,7 @@ type BucketSpec struct {
 
 // A Bucket is a portable resource claim that may be satisfied by binding to a
 // managed resource such as an AWS S3 bucket or Azure storage container.
+// +kubebuilder:resource:categories={crossplane,claim}
 // +kubebuilder:printcolumn:name="STATUS",type="string",JSONPath=".status.bindingPhase"
 // +kubebuilder:printcolumn:name="CLASS-KIND",type="string",JSONPath=".spec.classRef.kind"
 // +kubebuilder:printcolumn:name="CLASS-NAME",type="string",JSONPath=".spec.classRef.name"

--- a/apis/workload/v1alpha1/types.go
+++ b/apis/workload/v1alpha1/types.go
@@ -114,6 +114,7 @@ type KubernetesApplicationStatus struct {
 
 // A KubernetesApplication defines an application deployed by Crossplane to a
 // Kubernetes cluster, i.e. a portable KubernetesCluster resource claim.
+// +kubebuilder:resource:categories=crossplane
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="CLUSTER",type="string",JSONPath=".spec.targetRef.name"
 // +kubebuilder:printcolumn:name="STATUS",type="string",JSONPath=".status.state"
@@ -214,6 +215,7 @@ type KubernetesApplicationResourceStatus struct {
 // A KubernetesApplicationResource is a resource of a Kubernetes application.
 // Each resource templates a single Kubernetes resource to be deployed to its
 // scheduled KubernetesCluster.
+// +kubebuilder:resource:categories=crossplane
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="TEMPLATE-KIND",type="string",JSONPath=".spec.template.kind"
 // +kubebuilder:printcolumn:name="TEMPLATE-NAME",type="string",JSONPath=".spec.template.metadata.name"
@@ -240,6 +242,7 @@ type KubernetesApplicationResourceList struct {
 // +kubebuilder:object:root=true
 
 // A KubernetesTarget is a scheduling target for a Kubernetes Application.
+// +kubebuilder:resource:categories=crossplane
 // +kubebuilder:printcolumn:name="CLUSTER",type="string",JSONPath=".spec.clusterRef.name"
 type KubernetesTarget struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/cluster/charts/crossplane-types/crds/cache.crossplane.io_redisclusters.yaml
+++ b/cluster/charts/crossplane-types/crds/cache.crossplane.io_redisclusters.yaml
@@ -29,6 +29,9 @@ spec:
     type: date
   group: cache.crossplane.io
   names:
+    categories:
+    - crossplane
+    - claim
     kind: RedisCluster
     listKind: RedisClusterList
     plural: redisclusters

--- a/cluster/charts/crossplane-types/crds/compute.crossplane.io_kubernetesclusters.yaml
+++ b/cluster/charts/crossplane-types/crds/compute.crossplane.io_kubernetesclusters.yaml
@@ -29,6 +29,9 @@ spec:
     type: date
   group: compute.crossplane.io
   names:
+    categories:
+    - crossplane
+    - claim
     kind: KubernetesCluster
     listKind: KubernetesClusterList
     plural: kubernetesclusters

--- a/cluster/charts/crossplane-types/crds/compute.crossplane.io_machineinstances.yaml
+++ b/cluster/charts/crossplane-types/crds/compute.crossplane.io_machineinstances.yaml
@@ -29,6 +29,9 @@ spec:
     type: date
   group: compute.crossplane.io
   names:
+    categories:
+    - crossplane
+    - claim
     kind: MachineInstance
     listKind: MachineInstanceList
     plural: machineinstances

--- a/cluster/charts/crossplane-types/crds/core.oam.dev_applicationconfigurations.yaml
+++ b/cluster/charts/crossplane-types/crds/core.oam.dev_applicationconfigurations.yaml
@@ -10,6 +10,9 @@ metadata:
 spec:
   group: core.oam.dev
   names:
+    categories:
+    - crossplane
+    - oam
     kind: ApplicationConfiguration
     listKind: ApplicationConfigurationList
     plural: applicationconfigurations

--- a/cluster/charts/crossplane-types/crds/core.oam.dev_components.yaml
+++ b/cluster/charts/crossplane-types/crds/core.oam.dev_components.yaml
@@ -14,6 +14,9 @@ spec:
     type: string
   group: core.oam.dev
   names:
+    categories:
+    - crossplane
+    - oam
     kind: Component
     listKind: ComponentList
     plural: components

--- a/cluster/charts/crossplane-types/crds/core.oam.dev_containerizedworkloads.yaml
+++ b/cluster/charts/crossplane-types/crds/core.oam.dev_containerizedworkloads.yaml
@@ -10,6 +10,9 @@ metadata:
 spec:
   group: core.oam.dev
   names:
+    categories:
+    - crossplane
+    - oam
     kind: ContainerizedWorkload
     listKind: ContainerizedWorkloadList
     plural: containerizedworkloads

--- a/cluster/charts/crossplane-types/crds/core.oam.dev_manualscalertraits.yaml
+++ b/cluster/charts/crossplane-types/crds/core.oam.dev_manualscalertraits.yaml
@@ -10,6 +10,9 @@ metadata:
 spec:
   group: core.oam.dev
   names:
+    categories:
+    - crossplane
+    - oam
     kind: ManualScalerTrait
     listKind: ManualScalerTraitList
     plural: manualscalertraits

--- a/cluster/charts/crossplane-types/crds/core.oam.dev_scopedefinitions.yaml
+++ b/cluster/charts/crossplane-types/crds/core.oam.dev_scopedefinitions.yaml
@@ -14,6 +14,9 @@ spec:
     type: string
   group: core.oam.dev
   names:
+    categories:
+    - crossplane
+    - oam
     kind: ScopeDefinition
     listKind: ScopeDefinitionList
     plural: scopedefinitions

--- a/cluster/charts/crossplane-types/crds/core.oam.dev_traitdefinitions.yaml
+++ b/cluster/charts/crossplane-types/crds/core.oam.dev_traitdefinitions.yaml
@@ -14,6 +14,9 @@ spec:
     type: string
   group: core.oam.dev
   names:
+    categories:
+    - crossplane
+    - oam
     kind: TraitDefinition
     listKind: TraitDefinitionList
     plural: traitdefinitions

--- a/cluster/charts/crossplane-types/crds/core.oam.dev_workloaddefinitions.yaml
+++ b/cluster/charts/crossplane-types/crds/core.oam.dev_workloaddefinitions.yaml
@@ -14,6 +14,9 @@ spec:
     type: string
   group: core.oam.dev
   names:
+    categories:
+    - crossplane
+    - oam
     kind: WorkloadDefinition
     listKind: WorkloadDefinitionList
     plural: workloaddefinitions

--- a/cluster/charts/crossplane-types/crds/database.crossplane.io_mysqlinstances.yaml
+++ b/cluster/charts/crossplane-types/crds/database.crossplane.io_mysqlinstances.yaml
@@ -29,6 +29,9 @@ spec:
     type: date
   group: database.crossplane.io
   names:
+    categories:
+    - crossplane
+    - claim
     kind: MySQLInstance
     listKind: MySQLInstanceList
     plural: mysqlinstances

--- a/cluster/charts/crossplane-types/crds/database.crossplane.io_nosqlinstances.yaml
+++ b/cluster/charts/crossplane-types/crds/database.crossplane.io_nosqlinstances.yaml
@@ -29,6 +29,9 @@ spec:
     type: date
   group: database.crossplane.io
   names:
+    categories:
+    - crossplane
+    - claim
     kind: NoSQLInstance
     listKind: NoSQLInstanceList
     plural: nosqlinstances

--- a/cluster/charts/crossplane-types/crds/database.crossplane.io_postgresqlinstances.yaml
+++ b/cluster/charts/crossplane-types/crds/database.crossplane.io_postgresqlinstances.yaml
@@ -29,6 +29,9 @@ spec:
     type: date
   group: database.crossplane.io
   names:
+    categories:
+    - crossplane
+    - claim
     kind: PostgreSQLInstance
     listKind: PostgreSQLInstanceList
     plural: postgresqlinstances

--- a/cluster/charts/crossplane-types/crds/kubernetes.crossplane.io_providers.yaml
+++ b/cluster/charts/crossplane-types/crds/kubernetes.crossplane.io_providers.yaml
@@ -15,6 +15,8 @@ spec:
     type: string
   group: kubernetes.crossplane.io
   names:
+    categories:
+    - crossplane
     kind: Provider
     listKind: ProviderList
     plural: providers

--- a/cluster/charts/crossplane-types/crds/stacks.crossplane.io_clusterstackinstalls.yaml
+++ b/cluster/charts/crossplane-types/crds/stacks.crossplane.io_clusterstackinstalls.yaml
@@ -26,6 +26,8 @@ spec:
     type: date
   group: stacks.crossplane.io
   names:
+    categories:
+    - crossplane
     kind: ClusterStackInstall
     listKind: ClusterStackInstallList
     plural: clusterstackinstalls

--- a/cluster/charts/crossplane-types/crds/stacks.crossplane.io_stackdefinitions.yaml
+++ b/cluster/charts/crossplane-types/crds/stacks.crossplane.io_stackdefinitions.yaml
@@ -10,6 +10,8 @@ metadata:
 spec:
   group: stacks.crossplane.io
   names:
+    categories:
+    - crossplane
     kind: StackDefinition
     listKind: StackDefinitionList
     plural: stackdefinitions

--- a/cluster/charts/crossplane-types/crds/stacks.crossplane.io_stackinstalls.yaml
+++ b/cluster/charts/crossplane-types/crds/stacks.crossplane.io_stackinstalls.yaml
@@ -26,6 +26,8 @@ spec:
     type: date
   group: stacks.crossplane.io
   names:
+    categories:
+    - crossplane
     kind: StackInstall
     listKind: StackInstallList
     plural: stackinstalls

--- a/cluster/charts/crossplane-types/crds/stacks.crossplane.io_stacks.yaml
+++ b/cluster/charts/crossplane-types/crds/stacks.crossplane.io_stacks.yaml
@@ -20,6 +20,8 @@ spec:
     type: date
   group: stacks.crossplane.io
   names:
+    categories:
+    - crossplane
     kind: Stack
     listKind: StackList
     plural: stacks

--- a/cluster/charts/crossplane-types/crds/storage.crossplane.io_buckets.yaml
+++ b/cluster/charts/crossplane-types/crds/storage.crossplane.io_buckets.yaml
@@ -29,6 +29,9 @@ spec:
     type: date
   group: storage.crossplane.io
   names:
+    categories:
+    - crossplane
+    - claim
     kind: Bucket
     listKind: BucketList
     plural: buckets

--- a/cluster/charts/crossplane-types/crds/workload.crossplane.io_kubernetesapplicationresources.yaml
+++ b/cluster/charts/crossplane-types/crds/workload.crossplane.io_kubernetesapplicationresources.yaml
@@ -23,6 +23,8 @@ spec:
     type: string
   group: workload.crossplane.io
   names:
+    categories:
+    - crossplane
     kind: KubernetesApplicationResource
     listKind: KubernetesApplicationResourceList
     plural: kubernetesapplicationresources

--- a/cluster/charts/crossplane-types/crds/workload.crossplane.io_kubernetesapplications.yaml
+++ b/cluster/charts/crossplane-types/crds/workload.crossplane.io_kubernetesapplications.yaml
@@ -23,6 +23,8 @@ spec:
     type: integer
   group: workload.crossplane.io
   names:
+    categories:
+    - crossplane
     kind: KubernetesApplication
     listKind: KubernetesApplicationList
     plural: kubernetesapplications

--- a/cluster/charts/crossplane-types/crds/workload.crossplane.io_kubernetestargets.yaml
+++ b/cluster/charts/crossplane-types/crds/workload.crossplane.io_kubernetestargets.yaml
@@ -14,6 +14,8 @@ spec:
     type: string
   group: workload.crossplane.io
   names:
+    categories:
+    - crossplane
     kind: KubernetesTarget
     listKind: KubernetesTargetList
     plural: kubernetestargets

--- a/cluster/charts/crossplane/crds/stacks.crossplane.io_clusterstackinstalls.yaml
+++ b/cluster/charts/crossplane/crds/stacks.crossplane.io_clusterstackinstalls.yaml
@@ -26,6 +26,8 @@ spec:
     type: date
   group: stacks.crossplane.io
   names:
+    categories:
+    - crossplane
     kind: ClusterStackInstall
     listKind: ClusterStackInstallList
     plural: clusterstackinstalls

--- a/cluster/charts/crossplane/crds/stacks.crossplane.io_stackinstalls.yaml
+++ b/cluster/charts/crossplane/crds/stacks.crossplane.io_stackinstalls.yaml
@@ -26,6 +26,8 @@ spec:
     type: date
   group: stacks.crossplane.io
   names:
+    categories:
+    - crossplane
     kind: StackInstall
     listKind: StackInstallList
     plural: stackinstalls

--- a/cluster/charts/crossplane/templates/crds/cache.crossplane.io_redisclusters.yaml
+++ b/cluster/charts/crossplane/templates/crds/cache.crossplane.io_redisclusters.yaml
@@ -29,6 +29,9 @@ spec:
     type: date
   group: cache.crossplane.io
   names:
+    categories:
+    - crossplane
+    - claim
     kind: RedisCluster
     listKind: RedisClusterList
     plural: redisclusters

--- a/cluster/charts/crossplane/templates/crds/compute.crossplane.io_kubernetesclusters.yaml
+++ b/cluster/charts/crossplane/templates/crds/compute.crossplane.io_kubernetesclusters.yaml
@@ -29,6 +29,9 @@ spec:
     type: date
   group: compute.crossplane.io
   names:
+    categories:
+    - crossplane
+    - claim
     kind: KubernetesCluster
     listKind: KubernetesClusterList
     plural: kubernetesclusters

--- a/cluster/charts/crossplane/templates/crds/compute.crossplane.io_machineinstances.yaml
+++ b/cluster/charts/crossplane/templates/crds/compute.crossplane.io_machineinstances.yaml
@@ -29,6 +29,9 @@ spec:
     type: date
   group: compute.crossplane.io
   names:
+    categories:
+    - crossplane
+    - claim
     kind: MachineInstance
     listKind: MachineInstanceList
     plural: machineinstances

--- a/cluster/charts/crossplane/templates/crds/core.oam.dev_applicationconfigurations.yaml
+++ b/cluster/charts/crossplane/templates/crds/core.oam.dev_applicationconfigurations.yaml
@@ -10,6 +10,9 @@ metadata:
 spec:
   group: core.oam.dev
   names:
+    categories:
+    - crossplane
+    - oam
     kind: ApplicationConfiguration
     listKind: ApplicationConfigurationList
     plural: applicationconfigurations

--- a/cluster/charts/crossplane/templates/crds/core.oam.dev_components.yaml
+++ b/cluster/charts/crossplane/templates/crds/core.oam.dev_components.yaml
@@ -14,6 +14,9 @@ spec:
     type: string
   group: core.oam.dev
   names:
+    categories:
+    - crossplane
+    - oam
     kind: Component
     listKind: ComponentList
     plural: components

--- a/cluster/charts/crossplane/templates/crds/core.oam.dev_containerizedworkloads.yaml
+++ b/cluster/charts/crossplane/templates/crds/core.oam.dev_containerizedworkloads.yaml
@@ -10,6 +10,9 @@ metadata:
 spec:
   group: core.oam.dev
   names:
+    categories:
+    - crossplane
+    - oam
     kind: ContainerizedWorkload
     listKind: ContainerizedWorkloadList
     plural: containerizedworkloads

--- a/cluster/charts/crossplane/templates/crds/core.oam.dev_manualscalertraits.yaml
+++ b/cluster/charts/crossplane/templates/crds/core.oam.dev_manualscalertraits.yaml
@@ -10,6 +10,9 @@ metadata:
 spec:
   group: core.oam.dev
   names:
+    categories:
+    - crossplane
+    - oam
     kind: ManualScalerTrait
     listKind: ManualScalerTraitList
     plural: manualscalertraits

--- a/cluster/charts/crossplane/templates/crds/core.oam.dev_scopedefinitions.yaml
+++ b/cluster/charts/crossplane/templates/crds/core.oam.dev_scopedefinitions.yaml
@@ -14,6 +14,9 @@ spec:
     type: string
   group: core.oam.dev
   names:
+    categories:
+    - crossplane
+    - oam
     kind: ScopeDefinition
     listKind: ScopeDefinitionList
     plural: scopedefinitions

--- a/cluster/charts/crossplane/templates/crds/core.oam.dev_traitdefinitions.yaml
+++ b/cluster/charts/crossplane/templates/crds/core.oam.dev_traitdefinitions.yaml
@@ -14,6 +14,9 @@ spec:
     type: string
   group: core.oam.dev
   names:
+    categories:
+    - crossplane
+    - oam
     kind: TraitDefinition
     listKind: TraitDefinitionList
     plural: traitdefinitions

--- a/cluster/charts/crossplane/templates/crds/core.oam.dev_workloaddefinitions.yaml
+++ b/cluster/charts/crossplane/templates/crds/core.oam.dev_workloaddefinitions.yaml
@@ -14,6 +14,9 @@ spec:
     type: string
   group: core.oam.dev
   names:
+    categories:
+    - crossplane
+    - oam
     kind: WorkloadDefinition
     listKind: WorkloadDefinitionList
     plural: workloaddefinitions

--- a/cluster/charts/crossplane/templates/crds/database.crossplane.io_mysqlinstances.yaml
+++ b/cluster/charts/crossplane/templates/crds/database.crossplane.io_mysqlinstances.yaml
@@ -29,6 +29,9 @@ spec:
     type: date
   group: database.crossplane.io
   names:
+    categories:
+    - crossplane
+    - claim
     kind: MySQLInstance
     listKind: MySQLInstanceList
     plural: mysqlinstances

--- a/cluster/charts/crossplane/templates/crds/database.crossplane.io_nosqlinstances.yaml
+++ b/cluster/charts/crossplane/templates/crds/database.crossplane.io_nosqlinstances.yaml
@@ -29,6 +29,9 @@ spec:
     type: date
   group: database.crossplane.io
   names:
+    categories:
+    - crossplane
+    - claim
     kind: NoSQLInstance
     listKind: NoSQLInstanceList
     plural: nosqlinstances

--- a/cluster/charts/crossplane/templates/crds/database.crossplane.io_postgresqlinstances.yaml
+++ b/cluster/charts/crossplane/templates/crds/database.crossplane.io_postgresqlinstances.yaml
@@ -29,6 +29,9 @@ spec:
     type: date
   group: database.crossplane.io
   names:
+    categories:
+    - crossplane
+    - claim
     kind: PostgreSQLInstance
     listKind: PostgreSQLInstanceList
     plural: postgresqlinstances

--- a/cluster/charts/crossplane/templates/crds/kubernetes.crossplane.io_providers.yaml
+++ b/cluster/charts/crossplane/templates/crds/kubernetes.crossplane.io_providers.yaml
@@ -15,6 +15,8 @@ spec:
     type: string
   group: kubernetes.crossplane.io
   names:
+    categories:
+    - crossplane
     kind: Provider
     listKind: ProviderList
     plural: providers

--- a/cluster/charts/crossplane/templates/crds/stacks.crossplane.io_clusterstackinstalls.yaml
+++ b/cluster/charts/crossplane/templates/crds/stacks.crossplane.io_clusterstackinstalls.yaml
@@ -26,6 +26,8 @@ spec:
     type: date
   group: stacks.crossplane.io
   names:
+    categories:
+    - crossplane
     kind: ClusterStackInstall
     listKind: ClusterStackInstallList
     plural: clusterstackinstalls

--- a/cluster/charts/crossplane/templates/crds/stacks.crossplane.io_stackdefinitions.yaml
+++ b/cluster/charts/crossplane/templates/crds/stacks.crossplane.io_stackdefinitions.yaml
@@ -10,6 +10,8 @@ metadata:
 spec:
   group: stacks.crossplane.io
   names:
+    categories:
+    - crossplane
     kind: StackDefinition
     listKind: StackDefinitionList
     plural: stackdefinitions

--- a/cluster/charts/crossplane/templates/crds/stacks.crossplane.io_stackinstalls.yaml
+++ b/cluster/charts/crossplane/templates/crds/stacks.crossplane.io_stackinstalls.yaml
@@ -26,6 +26,8 @@ spec:
     type: date
   group: stacks.crossplane.io
   names:
+    categories:
+    - crossplane
     kind: StackInstall
     listKind: StackInstallList
     plural: stackinstalls

--- a/cluster/charts/crossplane/templates/crds/stacks.crossplane.io_stacks.yaml
+++ b/cluster/charts/crossplane/templates/crds/stacks.crossplane.io_stacks.yaml
@@ -20,6 +20,8 @@ spec:
     type: date
   group: stacks.crossplane.io
   names:
+    categories:
+    - crossplane
     kind: Stack
     listKind: StackList
     plural: stacks

--- a/cluster/charts/crossplane/templates/crds/storage.crossplane.io_buckets.yaml
+++ b/cluster/charts/crossplane/templates/crds/storage.crossplane.io_buckets.yaml
@@ -29,6 +29,9 @@ spec:
     type: date
   group: storage.crossplane.io
   names:
+    categories:
+    - crossplane
+    - claim
     kind: Bucket
     listKind: BucketList
     plural: buckets

--- a/cluster/charts/crossplane/templates/crds/workload.crossplane.io_kubernetesapplicationresources.yaml
+++ b/cluster/charts/crossplane/templates/crds/workload.crossplane.io_kubernetesapplicationresources.yaml
@@ -23,6 +23,8 @@ spec:
     type: string
   group: workload.crossplane.io
   names:
+    categories:
+    - crossplane
     kind: KubernetesApplicationResource
     listKind: KubernetesApplicationResourceList
     plural: kubernetesapplicationresources

--- a/cluster/charts/crossplane/templates/crds/workload.crossplane.io_kubernetesapplications.yaml
+++ b/cluster/charts/crossplane/templates/crds/workload.crossplane.io_kubernetesapplications.yaml
@@ -23,6 +23,8 @@ spec:
     type: integer
   group: workload.crossplane.io
   names:
+    categories:
+    - crossplane
     kind: KubernetesApplication
     listKind: KubernetesApplicationList
     plural: kubernetesapplications

--- a/cluster/charts/crossplane/templates/crds/workload.crossplane.io_kubernetestargets.yaml
+++ b/cluster/charts/crossplane/templates/crds/workload.crossplane.io_kubernetestargets.yaml
@@ -14,6 +14,8 @@ spec:
     type: string
   group: workload.crossplane.io
   names:
+    categories:
+    - crossplane
     kind: KubernetesTarget
     listKind: KubernetesTargetList
     plural: kubernetestargets


### PR DESCRIPTION
Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

<!--
Thank you for helping to improve Crossplane!

We strongly recommend you look through our contributor guide at https://git.io/fj2m9
if this is your first time opening a Crossplane pull request. You can find us in
https://slack.crossplane.io/messages/dev if you need any help contributing.
-->

### Description of your changes
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

Fixes #
-->
Fixes #1379 

Adding categories to our CRDs allows us to list them in groups across different `Kinds`. I believe these initial categories are relatively uncontroversial. They are as follows:

- OAM types: `crossplane` `oam`
- Claim types: `crossplane` `claim`
- Workload types: `crossplane`
- Stack types: `crossplane`
- Kubernetes Provider: `crossplane` 

### How has this code been tested?
<!--
Before reviewers can be confident in the correctness of a pull request,
it needs to tested and shown to be correct. In this section, briefly
describe the testing that has already been done or which is planned.
-->

I installed all CRDs then created some instances and demonstrated listing scenarios:

```
kubectl apply -f cluster/examples/oam/applicationconfiguration.yaml
kubectl apply -f cluster/examples/cache/rediscluster/resource-claim.yaml
kubectl apply -f cluster/examples/stacks/stackinstall.yaml
```

kubectl get oam
```
NAME                                                           DEFINITION-NAME
traitdefinition.core.oam.dev/manualscalertraits.core.oam.dev   manualscalertraits.core.oam.dev
NAME                                                      AGE
applicationconfiguration.core.oam.dev/example-appconfig   19s
NAME                                       WORKLOAD-KIND
component.core.oam.dev/example-component   ContainerizedWorkload
NAME                                                                  DEFINITION-NAME
workloaddefinition.core.oam.dev/containerizedworkloads.core.oam.dev   containerizedworkloads.core.oam.dev
```

kubectl get claim
```
NAME                                         STATUS   CLASS-KIND   CLASS-NAME   RESOURCE-KIND   RESOURCE-NAME   AGE
rediscluster.cache.crossplane.io/app-redis                                                                      25s
```

kubectl get crossplane
```
NAME                                         STATUS   CLASS-KIND   CLASS-NAME   RESOURCE-KIND   RESOURCE-NAME   AGE
rediscluster.cache.crossplane.io/app-redis                                                                      2m29s
NAME                                                          READY   SOURCE                    PACKAGE                   CRD   AGE
stackinstall.stacks.crossplane.io/sample-stack-from-package           registry.hub.docker.com   crossplane/sample-stack         30s
NAME                                                           DEFINITION-NAME
traitdefinition.core.oam.dev/manualscalertraits.core.oam.dev   manualscalertraits.core.oam.dev
NAME                                                      AGE
applicationconfiguration.core.oam.dev/example-appconfig   3m16s
NAME                                       WORKLOAD-KIND
component.core.oam.dev/example-component   ContainerizedWorkload
NAME                                                                  DEFINITION-NAME
workloaddefinition.core.oam.dev/containerizedworkloads.core.oam.dev   containerizedworkloads.core.oam.dev
```

### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every Crossplane pull request.
-->
I have:
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Ensured this PR contains a neat, self documenting set of commits.
- [ ] Updated any relevant [documentation] and [examples].
- [ ] Reported all new error conditions into the log or as an event, as
  appropriate.

For more about what we believe makes a pull request complete, see our
[definition of done].

[documentation]: https://github.com/crossplane/crossplane/tree/master/docs
[examples]: https://github.com/crossplane/crossplane/tree/master/cluster/examples
[definition of done]: https://github.com/crossplane/crossplane/tree/master/design/one-pager-definition-of-done.md
