### PR TITLE
[Flaky Test] Fix GetSecretsFromCW test flake

### DIFF
--- a/pkg/oam/workload/translate_test.go
+++ b/pkg/oam/workload/translate_test.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -543,7 +544,7 @@ func TestGetSecretsFromCWDeployment(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			r := secretsForCWDeployment(tc.args.w, tc.args.o, tc.args.p)
 
-			if diff := cmp.Diff(tc.want.result, r); diff != "" {
+			if diff := cmp.Diff(tc.want.result, r, cmpopts.SortSlices(func(i, j corev1.LocalObjectReference) bool { return i.Name < j.Name })); diff != "" {
 				t.Errorf("\nReason: %s\ngetSecretsFromCWDeployment(...): -want, +got:\n%s", tc.reason, diff)
 			}
 		})


### PR DESCRIPTION
Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

<!--
Thank you for helping to improve Crossplane!

We strongly recommend you look through our contributor guide at https://git.io/fj2m9
if this is your first time opening a Crossplane pull request. You can find us in
https://slack.crossplane.io/messages/dev if you need any help contributing.
-->

### Description of your changes
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

Fixes #
-->

This update changes the test for getting required secrets off of an OAM ContainerizedWorkload to sort the slice of LocalObjectReferences before comparison. Order is not predicatable because the secrets are stored in a map to avoid adding a secret to a KAR template multiple times.

Ref: https://crossplane.slack.com/archives/CKXQHM7U3/p1586267084198900 (thanks @displague!)

### How has this code been tested?
<!--
Before reviewers can be confident in the correctness of a pull request,
it needs to tested and shown to be correct. In this section, briefly
describe the testing that has already been done or which is planned.
-->

`make test`

### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every Crossplane pull request.
-->
I have:
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Ensured this PR contains a neat, self documenting set of commits.
- [ ] Updated any relevant [documentation] and [examples].
- [ ] Reported all new error conditions into the log or as an event, as
  appropriate.

For more about what we believe makes a pull request complete, see our
[definition of done].

[documentation]: https://github.com/crossplane/crossplane/tree/master/docs
[examples]: https://github.com/crossplane/crossplane/tree/master/cluster/examples
[definition of done]: https://github.com/crossplane/crossplane/tree/master/design/one-pager-definition-of-done.md
