### PR TITLE
stacks: controller ownerrefs require finalizer subresource rbac in openshift

### DIFF
--- a/pkg/stacks/unpack.go
+++ b/pkg/stacks/unpack.go
@@ -486,6 +486,16 @@ func (sp *StackPackage) applyRules() (v1alpha1.PermissionsSpec, error) {
 				kinds = append(kinds, crd.Spec.Names.Plural+"/scale")
 			}
 		}
+
+		// For the stack controller to set a controller owner reference on CRs
+		// that it owns, in some settings (OpenShift 4.3), it is necessary to
+		// give the controller access to a finalizers subresource, even if the
+		// crd does not present this subresource. External controllers will look
+		// for this rule. The error produced without it is: "cannot set
+		// blockOwnerDeletion if an ownerReference refers to a resource you
+		// can't set finalizers on"
+		kinds = append(kinds, crd.Spec.Names.Plural+"/finalizers")
+
 		rule := generateRBAC(kinds, crd.Spec.Group, verbs)
 		rbac.Rules = append(rbac.Rules, rule)
 	}

--- a/pkg/stacks/unpack_test.go
+++ b/pkg/stacks/unpack_test.go
@@ -304,6 +304,7 @@ spec:
       - samples.upbound.io
       resources:
       - siblings
+      - siblings/finalizers
       verbs:
       - '*'
     - apiGroups:
@@ -312,18 +313,21 @@ spec:
       - secondcousins
       - secondcousins/status
       - secondcousins/scale
+      - secondcousins/finalizers
       verbs:
       - '*'
     - apiGroups:
       - samples.upbound.io
       resources:
       - mytypes
+      - mytypes/finalizers
       verbs:
       - '*'
     - apiGroups:
       - samples.upbound.io
       resources:
       - cousins
+      - cousins/finalizers
       verbs:
       - '*'
     - apiGroups:
@@ -600,6 +604,7 @@ spec:
       - samples.upbound.io
       resources:
       - siblings
+      - siblings/finalizers
       verbs:
       - '*'
     - apiGroups:
@@ -608,18 +613,21 @@ spec:
       - secondcousins
       - secondcousins/status
       - secondcousins/scale
+      - secondcousins/finalizers
       verbs:
       - '*'
     - apiGroups:
       - samples.upbound.io
       resources:
       - mytypes
+      - mytypes/finalizers
       verbs:
       - '*'
     - apiGroups:
       - samples.upbound.io
       resources:
       - cousins
+      - cousins/finalizers
       verbs:
       - '*'
     - apiGroups:
@@ -932,6 +940,7 @@ spec:
       - samples.upbound.io
       resources:
       - mytypes
+      - mytypes/finalizers
       verbs:
       - '*'
     - apiGroups:
@@ -1091,6 +1100,7 @@ spec:
       - samples.upbound.io
       resources:
       - mytypes
+      - mytypes/finalizers
       verbs:
       - '*'
     - apiGroups:


### PR DESCRIPTION
For the stack controller to set a controller owner reference on CRs
that it owns, in some settings (OpenShift 4.3), it is necessary to
give the controller access to a finalizers subresource, even if the
crd does not present this subresource. External controllers will look
for this rule. The error produced without it is: "cannot set
blockOwnerDeletion if an ownerReference refers to a resource you
can't set finalizers on"

Similar to https://github.com/openshift/origin/issues/22958

### Description of your changes

Give Stack controllers RBAC rules that include full access to the `/finalizers` sub-resource for all resources that the Stack owns.

Fixes https://github.com/crossplane/stack-aws-sample/issues/17

### How has this code been tested?
<!--
Before reviewers can be confident in the correctness of a pull request,
it needs to tested and shown to be correct. In this section, briefly
describe the testing that has already been done or which is planned.
-->

`make test` has been updated with these expectations.

While the code has not been run in Openshift, the change in rules has been tested in OpenShift 4.3.

### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every Crossplane pull request.
-->
I have:
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Ensured this PR contains a neat, self documenting set of commits.
- [ ] Updated any relevant [documentation] and [examples].
- [ ] Reported all new error conditions into the log or as an event, as
  appropriate.

For more about what we believe makes a pull request complete, see our
[definition of done].

[documentation]: https://github.com/crossplane/crossplane/tree/master/docs
[examples]: https://github.com/crossplane/crossplane/tree/master/cluster/examples
[definition of done]: https://github.com/crossplane/crossplane/tree/master/design/one-pager-definition-of-done.md
