### PR TITLE
stacks: truncated resource names can not contain ".-"

### DIFF
--- a/pkg/stacks/truncate/truncate_test.go
+++ b/pkg/stacks/truncate/truncate_test.go
@@ -83,6 +83,12 @@ func Test_truncate(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name:    "TruncatedOnDot",
+			args:    args{str: "1234.678901", length: 10, suffixLength: 5},
+			want:    "1234-kjwi",
+			wantErr: false,
+		},
+		{
 			name: "hosted-stack-ns-example",
 			args: args{str: "cool-namespace-abcdefghijklmnopqrstuvwxyz", length: 32, suffixLength: 5},
 			want: "cool-namespace-abcdefghijkl-lzi4",


### PR DESCRIPTION
# Description of your changes

As discovered by @rathpc :

> When long names get truncated we are not explicitly checking what the last character is resulting in a possible issue as shown in the code block below. A . is next to a - which is considered INVALID for a job (possible other things)

This PR offers a fix by reducing the number of characters of the overall truncation by right trimming any `.` characters before the hyphenated suffix.

The DNS label (regex) restriction that triggers the error is not a name restriction in all of the places where we are using `Truncate`, but I think it is reasonable to make this change in all truncations.

### How has this code been tested?

`make test` (new test)

### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every Crossplane pull request.
-->
I have:
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Ensured this PR contains a neat, self documenting set of commits.
- [ ] Updated any relevant [documentation] and [examples].
- [ ] Reported all new error conditions into the log or as an event, as
  appropriate.

For more about what we believe makes a pull request complete, see our
[definition of done].

[documentation]: https://github.com/crossplane/crossplane/tree/master/docs
[examples]: https://github.com/crossplane/crossplane/tree/master/cluster/examples
[definition of done]: https://github.com/crossplane/crossplane/tree/master/design/one-pager-definition-of-done.md
