### PR TITLE
Support backing up and restoring Kubernetes targets

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/crossplane/crossplane
 go 1.13
 
 require (
-	github.com/crossplane/crossplane-runtime v0.6.0
+	github.com/crossplane/crossplane-runtime v0.6.1-0.20200406020956-f9d4e859f450
 	github.com/crossplane/crossplane-tools v0.0.0-20200219001116-bb8b2ce46330
 	github.com/docker/distribution v2.7.1+incompatible
 	github.com/evanphx/json-patch v4.5.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -65,8 +65,8 @@ github.com/coreos/go-semver v0.3.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3Ee
 github.com/coreos/go-systemd v0.0.0-20180511133405-39ca1b05acc7/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/coreos/pkg v0.0.0-20180108230652-97fdf19511ea/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
 github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwcJI5acqYI6dE=
-github.com/crossplane/crossplane-runtime v0.6.0 h1:MPATmc2/vX+ja5+ZDxpl1iMdSSKEs9fVwKBVdq1VBSg=
-github.com/crossplane/crossplane-runtime v0.6.0/go.mod h1:e12p4X6dbtqd9GOnph78Epd6aezyvmcMM1+6aQy3VzY=
+github.com/crossplane/crossplane-runtime v0.6.1-0.20200406020956-f9d4e859f450 h1:FjqA4H3s/LMOSzn16AgFMGFC6XpmlPBFV8sQJ1FL6Xg=
+github.com/crossplane/crossplane-runtime v0.6.1-0.20200406020956-f9d4e859f450/go.mod h1:e12p4X6dbtqd9GOnph78Epd6aezyvmcMM1+6aQy3VzY=
 github.com/crossplane/crossplane-tools v0.0.0-20200219001116-bb8b2ce46330 h1:zxdYGQnQbfyZSnRbKUJ16x5lRzkUTbH+uumVq03ijYo=
 github.com/crossplane/crossplane-tools v0.0.0-20200219001116-bb8b2ce46330/go.mod h1:C735A9X0x0lR8iGVOOxb49Mt70Ua4EM2b7PGaRPBLd4=
 github.com/dave/jennifer v1.3.0 h1:p3tl41zjjCZTNBytMwrUuiAnherNUZktlhPTKoF/sEk=

--- a/pkg/controller/oam/applicationconfiguration/apply.go
+++ b/pkg/controller/oam/applicationconfiguration/apply.go
@@ -54,7 +54,8 @@ type workloads struct {
 
 func (a *workloads) Apply(ctx context.Context, w []Workload) error {
 	for _, wl := range w {
-		if err := resource.Apply(ctx, a.client, wl.Workload, resource.ControllersMustMatch()); err != nil {
+		// TODO(negz): Update to resource.APIPatchingApplicator.
+		if err := resource.Apply(ctx, a.client, wl.Workload, resource.ControllersMustMatch()); err != nil { // nolint:staticcheck
 			return errors.Wrapf(err, errFmtApplyWorkload, wl.Workload.GetName())
 		}
 
@@ -71,7 +72,8 @@ func (a *workloads) Apply(ctx context.Context, w []Workload) error {
 				return errors.Wrapf(err, errFmtSetWorkloadRef, t.GetName(), wl.Workload.GetName())
 			}
 
-			if err := resource.Apply(ctx, a.client, t, resource.ControllersMustMatch()); err != nil {
+			// TODO(negz): Update to resource.APIPatchingApplicator.
+			if err := resource.Apply(ctx, a.client, t, resource.ControllersMustMatch()); err != nil { // nolint:staticcheck
 				return errors.Wrapf(err, errFmtApplyTrait, t.GetName())
 			}
 		}

--- a/pkg/controller/workload/kubernetes/resource/resource.go
+++ b/pkg/controller/workload/kubernetes/resource/resource.go
@@ -267,7 +267,8 @@ func (c *unstructuredClient) sync(ctx context.Context, template *unstructured.Un
 
 	rs := getRemoteStatus(remote)
 
-	return rs, errors.Wrap(resource.Apply(ctx, c.kube, template), errSyncResource)
+	// TODO(negz): Update to resource.APIPatchingApplicator.
+	return rs, errors.Wrap(resource.Apply(ctx, c.kube, template), errSyncResource) // nolint:staticcheck
 }
 
 func getRemoteStatus(u runtime.Unstructured) *v1alpha1.RemoteStatus {


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

We strongly recommend you look through our contributor guide at https://git.io/fj2m9
if this is your first time opening a Crossplane pull request. You can find us in
https://slack.crossplane.io/messages/dev if you need any help contributing.
-->

### Description of your changes
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

Fixes #
-->

### How has this code been tested?
<!--
Before reviewers can be confident in the correctness of a pull request,
it needs to tested and shown to be correct. In this section, briefly
describe the testing that has already been done or which is planned.
-->
This switches automatically generated targets from using the UID of their claim to the name of their claim. We use the new crossplane-runtime applicator logic that will adopt uncontrolled targets and refuse to adopt controlled targets.

### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every Crossplane pull request.
-->
I have:
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Ensured this PR contains a neat, self documenting set of commits.
- [ ] Updated any relevant [documentation] and [examples].
- [ ] Reported all new error conditions into the log or as an event, as
  appropriate.

For more about what we believe makes a pull request complete, see our
[definition of done].

[documentation]: https://github.com/crossplane/crossplane/tree/master/docs
[examples]: https://github.com/crossplane/crossplane/tree/master/cluster/examples
[definition of done]: https://github.com/crossplane/crossplane/tree/master/design/one-pager-definition-of-done.md
