### PR TITLE
Support backing up and restoring ApplicationConfigurations

### DIFF
--- a/pkg/controller/oam/applicationconfiguration/applicationconfiguration_test.go
+++ b/pkg/controller/oam/applicationconfiguration/applicationconfiguration_test.go
@@ -25,11 +25,11 @@ import (
 	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	runtimev1alpha1 "github.com/crossplane/crossplane-runtime/apis/core/v1alpha1"
+	"github.com/crossplane/crossplane-runtime/pkg/resource"
 	"github.com/crossplane/crossplane-runtime/pkg/resource/fake"
 	"github.com/crossplane/crossplane-runtime/pkg/test"
 
@@ -70,14 +70,12 @@ func TestReconciler(t *testing.T) {
 	workload.SetKind("workload")
 	workload.SetNamespace(namespace)
 	workload.SetName("workload")
-	workload.SetUID(types.UID("workload-uid"))
 
 	trait := &unstructured.Unstructured{}
 	trait.SetAPIVersion("v")
 	trait.SetKind("trait")
 	trait.SetNamespace(namespace)
 	trait.SetName("trait")
-	trait.SetUID(types.UID("trait-uid"))
 
 	type args struct {
 		m manager.Manager
@@ -154,7 +152,7 @@ func TestReconciler(t *testing.T) {
 					WithRenderer(ComponentRenderFn(func(_ context.Context, _ *v1alpha2.ApplicationConfiguration) ([]Workload, error) {
 						return []Workload{{Workload: workload}}, nil
 					})),
-					WithApplicator(WorkloadApplyFn(func(_ context.Context, _ []Workload) error {
+					WithApplicator(WorkloadApplyFn(func(_ context.Context, _ []Workload, _ ...resource.ApplyOption) error {
 						return errBoom
 					})),
 				},
@@ -184,7 +182,7 @@ func TestReconciler(t *testing.T) {
 					WithRenderer(ComponentRenderFn(func(_ context.Context, _ *v1alpha2.ApplicationConfiguration) ([]Workload, error) {
 						return []Workload{}, nil
 					})),
-					WithApplicator(WorkloadApplyFn(func(_ context.Context, _ []Workload) error {
+					WithApplicator(WorkloadApplyFn(func(_ context.Context, _ []Workload, _ ...resource.ApplyOption) error {
 						return nil
 					})),
 					WithGarbageCollector(GarbageCollectorFn(func(_ string, _ []v1alpha2.WorkloadStatus, _ []Workload) []unstructured.Unstructured {
@@ -212,7 +210,6 @@ func TestReconciler(t *testing.T) {
 										APIVersion: workload.GetAPIVersion(),
 										Kind:       workload.GetKind(),
 										Name:       workload.GetName(),
-										UID:        workload.GetUID(),
 									},
 								}),
 							)
@@ -228,7 +225,7 @@ func TestReconciler(t *testing.T) {
 					WithRenderer(ComponentRenderFn(func(_ context.Context, _ *v1alpha2.ApplicationConfiguration) ([]Workload, error) {
 						return []Workload{{ComponentName: componentName, Workload: workload}}, nil
 					})),
-					WithApplicator(WorkloadApplyFn(func(_ context.Context, _ []Workload) error {
+					WithApplicator(WorkloadApplyFn(func(_ context.Context, _ []Workload, _ ...resource.ApplyOption) error {
 						return nil
 					})),
 					WithGarbageCollector(GarbageCollectorFn(func(_ string, _ []v1alpha2.WorkloadStatus, _ []Workload) []unstructured.Unstructured {
@@ -267,14 +264,12 @@ func TestWorkloadStatus(t *testing.T) {
 	workload.SetKind("workload")
 	workload.SetNamespace(namespace)
 	workload.SetName("workload")
-	workload.SetUID(types.UID("workload-uid"))
 
 	trait := &unstructured.Unstructured{}
 	trait.SetAPIVersion("v")
 	trait.SetKind("trait")
 	trait.SetNamespace(namespace)
 	trait.SetName("trait")
-	trait.SetUID(types.UID("trait-uid"))
 
 	cases := map[string]struct {
 		w    Workload
@@ -292,7 +287,6 @@ func TestWorkloadStatus(t *testing.T) {
 					APIVersion: workload.GetAPIVersion(),
 					Kind:       workload.GetKind(),
 					Name:       workload.GetName(),
-					UID:        workload.GetUID(),
 				},
 				Traits: []v1alpha2.WorkloadTrait{
 					{
@@ -300,7 +294,6 @@ func TestWorkloadStatus(t *testing.T) {
 							APIVersion: trait.GetAPIVersion(),
 							Kind:       trait.GetKind(),
 							Name:       trait.GetName(),
-							UID:        trait.GetUID(),
 						},
 					},
 				},
@@ -327,14 +320,12 @@ func TestEligible(t *testing.T) {
 	workload.SetKind("workload")
 	workload.SetNamespace(namespace)
 	workload.SetName("workload")
-	workload.SetUID(types.UID("workload-uid"))
 
 	trait := &unstructured.Unstructured{}
 	trait.SetAPIVersion("v")
 	trait.SetKind("trait")
 	trait.SetNamespace(namespace)
 	trait.SetName("trait")
-	trait.SetUID(types.UID("trait-uid"))
 
 	type args struct {
 		namespace string
@@ -356,7 +347,6 @@ func TestEligible(t *testing.T) {
 							APIVersion: workload.GetAPIVersion(),
 							Kind:       workload.GetKind(),
 							Name:       workload.GetName(),
-							UID:        workload.GetUID(),
 						},
 						Traits: []v1alpha2.WorkloadTrait{
 							{
@@ -364,7 +354,6 @@ func TestEligible(t *testing.T) {
 									APIVersion: trait.GetAPIVersion(),
 									Kind:       trait.GetKind(),
 									Name:       trait.GetName(),
-									UID:        trait.GetUID(),
 								},
 							},
 						},
@@ -384,7 +373,6 @@ func TestEligible(t *testing.T) {
 							APIVersion: workload.GetAPIVersion(),
 							Kind:       workload.GetKind(),
 							Name:       workload.GetName(),
-							UID:        workload.GetUID(),
 						},
 						Traits: []v1alpha2.WorkloadTrait{
 							{
@@ -392,7 +380,6 @@ func TestEligible(t *testing.T) {
 									APIVersion: trait.GetAPIVersion(),
 									Kind:       trait.GetKind(),
 									Name:       trait.GetName(),
-									UID:        trait.GetUID(),
 								},
 							},
 						},
@@ -411,7 +398,6 @@ func TestEligible(t *testing.T) {
 							APIVersion: workload.GetAPIVersion(),
 							Kind:       workload.GetKind(),
 							Name:       workload.GetName(),
-							UID:        workload.GetUID(),
 						},
 						Traits: []v1alpha2.WorkloadTrait{
 							{
@@ -419,7 +405,6 @@ func TestEligible(t *testing.T) {
 									APIVersion: trait.GetAPIVersion(),
 									Kind:       trait.GetKind(),
 									Name:       trait.GetName(),
-									UID:        trait.GetUID(),
 								},
 							},
 						},


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

We strongly recommend you look through our contributor guide at https://git.io/fj2m9
if this is your first time opening a Crossplane pull request. You can find us in
https://slack.crossplane.io/messages/dev if you need any help contributing.
-->

### Description of your changes
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

Fixes #
-->
This take 2 of https://github.com/crossplane/crossplane/pull/1410, in which I somehow managed to close the PR and delete the underlying branch.

When an ApplicationConfiguration, its workloads, and its traits are backed up and subsequently restored using Velero the resources are allocated new UIDs. Owner references and resource status are also removed during the restore. This commit updates the ApplicationConfiguration controller to avoid reliance on UIDs for garbage collection. The controller will also 'adopt' any existing resources that it would otherwise create, as long as they're not controlled by another controller (i.e. as long as they have no controller reference).

### How has this code been tested?
<!--
Before reviewers can be confident in the correctness of a pull request,
it needs to tested and shown to be correct. In this section, briefly
describe the testing that has already been done or which is planned.
-->
See https://github.com/crossplane/crossplane/pull/1410

### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every Crossplane pull request.
-->
I have:
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Ensured this PR contains a neat, self documenting set of commits.
- [ ] Updated any relevant [documentation] and [examples].
- [ ] Reported all new error conditions into the log or as an event, as
  appropriate.

For more about what we believe makes a pull request complete, see our
[definition of done].

[documentation]: https://github.com/crossplane/crossplane/tree/master/docs
[examples]: https://github.com/crossplane/crossplane/tree/master/cluster/examples
[definition of done]: https://github.com/crossplane/crossplane/tree/master/design/one-pager-definition-of-done.md
