### PR TITLE
Do not sync KARs if KA is deleted

### DIFF
--- a/apis/workload/v1alpha1/types.go
+++ b/apis/workload/v1alpha1/types.go
@@ -37,6 +37,7 @@ const (
 	KubernetesApplicationStatePartial   KubernetesApplicationState = "PartiallySubmitted"
 	KubernetesApplicationStateSubmitted KubernetesApplicationState = "Submitted"
 	KubernetesApplicationStateFailed    KubernetesApplicationState = "Failed"
+	KubernetesApplicationStateDeleted   KubernetesApplicationState = "Deleted"
 )
 
 // A KubernetesApplicationSpec specifies the resources of a Kubernetes


### PR DESCRIPTION


Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

<!--
Thank you for helping to improve Crossplane!

We strongly recommend you look through our contributor guide at https://git.io/fj2m9
if this is your first time opening a Crossplane pull request. You can find us in
https://slack.crossplane.io/messages/dev if you need any help contributing.
-->

### Description of your changes
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

Fixes #
-->

In the case that a KubernetesApplication has been deleted, but is blocked on a subset of its KubernetesApplicationResources existing with controllerRefs to it, we do not want to attempt to create or update any KARs that have been deleted or are in the process of being deleted.

Potential fix for https://github.com/crossplane/app-wordpress/issues/48, which I have been unable to reproduce.

### How has this code been tested?
<!--
Before reviewers can be confident in the correctness of a pull request,
it needs to tested and shown to be correct. In this section, briefly
describe the testing that has already been done or which is planned.
-->

### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every Crossplane pull request.
-->
I have:
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Ensured this PR contains a neat, self documenting set of commits.
- [ ] Updated any relevant [documentation] and [examples].
- [ ] Reported all new error conditions into the log or as an event, as
  appropriate.

For more about what we believe makes a pull request complete, see our
[definition of done].

[documentation]: https://github.com/crossplane/crossplane/tree/master/docs
[examples]: https://github.com/crossplane/crossplane/tree/master/cluster/examples
[definition of done]: https://github.com/crossplane/crossplane/tree/master/design/one-pager-definition-of-done.md
