### PR TITLE
install: add value to helm chart to expose --restrict-core-apigroups in stack-manager

### DIFF
--- a/cluster/charts/crossplane-controllers/templates/stack-manager-deployment.yaml
+++ b/cluster/charts/crossplane-controllers/templates/stack-manager-deployment.yaml
@@ -44,6 +44,9 @@ spec:
         - --force-image-pull-policy
         - {{ .Values.forceImagePullPolicy | quote }}
         {{- end }}
+        {{- if .Values.restrictCoreApigroups }}
+        - --restrict-core-apigroups
+        {{- end }}
         {{- range $arg := .Values.args }}
         - {{ $arg }}
         {{- end }}

--- a/cluster/charts/crossplane-controllers/values.yaml.tmpl
+++ b/cluster/charts/crossplane-controllers/values.yaml.tmpl
@@ -44,3 +44,5 @@ resourcesStackManager:
     memory: 256Mi
 
 forceImagePullPolicy: ""
+
+restrictCoreApigroups: false

--- a/cluster/charts/crossplane/README.md
+++ b/cluster/charts/crossplane/README.md
@@ -292,16 +292,16 @@ and their default values.
 | `imagePullSecrets`               | Names of image pull secrets to use                              | `dockerhub`                                            |
 | `replicas`                       | The number of replicas to run for the Crossplane operator       | `1`                                                    |
 | `deploymentStrategy`             | The deployment strategy for the Crossplane operator             | `RollingUpdate`                                        |
-| `clusterStacks.aws.deploy`       | Deploy AWS stack                                                | `false`    
-| `clusterStacks.aws.version`      | AWS provider version to deploy                                     | `<latest released version>`   
-| `clusterStacks.gcp.deploy`       | Deploy GCP stack                                                | `false`    
-| `clusterStacks.gcp.version`      | GCP provider version to deploy                                     | `<latest released version>`   
-| `clusterStacks.azure.deploy`     | Deploy Azure stack                                              | `false`    
-| `clusterStacks.azure.version`    | Azure provider version to deploy                                   | `<latest released version>`   
-| `clusterStacks.rook.deploy`      | Deploy Rook stack                                               | `false`    
-| `clusterStacks.rook.version`     | Rook provider version to deploy                                    | `<latest released version>`   
-| `personas.deploy`                | Install roles and bindings for Crossplane user personas         | `true`     
-| `templateStacks.enabled`         | Enable experimental template stacks support                     | `true`     
+| `clusterStacks.aws.deploy`       | Deploy AWS stack                                                | `false`
+| `clusterStacks.aws.version`      | AWS provider version to deploy                                     | `<latest released version>`
+| `clusterStacks.gcp.deploy`       | Deploy GCP stack                                                | `false`
+| `clusterStacks.gcp.version`      | GCP provider version to deploy                                     | `<latest released version>`
+| `clusterStacks.azure.deploy`     | Deploy Azure stack                                              | `false`
+| `clusterStacks.azure.version`    | Azure provider version to deploy                                   | `<latest released version>`
+| `clusterStacks.rook.deploy`      | Deploy Rook stack                                               | `false`
+| `clusterStacks.rook.version`     | Rook provider version to deploy                                    | `<latest released version>`
+| `personas.deploy`                | Install roles and bindings for Crossplane user personas         | `true`
+| `templateStacks.enabled`         | Enable experimental template stacks support                     | `true`
 | `templateStacks.controllerImage` | Template Stack controller image                                 | `crossplane/templating-controller:v0.2.1`
 | `resourcesCrossplane.limits.cpu`        | CPU resource limits for Crossplane                       | `100m`
 | `resourcesCrossplane.limits.memory`     | Memory resource limits for Crossplane                    | `512Mi`
@@ -312,6 +312,7 @@ and their default values.
 | `resourcesStackManager.requests.cpu`    | CPU resource requests for StackManager                   | `100m`
 | `resourcesStackManager.requests.memory` | Memory resource requests for StackManager                | `256Mi`
 | `forceImagePullPolicy`           | Force the named ImagePullPolicy on Stack install and containers | ``
+| `restrictCoreApigroups`          | Enable API group restrictions for Stacks (e.g. when restricted, Stacks cannot use core Kubernetes types such as `Pod`) | `false` |
 
 ### Command Line
 

--- a/cluster/charts/crossplane/templates/stack-manager-deployment.yaml
+++ b/cluster/charts/crossplane/templates/stack-manager-deployment.yaml
@@ -44,6 +44,9 @@ spec:
         - --force-image-pull-policy
         - {{ .Values.forceImagePullPolicy | quote }}
         {{- end }}
+        {{- if .Values.restrictCoreApigroups }}
+        - --restrict-core-apigroups
+        {{- end }}
         {{- range $arg := .Values.args }}
         - {{ $arg }}
         {{- end }}

--- a/cluster/charts/crossplane/values.yaml.tmpl
+++ b/cluster/charts/crossplane/values.yaml.tmpl
@@ -54,3 +54,5 @@ resourcesStackManager:
     memory: 256Mi
 
 forceImagePullPolicy: ""
+
+restrictCoreApigroups: false

--- a/docs/install.md
+++ b/docs/install.md
@@ -298,16 +298,16 @@ and their default values.
 | `imagePullSecrets`               | Names of image pull secrets to use                              | `dockerhub`                                            |
 | `replicas`                       | The number of replicas to run for the Crossplane operator       | `1`                                                    |
 | `deploymentStrategy`             | The deployment strategy for the Crossplane operator             | `RollingUpdate`                                        |
-| `clusterStacks.aws.deploy`       | Deploy AWS stack                                                | `false`    
-| `clusterStacks.aws.version`      | AWS provider version to deploy                                     | `<latest released version>`   
-| `clusterStacks.gcp.deploy`       | Deploy GCP stack                                                | `false`    
-| `clusterStacks.gcp.version`      | GCP provider version to deploy                                     | `<latest released version>`   
-| `clusterStacks.azure.deploy`     | Deploy Azure stack                                              | `false`    
-| `clusterStacks.azure.version`    | Azure provider version to deploy                                   | `<latest released version>`   
-| `clusterStacks.rook.deploy`      | Deploy Rook stack                                               | `false`    
-| `clusterStacks.rook.version`     | Rook provider version to deploy                                    | `<latest released version>`   
-| `personas.deploy`                | Install roles and bindings for Crossplane user personas         | `true`     
-| `templateStacks.enabled`         | Enable experimental template stacks support                     | `true`     
+| `clusterStacks.aws.deploy`       | Deploy AWS stack                                                | `false`
+| `clusterStacks.aws.version`      | AWS provider version to deploy                                     | `<latest released version>`
+| `clusterStacks.gcp.deploy`       | Deploy GCP stack                                                | `false`
+| `clusterStacks.gcp.version`      | GCP provider version to deploy                                     | `<latest released version>`
+| `clusterStacks.azure.deploy`     | Deploy Azure stack                                              | `false`
+| `clusterStacks.azure.version`    | Azure provider version to deploy                                   | `<latest released version>`
+| `clusterStacks.rook.deploy`      | Deploy Rook stack                                               | `false`
+| `clusterStacks.rook.version`     | Rook provider version to deploy                                    | `<latest released version>`
+| `personas.deploy`                | Install roles and bindings for Crossplane user personas         | `true`
+| `templateStacks.enabled`         | Enable experimental template stacks support                     | `true`
 | `templateStacks.controllerImage` | Template Stack controller image                                 | `crossplane/templating-controller:v0.2.1`
 | `resourcesCrossplane.limits.cpu`        | CPU resource limits for Crossplane                       | `100m`
 | `resourcesCrossplane.limits.memory`     | Memory resource limits for Crossplane                    | `512Mi`
@@ -318,6 +318,7 @@ and their default values.
 | `resourcesStackManager.requests.cpu`    | CPU resource requests for StackManager                   | `100m`
 | `resourcesStackManager.requests.memory` | Memory resource requests for StackManager                | `256Mi`
 | `forceImagePullPolicy`           | Force the named ImagePullPolicy on Stack install and containers | ``
+| `restrictCoreApigroups`          | Enable API group restrictions for Stacks (e.g. when restricted, Stacks cannot use core Kubernetes types such as `Pod`) | `false` |
 
 ### Command Line
 


### PR DESCRIPTION
### Description of your changes

This PR adds a new value to the helm chart to expose the existing functionality of the `--restrict-core-apigroups` flag in stack-manager.

### How has this code been tested?

I have built locally and installed the helm chart into my minikube cluster with:

* no explicit value being set, which uses the default of `restrictCoreApigroups: false`.  Confirmed the stack-manager pod was started up without the `--restrict-core-apigroups` flag.
* `--set restrictCoreApigroups=true`.  Confirmed the stack-manager pod was started up with the `--restrict-core-apigroups` flag and the pod logged `DEBUG	stack-manager	Restricting core group use in the Stacks`.

### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every Crossplane pull request.
-->
I have:
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Ensured this PR contains a neat, self documenting set of commits.
- [x] Updated any relevant [documentation] and [examples].
- [x] Reported all new error conditions into the log or as an event, as
  appropriate.

For more about what we believe makes a pull request complete, see our
[definition of done].

[documentation]: https://github.com/crossplane/crossplane/tree/master/docs
[examples]: https://github.com/crossplane/crossplane/tree/master/cluster/examples
[definition of done]: https://github.com/crossplane/crossplane/tree/master/design/one-pager-definition-of-done.md
