### PR TITLE
Remove version as required field on ui-schema.yaml

### DIFF
--- a/design/design-doc-upbound-ui-spec.md
+++ b/design/design-doc-upbound-ui-spec.md
@@ -2,7 +2,12 @@
 
 * Owner: Steven Rathbauer ([@rathpc](https://github.com/rathpc))
 * Reviewers: Upbound Maintainers, Crossplane Maintainers
-* Status: Accepted, revision 1.0
+* Status: Accepted, revision 1.1
+
+## Revisions
+
+* 1.1 - Dan Mangum (@hasheddan)
+  * Removed references to `version` field in `ui-schema.yaml` required fields.
 
 ## Terms
 
@@ -29,7 +34,6 @@ OpenAPI v3
 Field | Description
 --- | ---
 `configSections` | An array of sections to display during the configuration of a resource. Each section should contain a `title` field, `items` field and optionally a `description` field.<br /><br />`title`: A string that labels the section.<br />`description`: A string which optionally provides additional details, instructions or context around the section.<br />`items`: An array of item objects to display within the section. [See below for details on currently supported items](#supportedItems).
-`version` | A number formatted per semantic versioning spec <https://semver.org/> for the version of the `ui-schema.yaml` file. This should be updated whenever the `ui-schema.yaml` file is updated.<br /><br />**Example**:<br />`0.1.0`
 
 ### Optional Fields
 

--- a/design/one-pager-stack-ui-metadata.md
+++ b/design/one-pager-stack-ui-metadata.md
@@ -2,7 +2,12 @@
 
 * Owner: Steven Rathbauer ([@rathpc](https://github.com/rathpc)), Marques Johansson ([@displague](https://github.com/displague))
 * Reviewers: Crossplane Maintainers
-* Status: Draft, revision 1.0
+* Status: Draft, revision 1.1
+
+## Revisions
+
+* 1.1 - Dan Mangum (@hasheddan)
+  * Removed references to `version` field in `ui-schema.yaml` required fields.
 
 ## Terms
 
@@ -101,7 +106,6 @@ This file contains multiple sections and a variety of different input types with
 validation and custom error messages.
 
 ```yaml
-version: 0.5
 configSections:
 - title: Configuration
   description: Enter information specific to the configuration you wish to create.
@@ -151,7 +155,6 @@ An example injection of the `ui-schema.yaml` as a CRD annotation follows. Keep i
 limited to 256kb (less in older versions).
 
 ```yaml
-version: 0.5
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
@@ -159,7 +162,6 @@ metadata:
   annotations:
     stacks.crossplane.io/ui-schema: |-
       ---
-      version: 0.5
       configSections:
       - title: Configuration
         description: Enter information specific to the configuration you wish to create.
@@ -203,7 +205,6 @@ metadata:
           - required: true
             customError: You must select an instance size for your configuration!
       ---
-      version: 0.5
       configSections:
       - title: Supplementary
         description: A supplementary UI annotation

--- a/pkg/stacks/unpack_test.go
+++ b/pkg/stacks/unpack_test.go
@@ -68,12 +68,10 @@ metadata:
     stacks.crossplane.io/icon-data-uri: data:image/svg+xml;base64,bW9jay1pY29uLWRhdGEtc3Zn
     stacks.crossplane.io/stack-title: Sample Crossplane Stack
     stacks.crossplane.io/ui-schema: |-
-      version: 0.5
       configSections:
       - title: group Title
         description: group Description
       ---
-      version: 0.5
       configSections:
       - title: sibling Title
         description: sibling Description
@@ -150,17 +148,14 @@ metadata:
     stacks.crossplane.io/resource-title-plural: Resources Title
     stacks.crossplane.io/stack-title: Sample Crossplane Stack
     stacks.crossplane.io/ui-schema: |-
-      version: 0.5
       configSections:
       - title: group Title
         description: group Description
       ---
-      version: 0.5
       configSections:
       - title: sibling Title
         description: sibling Description
       ---
-      version: 0.5
       configSections:
       - title: kind Title
         description: kind Description
@@ -198,7 +193,6 @@ metadata:
     stacks.crossplane.io/icon-data-uri: data:image/jpeg;base64,bW9jay1pY29uLWRhdGE=
     stacks.crossplane.io/stack-title: Sample Crossplane Stack
     stacks.crossplane.io/ui-schema: |-
-      version: 0.5
       configSections:
       - title: group Title
         description: group Description
@@ -368,12 +362,10 @@ metadata:
     stacks.crossplane.io/icon-data-uri: data:image/svg+xml;base64,bW9jay1pY29uLWRhdGEtc3Zn
     stacks.crossplane.io/stack-title: Sample Crossplane Stack
     stacks.crossplane.io/ui-schema: |-
-      version: 0.5
       configSections:
       - title: group Title
         description: group Description
       ---
-      version: 0.5
       configSections:
       - title: sibling Title
         description: sibling Description
@@ -450,17 +442,14 @@ metadata:
     stacks.crossplane.io/resource-title-plural: Resources Title
     stacks.crossplane.io/stack-title: Sample Crossplane Stack
     stacks.crossplane.io/ui-schema: |-
-      version: 0.5
       configSections:
       - title: group Title
         description: group Description
       ---
-      version: 0.5
       configSections:
       - title: sibling Title
         description: sibling Description
       ---
-      version: 0.5
       configSections:
       - title: kind Title
         description: kind Description
@@ -498,7 +487,6 @@ metadata:
     stacks.crossplane.io/icon-data-uri: data:image/jpeg;base64,bW9jay1pY29uLWRhdGE=
     stacks.crossplane.io/stack-title: Sample Crossplane Stack
     stacks.crossplane.io/ui-schema: |-
-      version: 0.5
       configSections:
       - title: group Title
         description: group Description
@@ -829,8 +817,7 @@ spec:
 }
 
 func simpleUIFile(name string) string {
-	return fmt.Sprintf(`version: 0.5
-configSections:
+	return fmt.Sprintf(`configSections:
 - title: %s Title
   description: %s Description
 `, name, name)


### PR DESCRIPTION
Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

<!--
Thank you for helping to improve Crossplane!

We strongly recommend you look through our contributor guide at https://git.io/fj2m9
if this is your first time opening a Crossplane pull request. You can find us in
https://slack.crossplane.io/messages/dev if you need any help contributing.
-->

### Description of your changes
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

Fixes #
-->

The `version` field of `ui-schema.yaml` is no longer required or used. It can be a confusing indicator in repos that provide ui-schema definitions. Will follow by removing `version` field from `ui-schema.yaml` files across crossplane repos.

### How has this code been tested?
<!--
Before reviewers can be confident in the correctness of a pull request,
it needs to tested and shown to be correct. In this section, briefly
describe the testing that has already been done or which is planned.
-->

`make reviewable`

### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every Crossplane pull request.
-->
I have:
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Ensured this PR contains a neat, self documenting set of commits.
- [x] Updated any relevant [documentation] and [examples].
- [ ] Reported all new error conditions into the log or as an event, as
  appropriate.

For more about what we believe makes a pull request complete, see our
[definition of done].

[documentation]: https://github.com/crossplane/crossplane/tree/master/docs
[examples]: https://github.com/crossplane/crossplane/tree/master/cluster/examples
[definition of done]: https://github.com/crossplane/crossplane/tree/master/design/one-pager-definition-of-done.md
