### PR TITLE
Re-enable updating CRDs on new StackInstalls

### DIFF
--- a/pkg/controller/stacks/install/installjob.go
+++ b/pkg/controller/stacks/install/installjob.go
@@ -39,6 +39,7 @@ import (
 
 	"github.com/crossplane/crossplane-runtime/pkg/logging"
 	"github.com/crossplane/crossplane-runtime/pkg/meta"
+	"github.com/crossplane/crossplane-runtime/pkg/resource"
 	"github.com/crossplane/crossplane/apis/stacks/v1alpha1"
 	"github.com/crossplane/crossplane/pkg/stacks"
 )
@@ -328,7 +329,7 @@ func (jc *stackInstallJobCompleter) replaceCRD(ctx context.Context, obj *unstruc
 	meta.AddLabels(obj, existing.GetLabels())
 	meta.AddAnnotations(obj, existing.GetAnnotations())
 
-	return jc.client.Update(ctx, obj)
+	return resource.NewAPIPatchingApplicator(jc.client).Apply(ctx, obj)
 }
 
 // TODO(displague) this is copied from stacks. centralize.


### PR DESCRIPTION

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

<!--
Thank you for helping to improve Crossplane!

We strongly recommend you look through our contributor guide at https://git.io/fj2m9
if this is your first time opening a Crossplane pull request. You can find us in
https://slack.crossplane.io/messages/dev if you need any help contributing.
-->

### Description of your changes
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

Fixes #
-->

Previously, the stack controller was updated to include the ability to install multiple stacks that depend on the same CRD, and update it to the newly installed version. This was broken when CRDs were changed to be updated without directly modifying the existing CRD (#1406). This re-enables the intended functionality, but is serving as a stop-gap fix in a larger refactoring effort.

### How has this code been tested?
<!--
Before reviewers can be confident in the correctness of a pull request,
it needs to tested and shown to be correct. In this section, briefly
describe the testing that has already been done or which is planned.
-->

Created an `app-wordpress` install in `crossplane-system`:
```
kubectl apply -f wordpress.yaml -n crossplane-system
```

Controller started successfully and observed labels on `WordpressInstance` CRD:
```
🤖 (crossplane) kubectl get customresourcedefinitions wordpressinstances.wordpress.apps.crossplane.io -o=jsonpath={.metadata.labels}

map[app.kubernetes.io/managed-by:stack-manager crossplane.io/scope:namespace namespace.crossplane.io/crossplane-system:true parent.stacks.crossplane.io/crossplane-system-wp-sample:true]
```

Created an `app-wordpress` install in `default`:
```
kubectl apply -f wordpress.yaml -n default
```

Controller started successfully and observed labels on `WordpressInstance` CRD:
```
🤖 (crossplane) kubectl get customresourcedefinitions wordpressinstances.wordpress.apps.crossplane.io -o=jsonpath={.metadata.labels}

map[app.kubernetes.io/managed-by:stack-manager crossplane.io/scope:namespace namespace.crossplane.io/crossplane-system:true namespace.crossplane.io/default:true parent.stacks.crossplane.io/crossplane-system-wp-sample:true parent.stacks.crossplane.io/default-wp-sample:true]
```

### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every Crossplane pull request.
-->
I have:
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Ensured this PR contains a neat, self documenting set of commits.
- [ ] Updated any relevant [documentation] and [examples].
- [ ] Reported all new error conditions into the log or as an event, as
  appropriate.

For more about what we believe makes a pull request complete, see our
[definition of done].

[documentation]: https://github.com/crossplane/crossplane/tree/master/docs
[examples]: https://github.com/crossplane/crossplane/tree/master/cluster/examples
[definition of done]: https://github.com/crossplane/crossplane/tree/master/design/one-pager-definition-of-done.md
