### PR TITLE
Enable backup and restore of stacks resources

### DIFF
--- a/design/one-pager-stack-relationship-labels.md
+++ b/design/one-pager-stack-relationship-labels.md
@@ -2,9 +2,16 @@
 
 - Owner: Steven Rathbauer ([@rathpc](https://github.com/rathpc))
 - Reviewers: Crossplane Maintainers
-- Status: Draft
+- Status: Draft, Revision 1.1
 
 **_NOTE: The focus for this design is long term and may not be implemented immediately_**
+
+## Revisions
+
+* 1.1 - Dan Mangum ([@hasheddan](https://github.com/hasheddan))
+  * Removed references to `core.crossplane.io/parent-uid` label as it no longer
+    applied in order to enable backup and restore of stacks
+    ([crossplane/crossplane#1389](https://github.com/crossplane/crossplane/issues/1389)).
 
 ## Proposal
 
@@ -17,7 +24,6 @@
 - **`core.crossplane.io/parent-kind`**
 - **`core.crossplane.io/parent-name`**
 - **`core.crossplane.io/parent-namespace`**
-- **`core.crossplane.io/parent-uid`**
 
 ## Problem
 
@@ -81,7 +87,6 @@ metadata:
     core.crossplane.io/parent-kind: "StackInstall"
     core.crossplane.io/parent-name: "sample-stack-wordpress"
     core.crossplane.io/parent-namespace: "app-project1-dev"
-    core.crossplane.io/parent-uid: "858ab465-ff60-49d8-a3e7-624ce841f339"
     app.kubernetes.io/managed-by: stack-manager
 ...
 ```
@@ -111,7 +116,6 @@ metadata:
     core.crossplane.io/parent-kind: "StackInstall"
     core.crossplane.io/parent-name: "sample-stack-wordpress"
     core.crossplane.io/parent-namespace: "app-project1-dev"
-    core.crossplane.io/parent-uid: "858ab465-ff60-49d8-a3e7-624ce841f339"
 ...
 ```
 
@@ -134,7 +138,6 @@ metadata:
     core.crossplane.io/parent-version: "v1alpha1"
     core.crossplane.io/parent-name: "sample-stack-wordpress"
     core.crossplane.io/parent-namespace: "app-project1-dev"
-    core.crossplane.io/parent-uid: "ec52c8c2-379f-45ec-9458-e40f070f8d2e"
     app.kubernetes.io/managed-by: stack-manager
 ...
 ```
@@ -153,7 +156,6 @@ metadata:
     core.crossplane.io/parent-version: "v1alpha1"
     core.crossplane.io/parent-name: "my-wordpressinstance"
     core.crossplane.io/parent-namespace: "app-project1-dev"
-    core.crossplane.io/parent-uid: "f2d13a15-1f9b-40a7-a173-a40abefa61bf"
     app.kubernetes.io/managed-by: stack-manager
 ...
 ```
@@ -172,7 +174,6 @@ metadata:
     core.crossplane.io/parent-version: "v1alpha1"
     core.crossplane.io/parent-name: "my-wordpressinstance"
     core.crossplane.io/parent-namespace: "app-project1-dev"
-    core.crossplane.io/parent-uid: "f2d13a15-1f9b-40a7-a173-a40abefa61bf"
     app.kubernetes.io/managed-by: stack-manager
 ...
 ```
@@ -191,7 +192,6 @@ metadata:
     core.crossplane.io/parent-version: "v1alpha1"
     core.crossplane.io/parent-name: "my-wordpressinstance"
     core.crossplane.io/parent-namespace: "app-project1-dev"
-    core.crossplane.io/parent-uid: "f2d13a15-1f9b-40a7-a173-a40abefa61bf"
     app.kubernetes.io/managed-by: stack-manager
 ...
 ```

--- a/pkg/controller/stacks/install/installjob_test.go
+++ b/pkg/controller/stacks/install/installjob_test.go
@@ -1325,7 +1325,6 @@ func TestCreateJobOutputObject(t *testing.T) {
 		stacks.LabelParentKind:      "StackInstall",
 		stacks.LabelParentNamespace: namespace,
 		stacks.LabelParentName:      resourceName,
-		stacks.LabelParentUID:       uidString,
 	}
 
 	type want struct {

--- a/pkg/controller/stacks/install/stackinstall.go
+++ b/pkg/controller/stacks/install/stackinstall.go
@@ -176,6 +176,12 @@ func (r *Reconciler) Reconcile(req reconcile.Request) (reconcile.Result, error) 
 		return reconcile.Result{}, err
 	}
 
+	meta.AddFinalizer(stackInstaller, installFinalizer)
+	err := r.kube.Update(ctx, stackInstaller)
+	if err != nil {
+		return fail(ctx, r.kube, stackInstaller, err)
+	}
+
 	executorinfo, err := r.executorInfoDiscoverer.Discover(ctx)
 	if err != nil {
 		return fail(ctx, r.kube, stackInstaller, err)
@@ -524,6 +530,11 @@ func (h *stackInstallHandler) delete(ctx context.Context) (reconcile.Result, err
 		if err := df(ctx); err != nil {
 			return fail(ctx, h.kube, h.ext, err)
 		}
+	}
+
+	meta.RemoveFinalizer(h.ext, installFinalizer)
+	if err := h.kube.Update(ctx, h.ext); err != nil {
+		return fail(ctx, h.kube, h.ext, err)
 	}
 
 	return reconcile.Result{}, nil

--- a/pkg/controller/stacks/install/stackinstall_test.go
+++ b/pkg/controller/stacks/install/stackinstall_test.go
@@ -235,6 +235,7 @@ func TestReconcile(t *testing.T) {
 							*obj.(*v1alpha1.StackInstall) = *(stackInstallResource())
 							return nil
 						},
+						MockUpdate: test.NewMockUpdateFn(nil),
 					},
 					hostKube:   nil,
 					hostClient: nil,
@@ -268,6 +269,7 @@ func TestReconcile(t *testing.T) {
 							*obj.(*v1alpha1.ClusterStackInstall) = *(clusterInstallResource())
 							return nil
 						},
+						MockUpdate: test.NewMockUpdateFn(nil),
 					},
 				},
 				stackinator: func() v1alpha1.StackInstaller { return &v1alpha1.ClusterStackInstall{} },
@@ -317,7 +319,7 @@ func TestReconcile(t *testing.T) {
 						APIVersion: v1alpha1.StackGroupVersionKind.GroupVersion().String(),
 					}),
 					withConditions(runtimev1alpha1.Available(), runtimev1alpha1.ReconcileSuccess()),
-					withFinalizers(),
+					withFinalizers(installFinalizer),
 				), err: nil},
 		},
 		{
@@ -330,6 +332,7 @@ func TestReconcile(t *testing.T) {
 							*obj.(*v1alpha1.StackInstall) = *(stackInstallResource(withDeletionTimestamp(time.Now())))
 							return nil
 						},
+						MockUpdate: test.NewMockUpdateFn(nil),
 					},
 				},
 				stackinator: func() v1alpha1.StackInstaller { return &v1alpha1.StackInstall{} },
@@ -366,6 +369,7 @@ func TestReconcile(t *testing.T) {
 							}
 							return nil
 						},
+						MockUpdate:       test.NewMockUpdateFn(nil),
 						MockStatusUpdate: func(ctx context.Context, obj runtime.Object, _ ...client.UpdateOption) error { return nil },
 					},
 					hostKube:   nil,
@@ -395,6 +399,7 @@ func TestReconcile(t *testing.T) {
 							*obj.(*v1alpha1.StackInstall) = *(stackInstallResource())
 							return nil
 						},
+						MockUpdate:       test.NewMockUpdateFn(nil),
 						MockStatusUpdate: func(ctx context.Context, obj runtime.Object, _ ...client.UpdateOption) error { return nil },
 					},
 				},
@@ -417,7 +422,7 @@ func TestReconcile(t *testing.T) {
 					hostKube: func() client.Client {
 						si := stackInstallResource()
 						labels := stacks.ParentLabels(si)
-						labels[stacks.LabelParentUID] = "different-parent-uid"
+						labels[stacks.LabelParentNamespace] = "not-cool-namespace"
 						job := job()
 						job.SetLabels(labels)
 						return fake.NewFakeClient(job)

--- a/pkg/controller/stacks/persona/persona_test.go
+++ b/pkg/controller/stacks/persona/persona_test.go
@@ -65,7 +65,6 @@ var (
 				stacks.LabelParentKind:                 "",
 				stacks.LabelParentName:                 namespace,
 				stacks.LabelParentNamespace:            "",
-				stacks.LabelParentUID:                  string(uid),
 				stacks.LabelParentVersion:              "",
 			},
 		},

--- a/pkg/stacks/relationship.go
+++ b/pkg/stacks/relationship.go
@@ -34,7 +34,6 @@ const (
 	LabelParentKind      = "core.crossplane.io/parent-kind"
 	LabelParentNamespace = "core.crossplane.io/parent-namespace"
 	LabelParentName      = "core.crossplane.io/parent-name"
-	LabelParentUID       = "core.crossplane.io/parent-uid"
 
 	LabelMultiParentPrefix = "parent.stacks.crossplane.io/"
 
@@ -130,7 +129,6 @@ func ParentLabels(i KindlyIdentifier) map[string]string {
 		LabelParentKind:      gvk.Kind,
 		LabelParentNamespace: truncate.LabelValue(i.GetNamespace()),
 		LabelParentName:      truncate.LabelValue(i.GetName()),
-		LabelParentUID:       string(i.GetUID()),
 	}
 	return labels
 }

--- a/pkg/stacks/relationship_test.go
+++ b/pkg/stacks/relationship_test.go
@@ -60,7 +60,6 @@ func TestParentLabels(t *testing.T) {
 			want: map[string]string{
 				LabelParentNamespace: namespace,
 				LabelParentName:      resourceName,
-				LabelParentUID:       uidString,
 				LabelParentGroup:     "",
 				LabelParentKind:      "",
 				LabelParentVersion:   "",
@@ -72,7 +71,6 @@ func TestParentLabels(t *testing.T) {
 			want: map[string]string{
 				LabelParentNamespace: sixtyThreeAs,
 				LabelParentName:      sixtyThreeAs,
-				LabelParentUID:       uidString,
 				LabelParentGroup:     "",
 				LabelParentKind:      "",
 				LabelParentVersion:   "",
@@ -84,7 +82,6 @@ func TestParentLabels(t *testing.T) {
 			want: map[string]string{
 				LabelParentNamespace: truncatedAsAndZ,
 				LabelParentName:      truncatedAsAndZ,
-				LabelParentUID:       uidString,
 				LabelParentGroup:     "",
 				LabelParentKind:      "",
 				LabelParentVersion:   "",


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

We strongly recommend you look through our contributor guide at https://git.io/fj2m9
if this is your first time opening a Crossplane pull request. You can find us in
https://slack.crossplane.io/messages/dev if you need any help contributing.
-->

### Description of your changes
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

Fixes #
-->

In order to allow stacks to regain control of their resources in a backup and restore scenario, we must not block on a mismatched UID in the parent labels, and must make sure to set finalizers in main reconciliation instead of in the creation steps.

Fixes #1389 
Ref #1407 

### How has this code been tested?
<!--
Before reviewers can be confident in the correctness of a pull request,
it needs to tested and shown to be correct. In this section, briefly
describe the testing that has already been done or which is planned.
-->

<details>
 <summary>Expand for testing steps</summary>


Created `ClusterStackInstall` for `provider-gcp` in `crossplane-system` namespace and `StackInstalls` for `app-wordpress` in the `crossplane-system` and `default` namespace. I then ran a velero backup with:

```
velero backup create crossplane-backup-nouid
```

I then killed the kind cluster and created a new one. I ran a velero restore with:

```
velero restore create --from-backup crossplane-backup-nouid
```

After the restore was complete, I restarted the core crossplane and stack manager controllers and saw them come to a steady state with the following labels on the corresponding resources:

```
🤖 (crossplane) kubectl get stacks wp-app -o=jsonpath={.metadata.labels} -n default

map[core.crossplane.io/parent-group:stacks.crossplane.io core.crossplane.io/parent-kind:StackInstall core.crossplane.io/parent-name:wp-app core.crossplane.io/parent-namespace:default core.crossplane.io/parent-version:v1alpha1 velero.io/backup-name:crossplane-backup-nouid-2 velero.io/restore-name:crossplane-backup-nouid-2-20200423113855]
```
```
🤖 (crossplane) kubectl get stacks wp-app -o=jsonpath={.metadata.labels} -n crossplane-system

map[core.crossplane.io/parent-group:stacks.crossplane.io core.crossplane.io/parent-kind:StackInstall core.crossplane.io/parent-name:wp-app core.crossplane.io/parent-namespace:crossplane-system core.crossplane.io/parent-version:v1alpha1 velero.io/backup-name:crossplane-backup-nouid-2 velero.io/restore-name:crossplane-backup-nouid-2-20200423113855]
```
```
🤖 (crossplane) kubectl get stacks provider-gcp -o=jsonpath={.metadata.labels} -n crossplane-system

map[core.crossplane.io/parent-group:stacks.crossplane.io core.crossplane.io/parent-kind:ClusterStackInstall core.crossplane.io/parent-name:provider-gcp core.crossplane.io/parent-namespace:crossplane-system core.crossplane.io/parent-version:v1alpha1 velero.io/backup-name:crossplane-backup-nouid-2 velero.io/restore-name:crossplane-backup-nouid-2-20200423113855]
```
```
🤖 (crossplane) kubectl get customresourcedefinitions cloudsqlinstances.database.gcp.crossplane.io -o=jsonpath={.metadata.labels}

map[app.kubernetes.io/managed-by:stack-manager crossplane.io/scope:environment namespace.crossplane.io/crossplane-system:true parent.stacks.crossplane.io/crossplane-system-provider-gcp:true velero.io/backup-name:crossplane-backup-nouid-2 velero.io/restore-name:crossplane-backup-nouid-2-20200423113855]
```
```
🤖 (crossplane) kubectl get customresourcedefinitions wordpressinstances.wordpress.apps.crossplane.io -o=jsonpath={.metadata.labels}

map[app.kubernetes.io/managed-by:stack-manager crossplane.io/scope:namespace namespace.crossplane.io/crossplane-system:true namespace.crossplane.io/default:true parent.stacks.crossplane.io/crossplane-system-wp-app:true parent.stacks.crossplane.io/default-wp-app:true velero.io/backup-name:crossplane-backup-nouid-2 velero.io/restore-name:crossplane-backup-nouid-2-20200423113855]
```
The following `Stacks`, `StackDefinitions`, `StackInstalls`, and `ClusterStackInstalls` were present:
```
🤖 (crossplane) kubectl get stackinstalls -A

NAMESPACE           NAME     READY   SOURCE   PACKAGE                           CRD   AGE
crossplane-system   wp-app   True             crossplane/app-wordpress:v0.3.0         6m
default             wp-app   True             crossplane/app-wordpress:v0.3.0         6m


🤖 (crossplane) kubectl get stacks -A

NAMESPACE           NAME           READY   VERSION   AGE
crossplane-system   provider-gcp   True    master    6m19s
crossplane-system   wp-app         True    v0.3.0    6m19s
default             wp-app         True    v0.3.0    6m19s

🤖 (crossplane) kubectl get stackdefinitions -A

NAMESPACE           NAME     AGE
crossplane-system   wp-app   6m36s
default             wp-app   6m36s

🤖 (crossplane) kubectl get clusterstackinstalls -A

NAMESPACE           NAME           READY   SOURCE   PACKAGE                          CRD   AGE
crossplane-system   provider-gcp   True             crossplane/provider-gcp:master         7m3s
```

I then deleted the `app-wordpress` `StackInstall` in the `default` namespaces and observed the `WordpressInstances` CRD with the following labels:
```
🤖 (crossplane) kubectl get customresourcedefinitions wordpressinstances.wordpress.apps.crossplane.io -o=jsonpath={.metadata.labels}

map[app.kubernetes.io/managed-by:stack-manager crossplane.io/scope:namespace namespace.crossplane.io/crossplane-system:true parent.stacks.crossplane.io/crossplane-system-wp-app:true velero.io/backup-name:crossplane-backup-nouid-2 velero.io/restore-name:crossplane-backup-nouid-2-20200423113855]
```

I also observed that both the corresponding `Stack` and `StackDefinition` were cleaned up:
```
🤖 (crossplane) kubectl get stackdefinitions -A

NAMESPACE           NAME     AGE

crossplane-system   wp-app   10m

🤖 (crossplane) kubectl get stacks -A

NAMESPACE           NAME           READY   VERSION   AGE
crossplane-system   provider-gcp   True    master    10m
crossplane-system   wp-app         True    v0.3.0    10m
```

Next I deleted the Wordpress `StackInstall` in the `crossplane-system` namespace and observed the following:
```
🤖 (crossplane) kubectl get customresourcedefinitions wordpressinstances.wordpress.apps.crossplane.io

Error from server (NotFound): customresourcedefinitions.apiextensions.k8s.io "wordpressinstances.wordpress.apps.crossplane.io" not found

🤖 (crossplane) kubectl get stacks -A

NAMESPACE           NAME           READY   VERSION   AGE
crossplane-system   provider-gcp   True    master    12m

🤖 (crossplane) kubectl get stackdefinitions -A

No resources found.
```

Lastly, I deleted the GCP `ClusterStackInstall` and observed the following:
```
🤖 (crossplane) kubectl get stacks -A

No resources found.

🤖 (crossplane) kubectl get crds | grep gcp

[no output]

🤖 (crossplane) kubectl get pods -A

NAMESPACE            NAME                                         READY   STATUS    RESTARTS   AGE
kube-system          coredns-6955765f44-5gd68                     1/1     Running   0          20m
kube-system          coredns-6955765f44-d9qxt                     1/1     Running   0          20m
kube-system          etcd-kind-control-plane                      1/1     Running   0          20m
kube-system          kindnet-xhllz                                1/1     Running   0          20m
kube-system          kube-apiserver-kind-control-plane            1/1     Running   0          20m
kube-system          kube-controller-manager-kind-control-plane   1/1     Running   0          20m
kube-system          kube-proxy-29t2g                             1/1     Running   0          20m
kube-system          kube-scheduler-kind-control-plane            1/1     Running   0          20m
local-path-storage   local-path-provisioner-7745554f7f-zksjj      1/1     Running   0          20m
velero               velero-795c8d58cd-bwz25                      1/1     Running   0          20m

🤖 (crossplane) kubectl get jobs -A

No resources found.
```

</details>

### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every Crossplane pull request.
-->
I have:
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Ensured this PR contains a neat, self documenting set of commits.
- [ ] Updated any relevant [documentation] and [examples].
- [ ] Reported all new error conditions into the log or as an event, as
  appropriate.

For more about what we believe makes a pull request complete, see our
[definition of done].

[documentation]: https://github.com/crossplane/crossplane/tree/master/docs
[examples]: https://github.com/crossplane/crossplane/tree/master/cluster/examples
[definition of done]: https://github.com/crossplane/crossplane/tree/master/design/one-pager-definition-of-done.md
