### PR TITLE
docs: update release docs to include promotion to master channel

### DIFF
--- a/docs/release/release-process.md
+++ b/docs/release/release-process.md
@@ -426,18 +426,21 @@ If everything looks good with the official versioned release that we just
 published, we can go ahead and run the `promote` pipeline for the core
 crossplane and provider repos. This is a very quick pipeline that doesn't
 rebuild anything, it simply makes metadata changes to the published release to
-also include the last release in the channel of your choice. Currently, we only
-support the `alpha` channel.
+also include the release in the channel of your choice.
+
+Currently, we only support the `master` and `alpha` channels.
 
 For the core crossplane and each provider repo, run the `promote` pipeline on
 the release branch and input the version you would like to promote (e.g.
-`v0.5.0`) and the channel you'd like to promote it to (e.g. `alpha`).  The first
-time you run this pipeline on a new release branch, you will not be prompted for
-values, so the pipeline will fail. Just run (not replay) it a second time to be
-prompted.
+`v0.5.0`) and the channel you'd like to promote it to.  The first time you run
+this pipeline on a new release branch, you will not be prompted for values, so
+the pipeline will fail. Just run (not replay) it a second time to be prompted.
 
-After the `promote` pipeline has succeeded, verify on DockerHub and the Helm
-chart repository that the release has been promoted to the right channel.
+* Run `promote` pipeline for `master` channel
+* Run `promote` pipeline for `alpha` channel
+
+After the `promote` pipelines have succeeded, verify on DockerHub and the Helm
+chart repository that the release has been promoted to the right channels.
 
 ### Publish Release Notes
 
@@ -478,4 +481,5 @@ steps.  Please refer to details for each step in the sections above.
 * Run the normal build pipeline on the release branch to build and publish the
   release
 * Publish release notes
-* Run promote pipeline to promote the patch release to the `alpha` channel
+* Run promote pipeline to promote the patch release to the `master` and `alpha`
+  channels


### PR DESCRIPTION
### Description of your changes

This PR updates the release docs to add new steps around including the new release into the master channel, for convenience sake of consumers of this channel.  The idea is that master channel subscribers would also get a chance to see and pick up official releases.

### How has this code been tested?

N/A, there are no logic/code/functional changes in this PR

### Checklist

I have:
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Ensured this PR contains a neat, self documenting set of commits.
- [x] Updated any relevant [documentation] and [examples].
- [x] Reported all new error conditions into the log or as an event, as
  appropriate.

For more about what we believe makes a pull request complete, see our
[definition of done].

[documentation]: https://github.com/crossplane/crossplane/tree/master/docs
[examples]: https://github.com/crossplane/crossplane/tree/master/cluster/examples
[definition of done]: https://github.com/crossplane/crossplane/tree/master/design/one-pager-definition-of-done.md

[skip ci]