### PR TITLE
Missing commit in 1412

### DIFF
--- a/pkg/controller/apiextensions/composite/api.go
+++ b/pkg/controller/apiextensions/composite/api.go
@@ -99,12 +99,13 @@ func (r *SelectorResolver) ResolveSelector(ctx context.Context, cr resource.Comp
 	if cr.GetCompositionReference() != nil {
 		return nil
 	}
+	labels := map[string]string{}
 	sel := cr.GetCompositionSelector()
-	if sel == nil {
-		return errors.New("no composition selector to resolve")
+	if sel != nil {
+		labels = sel.MatchLabels
 	}
 	list := &v1alpha1.CompositionList{}
-	if err := r.client.List(ctx, list, client.MatchingLabels(sel.MatchLabels)); err != nil {
+	if err := r.client.List(ctx, list, client.MatchingLabels(labels)); err != nil {
 		return errors.Wrap(err, "cannot list compositions")
 	}
 	apiVersion, kind := cr.GetObjectKind().GroupVersionKind().ToAPIVersionAndKind()


### PR DESCRIPTION
### Description of your changes

It seems like this commit was left in my local and didn't make it to https://github.com/crossplane/crossplane/pull/1412 during rebases :(

- Allow random selection if no composition selector is given.
- Composite resource should be deleted only if the composed
  resource Delete query returns NotFound.

Signed-off-by: Muvaffak Onus <onus.muvaffak@gmail.com>

<!--
Thank you for helping to improve Crossplane!

We strongly recommend you look through our contributor guide at https://git.io/fj2m9
if this is your first time opening a Crossplane pull request. You can find us in
https://slack.crossplane.io/messages/dev if you need any help contributing.
-->


<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

Fixes #
-->

### How has this code been tested?

Manually.
<!--
Before reviewers can be confident in the correctness of a pull request,
it needs to tested and shown to be correct. In this section, briefly
describe the testing that has already been done or which is planned.
-->

### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every Crossplane pull request.
-->
I have:
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Ensured this PR contains a neat, self documenting set of commits.
- [x] Updated any relevant [documentation] and [examples].
- [x] Reported all new error conditions into the log or as an event, as
  appropriate.

For more about what we believe makes a pull request complete, see our
[definition of done].

[documentation]: https://github.com/crossplane/crossplane/tree/master/docs
[examples]: https://github.com/crossplane/crossplane/tree/master/cluster/examples
[definition of done]: https://github.com/crossplane/crossplane/tree/master/design/one-pager-definition-of-done.md
