### PR TITLE
Restrict stacks deployment security context by default

### DIFF
--- a/cluster/charts/crossplane-controllers/templates/stack-manager-deployment.yaml
+++ b/cluster/charts/crossplane-controllers/templates/stack-manager-deployment.yaml
@@ -47,6 +47,9 @@ spec:
         {{- if .Values.insecureAllowAllApigroups }}
         - --insecure-allow-all-apigroups
         {{- end }}
+        {{- if .Values.insecurePassFullDeployment }}
+        - --insecure-pass-full-deployment
+        {{- end }}
         {{- range $arg := .Values.args }}
         - {{ $arg }}
         {{- end }}

--- a/cluster/charts/crossplane-controllers/templates/stack-manager-deployment.yaml
+++ b/cluster/charts/crossplane-controllers/templates/stack-manager-deployment.yaml
@@ -44,8 +44,8 @@ spec:
         - --force-image-pull-policy
         - {{ .Values.forceImagePullPolicy | quote }}
         {{- end }}
-        {{- if .Values.restrictCoreApigroups }}
-        - --restrict-core-apigroups
+        {{- if .Values.insecureAllowAllApigroups }}
+        - --insecure-allow-all-apigroups
         {{- end }}
         {{- range $arg := .Values.args }}
         - {{ $arg }}

--- a/cluster/charts/crossplane-controllers/values.yaml.tmpl
+++ b/cluster/charts/crossplane-controllers/values.yaml.tmpl
@@ -46,3 +46,5 @@ resourcesStackManager:
 forceImagePullPolicy: ""
 
 insecureAllowAllApigroups: false
+
+insecurePassFullDeployment: false

--- a/cluster/charts/crossplane-controllers/values.yaml.tmpl
+++ b/cluster/charts/crossplane-controllers/values.yaml.tmpl
@@ -45,4 +45,4 @@ resourcesStackManager:
 
 forceImagePullPolicy: ""
 
-restrictCoreApigroups: false
+insecureAllowAllApigroups: false

--- a/cluster/charts/crossplane/README.md
+++ b/cluster/charts/crossplane/README.md
@@ -312,7 +312,8 @@ and their default values.
 | `resourcesStackManager.requests.cpu`    | CPU resource requests for StackManager                   | `100m`
 | `resourcesStackManager.requests.memory` | Memory resource requests for StackManager                | `256Mi`
 | `forceImagePullPolicy`           | Force the named ImagePullPolicy on Stack install and containers | ``
-| `restrictCoreApigroups`          | Enable API group restrictions for Stacks (e.g. when restricted, Stacks cannot use core Kubernetes types such as `Pod`) | `false` |
+| `insecureAllowAllApigroups`      | Enable core Kubernetes API group permissions for Stacks. When enabled, Stacks may declare dependency on core Kubernetes API types.) | `false` |
+| `insecurePassFullDeployment`     | Enable stacks to pass their full deployment, including security context. When omitted, Stacks deployments will have security context removed and all containers will have `allowPrivilegeEscalation` set to false. | `false` |
 
 ### Command Line
 

--- a/cluster/charts/crossplane/templates/stack-manager-deployment.yaml
+++ b/cluster/charts/crossplane/templates/stack-manager-deployment.yaml
@@ -47,6 +47,9 @@ spec:
         {{- if .Values.insecureAllowAllApigroups }}
         - --insecure-allow-all-apigroups
         {{- end }}
+        {{- if .Values.insecurePassFullDeployment }}
+        - --insecure-pass-full-deployment
+        {{- end }}
         {{- range $arg := .Values.args }}
         - {{ $arg }}
         {{- end }}

--- a/cluster/charts/crossplane/templates/stack-manager-deployment.yaml
+++ b/cluster/charts/crossplane/templates/stack-manager-deployment.yaml
@@ -44,8 +44,8 @@ spec:
         - --force-image-pull-policy
         - {{ .Values.forceImagePullPolicy | quote }}
         {{- end }}
-        {{- if .Values.restrictCoreApigroups }}
-        - --restrict-core-apigroups
+        {{- if .Values.insecureAllowAllApigroups }}
+        - --insecure-allow-all-apigroups
         {{- end }}
         {{- range $arg := .Values.args }}
         - {{ $arg }}

--- a/cluster/charts/crossplane/values.yaml.tmpl
+++ b/cluster/charts/crossplane/values.yaml.tmpl
@@ -55,4 +55,4 @@ resourcesStackManager:
 
 forceImagePullPolicy: ""
 
-restrictCoreApigroups: false
+insecureAllowAllApigroups: false

--- a/cluster/charts/crossplane/values.yaml.tmpl
+++ b/cluster/charts/crossplane/values.yaml.tmpl
@@ -56,3 +56,5 @@ resourcesStackManager:
 forceImagePullPolicy: ""
 
 insecureAllowAllApigroups: false
+
+insecurePassFullDeployment: false

--- a/cmd/crossplane/stack/manage/manage.go
+++ b/cmd/crossplane/stack/manage/manage.go
@@ -60,6 +60,7 @@ func FromKingpin(cmd *kingpin.CmdClause) *Command {
 }
 
 // Run the stack manager.
+// nolint:gocyclo
 func (c *Command) Run(log logging.Logger) error {
 	log.Debug("Starting", "sync-period", c.Sync.String())
 

--- a/design/one-pager-stacks-security-isolation.md
+++ b/design/one-pager-stacks-security-isolation.md
@@ -2,7 +2,7 @@
 
 * Owner: Jared Watts (@jbw976)
 * Reviewers: Crossplane Maintainers
-* Status: Draft, revision 1.1
+* Status: Draft, revision 1.2
 
 ## Revisions
 
@@ -10,6 +10,8 @@
   * Cluster stacks may own Cluster scoped CRDs
     [#958](https://github.com/crossplane/crossplane/pull/958)
   * Namespaced stacks may depend on Cluster scoped CRDs [#958](https://github.com/crossplane/crossplane/pull/958)
+* 1.2 - Dan Mangum (@hasheddan)
+  * Added section on [Stack Deployment Privileges](#stack-deployment-privileges).
 
 ## Background
 
@@ -303,6 +305,32 @@ With these two separate types, an administrator can allow access to installing c
 
 If the install scope type does not match what the stack author has declared within their stack metadata, an error status
  should be set on the install resource and installation of the stack should not proceed.
+
+### Stack Deployment Privileges
+
+All `Deployments` for both cluster-scoped and namespace-scoped stacks have their
+pod and container-level security-context set to restrict root access. This can
+be overridden by running the crossplane stack manager with the
+`--insecure-pass-full-deployment` flag, in which case the security context of
+the `Deployment` provided in a stack's `install.yaml` will not be modified.
+
+The security context at the pod-level will be configured as follows by default:
+```yaml
+securityContext:
+  runAsNonRoot: true
+```
+
+The security-context at the container-level will be configured as follows by
+default:
+```yaml
+securityContext:
+  allowPrivilegeEscalation: false
+  privileged: false
+  runAsNonRoot: true
+```
+
+*Note: container-level security context always overrides pod-level, but we set
+the pod-level security context as well for completeness.*
 
 ###  Crossplane ClusterRoles / RBAC
 

--- a/docs/getting-started/install.md
+++ b/docs/getting-started/install.md
@@ -319,7 +319,8 @@ and their default values.
 | `resourcesStackManager.requests.cpu`    | CPU resource requests for StackManager                   | `100m`
 | `resourcesStackManager.requests.memory` | Memory resource requests for StackManager                | `256Mi`
 | `forceImagePullPolicy`           | Force the named ImagePullPolicy on Stack install and containers | ``
-| `restrictCoreApigroups`          | Enable API group restrictions for Stacks (e.g. when restricted, Stacks cannot use core Kubernetes types such as `Pod`) | `false` |
+| `insecureAllowAllApigroups`      | Enable core Kubernetes API group permissions for Stacks. When enabled, Stacks may declare dependency on core Kubernetes API types.) | `false` |
+| `insecurePassFullDeployment`     | Enable stacks to pass their full deployment, including security context. When omitted, Stacks deployments will have security context removed and all containers will have `allowPrivilegeEscalation` set to false. | `false` |
 
 ### Command Line
 

--- a/pkg/controller/stacks/stack/stack_test.go
+++ b/pkg/controller/stacks/stack/stack_test.go
@@ -221,11 +221,11 @@ func resource(rm ...resourceModifier) *v1alpha1.Stack {
 // mockFactory and mockHandler
 // ************************************************************************************************
 type mockFactory struct {
-	MockNewHandler func(logging.Logger, *v1alpha1.Stack, client.Client, client.Client, *hosted.Config, bool, string) handler
+	MockNewHandler func(logging.Logger, *v1alpha1.Stack, client.Client, client.Client, *hosted.Config, bool, bool, string) handler
 }
 
-func (f *mockFactory) newHandler(log logging.Logger, r *v1alpha1.Stack, c client.Client, h client.Client, hc *hosted.Config, allowCore bool, forceImagePullPolicy string) handler {
-	return f.MockNewHandler(log, r, c, nil, nil, allowCore, forceImagePullPolicy)
+func (f *mockFactory) newHandler(log logging.Logger, r *v1alpha1.Stack, c client.Client, h client.Client, hc *hosted.Config, allowCore, allowFullDeployment bool, forceImagePullPolicy string) handler {
+	return f.MockNewHandler(log, r, c, nil, nil, allowCore, allowFullDeployment, forceImagePullPolicy)
 }
 
 type mockHandler struct {
@@ -287,8 +287,40 @@ func withDeploymentSA(name string) deploymentSpecModifier {
 	return func(ds *apps.DeploymentSpec) {
 		ds.Template.Spec.ServiceAccountName = name
 	}
-
 }
+
+func withDeploymentSecurityContext(sc *corev1.PodSecurityContext) deploymentSpecModifier {
+	return func(ds *apps.DeploymentSpec) {
+		ds.Template.Spec.SecurityContext = sc
+	}
+}
+
+func withDeploymentContainerImagePullPolicy(imagePullPolicy string) deploymentSpecModifier {
+	return func(ds *apps.DeploymentSpec) {
+		for _, c := range [][]corev1.Container{
+			ds.Template.Spec.Containers,
+			ds.Template.Spec.InitContainers,
+		} {
+			for i := range c {
+				c[i].ImagePullPolicy = corev1.PullPolicy(imagePullPolicy)
+			}
+		}
+	}
+}
+
+func withDeploymentContainerSecurityContext(sc *corev1.SecurityContext) deploymentSpecModifier {
+	return func(ds *apps.DeploymentSpec) {
+		for _, c := range [][]corev1.Container{
+			ds.Template.Spec.Containers,
+			ds.Template.Spec.InitContainers,
+		} {
+			for i := range c {
+				c[i].SecurityContext = sc
+			}
+		}
+	}
+}
+
 func deploymentSpec(dsm ...deploymentSpecModifier) *apps.DeploymentSpec {
 	ds := &apps.DeploymentSpec{Selector: &metav1.LabelSelector{}}
 
@@ -355,7 +387,7 @@ func TestReconcile(t *testing.T) {
 					MockUpdate: test.NewMockUpdateFn(nil),
 				},
 				factory: &mockFactory{
-					MockNewHandler: func(logging.Logger, *v1alpha1.Stack, client.Client, client.Client, *hosted.Config, bool, string) handler {
+					MockNewHandler: func(logging.Logger, *v1alpha1.Stack, client.Client, client.Client, *hosted.Config, bool, bool, string) handler {
 						return &mockHandler{
 							MockSync: func(context.Context) (reconcile.Result, error) {
 								return reconcile.Result{}, nil
@@ -428,8 +460,40 @@ func TestCreate(t *testing.T) {
 		name       string
 		r          *v1alpha1.Stack
 		clientFunc func(*v1alpha1.Stack) client.Client
+		allowCore  bool
 		want       want
 	}{
+		{
+			name: "FailRestricedPermissions",
+			r: resource(
+				withPolicyRules([]rbac.PolicyRule{{
+					APIGroups: []string{"*"},
+					Resources: []string{"*"},
+					Verbs:     []string{"*"},
+				}}),
+				withFinalizers(stacksFinalizer)),
+			clientFunc: func(r *v1alpha1.Stack) client.Client {
+				mc := test.NewMockClient()
+				mc.MockStatusUpdate = func(ctx context.Context, obj runtime.Object, _ ...client.UpdateOption) error { return nil }
+				return mc
+			},
+			want: want{
+				result: resultRequeue,
+				err:    nil,
+				r: resource(
+					withFinalizers(stacksFinalizer),
+					withPolicyRules([]rbac.PolicyRule{{
+						APIGroups: []string{"*"},
+						Resources: []string{"*"},
+						Verbs:     []string{"*"},
+					}}),
+					withConditions(
+						runtimev1alpha1.Creating(),
+						runtimev1alpha1.ReconcileError(errors.Errorf("permissions contain a restricted rule")),
+					),
+				),
+			},
+		},
 		{
 			name: "FailRBAC",
 			r: resource(
@@ -539,15 +603,45 @@ func TestCreate(t *testing.T) {
 				),
 			},
 		},
+		{
+			name: "SuccessfulCreateAllowCore",
+			r: resource(
+				withGVK(v1alpha1.StackGroupVersionKind),
+				withFinalizers(stacksFinalizer),
+				withResourceVersion("1"),
+				withPolicyRules([]rbac.PolicyRule{{
+					APIGroups: []string{"*"},
+					Resources: []string{"*"},
+					Verbs:     []string{"*"},
+				}})),
+			allowCore:  true,
+			clientFunc: func(r *v1alpha1.Stack) client.Client { return fake.NewFakeClient(r) },
+			want: want{
+				result: requeueOnSuccess,
+				err:    nil,
+				r: resource(
+					withGVK(v1alpha1.StackGroupVersionKind),
+					withConditions(runtimev1alpha1.Available(), runtimev1alpha1.ReconcileSuccess()),
+					withFinalizers(stacksFinalizer),
+					withResourceVersion("2"),
+					withPolicyRules([]rbac.PolicyRule{{
+						APIGroups: []string{"*"},
+						Resources: []string{"*"},
+						Verbs:     []string{"*"},
+					}},
+					)),
+			},
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			handler := &stackHandler{
-				kube:     tt.clientFunc(tt.r),
-				hostKube: tt.clientFunc(tt.r),
-				ext:      tt.r,
-				log:      logging.NewNopLogger(),
+				kube:      tt.clientFunc(tt.r),
+				hostKube:  tt.clientFunc(tt.r),
+				ext:       tt.r,
+				log:       logging.NewNopLogger(),
+				allowCore: tt.allowCore,
 			}
 
 			got, err := handler.create(ctx)
@@ -1068,6 +1162,7 @@ func TestSyncSATokenSecret(t *testing.T) {
 // TestProcessDeployment
 // ************************************************************************************************
 func TestProcessDeployment(t *testing.T) {
+	trueVal := true
 	errBoom := errors.New("boom")
 	testDep := &apps.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
@@ -1091,6 +1186,7 @@ func TestProcessDeployment(t *testing.T) {
 		hostClientFunc       func() client.Client
 		hostawareCfg         *hosted.Config
 		forceImagePullPolicy string
+		passFullDeployment   bool
 		want                 want
 	}{
 		{
@@ -1220,6 +1316,12 @@ func TestProcessDeployment(t *testing.T) {
 						withDeploymentMatchLabels(map[string]string{"app": controllerDeploymentName}),
 						withDeploymentSA(resourceName),
 						withDeploymentContainer(controllerContainerName, controllerImageName),
+						withDeploymentSecurityContext(&corev1.PodSecurityContext{RunAsNonRoot: &runAsNonRoot}),
+						withDeploymentContainerSecurityContext(&corev1.SecurityContext{
+							AllowPrivilegeEscalation: &allowPrivilegeEscalation,
+							Privileged:               &privileged,
+							RunAsNonRoot:             &runAsNonRoot,
+						}),
 					),
 				},
 				controllerRef: &corev1.ObjectReference{
@@ -1248,6 +1350,12 @@ func TestProcessDeployment(t *testing.T) {
 						withDeploymentSA(resourceName),
 						withDeploymentContainer(controllerContainerName, controllerImageName),
 						withDeploymentPullPolicy(corev1.PullAlways),
+						withDeploymentSecurityContext(&corev1.PodSecurityContext{RunAsNonRoot: &runAsNonRoot}),
+						withDeploymentContainerSecurityContext(&corev1.SecurityContext{
+							AllowPrivilegeEscalation: &allowPrivilegeEscalation,
+							Privileged:               &privileged,
+							RunAsNonRoot:             &runAsNonRoot,
+						}),
 					),
 				},
 				controllerRef: &corev1.ObjectReference{
@@ -1283,6 +1391,12 @@ func TestProcessDeployment(t *testing.T) {
 						withDeploymentSA(resourceName),
 						withDeploymentContainer(controllerContainerName, controllerImageName),
 						withDeploymentPullPolicy(corev1.PullAlways),
+						withDeploymentSecurityContext(&corev1.PodSecurityContext{RunAsNonRoot: &runAsNonRoot}),
+						withDeploymentContainerSecurityContext(&corev1.SecurityContext{
+							AllowPrivilegeEscalation: &allowPrivilegeEscalation,
+							Privileged:               &privileged,
+							RunAsNonRoot:             &runAsNonRoot,
+						}),
 					),
 				},
 				controllerRef: &corev1.ObjectReference{
@@ -1293,7 +1407,6 @@ func TestProcessDeployment(t *testing.T) {
 				},
 			},
 		},
-
 		{
 			name:       "SuccessPullSecrets",
 			r:          resource(withControllerSpec(defaultControllerSpec(withDeploymentPullSecrets("foo")))),
@@ -1312,6 +1425,47 @@ func TestProcessDeployment(t *testing.T) {
 						withDeploymentSA(resourceName),
 						withDeploymentContainer(controllerContainerName, controllerImageName),
 						withDeploymentPullSecrets("foo"),
+						withDeploymentSecurityContext(&corev1.PodSecurityContext{RunAsNonRoot: &runAsNonRoot}),
+						withDeploymentContainerSecurityContext(&corev1.SecurityContext{
+							AllowPrivilegeEscalation: &allowPrivilegeEscalation,
+							Privileged:               &privileged,
+							RunAsNonRoot:             &runAsNonRoot,
+						}),
+					),
+				},
+				controllerRef: &corev1.ObjectReference{
+					Name:       controllerDeploymentName,
+					Namespace:  namespace,
+					Kind:       "Deployment",
+					APIVersion: "apps/v1",
+				},
+			},
+		},
+		{
+			name: "SuccessPassFullDeployment",
+			r: resource(withControllerSpec(defaultControllerSpec(withDeploymentContainerSecurityContext(&corev1.SecurityContext{
+				AllowPrivilegeEscalation: &trueVal,
+				Privileged:               &trueVal,
+			})))),
+			clientFunc:         fake.NewFakeClient,
+			passFullDeployment: true,
+			want: want{
+				err: nil,
+				d: &apps.Deployment{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      controllerDeploymentName,
+						Namespace: namespace,
+						Labels:    stackspkg.ParentLabels(resource(withControllerSpec(defaultControllerSpec()))),
+					},
+					Spec: *deploymentSpec(
+						withDeploymentTmplMeta(controllerDeploymentName, "", nil),
+						withDeploymentMatchLabels(map[string]string{"app": controllerDeploymentName}),
+						withDeploymentSA(resourceName),
+						withDeploymentContainer(controllerContainerName, controllerImageName),
+						withDeploymentContainerSecurityContext(&corev1.SecurityContext{
+							AllowPrivilegeEscalation: &trueVal,
+							Privileged:               &trueVal,
+						}),
 					),
 				},
 				controllerRef: &corev1.ObjectReference{
@@ -1355,6 +1509,7 @@ func TestProcessDeployment(t *testing.T) {
 							},
 							Spec: corev1.PodSpec{
 								ServiceAccountName:           "",
+								SecurityContext:              &corev1.PodSecurityContext{RunAsNonRoot: &runAsNonRoot},
 								AutomountServiceAccountToken: &disableAutoMount,
 								Containers: []corev1.Container{
 									{
@@ -1373,6 +1528,11 @@ func TestProcessDeployment(t *testing.T) {
 												Name:  envPodNamespace,
 												Value: namespace,
 											},
+										},
+										SecurityContext: &corev1.SecurityContext{
+											AllowPrivilegeEscalation: &allowPrivilegeEscalation,
+											Privileged:               &privileged,
+											RunAsNonRoot:             &runAsNonRoot,
 										},
 										VolumeMounts: []corev1.VolumeMount{
 											{
@@ -1457,6 +1617,7 @@ func TestProcessDeployment(t *testing.T) {
 							Spec: corev1.PodSpec{
 								ServiceAccountName:           "",
 								AutomountServiceAccountToken: &disableAutoMount,
+								SecurityContext:              &corev1.PodSecurityContext{RunAsNonRoot: &runAsNonRoot},
 								Containers: []corev1.Container{
 									{
 										Name:  controllerContainerName,
@@ -1474,6 +1635,11 @@ func TestProcessDeployment(t *testing.T) {
 												Name:  envPodNamespace,
 												Value: namespace + dashAlphabet,
 											},
+										},
+										SecurityContext: &corev1.SecurityContext{
+											AllowPrivilegeEscalation: &allowPrivilegeEscalation,
+											Privileged:               &privileged,
+											RunAsNonRoot:             &runAsNonRoot,
 										},
 										VolumeMounts: []corev1.VolumeMount{
 											{
@@ -1517,6 +1683,7 @@ func TestProcessDeployment(t *testing.T) {
 				hostAwareConfig:      tt.hostawareCfg,
 				ext:                  tt.r,
 				forceImagePullPolicy: tt.forceImagePullPolicy,
+				allowFullDeployment:  tt.passFullDeployment,
 			}
 			if tt.hostawareCfg == nil {
 				handler.hostKube = handler.kube
@@ -2778,37 +2945,37 @@ func Test_stackHandler_validateStackPermissions(t *testing.T) {
 	}{
 		{
 			name:      "DefaultPolicy",
-			allowCore: true,
+			allowCore: false,
 			ext:       resource(withPolicyRules(stackspkg.StackCoreRBACRules)),
 			wantErr:   nil,
 		},
 		{
 			name:      "DefaultPolicyWithoutRestrictions",
-			allowCore: false,
+			allowCore: true,
 			ext:       resource(withPolicyRules(stackspkg.StackCoreRBACRules)),
 			wantErr:   nil,
 		},
 		{
 			name:      "EverythingPolicy",
-			allowCore: true,
+			allowCore: false,
 			ext:       resource(withPolicyRules(everything)),
 			wantErr:   errors.New("permissions contain a restricted rule"),
 		},
 		{
 			name:      "EverythingPolicyWithoutRestrictions",
-			allowCore: false,
+			allowCore: true,
 			ext:       resource(withPolicyRules(everything)),
 			wantErr:   nil,
 		},
 		{
 			name:      "MixedPolicy",
-			allowCore: true,
+			allowCore: false,
 			ext:       resource(withPolicyRules(mixed)),
 			wantErr:   errors.New("permissions contain a restricted rule"),
 		},
 		{
 			name:      "MixedPolicyWithoutRestrictions",
-			allowCore: false,
+			allowCore: true,
 			ext:       resource(withPolicyRules(mixed)),
 			wantErr:   nil,
 		},

--- a/pkg/controller/stacks/stack/stack_test.go
+++ b/pkg/controller/stacks/stack/stack_test.go
@@ -295,19 +295,6 @@ func withDeploymentSecurityContext(sc *corev1.PodSecurityContext) deploymentSpec
 	}
 }
 
-func withDeploymentContainerImagePullPolicy(imagePullPolicy string) deploymentSpecModifier {
-	return func(ds *apps.DeploymentSpec) {
-		for _, c := range [][]corev1.Container{
-			ds.Template.Spec.Containers,
-			ds.Template.Spec.InitContainers,
-		} {
-			for i := range c {
-				c[i].ImagePullPolicy = corev1.PullPolicy(imagePullPolicy)
-			}
-		}
-	}
-}
-
 func withDeploymentContainerSecurityContext(sc *corev1.SecurityContext) deploymentSpecModifier {
 	return func(ds *apps.DeploymentSpec) {
 		for _, c := range [][]corev1.Container{

--- a/pkg/controller/stacks/stack/stack_test.go
+++ b/pkg/controller/stacks/stack/stack_test.go
@@ -224,8 +224,8 @@ type mockFactory struct {
 	MockNewHandler func(logging.Logger, *v1alpha1.Stack, client.Client, client.Client, *hosted.Config, bool, string) handler
 }
 
-func (f *mockFactory) newHandler(log logging.Logger, r *v1alpha1.Stack, c client.Client, h client.Client, hc *hosted.Config, restrictCore bool, forceImagePullPolicy string) handler {
-	return f.MockNewHandler(log, r, c, nil, nil, restrictCore, forceImagePullPolicy)
+func (f *mockFactory) newHandler(log logging.Logger, r *v1alpha1.Stack, c client.Client, h client.Client, hc *hosted.Config, allowCore bool, forceImagePullPolicy string) handler {
+	return f.MockNewHandler(log, r, c, nil, nil, allowCore, forceImagePullPolicy)
 }
 
 type mockHandler struct {
@@ -2771,54 +2771,54 @@ func Test_stackHandler_validateStackPermissions(t *testing.T) {
 
 	mixed := append(stackspkg.StackCoreRBACRules, everything...)
 	tests := []struct {
-		name         string
-		restrictCore bool
-		ext          *v1alpha1.Stack
-		wantErr      error
+		name      string
+		allowCore bool
+		ext       *v1alpha1.Stack
+		wantErr   error
 	}{
 		{
-			name:         "DefaultPolicy",
-			restrictCore: true,
-			ext:          resource(withPolicyRules(stackspkg.StackCoreRBACRules)),
-			wantErr:      nil,
+			name:      "DefaultPolicy",
+			allowCore: true,
+			ext:       resource(withPolicyRules(stackspkg.StackCoreRBACRules)),
+			wantErr:   nil,
 		},
 		{
-			name:         "DefaultPolicyWithoutRestrictions",
-			restrictCore: false,
-			ext:          resource(withPolicyRules(stackspkg.StackCoreRBACRules)),
-			wantErr:      nil,
+			name:      "DefaultPolicyWithoutRestrictions",
+			allowCore: false,
+			ext:       resource(withPolicyRules(stackspkg.StackCoreRBACRules)),
+			wantErr:   nil,
 		},
 		{
-			name:         "EverythingPolicy",
-			restrictCore: true,
-			ext:          resource(withPolicyRules(everything)),
-			wantErr:      errors.New("permissions contain a restricted rule"),
+			name:      "EverythingPolicy",
+			allowCore: true,
+			ext:       resource(withPolicyRules(everything)),
+			wantErr:   errors.New("permissions contain a restricted rule"),
 		},
 		{
-			name:         "EverythingPolicyWithoutRestrictions",
-			restrictCore: false,
-			ext:          resource(withPolicyRules(everything)),
-			wantErr:      nil,
+			name:      "EverythingPolicyWithoutRestrictions",
+			allowCore: false,
+			ext:       resource(withPolicyRules(everything)),
+			wantErr:   nil,
 		},
 		{
-			name:         "MixedPolicy",
-			restrictCore: true,
-			ext:          resource(withPolicyRules(mixed)),
-			wantErr:      errors.New("permissions contain a restricted rule"),
+			name:      "MixedPolicy",
+			allowCore: true,
+			ext:       resource(withPolicyRules(mixed)),
+			wantErr:   errors.New("permissions contain a restricted rule"),
 		},
 		{
-			name:         "MixedPolicyWithoutRestrictions",
-			restrictCore: false,
-			ext:          resource(withPolicyRules(mixed)),
-			wantErr:      nil,
+			name:      "MixedPolicyWithoutRestrictions",
+			allowCore: false,
+			ext:       resource(withPolicyRules(mixed)),
+			wantErr:   nil,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			h := &stackHandler{
-				restrictCore: tt.restrictCore,
-				ext:          tt.ext,
-				log:          logging.NewNopLogger(),
+				allowCore: tt.allowCore,
+				ext:       tt.ext,
+				log:       logging.NewNopLogger(),
 			}
 			gotErr := h.validateStackPermissions()
 

--- a/pkg/controller/stacks/stacks.go
+++ b/pkg/controller/stacks/stacks.go
@@ -27,7 +27,7 @@ import (
 )
 
 // Setup Crossplane Stacks controllers.
-func Setup(mgr ctrl.Manager, l logging.Logger, hostControllerNamespace, tsControllerImage string, restrictCore bool, forceImagePullPolicy string) error {
+func Setup(mgr ctrl.Manager, l logging.Logger, hostControllerNamespace, tsControllerImage string, allowCore bool, forceImagePullPolicy string) error {
 	if err := install.SetupStackInstall(mgr, l, hostControllerNamespace, tsControllerImage, forceImagePullPolicy); err != nil {
 		return err
 	}
@@ -39,7 +39,7 @@ func Setup(mgr ctrl.Manager, l logging.Logger, hostControllerNamespace, tsContro
 	if err := persona.Setup(mgr, l); err != nil {
 		return nil
 	}
-	if err := stack.Setup(mgr, l, hostControllerNamespace, restrictCore, forceImagePullPolicy); err != nil {
+	if err := stack.Setup(mgr, l, hostControllerNamespace, allowCore, forceImagePullPolicy); err != nil {
 		return err
 	}
 

--- a/pkg/controller/stacks/stacks.go
+++ b/pkg/controller/stacks/stacks.go
@@ -27,7 +27,7 @@ import (
 )
 
 // Setup Crossplane Stacks controllers.
-func Setup(mgr ctrl.Manager, l logging.Logger, hostControllerNamespace, tsControllerImage string, allowCore bool, forceImagePullPolicy string) error {
+func Setup(mgr ctrl.Manager, l logging.Logger, hostControllerNamespace, tsControllerImage string, allowCore, allowFullDeployment bool, forceImagePullPolicy string) error {
 	if err := install.SetupStackInstall(mgr, l, hostControllerNamespace, tsControllerImage, forceImagePullPolicy); err != nil {
 		return err
 	}
@@ -39,7 +39,7 @@ func Setup(mgr ctrl.Manager, l logging.Logger, hostControllerNamespace, tsContro
 	if err := persona.Setup(mgr, l); err != nil {
 		return nil
 	}
-	if err := stack.Setup(mgr, l, hostControllerNamespace, allowCore, forceImagePullPolicy); err != nil {
+	if err := stack.Setup(mgr, l, hostControllerNamespace, allowCore, allowFullDeployment, forceImagePullPolicy); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

We strongly recommend you look through our contributor guide at https://git.io/fj2m9
if this is your first time opening a Crossplane pull request. You can find us in
https://slack.crossplane.io/messages/dev if you need any help contributing.
-->

### Description of your changes
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

Fixes #
-->

This updates the default behavior to restrict core API groups permissions on stacks and also makes it default to deny root security context on stacks deployments.

Ref: #1441 

### How has this code been tested?
<!--
Before reviewers can be confident in the correctness of a pull request,
it needs to tested and shown to be correct. In this section, briefly
describe the testing that has already been done or which is planned.
-->

Unit testing, manual tests below:

<details>
 <summary>Manual testing:</summary>


Created a KIND cluster, then started a tenant kubernetes api server and controller manager using [kindred](https://github.com/crdsdev/kindred).
```
🤖 (crossplane) kindred tenant create
🤖 (crossplane) kubectl get pods -A
NAMESPACE            NAME                                                         READY   STATUS      RESTARTS   AGE
kube-system          coredns-6955765f44-2v4cn                                     1/1     Running     0          51m
kube-system          coredns-6955765f44-j7g74                                     1/1     Running     0          51m
kube-system          etcd-kind-control-plane                                      1/1     Running     0          51m
kube-system          kindnet-9lv48                                                1/1     Running     0          51m
kube-system          kube-apiserver-kind-control-plane                            1/1     Running     0          51m
kube-system          kube-controller-manager-kind-control-plane                   1/1     Running     2          51m
kube-system          kube-proxy-7bfxc                                             1/1     Running     0          51m
kube-system          kube-scheduler-kind-control-plane                            1/1     Running     3          51m
kube-tenant-27656    tenant-kube-apiserver-27656                                  1/1     Running     0          50m
kube-tenant-27656    tenant-kube-controller-manager-27656                         1/1     Running     3          50m
local-path-storage   local-path-provisioner-7745554f7f-tglnq                      1/1     Running     2          51m
```

I then obtained the kubeconfig for the tenant api server and started the stack maanger running against it.
```
🤖 (crossplane) kindred tenant config 27656 > tenant.conf

🤖 (crossplane) kubectl --kubeconfig=tenant.conf apply -f cluster/charts/crossplane/crds -R

🤖 (crossplane) kubectl --kubeconfig=tenant.conf apply -f cluster/charts/crossplane/templates/crds -R

🤖 (crossplane) go run cmd/crossplane/main.go stack manage -d --templates --templating-controller-image v0.3.0-rc --tenant-kubeconfig=/home/dan/code/github.com/crossplaneio/crossplane/tenant.conf --host-controller-namespace=kube-tenant-27656
```

The stack manager started successfully against the tenant API server. I then created a `ClusterStackInstall` for `provider-gcp` against the tenant cluster.
```
🤖 (crossplane) kubectl --kubeconfig=tenant.conf apply -f cluster/examples/provider/provider-gcp.yaml
```

The stack manager successfully started the GCP provider controller against the tenant api server, including installing and labelling its CRDs on the tenant:
```
🤖 (crossplane) kubectl get pods -A
NAMESPACE            NAME                                                         READY   STATUS      RESTARTS   AGE
kube-system          coredns-6955765f44-2v4cn                                     1/1     Running     0          51m
kube-system          coredns-6955765f44-j7g74                                     1/1     Running     0          51m
kube-system          etcd-kind-control-plane                                      1/1     Running     0          51m
kube-system          kindnet-9lv48                                                1/1     Running     0          51m
kube-system          kube-apiserver-kind-control-plane                            1/1     Running     0          51m
kube-system          kube-controller-manager-kind-control-plane                   1/1     Running     2          51m
kube-system          kube-proxy-7bfxc                                             1/1     Running     0          51m
kube-system          kube-scheduler-kind-control-plane                            1/1     Running     3          51m
kube-tenant-27656    crossplane-system.provider-gcp-8htjd                         0/1     Completed   0          11m
kube-tenant-27656    crossplane-system.provider-gcp-controller-76867f9799-wnvj8   1/1     Running     0          10m
kube-tenant-27656    tenant-kube-apiserver-27656                                  1/1     Running     0          50m
kube-tenant-27656    tenant-kube-controller-manager-27656                         1/1     Running     3          50m
local-path-storage   local-path-provisioner-7745554f7f-tglnq                      1/1     Running     2          51m

🤖 (crossplane) kubectl --kubeconfig=tenant.conf get crds | grep gcp
bucketclasses.storage.gcp.crossplane.io                   2020-04-27T15:41:33Z
buckets.storage.gcp.crossplane.io                         2020-04-27T15:41:33Z
cloudmemorystoreinstanceclasses.cache.gcp.crossplane.io   2020-04-27T15:41:35Z
cloudmemorystoreinstances.cache.gcp.crossplane.io         2020-04-27T15:41:35Z
cloudsqlinstanceclasses.database.gcp.crossplane.io        2020-04-27T15:41:33Z
cloudsqlinstances.database.gcp.crossplane.io              2020-04-27T15:41:33Z
connections.servicenetworking.gcp.crossplane.io           2020-04-27T15:41:33Z
gkeclusterclasses.compute.gcp.crossplane.io               2020-04-27T15:41:34Z
gkeclusterclasses.container.gcp.crossplane.io             2020-04-27T15:41:33Z
gkeclusters.compute.gcp.crossplane.io                     2020-04-27T15:41:35Z
gkeclusters.container.gcp.crossplane.io                   2020-04-27T15:41:33Z
globaladdresses.compute.gcp.crossplane.io                 2020-04-27T15:41:34Z
networks.compute.gcp.crossplane.io                        2020-04-27T15:41:34Z
nodepoolclasses.container.gcp.crossplane.io               2020-04-27T15:41:34Z
nodepools.container.gcp.crossplane.io                     2020-04-27T15:41:34Z
providers.gcp.crossplane.io                               2020-04-27T15:41:33Z
serviceaccounts.iam.gcp.crossplane.io                     2020-04-27T15:41:33Z
subnetworks.compute.gcp.crossplane.io                     2020-04-27T15:41:34Z
```

I then created a `Secret` and a `Provider` object with my GCP credentials against the tenant API server. Lastly, I statically provisioned a `GKECluster` against the tenant API server. The GCP controller successfully provisioned the GKE cluster.
```
🤖 (crossplane) cat gkecluster.yaml 
apiVersion: compute.gcp.crossplane.io/v1alpha3
kind: GKECluster
metadata:
  name: gkecluster-standard
  labels:
    oam: test
spec:
  writeConnectionSecretToRef:
    name: k8scluster
    namespace: crossplane-system
  machineType: n1-standard-1
  numNodes: 3
  zone: us-central1-b
  providerRef:
    name: gcp-provider
  reclaimPolicy: Delete

🤖 (crossplane) kubectl --kubeconfig=tenant.conf apply -f gkecluster.yaml

🤖 (crossplane) kubectl --kubeconfig=tenant.conf get -f gkecluster.yaml
NAME                  STATUS    STATE     CLUSTER-NAME   ENDPOINT         CLUSTER-CLASS   LOCATION        RECLAIM-POLICY   AGE
gkecluster-standard   Unbound   RUNNING                  35.226.118.186                   us-central1-b   Delete           3m28s
```

</details>

### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every Crossplane pull request.
-->
I have:
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Ensured this PR contains a neat, self documenting set of commits.
- [x] Updated any relevant [documentation] and [examples].
- [ ] Reported all new error conditions into the log or as an event, as
  appropriate.

For more about what we believe makes a pull request complete, see our
[definition of done].

[documentation]: https://github.com/crossplane/crossplane/tree/master/docs
[examples]: https://github.com/crossplane/crossplane/tree/master/cluster/examples
[definition of done]: https://github.com/crossplane/crossplane/tree/master/design/one-pager-definition-of-done.md
