### PR TITLE
Crossplane ClusterRole expansion for composition

### DIFF
--- a/cluster/charts/crossplane-types/templates/clusterrole.yaml
+++ b/cluster/charts/crossplane-types/templates/clusterrole.yaml
@@ -7,6 +7,25 @@ metadata:
     chart: {{ template "chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+aggregationRule:
+  clusterRoleSelectors:
+  - matchLabels:
+      rbac.crossplane.io/aggregate-to-crossplane-admin: "true"
+  - matchLabels:
+      rbac.crossplane.io/aggregate-to-crossplane: "true"
+rules: []
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ template "name" . }}:system:aggregate-to-crossplane
+  labels:
+    app: {{ template "name" . }}
+    chart: {{ template "chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    crossplane.io/scope: "system"
+    rbac.crossplane.io/aggregate-to-crossplane: "true"
 rules:
 - apiGroups:
   - ""
@@ -33,6 +52,7 @@ rules:
   - watch
   - create
   - update
+  - patch
 - apiGroups:
   - cache.crossplane.io
   - compute.crossplane.io

--- a/cluster/charts/crossplane/templates/clusterrole.yaml
+++ b/cluster/charts/crossplane/templates/clusterrole.yaml
@@ -7,6 +7,25 @@ metadata:
     chart: {{ template "chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+aggregationRule:
+  clusterRoleSelectors:
+  - matchLabels:
+      rbac.crossplane.io/aggregate-to-crossplane-admin: "true"
+  - matchLabels:
+      rbac.crossplane.io/aggregate-to-crossplane: "true"
+rules: []
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ template "name" . }}:system:aggregate-to-crossplane
+  labels:
+    app: {{ template "name" . }}
+    chart: {{ template "chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    crossplane.io/scope: "system"
+    rbac.crossplane.io/aggregate-to-crossplane: "true"
 rules:
 - apiGroups:
   - ""
@@ -33,6 +52,7 @@ rules:
   - watch
   - create
   - update
+  - patch
 - apiGroups:
   - cache.crossplane.io
   - compute.crossplane.io


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

We strongly recommend you look through our contributor guide at https://git.io/fj2m9
if this is your first time opening a Crossplane pull request. You can find us in
https://slack.crossplane.io/messages/dev if you need any help contributing.
-->

### Description of your changes

Using composition, Crossplane pod now provisions the managed resources directly and it needs the necessary ClusterRole to do that. There is already a `crossplane-admin` cluster role that when stacks are installed, the clusterrole to manage their CRs are aggregated to that persone. This PR expands the ClusterRole of Crossplane pod to include the ClusterRoles that `crossplane-admin` has so that the CRs of stacks can be part of composition.

In the end, we'll end up with Crossplane being able to deploy everything everywhere [as per the composition desig](https://github.com/crossplane/crossplane/pull/1163)n but this change only covers the case where managed resources are composed.

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

Fixes #
-->

### How has this code been tested?

Manually tested with Azure stack.

<!--
Before reviewers can be confident in the correctness of a pull request,
it needs to tested and shown to be correct. In this section, briefly
describe the testing that has already been done or which is planned.
-->

### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every Crossplane pull request.
-->
I have:
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Ensured this PR contains a neat, self documenting set of commits.
- [x] Updated any relevant [documentation] and [examples].
- [x] Reported all new error conditions into the log or as an event, as
  appropriate.

For more about what we believe makes a pull request complete, see our
[definition of done].

[documentation]: https://github.com/crossplane/crossplane/tree/master/docs
[examples]: https://github.com/crossplane/crossplane/tree/master/cluster/examples
[definition of done]: https://github.com/crossplane/crossplane/tree/master/design/one-pager-definition-of-done.md
