### PR TITLE
Add priorityClassName option to helm chart

### DIFF
--- a/cluster/charts/crossplane-controllers/templates/deployment.yaml
+++ b/cluster/charts/crossplane-controllers/templates/deployment.yaml
@@ -21,6 +21,9 @@ spec:
         app: {{ template "name" . }}
         release: {{ .Release.Name }}
     spec:
+      {{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName  | quote }}
+      {{- end }}
       {{- if not .Values.hostedConfig.enabled }}
       serviceAccountName: {{ template "name" . }}
       {{- end }}

--- a/cluster/charts/crossplane-controllers/templates/stack-manager-deployment.yaml
+++ b/cluster/charts/crossplane-controllers/templates/stack-manager-deployment.yaml
@@ -21,6 +21,9 @@ spec:
         app: {{ template "name" . }}-stack-manager
         release: {{ .Release.Name }}
     spec:
+      {{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName | quote }}
+      {{- end }}
       serviceAccountName: stack-manager
       containers:
       - image: {{ .Values.image.repository }}:{{ .Values.image.tag }}

--- a/cluster/charts/crossplane-controllers/values.yaml.tmpl
+++ b/cluster/charts/crossplane-controllers/values.yaml.tmpl
@@ -27,6 +27,8 @@ templateStacks:
   enabled: true
   controllerImage: crossplane/templating-controller:v0.2.1
 
+priorityClassName: ""
+
 resourcesCrossplane:
   limits:
     cpu: 100m

--- a/cluster/charts/crossplane/README.md
+++ b/cluster/charts/crossplane/README.md
@@ -303,6 +303,7 @@ and their default values.
 | `personas.deploy`                | Install roles and bindings for Crossplane user personas         | `true`
 | `templateStacks.enabled`         | Enable experimental template stacks support                     | `true`
 | `templateStacks.controllerImage` | Template Stack controller image                                 | `crossplane/templating-controller:v0.2.1`
+| `priorityClassName      `        | Priority class name for crossplane and stack manager pods       | `""`
 | `resourcesCrossplane.limits.cpu`        | CPU resource limits for Crossplane                       | `100m`
 | `resourcesCrossplane.limits.memory`     | Memory resource limits for Crossplane                    | `512Mi`
 | `resourcesCrossplane.requests.cpu`      | CPU resource requests for Crossplane                     | `100m`
@@ -311,7 +312,7 @@ and their default values.
 | `resourcesStackManager.limits.memory`   | Memory resource limits for StackManager                  | `512Mi`
 | `resourcesStackManager.requests.cpu`    | CPU resource requests for StackManager                   | `100m`
 | `resourcesStackManager.requests.memory` | Memory resource requests for StackManager                | `256Mi`
-| `forceImagePullPolicy`           | Force the named ImagePullPolicy on Stack install and containers | ``
+| `forceImagePullPolicy`           | Force the named ImagePullPolicy on Stack install and containers | `""`
 | `insecureAllowAllApigroups`      | Enable core Kubernetes API group permissions for Stacks. When enabled, Stacks may declare dependency on core Kubernetes API types.) | `false` |
 | `insecurePassFullDeployment`     | Enable stacks to pass their full deployment, including security context. When omitted, Stacks deployments will have security context removed and all containers will have `allowPrivilegeEscalation` set to false. | `false` |
 

--- a/cluster/charts/crossplane/templates/deployment.yaml
+++ b/cluster/charts/crossplane/templates/deployment.yaml
@@ -21,6 +21,9 @@ spec:
         app: {{ template "name" . }}
         release: {{ .Release.Name }}
     spec:
+      {{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName  | quote }}
+      {{- end }}
       {{- if not .Values.hostedConfig.enabled }}
       serviceAccountName: {{ template "name" . }}
       {{- end }}

--- a/cluster/charts/crossplane/templates/stack-manager-deployment.yaml
+++ b/cluster/charts/crossplane/templates/stack-manager-deployment.yaml
@@ -21,6 +21,9 @@ spec:
         app: {{ template "name" . }}-stack-manager
         release: {{ .Release.Name }}
     spec:
+      {{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName | quote }}
+      {{- end }}
       serviceAccountName: stack-manager
       containers:
       - image: {{ .Values.image.repository }}:{{ .Values.image.tag }}

--- a/cluster/charts/crossplane/values.yaml.tmpl
+++ b/cluster/charts/crossplane/values.yaml.tmpl
@@ -37,6 +37,8 @@ templateStacks:
   enabled: true
   controllerImage: crossplane/templating-controller:v0.2.1
 
+priorityClassName: ""
+
 resourcesCrossplane:
   limits:
     cpu: 100m

--- a/docs/getting-started/install.md
+++ b/docs/getting-started/install.md
@@ -310,6 +310,7 @@ and their default values.
 | `personas.deploy`                | Install roles and bindings for Crossplane user personas         | `true`
 | `templateStacks.enabled`         | Enable experimental template stacks support                     | `true`
 | `templateStacks.controllerImage` | Template Stack controller image                                 | `crossplane/templating-controller:v0.2.1`
+| `priorityClassName      `        | Priority class name for crossplane and stack manager pods       | `""`
 | `resourcesCrossplane.limits.cpu`        | CPU resource limits for Crossplane                       | `100m`
 | `resourcesCrossplane.limits.memory`     | Memory resource limits for Crossplane                    | `512Mi`
 | `resourcesCrossplane.requests.cpu`      | CPU resource requests for Crossplane                     | `100m`
@@ -318,7 +319,7 @@ and their default values.
 | `resourcesStackManager.limits.memory`   | Memory resource limits for StackManager                  | `512Mi`
 | `resourcesStackManager.requests.cpu`    | CPU resource requests for StackManager                   | `100m`
 | `resourcesStackManager.requests.memory` | Memory resource requests for StackManager                | `256Mi`
-| `forceImagePullPolicy`           | Force the named ImagePullPolicy on Stack install and containers | ``
+| `forceImagePullPolicy`           | Force the named ImagePullPolicy on Stack install and containers | `""`
 | `insecureAllowAllApigroups`      | Enable core Kubernetes API group permissions for Stacks. When enabled, Stacks may declare dependency on core Kubernetes API types.) | `false` |
 | `insecurePassFullDeployment`     | Enable stacks to pass their full deployment, including security context. When omitted, Stacks deployments will have security context removed and all containers will have `allowPrivilegeEscalation` set to false. | `false` |
 


### PR DESCRIPTION
Signed-off-by: Hasan Turken <turkenh@gmail.com>

<!--
Thank you for helping to improve Crossplane!

We strongly recommend you look through our contributor guide at https://git.io/fj2m9
if this is your first time opening a Crossplane pull request. You can find us in
https://slack.crossplane.io/messages/dev if you need any help contributing.
-->

### Description of your changes

This PR introduces priorityClassName variable to the crossplane helm chart.

https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/

> Pods can have priority. Priority indicates the importance of a Pod relative to other Pods. If a Pod cannot be scheduled, the scheduler tries to preempt (evict) lower priority Pods to make scheduling of the pending Pod possible.

https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/#priorityclass

> A PriorityClass is a non-namespaced object that defines a mapping from a priority class name to the integer value of the priority.

With this option, we will be able to assign higher priorities to crossplane and stack-manager pods.

### How has this code been tested?

1. Create a priority class named `crossplane-system-critical`

```
apiVersion: scheduling.k8s.io/v1
kind: PriorityClass
metadata:
  name: crossplane-system-critical
value: 1000000
globalDefault: false
description: "Priority class for crossplane and stack-manager pods."
```

2. Install crossplane helm chart with `--set priorityClassName: "crossplane-system-critical"`

3. Verify that, both crossplane and stack-manager pods running with this priority class set.

### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every Crossplane pull request.
-->
I have:
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Ensured this PR contains a neat, self documenting set of commits.
- [x] Updated any relevant [documentation] and [examples].
- [ ] Reported all new error conditions into the log or as an event, as
  appropriate.
