### PR TITLE
Add an example GKE cluster composition

### DIFF
--- a/cluster/examples/composition/azure-sqlserver/README.md
+++ b/cluster/examples/composition/azure-sqlserver/README.md
@@ -16,7 +16,8 @@ request. An application operator may request a `PrivatePostgreSQLServer` to use
 with their application by authoring a `PrivatePostgreSQLServerRequirement` in
 the namespace where their application is running.
 
-To try this example, first [create an Azure `Provider`] named `example`, then:
+To try this example, first install provider-azure and create an Azure `Provider`
+named `example` per the [Crossplane documentation], then:
 
 1. Define and publish the new resources by running `kubectl apply -f
    definitions/`.
@@ -45,5 +46,5 @@ $ kubectl describe networkgroups
 $ kubectl describe privatepostgresqlserverrequirementes
 ```
 
-[composite infrastructure resources]: https://github.com/crossplane/crossplane/pull/1163
-[create an Azure `Provider`]: https://crossplane.io/docs/v0.9/cloud-providers/azure/azure-provider.html
+[composite infrastructure resources]: https://github.com/crossplane/crossplane/blob/f0263cd/design/design-doc-composition.md
+[Crossplane documentation]: https://crossplane.io/docs/

--- a/cluster/examples/composition/gcp-gkecluster/README.md
+++ b/cluster/examples/composition/gcp-gkecluster/README.md
@@ -15,7 +15,8 @@ resource may subsequently be published as available for application operators to
 request - see the neighboring gcp-sqlserver for an example of a published
 resource.
 
-To try this example, first [create a GCP `Provider`] named `example`, then:
+To try this example, first install provider-gcp and create an GCP `Provider`
+named `example` per the [Crossplane documentation], then:
 
 1. Define and publish the new resources by running `kubectl apply -f
    definitions/`.
@@ -36,5 +37,5 @@ $ kubectl describe servicednetworks
 $ kubectl describe clusters
 ```
 
-[composite infrastructure resources]: https://github.com/crossplane/crossplane/pull/1163
-[create a GCP `Provider`]: https://crossplane.io/docs/v0.9/cloud-providers/gcp/gcp-provider.html
+[composite infrastructure resources]: https://github.com/crossplane/crossplane/blob/f0263cd/design/design-doc-composition.md
+[Crossplane documentation]: https://crossplane.io/docs/

--- a/cluster/examples/composition/gcp-gkecluster/README.md
+++ b/cluster/examples/composition/gcp-gkecluster/README.md
@@ -1,0 +1,40 @@
+# gcp-gkecluster
+
+This example demonstrates Crossplane's nascent support for [composite
+infrastructure resources]. It defines two new kind of resource, both in the
+`gke.example.org` API group:
+
+* `ServicedNetwork` - A GCP VPC network with service networking enabled,
+  allowing instances in this network to privately access GCP services such as
+  CloudSQL.
+* `Cluster` - A GKE cluster with two node pools.
+
+Both resources are defined but not published. Defined resources are cluster
+scoped and intended for use only by infrastructure operators. Any defined
+resource may subsequently be published as available for application operators to
+request - see the neighboring gcp-sqlserver for an example of a published
+resource.
+
+To try this example, first [create a GCP `Provider`] named `example`, then:
+
+1. Define and publish the new resources by running `kubectl apply -f
+   definitions/`.
+1. Create a `ServicedNetwork` by running `kubectl apply -f
+   servicednetwork.yaml`.
+1. Create a `Cluster` by running `kubectl apply -f cluster.yaml`.
+
+Use `kubectl describe` to view the status of your newly created resources:
+
+```shell
+# Make sure the new resources were correctly defined.
+$ kubectl describe infrastructuredefinitions
+
+# Make sure the ServicedNetwork is working:
+$ kubectl describe servicednetworks
+
+# Make sure the Cluster is working
+$ kubectl describe clusters
+```
+
+[composite infrastructure resources]: https://github.com/crossplane/crossplane/pull/1163
+[create a GCP `Provider`]: https://crossplane.io/docs/v0.9/cloud-providers/gcp/gcp-provider.html

--- a/cluster/examples/composition/gcp-gkecluster/cluster.yaml
+++ b/cluster/examples/composition/gcp-gkecluster/cluster.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: gke.example.org/v1alpha1
+kind: Cluster
+metadata:
+  name: example-gke
+  labels:
+    region: us-central1
+spec:
+  region: us-central1
+  zones:
+  - us-central1-a
+  - us-central1-b
+  cidrs:
+    nodes: 192.168.0.0/24
+    pods: 10.128.0.0/20
+    services: 172.16.0.0/16
+  servicedNetworkSelector:
+    matchLabels:
+      region: us-central1
+  reclaimPolicy: Delete
+  providerRef:
+    name: example

--- a/cluster/examples/composition/gcp-gkecluster/definitions/cluster.yaml
+++ b/cluster/examples/composition/gcp-gkecluster/definitions/cluster.yaml
@@ -1,0 +1,210 @@
+---
+# This allows Crossplane to manage our new composite resource.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: clusters.gke.example.org
+  labels:
+    rbac.crossplane.io/aggregate-to-crossplane: "true"
+rules:
+- apiGroups:
+  - gke.example.org
+  resources:
+  - clusters
+  - clusters/status
+  verbs:
+  - "*"
+---
+# This defines a GKE cluster with two identical node pools.
+apiVersion: apiextensions.crossplane.io/v1alpha1
+kind: InfrastructureDefinition
+metadata:
+  name: clusters.gke.example.org
+spec:
+  # The set of connection secret keys that this composite resource exposes. Each
+  # key must be provided by the connectionDetails of a composed resource.
+  connectionSecretKeys:
+  - kubeconfig
+  # The schema of this composite resource, in the form of a partial template for
+  # a Kubernetes CustomResourceDefinition.
+  crdSpecTemplate:
+    group: gke.example.org
+    version: v1alpha1
+    names:
+      kind: Cluster
+      listKind: ClusterList
+      plural: clusters
+      singular: cluster
+    validation:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            type: object
+            properties:
+              region:
+                type: string
+                description: Geographic region in which nodes will exist.
+              zones:
+                type: array
+                description: Geographic zones in which nodes will exist.
+                items:
+                  type: string
+              cidrs:
+                type: object
+                description: CIDRs for nodes, pods, and services.
+                properties:
+                  nodes:
+                    type: string
+                    description: CIDR for nodes.
+                  pods:
+                    type: string
+                    description: CIDR for pods.
+                  services:
+                    type: string
+                    description: CIDR for services.
+                required:
+                - nodes
+                - pods
+                - services
+              servicedNetworkSelector:
+                type: object
+                description: Selects a ServicedNetwork for this Cluster.
+                properties:
+                  matchLabels:
+                    type: object
+                    additionalProperties:
+                      type: string
+                required:
+                - matchLabels
+              providerRef:
+                type: object
+                description: Crossplane GCP provider credentials to use.
+                properties:
+                  name:
+                    type: string
+                required:
+                - name
+            required:
+            - region
+            - zones
+            - cidrs
+            - servicedNetworkSelector
+            - providerRef
+---
+apiVersion: apiextensions.crossplane.io/v1alpha1
+kind: Composition
+metadata:
+  name: clusters.gke.example.org
+spec:
+  writeConnectionSecretsToNamespace: crossplane-system
+  reclaimPolicy: Delete
+  from:
+    apiVersion: gke.example.org/v1alpha1
+    kind: Cluster
+  to:
+  - base:
+      apiVersion: compute.gcp.crossplane.io/v1beta1
+      kind: Subnetwork
+      spec:
+        forProvider:
+          privateIpGoogleAccess: true
+          secondaryIpRanges:
+            - rangeName: pods
+            - rangeName: services
+        reclaimPolicy: Delete
+    patches:
+      # Copy any labels from our Cluster to the Subnetwork that it composes.
+    - fromFieldPath: "metadata.labels"
+      toFieldPath: "metadata.labels"
+      # Set the external name annotation of the composed Subnetwork to that of
+      # the Cluster composite, if one exists.
+    - fromFieldPath: "metadata.annotations[crossplane.io/external-name]"
+      toFieldPath: "metadata.annotations[crossplane.io/external-name]"
+      # Use the providerRef of the Cluster.
+    - fromFieldPath: "spec.providerRef.name"
+      toFieldPath: "spec.providerRef.name"
+    - fromFieldPath: "spec.region"
+      toFieldPath: "spec.forProvider.region"
+    - fromFieldPath: "spec.cidrs.nodes"
+      toFieldPath: "spec.forProvider.ipCidrRange"
+    - fromFieldPath: "spec.cidrs.pods"
+      toFieldPath: "spec.forProvider.secondaryIpRanges[0].ipCidrRange"
+    - fromFieldPath: "spec.cidrs.services"
+      toFieldPath: "spec.forProvider.secondaryIpRanges[1].ipCidrRange"
+      # Use the networkGroupSelector of the Cluster to select a resource group
+      # in which to create the Subnetwork.
+    - fromFieldPath: "spec.servicedNetworkSelector"
+      toFieldPath: "spec.forProvider.networkSelector"
+  - base:
+      apiVersion: container.gcp.crossplane.io/v1beta1
+      kind: GKECluster
+      spec:
+        forProvider:
+          ipAllocationPolicy:
+            useIpAliases: true
+            clusterSecondaryRangeName: pods
+            servicesSecondaryRangeName: services
+          subnetworkSelector:
+            matchControllerRef: true
+        writeConnectionSecretToRef:
+          namespace: crossplane-system
+        reclaimPolicy: Delete
+    patches:
+    - fromFieldPath: "metadata.labels"
+      toFieldPath: "metadata.labels"
+    - fromFieldPath: "metadata.annotations[crossplane.io/external-name]"
+      toFieldPath: "metadata.annotations[crossplane.io/external-name]"
+    - fromFieldPath: "spec.providerRef.name"
+      toFieldPath: "spec.providerRef.name"
+    - fromFieldPath: "spec.region"
+      toFieldPath: "spec.forProvider.location"
+    - fromFieldPath: "spec.servicedNetworkSelector"
+      toFieldPath: "spec.forProvider.networkSelector"
+      # Store the connection secret for this GKECluster in a secret name derived
+      # from the Cluster's UID. Use the string format transform function to
+      # append -controlplane to the UID.
+    - fromFieldPath: "metadata.uid"
+      toFieldPath: "spec.writeConnectionSecretToRef.name"
+      transforms:
+      - type: string
+        string:
+          fmt: "%s-controlplane"
+    connectionDetails:
+    - fromConnectionSecretKey: kubeconfig
+  - base:
+      apiVersion: container.gcp.crossplane.io/v1alpha1
+      kind: NodePool
+      spec:
+        forProvider:
+          initialNodeCount: 1
+          clusterSelector:
+            matchControllerRef: true
+        reclaimPolicy: Delete
+    patches:
+    - fromFieldPath: "metadata.labels"
+      toFieldPath: "metadata.labels"
+    - fromFieldPath: "metadata.annotations[crossplane.io/external-name]"
+      toFieldPath: "metadata.annotations[crossplane.io/external-name]"
+    - fromFieldPath: "spec.providerRef.name"
+      toFieldPath: "spec.providerRef.name"
+    - fromFieldPath: "spec.zones"
+      toFieldPath: "spec.forProvider.locations"
+  - base:
+      apiVersion: container.gcp.crossplane.io/v1alpha1
+      kind: NodePool
+      spec:
+        forProvider:
+          initialNodeCount: 1
+          clusterSelector:
+            matchControllerRef: true
+        reclaimPolicy: Delete
+    patches:
+    - fromFieldPath: "metadata.labels"
+      toFieldPath: "metadata.labels"
+    - fromFieldPath: "metadata.annotations[crossplane.io/external-name]"
+      toFieldPath: "metadata.annotations[crossplane.io/external-name]"
+    - fromFieldPath: "spec.providerRef.name"
+      toFieldPath: "spec.providerRef.name"
+    - fromFieldPath: "spec.zones"
+      toFieldPath: "spec.forProvider.locations"

--- a/cluster/examples/composition/gcp-gkecluster/definitions/servicednetwork.yaml
+++ b/cluster/examples/composition/gcp-gkecluster/definitions/servicednetwork.yaml
@@ -1,0 +1,136 @@
+---
+# This allows Crossplane to manage our new composite resource.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: servicednetworks.gke.example.org
+  labels:
+    rbac.crossplane.io/aggregate-to-crossplane: "true"
+rules:
+- apiGroups:
+  - gke.example.org
+  resources:
+  - servicednetworks
+  - servicednetworks/status
+  verbs:
+  - "*"
+---
+# This defines our new 'ServicedNetwork', i.e. a VPC network that has a service
+# networking connection that allows instances in the VPC to access GCP services
+# like CloudSQL.
+apiVersion: apiextensions.crossplane.io/v1alpha1
+kind: InfrastructureDefinition
+metadata:
+  name: servicednetworks.gke.example.org
+spec:
+  # The schema of this composite resource, in the form of a partial template for
+  # a Kubernetes CustomResourceDefinition.
+  crdSpecTemplate:
+    group: gke.example.org
+    version: v1alpha1
+    names:
+      kind: ServicedNetwork
+      listKind: ServicedNetworkList
+      plural: servicednetworks
+      singular: servicednetwork
+    validation:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            type: object
+            properties:
+              region:
+                type: string
+                description: Geographic region in which nodes will exist.
+              providerRef:
+                type: object
+                description: Crossplane GCP provider credentials to use.
+                properties:
+                  name:
+                    type: string
+                required:
+                - name
+            required:
+            - region
+            - providerRef
+---
+# This specifies the resources that should be composed when a ServicedNetwork is
+# created. Multiple Compositions may exist for any one kind of composite
+# resource. The composite resource (i.e. the ServicedNetwork) can influence
+# which Composition is used via a spec.compositionSelector.matchLabels field
+# that is automatically added to all composite resources. In future it will be
+# possible mark a composition as the default, or force an
+# InfrastructureDefinition to use a particular Composition. Currently a
+# reference or selector must be specified.
+apiVersion: apiextensions.crossplane.io/v1alpha1
+kind: Composition
+metadata:
+  name: servicednetworks.gke.example.org
+spec:
+  writeConnectionSecretsToNamespace: crossplane-system
+  reclaimPolicy: Delete
+  from:
+    apiVersion: gke.example.org/v1alpha1
+    kind: ServicedNetwork
+  to:
+  - base:
+      apiVersion: compute.gcp.crossplane.io/v1beta1
+      kind: Network
+      spec:
+        forProvider:
+          autoCreateSubnetworks: false
+          routingConfig:
+            routingMode: REGIONAL
+        reclaimPolicy: Delete
+    patches:
+      # Copy any labels from our ServicedNetwork to the Network that it
+      # composes.
+    - fromFieldPath: "metadata.labels"
+      toFieldPath: "metadata.labels"
+      # Set the external name annotation of the composed Network to that of the
+      # ServicedNetwork composite, if one exists.
+    - fromFieldPath: "metadata.annotations[crossplane.io/external-name]"
+      toFieldPath: "metadata.annotations[crossplane.io/external-name]"
+      # Use the providerRef of the ServicedNetwork.
+    - fromFieldPath: "spec.providerRef.name"
+      toFieldPath: "spec.providerRef.name"
+  - base:
+      apiVersion: compute.gcp.crossplane.io/v1beta1
+      kind: GlobalAddress
+      spec:
+        forProvider:
+          purpose: VPC_PEERING
+          addressType: INTERNAL
+          prefixLength: 16
+          networkSelector:
+            # This selector ensures this GlobalAddress will select and use the
+            # above Network. They will both be controlled by the composite
+            # resource, and thus their controller references will match.
+            matchControllerRef: true
+        reclaimPolicy: Delete
+    patches:
+    - fromFieldPath: "metadata.labels"
+      toFieldPath: "metadata.labels"
+    - fromFieldPath: "metadata.annotations[crossplane.io/external-name]"
+      toFieldPath: "metadata.annotations[crossplane.io/external-name]"
+    - fromFieldPath: "spec.providerRef.name"
+      toFieldPath: "spec.providerRef.name"
+  - base:
+      apiVersion: servicenetworking.gcp.crossplane.io/v1beta1
+      kind: Connection
+      spec:
+        forProvider:
+          parent: services/servicenetworking.googleapis.com
+          networkSelector:
+            matchControllerRef: true
+          reservedPeeringRangeSelector:
+            matchControllerRef: true
+        reclaimPolicy: Delete
+    patches:
+    - fromFieldPath: "metadata.labels"
+      toFieldPath: "metadata.labels"
+    - fromFieldPath: "metadata.annotations[crossplane.io/external-name]"
+      toFieldPath: "metadata.annotations[crossplane.io/external-name]"
+    - fromFieldPath: "spec.providerRef.name"
+      toFieldPath: "spec.providerRef.name"

--- a/cluster/examples/composition/gcp-gkecluster/servicednetwork.yaml
+++ b/cluster/examples/composition/gcp-gkecluster/servicednetwork.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: gke.example.org/v1alpha1
+kind: ServicedNetwork
+metadata:
+  name: example-gke
+  labels:
+    region: us-central1
+spec:
+  region: us-central1
+  reclaimPolicy: Delete
+  providerRef:
+    name: example


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

We strongly recommend you look through our contributor guide at https://git.io/fj2m9
if this is your first time opening a Crossplane pull request. You can find us in
https://slack.crossplane.io/messages/dev if you need any help contributing.
-->

### Description of your changes
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

Fixes #
-->
This example demonstrates Crossplane's nascent support for composite infrastructure resources. It defines two new kind of resource, both in the `gke.example.org` API group:

* `ServicedNetwork` - A GCP VPC network with service networking enabled, allowing instances in this network to privately access GCP services such as CloudSQL.
* `Cluster` - A GKE cluster with two node pools.

### How has this code been tested?
<!--
Before reviewers can be confident in the correctness of a pull request,
it needs to tested and shown to be correct. In this section, briefly
describe the testing that has already been done or which is planned.
-->
By following the instructions in the newly added `gcp-gkecluster/README.md`

### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every Crossplane pull request.
-->
I have:
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Ensured this PR contains a neat, self documenting set of commits.
- [ ] Updated any relevant [documentation] and [examples].
- [ ] Reported all new error conditions into the log or as an event, as
  appropriate.

For more about what we believe makes a pull request complete, see our
[definition of done].

[documentation]: https://github.com/crossplane/crossplane/tree/master/docs
[examples]: https://github.com/crossplane/crossplane/tree/master/cluster/examples
[definition of done]: https://github.com/crossplane/crossplane/tree/master/design/one-pager-definition-of-done.md
