### PR TITLE
Update KubernetesApplication controller to use APIUpdatingApplicator

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/crossplane/crossplane
 go 1.13
 
 require (
-	github.com/crossplane/crossplane-runtime v0.8.0
+	github.com/crossplane/crossplane-runtime v0.8.1-0.20200512204508-290de7349949
 	github.com/crossplane/crossplane-tools v0.0.0-20200412230150-efd0edd4565b
 	github.com/crossplane/oam-kubernetes-runtime v0.0.0-20200426101222-2b61763c2e51
 	github.com/docker/distribution v2.7.1+incompatible

--- a/go.sum
+++ b/go.sum
@@ -75,8 +75,8 @@ github.com/coreos/pkg v0.0.0-20180108230652-97fdf19511ea/go.mod h1:E3G3o1h8I7cfc
 github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwcJI5acqYI6dE=
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
 github.com/crossplane/crossplane-runtime v0.7.1-0.20200421211018-be37c50cc2ab/go.mod h1:e12p4X6dbtqd9GOnph78Epd6aezyvmcMM1+6aQy3VzY=
-github.com/crossplane/crossplane-runtime v0.8.0 h1:IBm5LWVeqB2BjHpkykURHY0PSozXWfIXk7LfWtr27wY=
-github.com/crossplane/crossplane-runtime v0.8.0/go.mod h1:gNY/21MLBaz5KNP7hmfXbBXp8reYRbwY5B/97Kp4tgM=
+github.com/crossplane/crossplane-runtime v0.8.1-0.20200512204508-290de7349949 h1:m2LpYaLAwSJK5dF893bNC3wnMJqoF2y5ruZz37l6dDU=
+github.com/crossplane/crossplane-runtime v0.8.1-0.20200512204508-290de7349949/go.mod h1:gNY/21MLBaz5KNP7hmfXbBXp8reYRbwY5B/97Kp4tgM=
 github.com/crossplane/crossplane-tools v0.0.0-20200219001116-bb8b2ce46330 h1:zxdYGQnQbfyZSnRbKUJ16x5lRzkUTbH+uumVq03ijYo=
 github.com/crossplane/crossplane-tools v0.0.0-20200219001116-bb8b2ce46330/go.mod h1:C735A9X0x0lR8iGVOOxb49Mt70Ua4EM2b7PGaRPBLd4=
 github.com/crossplane/crossplane-tools v0.0.0-20200412230150-efd0edd4565b h1:BqGODFDKcq4hd8RZeWmh8BsjfHS0eAtGWMLtT74rsG8=
@@ -604,6 +604,7 @@ google.golang.org/grpc v1.21.1/go.mod h1:oYelfM1adQP15Ek0mdvEgi9Df8B9CZIaU1084ij
 google.golang.org/grpc v1.23.0 h1:AzbTB6ux+okLTzP8Ru1Xs41C303zdcfEht7MQnYJt5A=
 google.golang.org/grpc v1.23.0/go.mod h1:Y5yQAOtifL1yxbo5wqy6BxZv8vAUGQwXBOALyacEbxg=
 google.golang.org/grpc v1.23.1/go.mod h1:Y5yQAOtifL1yxbo5wqy6BxZv8vAUGQwXBOALyacEbxg=
+google.golang.org/grpc v1.26.0 h1:2dTRdpdFEEhJYQD8EMLB61nnrzSCTbG38PhqdhvOltg=
 google.golang.org/grpc v1.26.0/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8abTk=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6 h1:jMFz6MfLP0/4fUyZle81rXUoxOBFi19VUFKVDOQfozc=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=

--- a/pkg/controller/workload/kubernetes/application/application_test.go
+++ b/pkg/controller/workload/kubernetes/application/application_test.go
@@ -70,15 +70,23 @@ var (
 	}
 
 	targetRef = &v1alpha1.KubernetesTargetReference{Name: target.GetName()}
+)
 
-	resourceA = &v1alpha1.KubernetesApplicationResource{
+type karModifier func(*v1alpha1.KubernetesApplicationResource)
+
+func karWithState(s v1alpha1.KubernetesApplicationResourceState) karModifier {
+	return func(r *v1alpha1.KubernetesApplicationResource) { r.Status.State = s }
+}
+
+func kar(rm ...karModifier) *v1alpha1.KubernetesApplicationResource {
+	k := &v1alpha1.KubernetesApplicationResource{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace:   objectMeta.GetNamespace(),
 			Name:        templateA.GetName(),
 			Labels:      templateA.GetLabels(),
 			Annotations: templateA.GetAnnotations(),
 			OwnerReferences: []metav1.OwnerReference{
-				*(metav1.NewControllerRef(kubeApp(), v1alpha1.KubernetesApplicationGroupVersionKind)),
+				*(metav1.NewControllerRef(kubeApp(withUID(uid)), v1alpha1.KubernetesApplicationGroupVersionKind)),
 			},
 		},
 		Spec: templateA.Spec,
@@ -86,7 +94,13 @@ var (
 			State: v1alpha1.KubernetesApplicationResourceStateScheduled,
 		},
 	}
-)
+
+	for _, m := range rm {
+		m(k)
+	}
+
+	return k
+}
 
 type kubeAppModifier func(*v1alpha1.KubernetesApplication)
 
@@ -113,6 +127,12 @@ func withSubmittedResources(i int) kubeAppModifier {
 func withTarget(name string) kubeAppModifier {
 	return func(r *v1alpha1.KubernetesApplication) {
 		r.Spec.Target = &v1alpha1.KubernetesTargetReference{Name: name}
+	}
+}
+
+func withUID(u types.UID) kubeAppModifier {
+	return func(r *v1alpha1.KubernetesApplication) {
+		r.UID = u
 	}
 }
 
@@ -639,38 +659,40 @@ func TestSyncApplicationResource(t *testing.T) {
 			ar: &applicationResourceClient{
 				kube: &test.MockClient{
 					MockGet: func(_ context.Context, _ types.NamespacedName, obj runtime.Object) error {
-						r := resourceA.DeepCopy()
+						r := kar()
+						r.SetOwnerReferences([]metav1.OwnerReference{})
 						r.Status.State = v1alpha1.KubernetesApplicationResourceStateSubmitted
 
 						*obj.(*v1alpha1.KubernetesApplicationResource) = *r
 						return nil
 					},
+					MockUpdate: test.NewMockUpdateFn(nil),
 				},
 			},
-			template:      resourceA,
+			template:      kar(),
 			wantSubmitted: true,
 		},
 		{
-			name: "ExistingResourceHasDifferentController",
+			name: "ExistingResourceIsNotControllable",
 			ar: &applicationResourceClient{
 				kube: &test.MockClient{
 					MockGet: func(_ context.Context, _ types.NamespacedName, obj runtime.Object) error {
-						r := resourceA.DeepCopy()
-						r.SetOwnerReferences([]metav1.OwnerReference{})
+						r := kar()
+						truePtr := true
+						r.SetOwnerReferences([]metav1.OwnerReference{
+							{
+								Controller: &truePtr,
+								UID:        types.UID("some-other-uid"),
+							},
+						})
 
 						*obj.(*v1alpha1.KubernetesApplicationResource) = *r
 						return nil
 					},
 				},
 			},
-			template: resourceA,
-			wantErr: errors.WithStack(errors.Errorf("cannot sync %s: %s %s exists and is not controlled by %s %s",
-				v1alpha1.KubernetesApplicationResourceKind,
-				v1alpha1.KubernetesApplicationResourceKind,
-				templateA.GetName(),
-				v1alpha1.KubernetesApplicationKind,
-				objectMeta.GetName(),
-			)),
+			template: kar(),
+			wantErr:  errors.WithStack(errors.Errorf("cannot sync %s: existing object is not controlled by UID \"%s\"", v1alpha1.KubernetesApplicationResourceKind, uid)),
 		},
 		{
 
@@ -678,8 +700,8 @@ func TestSyncApplicationResource(t *testing.T) {
 			ar: &applicationResourceClient{
 				kube: &test.MockClient{MockGet: test.NewMockGetFn(errorBoom)},
 			},
-			template: resourceA,
-			wantErr:  errors.Wrapf(errorBoom, "cannot sync %s", v1alpha1.KubernetesApplicationResourceKind),
+			template: kar(),
+			wantErr:  errors.Wrapf(errorBoom, "cannot sync %s: cannot get object", v1alpha1.KubernetesApplicationResourceKind),
 		},
 	}
 
@@ -709,7 +731,7 @@ func TestRenderTemplate(t *testing.T) {
 			name:     "Successful",
 			app:      kubeApp(withTarget(target.GetName())),
 			template: &templateA,
-			want:     resourceA,
+			want:     kar(),
 		},
 	}
 

--- a/pkg/controller/workload/kubernetes/application/application_test.go
+++ b/pkg/controller/workload/kubernetes/application/application_test.go
@@ -659,9 +659,8 @@ func TestSyncApplicationResource(t *testing.T) {
 			ar: &applicationResourceClient{
 				kube: &test.MockClient{
 					MockGet: func(_ context.Context, _ types.NamespacedName, obj runtime.Object) error {
-						r := kar()
+						r := kar(karWithState(v1alpha1.KubernetesApplicationResourceStateSubmitted))
 						r.SetOwnerReferences([]metav1.OwnerReference{})
-						r.Status.State = v1alpha1.KubernetesApplicationResourceStateSubmitted
 
 						*obj.(*v1alpha1.KubernetesApplicationResource) = *r
 						return nil

--- a/pkg/controller/workload/kubernetes/resource/resource.go
+++ b/pkg/controller/workload/kubernetes/resource/resource.go
@@ -266,9 +266,7 @@ func (c *unstructuredClient) sync(ctx context.Context, template *unstructured.Un
 	}
 
 	rs := getRemoteStatus(remote)
-
-	// TODO(negz): Update to resource.APIPatchingApplicator.
-	return rs, errors.Wrap(resource.Apply(ctx, c.kube, template), errSyncResource) // nolint:staticcheck
+	return rs, errors.Wrap(resource.NewAPIPatchingApplicator(c.kube).Apply(ctx, template), errSyncResource)
 }
 
 func getRemoteStatus(u runtime.Unstructured) *v1alpha1.RemoteStatus {

--- a/pkg/controller/workload/kubernetes/target/target.go
+++ b/pkg/controller/workload/kubernetes/target/target.go
@@ -67,7 +67,7 @@ func Setup(mgr ctrl.Manager, l logging.Logger) error {
 		Complete(&Reconciler{
 			client: resource.ClientApplicator{
 				Client:     mgr.GetClient(),
-				Applicator: resource.NewAPIUpdatingApplicator(mgr.GetClient()),
+				Applicator: resource.NewAPIPatchingApplicator(mgr.GetClient()),
 			},
 			log: l.WithValues("controller", name)})
 }


### PR DESCRIPTION

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

<!--
Thank you for helping to improve Crossplane!

We strongly recommend you look through our contributor guide at https://git.io/fj2m9
if this is your first time opening a Crossplane pull request. You can find us in
https://slack.crossplane.io/messages/dev if you need any help contributing.
-->

### Description of your changes
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

Fixes #
-->

Making use of the APIUpdatingApplicator allows the KA controller to also use the MustBeControllableBy apply option, which fixes the bug of a KA being unable to regain control of its KARs in a backup and restore scenario.

Depends on https://github.com/crossplane/crossplane-runtime/pull/176

### How has this code been tested?
<!--
Before reviewers can be confident in the correctness of a pull request,
it needs to tested and shown to be correct. In this section, briefly
describe the testing that has already been done or which is planned.
-->

I tested this scenario by running the crossplane and stack-manager controllers locally against a Kind cluster, then installing, `provider-gcp`, `stack-gcp-sample`, and `app-wordpress`. I then created a `GCPSample` and `WordpressInstance` and waited for the site to come up. Then I backed up the cluster state with Velero and deleted the cluster. I then created a new Kind cluster, installed Velero, did a restore of my backup and started the crossplane and stack-manager controllers locally. Previously, the `KubernetesApplication` was reporting a status of `FAILED` and did not clean up its KARs on deletion because it was unable to establish ownership because the restored KARs did not have owner references. Now that the KA controller is using `MustBeControllableBy`, the KA is able to regain control of its KARs. I verified that everything was cleaned up as expected when I deleted the restored `WordpressInstance`.

<details>
 <summary>TestingArtifacts</summary>

**Pre-Backup**

```
$ kubectl get gcp

NAME                                                  AGE
network.compute.gcp.crossplane.io/tbs-infra-network   17m
NAME                                                        AGE
subnetwork.compute.gcp.crossplane.io/tbs-infra-subnetwork   17m
NAME                                                              AGE
globaladdress.compute.gcp.crossplane.io/tbs-infra-globaladdress   17m
NAME                                                               STATUS   STATE     CLUSTER-NAME   ENDPOINT       CLUSTER-CLASS               LOCATION     RECLAIM-POLICY   AGE
gkecluster.compute.gcp.crossplane.io/default-my-wp-cluster-67t5x   Bound    RUNNING                  34.83.86.139   tbs-infra-gkeclusterclass   us-west1-b   Delete           16m
NAME                                                                  PROVIDER-REF             RECLAIM-POLICY   AGE
gkeclusterclass.compute.gcp.crossplane.io/tbs-infra-gkeclusterclass   tbs-infra-gcp-provider   Delete           17m
NAME                                                PROJECT-ID              AGE
provider.gcp.crossplane.io/gcp-provider             crossplane-playground   18m
provider.gcp.crossplane.io/tbs-infra-gcp-provider   crossplane-playground   17m
NAME                                                                                            PROVIDER-REF   RECLAIM-POLICY   AGE
cloudmemorystoreinstanceclass.cache.gcp.crossplane.io/tbs-infra-cloudmemorystoreinstanceclass   gcp-provider   Delete           17m
NAME                                                                  STATUS   STATE      CLASS                                   VERSION     AGE
cloudsqlinstance.database.gcp.crossplane.io/default-my-wp-sql-jwvkq   Bound    RUNNABLE   tbs-infra-cloudsqlinstanceclass-mysql   MYSQL_5_7   9m48s
NAME                                                                                          PROVIDER-REF             RECLAIM-POLICY   AGE
cloudsqlinstanceclass.database.gcp.crossplane.io/tbs-infra-cloudsqlinstanceclass-mysql        tbs-infra-gcp-provider   Delete           17m
cloudsqlinstanceclass.database.gcp.crossplane.io/tbs-infra-cloudsqlinstanceclass-postgresql   tbs-infra-gcp-provider   Delete           17m
NAME                                                                  AGE
connection.servicenetworking.gcp.crossplane.io/tbs-infra-connection   17m
```

```
$ kubectl get claim

NAME                                                    STATUS   CLASS-KIND        CLASS-NAME                  RESOURCE-KIND   RESOURCE-NAME                 AGE
kubernetescluster.compute.crossplane.io/my-wp-cluster   Bound    GKEClusterClass   tbs-infra-gkeclusterclass   GKECluster      default-my-wp-cluster-67t5x   17m
NAME                                             STATUS   CLASS-KIND              CLASS-NAME                              RESOURCE-KIND      RESOURCE-NAME             AGE
mysqlinstance.database.crossplane.io/my-wp-sql   Bound    CloudSQLInstanceClass   tbs-infra-cloudsqlinstanceclass-mysql   CloudSQLInstance   default-my-wp-sql-jwvkq   17m 
```

```
$ kubectl get kubernetesapplications

NAME        CLUSTER         STATUS      DESIRED   SUBMITTED
my-wp-app   my-wp-cluster   Submitted   3         3
```

```
$ kubectl get kubernetesapplicationresources

NAME               TEMPLATE-KIND   TEMPLATE-NAME   CLUSTER         STATUS
my-wp-deployment   Deployment      wordpress       my-wp-cluster   Submitted
my-wp-namespace    Namespace       my-wp           my-wp-cluster   Submitted
my-wp-service      Service         wordpress       my-wp-cluster   Submitted
```

```
$ kubectl get secrets

NAME                        TYPE                                  DATA   AGE
app-wordpress-token-p4vvl   kubernetes.io/service-account-token   3      17m
default-token-gcx54         kubernetes.io/service-account-token   3      32m
gcp-sample-token-skl6z      kubernetes.io/service-account-token   3      17m
gcp-token-rjslk             kubernetes.io/service-account-token   3      19m
my-wp-cluster               connection.crossplane.io/v1alpha1     7      13m
sql                         connection.crossplane.io/v1alpha1     12     4m6s
```

**After backup and restore**

```
$ kubectl get gcp

NAME                                                              AGE
globaladdress.compute.gcp.crossplane.io/tbs-infra-globaladdress   67s
NAME                                                        AGE
subnetwork.compute.gcp.crossplane.io/tbs-infra-subnetwork   67s
NAME                                                  AGE
network.compute.gcp.crossplane.io/tbs-infra-network   67s
NAME                                                                  PROVIDER-REF             RECLAIM-POLICY   AGE
gkeclusterclass.compute.gcp.crossplane.io/tbs-infra-gkeclusterclass   tbs-infra-gcp-provider   Delete           67s
NAME                                                               STATUS   STATE     CLUSTER-NAME   ENDPOINT       CLUSTER-CLASS               LOCATION     RECLAIM-POLICY   AGE
gkecluster.compute.gcp.crossplane.io/default-my-wp-cluster-67t5x   Bound    RUNNING                  34.83.86.139   tbs-infra-gkeclusterclass   us-west1-b   Delete           67s
NAME                                                PROJECT-ID              AGE
provider.gcp.crossplane.io/gcp-provider             crossplane-playground   67s
provider.gcp.crossplane.io/tbs-infra-gcp-provider   crossplane-playground   67s
NAME                                                                                            PROVIDER-REF   RECLAIM-POLICY   AGE
cloudmemorystoreinstanceclass.cache.gcp.crossplane.io/tbs-infra-cloudmemorystoreinstanceclass   gcp-provider   Delete           67s
NAME                                                                                          PROVIDER-REF             RECLAIM-POLICY   AGE
cloudsqlinstanceclass.database.gcp.crossplane.io/tbs-infra-cloudsqlinstanceclass-mysql        tbs-infra-gcp-provider   Delete           67s
cloudsqlinstanceclass.database.gcp.crossplane.io/tbs-infra-cloudsqlinstanceclass-postgresql   tbs-infra-gcp-provider   Delete           67s
NAME                                                                  STATUS   STATE      CLASS                                   VERSION     AGE
cloudsqlinstance.database.gcp.crossplane.io/default-my-wp-sql-jwvkq   Bound    RUNNABLE   tbs-infra-cloudsqlinstanceclass-mysql   MYSQL_5_7   67s
NAME                                                                  AGE
connection.servicenetworking.gcp.crossplane.io/tbs-infra-connection   67s
```

```
$ kubectl get claim

NAME                                                    STATUS   CLASS-KIND        CLASS-NAME                  RESOURCE-KIND   RESOURCE-NAME                 AGE
kubernetescluster.compute.crossplane.io/my-wp-cluster   Bound    GKEClusterClass   tbs-infra-gkeclusterclass   GKECluster      default-my-wp-cluster-67t5x   99s
NAME                                             STATUS   CLASS-KIND              CLASS-NAME                              RESOURCE-KIND      RESOURCE-NAME             AGE
mysqlinstance.database.crossplane.io/my-wp-sql   Bound    CloudSQLInstanceClass   tbs-infra-cloudsqlinstanceclass-mysql   CloudSQLInstance   default-my-wp-sql-jwvkq   99s
```

```
$ kubectl get kubernetesapplications

NAME        CLUSTER         STATUS      DESIRED   SUBMITTED
my-wp-app   my-wp-cluster   Submitted   3         3
```

```
$ kubectl get kubernetesapplicationresources

NAME               TEMPLATE-KIND   TEMPLATE-NAME   CLUSTER         STATUS
my-wp-deployment   Deployment      wordpress       my-wp-cluster   Submitted
my-wp-namespace    Namespace       my-wp           my-wp-cluster   Submitted
my-wp-service      Service         wordpress       my-wp-cluster   Submitted

```

```
$ kubectl get secrets

NAME                        TYPE                                  DATA   AGE
app-wordpress-token-2rrp2   kubernetes.io/service-account-token   3      2m37s
default-token-vtv4g         kubernetes.io/service-account-token   3      4m33s
gcp-sample-token-t4rpr      kubernetes.io/service-account-token   3      2m37s
gcp-token-9d4w7             kubernetes.io/service-account-token   3      2m37s
my-wp-cluster               connection.crossplane.io/v1alpha1     7      2m43s
sql                         connection.crossplane.io/v1alpha1     12     2m43s
```

**After deleting `WordpressInstance`**

```
$ kubectl get gcp

NAME                                                              AGE
globaladdress.compute.gcp.crossplane.io/tbs-infra-globaladdress   4m30s
NAME                                                        AGE
subnetwork.compute.gcp.crossplane.io/tbs-infra-subnetwork   4m30s
NAME                                                  AGE
network.compute.gcp.crossplane.io/tbs-infra-network   4m30s
NAME                                                                  PROVIDER-REF             RECLAIM-POLICY   AGE
gkeclusterclass.compute.gcp.crossplane.io/tbs-infra-gkeclusterclass   tbs-infra-gcp-provider   Delete           4m30s
NAME                                                PROJECT-ID              AGE
provider.gcp.crossplane.io/gcp-provider             crossplane-playground   4m30s
provider.gcp.crossplane.io/tbs-infra-gcp-provider   crossplane-playground   4m30s
NAME                                                                                            PROVIDER-REF   RECLAIM-POLICY   AGE
cloudmemorystoreinstanceclass.cache.gcp.crossplane.io/tbs-infra-cloudmemorystoreinstanceclass   gcp-provider   Delete           4m30s
NAME                                                                                          PROVIDER-REF             RECLAIM-POLICY   AGE
cloudsqlinstanceclass.database.gcp.crossplane.io/tbs-infra-cloudsqlinstanceclass-mysql        tbs-infra-gcp-provider   Delete           4m30s
cloudsqlinstanceclass.database.gcp.crossplane.io/tbs-infra-cloudsqlinstanceclass-postgresql   tbs-infra-gcp-provider   Delete           4m30s
NAME                                                                  AGE
connection.servicenetworking.gcp.crossplane.io/tbs-infra-connection   4m30s
```

```
$ kubectl get claim

No resources.
```

```
$ kubectl get kubernetesapplications

No resources.
```

```
$ kubectl get kubernetesapplicationresources

No resources.
```

```
$ kubectl get secrets

NAME                        TYPE                                  DATA   AGE
app-wordpress-token-2rrp2   kubernetes.io/service-account-token   3      4m45s
default-token-vtv4g         kubernetes.io/service-account-token   3      6m41s
gcp-sample-token-t4rpr      kubernetes.io/service-account-token   3      4m45s
gcp-token-9d4w7             kubernetes.io/service-account-token   3      4m45s
```

</details>

### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every Crossplane pull request.
-->
I have:
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Ensured this PR contains a neat, self documenting set of commits.
- [ ] Updated any relevant [documentation] and [examples].
- [ ] Reported all new error conditions into the log or as an event, as
  appropriate.

For more about what we believe makes a pull request complete, see our
[definition of done].

[documentation]: https://github.com/crossplane/crossplane/tree/master/docs
[examples]: https://github.com/crossplane/crossplane/tree/master/cluster/examples
[definition of done]: https://github.com/crossplane/crossplane/tree/master/design/one-pager-definition-of-done.md
