### PR TITLE
Shorter composite and composed resource names

### DIFF
--- a/pkg/controller/apiextensions/composite/composed/api.go
+++ b/pkg/controller/apiextensions/composite/composed/api.go
@@ -39,10 +39,11 @@ const (
 	errNamePrefix = "name prefix is not found in labels"
 )
 
+// Label keys.
 const (
-	// LabelKeyNamePrefixForComposed is the prefix that will be used by composed
-	// resources.
 	LabelKeyNamePrefixForComposed = "crossplane.io/root-composite"
+	LabelKeyRequirementName       = "crossplane.io/requirement-name"
+	LabelKeyRequirementNamespace  = "crossplane.io/requirement-namespace"
 )
 
 // ConfigureFn is a function that implements Configurator interface.
@@ -70,7 +71,11 @@ func (*DefaultConfigurator) Configure(cp resource.Composite, cd resource.Compose
 		return errors.New(errNamePrefix)
 	}
 	// This label will be used if composed resource is yet another composite.
-	meta.AddLabels(cd, map[string]string{LabelKeyNamePrefixForComposed: cp.GetLabels()[LabelKeyNamePrefixForComposed]})
+	meta.AddLabels(cd, map[string]string{
+		LabelKeyNamePrefixForComposed: cp.GetLabels()[LabelKeyNamePrefixForComposed],
+		LabelKeyRequirementName:       cp.GetLabels()[LabelKeyRequirementName],
+		LabelKeyRequirementNamespace:  cp.GetLabels()[LabelKeyRequirementNamespace],
+	})
 	// Unmarshalling the template will overwrite any existing fields, so we must
 	// restore the existing name, if any. We also set generate name in case we
 	// haven't yet named this composed resource.

--- a/pkg/controller/apiextensions/composite/composed/api.go
+++ b/pkg/controller/apiextensions/composite/composed/api.go
@@ -41,7 +41,7 @@ const (
 
 // Label keys.
 const (
-	LabelKeyNamePrefixForComposed = "crossplane.io/root-composite"
+	LabelKeyNamePrefixForComposed = "crossplane.io/composite"
 	LabelKeyRequirementName       = "crossplane.io/requirement-name"
 	LabelKeyRequirementNamespace  = "crossplane.io/requirement-namespace"
 )

--- a/pkg/controller/apiextensions/composite/composed/api_test.go
+++ b/pkg/controller/apiextensions/composite/composed/api_test.go
@@ -86,12 +86,20 @@ func TestConfigure(t *testing.T) {
 		"Success": {
 			reason: "Configuration should result in the right object with correct generateName",
 			args: args{
-				cp: &fake.Composite{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{LabelKeyNamePrefixForComposed: "cp"}}},
+				cp: &fake.Composite{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{
+					LabelKeyNamePrefixForComposed: "ola",
+					LabelKeyRequirementName:       "rola",
+					LabelKeyRequirementNamespace:  "rolans",
+				}}},
 				cd: &fake.Composed{ObjectMeta: metav1.ObjectMeta{Name: "cd"}},
 				t:  v1alpha1.ComposedTemplate{Base: runtime.RawExtension{Raw: tmpl}},
 			},
 			want: want{
-				cd: &fake.Composed{ObjectMeta: metav1.ObjectMeta{Name: "cd", GenerateName: "cp-", Labels: map[string]string{LabelKeyNamePrefixForComposed: "cp"}}},
+				cd: &fake.Composed{ObjectMeta: metav1.ObjectMeta{Name: "cd", GenerateName: "ola-", Labels: map[string]string{
+					LabelKeyNamePrefixForComposed: "ola",
+					LabelKeyRequirementName:       "rola",
+					LabelKeyRequirementNamespace:  "rolans",
+				}}},
 			},
 		},
 	}

--- a/pkg/controller/apiextensions/composite/composed/api_test.go
+++ b/pkg/controller/apiextensions/composite/composed/api_test.go
@@ -71,15 +71,27 @@ func TestConfigure(t *testing.T) {
 				err: errors.Wrap(errors.New("invalid character 'o' looking for beginning of value"), errUnmarshal),
 			},
 		},
-		"Success": {
-			reason: "Configuration should result in the right object with correct generateName",
+		"NoLabel": {
+			reason: "The name prefix label has to be set",
 			args: args{
-				cp: &fake.Composite{ObjectMeta: metav1.ObjectMeta{Name: "cp"}},
+				cp: &fake.Composite{},
 				cd: &fake.Composed{ObjectMeta: metav1.ObjectMeta{Name: "cd"}},
 				t:  v1alpha1.ComposedTemplate{Base: runtime.RawExtension{Raw: tmpl}},
 			},
 			want: want{
-				cd: &fake.Composed{ObjectMeta: metav1.ObjectMeta{Name: "cd", GenerateName: "cp-"}},
+				cd:  &fake.Composed{ObjectMeta: metav1.ObjectMeta{Name: "cd"}},
+				err: errors.New(errNamePrefix),
+			},
+		},
+		"Success": {
+			reason: "Configuration should result in the right object with correct generateName",
+			args: args{
+				cp: &fake.Composite{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{LabelKeyNamePrefixForComposed: "cp"}}},
+				cd: &fake.Composed{ObjectMeta: metav1.ObjectMeta{Name: "cd"}},
+				t:  v1alpha1.ComposedTemplate{Base: runtime.RawExtension{Raw: tmpl}},
+			},
+			want: want{
+				cd: &fake.Composed{ObjectMeta: metav1.ObjectMeta{Name: "cd", GenerateName: "cp-", Labels: map[string]string{LabelKeyNamePrefixForComposed: "cp"}}},
 			},
 		},
 	}

--- a/pkg/controller/apiextensions/composite/reconciler.go
+++ b/pkg/controller/apiextensions/composite/reconciler.go
@@ -177,7 +177,7 @@ func NewReconciler(mgr manager.Manager, of resource.CompositeKind, opts ...Recon
 
 		composite: compositeResource{
 			CompositionSelector: NewAPILabelSelectorResolver(kube),
-			Configurator:        NewAPIConfigurator(kube),
+			Configurator:        NewConfiguratorChain(NewAPINamingConfigurator(kube), NewAPIConfigurator(kube)),
 			ConnectionPublisher: NewAPIFilteredSecretPublisher(kube, []string{}),
 		},
 

--- a/pkg/controller/apiextensions/requirement/configurator.go
+++ b/pkg/controller/apiextensions/requirement/configurator.go
@@ -33,7 +33,7 @@ import (
 // The requirement's external name annotation, if any, is propagated to the
 // composite resource.
 func Configure(_ context.Context, rq resource.Requirement, cp resource.Composite) error {
-	cp.SetGenerateName(fmt.Sprintf("%s-%s-", rq.GetNamespace(), rq.GetName()))
+	cp.SetGenerateName(fmt.Sprintf("%s-", rq.GetName()))
 	if meta.GetExternalName(rq) != "" {
 		meta.SetExternalName(cp, meta.GetExternalName(rq))
 	}

--- a/pkg/controller/apiextensions/requirement/configurator.go
+++ b/pkg/controller/apiextensions/requirement/configurator.go
@@ -29,7 +29,7 @@ import (
 )
 
 // Configure the supplied composite resource. The composite resource name is
-// derived from the supplied requirement, as {namespace}-{name}-{random-string}.
+// derived from the supplied requirement, as {name}-{random-string}.
 // The requirement's external name annotation, if any, is propagated to the
 // composite resource.
 func Configure(_ context.Context, rq resource.Requirement, cp resource.Composite) error {

--- a/pkg/controller/apiextensions/requirement/configurator.go
+++ b/pkg/controller/apiextensions/requirement/configurator.go
@@ -26,6 +26,8 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
 	"github.com/crossplane/crossplane-runtime/pkg/resource/unstructured/composite"
 	"github.com/crossplane/crossplane-runtime/pkg/resource/unstructured/requirement"
+
+	"github.com/crossplane/crossplane/pkg/controller/apiextensions/composite/composed"
 )
 
 // Configure the supplied composite resource. The composite resource name is
@@ -37,6 +39,10 @@ func Configure(_ context.Context, rq resource.Requirement, cp resource.Composite
 	if meta.GetExternalName(rq) != "" {
 		meta.SetExternalName(cp, meta.GetExternalName(rq))
 	}
+	meta.AddLabels(cp, map[string]string{
+		composed.LabelKeyRequirementName:      rq.GetName(),
+		composed.LabelKeyRequirementNamespace: rq.GetNamespace(),
+	})
 
 	urq, ok := rq.(*requirement.Unstructured)
 	if !ok {


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

We strongly recommend you look through our contributor guide at https://git.io/fj2m9
if this is your first time opening a Crossplane pull request. You can find us in
https://slack.crossplane.io/messages/dev if you need any help contributing.
-->

### Description of your changes

Currently, the name of the composed resources get to be way too long for some provider validations, like `crossplane-system-myrequirement-sdas2-dsdh4` while it's not necessary to include the namespace as prefix and also yet another random string as postfix. With this change:
* Requirement name: `myrequirement`
* Composite name: `myrequirement-dshn3`
* A composed resource name: `myrequirement-hdsn2`

However, in Kubernetes, children resources have the name of their parents as prefix like:
* Deployment: `deploymentname`
* ReplicaSet: `deploymentname-dsjn3ndshh`
* Pod: `deploymentname-dsjn3ndshh-idsjn`

So, I think we should keep following the convention for composed resource name and make it `myrequirement-dshn3-hdsn2`, however, this increases the likeliness of failure in name validation of managed resources since it's longer; see https://github.com/crossplane/provider-gcp/issues/222 and https://github.com/crossplane/stack-azure-sample/issues/26 . In practice, it's fine if we have only one rand string set but it's against the convention.

I think we should do the truncation for `external-name` annotation generation as proposed in https://github.com/crossplane/provider-gcp/issues/222#issuecomment-617680890 . So, I'll keep this in draft until we resolve that discussion. If we do the truncation, then it should be fine to keep the convention.

Fixes https://github.com/crossplane/crossplane/issues/1598

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

Fixes #
-->

### How has this code been tested?
<!--
Before reviewers can be confident in the correctness of a pull request,
it needs to tested and shown to be correct. In this section, briefly
describe the testing that has already been done or which is planned.
-->

### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every Crossplane pull request.
-->
I have:
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Ensured this PR contains a neat, self documenting set of commits.
- [x] Updated any relevant [documentation] and [examples].
- [x] Reported all new error conditions into the log or as an event, as
  appropriate.

For more about what we believe makes a pull request complete, see our
[definition of done].

[documentation]: https://github.com/crossplane/crossplane/tree/master/docs
[examples]: https://github.com/crossplane/crossplane/tree/master/cluster/examples
[definition of done]: https://github.com/crossplane/crossplane/tree/master/design/one-pager-definition-of-done.md
