### PR TITLE
Add kind as one of the local Kubernetes development environment tool

### DIFF
--- a/cluster/local/README.md
+++ b/cluster/local/README.md
@@ -1,29 +1,51 @@
 # Crossplane Local Deployment and Test
 
-The Local Framework is used to run end to end and integration tests on Crossplane. The framework depends on a running instance of Kubernetes.
-The framework also provides scripts for starting Kubernetes using `minikube` so users can
-quickly spin up a Kubernetes cluster.The Local framework is designed to install Crossplane, run tests, and uninstall Crossplane.
-
-## Requirements
-1. Docker version => 1.2 && < 17.0
-2. Ubuntu 16, Fedora 29 (the framework has only been tested on these versions of linux distributions)
-3. Kubernetes with kubectl configured
-4. Crossplane
+The Local Framework is used to run end to end and integration tests on Crossplane.
+The framework depends on a running instance of Kubernetes. The framework also
+provides scripts for starting a local Kubernetes using `kind`, `minikube` and `microk8s`
+so users can quickly spin up a Kubernetes cluster.The Local framework is designed
+to install Crossplane, run tests, and uninstall Crossplane.
 
 ## Instructions
 
 ## Setup
 
 ### Install Kubernetes
-You can choose any Kubernetes flavor of your choice.  The test framework only depends on kubectl being configured.
-The framework also provides scripts to install Kubernetes.
+You can choose any Kubernetes flavor of your choice.  The test framework only
+depends on kubectl being configured. The framework also provides scripts to install Kubernetes.
 
-- **Minikube** (recommended for MacOS): Run [minikube.sh](./minikube.sh) to setup a single-node Minikube Kubernetes.
+- **kind**: Run [kind.sh](./kind.sh) to setup a single-node Minikube Kubernetes.
+  - kind v0.8.0 and higher is supported
+- **Minikube**: Run [minikube.sh](./minikube.sh) to setup a single-node Minikube Kubernetes.
   - Minikube v0.28.2 and higher is supported
-- **MicroK8s** (recommended for Linux): Run [microk8s.sh](./microk8s.sh) to setup a single-node Microk8s Kubernetes.
+- **MicroK8s**: Run [microk8s.sh](./microk8s.sh) to setup a single-node Microk8s Kubernetes.
   - MicroK8s v1.14 (move from dockerd to containerd) and higher is supported
 
-#### Minikube (recommended for MacOS)
+#### Kind
+Starting the cluster on kind is as simple as running:
+```console
+cluster/local/kind.sh up
+```
+You can check the default Kubernetes version in the script and override it.
+
+To copy Crossplane image generated from your local build into the local registry in
+the kind cluster and install it via Helm, run the following commands after
+`kind.sh up` succeeded:
+```console
+cluster/local/kind.sh helm-install
+```
+
+Stopping the cluster and destroying the kind cluster can be done with:
+```console
+cluster/local/kind.sh clean
+```
+
+For complete list of subcommands supported by `kind.sh`, run:
+```console
+cluster/local/kind.sh
+```
+
+#### Minikube
 Starting the cluster on Minikube is as simple as running:
 ```console
 cluster/local/minikube.sh up
@@ -44,7 +66,7 @@ For complete list of subcommands supported by `minikube.sh`, run:
 cluster/local/minikube.sh
 ```
 
-#### MicroK8s (recommended for Linux)
+#### MicroK8s
 Starting the cluster on MicroK8s is as simple as running:
 ```console
 cluster/local/microk8s.sh up
@@ -93,7 +115,11 @@ deleting or scaling down the `crossplane` deployment in the namespace
 `crossplane-system`.
 
 ## Run Tests
-The following sections provide commands helpful for development environments. `minikube.sh` may be replaced with [`local.sh`](./local.sh) or [`microk8s.sh`](./microk8s.sh) in those environments. These commands expect to be run from the project root.
+The following sections provide commands helpful for development environments.
+`kind.sh` may be replaced with [`local.sh`](./local.sh), [`microk8s.sh`](./microk8s.sh),
+or [`minikube.sh`](./minikube.sh) in those environments. These commands expect to be
+run from the project root.
+
 #### 1. Build crossplane
 ```
 make build
@@ -101,12 +127,12 @@ make build
 
 #### 2. Start Kubernetes
 ```
-cluster/local/minikube.sh up
+cluster/local/kind.sh up
 ```
 
 #### 3. Install Crossplane
 ```
-cluster/local/minikube.sh helm-install
+cluster/local/kind.sh helm-install
 ```
 
 #### 4. Interact with Crossplane
@@ -119,17 +145,20 @@ make test
 
 #### 6. Uninstall Crossplane
 ```
-cluster/local/minikube.sh helm-delete
+cluster/local/kind.sh helm-delete
 ```  
 
 #### 7. Stop Kubernetes
 ```
-cluster/local/minikube.sh down
+cluster/local/kind.sh down
 ```
 
 ## Run Integration Tests
-In addition to the `minikube.sh` tests described above which gives some flexibility on interacting with the cluster, one could also test the integration of the built artifacts with the cluster in a single command.
-This will create a new Kubernetes cluster using `kind` tool, and then installs Crossplane and checks a few assertions, and finally destructs the cluster.
+In addition to the manual testing procedure described above which gives some
+flexibility on interacting with the cluster, one could also test the integration
+of the built artifacts with the cluster in a single command. This will create a
+new Kubernetes cluster using `kind` tool, and then installs Crossplane and checks
+a few assertions, and finally destructs the cluster.
 
 #### 1. Build crossplane
 ```

--- a/cluster/local/kind.sh
+++ b/cluster/local/kind.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+
+set -e
+
+scriptdir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+# shellcheck disable=SC1090
+projectdir="${scriptdir}/../.."
+
+# get the build environment variables from the special build.vars target in the main makefile
+eval $(make --no-print-directory -C ${scriptdir}/../.. build.vars)
+
+BUILD_IMAGE="${BUILD_REGISTRY}/${PROJECT_NAME}-amd64"
+DEPLOYMENT_IMAGE="${DOCKER_REGISTRY}/${PROJECT_NAME}:master"
+DEFAULT_NAMESPACE="crossplane-system"
+
+function copy_image_to_cluster() {
+    local build_image=$1
+    local final_image=$2
+    docker tag "${build_image}" "${final_image}"
+    kind load docker-image "${final_image}"
+    echo "Tagged image: ${final_image}"
+}
+
+# Deletes pods with application prefix. Namespace is expected as the first argument
+function delete_pods() {
+    for pod in $(kubectl get pods -n "$2" -l "app=$1" --no-headers -o custom-columns=NAME:.metadata.name); do
+        kubectl delete pod "$pod" -n "$2"
+    done
+}
+
+# current kubectl context == kind-kind, returns boolean
+function check_context() {
+    if [ "$(kubectl config view 2>/dev/null | awk '/current-context/ {print $NF}')" = "kind-kind" ]; then
+        return 0
+    fi
+
+    return 1
+}
+
+# configure kind
+KUBE_IMAGE=${KUBE_IMAGE:-"kindest/node:v1.15.11@sha256:6cc31f3533deb138792db2c7d1ffc36f7456a06f1db5556ad3b6927641016f50"}
+
+case "${1:-}" in
+  up)
+    kind create cluster --image "${KUBE_IMAGE}" --wait 5m
+
+    kubectl apply -f ${scriptdir}/helm-rbac.yaml
+    ${HELM} init --service-account tiller
+    kubectl -n kube-system rollout status deploy/tiller-deploy
+
+    copy_image_to_cluster ${BUILD_IMAGE} ${DEPLOYMENT_IMAGE}
+    ;;
+  update)
+    helm_tag="$(cat _output/version)"
+    copy_image_to_cluster ${BUILD_IMAGE} ${DEPLOYMENT_IMAGE}
+    copy_image_to_cluster ${BUILD_IMAGE} "${DOCKER_REGISTRY}/${PROJECT_NAME}:${helm_tag}"
+    ;;
+  restart)
+    if check_context; then
+        [ "$2" ] && ns=$2 || ns="${DEFAULT_NAMESPACE}"
+        echo "Restarting \"${PROJECT_NAME}\" deployment pods in \"$ns\" namespace."
+        delete_pods ${PROJECT_NAME} ${ns}
+    else
+      echo "To prevent accidental data loss acting only on 'kind-kind' context. No action is taken."
+    fi
+    ;;
+  helm-install)
+    echo "copying image for helm"
+    helm_tag="$(cat _output/version)"
+    copy_image_to_cluster ${BUILD_IMAGE} "${DOCKER_REGISTRY}/${PROJECT_NAME}:${helm_tag}"
+
+    [ "$2" ] && ns=$2 || ns="${DEFAULT_NAMESPACE}"
+    echo "installing helm package(s) into \"$ns\" namespace"
+    ${HELM} install --name ${PROJECT_NAME} --namespace ${ns} ${projectdir}/cluster/charts/${PROJECT_NAME} --set image.pullPolicy=Never,imagePullSecrets=''
+    ;;
+  helm-upgrade)
+    echo "copying image for helm"
+    helm_tag="$(cat _output/version)"
+    copy_image_to_cluster ${BUILD_IMAGE} "${DOCKER_REGISTRY}/${PROJECT_NAME}:${helm_tag}"
+    ${HELM} upgrade ${PROJECT_NAME} ${projectdir}/cluster/charts/${PROJECT_NAME}
+    ;;
+  helm-delete)
+    echo "removing helm package"
+    ${HELM} del --purge ${PROJECT_NAME}
+    ;;
+  helm-list)
+    ${HELM} list ${PROJECT_NAME} --all
+    ;;
+  clean)
+    kind delete cluster
+    ;;
+  *)
+    echo "usage:" >&2
+    echo "  $0 up - create a new kind cluster" >&2
+    echo "  $0 clean - delete the kind cluster" >&2
+    echo "  $0 update - push project docker images to kind cluster registry" >&2
+    echo "  $0 restart project deployment pod(s) in specified namespace [default: \"${DEFAULT_NAMESPACE}\"]" >&2
+    echo "  $0 helm-install package(s) into provided namespace [default: \"${DEFAULT_NAMESPACE}\"]" >&2
+    echo "  $0 helm-upgrade - deploy the latest docker images and helm charts to kind cluster" >&2
+    echo "  $0 helm-delete package(s)" >&2
+    echo "  $0 helm-list all package(s)" >&2
+esac


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

We strongly recommend you look through our contributor guide at https://git.io/fj2m9
if this is your first time opening a Crossplane pull request. You can find us in
https://slack.crossplane.io/messages/dev if you need any help contributing.
-->

### Description of your changes

It adds a script that has the same interface with `minikube.sh` to make `kind` easier to use for testing Crossplane.

I wanted to use kind for a long time because it's faster than Minikube and doesn't require a VM. However, it wasn't suitable for local manual Crosssplane tests since the restart/sleep of the computer would kill the cluster(see https://github.com/kubernetes-sigs/kind/issues/148), hence loose CRs which results in leaked cloud resources. In [v0.8.0](https://github.com/kubernetes-sigs/kind/releases/tag/v0.8.0), this has been fixed. @BenTheElder thank you so much for the fix!

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

Fixes #
-->

### How has this code been tested?

`make`
`cluster/local/kind.sh up`
`cluster/local/kind.sh helm-install`

Crossplane came up. Created a few CRs.

*restarted the computer*

Crossplane and CRs are still there!

<!--
Before reviewers can be confident in the correctness of a pull request,
it needs to tested and shown to be correct. In this section, briefly
describe the testing that has already been done or which is planned.
-->

### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every Crossplane pull request.
-->
I have:
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Ensured this PR contains a neat, self documenting set of commits.
- [x] Updated any relevant [documentation] and [examples].
- [x] Reported all new error conditions into the log or as an event, as
  appropriate.

For more about what we believe makes a pull request complete, see our
[definition of done].

[documentation]: https://github.com/crossplane/crossplane/tree/master/docs
[examples]: https://github.com/crossplane/crossplane/tree/master/cluster/examples
[definition of done]: https://github.com/crossplane/crossplane/tree/master/design/one-pager-definition-of-done.md
