### PR TITLE
Add master CIDR block field to GKE composition example 

### DIFF
--- a/cluster/examples/composition/gcp-gkecluster/cluster.yaml
+++ b/cluster/examples/composition/gcp-gkecluster/cluster.yaml
@@ -11,9 +11,10 @@ spec:
   - us-central1-a
   - us-central1-b
   cidrs:
-    nodes: 192.168.0.0/24
-    pods: 10.128.0.0/20
-    services: 172.16.0.0/16
+    master: 192.168.20.32/28
+    nodes: 192.168.1.0/24
+    pods: 10.129.0.0/20
+    services: 172.17.0.0/16
   servicedNetworkSelector:
     matchLabels:
       region: us-central1

--- a/cluster/examples/composition/gcp-gkecluster/cluster.yaml
+++ b/cluster/examples/composition/gcp-gkecluster/cluster.yaml
@@ -12,9 +12,9 @@ spec:
   - us-central1-b
   cidrs:
     master: 192.168.20.32/28
-    nodes: 192.168.1.0/24
-    pods: 10.129.0.0/20
-    services: 172.17.0.0/16
+    nodes: 192.168.0.0/24
+    pods: 10.128.0.0/20
+    services: 172.16.0.0/16
   servicedNetworkSelector:
     matchLabels:
       region: us-central1

--- a/cluster/examples/composition/gcp-gkecluster/definitions/cluster.yaml
+++ b/cluster/examples/composition/gcp-gkecluster/definitions/cluster.yaml
@@ -54,6 +54,9 @@ spec:
                 type: object
                 description: CIDRs for nodes, pods, and services.
                 properties:
+                  master:
+                    type: string
+                    description: CIDR for master node(s).
                   nodes:
                     type: string
                     description: CIDR for nodes.
@@ -141,6 +144,9 @@ spec:
       kind: GKECluster
       spec:
         forProvider:
+          privateClusterConfig:
+            enablePrivateEndpoint: false
+            enablePrivateNodes: true
           ipAllocationPolicy:
             useIpAliases: true
             clusterSecondaryRangeName: pods
@@ -161,6 +167,8 @@ spec:
       toFieldPath: "spec.forProvider.location"
     - fromFieldPath: "spec.servicedNetworkSelector"
       toFieldPath: "spec.forProvider.networkSelector"
+    - fromFieldPath: "spec.cidrs.master"
+      toFieldPath: "spec.forProvider.privateClusterConfig.masterIpv4CidrBlock"
       # Store the connection secret for this GKECluster in a secret name derived
       # from the Cluster's UID. Use the string format transform function to
       # append -controlplane to the UID.

--- a/cluster/examples/composition/gcp-gkecluster/definitions/cluster.yaml
+++ b/cluster/examples/composition/gcp-gkecluster/definitions/cluster.yaml
@@ -144,6 +144,8 @@ spec:
       kind: GKECluster
       spec:
         forProvider:
+          masterAuth:
+            username: admin
           privateClusterConfig:
             enablePrivateEndpoint: false
             enablePrivateNodes: true

--- a/cluster/examples/composition/gcp-gkecluster/definitions/cluster.yaml
+++ b/cluster/examples/composition/gcp-gkecluster/definitions/cluster.yaml
@@ -146,9 +146,6 @@ spec:
         forProvider:
           masterAuth:
             username: admin
-          privateClusterConfig:
-            enablePrivateEndpoint: false
-            enablePrivateNodes: true
           ipAllocationPolicy:
             useIpAliases: true
             clusterSecondaryRangeName: pods

--- a/cluster/examples/composition/gcp-gkecluster/servicednetwork.yaml
+++ b/cluster/examples/composition/gcp-gkecluster/servicednetwork.yaml
@@ -2,7 +2,7 @@
 apiVersion: gke.example.org/v1alpha1
 kind: ServicedNetwork
 metadata:
-  name: example-gke
+  name: example-vpc
   labels:
     region: us-central1
 spec:


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

We strongly recommend you look through our contributor guide at https://git.io/fj2m9
if this is your first time opening a Crossplane pull request. You can find us in
https://slack.crossplane.io/messages/dev if you need any help contributing.
-->

### Description of your changes

Add master CIDR block field to GKE composition example to enable multiple clusters to be created. We can't embed into the composition because it shouldn't overlap with other master CIDR blocks.

@negz FWIW, I think we've been taking the approach of specifying the provider on class, i.e. composition, but in this example we take it from the namespaced user. Given infra-ops are the ones who make decisions about which account to use, I'd say it's better in `Composition` but I didn't want to block this PR, so it's not included.

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

Fixes #
-->

### How has this code been tested?

Manually by created 2 instances.

<!--
Before reviewers can be confident in the correctness of a pull request,
it needs to tested and shown to be correct. In this section, briefly
describe the testing that has already been done or which is planned.
-->

### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every Crossplane pull request.
-->
I have:
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Ensured this PR contains a neat, self documenting set of commits.
- [x] Updated any relevant [documentation] and [examples].
- [x] Reported all new error conditions into the log or as an event, as
  appropriate.

For more about what we believe makes a pull request complete, see our
[definition of done].

[documentation]: https://github.com/crossplane/crossplane/tree/master/docs
[examples]: https://github.com/crossplane/crossplane/tree/master/cluster/examples
[definition of done]: https://github.com/crossplane/crossplane/tree/master/design/one-pager-definition-of-done.md
