### PR TITLE
Doc fix : KubernetesCluster classSelector must match GKEClusterClass …

### DIFF
--- a/docs/getting-started/workload.md
+++ b/docs/getting-started/workload.md
@@ -74,7 +74,7 @@ metadata:
 spec:
   classSelector:
     matchLabels:
-      example: "true"
+      guide: quickstart
   writeConnectionSecretToRef:
     name: k8scluster
 ```


### PR DESCRIPTION
If I understood the doc correctly, the KubernetesCluster classSelector `matchLabels` must match the class label defined in GKEClusterClass.