### PR TITLE
fix install link to use latest official docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ API.
 With Crossplane you can:
 
 * **Provision & manage cloud infrastructure with kubectl**
-  * [Install Crossplane] to provision and manage cloud infrastructure and
+  * [Install Crossplane][documentation] to provision and manage cloud infrastructure and
     services from any Kubernetes cluster.
   * Provision infrastructure primitives from any provider ([GCP], [AWS],
     [Azure], [Alibaba], on-prem) and use them alongside existing application
@@ -132,7 +132,6 @@ Crossplane is under the Apache 2.0 license.
 <!-- Named links -->
 
 [Crossplane]: https://crossplane.io
-[Install Crossplane]: docs/getting-started/install-configure.md
 [documentation]: https://crossplane.io/docs/latest
 [GCP]: https://github.com/crossplane/provider-gcp
 [AWS]: https://github.com/crossplane/provider-aws


### PR DESCRIPTION
The Install Crossplane link in the main readme should point to the main docs, since the markdown rendering isn't great in the browser and the GitHub mobile app shows all the the `<div>` tags, so sending them to the https://crossplane.io install docs is a much better experience.

Today it shows this:
![image](https://user-images.githubusercontent.com/284840/82377034-e196db80-99d7-11ea-9976-d0915703a492.png)

crossplane.io/docs is much better for a mobile browsing experience:

![image](https://user-images.githubusercontent.com/284840/82377323-5a963300-99d8-11ea-9845-fb0f6763c1e8.png)


### Checklist
I have:
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [x] Ensured this PR contains a neat, self documenting set of commits.
- [x] Updated any relevant [documentation] and [examples].
- [ ] Reported all new error conditions into the log or as an event, as
  appropriate.

[skip ci]