### PR TITLE
Fix two issues of doc `install-configure` and `provision infrastructure`

### DIFF
--- a/docs/getting-started/install-configure.md
+++ b/docs/getting-started/install-configure.md
@@ -338,7 +338,7 @@ kubectl crossplane package install --cluster --namespace crossplane-system ${PAC
 ### Create a Provider Secret
 
 ```
-kubectl create secret generic alibaba-creds --from-literal=accessKeyId=<your-key> --from-literal=accessKeySecret=<your-secret>
+kubectl create secret generic alibaba-creds --from-literal=accessKeyId=<your-key> --from-literal=accessKeySecret=<your-secret> -n crossplane-system
 ```
 
 ### Configure the Provider

--- a/docs/getting-started/install-configure.md
+++ b/docs/getting-started/install-configure.md
@@ -354,6 +354,7 @@ spec:
     namespace: crossplane-system
     name: alibaba-creds
     key: credentials
+  region: cn-beijing
 ```
 
 Then apply it:


### PR DESCRIPTION
region is required resource type for kind Provider
of Alibaba Cloud or it will raise error message:
error: the server doesn't have a resource type "region"

Signed-off-by: zzxwill <zzxwill@gmail.com>
(cherry picked from commit e11286b7b1762ab2c1908556415cfc7bce8adc9f)

<!--
Thank you for helping to improve Crossplane!

We strongly recommend you look through our contributor guide at https://git.io/fj2m9
if this is your first time opening a Crossplane pull request. You can find us in
https://slack.crossplane.io/messages/dev if you need any help contributing.
-->

### Description of your changes
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

Fixes #1558
-->

### How has this code been tested?
<!--
Before reviewers can be confident in the correctness of a pull request,
it needs to tested and shown to be correct. In this section, briefly
describe the testing that has already been done or which is planned.
-->

### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every Crossplane pull request.
-->
I have:
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [x] Ensured this PR contains a neat, self documenting set of commits.
- [x] Updated any relevant [documentation] and [examples].
- [x] Reported all new error conditions into the log or as an event, as
  appropriate.

For more about what we believe makes a pull request complete, see our
[definition of done].

[documentation]: https://github.com/crossplane/crossplane/tree/master/docs
[examples]: https://github.com/crossplane/crossplane/tree/master/cluster/examples
[definition of done]: https://github.com/crossplane/crossplane/tree/master/design/one-pager-definition-of-done.md
