### PR TITLE
KubernetesApplication manages the deletion of KARs

### DIFF
--- a/apis/workload/v1alpha1/types.go
+++ b/apis/workload/v1alpha1/types.go
@@ -37,7 +37,7 @@ const (
 	KubernetesApplicationStatePartial   KubernetesApplicationState = "PartiallySubmitted"
 	KubernetesApplicationStateSubmitted KubernetesApplicationState = "Submitted"
 	KubernetesApplicationStateFailed    KubernetesApplicationState = "Failed"
-	KubernetesApplicationStateDeleted   KubernetesApplicationState = "Deleted"
+	KubernetesApplicationStateDeleting  KubernetesApplicationState = "Deleting"
 )
 
 // A KubernetesApplicationSpec specifies the resources of a Kubernetes


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

We strongly recommend you look through our contributor guide at https://git.io/fj2m9
if this is your first time opening a Crossplane pull request. You can find us in
https://slack.crossplane.io/messages/dev if you need any help contributing.
-->

### Description of your changes

KA needs to delete KARs before it's removed from the cluster so that it guarantees the remote resources are removed.

The original approach of this controller was letting Kubernetes GC to handle that, however, that only works if the deletion policy is `Foreground`, which is not default in kubectl or controller-runtime clients. This PR allows the deletion to work as expected in the default `Background` mode.

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

Fixes #
-->

### How has this code been tested?

Manually tested.

<!--
Before reviewers can be confident in the correctness of a pull request,
it needs to tested and shown to be correct. In this section, briefly
describe the testing that has already been done or which is planned.
-->

### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every Crossplane pull request.
-->
I have:
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Ensured this PR contains a neat, self documenting set of commits.
- [x] Updated any relevant [documentation] and [examples].
- [x] Reported all new error conditions into the log or as an event, as
  appropriate.

For more about what we believe makes a pull request complete, see our
[definition of done].

[documentation]: https://github.com/crossplane/crossplane/tree/master/docs
[examples]: https://github.com/crossplane/crossplane/tree/master/cluster/examples
[definition of done]: https://github.com/crossplane/crossplane/tree/master/design/one-pager-definition-of-done.md
