### PR TITLE
docs: clarify RBAC note for publish infrastructure quick start to improve visibility

### DIFF
--- a/docs/getting-started/publish-infrastructure.md
+++ b/docs/getting-started/publish-infrastructure.md
@@ -33,11 +33,16 @@ parameter, and specifies that it will create a connection `Secret` with keys for
 each provider that can satisfy and be parameterized by a `PostgreSQLInstance`.
 Let's get started!
 
-> Note: Crossplane must be granted RBAC permissions to managed new
-> infrastructure types that we define. This is covered in greater detail in the
-> [composition] section, but you can run the following command to grant all
-> necessary RBAC permissions for this quick start guide: `kubectl apply -f
-> https://raw.githubusercontent.com/crossplane/crossplane/master/docs/snippets/publish/clusterrole.yaml`
+## Grant RBAC Permissions
+
+Crossplane must be granted RBAC permissions to manage new infrastructure types
+that we define. This is covered in greater detail in the [composition] section,
+but you can easily run the following command now to grant all necessary RBAC
+permissions for the remainder of this quick start guide:
+
+```console
+kubectl apply -f https://raw.githubusercontent.com/crossplane/crossplane/master/docs/snippets/publish/clusterrole.yaml
+```
 
 ## Create InfrastructureDefinition
 


### PR DESCRIPTION
### Description of your changes

This PR makes the note about granting RBAC permissions in the publishing infrastructure quick start much more visible.  I missed this note completely when following the docs and others mentioned that missed it too.

I have moved it to a section with a code block so that folks scanning the document should no longer miss it and run into errors.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

N/A, docs only change

[contribution process]: https://git.io/fj2m9

[skip ci]