### PR TITLE
Select a random Composition when several match

### DIFF
--- a/pkg/controller/apiextensions/composite/api.go
+++ b/pkg/controller/apiextensions/composite/api.go
@@ -150,7 +150,7 @@ func (r *APILabelSelectorResolver) SelectComposition(ctx context.Context, cp res
 	v, k := cp.GetObjectKind().GroupVersionKind().ToAPIVersionAndKind()
 
 	for _, comp := range list.Items {
-		if comp.Spec.From.APIVersion == v || comp.Spec.From.Kind == k {
+		if comp.Spec.From.APIVersion == v && comp.Spec.From.Kind == k {
 			// This composition is compatible with our composite resource.
 			candidates = append(candidates, comp.Name)
 		}

--- a/pkg/controller/apiextensions/composite/api.go
+++ b/pkg/controller/apiextensions/composite/api.go
@@ -18,6 +18,8 @@ package composite
 
 import (
 	"context"
+	"math/rand"
+	"time"
 
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
@@ -143,17 +145,25 @@ func (r *APILabelSelectorResolver) SelectComposition(ctx context.Context, cp res
 	if err := r.client.List(ctx, list, client.MatchingLabels(labels)); err != nil {
 		return errors.Wrap(err, errListCompositions)
 	}
-	apiVersion, kind := cp.GetObjectKind().GroupVersionKind().ToAPIVersionAndKind()
+
+	candidates := make([]string, 0, len(list.Items))
+	v, k := cp.GetObjectKind().GroupVersionKind().ToAPIVersionAndKind()
+
 	for _, comp := range list.Items {
-		if comp.Spec.From.APIVersion != apiVersion || comp.Spec.From.Kind != kind {
-			continue
+		if comp.Spec.From.APIVersion == v || comp.Spec.From.Kind == k {
+			// This composition is compatible with our composite resource.
+			candidates = append(candidates, comp.Name)
 		}
-
-		cp.SetCompositionReference(&corev1.ObjectReference{Name: comp.Name})
-
-		return errors.Wrap(r.client.Update(ctx, cp), errUpdateComposite)
 	}
-	return errors.New(errNoCompatibleComposition)
+
+	if len(candidates) == 0 {
+		return errors.New(errNoCompatibleComposition)
+	}
+
+	random := rand.New(rand.NewSource(time.Now().UnixNano()))
+	selected := candidates[random.Intn(len(candidates))]
+	cp.SetCompositionReference(&corev1.ObjectReference{Name: selected})
+	return errors.Wrap(r.client.Update(ctx, cp), errUpdateComposite)
 }
 
 // NewAPIDefaultCompositionSelector returns a APIDefaultCompositionSelector.


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
A composite resource may select a Composition using labels. This can be used to describe the desired Composition in general terms; i.e. 'a Composition of prod resources' or 'a Composition of east coast resources'. It's possible that many Compositions will match these labels. If this happens, we should select one of the matching Compositions at random. This allows infrastructure operators to ensure Composite resources will be spread evenly across multiple Compositions (which may mean multiple regions, or cloud providers, etc).

I'd like to make this weighted random selection at some point in the future, per https://github.com/crossplane/crossplane/issues/967#issuecomment-637835664

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested
I ran the existing unit tests and confirmed full code coverage. I don't think there's much value in testing or mocking out the randomness, and I think this change is tiny enough that I feel confident without manual testing.

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
