### PR TITLE
add make install command to install crds to cluster

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -190,6 +190,14 @@ submodules:
 	@git submodule sync
 	@git submodule update --init --recursive
 
+# Install CRDs into a cluster. This is for convenience.
+install: reviewable
+	kubectl apply -f cluster/charts/crossplane-types/crds/
+
+# Uninstall CRDs from a cluster. This is for convenience.
+uninstall:
+	kubectl delete -f cluster/charts/crossplane-types/crds/
+
 # This is for running out-of-cluster locally, and is for convenience. Running
 # this make target will print out the command which was used. For more control,
 # try running the binary directly with different arguments.
@@ -198,7 +206,7 @@ run: go.build
 	@# To see other arguments that can be provided, run the command with --help instead
 	$(GO_OUT_DIR)/$(PROJECT_NAME) --debug
 
-.PHONY: manifests cobertura reviewable submodules fallthrough test-integration run gen-kustomize-crds
+.PHONY: manifests cobertura reviewable submodules fallthrough test-integration run install gen-kustomize-crds
 
 # ====================================================================================
 # Special Targets

--- a/Makefile
+++ b/Makefile
@@ -191,12 +191,12 @@ submodules:
 	@git submodule update --init --recursive
 
 # Install CRDs into a cluster. This is for convenience.
-install: reviewable
-	kubectl apply -f cluster/charts/crossplane-types/crds/
+install-crds: $(KUBECTL) reviewable
+	$(KUBECTL) apply -f cluster/charts/crossplane-types/crds/
 
 # Uninstall CRDs from a cluster. This is for convenience.
-uninstall:
-	kubectl delete -f cluster/charts/crossplane-types/crds/
+uninstall-crds:
+	$(KUBECTL) delete -f cluster/charts/crossplane-types/crds/
 
 # This is for running out-of-cluster locally, and is for convenience. Running
 # this make target will print out the command which was used. For more control,
@@ -206,7 +206,7 @@ run: go.build
 	@# To see other arguments that can be provided, run the command with --help instead
 	$(GO_OUT_DIR)/$(PROJECT_NAME) --debug
 
-.PHONY: manifests cobertura reviewable submodules fallthrough test-integration run install gen-kustomize-crds
+.PHONY: manifests cobertura reviewable submodules fallthrough test-integration run install-crds uninstall-crds gen-kustomize-crds
 
 # ====================================================================================
 # Special Targets


### PR DESCRIPTION
Signed-off-by: 天元 <jianbo.sjb@alibaba-inc.com>


### Description of your changes

Add a `make install` command to install install crds to cluster, this is for convenience like `make run`. Mainly for debug and develop.

Fixes #

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
