### PR TITLE
Use CONTAINER_NAME env var to get image if no name is set

### DIFF
--- a/cluster/charts/crossplane-controllers/templates/package-manager-deployment.yaml
+++ b/cluster/charts/crossplane-controllers/templates/package-manager-deployment.yaml
@@ -72,6 +72,9 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        # The container name
+        - name: CONTAINER_NAME
+          value: {{ .Chart.Name }}
         resources:
           {{- toYaml .Values.resourcesPackageManager | nindent 12 }}
       {{- if .Values.hostedConfig.enabled }}

--- a/cluster/charts/crossplane/templates/package-manager-deployment.yaml
+++ b/cluster/charts/crossplane/templates/package-manager-deployment.yaml
@@ -72,6 +72,9 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        # The container name
+        - name: CONTAINER_NAME
+          value: {{ .Chart.Name }}
         resources:
           {{- toYaml .Values.resourcesPackageManager | nindent 12 }}
       {{- if .Values.hostedConfig.enabled }}


### PR DESCRIPTION


<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

This updates the logic when finding a container in a pod spec to check
the CONTAINER_NAME env var when no name is supplied and there is more
than one container in the Pod.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

Fixes #1659 

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

Manual testing will be done with updated helm chart before this is moved out of draft.

[contribution process]: https://git.io/fj2m9
