### PR TITLE
local dev: preload locally cached Helm image to dev cluster

### DIFF
--- a/cluster/local/kind.sh
+++ b/cluster/local/kind.sh
@@ -45,6 +45,11 @@ case "${1:-}" in
   up)
     kind create cluster --image "${KUBE_IMAGE}" --wait 5m
 
+    # We'll use locally cached image instead of having it downloaded by kind
+    # cluster.
+    docker pull "gcr.io/kubernetes-helm/tiller:${HELM_VERSION}"
+    copy_image_to_cluster "gcr.io/kubernetes-helm/tiller:${HELM_VERSION}" "gcr.io/kubernetes-helm/tiller:${HELM_VERSION}"
+
     kubectl apply -f ${scriptdir}/helm-rbac.yaml
     ${HELM} init --service-account tiller
     kubectl -n kube-system rollout status deploy/tiller-deploy

--- a/cluster/local/microk8s.sh
+++ b/cluster/local/microk8s.sh
@@ -33,7 +33,7 @@ function wait_for_ready() {
 function copy_image_to_cluster() {
     local build_image=$1
     local final_image=$2
-    docker tag "${build_image}" "${final_image}" && docker push "${final_image}"
+    docker tag "${build_image}" "localhost:32000/${final_image}" && docker push "${final_image}"
     echo "Tagged image: ${final_image}"
 }
 
@@ -52,6 +52,10 @@ case "${1:-}" in
 
     microk8s.enable registry
 
+    # We'll use locally cached image instead of having it downloaded by the
+    # cluster.
+    docker pull "gcr.io/kubernetes-helm/tiller:${HELM_VERSION}"
+    copy_image_to_cluster "gcr.io/kubernetes-helm/tiller:${HELM_VERSION}" "gcr.io/kubernetes-helm/tiller:${HELM_VERSION}"
     kubectl apply -f ${scriptdir}/helm-rbac.yaml
     ${HELM} init --service-account tiller
 

--- a/cluster/local/minikube.sh
+++ b/cluster/local/minikube.sh
@@ -63,6 +63,10 @@ case "${1:-}" in
 
     minikube addons enable ingress
 
+    # We'll use locally cached image instead of having it downloaded by the
+    # cluster.
+    docker pull "gcr.io/kubernetes-helm/tiller:${HELM_VERSION}"
+    copy_image_to_cluster "gcr.io/kubernetes-helm/tiller:${HELM_VERSION}" "gcr.io/kubernetes-helm/tiller:${HELM_VERSION}"
     kubectl apply -f ${scriptdir}/helm-rbac.yaml
     ${HELM} init --service-account tiller
     kubectl -n kube-system rollout status deploy/tiller-deploy


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

It's unnecessary to download Tiller image each time so we load it before initialization of Helm.

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Manually.

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
