### PR TITLE
readme: Add CNCF sandbox project mention

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 ![Crossplane](docs/media/banner.png)
 
-Crossplane is an open source Kubernetes add-on that extends any cluster with
-the ability to provision and manage cloud infrastructure, services, and
-applications using kubectl, GitOps, or any tool that works with the Kubernetes
-API.
+Crossplane, a [Cloud Native Computing Foundation][CNCF] sandbox project, is an
+open source Kubernetes add-on that extends any cluster with the ability to
+provision and manage cloud infrastructure, services, and applications using
+kubectl, GitOps, or any tool that works with the Kubernetes API.
 
 With Crossplane you can:
 
@@ -132,6 +132,7 @@ Crossplane is under the Apache 2.0 license.
 <!-- Named links -->
 
 [Crossplane]: https://crossplane.io
+[CNCF]: https://cncf.io
 [documentation]: https://crossplane.io/docs/latest
 [GCP]: https://github.com/crossplane/provider-gcp
 [AWS]: https://github.com/crossplane/provider-aws


### PR DESCRIPTION
### Description of your changes

This PR adds a specific mention to the main README.md that Crossplane is a "Cloud Native Computing Foundation sandbox project", as suggested in the website guidelines: https://github.com/cncf/foundation/blob/master/website-guidelines.md

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

N/A 

[contribution process]: https://git.io/fj2m9

[skip ci]