### PR TITLE
Run Crossplane with log level info by default

### DIFF
--- a/cluster/charts/crossplane-controllers/templates/deployment.yaml
+++ b/cluster/charts/crossplane-controllers/templates/deployment.yaml
@@ -29,9 +29,11 @@ spec:
       {{- end }}
       containers:
       - image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+        {{- if .Values.args }}
         args:
         {{- range $arg := .Values.args }}
         - {{ $arg }}
+        {{- end }}
         {{- end }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         name: {{ .Chart.Name }}

--- a/cluster/charts/crossplane-controllers/values.yaml.tmpl
+++ b/cluster/charts/crossplane-controllers/values.yaml.tmpl
@@ -9,8 +9,7 @@ image:
   tag: %%VERSION%%
   pullPolicy: Always
 
-args:
-- '--debug'
+args: {}
 
 imagePullSecrets:
 - dockerhub

--- a/cluster/charts/crossplane/templates/deployment.yaml
+++ b/cluster/charts/crossplane/templates/deployment.yaml
@@ -29,9 +29,11 @@ spec:
       {{- end }}
       containers:
       - image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+        {{- if .Values.args }}
         args:
         {{- range $arg := .Values.args }}
         - {{ $arg }}
+        {{- end }}
         {{- end }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         name: {{ .Chart.Name }}

--- a/cluster/charts/crossplane/values.yaml.tmpl
+++ b/cluster/charts/crossplane/values.yaml.tmpl
@@ -7,8 +7,7 @@ image:
   tag: %%VERSION%%
   pullPolicy: Always
 
-args:
-- '--debug'
+args: {}
 
 imagePullSecrets:
 - dockerhub


### PR DESCRIPTION


<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Currently Crossplane runs with a log level of debug, resulting in
copious amounts of logging, particularly for controller-runtime, which
has its logger enabled when the --debug flag is passed to Crossplane.
This updates Crossplane to default to info level, but still allows users
to set to debug if desired.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

`make build` then `helm template`. Output shows debug flag no longer present:

<details>
  <summary>Click to expand</summary>

```yaml
# Source: crossplane/templates/deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: crossplane
  labels:
    app: crossplane
    chart: crossplane-0.13.0-rc.30.g01a480dd-dirty
    release: RELEASE-NAME
    heritage: Helm
spec:
  replicas: 1
  selector:
    matchLabels:
      app: crossplane
      release: RELEASE-NAME
  strategy:
    type: RollingUpdate
  template:
    metadata:
      labels:
        app: crossplane
        release: RELEASE-NAME
    spec:
      serviceAccountName: crossplane
      containers:
      - image: crossplane/crossplane:v0.13.0-rc.30.g01a480dd-dirty
        imagePullPolicy: Always
        name: crossplane
        resources:
            limits:
              cpu: 100m
              memory: 512Mi
            requests:
              cpu: 100m
              memory: 256Mi
---
# Source: crossplane/templates/package-manager-deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: crossplane-package-manager
  labels:
    app: crossplane-package-manager
    chart: crossplane-0.13.0-rc.30.g01a480dd-dirty
    release: RELEASE-NAME
    heritage: Helm
spec:
  replicas: 1
  selector:
    matchLabels:
      app: crossplane-package-manager
      release: RELEASE-NAME
  strategy:
    type: RollingUpdate
  template:
    metadata:
      labels:
        app: crossplane-package-manager
        release: RELEASE-NAME
    spec:
      serviceAccountName: package-manager
      containers:
      - image: crossplane/crossplane:v0.13.0-rc.30.g01a480dd-dirty
        args:
        - package
        - manage
        - --templates
        - --templating-controller-image
        - "crossplane/templating-controller:v0.2.1"
        imagePullPolicy: Always
        name: crossplane
        env:
        # The pod name to pass with the downward API
        - name: POD_NAME
          valueFrom:
            fieldRef:
              fieldPath: metadata.name
        # The pod namespace to pass with the downward API
        - name: POD_NAMESPACE
          valueFrom:
            fieldRef:
              fieldPath: metadata.namespace
        resources:
            limits:
              cpu: 100m
              memory: 512Mi
            requests:
              cpu: 100m
              memory: 256Mi
```

</details>


[contribution process]: https://git.io/fj2m9
