### PR TITLE
Add basic security context to crossplane and package manager deployments

### DIFF
--- a/cluster/charts/crossplane-controllers/templates/deployment.yaml
+++ b/cluster/charts/crossplane-controllers/templates/deployment.yaml
@@ -39,6 +39,9 @@ spec:
         name: {{ .Chart.Name }}
         resources:
           {{- toYaml .Values.resourcesCrossplane | nindent 12 }}
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
       {{- if .Values.hostedConfig.enabled }}
         env:
           - name: KUBERNETES_SERVICE_HOST

--- a/cluster/charts/crossplane-controllers/templates/package-manager-deployment.yaml
+++ b/cluster/charts/crossplane-controllers/templates/package-manager-deployment.yaml
@@ -74,6 +74,9 @@ spec:
               fieldPath: metadata.namespace
         resources:
           {{- toYaml .Values.resourcesPackageManager | nindent 12 }}
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
       {{- if .Values.hostedConfig.enabled }}
         volumeMounts:
           - mountPath: /var/run/secrets/tenant

--- a/cluster/charts/crossplane/templates/deployment.yaml
+++ b/cluster/charts/crossplane/templates/deployment.yaml
@@ -39,6 +39,9 @@ spec:
         name: {{ .Chart.Name }}
         resources:
           {{- toYaml .Values.resourcesCrossplane | nindent 12 }}
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
       {{- if .Values.hostedConfig.enabled }}
         env:
           - name: KUBERNETES_SERVICE_HOST

--- a/cluster/charts/crossplane/templates/package-manager-deployment.yaml
+++ b/cluster/charts/crossplane/templates/package-manager-deployment.yaml
@@ -74,6 +74,9 @@ spec:
               fieldPath: metadata.namespace
         resources:
           {{- toYaml .Values.resourcesPackageManager | nindent 12 }}
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
       {{- if .Values.hostedConfig.enabled }}
         volumeMounts:
           - mountPath: /var/run/secrets/tenant


### PR DESCRIPTION


<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Restricts privilege escalation and specifies a read only filesystem for
both the core crossplane and package manager deployments.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

Building and deploying new helm chart.

[contribution process]: https://git.io/fj2m9
