### PR TITLE
Refactor common InfraDefs to XRDs

### DIFF
--- a/cluster/composition/clusterroles/bucket.yaml
+++ b/cluster/composition/clusterroles/bucket.yaml
@@ -2,16 +2,16 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: buckets.common.crossplane.io
+  name: compositebuckets.common.crossplane.io
   labels:
     rbac.crossplane.io/aggregate-to-crossplane: "true"
 rules:
   - apiGroups:
       - common.crossplane.io
     resources:
+      - compositebuckets
+      - compositebuckets/status
       - buckets
       - buckets/status
-      - bucketrequirements
-      - bucketrequirements/status
     verbs:
       - "*"

--- a/cluster/composition/clusterroles/kubernetescluster.yaml
+++ b/cluster/composition/clusterroles/kubernetescluster.yaml
@@ -2,16 +2,16 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: kubernetesclusters.common.crossplane.io
+  name: compositekubernetesclusters.common.crossplane.io
   labels:
     rbac.crossplane.io/aggregate-to-crossplane: "true"
 rules:
   - apiGroups:
       - common.crossplane.io
     resources:
-      - kubernetesclusters
-      - kubernetesclusters/status
-      - kubernetesclusterrequirements
-      - kubernetesclusterrequirements/status
+      - compositekubernetesclusters
+      - compositekubernetesclusters/status
+      - kubernetescluster
+      - kubernetescluster/status
     verbs:
       - "*"

--- a/cluster/composition/clusterroles/machineinstance.yaml
+++ b/cluster/composition/clusterroles/machineinstance.yaml
@@ -2,16 +2,16 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: machineinstances.common.crossplane.io
+  name: compositemachineinstances.common.crossplane.io
   labels:
     rbac.crossplane.io/aggregate-to-crossplane: "true"
 rules:
   - apiGroups:
       - common.crossplane.io
     resources:
-      - machineinstances
-      - machineinstances/status
-      - machineinstancerequirements
-      - machineinstancerequirements/status
+      - compositemachineinstances
+      - compositemachineinstances/status
+      - machineinstance
+      - machineinstance/status
     verbs:
       - "*"

--- a/cluster/composition/clusterroles/mysqlinstance.yaml
+++ b/cluster/composition/clusterroles/mysqlinstance.yaml
@@ -2,16 +2,16 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: mysqlinstances.common.crossplane.io
+  name: compositemysqlinstances.common.crossplane.io
   labels:
     rbac.crossplane.io/aggregate-to-crossplane: "true"
 rules:
   - apiGroups:
       - common.crossplane.io
     resources:
-      - mysqlinstances
-      - mysqlinstances/status
-      - mysqlinstancerequirements
-      - mysqlinstancerequirements/status
+      - compositemysqlinstances
+      - compositemysqlinstances/status
+      - mysqlinstance
+      - mysqlinstance/status
     verbs:
       - "*"

--- a/cluster/composition/clusterroles/nosqlinstance.yaml
+++ b/cluster/composition/clusterroles/nosqlinstance.yaml
@@ -2,16 +2,16 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: nosqlinstances.common.crossplane.io
+  name: compositenosqlinstances.common.crossplane.io
   labels:
     rbac.crossplane.io/aggregate-to-crossplane: "true"
 rules:
   - apiGroups:
       - common.crossplane.io
     resources:
-      - nosqlinstances
-      - nosqlinstances/status
-      - nosqlinstancerequirements
-      - nosqlinstancerequirements/status
+      - compositenosqlinstances
+      - compositenosqlinstances/status
+      - nosqlinstance
+      - nosqlinstance/status
     verbs:
       - "*"

--- a/cluster/composition/clusterroles/postgresqlinstance.yaml
+++ b/cluster/composition/clusterroles/postgresqlinstance.yaml
@@ -2,16 +2,16 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: postgresqlinstances.common.crossplane.io
+  name: compositepostgresqlinstances.common.crossplane.io
   labels:
     rbac.crossplane.io/aggregate-to-crossplane: "true"
 rules:
   - apiGroups:
       - common.crossplane.io
     resources:
-      - postgresqlinstances
-      - postgresqlinstances/status
-      - postgresqlinstancerequirements
-      - postgresqlinstancerequirements/status
+      - compositepostgresqlinstances
+      - compositepostgresqlinstances/status
+      - postgresqlinstance
+      - postgresqlinstance/status
     verbs:
       - "*"

--- a/cluster/composition/clusterroles/rediscluster.yaml
+++ b/cluster/composition/clusterroles/rediscluster.yaml
@@ -2,16 +2,16 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: redisclusters.common.crossplane.io
+  name: compositeredisclusters.common.crossplane.io
   labels:
     rbac.crossplane.io/aggregate-to-crossplane: "true"
 rules:
   - apiGroups:
       - common.crossplane.io
     resources:
-      - redisclusters
-      - redisclusters/status
-      - redisclusterrequirements
-      - redisclusterrequirements/status
+      - compositeredisclusters
+      - compositeredisclusters/status
+      - rediscluster
+      - rediscluster/status
     verbs:
       - "*"

--- a/cluster/composition/definitions/bucket.yaml
+++ b/cluster/composition/definitions/bucket.yaml
@@ -1,24 +1,17 @@
 ---
 apiVersion: apiextensions.crossplane.io/v1alpha1
-kind: InfrastructureDefinition
+kind: CompositeResourceDefinition
 metadata:
-  name: buckets.common.crossplane.io
+  name: compositebuckets.common.crossplane.io
 spec:
+  claimNames:
+    kind: Bucket
+    plural: buckets
   crdSpecTemplate:
     group: common.crossplane.io
     version: v1alpha1
     names:
       categories:
         - crossplane
-      kind: Bucket
-      listKind: BucketList
-      plural: buckets
-      singular: bucket
----
-apiVersion: apiextensions.crossplane.io/v1alpha1
-kind: InfrastructurePublication
-metadata:
-  name: buckets.common.crossplane.io
-spec:
-  infrastructureDefinitionRef:
-    name: buckets.common.crossplane.io
+      kind: CompositeBucket
+      plural: compositebuckets

--- a/cluster/composition/definitions/kubernetescluster.yaml
+++ b/cluster/composition/definitions/kubernetescluster.yaml
@@ -1,9 +1,12 @@
 ---
 apiVersion: apiextensions.crossplane.io/v1alpha1
-kind: InfrastructureDefinition
+kind: CompositeResourceDefinition
 metadata:
-  name: kubernetesclusters.common.crossplane.io
+  name: compositekubernetesclusters.common.crossplane.io
 spec:
+  claimNames:
+    kind: KubernetesCluster
+    plural: kubernetesclusters
   connectionSecretKeys:
     - kubeconfig
   crdSpecTemplate:
@@ -12,10 +15,8 @@ spec:
     names:
       categories:
         - crossplane
-      kind: KubernetesCluster
-      listKind: KubernetesClusterList
-      plural: kubernetesclusters
-      singular: kubernetescluster
+      kind: CompositeKubernetesCluster
+      plural: compositekubernetesclusters
     validation:
       openAPIV3Schema:
         type: object
@@ -29,11 +30,3 @@ spec:
                 type: string
             required:
               - version
----
-apiVersion: apiextensions.crossplane.io/v1alpha1
-kind: InfrastructurePublication
-metadata:
-  name: kubernetesclusters.common.crossplane.io
-spec:
-  infrastructureDefinitionRef:
-    name: kubernetesclusters.common.crossplane.io

--- a/cluster/composition/definitions/machineinstance.yaml
+++ b/cluster/composition/definitions/machineinstance.yaml
@@ -1,24 +1,17 @@
 ---
 apiVersion: apiextensions.crossplane.io/v1alpha1
-kind: InfrastructureDefinition
+kind: CompositeResourceDefinition
 metadata:
-  name: machineinstances.common.crossplane.io
+  name: compositemachineinstances.common.crossplane.io
 spec:
+  claimNames:
+    kind: MachineInstance
+    plural: machineinstances
   crdSpecTemplate:
     group: common.crossplane.io
     version: v1alpha1
     names:
       categories:
         - crossplane
-      kind: MachineInstance
-      listKind: MachineInstanceList
-      plural: machineinstances
-      singular: machineinstance
----
-apiVersion: apiextensions.crossplane.io/v1alpha1
-kind: InfrastructurePublication
-metadata:
-  name: machineinstances.common.crossplane.io
-spec:
-  infrastructureDefinitionRef:
-    name: machineinstances.common.crossplane.io
+      kind: CompositeMachineInstance
+      plural: compositemachineinstances

--- a/cluster/composition/definitions/mysqlinstance.yaml
+++ b/cluster/composition/definitions/mysqlinstance.yaml
@@ -1,9 +1,12 @@
 ---
 apiVersion: apiextensions.crossplane.io/v1alpha1
-kind: InfrastructureDefinition
+kind: CompositeResourceDefinition
 metadata:
-  name: mysqlinstances.common.crossplane.io
+  name: compositemysqlinstances.common.crossplane.io
 spec:
+  claimNames:
+    kind: MySQLInstance
+    plural: mysqlinstances
   connectionSecretKeys:
     - username
     - password
@@ -15,10 +18,8 @@ spec:
     names:
       categories:
         - crossplane
-      kind: MySQLInstance
-      listKind: MySQLInstanceList
-      plural: mysqlinstances
-      singular: mysqlinstance
+      kind: CompositeMySQLInstance
+      plural: compositemysqlinstances
     validation:
       openAPIV3Schema:
         type: object
@@ -38,11 +39,3 @@ spec:
             required:
               - version
               - storageGB
----
-apiVersion: apiextensions.crossplane.io/v1alpha1
-kind: InfrastructurePublication
-metadata:
-  name: mysqlinstances.common.crossplane.io
-spec:
-  infrastructureDefinitionRef:
-    name: mysqlinstances.common.crossplane.io

--- a/cluster/composition/definitions/nosqlinstance.yaml
+++ b/cluster/composition/definitions/nosqlinstance.yaml
@@ -1,24 +1,17 @@
 ---
 apiVersion: apiextensions.crossplane.io/v1alpha1
-kind: InfrastructureDefinition
+kind: CompositeResourceDefinition
 metadata:
-  name: nosqlinstances.common.crossplane.io
+  name: compositenosqlinstances.common.crossplane.io
 spec:
+  claimNames:
+    kind: NoSQLInstance
+    plural: nosqlinstances
   crdSpecTemplate:
     group: common.crossplane.io
     version: v1alpha1
     names:
       categories:
         - crossplane
-      kind: NoSQLInstance
-      listKind: NoSQLInstanceList
-      plural: nosqlinstances
-      singular: nosqlinstance
----
-apiVersion: apiextensions.crossplane.io/v1alpha1
-kind: InfrastructurePublication
-metadata:
-  name: nosqlinstances.common.crossplane.io
-spec:
-  infrastructureDefinitionRef:
-    name: nosqlinstances.common.crossplane.io
+      kind: CompositeNoSQLInstance
+      plural: compositenosqlinstances

--- a/cluster/composition/definitions/postgresqlinstance.yaml
+++ b/cluster/composition/definitions/postgresqlinstance.yaml
@@ -1,9 +1,12 @@
 ---
 apiVersion: apiextensions.crossplane.io/v1alpha1
-kind: InfrastructureDefinition
+kind: CompositeResourceDefinition
 metadata:
-  name: postgresqlinstances.common.crossplane.io
+  name: compositepostgresqlinstances.common.crossplane.io
 spec:
+  claimNames:
+    kind: PostgreSQLInstance
+    plural: postgresqlinstances
   connectionSecretKeys:
     - username
     - password
@@ -15,10 +18,8 @@ spec:
     names:
       categories:
         - crossplane
-      kind: PostgreSQLInstance
-      listKind: PostgreSQLInstanceList
-      plural: postgresqlinstances
-      singular: postgresqlinstance
+      kind: CompositePostgreSQLInstance
+      plural: compositepostgresqlinstances
     validation:
       openAPIV3Schema:
         type: object
@@ -38,11 +39,3 @@ spec:
             required:
               - version
               - storageGB
----
-apiVersion: apiextensions.crossplane.io/v1alpha1
-kind: InfrastructurePublication
-metadata:
-  name: postgresqlinstances.common.crossplane.io
-spec:
-  infrastructureDefinitionRef:
-    name: postgresqlinstances.common.crossplane.io

--- a/cluster/composition/definitions/rediscluster.yaml
+++ b/cluster/composition/definitions/rediscluster.yaml
@@ -1,9 +1,12 @@
 ---
 apiVersion: apiextensions.crossplane.io/v1alpha1
-kind: InfrastructureDefinition
+kind: CompositeResourceDefinition
 metadata:
-  name: redisclusters.common.crossplane.io
+  name: compositeredisclusters.common.crossplane.io
 spec:
+  claimNames:
+    kind: RedisCluster
+    plural: redisclusters
   connectionSecretKeys:
     - endpoint
     - password
@@ -14,10 +17,8 @@ spec:
     names:
       categories:
         - crossplane
-      kind: RedisCluster
-      listKind: RedisClusterList
-      plural: redisclusters
-      singular: rediscluster
+      kind: CompositeRedisCluster
+      plural: compositeredisclusters
     validation:
       openAPIV3Schema:
         type: object
@@ -36,11 +37,3 @@ spec:
                 type: string
             required:
               - version
----
-apiVersion: apiextensions.crossplane.io/v1alpha1
-kind: InfrastructurePublication
-metadata:
-  name: redisclusters.common.crossplane.io
-spec:
-  infrastructureDefinitionRef:
-    name: redisclusters.common.crossplane.io


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Follow up to #1679 to refactor common infradefs to XRDs and update their cluster roles.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

1. Install Crossplane
2. Create new `ClusterRole`s
3. Create XRDs and see that they are installed successfully and their XRC variants exist as CRDs

```
🤖 (crossplane) kubectl get xrd
NAME                                                AGE
compositebuckets.common.crossplane.io               11m
compositekubernetesclusters.common.crossplane.io    11m
compositemachineinstances.common.crossplane.io      11m
compositemysqlinstances.common.crossplane.io        11m
compositenosqlinstances.common.crossplane.io        11m
compositepostgresqlinstances.common.crossplane.io   11m
compositeredisclusters.common.crossplane.io         11m
```

```
🤖 (crossplane) kubectl get crds | grep common
buckets.common.crossplane.io                               2020-08-26T15:41:03Z
compositebuckets.common.crossplane.io                      2020-08-26T15:41:03Z
compositekubernetesclusters.common.crossplane.io           2020-08-26T15:41:03Z
compositemachineinstances.common.crossplane.io             2020-08-26T15:41:03Z
compositemysqlinstances.common.crossplane.io               2020-08-26T15:41:03Z
compositenosqlinstances.common.crossplane.io               2020-08-26T15:41:03Z
compositepostgresqlinstances.common.crossplane.io          2020-08-26T15:41:03Z
compositeredisclusters.common.crossplane.io                2020-08-26T15:41:04Z
kubernetesclusters.common.crossplane.io                    2020-08-26T15:41:03Z
machineinstances.common.crossplane.io                      2020-08-26T15:41:05Z
mysqlinstances.common.crossplane.io                        2020-08-26T15:41:04Z
nosqlinstances.common.crossplane.io                        2020-08-26T15:41:03Z
postgresqlinstances.common.crossplane.io                   2020-08-26T15:41:05Z
redisclusters.common.crossplane.io                         2020-08-26T15:41:04Z
```

[contribution process]: https://git.io/fj2m9
