### PR TITLE
Make suggested chart parameters use alpha image

### DIFF
--- a/cluster/charts/crossplane/README.md
+++ b/cluster/charts/crossplane/README.md
@@ -326,7 +326,7 @@ deploymentStrategy: RollingUpdate
 
 image:
   repository: crossplane/crossplane
-  tag: master
+  tag: alpha
   pullPolicy: Always
 
 imagePullSecrets:

--- a/docs/reference/install.md
+++ b/docs/reference/install.md
@@ -333,7 +333,7 @@ deploymentStrategy: RollingUpdate
 
 image:
   repository: crossplane/crossplane
-  tag: master
+  tag: alpha
   pullPolicy: Always
 
 imagePullSecrets:


### PR DESCRIPTION


<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

The helm installation command that demonstrates how to supply custom
values.yaml file uses alpha chart but master image. If behavior or API
types have diverged since the last release, this can cause issues in the
installation.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

A user in Slack had a negative experience with this ([message](https://crossplane.slack.com/archives/CEG3T90A1/p1599190136072500?thread_ts=1599189794.068200&cid=CEG3T90A1)).

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

n/a (still letting CI run because one of the changed files is generated)

[contribution process]: https://git.io/fj2m9
