### PR TITLE
Register pkg meta types with scheme

### DIFF
--- a/apis/pkg/meta/v1alpha1/register.go
+++ b/apis/pkg/meta/v1alpha1/register.go
@@ -35,6 +35,9 @@ var (
 
 	// SchemeBuilder is used to add go types to the GroupVersionKind scheme
 	SchemeBuilder = &scheme.Builder{GroupVersion: SchemeGroupVersion}
+
+	// AddToScheme adds all registered types to scheme
+	AddToScheme = SchemeBuilder.AddToScheme
 )
 
 // Provider type metadata.
@@ -52,3 +55,8 @@ var (
 	ConfigurationKindAPIVersion   = ConfigurationKind + "." + SchemeGroupVersion.String()
 	ConfigurationGroupVersionKind = SchemeGroupVersion.WithKind(ConfigurationKind)
 )
+
+func init() {
+	SchemeBuilder.Register(&Configuration{})
+	SchemeBuilder.Register(&Provider{})
+}


### PR DESCRIPTION

<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Crossplane does not register pkg meta types in its controller manager
scheme, but consumers of the crossplane-runtime package parser may want
to register the pkg meta types to the meta scheme they pass to the
parser. Currently, they are required to manually call Register for the
types to actually be registered with the scheme, which can be unexpected
because most other types are registered automatically in their init
function. Note that these types should never be registered with the
Crossplaen controllers because they are not actually installed into the
Kubernetes cluster.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>
I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

Tested with https://github.com/crossplane/crossplane-runtime/pull/194

[contribution process]: https://git.io/fj2m9
