### PR TITLE
Bootstrap initial Crank scaffolding

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ NPROCS ?= 1
 # to half the number of CPU cores.
 GO_TEST_PARALLEL := $(shell echo $$(( $(NPROCS) / 2 )))
 
-GO_STATIC_PACKAGES = $(GO_PROJECT)/cmd/crossplane
+GO_STATIC_PACKAGES = $(GO_PROJECT)/cmd/crossplane $(GO_PROJECT)/cmd/crank
 GO_LDFLAGS += -X $(GO_PROJECT)/pkg/version.Version=$(VERSION)
 GO_SUBDIRS += cmd pkg apis
 GO111MODULE = on

--- a/cmd/crank/configuration/configuration.go
+++ b/cmd/crank/configuration/configuration.go
@@ -1,0 +1,54 @@
+/*
+Copyright 2020 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package configuration
+
+// Cmd is the root command for Configurations.
+type Cmd struct {
+	Get    GetCmd    `cmd:"" help:"Get installed Configurations."`
+	Create CreateCmd `cmd:"" help:"Create a Configuration."`
+}
+
+// Run runs the Configuration command.
+func (r *Cmd) Run() error {
+	return nil
+}
+
+// GetCmd gets one or more Configurations in the cluster.
+type GetCmd struct {
+	Name string `arg:"" optional:"" name:"name" help:"Name of Configuration."`
+
+	Revisions bool `short:"r" help:"List revisions for each Configuration."`
+}
+
+// Run the Get command.
+func (b *GetCmd) Run() error {
+	return nil
+}
+
+// CreateCmd creates a Configuration in the cluster.
+type CreateCmd struct {
+	Name    string `arg:"" name:"name" help:"Name of Configuration."`
+	Package string `arg:"" name:"package" help:"Image containing Configuration package."`
+
+	History  int  `help:"Revision history limit."`
+	Activate bool `short:"a" help:"Enable automatic revision activation policy."`
+}
+
+// Run the CreateCmd.
+func (p *CreateCmd) Run() error {
+	return nil
+}

--- a/cmd/crank/main.go
+++ b/cmd/crank/main.go
@@ -1,0 +1,40 @@
+/*
+Copyright 2020 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"github.com/alecthomas/kong"
+
+	"github.com/crossplane/crossplane/cmd/crank/configuration"
+	"github.com/crossplane/crossplane/cmd/crank/pkg"
+	"github.com/crossplane/crossplane/cmd/crank/provider"
+)
+
+var cli struct {
+	Configuration configuration.Cmd `cmd:"" help:"Interact with Configurations."`
+	Provider      provider.Cmd      `cmd:"" help:"Interact with Providers."`
+	Pkg           pkg.Cmd           `cmd:"" help:"Build and publish packages."`
+}
+
+func main() {
+	ctx := kong.Parse(&cli,
+		kong.Name("crank"),
+		kong.Description("A tool for building platforms on Crossplane."),
+		kong.UsageOnError())
+	err := ctx.Run()
+	ctx.FatalIfErrorf(err)
+}

--- a/cmd/crank/pkg/pkg.go
+++ b/cmd/crank/pkg/pkg.go
@@ -1,0 +1,54 @@
+/*
+Copyright 2020 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pkg
+
+// Cmd is the root package command.
+type Cmd struct {
+	Build BuildCmd `cmd:"" help:"Build a Crossplane package."`
+	Push  PushCmd  `cmd:"" help:"Push a Crossplane package to a registry."`
+}
+
+// Run runs the package command.
+func (r *Cmd) Run() error {
+	return nil
+}
+
+// BuildCmd build a package.
+type BuildCmd struct {
+	Name string `arg:"" optional:"" name:"name" help:"Name of the package to be built. Defaults to name in crossplane.yaml."`
+
+	Tag      string `short:"t" help:"Package version tag." default:"latest"`
+	Registry string `short:"r" help:"Package registry." default:"registry.upbound.io"`
+}
+
+// Run runs the Build command.
+func (b *BuildCmd) Run() error {
+	return nil
+}
+
+// PushCmd pushes a package to a registry.
+type PushCmd struct {
+	Name string `arg:"" optional:"" name:"name" help:"Name of the package to be pushed. Defaults to name in crossplane.yaml."`
+
+	Tag      string `short:"t" help:"Package version tag." default:"latest"`
+	Registry string `short:"r" help:"Package registry." default:"registry.upbound.io"`
+}
+
+// Run runs the Push command.
+func (p *PushCmd) Run() error {
+	return nil
+}

--- a/cmd/crank/provider/provider.go
+++ b/cmd/crank/provider/provider.go
@@ -1,0 +1,54 @@
+/*
+Copyright 2020 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package provider
+
+// Cmd is the root command for Providers.
+type Cmd struct {
+	Get    GetCmd    `cmd:"" help:"Get installed Providers."`
+	Create CreateCmd `cmd:"" help:"Create a Provider."`
+}
+
+// Run runs the Provider command.
+func (r *Cmd) Run() error {
+	return nil
+}
+
+// GetCmd gets one or more Providers in the cluster.
+type GetCmd struct {
+	Name string `arg:"" optional:"" name:"name" help:"Name of Provider."`
+
+	Revisions bool `short:"r" help:"List revisions for each Provider."`
+}
+
+// Run the Get command.
+func (b *GetCmd) Run() error {
+	return nil
+}
+
+// CreateCmd creates a Provider in the cluster.
+type CreateCmd struct {
+	Name    string `arg:"" name:"name" help:"Name of Provider."`
+	Package string `arg:"" name:"package" help:"Image containing Provider package."`
+
+	History  int  `help:"Revision history limit."`
+	Activate bool `short:"a" help:"Enable automatic revision activation policy."`
+}
+
+// Run the CreateCmd.
+func (p *CreateCmd) Run() error {
+	return nil
+}

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/crossplane/crossplane
 go 1.13
 
 require (
+	github.com/alecthomas/kong v0.2.11
 	github.com/crossplane/crossplane-runtime v0.9.1-0.20200909163703-c8aaffcea500
 	github.com/crossplane/crossplane-tools v0.0.0-20200412230150-efd0edd4565b
 	github.com/crossplane/oam-kubernetes-runtime v0.0.0-20200426101222-2b61763c2e51

--- a/go.sum
+++ b/go.sum
@@ -37,6 +37,8 @@ github.com/PuerkitoBio/urlesc v0.0.0-20160726150825-5bd2802263f2/go.mod h1:uGdko
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 h1:d+Bc7a5rLufV/sSk/8dngufqelfh6jnri85riMAaF/M=
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
 github.com/agnivade/levenshtein v1.0.1/go.mod h1:CURSv5d9Uaml+FovSIICkLbAUZ9S4RqaHDIsdSBg7lM=
+github.com/alecthomas/kong v0.2.11 h1:RKeJXXWfg9N47RYfMm0+igkxBCTF4bzbneAxaqid0c4=
+github.com/alecthomas/kong v0.2.11/go.mod h1:kQOmtJgV+Lb4aj+I2LEn40cbtawdWJ9Y8QLq+lElKxE=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751 h1:JYp7IbQjafoB+tBA3gMyHYHrpOtNuDiK/uB5uXxq5wM=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

This adds the initial scaffolding for `crank` commands that are the minimum requirement for the v0.13 release. It introduces [`kong`](https://github.com/alecthomas/kong) as our new CLI framework, which we intend to eventually fully migrate to from `kingpin`. The purpose of this scaffolding PR is to allow implementation work to be broken into pieces that can be accomplished by multiple people. It also sets up the build infrastructure to start building and publishing the `crank` binary.

`crank` is based on the package manager and CLI POC at https://github.com/hasheddan/crank

Follow up work is to create individual issues for the work required to implement each of the subcommands.

ref https://github.com/crossplane/crossplane/issues/1673

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

`make reviewable`

[contribution process]: https://git.io/fj2m9
