### PR TITLE
Mark KubeApp API types deprecated

### DIFF
--- a/apis/workload/v1alpha1/types.go
+++ b/apis/workload/v1alpha1/types.go
@@ -115,6 +115,7 @@ type KubernetesApplicationStatus struct {
 
 // A KubernetesApplication defines an application deployed by Crossplane to a
 // Kubernetes cluster, i.e. a portable KubernetesCluster resource claim.
+// Deprecated: See https://github.com/crossplane/crossplane/issues/1595
 // +kubebuilder:resource:categories=crossplane
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="CLUSTER",type="string",JSONPath=".spec.targetRef.name"
@@ -216,6 +217,7 @@ type KubernetesApplicationResourceStatus struct {
 // A KubernetesApplicationResource is a resource of a Kubernetes application.
 // Each resource templates a single Kubernetes resource to be deployed to its
 // scheduled KubernetesCluster.
+// Deprecated: See // Deprecated: See https://github.com/crossplane/crossplane/issues/1595
 // +kubebuilder:resource:categories=crossplane
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="TEMPLATE-KIND",type="string",JSONPath=".spec.template.kind"
@@ -243,6 +245,7 @@ type KubernetesApplicationResourceList struct {
 // +kubebuilder:object:root=true
 
 // A KubernetesTarget is a scheduling target for a Kubernetes Application.
+// Deprecated: See https://github.com/crossplane/crossplane/issues/1595
 // +kubebuilder:resource:categories=crossplane
 // +kubebuilder:printcolumn:name="CLUSTER",type="string",JSONPath=".spec.clusterRef.name"
 type KubernetesTarget struct {

--- a/cluster/charts/crossplane-types/crds/workload.crossplane.io_kubernetesapplicationresources.yaml
+++ b/cluster/charts/crossplane-types/crds/workload.crossplane.io_kubernetesapplicationresources.yaml
@@ -34,7 +34,7 @@ spec:
     status: {}
   validation:
     openAPIV3Schema:
-      description: A KubernetesApplicationResource is a resource of a Kubernetes application. Each resource templates a single Kubernetes resource to be deployed to its scheduled KubernetesCluster.
+      description: 'A KubernetesApplicationResource is a resource of a Kubernetes application. Each resource templates a single Kubernetes resource to be deployed to its scheduled KubernetesCluster. Deprecated: See // Deprecated: See https://github.com/crossplane/crossplane/issues/1595'
       properties:
         apiVersion:
           description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'

--- a/cluster/charts/crossplane-types/crds/workload.crossplane.io_kubernetesapplications.yaml
+++ b/cluster/charts/crossplane-types/crds/workload.crossplane.io_kubernetesapplications.yaml
@@ -34,7 +34,7 @@ spec:
     status: {}
   validation:
     openAPIV3Schema:
-      description: A KubernetesApplication defines an application deployed by Crossplane to a Kubernetes cluster, i.e. a portable KubernetesCluster resource claim.
+      description: 'A KubernetesApplication defines an application deployed by Crossplane to a Kubernetes cluster, i.e. a portable KubernetesCluster resource claim. Deprecated: See https://github.com/crossplane/crossplane/issues/1595'
       properties:
         apiVersion:
           description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'

--- a/cluster/charts/crossplane-types/crds/workload.crossplane.io_kubernetestargets.yaml
+++ b/cluster/charts/crossplane-types/crds/workload.crossplane.io_kubernetestargets.yaml
@@ -24,7 +24,7 @@ spec:
   subresources: {}
   validation:
     openAPIV3Schema:
-      description: A KubernetesTarget is a scheduling target for a Kubernetes Application.
+      description: 'A KubernetesTarget is a scheduling target for a Kubernetes Application. Deprecated: See https://github.com/crossplane/crossplane/issues/1595'
       properties:
         apiVersion:
           description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'

--- a/cluster/charts/crossplane/templates/crds/workload.crossplane.io_kubernetesapplicationresources.yaml
+++ b/cluster/charts/crossplane/templates/crds/workload.crossplane.io_kubernetesapplicationresources.yaml
@@ -34,7 +34,7 @@ spec:
     status: {}
   validation:
     openAPIV3Schema:
-      description: A KubernetesApplicationResource is a resource of a Kubernetes application. Each resource templates a single Kubernetes resource to be deployed to its scheduled KubernetesCluster.
+      description: 'A KubernetesApplicationResource is a resource of a Kubernetes application. Each resource templates a single Kubernetes resource to be deployed to its scheduled KubernetesCluster. Deprecated: See // Deprecated: See https://github.com/crossplane/crossplane/issues/1595'
       properties:
         apiVersion:
           description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'

--- a/cluster/charts/crossplane/templates/crds/workload.crossplane.io_kubernetesapplications.yaml
+++ b/cluster/charts/crossplane/templates/crds/workload.crossplane.io_kubernetesapplications.yaml
@@ -34,7 +34,7 @@ spec:
     status: {}
   validation:
     openAPIV3Schema:
-      description: A KubernetesApplication defines an application deployed by Crossplane to a Kubernetes cluster, i.e. a portable KubernetesCluster resource claim.
+      description: 'A KubernetesApplication defines an application deployed by Crossplane to a Kubernetes cluster, i.e. a portable KubernetesCluster resource claim. Deprecated: See https://github.com/crossplane/crossplane/issues/1595'
       properties:
         apiVersion:
           description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'

--- a/cluster/charts/crossplane/templates/crds/workload.crossplane.io_kubernetestargets.yaml
+++ b/cluster/charts/crossplane/templates/crds/workload.crossplane.io_kubernetestargets.yaml
@@ -24,7 +24,7 @@ spec:
   subresources: {}
   validation:
     openAPIV3Schema:
-      description: A KubernetesTarget is a scheduling target for a Kubernetes Application.
+      description: 'A KubernetesTarget is a scheduling target for a Kubernetes Application. Deprecated: See https://github.com/crossplane/crossplane/issues/1595'
       properties:
         apiVersion:
           description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Kubernetes Applications are deprecated per https://github.com/crossplane/crossplane/issues/1595. This PR marks them as such.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
