### PR TITLE
Introduce the Crossplane RBAC Manager

### DIFF
--- a/cluster/charts/crossplane-controllers/templates/rbac-manager-deployment.yaml
+++ b/cluster/charts/crossplane-controllers/templates/rbac-manager-deployment.yaml
@@ -1,0 +1,76 @@
+{{- if .Values.rbacManager.deploy }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "name" . }}-rbac-manager
+  labels:
+    app: {{ template "name" . }}-rbac-manager
+    chart: {{ template "chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  replicas: {{ .Values.replicas }}
+  selector:
+    matchLabels:
+      app: {{ template "name" . }}-rbac-manager
+      release: {{ .Release.Name }}
+  strategy:
+    type: {{ .Values.deploymentStrategy }}
+  template:
+    metadata:
+      labels:
+        app: {{ template "name" . }}-rbac-manager
+        release: {{ .Release.Name }}
+    spec:
+      {{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName | quote }}
+      {{- end }}
+      {{- if not .Values.hostedConfig.enabled }}
+      serviceAccountName: rbac-manager
+      {{- end }}
+      containers:
+      - image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+        args:
+        - rbac
+        - --manage={{ .Values.rbacManager.managementPolicy }}
+        {{- range $arg := .Values.args }}
+        - {{ $arg }}
+        {{- end }}
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        name: {{ .Chart.Name }}
+        env:
+        # The pod name to pass with the downward API
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        # The pod namespace to pass with the downward API
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        resources:
+          {{- toYaml .Values.resourcesRBACManager | nindent 12 }}
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+      {{- if .Values.hostedConfig.enabled }}
+        env:
+          - name: KUBERNETES_SERVICE_HOST
+            value: {{ .Values.hostedConfig.tenantKubernetesServiceHost | quote }}
+          - name: KUBERNETES_SERVICE_PORT
+            value: {{ .Values.hostedConfig.tenantKubernetesServicePort | quote }}
+        volumeMounts:
+          - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+            name: sa-token
+            readOnly: true
+      automountServiceAccountToken: false
+      serviceAccount: ""
+      serviceAccountName: ""
+      volumes:
+        - name: sa-token
+          secret:
+            defaultMode: 420
+            secretName: {{ .Values.hostedConfig.rbacManagerSATokenSecret | quote }}
+      {{- end }}
+{{- end}}

--- a/cluster/charts/crossplane-controllers/templates/rbac-manager-deployment.yaml
+++ b/cluster/charts/crossplane-controllers/templates/rbac-manager-deployment.yaml
@@ -32,23 +32,14 @@ spec:
       - image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
         args:
         - rbac
+        {{- if .Values.rbacManager.managementPolicy }}
         - --manage={{ .Values.rbacManager.managementPolicy }}
+        {{- end }}
         {{- range $arg := .Values.args }}
         - {{ $arg }}
         {{- end }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         name: {{ .Chart.Name }}
-        env:
-        # The pod name to pass with the downward API
-        - name: POD_NAME
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.name
-        # The pod namespace to pass with the downward API
-        - name: POD_NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
         resources:
           {{- toYaml .Values.resourcesRBACManager | nindent 12 }}
         securityContext:

--- a/cluster/charts/crossplane-controllers/values.yaml.tmpl
+++ b/cluster/charts/crossplane-controllers/values.yaml.tmpl
@@ -11,6 +11,10 @@ image:
 
 args: {}
 
+rbacManager:
+  deploy: true
+  managementPolicy: All
+
 imagePullSecrets:
 - dockerhub
 
@@ -21,6 +25,7 @@ hostedConfig:
   tenantKubernetesServicePort: ""
   controllerNamespace: ""
   crossplaneSATokenSecret: ""
+  rbacManagerSATokenSecret: ""
 
 templateStacks:
   enabled: true
@@ -37,6 +42,14 @@ resourcesCrossplane:
     memory: 256Mi
 
 resourcesPackageManager:
+  limits:
+    cpu: 100m
+    memory: 512Mi
+  requests:
+    cpu: 100m
+    memory: 256Mi
+
+resourcesRBACManager:
   limits:
     cpu: 100m
     memory: 512Mi

--- a/cluster/charts/crossplane-types/templates/clusterrole.yaml
+++ b/cluster/charts/crossplane-types/templates/clusterrole.yaml
@@ -9,6 +9,8 @@ metadata:
     heritage: {{ .Release.Service }}
 aggregationRule:
   clusterRoleSelectors:
+  # TODO(negz): Remove aggregate-to-crossplane-admin. The Crossplane service
+  # account should not be granted the same access as a Crossplane administrator.
   - matchLabels:
       rbac.crossplane.io/aggregate-to-crossplane-admin: "true"
   - matchLabels:

--- a/cluster/charts/crossplane-types/templates/rbac-manager-clusterrole.yaml
+++ b/cluster/charts/crossplane-types/templates/rbac-manager-clusterrole.yaml
@@ -1,0 +1,60 @@
+{{- if .Values.rbacManager.deploy }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ template "name" . }}-rbac-manager
+  labels:
+    app: {{ template "name" . }}
+    chart: {{ template "chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apiextensions.crossplane.io
+  resources:
+  - compositeresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterroles
+  - roles
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  # The RBAC manager may grant access it does not have.
+  - escalate
+  - bind
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterrolebindings
+  verbs:
+  - create
+  - update
+  - patch
+{{- end}}

--- a/cluster/charts/crossplane-types/templates/rbac-manager-clusterrolebinding.yaml
+++ b/cluster/charts/crossplane-types/templates/rbac-manager-clusterrolebinding.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.rbacManager.deploy }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ template "name" . }}-rbac-manager
+  labels:
+    app: {{ template "name" . }}
+    chart: {{ template "chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "name" . }}-rbac-manager
+subjects:
+- kind: ServiceAccount
+  name: rbac-manager
+  namespace: {{ .Release.Namespace }}
+{{- end}}

--- a/cluster/charts/crossplane-types/templates/rbac-manager-managed-clusterroles.yaml
+++ b/cluster/charts/crossplane-types/templates/rbac-manager-managed-clusterroles.yaml
@@ -1,0 +1,263 @@
+{{- if .Values.rbacManager.deploy }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ template "name" . }}-admin
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "name" . }}-admin
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: {{ template "name" . }}:master
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ template "name" . }}-admin
+  labels:
+    app: {{ template "name" . }}
+    chart: {{ template "chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+aggregationRule:
+  clusterRoleSelectors:
+  - matchLabels:
+      rbac.crossplane.io/aggregate-to-admin: "true"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ template "name" . }}-edit
+  labels:
+    app: {{ template "name" . }}
+    chart: {{ template "chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+aggregationRule:
+  clusterRoleSelectors:
+  - matchLabels:
+      rbac.crossplane.io/aggregate-to-edit: "true"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ template "name" . }}-view
+  labels:
+    app: {{ template "name" . }}
+    chart: {{ template "chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+aggregationRule:
+  clusterRoleSelectors:
+  - matchLabels:
+      rbac.crossplane.io/aggregate-to-view: "true"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ template "name" . }}-browse
+  labels:
+    app: {{ template "name" . }}
+    chart: {{ template "chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+aggregationRule:
+  clusterRoleSelectors:
+  - matchLabels:
+      rbac.crossplane.io/aggregate-to-browse: "true"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ template "name" . }}:aggregate-to-admin
+  labels:
+    rbac.crossplane.io/aggregate-to-admin: "true"
+    app: {{ template "name" . }}
+    chart: {{ template "chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+rules:
+# Crossplane administrators have access to view events.
+- apiGroups: [""]
+  resources: [events]
+  verbs: [get, list, watch]
+# Crossplane administrators must create provider credential secrets, and may
+# need to read or otherwise interact with connection secrets. They may also need
+# to create or annotate namespaces.
+- apiGroups: [""]
+  resources: [secrets, namespaces]
+  verbs: ["*"]
+# Crossplane administrators have access to view the roles that they may be able
+# to grant to other subjects.
+- apiGroups: [rbac.authorization.k8s.io]
+  resources: [clusterroles, roles]
+  verbs: [get, list, watch]
+# Crossplane administrators have access to grant the access they have to other
+# subjects.
+- apiGroups: [rbac.authorization.k8s.io]
+  resources: [clusterrolebindings, rolebindings]
+  verbs: ["*"]
+# Crossplane administrators have full access to built in Crossplane types.
+- apiGroups:
+  - apiextensions.crossplane.io
+  - pkg.crossplane.io
+  resources: ["*"]
+  verbs: ["*"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ template "name" . }}:aggregate-to-edit
+  labels:
+    rbac.crossplane.io/aggregate-to-edit: "true"
+    app: {{ template "name" . }}
+    chart: {{ template "chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+rules:
+# Crossplane editors have access to view events.
+- apiGroups: [""]
+  resources: [events]
+  verbs: [get, list, watch]
+# Crossplane editors must create provider credential secrets, and may need to
+# read or otherwise interact with connection secrets.
+- apiGroups: [""]
+  resources: [secrets]
+  verbs: ["*"]
+# Crossplane editors may see which namespaces exist, but not edit them.
+- apiGroups: [""]
+  resources: [namespaces]
+  verbs: [get, list, watch]
+# Crossplane editors have full access to built in Crossplane types.
+- apiGroups:
+  - apiextensions.crossplane.io
+  - pkg.crossplane.io
+  resources: ["*"]
+  verbs: ["*"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ template "name" . }}:aggregate-to-view
+  labels:
+    rbac.crossplane.io/aggregate-to-view: "true"
+    app: {{ template "name" . }}
+    chart: {{ template "chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+rules:
+# Crossplane viewers have access to view events.
+- apiGroups: [""]
+  resources: [events]
+  verbs: [get, list, watch]
+# Crossplane viewers may see which namespaces exist.
+- apiGroups: [""]
+  resources: [namespaces]
+  verbs: [get, list, watch]
+# Crossplane viewers have read-only access to built in Crossplane types.
+- apiGroups:
+  - apiextensions.crossplane.io
+  - pkg.crossplane.io
+  resources: ["*"]
+  verbs: [get, list, watch]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ template "name" . }}:aggregate-to-browse
+  labels:
+    rbac.crossplane.io/aggregate-to-browse: "true"
+    app: {{ template "name" . }}
+    chart: {{ template "chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+rules:
+# Crossplane browsers have access to view events.
+- apiGroups: [""]
+  resources: [events]
+  verbs: [get, list, watch]
+# Crossplane browsers have read-only access to compositions and XRDs. This
+# allows them to discover and select an appropriate composition when creating a
+# resource claim.
+- apiGroups:
+  - apiextensions.crossplane.io
+  resources: ["*"]
+  verbs: [get, list, watch]
+{{- if .Values.rbacManager.managementPolicy }}
+# The below ClusterRoles are aggregated to the namespaced RBAC roles created by
+# the Crossplane RBAC manager when it is running in --manage=All mode.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ template "name" . }}:aggregate-to-ns-admin
+  labels:
+    rbac.crossplane.io/aggregate-to-ns-admin: "true"
+    rbac.crossplane.io/base-of-ns-admin: "true"
+    app: {{ template "name" . }}
+    chart: {{ template "chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+rules:
+# Crossplane namespace admins have access to view events.
+- apiGroups: [""]
+  resources: [events]
+  verbs: [get, list, watch]
+# Crossplane namespace admins may need to read or otherwise interact with
+# resource claim connection secrets.
+- apiGroups: [""]
+  resources: [secrets]
+  verbs: ["*"]
+# Crossplane namespace admins have access to view the roles that they may be
+# able to grant to other subjects.
+- apiGroups: [rbac.authorization.k8s.io]
+  resources: [roles]
+  verbs: [get, list, watch]
+# Crossplane namespace admins have access to grant the access they have to other
+# subjects.
+- apiGroups: [rbac.authorization.k8s.io]
+  resources: [rolebindings]
+  verbs: ["*"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ template "name" . }}:aggregate-to-ns-edit
+  labels:
+    rbac.crossplane.io/aggregate-to-ns-edit: "true"
+    rbac.crossplane.io/base-of-ns-edit: "true"
+    app: {{ template "name" . }}
+    chart: {{ template "chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+rules:
+# Crossplane namespace editors have access to view events.
+- apiGroups: [""]
+  resources: [events]
+  verbs: [get, list, watch]
+# Crossplane namespace editors may need to read or otherwise interact with
+# resource claim connection secrets.
+- apiGroups: [""]
+  resources: [secrets]
+  verbs: ["*"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ template "name" . }}:aggregate-to-ns-view
+  labels:
+    rbac.crossplane.io/aggregate-to-ns-view: "true"
+    rbac.crossplane.io/base-of-ns-view: "true"
+    app: {{ template "name" . }}
+    chart: {{ template "chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+rules:
+# Crossplane namespace viewers have access to view events.
+- apiGroups: [""]
+  resources: [events]
+  verbs: [get, list, watch]
+{{- end}}
+{{- end}}

--- a/cluster/charts/crossplane-types/templates/rbac-manager-serviceaccount.yaml
+++ b/cluster/charts/crossplane-types/templates/rbac-manager-serviceaccount.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.rbacManager.deploy }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: rbac-manager
+  labels:
+    app: {{ template "name" . }}
+    chart: {{ template "chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+{{- end}}

--- a/cluster/charts/crossplane-types/values.yaml.tmpl
+++ b/cluster/charts/crossplane-types/values.yaml.tmpl
@@ -3,5 +3,11 @@ nameOverride: crossplane
 imagePullSecrets:
 - dockerhub
 
-personas:
+rbacManager:
   deploy: true
+  managementPolicy: All
+
+# Deprecated. Use rbacManager instead.
+# TODO(negz): Disable deployment of the (deprecated) package manager by default.
+personas:
+  deploy: false

--- a/cluster/charts/crossplane/templates/clusterrole.yaml
+++ b/cluster/charts/crossplane/templates/clusterrole.yaml
@@ -9,6 +9,8 @@ metadata:
     heritage: {{ .Release.Service }}
 aggregationRule:
   clusterRoleSelectors:
+  # TODO(negz): Remove aggregate-to-crossplane-admin. The Crossplane service
+  # account should not be granted the same access as a Crossplane administrator.
   - matchLabels:
       rbac.crossplane.io/aggregate-to-crossplane-admin: "true"
   - matchLabels:

--- a/cluster/charts/crossplane/templates/rbac-manager-clusterrole.yaml
+++ b/cluster/charts/crossplane/templates/rbac-manager-clusterrole.yaml
@@ -1,0 +1,60 @@
+{{- if .Values.rbacManager.deploy }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ template "name" . }}-rbac-manager
+  labels:
+    app: {{ template "name" . }}
+    chart: {{ template "chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apiextensions.crossplane.io
+  resources:
+  - compositeresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterroles
+  - roles
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  # The RBAC manager may grant access it does not have.
+  - escalate
+  - bind
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterrolebindings
+  verbs:
+  - create
+  - update
+  - patch
+{{- end}}

--- a/cluster/charts/crossplane/templates/rbac-manager-clusterrolebinding.yaml
+++ b/cluster/charts/crossplane/templates/rbac-manager-clusterrolebinding.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.rbacManager.deploy }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ template "name" . }}-rbac-manager
+  labels:
+    app: {{ template "name" . }}
+    chart: {{ template "chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "name" . }}-rbac-manager
+subjects:
+- kind: ServiceAccount
+  name: rbac-manager
+  namespace: {{ .Release.Namespace }}
+{{- end}}

--- a/cluster/charts/crossplane/templates/rbac-manager-deployment.yaml
+++ b/cluster/charts/crossplane/templates/rbac-manager-deployment.yaml
@@ -1,0 +1,76 @@
+{{- if .Values.rbacManager.deploy }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "name" . }}-rbac-manager
+  labels:
+    app: {{ template "name" . }}-rbac-manager
+    chart: {{ template "chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  replicas: {{ .Values.replicas }}
+  selector:
+    matchLabels:
+      app: {{ template "name" . }}-rbac-manager
+      release: {{ .Release.Name }}
+  strategy:
+    type: {{ .Values.deploymentStrategy }}
+  template:
+    metadata:
+      labels:
+        app: {{ template "name" . }}-rbac-manager
+        release: {{ .Release.Name }}
+    spec:
+      {{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName | quote }}
+      {{- end }}
+      {{- if not .Values.hostedConfig.enabled }}
+      serviceAccountName: rbac-manager
+      {{- end }}
+      containers:
+      - image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+        args:
+        - rbac
+        - --manage={{ .Values.rbacManager.managementPolicy }}
+        {{- range $arg := .Values.args }}
+        - {{ $arg }}
+        {{- end }}
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        name: {{ .Chart.Name }}
+        env:
+        # The pod name to pass with the downward API
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        # The pod namespace to pass with the downward API
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        resources:
+          {{- toYaml .Values.resourcesRBACManager | nindent 12 }}
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+      {{- if .Values.hostedConfig.enabled }}
+        env:
+          - name: KUBERNETES_SERVICE_HOST
+            value: {{ .Values.hostedConfig.tenantKubernetesServiceHost | quote }}
+          - name: KUBERNETES_SERVICE_PORT
+            value: {{ .Values.hostedConfig.tenantKubernetesServicePort | quote }}
+        volumeMounts:
+          - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+            name: sa-token
+            readOnly: true
+      automountServiceAccountToken: false
+      serviceAccount: ""
+      serviceAccountName: ""
+      volumes:
+        - name: sa-token
+          secret:
+            defaultMode: 420
+            secretName: {{ .Values.hostedConfig.rbacManagerSATokenSecret | quote }}
+      {{- end }}
+{{- end}}

--- a/cluster/charts/crossplane/templates/rbac-manager-deployment.yaml
+++ b/cluster/charts/crossplane/templates/rbac-manager-deployment.yaml
@@ -32,23 +32,14 @@ spec:
       - image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
         args:
         - rbac
+        {{- if .Values.rbacManager.managementPolicy }}
         - --manage={{ .Values.rbacManager.managementPolicy }}
+        {{- end }}
         {{- range $arg := .Values.args }}
         - {{ $arg }}
         {{- end }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         name: {{ .Chart.Name }}
-        env:
-        # The pod name to pass with the downward API
-        - name: POD_NAME
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.name
-        # The pod namespace to pass with the downward API
-        - name: POD_NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
         resources:
           {{- toYaml .Values.resourcesRBACManager | nindent 12 }}
         securityContext:

--- a/cluster/charts/crossplane/templates/rbac-manager-managed-clusterroles.yaml
+++ b/cluster/charts/crossplane/templates/rbac-manager-managed-clusterroles.yaml
@@ -1,0 +1,263 @@
+{{- if .Values.rbacManager.deploy }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ template "name" . }}-admin
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "name" . }}-admin
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: {{ template "name" . }}:master
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ template "name" . }}-admin
+  labels:
+    app: {{ template "name" . }}
+    chart: {{ template "chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+aggregationRule:
+  clusterRoleSelectors:
+  - matchLabels:
+      rbac.crossplane.io/aggregate-to-admin: "true"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ template "name" . }}-edit
+  labels:
+    app: {{ template "name" . }}
+    chart: {{ template "chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+aggregationRule:
+  clusterRoleSelectors:
+  - matchLabels:
+      rbac.crossplane.io/aggregate-to-edit: "true"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ template "name" . }}-view
+  labels:
+    app: {{ template "name" . }}
+    chart: {{ template "chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+aggregationRule:
+  clusterRoleSelectors:
+  - matchLabels:
+      rbac.crossplane.io/aggregate-to-view: "true"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ template "name" . }}-browse
+  labels:
+    app: {{ template "name" . }}
+    chart: {{ template "chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+aggregationRule:
+  clusterRoleSelectors:
+  - matchLabels:
+      rbac.crossplane.io/aggregate-to-browse: "true"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ template "name" . }}:aggregate-to-admin
+  labels:
+    rbac.crossplane.io/aggregate-to-admin: "true"
+    app: {{ template "name" . }}
+    chart: {{ template "chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+rules:
+# Crossplane administrators have access to view events.
+- apiGroups: [""]
+  resources: [events]
+  verbs: [get, list, watch]
+# Crossplane administrators must create provider credential secrets, and may
+# need to read or otherwise interact with connection secrets. They may also need
+# to create or annotate namespaces.
+- apiGroups: [""]
+  resources: [secrets, namespaces]
+  verbs: ["*"]
+# Crossplane administrators have access to view the roles that they may be able
+# to grant to other subjects.
+- apiGroups: [rbac.authorization.k8s.io]
+  resources: [clusterroles, roles]
+  verbs: [get, list, watch]
+# Crossplane administrators have access to grant the access they have to other
+# subjects.
+- apiGroups: [rbac.authorization.k8s.io]
+  resources: [clusterrolebindings, rolebindings]
+  verbs: ["*"]
+# Crossplane administrators have full access to built in Crossplane types.
+- apiGroups:
+  - apiextensions.crossplane.io
+  - pkg.crossplane.io
+  resources: ["*"]
+  verbs: ["*"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ template "name" . }}:aggregate-to-edit
+  labels:
+    rbac.crossplane.io/aggregate-to-edit: "true"
+    app: {{ template "name" . }}
+    chart: {{ template "chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+rules:
+# Crossplane editors have access to view events.
+- apiGroups: [""]
+  resources: [events]
+  verbs: [get, list, watch]
+# Crossplane editors must create provider credential secrets, and may need to
+# read or otherwise interact with connection secrets.
+- apiGroups: [""]
+  resources: [secrets]
+  verbs: ["*"]
+# Crossplane editors may see which namespaces exist, but not edit them.
+- apiGroups: [""]
+  resources: [namespaces]
+  verbs: [get, list, watch]
+# Crossplane editors have full access to built in Crossplane types.
+- apiGroups:
+  - apiextensions.crossplane.io
+  - pkg.crossplane.io
+  resources: ["*"]
+  verbs: ["*"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ template "name" . }}:aggregate-to-view
+  labels:
+    rbac.crossplane.io/aggregate-to-view: "true"
+    app: {{ template "name" . }}
+    chart: {{ template "chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+rules:
+# Crossplane viewers have access to view events.
+- apiGroups: [""]
+  resources: [events]
+  verbs: [get, list, watch]
+# Crossplane viewers may see which namespaces exist.
+- apiGroups: [""]
+  resources: [namespaces]
+  verbs: [get, list, watch]
+# Crossplane viewers have read-only access to built in Crossplane types.
+- apiGroups:
+  - apiextensions.crossplane.io
+  - pkg.crossplane.io
+  resources: ["*"]
+  verbs: [get, list, watch]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ template "name" . }}:aggregate-to-browse
+  labels:
+    rbac.crossplane.io/aggregate-to-browse: "true"
+    app: {{ template "name" . }}
+    chart: {{ template "chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+rules:
+# Crossplane browsers have access to view events.
+- apiGroups: [""]
+  resources: [events]
+  verbs: [get, list, watch]
+# Crossplane browsers have read-only access to compositions and XRDs. This
+# allows them to discover and select an appropriate composition when creating a
+# resource claim.
+- apiGroups:
+  - apiextensions.crossplane.io
+  resources: ["*"]
+  verbs: [get, list, watch]
+{{- if .Values.rbacManager.managementPolicy }}
+# The below ClusterRoles are aggregated to the namespaced RBAC roles created by
+# the Crossplane RBAC manager when it is running in --manage=All mode.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ template "name" . }}:aggregate-to-ns-admin
+  labels:
+    rbac.crossplane.io/aggregate-to-ns-admin: "true"
+    rbac.crossplane.io/base-of-ns-admin: "true"
+    app: {{ template "name" . }}
+    chart: {{ template "chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+rules:
+# Crossplane namespace admins have access to view events.
+- apiGroups: [""]
+  resources: [events]
+  verbs: [get, list, watch]
+# Crossplane namespace admins may need to read or otherwise interact with
+# resource claim connection secrets.
+- apiGroups: [""]
+  resources: [secrets]
+  verbs: ["*"]
+# Crossplane namespace admins have access to view the roles that they may be
+# able to grant to other subjects.
+- apiGroups: [rbac.authorization.k8s.io]
+  resources: [roles]
+  verbs: [get, list, watch]
+# Crossplane namespace admins have access to grant the access they have to other
+# subjects.
+- apiGroups: [rbac.authorization.k8s.io]
+  resources: [rolebindings]
+  verbs: ["*"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ template "name" . }}:aggregate-to-ns-edit
+  labels:
+    rbac.crossplane.io/aggregate-to-ns-edit: "true"
+    rbac.crossplane.io/base-of-ns-edit: "true"
+    app: {{ template "name" . }}
+    chart: {{ template "chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+rules:
+# Crossplane namespace editors have access to view events.
+- apiGroups: [""]
+  resources: [events]
+  verbs: [get, list, watch]
+# Crossplane namespace editors may need to read or otherwise interact with
+# resource claim connection secrets.
+- apiGroups: [""]
+  resources: [secrets]
+  verbs: ["*"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ template "name" . }}:aggregate-to-ns-view
+  labels:
+    rbac.crossplane.io/aggregate-to-ns-view: "true"
+    rbac.crossplane.io/base-of-ns-view: "true"
+    app: {{ template "name" . }}
+    chart: {{ template "chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+rules:
+# Crossplane namespace viewers have access to view events.
+- apiGroups: [""]
+  resources: [events]
+  verbs: [get, list, watch]
+{{- end}}
+{{- end}}

--- a/cluster/charts/crossplane/templates/rbac-manager-serviceaccount.yaml
+++ b/cluster/charts/crossplane/templates/rbac-manager-serviceaccount.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.rbacManager.deploy }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: rbac-manager
+  labels:
+    app: {{ template "name" . }}
+    chart: {{ template "chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+{{- end}}

--- a/cluster/charts/crossplane/values.yaml.tmpl
+++ b/cluster/charts/crossplane/values.yaml.tmpl
@@ -12,8 +12,14 @@ args: {}
 imagePullSecrets:
 - dockerhub
 
-personas:
+rbacManager:
   deploy: true
+  managementPolicy: All
+
+# Deprecated. Use rbacManager instead.
+# TODO(negz): Disable deployment of the (deprecated) package manager by default.
+personas:
+  deploy: false
 
 clusterPackages:
   aws:
@@ -39,6 +45,14 @@ templateStacks:
 priorityClassName: ""
 
 resourcesCrossplane:
+  limits:
+    cpu: 100m
+    memory: 512Mi
+  requests:
+    cpu: 100m
+    memory: 256Mi
+
+resourcesRBACManager:
   limits:
     cpu: 100m
     memory: 512Mi

--- a/cmd/crossplane/main.go
+++ b/cmd/crossplane/main.go
@@ -28,6 +28,7 @@ import (
 	"github.com/crossplane/crossplane/cmd/crossplane/core"
 	"github.com/crossplane/crossplane/cmd/crossplane/package/manage"
 	"github.com/crossplane/crossplane/cmd/crossplane/package/unpack"
+	"github.com/crossplane/crossplane/cmd/crossplane/rbac"
 )
 
 func main() {
@@ -38,6 +39,7 @@ func main() {
 	)
 
 	c := core.FromKingpin(app.Command("core", "Start core Crossplane controllers.").Default())
+	r := rbac.FromKingpin(app.Command("rbac", "Start Crossplane RBAC Manager controllers."))
 	m := manage.FromKingpin(pkg.Command("manage", "Start Crossplane Package Manager controllers"))
 	u := unpack.FromKingpin(pkg.Command("unpack", "Unpack a Package").Alias("unpackage"))
 	cmd := kingpin.MustParse(app.Parse(os.Args[1:]))
@@ -55,6 +57,8 @@ func main() {
 	switch cmd {
 	case c.Name:
 		kingpin.FatalIfError(c.Run(logging.NewLogrLogger(zl.WithName("crossplane"))), "cannot run crossplane")
+	case r.Name:
+		kingpin.FatalIfError(r.Run(logging.NewLogrLogger(zl.WithName("rbac"))), "cannot run RBAC manager")
 	case m.Name:
 		kingpin.FatalIfError(m.Run(logging.NewLogrLogger(zl.WithName("package-manager"))), "cannot run package manager")
 	case u.Name:

--- a/cmd/crossplane/rbac/rbac.go
+++ b/cmd/crossplane/rbac/rbac.go
@@ -45,13 +45,12 @@ type Command struct {
 func FromKingpin(cmd *kingpin.CmdClause) *Command {
 	c := &Command{Name: cmd.FullCommand()}
 	cmd.Flag("sync", "Controller manager sync period duration such as 300ms, 1.5h or 2h45m").Short('s').Default("1h").DurationVar(&c.Sync)
-	cmd.Flag("manage", "").Short('m').Default(ManagementPolicyAll).EnumVar(&c.ManagementPolicy, ManagementPolicyAll, ManagementPolicyBasic)
+	cmd.Flag("manage", "RBAC management policy.").Short('m').Default(ManagementPolicyAll).EnumVar(&c.ManagementPolicy, ManagementPolicyAll, ManagementPolicyBasic)
 
 	return c
 }
 
 // Run the RBAC manager.
-// nolint:gocyclo
 func (c *Command) Run(log logging.Logger) error {
 	log.Debug("Starting", "sync-period", c.Sync.String(), "policy", c.ManagementPolicy)
 

--- a/cmd/crossplane/rbac/rbac.go
+++ b/cmd/crossplane/rbac/rbac.go
@@ -1,0 +1,77 @@
+/*
+Copyright 2019 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rbac
+
+import (
+	"time"
+
+	"github.com/pkg/errors"
+	"gopkg.in/alecthomas/kingpin.v2"
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	"github.com/crossplane/crossplane-runtime/pkg/logging"
+	"github.com/crossplane/crossplane/apis"
+	"github.com/crossplane/crossplane/pkg/controller/rbac"
+)
+
+// Available RBAC management policies.
+const (
+	ManagementPolicyAll   = string(rbac.ManagementPolicyAll)
+	ManagementPolicyBasic = string(rbac.ManagementPolicyBasic)
+)
+
+// Command configuration for the RBAC manager.
+type Command struct {
+	Name             string
+	Sync             time.Duration
+	ManagementPolicy string
+}
+
+// FromKingpin produces the RBAC manager command from a Kingpin command.
+func FromKingpin(cmd *kingpin.CmdClause) *Command {
+	c := &Command{Name: cmd.FullCommand()}
+	cmd.Flag("sync", "Controller manager sync period duration such as 300ms, 1.5h or 2h45m").Short('s').Default("1h").DurationVar(&c.Sync)
+	cmd.Flag("manage", "").Short('m').Default(ManagementPolicyAll).EnumVar(&c.ManagementPolicy, ManagementPolicyAll, ManagementPolicyBasic)
+
+	return c
+}
+
+// Run the RBAC manager.
+// nolint:gocyclo
+func (c *Command) Run(log logging.Logger) error {
+	log.Debug("Starting", "sync-period", c.Sync.String(), "policy", c.ManagementPolicy)
+
+	cfg, err := ctrl.GetConfig()
+	if err != nil {
+		return errors.Wrap(err, "Cannot get config")
+	}
+
+	mgr, err := ctrl.NewManager(cfg, ctrl.Options{SyncPeriod: &c.Sync})
+	if err != nil {
+		return errors.Wrap(err, "Cannot create manager")
+	}
+
+	if err := apis.AddToScheme(mgr.GetScheme()); err != nil {
+		return errors.Wrap(err, "Cannot add core Crossplane APIs to scheme")
+	}
+
+	if err := rbac.Setup(mgr, log, rbac.ManagementPolicy(c.ManagementPolicy)); err != nil {
+		return errors.Wrap(err, "Cannot add RBAC controllers to manager")
+	}
+
+	return errors.Wrap(mgr.Start(ctrl.SetupSignalHandler()), "Cannot start controller manager")
+}

--- a/pkg/controller/apiextensions/apiextensions.go
+++ b/pkg/controller/apiextensions/apiextensions.go
@@ -25,7 +25,7 @@ import (
 	"github.com/crossplane/crossplane/pkg/controller/apiextensions/offered"
 )
 
-// Setup workload controllers.
+// Setup API extensions controllers.
 func Setup(mgr ctrl.Manager, l logging.Logger) error {
 	for _, setup := range []func(ctrl.Manager, logging.Logger) error{
 		definition.Setup,

--- a/pkg/controller/rbac/definition/reconciler.go
+++ b/pkg/controller/rbac/definition/reconciler.go
@@ -1,0 +1,202 @@
+/*
+Copyright 2020 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package definition
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/pkg/errors"
+	rbacv1 "k8s.io/api/rbac/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	kcontroller "sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"github.com/crossplane/crossplane-runtime/pkg/event"
+	"github.com/crossplane/crossplane-runtime/pkg/logging"
+	"github.com/crossplane/crossplane-runtime/pkg/meta"
+	"github.com/crossplane/crossplane-runtime/pkg/resource"
+	"github.com/crossplane/crossplane-runtime/pkg/resource/unstructured"
+
+	"github.com/crossplane/crossplane/apis/apiextensions/v1alpha1"
+)
+
+const (
+	shortWait = 30 * time.Second
+
+	timeout        = 2 * time.Minute
+	maxConcurrency = 5
+
+	errGetXRD    = "cannot get CompositeResourceDefinition"
+	errApplyRole = "cannot apply ClusterRoles"
+)
+
+// Event reasons.
+const (
+	reasonApplyRoles event.Reason = "ApplyClusterRoles"
+)
+
+// A ClusterRoleRenderer renders ClusterRoles for a given XRD.
+type ClusterRoleRenderer interface {
+	// RenderClusterRoles for the supplied XRD.
+	RenderClusterRoles(d *v1alpha1.CompositeResourceDefinition) []rbacv1.ClusterRole
+}
+
+// A ClusterRoleRenderFn renders ClusterRoles for the supplied XRD.
+type ClusterRoleRenderFn func(d *v1alpha1.CompositeResourceDefinition) []rbacv1.ClusterRole
+
+// RenderClusterRoles renders ClusterRoles for the supplied XRD.
+func (fn ClusterRoleRenderFn) RenderClusterRoles(d *v1alpha1.CompositeResourceDefinition) []rbacv1.ClusterRole {
+	return fn(d)
+}
+
+// Setup adds a controller that reconciles a CompositeResourceDefinition by
+// creating a series of opinionated ClusterRoles that may be bound to allow
+// access to the resources it defines.
+func Setup(mgr ctrl.Manager, log logging.Logger) error {
+	name := "rbac/" + strings.ToLower(v1alpha1.CompositeResourceDefinitionGroupKind)
+
+	return ctrl.NewControllerManagedBy(mgr).
+		Named(name).
+		For(&v1alpha1.CompositeResourceDefinition{}).
+		Owns(&rbacv1.ClusterRole{}).
+		WithOptions(kcontroller.Options{MaxConcurrentReconciles: maxConcurrency}).
+		Complete(NewReconciler(mgr,
+			WithLogger(log.WithValues("controller", name)),
+			WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name)))))
+}
+
+// ReconcilerOption is used to configure the Reconciler.
+type ReconcilerOption func(*Reconciler)
+
+// WithLogger specifies how the Reconciler should log messages.
+func WithLogger(log logging.Logger) ReconcilerOption {
+	return func(r *Reconciler) {
+		r.log = log
+	}
+}
+
+// WithRecorder specifies how the Reconciler should record Kubernetes events.
+func WithRecorder(er event.Recorder) ReconcilerOption {
+	return func(r *Reconciler) {
+		r.record = er
+	}
+}
+
+// WithClientApplicator specifies how the Reconciler should interact with the
+// Kubernetes API.
+func WithClientApplicator(ca resource.ClientApplicator) ReconcilerOption {
+	return func(r *Reconciler) {
+		r.client = ca
+	}
+}
+
+// WithClusterRoleRenderer specifies how the Reconciler should render RBAC
+// ClusterRoles.
+func WithClusterRoleRenderer(rr ClusterRoleRenderer) ReconcilerOption {
+	return func(r *Reconciler) {
+		r.rbac = rr
+	}
+}
+
+// NewReconciler returns a Reconciler of CompositeResourceDefinitions.
+func NewReconciler(mgr manager.Manager, opts ...ReconcilerOption) *Reconciler {
+	kube := unstructured.NewClient(mgr.GetClient())
+
+	r := &Reconciler{
+		mgr: mgr,
+
+		// TODO(negz): Is Updating appropriate here? Probably.
+		client: resource.ClientApplicator{
+			Client:     kube,
+			Applicator: resource.NewAPIUpdatingApplicator(kube),
+		},
+
+		rbac: ClusterRoleRenderFn(RenderClusterRoles),
+
+		log:    logging.NewNopLogger(),
+		record: event.NewNopRecorder(),
+	}
+
+	for _, f := range opts {
+		f(r)
+	}
+	return r
+}
+
+// A Reconciler reconciles CompositeResourceDefinitions.
+type Reconciler struct {
+	client resource.ClientApplicator
+	mgr    manager.Manager
+	rbac   ClusterRoleRenderer
+
+	log    logging.Logger
+	record event.Recorder
+}
+
+// Reconcile a CompositeResourceDefinition by creating a series of opinionated
+// ClusterRoles that may be bound to allow access to the resources it defines.
+func (r *Reconciler) Reconcile(req reconcile.Request) (reconcile.Result, error) {
+
+	log := r.log.WithValues("request", req)
+	log.Debug("Reconciling")
+
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	d := &v1alpha1.CompositeResourceDefinition{}
+	if err := r.client.Get(ctx, req.NamespacedName, d); err != nil {
+		// In case object is not found, most likely the object was deleted and
+		// then disappeared while the event was in the processing queue. We
+		// don't need to take any action in that case.
+		log.Debug(errGetXRD, "error", err)
+		return reconcile.Result{}, errors.Wrap(resource.IgnoreNotFound(err), errGetXRD)
+	}
+
+	log = log.WithValues(
+		"uid", d.GetUID(),
+		"version", d.GetResourceVersion(),
+		"name", d.GetName(),
+	)
+
+	if meta.WasDeleted(d) {
+		// There's nothing to do if our XRD is being deleted. Any ClusterRoles
+		// we created will be garbage collected by Kubernetes.
+		return reconcile.Result{Requeue: false}, nil
+	}
+
+	for _, cr := range r.rbac.RenderClusterRoles(d) {
+		cr := cr // Pin range variable so we can take its address.
+
+		if err := r.client.Apply(ctx, &cr, resource.MustBeControllableBy(d.GetUID())); err != nil {
+			log.Debug(errApplyRole, "error", err)
+			r.record.Event(d, event.Warning(reasonApplyRoles, errors.Wrap(err, errApplyRole)))
+			return reconcile.Result{RequeueAfter: shortWait}, nil
+		}
+
+		log.Debug("Applied RBAC ClusterRole", "role-name", cr.GetName())
+	}
+
+	// TODO(negz): Add a condition that indicates the RBAC manager is managing
+	// cluster roles for this XRD?
+	r.record.Event(d, event.Normal(reasonApplyRoles, "Applied RBAC ClusterRoles"))
+
+	// There's no need to requeue explicitly - we're watching all XRDs.
+	return reconcile.Result{Requeue: false}, nil
+}

--- a/pkg/controller/rbac/definition/reconciler_test.go
+++ b/pkg/controller/rbac/definition/reconciler_test.go
@@ -1,0 +1,169 @@
+/*
+Copyright 2020 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package definition
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/pkg/errors"
+	rbacv1 "k8s.io/api/rbac/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"github.com/crossplane/crossplane-runtime/pkg/resource"
+	"github.com/crossplane/crossplane-runtime/pkg/resource/fake"
+	"github.com/crossplane/crossplane-runtime/pkg/test"
+
+	"github.com/crossplane/crossplane/apis/apiextensions/v1alpha1"
+)
+
+func TestReconcile(t *testing.T) {
+	errBoom := errors.New("boom")
+	now := metav1.Now()
+
+	type args struct {
+		mgr  manager.Manager
+		opts []ReconcilerOption
+	}
+	type want struct {
+		r   reconcile.Result
+		err error
+	}
+
+	cases := map[string]struct {
+		reason string
+		args   args
+		want   want
+	}{
+		"CompositeResourceDefinitionNotFound": {
+			reason: "We should not return an error if the CompositeResourceDefinition was not found.",
+			args: args{
+				mgr: &fake.Manager{},
+				opts: []ReconcilerOption{
+					WithClientApplicator(resource.ClientApplicator{
+						Client: &test.MockClient{
+							MockGet: test.NewMockGetFn(kerrors.NewNotFound(schema.GroupResource{}, "")),
+						},
+					}),
+				},
+			},
+			want: want{
+				r: reconcile.Result{},
+			},
+		},
+		"GetCompositeResourceDefinitionError": {
+			reason: "We should return any other error encountered while getting an CompositeResourceDefinition.",
+			args: args{
+				mgr: &fake.Manager{},
+				opts: []ReconcilerOption{
+					WithClientApplicator(resource.ClientApplicator{
+						Client: &test.MockClient{
+							MockGet: test.NewMockGetFn(errBoom),
+						},
+					}),
+				},
+			},
+			want: want{
+				err: errors.Wrap(errBoom, errGetXRD),
+			},
+		},
+		"CompositeResourceDefinitionDeleted": {
+			reason: "We should return early if the CompositeResourceDefinition was deleted.",
+			args: args{
+				mgr: &fake.Manager{},
+				opts: []ReconcilerOption{
+					WithClientApplicator(resource.ClientApplicator{
+						Client: &test.MockClient{
+							MockGet: test.NewMockGetFn(nil, func(o runtime.Object) error {
+								d := o.(*v1alpha1.CompositeResourceDefinition)
+								d.SetDeletionTimestamp(&now)
+								return nil
+							}),
+						},
+					}),
+				},
+			},
+			want: want{
+				r: reconcile.Result{Requeue: false},
+			},
+		},
+		"ApplyClusterRoleError": {
+			reason: "We should requeue when an error is encountered applying a ClusterRole.",
+			args: args{
+				mgr: &fake.Manager{},
+				opts: []ReconcilerOption{
+					WithClientApplicator(resource.ClientApplicator{
+						Client: &test.MockClient{
+							MockGet: test.NewMockGetFn(nil),
+						},
+						Applicator: resource.ApplyFn(func(context.Context, runtime.Object, ...resource.ApplyOption) error {
+							return errBoom
+						}),
+					}),
+					WithClusterRoleRenderer(ClusterRoleRenderFn(func(*v1alpha1.CompositeResourceDefinition) []rbacv1.ClusterRole {
+						return []rbacv1.ClusterRole{{}}
+					})),
+				},
+			},
+			want: want{
+				r: reconcile.Result{RequeueAfter: shortWait},
+			},
+		},
+		"Successful": {
+			reason: "We should not requeue when we successfully apply our ClusterRoles.",
+			args: args{
+				mgr: &fake.Manager{},
+				opts: []ReconcilerOption{
+					WithClientApplicator(resource.ClientApplicator{
+						Client: &test.MockClient{
+							MockGet: test.NewMockGetFn(nil),
+						},
+						Applicator: resource.ApplyFn(func(context.Context, runtime.Object, ...resource.ApplyOption) error {
+							return nil
+						}),
+					}),
+					WithClusterRoleRenderer(ClusterRoleRenderFn(func(*v1alpha1.CompositeResourceDefinition) []rbacv1.ClusterRole {
+						return []rbacv1.ClusterRole{{}}
+					})),
+				},
+			},
+			want: want{
+				r: reconcile.Result{Requeue: false},
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			r := NewReconciler(tc.args.mgr, tc.args.opts...)
+			got, err := r.Reconcile(reconcile.Request{})
+
+			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
+				t.Errorf("\n%s\nr.Reconcile(...): -want error, +got error:\n%s", tc.reason, diff)
+			}
+			if diff := cmp.Diff(tc.want.r, got, test.EquateErrors()); diff != "" {
+				t.Errorf("\n%s\nr.Reconcile(...): -want, +got:\n%s", tc.reason, diff)
+			}
+		})
+	}
+}

--- a/pkg/controller/rbac/definition/roles.go
+++ b/pkg/controller/rbac/definition/roles.go
@@ -1,0 +1,150 @@
+/*
+Copyright 2020 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package definition
+
+import (
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/crossplane/crossplane-runtime/pkg/meta"
+	"github.com/crossplane/crossplane/apis/apiextensions/v1alpha1"
+)
+
+// TODO(negz): Aggregate to the crossplane service account role, too.
+
+const (
+	namePrefix       = "crossplane:composite:"
+	nameSuffixEdit   = ":aggregate-to-edit"
+	nameSuffixView   = ":aggregate-to-view"
+	nameSuffixBrowse = ":aggregate-to-browse"
+
+	keyAggregateToCrossplane = "rbac.crossplane.io/aggregate-to-crossplane"
+
+	keyAggregateToAdmin   = "rbac.crossplane.io/aggregate-to-admin"
+	keyAggregateToNSAdmin = "rbac.crossplane.io/aggregate-to-ns-admin"
+
+	keyAggregateToEdit   = "rbac.crossplane.io/aggregate-to-edit"
+	keyAggregateToNSEdit = "rbac.crossplane.io/aggregate-to-ns-edit"
+
+	keyAggregateToView   = "rbac.crossplane.io/aggregate-to-view"
+	keyAggregateToNSView = "rbac.crossplane.io/aggregate-to-ns-view"
+
+	keyAggregateToBrowse = "rbac.crossplane.io/aggregate-to-browse"
+
+	keyXRD = "rbac.crossplane.io/xrd"
+
+	valTrue = "true"
+)
+
+var (
+	verbsEdit   = []string{rbacv1.VerbAll}
+	verbsView   = []string{"get", "list", "watch"}
+	verbsBrowse = []string{"get", "list", "watch"}
+)
+
+// RenderClusterRoles returns two ClusterRoles for the supplied XRD; one that
+// grants all verbs on the composite resource it defines and claim it offers (if
+// any), and one that grants "read-only" verbs.
+func RenderClusterRoles(d *v1alpha1.CompositeResourceDefinition) []rbacv1.ClusterRole {
+	edit := &rbacv1.ClusterRole{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: namePrefix + d.GetName() + nameSuffixEdit,
+			Labels: map[string]string{
+				// Edit rules aggregate to the Crossplane ClusterRole too.
+				// Crossplane needs access to reconcile all composite resources
+				// and composite resource claims.
+				keyAggregateToCrossplane: valTrue,
+
+				// Edit rules aggregate to admin too. Currently edit and admin
+				// differ only in their base roles.
+				keyAggregateToAdmin:   valTrue,
+				keyAggregateToNSAdmin: valTrue,
+
+				keyAggregateToEdit:   valTrue,
+				keyAggregateToNSEdit: valTrue,
+
+				keyXRD: d.GetName(),
+			},
+		},
+		Rules: []rbacv1.PolicyRule{
+			{
+				APIGroups: []string{d.Spec.CRDSpecTemplate.Group},
+				Resources: []string{d.Spec.CRDSpecTemplate.Names.Plural},
+				Verbs:     verbsEdit,
+			},
+		},
+	}
+
+	view := &rbacv1.ClusterRole{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: namePrefix + d.GetName() + nameSuffixView,
+			Labels: map[string]string{
+				keyAggregateToView:   valTrue,
+				keyAggregateToNSView: valTrue,
+
+				keyXRD: d.GetName(),
+			},
+		},
+		Rules: []rbacv1.PolicyRule{
+			{
+				APIGroups: []string{d.Spec.CRDSpecTemplate.Group},
+				Resources: []string{d.Spec.CRDSpecTemplate.Names.Plural},
+				Verbs:     verbsView,
+			},
+		},
+	}
+
+	browse := &rbacv1.ClusterRole{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: namePrefix + d.GetName() + nameSuffixBrowse,
+			Labels: map[string]string{
+				keyAggregateToBrowse: valTrue,
+
+				keyXRD: d.GetName(),
+			},
+		},
+		Rules: []rbacv1.PolicyRule{
+			{
+				APIGroups: []string{d.Spec.CRDSpecTemplate.Group},
+				Resources: []string{d.Spec.CRDSpecTemplate.Names.Plural},
+				Verbs:     verbsBrowse,
+			},
+		},
+	}
+
+	if d.Spec.ClaimNames != nil {
+		edit.Rules = append(edit.Rules, rbacv1.PolicyRule{
+			APIGroups: []string{d.Spec.CRDSpecTemplate.Group},
+			Resources: []string{d.Spec.ClaimNames.Plural},
+			Verbs:     verbsEdit,
+		})
+
+		view.Rules = append(view.Rules, rbacv1.PolicyRule{
+			APIGroups: []string{d.Spec.CRDSpecTemplate.Group},
+			Resources: []string{d.Spec.ClaimNames.Plural},
+			Verbs:     verbsView,
+		})
+
+		// The browse role only includes composite resources; not claims.
+	}
+
+	for _, o := range []metav1.Object{edit, view, browse} {
+		meta.AddOwnerReference(o, meta.AsController(meta.TypedReferenceTo(d, v1alpha1.CompositeResourceDefinitionGroupVersionKind)))
+	}
+
+	return []rbacv1.ClusterRole{*edit, *view, *browse}
+}

--- a/pkg/controller/rbac/definition/roles.go
+++ b/pkg/controller/rbac/definition/roles.go
@@ -56,9 +56,7 @@ var (
 	verbsBrowse = []string{"get", "list", "watch"}
 )
 
-// RenderClusterRoles returns two ClusterRoles for the supplied XRD; one that
-// grants all verbs on the composite resource it defines and claim it offers (if
-// any), and one that grants "read-only" verbs.
+// RenderClusterRoles returns ClusterRoles for the supplied XRD.
 func RenderClusterRoles(d *v1alpha1.CompositeResourceDefinition) []rbacv1.ClusterRole {
 	edit := &rbacv1.ClusterRole{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/controller/rbac/definition/roles_test.go
+++ b/pkg/controller/rbac/definition/roles_test.go
@@ -1,0 +1,214 @@
+/*
+Copyright 2020 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package definition
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/crossplane/crossplane/apis/apiextensions/v1alpha1"
+)
+
+func TestRenderClusterRoles(t *testing.T) {
+	group := "example.org"
+	pluralXR := "coolcomposites"
+	pluralXRC := "coolclaims"
+	name := pluralXR + "." + group
+	uid := types.UID("no-you-id")
+
+	ctrl := true
+	owner := metav1.OwnerReference{
+		APIVersion: v1alpha1.CompositeResourceDefinitionGroupVersionKind.GroupVersion().String(),
+		Kind:       v1alpha1.CompositeResourceDefinitionKind,
+		Name:       name,
+		UID:        uid,
+		Controller: &ctrl,
+	}
+
+	cases := map[string]struct {
+		reason string
+		d      *v1alpha1.CompositeResourceDefinition
+		want   []rbacv1.ClusterRole
+	}{
+		"DoesNotOfferClaim": {
+			reason: "An XRD that does not offer a claim should produce ClusterRoles that grant access to only the composite",
+			d: &v1alpha1.CompositeResourceDefinition{
+				ObjectMeta: metav1.ObjectMeta{Name: name, UID: uid},
+				Spec: v1alpha1.CompositeResourceDefinitionSpec{
+					CRDSpecTemplate: v1alpha1.CRDSpecTemplate{
+						Group: group,
+						Names: v1beta1.CustomResourceDefinitionNames{Plural: pluralXR},
+					},
+				},
+			},
+			want: []rbacv1.ClusterRole{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            namePrefix + name + nameSuffixEdit,
+						OwnerReferences: []metav1.OwnerReference{owner},
+						Labels: map[string]string{
+							keyAggregateToCrossplane: valTrue,
+							keyAggregateToAdmin:      valTrue,
+							keyAggregateToNSAdmin:    valTrue,
+							keyAggregateToEdit:       valTrue,
+							keyAggregateToNSEdit:     valTrue,
+							keyXRD:                   name,
+						},
+					},
+					Rules: []rbacv1.PolicyRule{
+						{
+							APIGroups: []string{group},
+							Resources: []string{pluralXR},
+							Verbs:     verbsEdit,
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            namePrefix + name + nameSuffixView,
+						OwnerReferences: []metav1.OwnerReference{owner},
+						Labels: map[string]string{
+							keyAggregateToView:   valTrue,
+							keyAggregateToNSView: valTrue,
+							keyXRD:               name,
+						},
+					},
+					Rules: []rbacv1.PolicyRule{
+						{
+							APIGroups: []string{group},
+							Resources: []string{pluralXR},
+							Verbs:     verbsView,
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            namePrefix + name + nameSuffixBrowse,
+						OwnerReferences: []metav1.OwnerReference{owner},
+						Labels: map[string]string{
+							keyAggregateToBrowse: valTrue,
+							keyXRD:               name,
+						},
+					},
+					Rules: []rbacv1.PolicyRule{
+						{
+							APIGroups: []string{group},
+							Resources: []string{pluralXR},
+							Verbs:     verbsBrowse,
+						},
+					},
+				},
+			},
+		},
+		"OffersClaim": {
+			reason: "An XRD that offers a claim should produce ClusterRoles that grant access to that claim",
+			d: &v1alpha1.CompositeResourceDefinition{
+				ObjectMeta: metav1.ObjectMeta{Name: name, UID: uid},
+				Spec: v1alpha1.CompositeResourceDefinitionSpec{
+					ClaimNames: &v1beta1.CustomResourceDefinitionNames{Plural: pluralXRC},
+					CRDSpecTemplate: v1alpha1.CRDSpecTemplate{
+						Group: group,
+						Names: v1beta1.CustomResourceDefinitionNames{Plural: pluralXR},
+					},
+				},
+			},
+			want: []rbacv1.ClusterRole{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            namePrefix + name + nameSuffixEdit,
+						OwnerReferences: []metav1.OwnerReference{owner},
+						Labels: map[string]string{
+							keyAggregateToCrossplane: valTrue,
+							keyAggregateToAdmin:      valTrue,
+							keyAggregateToNSAdmin:    valTrue,
+							keyAggregateToEdit:       valTrue,
+							keyAggregateToNSEdit:     valTrue,
+							keyXRD:                   name,
+						},
+					},
+					Rules: []rbacv1.PolicyRule{
+						{
+							APIGroups: []string{group},
+							Resources: []string{pluralXR},
+							Verbs:     verbsEdit,
+						},
+						{
+							APIGroups: []string{group},
+							Resources: []string{pluralXRC},
+							Verbs:     verbsEdit,
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            namePrefix + name + nameSuffixView,
+						OwnerReferences: []metav1.OwnerReference{owner},
+						Labels: map[string]string{
+							keyAggregateToView:   valTrue,
+							keyAggregateToNSView: valTrue,
+							keyXRD:               name,
+						},
+					},
+					Rules: []rbacv1.PolicyRule{
+						{
+							APIGroups: []string{group},
+							Resources: []string{pluralXR},
+							Verbs:     verbsView,
+						},
+						{
+							APIGroups: []string{group},
+							Resources: []string{pluralXRC},
+							Verbs:     verbsView,
+						},
+					},
+				},
+				{
+					// The browse role never includes claims.
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            namePrefix + name + nameSuffixBrowse,
+						OwnerReferences: []metav1.OwnerReference{owner},
+						Labels: map[string]string{
+							keyAggregateToBrowse: valTrue,
+							keyXRD:               name,
+						},
+					},
+					Rules: []rbacv1.PolicyRule{
+						{
+							APIGroups: []string{group},
+							Resources: []string{pluralXR},
+							Verbs:     verbsBrowse,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got := RenderClusterRoles(tc.d)
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("RenderClusterRoles(...): -want, +got:\n%s\n", diff)
+			}
+		})
+	}
+}

--- a/pkg/controller/rbac/namespace/reconciler.go
+++ b/pkg/controller/rbac/namespace/reconciler.go
@@ -1,0 +1,213 @@
+/*
+Copyright 2020 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package namespace
+
+import (
+	"context"
+	"time"
+
+	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	kcontroller "sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+
+	"github.com/crossplane/crossplane-runtime/pkg/event"
+	"github.com/crossplane/crossplane-runtime/pkg/logging"
+	"github.com/crossplane/crossplane-runtime/pkg/meta"
+	"github.com/crossplane/crossplane-runtime/pkg/resource"
+	"github.com/crossplane/crossplane-runtime/pkg/resource/unstructured"
+)
+
+const (
+	shortWait = 30 * time.Second
+
+	timeout        = 2 * time.Minute
+	maxConcurrency = 5
+
+	errGetNamespace = "cannot get CompositeResourceDefinition"
+	errApplyRole    = "cannot apply Roles"
+	errListRoles    = "cannot list ClusterRoles"
+)
+
+// Event reasons.
+const (
+	reasonApplyRoles event.Reason = "ApplyRoles"
+)
+
+// A RoleRenderer renders Roles for a given Namespace.
+type RoleRenderer interface {
+	// RenderRoles for the supplied Namespace.
+	RenderRoles(d *corev1.Namespace, crs []rbacv1.ClusterRole) []rbacv1.Role
+}
+
+// A RoleRenderFn renders Roles for the supplied Namespace.
+type RoleRenderFn func(d *corev1.Namespace, crs []rbacv1.ClusterRole) []rbacv1.Role
+
+// RenderRoles renders Roles for the supplied Namespace.
+func (fn RoleRenderFn) RenderRoles(d *corev1.Namespace, crs []rbacv1.ClusterRole) []rbacv1.Role {
+	return fn(d, crs)
+}
+
+// Setup adds a controller that reconciles a Namespace by creating a series of
+// opinionated Roles that may be bound to allow access to resources within that
+// namespace.
+func Setup(mgr ctrl.Manager, log logging.Logger) error {
+	name := "rbac/namespace"
+
+	return ctrl.NewControllerManagedBy(mgr).
+		Named(name).
+		For(&corev1.Namespace{}).
+		Owns(&rbacv1.Role{}).
+		Watches(&source.Kind{Type: &rbacv1.ClusterRole{}}, &EnqueueRequestForNamespaces{client: mgr.GetClient()}).
+		WithOptions(kcontroller.Options{MaxConcurrentReconciles: maxConcurrency}).
+		Complete(NewReconciler(mgr,
+			WithLogger(log.WithValues("controller", name)),
+			WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name)))))
+}
+
+// ReconcilerOption is used to configure the Reconciler.
+type ReconcilerOption func(*Reconciler)
+
+// WithLogger specifies how the Reconciler should log messages.
+func WithLogger(log logging.Logger) ReconcilerOption {
+	return func(r *Reconciler) {
+		r.log = log
+	}
+}
+
+// WithRecorder specifies how the Reconciler should record Kubernetes events.
+func WithRecorder(er event.Recorder) ReconcilerOption {
+	return func(r *Reconciler) {
+		r.record = er
+	}
+}
+
+// WithClientApplicator specifies how the Reconciler should interact with the
+// Kubernetes API.
+func WithClientApplicator(ca resource.ClientApplicator) ReconcilerOption {
+	return func(r *Reconciler) {
+		r.client = ca
+	}
+}
+
+// WithRoleRenderer specifies how the Reconciler should render RBAC
+// Roles.
+func WithRoleRenderer(rr RoleRenderer) ReconcilerOption {
+	return func(r *Reconciler) {
+		r.rbac = rr
+	}
+}
+
+// NewReconciler returns a Reconciler of Namespaces.
+func NewReconciler(mgr manager.Manager, opts ...ReconcilerOption) *Reconciler {
+	kube := unstructured.NewClient(mgr.GetClient())
+
+	r := &Reconciler{
+		mgr: mgr,
+
+		// TODO(negz): Is Updating appropriate here? Probably.
+		client: resource.ClientApplicator{
+			Client:     kube,
+			Applicator: resource.NewAPIUpdatingApplicator(kube),
+		},
+
+		rbac: RoleRenderFn(RenderRoles),
+
+		log:    logging.NewNopLogger(),
+		record: event.NewNopRecorder(),
+	}
+
+	for _, f := range opts {
+		f(r)
+	}
+	return r
+}
+
+// A Reconciler reconciles Namespaces.
+type Reconciler struct {
+	client resource.ClientApplicator
+	mgr    manager.Manager
+	rbac   RoleRenderer
+
+	log    logging.Logger
+	record event.Recorder
+}
+
+// Reconcile a Namespaces by creating a series of opinionated Roles that may be
+// bound to allow access to resources within that namespace.
+func (r *Reconciler) Reconcile(req reconcile.Request) (reconcile.Result, error) {
+
+	log := r.log.WithValues("request", req)
+	log.Debug("Reconciling")
+
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	ns := &corev1.Namespace{}
+	if err := r.client.Get(ctx, req.NamespacedName, ns); err != nil {
+		// In case object is not found, most likely the object was deleted and
+		// then disappeared while the event was in the processing queue. We
+		// don't need to take any action in that case.
+		log.Debug(errGetNamespace, "error", err)
+		return reconcile.Result{}, errors.Wrap(resource.IgnoreNotFound(err), errGetNamespace)
+	}
+
+	log = log.WithValues(
+		"uid", ns.GetUID(),
+		"version", ns.GetResourceVersion(),
+		"name", ns.GetName(),
+	)
+
+	if meta.WasDeleted(ns) {
+		// There's nothing to do if our namespace is being deleted. Any Roles we
+		// created will be deleted along with the namespace.
+		return reconcile.Result{Requeue: false}, nil
+	}
+
+	// NOTE(negz): We don't expect there to be an unwieldy amount of roles, so
+	// we just list and pass them all.
+	l := &rbacv1.ClusterRoleList{}
+	if err := r.client.List(ctx, l); err != nil {
+		log.Debug(errListRoles, "error", err)
+		r.record.Event(ns, event.Warning(reasonApplyRoles, errors.Wrap(err, errListRoles)))
+		return reconcile.Result{RequeueAfter: shortWait}, nil
+	}
+
+	for _, rl := range r.rbac.RenderRoles(ns, l.Items) {
+		rl := rl // Pin range variable so we can take its address.
+
+		if err := r.client.Apply(ctx, &rl, resource.MustBeControllableBy(ns.GetUID())); err != nil {
+			log.Debug(errApplyRole, "error", err)
+			r.record.Event(ns, event.Warning(reasonApplyRoles, errors.Wrap(err, errApplyRole)))
+			return reconcile.Result{RequeueAfter: shortWait}, nil
+		}
+
+		log.Debug("Applied RBAC Role", "role-name", rl.GetName())
+	}
+
+	r.record.Event(ns, event.Normal(reasonApplyRoles, "Applied RBAC Roles"))
+
+	// TODO(negz): Requeue every 30 seconds or so, in case the ClusterRoles we
+	// aggregate change? Or create an EventHandler that enqueues requests for
+	// all namespaces whenever a ClusterRole with a Crossplane RBAC label
+	// changes.
+	return reconcile.Result{Requeue: false}, nil
+}

--- a/pkg/controller/rbac/namespace/reconciler_test.go
+++ b/pkg/controller/rbac/namespace/reconciler_test.go
@@ -1,0 +1,187 @@
+/*
+Copyright 2020 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package namespace
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"github.com/crossplane/crossplane-runtime/pkg/resource"
+	"github.com/crossplane/crossplane-runtime/pkg/resource/fake"
+	"github.com/crossplane/crossplane-runtime/pkg/test"
+)
+
+func TestReconcile(t *testing.T) {
+	errBoom := errors.New("boom")
+	now := metav1.Now()
+
+	type args struct {
+		mgr  manager.Manager
+		opts []ReconcilerOption
+	}
+	type want struct {
+		r   reconcile.Result
+		err error
+	}
+
+	cases := map[string]struct {
+		reason string
+		args   args
+		want   want
+	}{
+		"NamespaceNotFound": {
+			reason: "We should not return an error if the Namespace was not found.",
+			args: args{
+				mgr: &fake.Manager{},
+				opts: []ReconcilerOption{
+					WithClientApplicator(resource.ClientApplicator{
+						Client: &test.MockClient{
+							MockGet: test.NewMockGetFn(kerrors.NewNotFound(schema.GroupResource{}, "")),
+						},
+					}),
+				},
+			},
+			want: want{
+				r: reconcile.Result{},
+			},
+		},
+		"GetNamespaceError": {
+			reason: "We should return any other error encountered while getting an Namespace.",
+			args: args{
+				mgr: &fake.Manager{},
+				opts: []ReconcilerOption{
+					WithClientApplicator(resource.ClientApplicator{
+						Client: &test.MockClient{
+							MockGet: test.NewMockGetFn(errBoom),
+						},
+					}),
+				},
+			},
+			want: want{
+				err: errors.Wrap(errBoom, errGetNamespace),
+			},
+		},
+		"NamespaceDeleted": {
+			reason: "We should return early if the namespace was deleted.",
+			args: args{
+				mgr: &fake.Manager{},
+				opts: []ReconcilerOption{
+					WithClientApplicator(resource.ClientApplicator{
+						Client: &test.MockClient{
+							MockGet: test.NewMockGetFn(nil, func(o runtime.Object) error {
+								d := o.(*corev1.Namespace)
+								d.SetDeletionTimestamp(&now)
+								return nil
+							}),
+						},
+					}),
+				},
+			},
+			want: want{
+				r: reconcile.Result{Requeue: false},
+			},
+		},
+		"ListClusterRolesError": {
+			reason: "We should requeue when an error is encountered listing ClusterRoles.",
+			args: args{
+				mgr: &fake.Manager{},
+				opts: []ReconcilerOption{
+					WithClientApplicator(resource.ClientApplicator{
+						Client: &test.MockClient{
+							MockGet:  test.NewMockGetFn(nil),
+							MockList: test.NewMockListFn(errBoom),
+						},
+					}),
+				},
+			},
+			want: want{
+				r: reconcile.Result{RequeueAfter: shortWait},
+			},
+		},
+		"ApplyRoleError": {
+			reason: "We should requeue when an error is encountered applying a Role.",
+			args: args{
+				mgr: &fake.Manager{},
+				opts: []ReconcilerOption{
+					WithClientApplicator(resource.ClientApplicator{
+						Client: &test.MockClient{
+							MockGet:  test.NewMockGetFn(nil),
+							MockList: test.NewMockListFn(nil),
+						},
+						Applicator: resource.ApplyFn(func(context.Context, runtime.Object, ...resource.ApplyOption) error {
+							return errBoom
+						}),
+					}),
+					WithRoleRenderer(RoleRenderFn(func(*corev1.Namespace, []rbacv1.ClusterRole) []rbacv1.Role {
+						return []rbacv1.Role{{}}
+					})),
+				},
+			},
+			want: want{
+				r: reconcile.Result{RequeueAfter: shortWait},
+			},
+		},
+		"Successful": {
+			reason: "We should not requeue when we successfully apply our Roles.",
+			args: args{
+				mgr: &fake.Manager{},
+				opts: []ReconcilerOption{
+					WithClientApplicator(resource.ClientApplicator{
+						Client: &test.MockClient{
+							MockGet:  test.NewMockGetFn(nil),
+							MockList: test.NewMockListFn(nil),
+						},
+						Applicator: resource.ApplyFn(func(context.Context, runtime.Object, ...resource.ApplyOption) error {
+							return nil
+						}),
+					}),
+					WithRoleRenderer(RoleRenderFn(func(*corev1.Namespace, []rbacv1.ClusterRole) []rbacv1.Role {
+						return []rbacv1.Role{{}}
+					})),
+				},
+			},
+			want: want{
+				r: reconcile.Result{Requeue: false},
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			r := NewReconciler(tc.args.mgr, tc.args.opts...)
+			got, err := r.Reconcile(reconcile.Request{})
+
+			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
+				t.Errorf("\n%s\nr.Reconcile(...): -want error, +got error:\n%s", tc.reason, diff)
+			}
+			if diff := cmp.Diff(tc.want.r, got, test.EquateErrors()); diff != "" {
+				t.Errorf("\n%s\nr.Reconcile(...): -want, +got:\n%s", tc.reason, diff)
+			}
+		})
+	}
+}

--- a/pkg/controller/rbac/namespace/reconciler_test.go
+++ b/pkg/controller/rbac/namespace/reconciler_test.go
@@ -71,7 +71,7 @@ func TestReconcile(t *testing.T) {
 			},
 		},
 		"GetNamespaceError": {
-			reason: "We should return any other error encountered while getting an Namespace.",
+			reason: "We should return any other error encountered while getting a Namespace.",
 			args: args{
 				mgr: &fake.Manager{},
 				opts: []ReconcilerOption{

--- a/pkg/controller/rbac/namespace/roles.go
+++ b/pkg/controller/rbac/namespace/roles.go
@@ -1,0 +1,131 @@
+/*
+Copyright 2020 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICEE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIO OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package namespace
+
+import (
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/crossplane/crossplane-runtime/pkg/meta"
+)
+
+const (
+	nameAdmin = "crossplane-admin"
+	nameEdit  = "crossplane-edit"
+	nameView  = "crossplane-view"
+
+	keyPrefix = "rbac.crossplane.io/"
+
+	keyAggToAdmin = keyPrefix + "aggregate-to-ns-admin"
+	keyAggToEdit  = keyPrefix + "aggregate-to-ns-edit"
+	keyAggToView  = keyPrefix + "aggregate-to-ns-view"
+
+	keyBaseOfAdmin = keyPrefix + "base-of-ns-admin"
+	keyBaseOfEdit  = keyPrefix + "base-of-ns-edit"
+	keyBaseOfView  = keyPrefix + "base-of-ns-view"
+
+	keyXRD = keyPrefix + "xrd"
+
+	keyAggregated = "aggregated-by-crossplane"
+
+	valTrue   = "true"
+	valAccept = "xrd-claim-accepted"
+)
+
+// RenderRoles for the supplied namespace by aggregating rules from the supplied
+// cluster roles.
+func RenderRoles(ns *corev1.Namespace, crs []rbacv1.ClusterRole) []rbacv1.Role {
+	admin := &rbacv1.Role{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:   ns.GetName(),
+			Name:        nameAdmin,
+			Annotations: map[string]string{keyPrefix + keyAggregated: valTrue},
+		},
+	}
+	edit := &rbacv1.Role{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:   ns.GetName(),
+			Name:        nameEdit,
+			Annotations: map[string]string{keyPrefix + keyAggregated: valTrue},
+		},
+	}
+	view := &rbacv1.Role{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:   ns.GetName(),
+			Name:        nameView,
+			Annotations: map[string]string{keyPrefix + keyAggregated: valTrue},
+		},
+	}
+
+	gvk := schema.GroupVersionKind{Version: "v1", Kind: "Namespace"}
+	meta.AddOwnerReference(admin, meta.AsController(meta.TypedReferenceTo(ns, gvk)))
+	meta.AddOwnerReference(edit, meta.AsController(meta.TypedReferenceTo(ns, gvk)))
+	meta.AddOwnerReference(view, meta.AsController(meta.TypedReferenceTo(ns, gvk)))
+
+	accepts := map[string]bool{}
+	for k, v := range ns.GetAnnotations() {
+		if strings.HasPrefix(k, keyPrefix) && v == valAccept {
+			accepts[strings.TrimPrefix(k, keyPrefix)] = true
+		}
+	}
+
+	acrs := crSelector{keyAggToAdmin, keyBaseOfAdmin, accepts}
+	ecrs := crSelector{keyAggToEdit, keyBaseOfEdit, accepts}
+	vcrs := crSelector{keyAggToView, keyBaseOfView, accepts}
+
+	// TODO(negz): Annotate rendered Roles to indicate which ClusterRoles they
+	// are aggregating rules from? This aggregation is likely to be surprising
+	// to the uninitiated.
+	for _, cr := range crs {
+		if acrs.Select(cr) {
+			admin.Rules = append(admin.Rules, cr.Rules...)
+		}
+
+		if ecrs.Select(cr) {
+			edit.Rules = append(edit.Rules, cr.Rules...)
+		}
+
+		if vcrs.Select(cr) {
+			view.Rules = append(view.Rules, cr.Rules...)
+		}
+	}
+
+	return []rbacv1.Role{*admin, *edit, *view}
+}
+
+type crSelector struct {
+	keyAgg  string
+	keyBase string
+	accepts map[string]bool
+}
+
+func (s crSelector) Select(cr rbacv1.ClusterRole) bool {
+	l := cr.GetLabels()
+
+	// All cluster roles must have an aggregation key to be selected.
+	if l[s.keyAgg] != valTrue {
+		return false
+	}
+
+	// Cluster roles must either be the base of this role, or pertain to an XRD
+	// that this namespace accepts a claim from.
+	return l[s.keyBase] == valTrue || s.accepts[l[keyXRD]]
+}

--- a/pkg/controller/rbac/namespace/roles_test.go
+++ b/pkg/controller/rbac/namespace/roles_test.go
@@ -1,0 +1,308 @@
+/*
+Copyright 2020 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package namespace
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+func TestCRSelector(t *testing.T) {
+	xrdName := "composites.example.org"
+
+	type fields struct {
+		keyAgg  string
+		keyBase string
+		accepts map[string]bool
+	}
+
+	cases := map[string]struct {
+		reason string
+		fields fields
+		cr     rbacv1.ClusterRole
+		want   bool
+	}{
+		"MissingAggregationLabel": {
+			reason: "Only ClusterRoles with the aggregation label should be selected",
+			fields: fields{
+				keyAgg:  keyAggToAdmin,
+				keyBase: keyBaseOfAdmin,
+				accepts: map[string]bool{xrdName: true},
+			},
+			cr: rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{
+				keyBaseOfAdmin: valTrue,
+			}}},
+			want: false,
+		},
+		"OnlyAggregationLabel": {
+			reason: "ClusterRoles must have either the base label or the label of an accepted XRD to be selected",
+			fields: fields{
+				keyAgg:  keyAggToAdmin,
+				keyBase: keyBaseOfAdmin,
+				accepts: map[string]bool{xrdName: true},
+			},
+			cr: rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{
+				keyAggToAdmin: valTrue,
+			}}},
+			want: false,
+		},
+		"IsBaseRole": {
+			reason: "ClusterRoles with the aggregation and base labels should be selected",
+			fields: fields{
+				keyAgg:  keyAggToAdmin,
+				keyBase: keyBaseOfAdmin,
+				accepts: map[string]bool{xrdName: true},
+			},
+			cr: rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{
+				keyAggToAdmin:  valTrue,
+				keyBaseOfAdmin: valTrue,
+			}}},
+			want: true,
+		},
+		"IsAcceptedXRDRole": {
+			reason: "ClusterRoles with the aggregation and an accepted XRD label should be selected",
+			fields: fields{
+				keyAgg:  keyAggToAdmin,
+				keyBase: keyBaseOfAdmin,
+				accepts: map[string]bool{xrdName: true},
+			},
+			cr: rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{
+				keyAggToAdmin: valTrue,
+				keyXRD:        xrdName,
+			}}},
+			want: true,
+		},
+		"IsUnknownXRDRole": {
+			reason: "ClusterRoles with the aggregation label but an unknown XRD label should be ignored",
+			fields: fields{
+				keyAgg:  keyAggToAdmin,
+				keyBase: keyBaseOfAdmin,
+				accepts: map[string]bool{xrdName: true},
+			},
+			cr: rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{
+				keyAggToAdmin: valTrue,
+				keyXRD:        "unknown.example.org", // An XRD we don't accept.
+			}}},
+			want: false,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			crs := crSelector{tc.fields.keyAgg, tc.fields.keyBase, tc.fields.accepts}
+			got := crs.Select(tc.cr)
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("crs.Select(...): -want, +got:\n%s\n", diff)
+			}
+		})
+	}
+
+}
+
+func TestRenderClusterRoles(t *testing.T) {
+	name := "spacename"
+	uid := types.UID("no-you-id")
+
+	ctrl := true
+	owner := metav1.OwnerReference{
+		APIVersion: "v1",
+		Kind:       "Namespace",
+		Name:       name,
+		UID:        uid,
+		Controller: &ctrl,
+	}
+
+	crNameA := "A"
+	crNameB := "B"
+	crNameC := "C"
+
+	ruleA := rbacv1.PolicyRule{APIGroups: []string{"A"}}
+	ruleB := rbacv1.PolicyRule{APIGroups: []string{"B"}}
+	ruleC := rbacv1.PolicyRule{APIGroups: []string{"C"}}
+
+	xrdName := "guilty-gear-xrd"
+
+	type args struct {
+		ns  *corev1.Namespace
+		crs []rbacv1.ClusterRole
+	}
+
+	cases := map[string]struct {
+		reason string
+		args   args
+		want   []rbacv1.Role
+	}{
+		"APlainOldNamespace": {
+			reason: "A namespace with no annotations should get admin, edit, and view roles with only base rules, if any exist.",
+			args: args{
+				ns: &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: name, UID: uid}},
+				crs: []rbacv1.ClusterRole{
+					{
+						// This role's rules should be aggregated to the admin role.
+						ObjectMeta: metav1.ObjectMeta{
+							Name: crNameA,
+							Labels: map[string]string{
+								keyAggToAdmin:  valTrue,
+								keyBaseOfAdmin: valTrue,
+							},
+						},
+						Rules: []rbacv1.PolicyRule{ruleA},
+					},
+					{
+						// This role's rules should also be aggregated to the admin role.
+						ObjectMeta: metav1.ObjectMeta{
+							Name: crNameB,
+							Labels: map[string]string{
+								keyAggToAdmin:  valTrue,
+								keyBaseOfAdmin: valTrue,
+							},
+						},
+						Rules: []rbacv1.PolicyRule{ruleB},
+					},
+					{
+						// This role doesn't have any interesting labels. It should not be aggregated.
+						ObjectMeta: metav1.ObjectMeta{
+							Name:   crNameC,
+							Labels: map[string]string{},
+						},
+						Rules: []rbacv1.PolicyRule{ruleC},
+					},
+				},
+			},
+			want: []rbacv1.Role{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace:       name,
+						Name:            nameAdmin,
+						OwnerReferences: []metav1.OwnerReference{owner},
+						Annotations:     map[string]string{keyPrefix + keyAggregated: valTrue},
+					},
+					Rules: []rbacv1.PolicyRule{ruleA, ruleB},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace:       name,
+						Name:            nameEdit,
+						OwnerReferences: []metav1.OwnerReference{owner},
+						Annotations:     map[string]string{keyPrefix + keyAggregated: valTrue},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace:       name,
+						Name:            nameView,
+						OwnerReferences: []metav1.OwnerReference{owner},
+						Annotations:     map[string]string{keyPrefix + keyAggregated: valTrue},
+					},
+				},
+			},
+		},
+		"ANamespaceThatAcceptsClaims": {
+			reason: "A namespace that is annotated to accept claims should get admin, edit, and view roles with base and XRD rules, if they exist.",
+			args: args{
+				ns: &corev1.Namespace{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:        name,
+						UID:         uid,
+						Annotations: map[string]string{keyPrefix + xrdName: valAccept},
+					},
+				},
+				crs: []rbacv1.ClusterRole{
+					{
+						// This role's rules should be aggregated to the admin and edit roles.
+						ObjectMeta: metav1.ObjectMeta{
+							Name: crNameA,
+							Labels: map[string]string{
+								keyAggToAdmin:  valTrue,
+								keyBaseOfAdmin: valTrue,
+								keyAggToEdit:   valTrue,
+								keyBaseOfEdit:  valTrue,
+							},
+						},
+						Rules: []rbacv1.PolicyRule{ruleA},
+					},
+					{
+						// This role's rules should also be aggregated to the admin and edit roles.
+						ObjectMeta: metav1.ObjectMeta{
+							Name: crNameB,
+							Labels: map[string]string{
+								keyAggToAdmin: valTrue,
+								keyAggToEdit:  valTrue,
+								keyXRD:        xrdName, // The namespace accepts the claim this XRD offers.
+							},
+						},
+						Rules: []rbacv1.PolicyRule{ruleB},
+					},
+					{
+						// This role's rules should be aggregated to the view role.
+						ObjectMeta: metav1.ObjectMeta{
+							Name: crNameC,
+							Labels: map[string]string{
+								keyAggToView: valTrue,
+								keyXRD:       xrdName, // The namespace accepts the claim this XRD offers.
+							},
+						},
+						Rules: []rbacv1.PolicyRule{ruleC},
+					},
+				},
+			},
+			want: []rbacv1.Role{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace:       name,
+						Name:            nameAdmin,
+						OwnerReferences: []metav1.OwnerReference{owner},
+						Annotations:     map[string]string{keyPrefix + keyAggregated: valTrue},
+					},
+					Rules: []rbacv1.PolicyRule{ruleA, ruleB},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace:       name,
+						Name:            nameEdit,
+						OwnerReferences: []metav1.OwnerReference{owner},
+						Annotations:     map[string]string{keyPrefix + keyAggregated: valTrue},
+					},
+					Rules: []rbacv1.PolicyRule{ruleA, ruleB},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace:       name,
+						Name:            nameView,
+						OwnerReferences: []metav1.OwnerReference{owner},
+						Annotations:     map[string]string{keyPrefix + keyAggregated: valTrue},
+					},
+					Rules: []rbacv1.PolicyRule{ruleC},
+				},
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got := RenderRoles(tc.args.ns, tc.args.crs)
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("RenderRoles(...): -want, +got:\n%s\n", diff)
+			}
+		})
+	}
+}

--- a/pkg/controller/rbac/namespace/watch.go
+++ b/pkg/controller/rbac/namespace/watch.go
@@ -1,0 +1,101 @@
+/*
+Copyright 2020 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package namespace
+
+import (
+	"context"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/workqueue"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+type adder interface {
+	Add(item interface{})
+}
+
+// EnqueueRequestForNamespaces enqueues a reconcile for all namespaces whenever
+// a ClusterRole with the aggregation labels we're concerned with changes. This
+// is unusual, but we expect there to be relatively few ClusterRoles, and we
+// have no way of relating a specific ClusterRoles back to the Roles that
+// aggregate it. This is the approach the upstream aggregation controller uses.
+// https://github.com/kubernetes/kubernetes/blob/323f348/pkg/controller/clusterroleaggregation/clusterroleaggregation_controller.go#L188
+type EnqueueRequestForNamespaces struct {
+	client client.Reader
+}
+
+// Create adds a NamespacedName for the supplied CreateEvent if its Object is an
+// aggregated ClusterRole.
+func (e *EnqueueRequestForNamespaces) Create(evt event.CreateEvent, q workqueue.RateLimitingInterface) {
+	e.add(evt.Object, q)
+}
+
+// Update adds a NamespacedName for the supplied UpdateEvent if its Object is an
+// aggregated ClusterRole.
+func (e *EnqueueRequestForNamespaces) Update(evt event.UpdateEvent, q workqueue.RateLimitingInterface) {
+	e.add(evt.ObjectOld, q)
+	e.add(evt.ObjectNew, q)
+}
+
+// Delete adds a NamespacedName for the supplied DeleteEvent if its Object is an
+// aggregated ClusterRole.
+func (e *EnqueueRequestForNamespaces) Delete(evt event.DeleteEvent, q workqueue.RateLimitingInterface) {
+	e.add(evt.Object, q)
+}
+
+// Generic adds a NamespacedName for the supplied GenericEvent if its Object is
+// an aggregated ClusterRole.
+func (e *EnqueueRequestForNamespaces) Generic(evt event.GenericEvent, q workqueue.RateLimitingInterface) {
+	e.add(evt.Object, q)
+}
+
+func (e *EnqueueRequestForNamespaces) add(obj runtime.Object, queue adder) {
+	cr, ok := obj.(*rbacv1.ClusterRole)
+	if !ok {
+		return
+	}
+
+	if !aggregates(cr) {
+		return
+	}
+
+	l := &corev1.NamespaceList{}
+	if err := e.client.List(context.Background(), l); err != nil {
+		return
+	}
+
+	for _, ns := range l.Items {
+		queue.Add(reconcile.Request{NamespacedName: types.NamespacedName{Name: ns.GetName()}})
+	}
+
+}
+
+func aggregates(obj metav1.Object) bool {
+	for k := range obj.GetLabels() {
+		if strings.HasPrefix(k, keyPrefix) {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/controller/rbac/namespace/watch_test.go
+++ b/pkg/controller/rbac/namespace/watch_test.go
@@ -1,0 +1,90 @@
+/*
+Copyright 2020 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package namespace
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"github.com/crossplane/crossplane-runtime/pkg/test"
+)
+
+var (
+	_ handler.EventHandler = &EnqueueRequestForNamespaces{}
+)
+
+type addFn func(item interface{})
+
+func (fn addFn) Add(item interface{}) {
+	fn(item)
+}
+
+func TestAdd(t *testing.T) {
+	name := "coolname"
+
+	cases := map[string]struct {
+		client client.Reader
+		obj    runtime.Object
+		queue  adder
+	}{
+		"ObjectIsNotAClusterRole": {
+			queue: addFn(func(_ interface{}) { t.Errorf("queue.Add() called unexpectedly") }),
+		},
+		"ClusterRoleIsNotAggregated": {
+			obj:   &rbacv1.ClusterRole{},
+			queue: addFn(func(_ interface{}) { t.Errorf("queue.Add() called unexpectedly") }),
+		},
+		"ListNamespacesError": {
+			client: &test.MockClient{
+				MockList: test.NewMockListFn(errors.New("boom")),
+			},
+			obj:   &rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{keyAggToAdmin: valTrue}}},
+			queue: addFn(func(_ interface{}) { t.Errorf("queue.Add() called unexpectedly") }),
+		},
+		"SuccessfulEnqueue": {
+			client: &test.MockClient{
+				MockList: test.NewMockListFn(nil, func(o runtime.Object) error {
+					nsl := o.(*corev1.NamespaceList)
+					*nsl = corev1.NamespaceList{Items: []corev1.Namespace{{ObjectMeta: metav1.ObjectMeta{Name: name}}}}
+					return nil
+				}),
+			},
+			obj: &rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{keyAggToAdmin: valTrue}}},
+			queue: addFn(func(got interface{}) {
+				want := reconcile.Request{NamespacedName: types.NamespacedName{Name: name}}
+				if diff := cmp.Diff(want, got); diff != "" {
+					t.Errorf("-want, +got:\n%s\n", diff)
+				}
+			}),
+		},
+	}
+
+	for _, tc := range cases {
+		e := &EnqueueRequestForNamespaces{client: tc.client}
+		e.add(tc.obj, tc.queue)
+	}
+}

--- a/pkg/controller/rbac/rbac.go
+++ b/pkg/controller/rbac/rbac.go
@@ -1,0 +1,60 @@
+/*
+Copyright 2020 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rbac
+
+import (
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	"github.com/crossplane/crossplane-runtime/pkg/logging"
+
+	"github.com/crossplane/crossplane/pkg/controller/rbac/definition"
+	"github.com/crossplane/crossplane/pkg/controller/rbac/namespace"
+)
+
+// The ManagementPolicy specifies which roles the RBAC manager should manage.
+type ManagementPolicy string
+
+const (
+	// ManagementPolicyAll indicates that all RBAC manager functionality should
+	// be enabled.
+	ManagementPolicyAll ManagementPolicy = "All"
+
+	// ManagementPolicyBasic indicates that basic RBAC manager functionality
+	// should be enabled. The RBAC manager will create ClusterRoles for each
+	// XRD. The ClusterRoles it creates will aggregate to the core Crossplane
+	// ClusterRoles (e.g. crossplane, crossplane-admin, etc).
+	ManagementPolicyBasic ManagementPolicy = "Basic"
+)
+
+// Setup RBAC manager controllers.
+func Setup(mgr ctrl.Manager, l logging.Logger, mp ManagementPolicy) error {
+	// Basic controllers.
+	fns := []func(ctrl.Manager, logging.Logger) error{
+		definition.Setup,
+	}
+
+	if mp == ManagementPolicyAll {
+		fns = append(fns, namespace.Setup)
+	}
+
+	for _, setup := range fns {
+		if err := setup(mgr, l); err != nil {
+			return err
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Partial fix for https://github.com/crossplane/crossplane/issues/1637

This PR introduces the RBAC manager - a distinct deployment that generates opinionated RBAC roles that grant access to Crossplane resources as they are created. Currently the RBAC manager grants access to newly defined composite resources and their claims. Deploying the RBAC manager is optional. It is deployed by default. See [the design document](https://github.com/crossplane/crossplane/blob/5fa48962bb75d559639d18a2c47181611c97c8c5/design/design-doc-rbac-manager.md) for further context.

Note that while the RBAC manager grants Crossplane itself access to reconcile composite resources, Crossplane must be manually granted access to manage any composed resources; i.e. a provider's managed resources. A future PR will introduce support for granting Crossplane access to manage the resources of any provider installed via the v2 package manager.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
In addition to the unit tests, this PR has been tested manually. See comments below for details. Reviewers, it's probably worth double-checking my Helm updates; I found our Helm chart architecture tough to understand.

[contribution process]: https://git.io/fj2m9
