### PR TITLE
Bump kind usage to 1.16.15

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,7 +42,7 @@ make
 ./cluster/local/kind.sh help
 
 # Start a new kind cluster. Specifying KUBE_IMAGE is optional.
-KUBE_IMAGE=kindest/node:v1.16.9 ./cluster/local/kind.sh up
+KUBE_IMAGE=kindest/node:v1.16.15 ./cluster/local/kind.sh up
 
 # Use Helm to deploy the local build of Crossplane.
 ./cluster/local/kind.sh helm-install

--- a/cluster/local/kind.sh
+++ b/cluster/local/kind.sh
@@ -40,7 +40,7 @@ function check_context() {
 }
 
 # configure kind
-KUBE_IMAGE=${KUBE_IMAGE:-"kindest/node:v1.15.11@sha256:6cc31f3533deb138792db2c7d1ffc36f7456a06f1db5556ad3b6927641016f50"}
+KUBE_IMAGE=${KUBE_IMAGE:-"kindest/node:v1.16.15@sha256:a89c771f7de234e6547d43695c7ab047809ffc71a0c3b65aa54eda051c45ed20"}
 KIND_NAME=${KIND_NAME:-"kind"}
 case "${1:-}" in
   up)

--- a/docs/getting-started/install-configure.md
+++ b/docs/getting-started/install-configure.md
@@ -32,7 +32,7 @@ brew install kind
 brew install kubectl
 brew install helm
 
-kind create cluster --image kindest/node:v1.16.9 --wait 5m
+kind create cluster --image kindest/node:v1.16.15 --wait 5m
 ```
 
 </div>
@@ -224,7 +224,7 @@ PROJECT_ID=my-project
 SA_NAME=my-service-account-name
 
 # create service account
-SA="${SA_NAME}@${PROJECT_ID}.iam.gserviceaccount.com" 
+SA="${SA_NAME}@${PROJECT_ID}.iam.gserviceaccount.com"
 gcloud iam service-accounts create $SA_NAME --project $PROJECT_ID
 
 # enable cloud API


### PR DESCRIPTION
### Description of your changes

This PR bumps all references/usage of `kind` in this repo to consistently use the latest 1.16 version: `1.16.15`

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

I brought up a locally built version of crossplane with the following and verified everything was running OK and on the correct versions:
```
cluster/local/kind.sh up
cluster/local/kind.sh helm-install
```

[contribution process]: https://git.io/fj2m9
