### PR TITLE
Make controller ref in package revision status not a pointer

### DIFF
--- a/apis/pkg/v1alpha1/interfaces.go
+++ b/apis/pkg/v1alpha1/interfaces.go
@@ -229,8 +229,8 @@ type PackageRevision interface {
 	GetObjects() []runtimev1alpha1.TypedReference
 	SetObjects(c []runtimev1alpha1.TypedReference)
 
-	GetControllerReference() *runtimev1alpha1.Reference
-	SetControllerReference(c *runtimev1alpha1.Reference)
+	GetControllerReference() runtimev1alpha1.Reference
+	SetControllerReference(c runtimev1alpha1.Reference)
 
 	GetSource() string
 	SetSource(s string)
@@ -266,12 +266,12 @@ func (p *ProviderRevision) SetObjects(c []runtimev1alpha1.TypedReference) {
 }
 
 // GetControllerReference of this ProviderRevision.
-func (p *ProviderRevision) GetControllerReference() *runtimev1alpha1.Reference {
+func (p *ProviderRevision) GetControllerReference() runtimev1alpha1.Reference {
 	return p.Status.ControllerRef
 }
 
 // SetControllerReference of this ProviderRevision.
-func (p *ProviderRevision) SetControllerReference(c *runtimev1alpha1.Reference) {
+func (p *ProviderRevision) SetControllerReference(c runtimev1alpha1.Reference) {
 	p.Status.ControllerRef = c
 }
 
@@ -336,12 +336,12 @@ func (p *ConfigurationRevision) SetObjects(c []runtimev1alpha1.TypedReference) {
 }
 
 // GetControllerReference of this ConfigurationRevision.
-func (p *ConfigurationRevision) GetControllerReference() *runtimev1alpha1.Reference {
+func (p *ConfigurationRevision) GetControllerReference() runtimev1alpha1.Reference {
 	return p.Status.ControllerRef
 }
 
 // SetControllerReference of this ConfigurationRevision.
-func (p *ConfigurationRevision) SetControllerReference(c *runtimev1alpha1.Reference) {
+func (p *ConfigurationRevision) SetControllerReference(c runtimev1alpha1.Reference) {
 	p.Status.ControllerRef = c
 }
 

--- a/apis/pkg/v1alpha1/revision_types.go
+++ b/apis/pkg/v1alpha1/revision_types.go
@@ -62,7 +62,7 @@ type Dependency struct {
 // PackageRevisionStatus represents the observed state of a PackageRevision.
 type PackageRevisionStatus struct {
 	runtimev1alpha1.ConditionedStatus `json:",inline"`
-	ControllerRef                     *runtimev1alpha1.Reference `json:"controllerRef,omitempty"`
+	ControllerRef                     runtimev1alpha1.Reference `json:"controllerRef,omitempty"`
 
 	// Crossplane is a semantic version for supported Crossplane version for the
 	// package.

--- a/apis/pkg/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/pkg/v1alpha1/zz_generated.deepcopy.go
@@ -213,11 +213,7 @@ func (in *PackageRevisionSpec) DeepCopy() *PackageRevisionSpec {
 func (in *PackageRevisionStatus) DeepCopyInto(out *PackageRevisionStatus) {
 	*out = *in
 	in.ConditionedStatus.DeepCopyInto(&out.ConditionedStatus)
-	if in.ControllerRef != nil {
-		in, out := &in.ControllerRef, &out.ControllerRef
-		*out = new(corev1alpha1.Reference)
-		**out = **in
-	}
+	out.ControllerRef = in.ControllerRef
 	if in.DependsOn != nil {
 		in, out := &in.DependsOn, &out.DependsOn
 		*out = make([]Dependency, len(*in))

--- a/pkg/controller/pkg/revision/reconciler.go
+++ b/pkg/controller/pkg/revision/reconciler.go
@@ -383,7 +383,7 @@ func (r *Reconciler) Reconcile(req reconcile.Request) (reconcile.Result, error) 
 			pr.SetConditions(v1alpha1.Unhealthy())
 			return reconcile.Result{RequeueAfter: shortWait}, errors.Wrap(r.client.Status().Update(ctx, pr), errUpdateStatus)
 		}
-		pr.SetControllerReference(&runtimev1alpha1.Reference{Name: d.GetName()})
+		pr.SetControllerReference(runtimev1alpha1.Reference{Name: d.GetName()})
 	}
 
 	// Update object list in package revision status and set ready condition to

--- a/pkg/controller/pkg/revision/reconciler_test.go
+++ b/pkg/controller/pkg/revision/reconciler_test.go
@@ -479,7 +479,7 @@ func TestReconcile(t *testing.T) {
 										Name:       "test",
 									},
 								})
-								want.SetControllerReference(&runtimev1alpha1.Reference{Name: "test-providerrev"})
+								want.SetControllerReference(runtimev1alpha1.Reference{Name: "test-providerrev"})
 
 								if diff := cmp.Diff(want, o); diff != "" {
 									t.Errorf("-want, +got:\n%s", diff)


### PR DESCRIPTION

<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
ControllerRef was originally an optional part of the package revision
spec and was not updated to not be a pointer when it was moved to the
status. This updates it to be a Reference instead of *Reference.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>


I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

`make build`
`make reviewable`

[contribution process]: https://git.io/fj2m9
