### PR TITLE
Clean up package and package revision reconcilers

### DIFF
--- a/apis/pkg/v1alpha1/interfaces.go
+++ b/apis/pkg/v1alpha1/interfaces.go
@@ -18,6 +18,7 @@ package v1alpha1
 
 import (
 	corev1 "k8s.io/api/core/v1"
+	rbac "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 
 	runtimev1alpha1 "github.com/crossplane/crossplane-runtime/apis/core/v1alpha1"
@@ -232,6 +233,15 @@ type PackageRevision interface {
 	GetControllerReference() runtimev1alpha1.Reference
 	SetControllerReference(c runtimev1alpha1.Reference)
 
+	GetCrossplaneVersion() string
+	SetCrossplaneVersion(v string)
+
+	GetDependencies() []Dependency
+	SetDependencies(d []Dependency)
+
+	GetPermissionRequests() []rbac.PolicyRule
+	SetPermissionRequests(p []rbac.PolicyRule)
+
 	GetSource() string
 	SetSource(s string)
 
@@ -273,6 +283,36 @@ func (p *ProviderRevision) GetControllerReference() runtimev1alpha1.Reference {
 // SetControllerReference of this ProviderRevision.
 func (p *ProviderRevision) SetControllerReference(c runtimev1alpha1.Reference) {
 	p.Status.ControllerRef = c
+}
+
+// GetCrossplaneVersion of this ProviderRevision.
+func (p *ProviderRevision) GetCrossplaneVersion() string {
+	return p.Status.Crossplane
+}
+
+// SetCrossplaneVersion of this ProviderRevision.
+func (p *ProviderRevision) SetCrossplaneVersion(v string) {
+	p.Status.Crossplane = v
+}
+
+// GetDependencies of this ProviderRevision.
+func (p *ProviderRevision) GetDependencies() []Dependency {
+	return p.Status.DependsOn
+}
+
+// SetDependencies of this ProviderRevision.
+func (p *ProviderRevision) SetDependencies(d []Dependency) {
+	p.Status.DependsOn = d
+}
+
+// GetPermissionRequests of this ProviderRevision.
+func (p *ProviderRevision) GetPermissionRequests() []rbac.PolicyRule {
+	return p.Status.PermissionRequests
+}
+
+// SetPermissionRequests of this ProviderRevision.
+func (p *ProviderRevision) SetPermissionRequests(r []rbac.PolicyRule) {
+	p.Status.PermissionRequests = r
 }
 
 // GetSource of this ProviderRevision.
@@ -343,6 +383,36 @@ func (p *ConfigurationRevision) GetControllerReference() runtimev1alpha1.Referen
 // SetControllerReference of this ConfigurationRevision.
 func (p *ConfigurationRevision) SetControllerReference(c runtimev1alpha1.Reference) {
 	p.Status.ControllerRef = c
+}
+
+// GetCrossplaneVersion of this ConfigurationRevision.
+func (p *ConfigurationRevision) GetCrossplaneVersion() string {
+	return p.Status.Crossplane
+}
+
+// SetCrossplaneVersion of this ConfigurationRevision.
+func (p *ConfigurationRevision) SetCrossplaneVersion(v string) {
+	p.Status.Crossplane = v
+}
+
+// GetDependencies of this ConfigurationRevision.
+func (p *ConfigurationRevision) GetDependencies() []Dependency {
+	return p.Status.DependsOn
+}
+
+// SetDependencies of this ConfigurationRevision.
+func (p *ConfigurationRevision) SetDependencies(d []Dependency) {
+	p.Status.DependsOn = d
+}
+
+// GetPermissionRequests of this ConfigurationRevision.
+func (p *ConfigurationRevision) GetPermissionRequests() []rbac.PolicyRule {
+	return p.Status.PermissionRequests
+}
+
+// SetPermissionRequests of this ConfigurationRevision.
+func (p *ConfigurationRevision) SetPermissionRequests(r []rbac.PolicyRule) {
+	p.Status.PermissionRequests = r
 }
 
 // GetSource of this ConfigurationRevision.

--- a/pkg/controller/pkg/manager/podman.go
+++ b/pkg/controller/pkg/manager/podman.go
@@ -40,7 +40,7 @@ var (
 
 // A PodManager manages pods.
 type PodManager interface {
-	Run(context.Context, v1alpha1.Package) (string, error)
+	Sync(context.Context, v1alpha1.Package) (string, error)
 	GarbageCollect(context.Context, string, v1alpha1.Package) error
 }
 
@@ -58,9 +58,9 @@ func NewPackagePodManager(client client.Client, namespace string) *PackagePodMan
 	}
 }
 
-// Run manages pods for the package. It is meant to be called repeatedly if the
+// Sync manages pods for the package. It is meant to be called repeatedly if the
 // pod is to be continuously managed.
-func (m *PackagePodManager) Run(ctx context.Context, p v1alpha1.Package) (string, error) {
+func (m *PackagePodManager) Sync(ctx context.Context, p v1alpha1.Package) (string, error) {
 	// Identify or create pod.
 	pod := &corev1.Pod{}
 	podName := imageToPod(p.GetSource())

--- a/pkg/controller/pkg/manager/podman_test.go
+++ b/pkg/controller/pkg/manager/podman_test.go
@@ -32,7 +32,7 @@ import (
 	"github.com/crossplane/crossplane/apis/pkg/v1alpha1"
 )
 
-func TestPackagePodManagerRun(t *testing.T) {
+func TestPackagePodManagerSync(t *testing.T) {
 	errBoom := errors.New("boom")
 
 	type args struct {
@@ -261,14 +261,14 @@ func TestPackagePodManagerRun(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			want, err := tc.args.manager.Run(context.TODO(), tc.args.pkg)
+			want, err := tc.args.manager.Sync(context.TODO(), tc.args.pkg)
 
 			if diff := cmp.Diff(tc.want.err, err, cmpopts.EquateErrors()); diff != "" {
-				t.Errorf("\n%s\nmanager.Run(...): -want error, +got error:\n%s", tc.reason, diff)
+				t.Errorf("\n%s\nmanager.Sync(...): -want error, +got error:\n%s", tc.reason, diff)
 			}
 
 			if diff := cmp.Diff(tc.want.hash, want); diff != "" {
-				t.Errorf("\n%s\nmanager.Run(...): -want hash, +got hash:\n%s", tc.reason, diff)
+				t.Errorf("\n%s\nmanager.Sync(...): -want hash, +got hash:\n%s", tc.reason, diff)
 			}
 		})
 	}

--- a/pkg/controller/pkg/manager/reconciler.go
+++ b/pkg/controller/pkg/manager/reconciler.go
@@ -220,7 +220,7 @@ func (r *Reconciler) Reconcile(req reconcile.Request) (reconcile.Result, error) 
 
 	p.SetConditions(v1alpha1.Unpacking())
 
-	hash, err := r.podManager.Run(ctx, p)
+	hash, err := r.podManager.Sync(ctx, p)
 	if err != nil {
 		log.Debug(errListRevisions, "error", err)
 		r.record.Event(p, event.Warning(reasonUnpack, err))

--- a/pkg/controller/pkg/manager/reconciler_test.go
+++ b/pkg/controller/pkg/manager/reconciler_test.go
@@ -39,11 +39,11 @@ import (
 var _ PodManager = &MockPodManager{}
 
 type MockPodManager struct {
-	MockRun            func() (string, error)
+	MockSync           func() (string, error)
 	MockGarbageCollect func() error
 }
 
-func NewMockRunFn(hash string, err error) func() (string, error) {
+func NewMockSyncFn(hash string, err error) func() (string, error) {
 	return func() (string, error) {
 		return hash, err
 	}
@@ -53,8 +53,8 @@ func NewMockGarbageCollectFn(err error) func() error {
 	return func() error { return err }
 }
 
-func (m *MockPodManager) Run(context.Context, v1alpha1.Package) (string, error) {
-	return m.MockRun()
+func (m *MockPodManager) Sync(context.Context, v1alpha1.Package) (string, error) {
+	return m.MockSync()
 }
 func (m *MockPodManager) GarbageCollect(context.Context, string, v1alpha1.Package) error {
 	return m.MockGarbageCollect()
@@ -165,7 +165,7 @@ func TestReconcile(t *testing.T) {
 						}),
 					},
 					podManager: &MockPodManager{
-						MockRun: NewMockRunFn("1234567", nil),
+						MockSync: NewMockSyncFn("1234567", nil),
 					},
 					log:    logging.NewNopLogger(),
 					record: event.NewNopRecorder(),
@@ -211,7 +211,7 @@ func TestReconcile(t *testing.T) {
 						}),
 					},
 					podManager: &MockPodManager{
-						MockRun: NewMockRunFn("1234567", nil),
+						MockSync: NewMockSyncFn("1234567", nil),
 					},
 					log:    logging.NewNopLogger(),
 					record: event.NewNopRecorder(),
@@ -269,7 +269,7 @@ func TestReconcile(t *testing.T) {
 						}),
 					},
 					podManager: &MockPodManager{
-						MockRun: NewMockRunFn("1234567", nil),
+						MockSync: NewMockSyncFn("1234567", nil),
 					},
 					log:    logging.NewNopLogger(),
 					record: event.NewNopRecorder(),
@@ -338,7 +338,7 @@ func TestReconcile(t *testing.T) {
 						}),
 					},
 					podManager: &MockPodManager{
-						MockRun: NewMockRunFn("1234567", nil),
+						MockSync: NewMockSyncFn("1234567", nil),
 					},
 					log:    logging.NewNopLogger(),
 					record: event.NewNopRecorder(),
@@ -398,7 +398,7 @@ func TestReconcile(t *testing.T) {
 						}),
 					},
 					podManager: &MockPodManager{
-						MockRun: NewMockRunFn("1234567", nil),
+						MockSync: NewMockSyncFn("1234567", nil),
 					},
 					log:    logging.NewNopLogger(),
 					record: event.NewNopRecorder(),
@@ -458,7 +458,7 @@ func TestReconcile(t *testing.T) {
 						}),
 					},
 					podManager: &MockPodManager{
-						MockRun: NewMockRunFn("1234567", nil),
+						MockSync: NewMockSyncFn("1234567", nil),
 					},
 					log:    logging.NewNopLogger(),
 					record: event.NewNopRecorder(),
@@ -547,7 +547,7 @@ func TestReconcile(t *testing.T) {
 						}),
 					},
 					podManager: &MockPodManager{
-						MockRun:            NewMockRunFn("1234567", nil),
+						MockSync:           NewMockSyncFn("1234567", nil),
 						MockGarbageCollect: NewMockGarbageCollectFn(nil),
 					},
 					log:    logging.NewNopLogger(),
@@ -628,7 +628,7 @@ func TestReconcile(t *testing.T) {
 						}),
 					},
 					podManager: &MockPodManager{
-						MockRun:            NewMockRunFn("1234567", nil),
+						MockSync:           NewMockSyncFn("1234567", nil),
 						MockGarbageCollect: NewMockGarbageCollectFn(nil),
 					},
 					log:    logging.NewNopLogger(),

--- a/pkg/controller/pkg/revision/establisher.go
+++ b/pkg/controller/pkg/revision/establisher.go
@@ -50,6 +50,9 @@ type Establisher interface {
 	// GetResourceRefs returns references to all objects that have had ownership
 	// or control established.
 	GetResourceRefs() []runtimev1alpha1.TypedReference
+
+	// Reset clears all cached objects and references.
+	Reset()
 }
 
 // APIEstablisher establishes control or ownership of resources in the API
@@ -82,13 +85,15 @@ func (e *APIEstablisher) GetResourceRefs() []runtimev1alpha1.TypedReference {
 	return e.resourceRefs
 }
 
+// Reset clears all cached objects and references.
+func (e *APIEstablisher) Reset() {
+	e.allObjs, e.resourceRefs = nil, nil
+}
+
 // Check checks that control or ownership of resources can be established by
 // parent. It seeds the object list used during establishment, so it should
 // always be called before.
 func (e *APIEstablisher) Check(ctx context.Context, objs []runtime.Object, parent resource.Object, control bool) error {
-	// Reset all objects and references.
-	e.allObjs = nil
-	e.resourceRefs = nil
 	for _, res := range objs {
 		// Assert desired object to resource.Object so that we can access its
 		// metadata.

--- a/pkg/controller/pkg/revision/establisher_test.go
+++ b/pkg/controller/pkg/revision/establisher_test.go
@@ -37,252 +37,12 @@ import (
 
 var _ Establisher = &APIEstablisher{}
 
-var trueVal = true
-
-func TestAPIEstablisherCheck(t *testing.T) {
-	errBoom := errors.New("boom")
-
-	type args struct {
-		est     *APIEstablisher
-		objs    []runtime.Object
-		parent  resource.Object
-		control bool
-	}
-
-	type want struct {
-		err  error
-		objs []currentDesired
-	}
-
-	cases := map[string]struct {
-		reason string
-		args   args
-		want   want
-	}{
-		"SuccessfulExistsEstablishControl": {
-			reason: "All checks should be successful if we can establish control for a parent of existing objects.",
-			args: args{
-				est: &APIEstablisher{
-					client: &test.MockClient{
-						MockGet:    test.NewMockGetFn(nil),
-						MockUpdate: test.NewMockUpdateFn(nil),
-					},
-				},
-				objs: []runtime.Object{
-					&apiextensions.CustomResourceDefinition{},
-				},
-				parent: &v1alpha1.ProviderRevision{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "test",
-					},
-				},
-				control: true,
-			},
-			want: want{
-				objs: []currentDesired{{
-					Current: &apiextensions.CustomResourceDefinition{},
-					Desired: &apiextensions.CustomResourceDefinition{
-						ObjectMeta: metav1.ObjectMeta{
-							OwnerReferences: []metav1.OwnerReference{{Name: "test", Controller: &trueVal}},
-						},
-					},
-					Exists: true,
-				}},
-			},
-		},
-		"SuccessfulNotExistEstablishControl": {
-			reason: "All checks should be successful if we can establish control for a parent of new objects.",
-			args: args{
-				est: &APIEstablisher{
-					client: &test.MockClient{
-						MockGet:    test.NewMockGetFn(kerrors.NewNotFound(schema.GroupResource{}, "")),
-						MockCreate: test.NewMockCreateFn(nil),
-					},
-				},
-				objs: []runtime.Object{
-					&apiextensions.CustomResourceDefinition{},
-				},
-				parent: &v1alpha1.ProviderRevision{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "test",
-					},
-				},
-				control: true,
-			},
-			want: want{
-				objs: []currentDesired{{
-					Desired: &apiextensions.CustomResourceDefinition{
-						ObjectMeta: metav1.ObjectMeta{
-							OwnerReferences: []metav1.OwnerReference{{Name: "test", Controller: &trueVal}},
-						},
-					},
-					Exists: false,
-				}},
-			},
-		},
-		"SuccessfulExistsEstablishOwnership": {
-			reason: "All checks should be successful if we can establish ownership for a parent of existing objects.",
-			args: args{
-				est: &APIEstablisher{
-					client: &test.MockClient{
-						MockGet:    test.NewMockGetFn(nil),
-						MockUpdate: test.NewMockUpdateFn(nil),
-					},
-				},
-				objs: []runtime.Object{
-					&apiextensions.CustomResourceDefinition{},
-				},
-				parent: &v1alpha1.ProviderRevision{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "test",
-					},
-				},
-				control: false,
-			},
-			want: want{
-				objs: []currentDesired{{
-					Current: &apiextensions.CustomResourceDefinition{
-						ObjectMeta: metav1.ObjectMeta{
-							OwnerReferences: []metav1.OwnerReference{{Name: "test"}},
-						},
-					},
-					Desired: &apiextensions.CustomResourceDefinition{},
-					Exists:  true,
-				}},
-			},
-		},
-		"SuccessfulNotExistEstablishOwnership": {
-			reason: "All checks should be successful if we can establish ownership for a parent of new objects.",
-			args: args{
-				est: &APIEstablisher{
-					client: &test.MockClient{
-						MockGet:    test.NewMockGetFn(kerrors.NewNotFound(schema.GroupResource{}, "")),
-						MockCreate: test.NewMockCreateFn(nil),
-					},
-				},
-				objs: []runtime.Object{
-					&apiextensions.CustomResourceDefinition{},
-				},
-				parent: &v1alpha1.ProviderRevision{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "test",
-					},
-				},
-				control: false,
-			},
-			want: want{
-				objs: []currentDesired{{
-					Desired: &apiextensions.CustomResourceDefinition{
-						ObjectMeta: metav1.ObjectMeta{
-							OwnerReferences: []metav1.OwnerReference{{Name: "test"}},
-						},
-					},
-					Exists: false,
-				}},
-			},
-		},
-		"FailedGet": {
-			reason: "Cannot determine ability to own or control object if we cannot get it.",
-			args: args{
-				est: &APIEstablisher{
-					client: &test.MockClient{
-						MockGet: test.NewMockGetFn(errBoom),
-					},
-				},
-				objs: []runtime.Object{
-					&apiextensions.CustomResourceDefinition{},
-				},
-				parent:  &v1alpha1.ProviderRevision{},
-				control: true,
-			},
-			want: want{
-				err: errBoom,
-			},
-		},
-		"FailedCreate": {
-			reason: "Cannot establish control of object if we cannot create it.",
-			args: args{
-				est: &APIEstablisher{
-					client: &test.MockClient{
-						MockGet:    test.NewMockGetFn(kerrors.NewNotFound(schema.GroupResource{}, "")),
-						MockCreate: test.NewMockCreateFn(errBoom),
-					},
-				},
-				objs: []runtime.Object{
-					&apiextensions.CustomResourceDefinition{},
-				},
-				parent: &v1alpha1.ProviderRevision{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "test",
-					},
-				},
-				control: true,
-			},
-			want: want{
-				err: errBoom,
-				objs: []currentDesired{{
-					Desired: &apiextensions.CustomResourceDefinition{
-						ObjectMeta: metav1.ObjectMeta{
-							OwnerReferences: []metav1.OwnerReference{{Name: "test", Controller: &trueVal}},
-						},
-					},
-					Exists: false,
-				}},
-			},
-		},
-		"FailedUpdate": {
-			reason: "Cannot establish control of existing object if we cannot update it.",
-			args: args{
-				est: &APIEstablisher{
-					client: &test.MockClient{
-						MockGet:    test.NewMockGetFn(nil),
-						MockUpdate: test.NewMockUpdateFn(errBoom),
-					},
-				},
-				objs: []runtime.Object{
-					&apiextensions.CustomResourceDefinition{},
-				},
-				parent: &v1alpha1.ProviderRevision{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "test",
-					},
-				},
-				control: true,
-			},
-			want: want{
-				err: errBoom,
-				objs: []currentDesired{{
-					Current: &apiextensions.CustomResourceDefinition{},
-					Desired: &apiextensions.CustomResourceDefinition{
-						ObjectMeta: metav1.ObjectMeta{
-							OwnerReferences: []metav1.OwnerReference{{Name: "test", Controller: &trueVal}},
-						},
-					},
-					Exists: true,
-				}},
-			},
-		},
-	}
-
-	for name, tc := range cases {
-		t.Run(name, func(t *testing.T) {
-			err := tc.args.est.Check(context.TODO(), tc.args.objs, tc.args.parent, tc.args.control)
-
-			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
-				t.Errorf("\n%s\ne.Check(...): -want error, +got error:\n%s", tc.reason, diff)
-			}
-			if diff := cmp.Diff(tc.want.objs, tc.args.est.allObjs, test.EquateErrors()); diff != "" {
-				t.Errorf("\n%s\ne.Check(...): -want, +got:\n%s", tc.reason, diff)
-			}
-		})
-	}
-}
-
 func TestAPIEstablisherEstablish(t *testing.T) {
 	errBoom := errors.New("boom")
 
 	type args struct {
 		est     *APIEstablisher
+		objs    []runtime.Object
 		parent  resource.Object
 		control bool
 	}
@@ -305,15 +65,11 @@ func TestAPIEstablisherEstablish(t *testing.T) {
 						MockGet:    test.NewMockGetFn(nil),
 						MockUpdate: test.NewMockUpdateFn(nil),
 					},
-					allObjs: []currentDesired{
-						{
-							Current: &apiextensions.CustomResourceDefinition{},
-							Desired: &apiextensions.CustomResourceDefinition{
-								ObjectMeta: metav1.ObjectMeta{
-									Name: "ref-me",
-								},
-							},
-							Exists: true,
+				},
+				objs: []runtime.Object{
+					&apiextensions.CustomResourceDefinition{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "ref-me",
 						},
 					},
 				},
@@ -329,18 +85,14 @@ func TestAPIEstablisherEstablish(t *testing.T) {
 			args: args{
 				est: &APIEstablisher{
 					client: &test.MockClient{
-						MockGet:    test.NewMockGetFn(nil),
+						MockGet:    test.NewMockGetFn(kerrors.NewNotFound(schema.GroupResource{}, "")),
 						MockCreate: test.NewMockCreateFn(nil),
 					},
-					allObjs: []currentDesired{
-						{
-							Current: &apiextensions.CustomResourceDefinition{},
-							Desired: &apiextensions.CustomResourceDefinition{
-								ObjectMeta: metav1.ObjectMeta{
-									Name: "ref-me",
-								},
-							},
-							Exists: false,
+				},
+				objs: []runtime.Object{
+					&apiextensions.CustomResourceDefinition{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "ref-me",
 						},
 					},
 				},
@@ -359,15 +111,11 @@ func TestAPIEstablisherEstablish(t *testing.T) {
 						MockGet:    test.NewMockGetFn(nil),
 						MockUpdate: test.NewMockUpdateFn(nil),
 					},
-					allObjs: []currentDesired{
-						{
-							Current: &apiextensions.CustomResourceDefinition{},
-							Desired: &apiextensions.CustomResourceDefinition{
-								ObjectMeta: metav1.ObjectMeta{
-									Name: "ref-me",
-								},
-							},
-							Exists: true,
+				},
+				objs: []runtime.Object{
+					&apiextensions.CustomResourceDefinition{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "ref-me",
 						},
 					},
 				},
@@ -383,18 +131,14 @@ func TestAPIEstablisherEstablish(t *testing.T) {
 			args: args{
 				est: &APIEstablisher{
 					client: &test.MockClient{
-						MockGet:    test.NewMockGetFn(nil),
+						MockGet:    test.NewMockGetFn(kerrors.NewNotFound(schema.GroupResource{}, "")),
 						MockCreate: test.NewMockCreateFn(nil),
 					},
-					allObjs: []currentDesired{
-						{
-							Current: &apiextensions.CustomResourceDefinition{},
-							Desired: &apiextensions.CustomResourceDefinition{
-								ObjectMeta: metav1.ObjectMeta{
-									Name: "ref-me",
-								},
-							},
-							Exists: false,
+				},
+				objs: []runtime.Object{
+					&apiextensions.CustomResourceDefinition{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "ref-me",
 						},
 					},
 				},
@@ -413,15 +157,11 @@ func TestAPIEstablisherEstablish(t *testing.T) {
 						MockGet:    test.NewMockGetFn(kerrors.NewNotFound(schema.GroupResource{}, "")),
 						MockCreate: test.NewMockCreateFn(errBoom),
 					},
-					allObjs: []currentDesired{
-						{
-							Current: &apiextensions.CustomResourceDefinition{},
-							Desired: &apiextensions.CustomResourceDefinition{
-								ObjectMeta: metav1.ObjectMeta{
-									Name: "ref-me",
-								},
-							},
-							Exists: false,
+				},
+				objs: []runtime.Object{
+					&apiextensions.CustomResourceDefinition{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "ref-me",
 						},
 					},
 				},
@@ -444,15 +184,11 @@ func TestAPIEstablisherEstablish(t *testing.T) {
 						MockGet:    test.NewMockGetFn(nil),
 						MockUpdate: test.NewMockUpdateFn(errBoom),
 					},
-					allObjs: []currentDesired{
-						{
-							Current: &apiextensions.CustomResourceDefinition{},
-							Desired: &apiextensions.CustomResourceDefinition{
-								ObjectMeta: metav1.ObjectMeta{
-									Name: "ref-me",
-								},
-							},
-							Exists: true,
+				},
+				objs: []runtime.Object{
+					&apiextensions.CustomResourceDefinition{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "ref-me",
 						},
 					},
 				},
@@ -471,12 +207,12 @@ func TestAPIEstablisherEstablish(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			err := tc.args.est.Establish(context.TODO(), tc.args.parent, tc.args.control)
+			refs, err := tc.args.est.Establish(context.TODO(), tc.args.objs, tc.args.parent, tc.args.control)
 
 			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\ne.Check(...): -want error, +got error:\n%s", tc.reason, diff)
 			}
-			if diff := cmp.Diff(tc.want.refs, tc.args.est.resourceRefs, test.EquateErrors()); diff != "" {
+			if diff := cmp.Diff(tc.want.refs, refs, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\ne.Check(...): -want, +got:\n%s", tc.reason, diff)
 			}
 		})

--- a/pkg/controller/pkg/revision/hook.go
+++ b/pkg/controller/pkg/revision/hook.go
@@ -40,9 +40,8 @@ const (
 	errNotConfiguration = "not a configuration package"
 )
 
-// A Hook performs operations before and after a revision establishes
-// objects.
-type Hook interface {
+// A Hooks performs operations before and after a revision establishes objects.
+type Hooks interface {
 	// Pre performs operations meant to happen before establishing objects.
 	Pre(context.Context, runtime.Object, v1alpha1.PackageRevision) error
 
@@ -50,24 +49,24 @@ type Hook interface {
 	Post(context.Context, runtime.Object, v1alpha1.PackageRevision) error
 }
 
-// ProviderHook preforms operations for a provider package that requires a
+// ProviderHooks performs operations for a provider package that requires a
 // controller before and after the revision establishes objects.
-type ProviderHook struct {
+type ProviderHooks struct {
 	client    resource.ClientApplicator
 	namespace string
 }
 
-// NewProviderHook creates a new ProviderHook.
-func NewProviderHook(client resource.ClientApplicator, namespace string) *ProviderHook {
-	return &ProviderHook{
+// NewProviderHooks creates a new ProviderHooks.
+func NewProviderHooks(client resource.ClientApplicator, namespace string) *ProviderHooks {
+	return &ProviderHooks{
 		client:    client,
 		namespace: namespace,
 	}
 }
 
-// Pre cleans up a packaged controller and service account if the
-// revision is inactive.
-func (h *ProviderHook) Pre(ctx context.Context, pkg runtime.Object, pr v1alpha1.PackageRevision) error {
+// Pre cleans up a packaged controller and service account if the revision is
+// inactive.
+func (h *ProviderHooks) Pre(ctx context.Context, pkg runtime.Object, pr v1alpha1.PackageRevision) error {
 	pkgProvider, ok := pkg.(*pkgmeta.Provider)
 	if !ok {
 		return errors.New(errNotProvider)
@@ -92,7 +91,7 @@ func (h *ProviderHook) Pre(ctx context.Context, pkg runtime.Object, pr v1alpha1.
 
 // Post creates a packaged provider controller and service account if the
 // revision is active.
-func (h *ProviderHook) Post(ctx context.Context, pkg runtime.Object, pr v1alpha1.PackageRevision) error {
+func (h *ProviderHooks) Post(ctx context.Context, pkg runtime.Object, pr v1alpha1.PackageRevision) error {
 	pkgProvider, ok := pkg.(*pkgmeta.Provider)
 	if !ok {
 		return errors.New("not a provider package")
@@ -111,17 +110,17 @@ func (h *ProviderHook) Post(ctx context.Context, pkg runtime.Object, pr v1alpha1
 	return nil
 }
 
-// ConfigurationHook preforms operations for a configuration package before and
+// ConfigurationHooks performs operations for a configuration package before and
 // after the revision establishes objects.
-type ConfigurationHook struct{}
+type ConfigurationHooks struct{}
 
-// NewConfigurationHook creates a new ConfigurationHook.
-func NewConfigurationHook() *ConfigurationHook {
-	return &ConfigurationHook{}
+// NewConfigurationHooks creates a new ConfigurationHook.
+func NewConfigurationHooks() *ConfigurationHooks {
+	return &ConfigurationHooks{}
 }
 
 // Pre sets status fields based on the configuration package.
-func (h *ConfigurationHook) Pre(ctx context.Context, pkg runtime.Object, pr v1alpha1.PackageRevision) error {
+func (h *ConfigurationHooks) Pre(ctx context.Context, pkg runtime.Object, pr v1alpha1.PackageRevision) error {
 	pkgConfig, ok := pkg.(*pkgmeta.Configuration)
 	if !ok {
 		return errors.New(errNotConfiguration)
@@ -133,25 +132,25 @@ func (h *ConfigurationHook) Pre(ctx context.Context, pkg runtime.Object, pr v1al
 }
 
 // Post is a no op for configuration packages.
-func (h *ConfigurationHook) Post(context.Context, runtime.Object, v1alpha1.PackageRevision) error {
+func (h *ConfigurationHooks) Post(context.Context, runtime.Object, v1alpha1.PackageRevision) error {
 	return nil
 }
 
-// NopHook performs no operations.
-type NopHook struct{}
+// NopHooks performs no operations.
+type NopHooks struct{}
 
-// NewNopHook creates a hook that does nothing.
-func NewNopHook() *NopHook {
-	return &NopHook{}
+// NewNopHooks creates a hook that does nothing.
+func NewNopHooks() *NopHooks {
+	return &NopHooks{}
 }
 
 // Pre does nothing and returns nil.
-func (h *NopHook) Pre(context.Context, runtime.Object, v1alpha1.PackageRevision) error {
+func (h *NopHooks) Pre(context.Context, runtime.Object, v1alpha1.PackageRevision) error {
 	return nil
 }
 
 // Post does nothing and returns nil.
-func (h *NopHook) Post(context.Context, runtime.Object, v1alpha1.PackageRevision) error {
+func (h *NopHooks) Post(context.Context, runtime.Object, v1alpha1.PackageRevision) error {
 	return nil
 }
 

--- a/pkg/controller/pkg/revision/hook.go
+++ b/pkg/controller/pkg/revision/hook.go
@@ -1,0 +1,178 @@
+/*
+Copyright 2020 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package revision
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	runtimev1alpha1 "github.com/crossplane/crossplane-runtime/apis/core/v1alpha1"
+	"github.com/crossplane/crossplane-runtime/pkg/reference"
+	"github.com/crossplane/crossplane-runtime/pkg/resource"
+
+	pkgmeta "github.com/crossplane/crossplane/apis/pkg/meta/v1alpha1"
+	"github.com/crossplane/crossplane/apis/pkg/v1alpha1"
+)
+
+const (
+	errNotProvider              = "not a provider package"
+	errDeleteProviderDeployment = "cannot delete provider package deployment"
+	errDeleteProviderSA         = "cannot delete provider package service account"
+	errApplyProviderDeployment  = "cannot apply provider package deployment"
+	errApplyProviderSA          = "cannot apply provider package service account"
+
+	errNotConfiguration = "not a configuration package"
+)
+
+// A Hook performs operations before and after a revision establishes
+// objects.
+type Hook interface {
+	// Pre performs operations meant to happen before establishing objects.
+	Pre(context.Context, runtime.Object, v1alpha1.PackageRevision) error
+
+	// Post performs operations meant to happen after establishing objects.
+	Post(context.Context, runtime.Object, v1alpha1.PackageRevision) error
+}
+
+// ProviderHook preforms operations for a provider package that requires a
+// controller before and after the revision establishes objects.
+type ProviderHook struct {
+	client    resource.ClientApplicator
+	namespace string
+}
+
+// NewProviderHook creates a new ProviderHook.
+func NewProviderHook(client resource.ClientApplicator, namespace string) *ProviderHook {
+	return &ProviderHook{
+		client:    client,
+		namespace: namespace,
+	}
+}
+
+// Pre cleans up a packaged controller and service account if the
+// revision is inactive.
+func (h *ProviderHook) Pre(ctx context.Context, pkg runtime.Object, pr v1alpha1.PackageRevision) error {
+	pkgProvider, ok := pkg.(*pkgmeta.Provider)
+	if !ok {
+		return errors.New(errNotProvider)
+	}
+	// Always set revision status fields.
+	pr.SetDependencies(convertDependencies(pkgProvider.Spec.DependsOn))
+	pr.SetCrossplaneVersion(reference.FromPtrValue(pkgProvider.Spec.Crossplane))
+
+	// Do not clean up SA and controller if revision is not inactive.
+	if pr.GetDesiredState() != v1alpha1.PackageRevisionInactive {
+		return nil
+	}
+	s, d := buildProviderDeployment(pkgProvider, pr, h.namespace)
+	if err := h.client.Delete(ctx, d); resource.IgnoreNotFound(err) != nil {
+		return errors.Wrap(err, errDeleteProviderDeployment)
+	}
+	if err := h.client.Delete(ctx, s); resource.IgnoreNotFound(err) != nil {
+		return errors.Wrap(err, errDeleteProviderSA)
+	}
+	return nil
+}
+
+// Post creates a packaged provider controller and service account if the
+// revision is active.
+func (h *ProviderHook) Post(ctx context.Context, pkg runtime.Object, pr v1alpha1.PackageRevision) error {
+	pkgProvider, ok := pkg.(*pkgmeta.Provider)
+	if !ok {
+		return errors.New("not a provider package")
+	}
+	if pr.GetDesiredState() != v1alpha1.PackageRevisionActive {
+		return nil
+	}
+	s, d := buildProviderDeployment(pkgProvider, pr, h.namespace)
+	if err := h.client.Apply(ctx, s); err != nil {
+		return errors.Wrap(err, errApplyProviderSA)
+	}
+	if err := h.client.Apply(ctx, d); err != nil {
+		return errors.Wrap(err, errApplyProviderDeployment)
+	}
+	pr.SetControllerReference(runtimev1alpha1.Reference{Name: d.GetName()})
+	return nil
+}
+
+// ConfigurationHook preforms operations for a configuration package before and
+// after the revision establishes objects.
+type ConfigurationHook struct{}
+
+// NewConfigurationHook creates a new ConfigurationHook.
+func NewConfigurationHook() *ConfigurationHook {
+	return &ConfigurationHook{}
+}
+
+// Pre sets status fields based on the configuration package.
+func (h *ConfigurationHook) Pre(ctx context.Context, pkg runtime.Object, pr v1alpha1.PackageRevision) error {
+	pkgConfig, ok := pkg.(*pkgmeta.Configuration)
+	if !ok {
+		return errors.New(errNotConfiguration)
+	}
+	// Always set revision status fields.
+	pr.SetDependencies(convertDependencies(pkgConfig.Spec.DependsOn))
+	pr.SetCrossplaneVersion(reference.FromPtrValue(pkgConfig.Spec.Crossplane))
+	return nil
+}
+
+// Post is a no op for configuration packages.
+func (h *ConfigurationHook) Post(context.Context, runtime.Object, v1alpha1.PackageRevision) error {
+	return nil
+}
+
+// NopHook performs no operations.
+type NopHook struct{}
+
+// NewNopHook creates a hook that does nothing.
+func NewNopHook() *NopHook {
+	return &NopHook{}
+}
+
+// Pre does nothing and returns nil.
+func (h *NopHook) Pre(context.Context, runtime.Object, v1alpha1.PackageRevision) error {
+	return nil
+}
+
+// Post does nothing and returns nil.
+func (h *NopHook) Post(context.Context, runtime.Object, v1alpha1.PackageRevision) error {
+	return nil
+}
+
+// convertDependencies converts package meta dependencies to package revision
+// dependencies.
+func convertDependencies(deps []pkgmeta.Dependency) []v1alpha1.Dependency {
+	dependsOn := make([]v1alpha1.Dependency, len(deps))
+	for i, d := range deps {
+		// Skip dependencies that are malformed.
+		if (d.Configuration == nil && d.Provider == nil) || (d.Configuration != nil && d.Provider != nil) {
+			continue
+		}
+		p := v1alpha1.Dependency{}
+		if d.Configuration != nil {
+			p.Package = *d.Configuration
+		}
+		if d.Provider != nil {
+			p.Package = *d.Provider
+		}
+		p.Version = d.Version
+		dependsOn[i] = p
+	}
+	return dependsOn
+}

--- a/pkg/controller/pkg/revision/hook_test.go
+++ b/pkg/controller/pkg/revision/hook_test.go
@@ -43,7 +43,7 @@ func TestHookPre(t *testing.T) {
 	errBoom := errors.New("boom")
 
 	type args struct {
-		hook Hook
+		hook Hooks
 		pkg  runtime.Object
 		rev  v1alpha1.PackageRevision
 	}
@@ -61,7 +61,7 @@ func TestHookPre(t *testing.T) {
 		"ErrNotProvider": {
 			reason: "Should return error if not provider.",
 			args: args{
-				hook: &ProviderHook{},
+				hook: &ProviderHooks{},
 			},
 			want: want{
 				err: errors.New(errNotProvider),
@@ -70,7 +70,7 @@ func TestHookPre(t *testing.T) {
 		"ErrNotConfiguration": {
 			reason: "Should return error if not configuration.",
 			args: args{
-				hook: &ConfigurationHook{},
+				hook: &ConfigurationHooks{},
 			},
 			want: want{
 				err: errors.New(errNotConfiguration),
@@ -79,7 +79,7 @@ func TestHookPre(t *testing.T) {
 		"ProviderActive": {
 			reason: "Should only update status if provider revision is active.",
 			args: args{
-				hook: &ProviderHook{},
+				hook: &ProviderHooks{},
 				pkg: &pkgmeta.Provider{
 					Spec: pkgmeta.ProviderSpec{
 						Crossplane: &crossplane,
@@ -113,7 +113,7 @@ func TestHookPre(t *testing.T) {
 		"Configuration": {
 			reason: "Should always update status for configuration revisions.",
 			args: args{
-				hook: &ConfigurationHook{},
+				hook: &ConfigurationHooks{},
 				pkg: &pkgmeta.Configuration{
 					Spec: pkgmeta.ConfigurationSpec{
 						Crossplane: &crossplane,
@@ -147,7 +147,7 @@ func TestHookPre(t *testing.T) {
 		"ErrProviderDeleteDeployment": {
 			reason: "Should return error if we fail to delete deployment for inactive provider revision.",
 			args: args{
-				hook: &ProviderHook{
+				hook: &ProviderHooks{
 					client: resource.ClientApplicator{
 						Client: &test.MockClient{
 							MockDelete: test.NewMockDeleteFn(nil, func(o runtime.Object) error {
@@ -196,7 +196,7 @@ func TestHookPre(t *testing.T) {
 		"ErrProviderDeleteSA": {
 			reason: "Should return error if we fail to delete service account for inactive provider revision.",
 			args: args{
-				hook: &ProviderHook{
+				hook: &ProviderHooks{
 					client: resource.ClientApplicator{
 						Client: &test.MockClient{
 							MockDelete: test.NewMockDeleteFn(nil, func(o runtime.Object) error {
@@ -245,7 +245,7 @@ func TestHookPre(t *testing.T) {
 		"SuccessfulProviderDelete": {
 			reason: "Should update status and not return error when deployment and service account deleted successfully.",
 			args: args{
-				hook: &ProviderHook{
+				hook: &ProviderHooks{
 					client: resource.ClientApplicator{
 						Client: &test.MockClient{
 							MockDelete: test.NewMockDeleteFn(nil, func(o runtime.Object) error {
@@ -304,7 +304,7 @@ func TestHookPost(t *testing.T) {
 	errBoom := errors.New("boom")
 
 	type args struct {
-		hook Hook
+		hook Hooks
 		pkg  runtime.Object
 		rev  v1alpha1.PackageRevision
 	}
@@ -322,7 +322,7 @@ func TestHookPost(t *testing.T) {
 		"ErrNotProvider": {
 			reason: "Should return error if not provider.",
 			args: args{
-				hook: &ProviderHook{},
+				hook: &ProviderHooks{},
 			},
 			want: want{
 				err: errors.New(errNotProvider),
@@ -331,7 +331,7 @@ func TestHookPost(t *testing.T) {
 		"ProviderInactive": {
 			reason: "Should do nothing if provider revision is inactive.",
 			args: args{
-				hook: &ProviderHook{},
+				hook: &ProviderHooks{},
 				pkg:  &pkgmeta.Provider{},
 				rev: &v1alpha1.ProviderRevision{
 					Spec: v1alpha1.PackageRevisionSpec{
@@ -350,7 +350,7 @@ func TestHookPost(t *testing.T) {
 		"ErrProviderApplySA": {
 			reason: "Should return error if we fail to apply service account for active providerrevision.",
 			args: args{
-				hook: &ProviderHook{
+				hook: &ProviderHooks{
 					client: resource.ClientApplicator{
 						Applicator: resource.ApplyFn(func(_ context.Context, o runtime.Object, _ ...resource.ApplyOption) error {
 							switch o.(type) {
@@ -382,7 +382,7 @@ func TestHookPost(t *testing.T) {
 		"ErrProviderApplyDeployment": {
 			reason: "Should return error if we fail to apply deployment for active provider revision.",
 			args: args{
-				hook: &ProviderHook{
+				hook: &ProviderHooks{
 					client: resource.ClientApplicator{
 						Applicator: resource.ApplyFn(func(_ context.Context, o runtime.Object, _ ...resource.ApplyOption) error {
 							switch o.(type) {
@@ -414,7 +414,7 @@ func TestHookPost(t *testing.T) {
 		"SuccessfulProviderApply": {
 			reason: "Should not return error if successfully applied service account and deployment for active provider revision.",
 			args: args{
-				hook: &ProviderHook{
+				hook: &ProviderHooks{
 					client: resource.ClientApplicator{
 						Applicator: resource.ApplyFn(func(_ context.Context, o runtime.Object, _ ...resource.ApplyOption) error {
 							return nil

--- a/pkg/controller/pkg/revision/hook_test.go
+++ b/pkg/controller/pkg/revision/hook_test.go
@@ -1,0 +1,453 @@
+/*
+Copyright 2020 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package revision
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/pkg/errors"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/crossplane/crossplane-runtime/pkg/resource"
+	"github.com/crossplane/crossplane-runtime/pkg/test"
+
+	pkgmeta "github.com/crossplane/crossplane/apis/pkg/meta/v1alpha1"
+	"github.com/crossplane/crossplane/apis/pkg/v1alpha1"
+)
+
+var (
+	crossplane  = "v0.11.1"
+	providerDep = "crossplane/provider-aws"
+	version     = "v0.1.1"
+)
+
+func TestHookPre(t *testing.T) {
+	errBoom := errors.New("boom")
+
+	type args struct {
+		hook Hook
+		pkg  runtime.Object
+		rev  v1alpha1.PackageRevision
+	}
+
+	type want struct {
+		err error
+		rev v1alpha1.PackageRevision
+	}
+
+	cases := map[string]struct {
+		reason string
+		args   args
+		want   want
+	}{
+		"ErrNotProvider": {
+			reason: "Should return error if not provider.",
+			args: args{
+				hook: &ProviderHook{},
+			},
+			want: want{
+				err: errors.New(errNotProvider),
+			},
+		},
+		"ErrNotConfiguration": {
+			reason: "Should return error if not configuration.",
+			args: args{
+				hook: &ConfigurationHook{},
+			},
+			want: want{
+				err: errors.New(errNotConfiguration),
+			},
+		},
+		"ProviderActive": {
+			reason: "Should only update status if provider revision is active.",
+			args: args{
+				hook: &ProviderHook{},
+				pkg: &pkgmeta.Provider{
+					Spec: pkgmeta.ProviderSpec{
+						Crossplane: &crossplane,
+						DependsOn: []pkgmeta.Dependency{{
+							Provider: &providerDep,
+							Version:  version,
+						}},
+					},
+				},
+				rev: &v1alpha1.ProviderRevision{
+					Spec: v1alpha1.PackageRevisionSpec{
+						DesiredState: v1alpha1.PackageRevisionActive,
+					},
+				},
+			},
+			want: want{
+				rev: &v1alpha1.ProviderRevision{
+					Spec: v1alpha1.PackageRevisionSpec{
+						DesiredState: v1alpha1.PackageRevisionActive,
+					},
+					Status: v1alpha1.PackageRevisionStatus{
+						Crossplane: crossplane,
+						DependsOn: []v1alpha1.Dependency{{
+							Package: providerDep,
+							Version: version,
+						}},
+					},
+				},
+			},
+		},
+		"Configuration": {
+			reason: "Should always update status for configuration revisions.",
+			args: args{
+				hook: &ConfigurationHook{},
+				pkg: &pkgmeta.Configuration{
+					Spec: pkgmeta.ConfigurationSpec{
+						Crossplane: &crossplane,
+						DependsOn: []pkgmeta.Dependency{{
+							Provider: &providerDep,
+							Version:  version,
+						}},
+					},
+				},
+				rev: &v1alpha1.ConfigurationRevision{
+					Spec: v1alpha1.PackageRevisionSpec{
+						DesiredState: v1alpha1.PackageRevisionActive,
+					},
+				},
+			},
+			want: want{
+				rev: &v1alpha1.ConfigurationRevision{
+					Spec: v1alpha1.PackageRevisionSpec{
+						DesiredState: v1alpha1.PackageRevisionActive,
+					},
+					Status: v1alpha1.PackageRevisionStatus{
+						Crossplane: crossplane,
+						DependsOn: []v1alpha1.Dependency{{
+							Package: providerDep,
+							Version: version,
+						}},
+					},
+				},
+			},
+		},
+		"ErrProviderDeleteDeployment": {
+			reason: "Should return error if we fail to delete deployment for inactive provider revision.",
+			args: args{
+				hook: &ProviderHook{
+					client: resource.ClientApplicator{
+						Client: &test.MockClient{
+							MockDelete: test.NewMockDeleteFn(nil, func(o runtime.Object) error {
+								switch o.(type) {
+								case *appsv1.Deployment:
+									return errBoom
+								case *corev1.ServiceAccount:
+									return nil
+								}
+								return nil
+							}),
+						},
+					},
+				},
+				pkg: &pkgmeta.Provider{
+					Spec: pkgmeta.ProviderSpec{
+						Crossplane: &crossplane,
+						DependsOn: []pkgmeta.Dependency{{
+							Provider: &providerDep,
+							Version:  version,
+						}},
+					},
+				},
+				rev: &v1alpha1.ProviderRevision{
+					Spec: v1alpha1.PackageRevisionSpec{
+						DesiredState: v1alpha1.PackageRevisionInactive,
+					},
+				},
+			},
+			want: want{
+				rev: &v1alpha1.ProviderRevision{
+					Spec: v1alpha1.PackageRevisionSpec{
+						DesiredState: v1alpha1.PackageRevisionInactive,
+					},
+					Status: v1alpha1.PackageRevisionStatus{
+						Crossplane: crossplane,
+						DependsOn: []v1alpha1.Dependency{{
+							Package: providerDep,
+							Version: version,
+						}},
+					},
+				},
+				err: errors.Wrap(errBoom, errDeleteProviderDeployment),
+			},
+		},
+		"ErrProviderDeleteSA": {
+			reason: "Should return error if we fail to delete service account for inactive provider revision.",
+			args: args{
+				hook: &ProviderHook{
+					client: resource.ClientApplicator{
+						Client: &test.MockClient{
+							MockDelete: test.NewMockDeleteFn(nil, func(o runtime.Object) error {
+								switch o.(type) {
+								case *appsv1.Deployment:
+									return nil
+								case *corev1.ServiceAccount:
+									return errBoom
+								}
+								return nil
+							}),
+						},
+					},
+				},
+				pkg: &pkgmeta.Provider{
+					Spec: pkgmeta.ProviderSpec{
+						Crossplane: &crossplane,
+						DependsOn: []pkgmeta.Dependency{{
+							Provider: &providerDep,
+							Version:  version,
+						}},
+					},
+				},
+				rev: &v1alpha1.ProviderRevision{
+					Spec: v1alpha1.PackageRevisionSpec{
+						DesiredState: v1alpha1.PackageRevisionInactive,
+					},
+				},
+			},
+			want: want{
+				rev: &v1alpha1.ProviderRevision{
+					Spec: v1alpha1.PackageRevisionSpec{
+						DesiredState: v1alpha1.PackageRevisionInactive,
+					},
+					Status: v1alpha1.PackageRevisionStatus{
+						Crossplane: crossplane,
+						DependsOn: []v1alpha1.Dependency{{
+							Package: providerDep,
+							Version: version,
+						}},
+					},
+				},
+				err: errors.Wrap(errBoom, errDeleteProviderSA),
+			},
+		},
+		"SuccessfulProviderDelete": {
+			reason: "Should update status and not return error when deployment and service account deleted successfully.",
+			args: args{
+				hook: &ProviderHook{
+					client: resource.ClientApplicator{
+						Client: &test.MockClient{
+							MockDelete: test.NewMockDeleteFn(nil, func(o runtime.Object) error {
+								return nil
+							}),
+						},
+					},
+				},
+				pkg: &pkgmeta.Provider{
+					Spec: pkgmeta.ProviderSpec{
+						Crossplane: &crossplane,
+						DependsOn: []pkgmeta.Dependency{{
+							Provider: &providerDep,
+							Version:  version,
+						}},
+					},
+				},
+				rev: &v1alpha1.ProviderRevision{
+					Spec: v1alpha1.PackageRevisionSpec{
+						DesiredState: v1alpha1.PackageRevisionInactive,
+					},
+				},
+			},
+			want: want{
+				rev: &v1alpha1.ProviderRevision{
+					Spec: v1alpha1.PackageRevisionSpec{
+						DesiredState: v1alpha1.PackageRevisionInactive,
+					},
+					Status: v1alpha1.PackageRevisionStatus{
+						Crossplane: crossplane,
+						DependsOn: []v1alpha1.Dependency{{
+							Package: providerDep,
+							Version: version,
+						}},
+					},
+				},
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			err := tc.args.hook.Pre(context.TODO(), tc.args.pkg, tc.args.rev)
+
+			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
+				t.Errorf("\n%s\nh.Pre(...): -want error, +got error:\n%s", tc.reason, diff)
+			}
+			if diff := cmp.Diff(tc.want.rev, tc.args.rev, test.EquateErrors()); diff != "" {
+				t.Errorf("\n%s\nh.Pre(...): -want, +got:\n%s", tc.reason, diff)
+			}
+		})
+	}
+}
+
+func TestHookPost(t *testing.T) {
+	errBoom := errors.New("boom")
+
+	type args struct {
+		hook Hook
+		pkg  runtime.Object
+		rev  v1alpha1.PackageRevision
+	}
+
+	type want struct {
+		err error
+		rev v1alpha1.PackageRevision
+	}
+
+	cases := map[string]struct {
+		reason string
+		args   args
+		want   want
+	}{
+		"ErrNotProvider": {
+			reason: "Should return error if not provider.",
+			args: args{
+				hook: &ProviderHook{},
+			},
+			want: want{
+				err: errors.New(errNotProvider),
+			},
+		},
+		"ProviderInactive": {
+			reason: "Should do nothing if provider revision is inactive.",
+			args: args{
+				hook: &ProviderHook{},
+				pkg:  &pkgmeta.Provider{},
+				rev: &v1alpha1.ProviderRevision{
+					Spec: v1alpha1.PackageRevisionSpec{
+						DesiredState: v1alpha1.PackageRevisionInactive,
+					},
+				},
+			},
+			want: want{
+				rev: &v1alpha1.ProviderRevision{
+					Spec: v1alpha1.PackageRevisionSpec{
+						DesiredState: v1alpha1.PackageRevisionInactive,
+					},
+				},
+			},
+		},
+		"ErrProviderApplySA": {
+			reason: "Should return error if we fail to apply service account for active providerrevision.",
+			args: args{
+				hook: &ProviderHook{
+					client: resource.ClientApplicator{
+						Applicator: resource.ApplyFn(func(_ context.Context, o runtime.Object, _ ...resource.ApplyOption) error {
+							switch o.(type) {
+							case *appsv1.Deployment:
+								return nil
+							case *corev1.ServiceAccount:
+								return errBoom
+							}
+							return nil
+						}),
+					},
+				},
+				pkg: &pkgmeta.Provider{},
+				rev: &v1alpha1.ProviderRevision{
+					Spec: v1alpha1.PackageRevisionSpec{
+						DesiredState: v1alpha1.PackageRevisionActive,
+					},
+				},
+			},
+			want: want{
+				rev: &v1alpha1.ProviderRevision{
+					Spec: v1alpha1.PackageRevisionSpec{
+						DesiredState: v1alpha1.PackageRevisionActive,
+					},
+				},
+				err: errors.Wrap(errBoom, errApplyProviderSA),
+			},
+		},
+		"ErrProviderApplyDeployment": {
+			reason: "Should return error if we fail to apply deployment for active provider revision.",
+			args: args{
+				hook: &ProviderHook{
+					client: resource.ClientApplicator{
+						Applicator: resource.ApplyFn(func(_ context.Context, o runtime.Object, _ ...resource.ApplyOption) error {
+							switch o.(type) {
+							case *appsv1.Deployment:
+								return errBoom
+							case *corev1.ServiceAccount:
+								return nil
+							}
+							return nil
+						}),
+					},
+				},
+				pkg: &pkgmeta.Provider{},
+				rev: &v1alpha1.ProviderRevision{
+					Spec: v1alpha1.PackageRevisionSpec{
+						DesiredState: v1alpha1.PackageRevisionActive,
+					},
+				},
+			},
+			want: want{
+				rev: &v1alpha1.ProviderRevision{
+					Spec: v1alpha1.PackageRevisionSpec{
+						DesiredState: v1alpha1.PackageRevisionActive,
+					},
+				},
+				err: errors.Wrap(errBoom, errApplyProviderDeployment),
+			},
+		},
+		"SuccessfulProviderApply": {
+			reason: "Should not return error if successfully applied service account and deployment for active provider revision.",
+			args: args{
+				hook: &ProviderHook{
+					client: resource.ClientApplicator{
+						Applicator: resource.ApplyFn(func(_ context.Context, o runtime.Object, _ ...resource.ApplyOption) error {
+							return nil
+						}),
+					},
+				},
+				pkg: &pkgmeta.Provider{},
+				rev: &v1alpha1.ProviderRevision{
+					Spec: v1alpha1.PackageRevisionSpec{
+						DesiredState: v1alpha1.PackageRevisionActive,
+					},
+				},
+			},
+			want: want{
+				rev: &v1alpha1.ProviderRevision{
+					Spec: v1alpha1.PackageRevisionSpec{
+						DesiredState: v1alpha1.PackageRevisionActive,
+					},
+				},
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			err := tc.args.hook.Post(context.TODO(), tc.args.pkg, tc.args.rev)
+
+			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
+				t.Errorf("\n%s\nh.Post(...): -want error, +got error:\n%s", tc.reason, diff)
+			}
+			if diff := cmp.Diff(tc.want.rev, tc.args.rev, test.EquateErrors()); diff != "" {
+				t.Errorf("\n%s\nh.Post(...): -want, +got:\n%s", tc.reason, diff)
+			}
+		})
+	}
+}

--- a/pkg/controller/pkg/revision/reconciler.go
+++ b/pkg/controller/pkg/revision/reconciler.go
@@ -389,6 +389,10 @@ func (r *Reconciler) Reconcile(req reconcile.Request) (reconcile.Result, error) 
 	// Update object list in package revision status and set ready condition to
 	// true.
 	pr.SetObjects(r.establisher.GetResourceRefs())
+
+	// Clear all objects and references cached by the establisher.
+	r.establisher.Reset()
+
 	// TODO(hasheddan): set remaining status fields (dependencies, crossplane
 	// version, permission requests)
 	r.record.Event(pr, event.Normal(reasonInstall, "Successfully installed package revision"))

--- a/pkg/controller/pkg/revision/reconciler.go
+++ b/pkg/controller/pkg/revision/reconciler.go
@@ -26,9 +26,9 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	runtimev1alpha1 "github.com/crossplane/crossplane-runtime/apis/core/v1alpha1"
 	"github.com/crossplane/crossplane-runtime/pkg/event"
 	"github.com/crossplane/crossplane-runtime/pkg/logging"
 	"github.com/crossplane/crossplane-runtime/pkg/parser"
@@ -52,11 +52,10 @@ const (
 
 	errInitParserBackend = "cannot initialize parser backend"
 	errParseLogs         = "cannot parse pod logs"
+	errOneMeta           = "cannot install package with multiple meta types"
 
-	errDeleteProviderDeployment = "cannot delete provider package deployment"
-	errDeleteProviderSA         = "cannot delete provider package service account"
-	errCreateProviderDeployment = "cannot create provider package deployment"
-	errCreateProviderSA         = "cannot create provider package service account"
+	errPreHook  = "cannot run pre establish hook for package"
+	errPostHook = "cannot run post establish hook for package"
 
 	errEstablishControl = "cannot establish control of object"
 )
@@ -70,14 +69,6 @@ const (
 
 // ReconcilerOption is used to configure the Reconciler.
 type ReconcilerOption func(*Reconciler)
-
-// WithInstallNamespace determines the namespace where install jobs will be
-// created.
-func WithInstallNamespace(n string) ReconcilerOption {
-	return func(r *Reconciler) {
-		r.namespace = n
-	}
-}
 
 // WithNewPackageRevisionFn determines the type of package being reconciled.
 func WithNewPackageRevisionFn(f func() v1alpha1.PackageRevision) ReconcilerOption {
@@ -97,6 +88,14 @@ func WithLogger(log logging.Logger) ReconcilerOption {
 func WithRecorder(er event.Recorder) ReconcilerOption {
 	return func(r *Reconciler) {
 		r.record = er
+	}
+}
+
+// WithHook specifies how the Reconciler should perform pre and post object
+// establishment operations.
+func WithHook(h Hook) ReconcilerOption {
+	return func(r *Reconciler) {
+		r.hook = h
 	}
 }
 
@@ -153,8 +152,8 @@ func BuildObjectScheme() (*runtime.Scheme, error) {
 
 // Reconciler reconciles packages.
 type Reconciler struct {
-	namespace    string
-	client       resource.ClientApplicator
+	client       client.Client
+	hook         Hook
 	establisher  Establisher
 	podLogClient kubernetes.Interface
 	parser       parser.Parser
@@ -187,7 +186,10 @@ func SetupProviderRevision(mgr ctrl.Manager, l logging.Logger, namespace string)
 
 	r := NewReconciler(mgr,
 		clientset,
-		WithInstallNamespace(namespace),
+		WithHook(NewProviderHook(resource.ClientApplicator{
+			Client:     mgr.GetClient(),
+			Applicator: resource.NewAPIUpdatingApplicator(mgr.GetClient()),
+		}, namespace)),
 		WithNewPackageRevisionFn(nr),
 		WithParser(parser.New(metaScheme, objScheme)),
 		WithParserBackend(parser.NewPodLogBackend(parser.PodNamespace(namespace))),
@@ -223,7 +225,7 @@ func SetupConfigurationRevision(mgr ctrl.Manager, l logging.Logger, namespace st
 
 	r := NewReconciler(mgr,
 		clientset,
-		WithInstallNamespace(namespace),
+		WithHook(NewConfigurationHook()),
 		WithNewPackageRevisionFn(nr),
 		WithParser(parser.New(metaScheme, objScheme)),
 		WithParserBackend(parser.NewPodLogBackend(parser.PodNamespace(namespace))),
@@ -241,10 +243,8 @@ func SetupConfigurationRevision(mgr ctrl.Manager, l logging.Logger, namespace st
 // NewReconciler creates a new package reconciler.
 func NewReconciler(mgr ctrl.Manager, clientset kubernetes.Interface, opts ...ReconcilerOption) *Reconciler {
 	r := &Reconciler{
-		client: resource.ClientApplicator{
-			Client:     mgr.GetClient(),
-			Applicator: resource.NewAPIUpdatingApplicator(mgr.GetClient()),
-		},
+		client:       mgr.GetClient(),
+		hook:         NewNopHook(),
 		establisher:  NewAPIEstablisher(mgr.GetClient()),
 		podLogClient: clientset,
 		parser:       parser.New(nil, nil),
@@ -312,33 +312,21 @@ func (r *Reconciler) Reconcile(req reconcile.Request) (reconcile.Result, error) 
 		return reconcile.Result{RequeueAfter: longWait}, errors.Wrap(r.client.Status().Update(ctx, pr), errUpdateStatus)
 	}
 
-	desiredState := pr.GetDesiredState()
+	// NOTE(hasheddan): the linter should check this property already, but if a
+	// consumer forgets to pass an option to guarantee one meta object, we check
+	// here to avoid a potential panic on 0 index below.
+	if len(pkg.GetMeta()) != 1 {
+		r.record.Event(pr, event.Warning(reasonLint, errors.New(errOneMeta)))
+		pr.SetConditions(v1alpha1.Unhealthy())
+		return reconcile.Result{RequeueAfter: longWait}, errors.Wrap(r.client.Status().Update(ctx, pr), errUpdateStatus)
+	}
 
-	// If revision is inactive and is a provider, we must make sure controller
-	// is not running before we clean up resources.
-	if pr.GetObjectKind().GroupVersionKind() == v1alpha1.ProviderRevisionGroupVersionKind && desiredState == v1alpha1.PackageRevisionInactive {
-		// TODO(hasheddan): we are safe to 0 index and assert to Provider meta
-		// type here because of the linting checks we pass in for the
-		// ProviderRevision controller. Having those checks passed at controller
-		// setup and doing this assertion in the reconciler is not a great
-		// practice because it is not obvious that they are related or that
-		// changing the checks could cause panic here. It would be good to
-		// remove all conditional logic from this reconcile loop so that it is
-		// less difficult to maintain in the future.
-		pkgProvider := pkg.GetMeta()[0].(*pkgmeta.Provider)
-		s, d := buildProviderDeployment(pkgProvider, pr, r.namespace)
-		if err := r.client.Delete(ctx, d); resource.IgnoreNotFound(err) != nil {
-			log.Debug(errDeleteProviderDeployment, "error", err)
-			r.record.Event(pr, event.Warning(errDeleteProviderDeployment, err))
-			pr.SetConditions(v1alpha1.Unhealthy())
-			return reconcile.Result{RequeueAfter: shortWait}, errors.Wrap(r.client.Status().Update(ctx, pr), errUpdateStatus)
-		}
-		if err := r.client.Delete(ctx, s); resource.IgnoreNotFound(err) != nil {
-			log.Debug(errDeleteProviderSA, "error", err)
-			r.record.Event(pr, event.Warning(errDeleteProviderSA, err))
-			pr.SetConditions(v1alpha1.Unhealthy())
-			return reconcile.Result{RequeueAfter: shortWait}, errors.Wrap(r.client.Status().Update(ctx, pr), errUpdateStatus)
-		}
+	pkgMeta := pkg.GetMeta()[0]
+	if err := r.hook.Pre(ctx, pkgMeta, pr); err != nil {
+		log.Debug(errPreHook, "error", err)
+		r.record.Event(pr, event.Warning(errPreHook, err))
+		pr.SetConditions(v1alpha1.Unhealthy())
+		return reconcile.Result{RequeueAfter: shortWait}, errors.Wrap(r.client.Status().Update(ctx, pr), errUpdateStatus)
 	}
 
 	// NOTE(hasheddan): the following logic enforces the present guarantees of
@@ -365,25 +353,11 @@ func (r *Reconciler) Reconcile(req reconcile.Request) (reconcile.Result, error) 
 		return reconcile.Result{RequeueAfter: shortWait}, errors.Wrap(r.client.Status().Update(ctx, pr), errUpdateStatus)
 	}
 
-	// If package is a provider package, all resources have been created, and
-	// the revision is active, we should start the controller.
-	if pr.GetObjectKind().GroupVersionKind() == v1alpha1.ProviderRevisionGroupVersionKind && desiredState == v1alpha1.PackageRevisionActive {
-		// TODO(hasheddan): see comment on conditional logic above.
-		pkgProvider := pkg.GetMeta()[0].(*pkgmeta.Provider)
-		s, d := buildProviderDeployment(pkgProvider, pr, r.namespace)
-		if err := r.client.Apply(ctx, s); err != nil {
-			log.Debug(errCreateProviderSA, "error", err)
-			r.record.Event(pr, event.Warning(errCreateProviderSA, err))
-			pr.SetConditions(v1alpha1.Unhealthy())
-			return reconcile.Result{RequeueAfter: shortWait}, errors.Wrap(r.client.Status().Update(ctx, pr), errUpdateStatus)
-		}
-		if err := r.client.Apply(ctx, d); err != nil {
-			log.Debug(errCreateProviderDeployment, "error", err)
-			r.record.Event(pr, event.Warning(errCreateProviderDeployment, err))
-			pr.SetConditions(v1alpha1.Unhealthy())
-			return reconcile.Result{RequeueAfter: shortWait}, errors.Wrap(r.client.Status().Update(ctx, pr), errUpdateStatus)
-		}
-		pr.SetControllerReference(runtimev1alpha1.Reference{Name: d.GetName()})
+	if err := r.hook.Post(ctx, pkgMeta, pr); err != nil {
+		log.Debug(errPostHook, "error", err)
+		r.record.Event(pr, event.Warning(errPostHook, err))
+		pr.SetConditions(v1alpha1.Unhealthy())
+		return reconcile.Result{RequeueAfter: shortWait}, errors.Wrap(r.client.Status().Update(ctx, pr), errUpdateStatus)
 	}
 
 	// Update object list in package revision status and set ready condition to
@@ -393,8 +367,6 @@ func (r *Reconciler) Reconcile(req reconcile.Request) (reconcile.Result, error) 
 	// Clear all objects and references cached by the establisher.
 	r.establisher.Reset()
 
-	// TODO(hasheddan): set remaining status fields (dependencies, crossplane
-	// version, permission requests)
 	r.record.Event(pr, event.Normal(reasonInstall, "Successfully installed package revision"))
 	pr.SetConditions(v1alpha1.Healthy())
 	return reconcile.Result{RequeueAfter: longWait}, errors.Wrap(r.client.Status().Update(ctx, pr), errUpdateStatus)

--- a/pkg/controller/pkg/revision/reconciler_test.go
+++ b/pkg/controller/pkg/revision/reconciler_test.go
@@ -84,6 +84,8 @@ func (e *MockEstablisher) GetResourceRefs() []runtimev1alpha1.TypedReference {
 	return e.MockGetResourceRefs()
 }
 
+func (e *MockEstablisher) Reset() {}
+
 func TestReconcile(t *testing.T) {
 	errBoom := errors.New("boom")
 

--- a/pkg/controller/pkg/revision/reconciler_test.go
+++ b/pkg/controller/pkg/revision/reconciler_test.go
@@ -89,7 +89,7 @@ func (e *MockEstablisher) GetResourceRefs() []runtimev1alpha1.TypedReference {
 
 func (e *MockEstablisher) Reset() {}
 
-var _ Hook = &MockHook{}
+var _ Hooks = &MockHook{}
 
 type MockHook struct {
 	MockPre  func() error
@@ -442,7 +442,7 @@ func TestReconcile(t *testing.T) {
 							MockDelete: test.NewMockDeleteFn(nil),
 						},
 					},
-					hook:        NewNopHook(),
+					hook:        NewNopHooks(),
 					establisher: NewMockEstablisher(),
 					backend:     parser.NewEchoBackend(string(providerBytes)),
 					linter:      NewPackageLinter(nil, nil, nil),
@@ -485,7 +485,7 @@ func TestReconcile(t *testing.T) {
 							MockDelete: test.NewMockDeleteFn(nil),
 						},
 					},
-					hook: NewNopHook(),
+					hook: NewNopHooks(),
 					establisher: &MockEstablisher{
 						MockCheck:           NewMockCheckFn(nil),
 						MockEstablish:       NewMockEstablishFn(errBoom),
@@ -532,7 +532,7 @@ func TestReconcile(t *testing.T) {
 							MockDelete: test.NewMockDeleteFn(nil),
 						},
 					},
-					hook:        NewNopHook(),
+					hook:        NewNopHooks(),
 					establisher: NewMockEstablisher(),
 					backend:     parser.NewEchoBackend(string(providerBytes)),
 					linter:      NewPackageLinter(nil, nil, nil),
@@ -575,7 +575,7 @@ func TestReconcile(t *testing.T) {
 							MockDelete: test.NewMockDeleteFn(nil),
 						},
 					},
-					hook: NewNopHook(),
+					hook: NewNopHooks(),
 					establisher: &MockEstablisher{
 						MockCheck:           NewMockCheckFn(errBoom),
 						MockEstablish:       NewMockEstablishFn(nil),


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Follow up to #1675 

Cleans up some of the v2 package manager implementation. Please see individual commits for details, highlights include:
- Fixed TODO to set crossplane version, dependencies, and permission requests in revision status
- Added `Reset()` method to `Establisher` to clear cached objects and references. Previously cache was being cleared at beginning of each `Check()` call, which meant we were holding objects in memory until next reconcile. We now call `Reset()` at the end of each reconcile.
- Introduced `Hook` interface. This allows the controller deployment creation / clean up for provider packages to be moved out of the package revision reconcile logic, so that it remains agnostic about the revision type it is reconciling. `ProviderHook` and `ConfigurationHook` implementations were introduced.
- Renamed main pod manager method to `Sync` to more clearly indicate it actual behavior (changed from `Run`)
- Cleaned up some unit tests.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

`make build`
`make test`

Ran locally against `kind` cluster using [xp-package-ports](https://github.com/hasheddan/xp-package-ports).

Verified status updated appropriately for `hasheddan/xp3-provider-aws:v0.11.1`:

<details>
  <summary>Click to expand</summary>


```
status:
  conditions:
  - lastTransitionTime: "2020-09-17T18:07:12Z"
    reason: HealthyPackageRevision
    status: "True"
    type: Healthy
  controllerRef:
    name: my-aws-install-5f91f2fe6662
  crossplane: v0.12.0
  objectRefs:
  - apiVersion: apiextensions.k8s.io/v1beta1
    kind: CustomResourceDefinition
    name: replicationgroupclasses.cache.aws.crossplane.io
    uid: 713e1a5f-d036-4909-9a88-840c7ab37c43
  - apiVersion: apiextensions.k8s.io/v1beta1
    kind: CustomResourceDefinition
    name: nodegroups.eks.aws.crossplane.io
    uid: daff115f-ab95-4911-a1b0-d23c7ecc6e9b
  - apiVersion: apiextensions.k8s.io/v1beta1
    kind: CustomResourceDefinition
    name: vpcs.ec2.aws.crossplane.io
    uid: 444166fe-0ac5-484f-844f-cc37011a141c
  - apiVersion: apiextensions.k8s.io/v1beta1
    kind: CustomResourceDefinition
    name: s3buckets.storage.aws.crossplane.io
    uid: b318d2c5-57cd-4be5-9a3f-80c24495ee63
  - apiVersion: apiextensions.k8s.io/v1beta1
    kind: CustomResourceDefinition
    name: iamroles.identity.aws.crossplane.io
    uid: 33e8c7b7-eda4-47c5-a352-87ab57a51f56
  - apiVersion: apiextensions.k8s.io/v1beta1
    kind: CustomResourceDefinition
    name: iamgroups.identity.aws.crossplane.io
    uid: 2125bf25-0322-4289-bc92-88a2f44bcf32
  - apiVersion: apiextensions.k8s.io/v1beta1
    kind: CustomResourceDefinition
    name: certificateauthoritypermissions.acmpca.aws.crossplane.io
    uid: d78a553c-1d97-4099-8110-8819fe5423b8
  - apiVersion: apiextensions.k8s.io/v1beta1
    kind: CustomResourceDefinition
    name: dynamotables.database.aws.crossplane.io
    uid: f0655411-7b77-472a-9522-86cf1a5edd74
  - apiVersion: apiextensions.k8s.io/v1beta1
    kind: CustomResourceDefinition
    name: iamuserpolicyattachments.identity.aws.crossplane.io
    uid: d29427b3-65a7-459c-9ace-98281b2e6a27
  - apiVersion: apiextensions.k8s.io/v1beta1
    kind: CustomResourceDefinition
    name: certificates.acm.aws.crossplane.io
    uid: dc324516-5b27-48ef-9047-de39a5850d18
  - apiVersion: apiextensions.k8s.io/v1beta1
    kind: CustomResourceDefinition
    name: iamgrouppolicyattachments.identity.aws.crossplane.io
    uid: 1f6d214d-50b0-4714-bf3c-f83d0fb256c1
  - apiVersion: apiextensions.k8s.io/v1beta1
    kind: CustomResourceDefinition
    name: elbs.elasticloadbalancing.aws.crossplane.io
    uid: 223a6b13-0191-4fd4-a3c9-b434fa26a110
  - apiVersion: apiextensions.k8s.io/v1beta1
    kind: CustomResourceDefinition
    name: clusters.redshift.aws.crossplane.io
    uid: 1f3c7890-cd2b-4558-8748-efc578603484
  - apiVersion: apiextensions.k8s.io/v1beta1
    kind: CustomResourceDefinition
    name: queues.applicationintegration.aws.crossplane.io
    uid: b3b60043-ee93-4368-bd3c-98d6d203b4cd
  - apiVersion: apiextensions.k8s.io/v1beta1
    kind: CustomResourceDefinition
    name: providers.aws.crossplane.io
    uid: b427ea0a-dad3-4a3b-ac98-6effee221f20
  - apiVersion: apiextensions.k8s.io/v1beta1
    kind: CustomResourceDefinition
    name: clusters.eks.aws.crossplane.io
    uid: dcc12620-2016-4f1a-a77a-714c002ff099
  - apiVersion: apiextensions.k8s.io/v1beta1
    kind: CustomResourceDefinition
    name: elbattachments.elasticloadbalancing.aws.crossplane.io
    uid: df8f5c1f-8202-4bbd-bd93-d6c50a4195b4
  - apiVersion: apiextensions.k8s.io/v1beta1
    kind: CustomResourceDefinition
    name: iamusers.identity.aws.crossplane.io
    uid: 043d5a12-8ec0-42ae-879d-9b1d8be283f7
  - apiVersion: apiextensions.k8s.io/v1beta1
    kind: CustomResourceDefinition
    name: eksclusterclasses.compute.aws.crossplane.io
    uid: b4408aba-a492-4de8-b627-a8c3aefcf08c
  - apiVersion: apiextensions.k8s.io/v1beta1
    kind: CustomResourceDefinition
    name: securitygroups.ec2.aws.crossplane.io
    uid: 46cb5475-4b3b-4210-906f-971ba4d8f362
  - apiVersion: apiextensions.k8s.io/v1beta1
    kind: CustomResourceDefinition
    name: dbsubnetgroups.database.aws.crossplane.io
    uid: 5605db24-a032-4eb3-9c8c-3c254a79c99b
  - apiVersion: apiextensions.k8s.io/v1beta1
    kind: CustomResourceDefinition
    name: s3bucketclasses.storage.aws.crossplane.io
    uid: 093eb66e-f31b-481b-bdf1-ea4f3c489bd2
  - apiVersion: apiextensions.k8s.io/v1beta1
    kind: CustomResourceDefinition
    name: iampolicies.identity.aws.crossplane.io
    uid: 220c3e4f-2641-43f4-bb4a-d7b2a10351bc
  - apiVersion: apiextensions.k8s.io/v1beta1
    kind: CustomResourceDefinition
    name: iamgroupusermemberships.identity.aws.crossplane.io
    uid: a0bc847c-ba14-4884-b8a7-6df38a70b0d7
  - apiVersion: apiextensions.k8s.io/v1beta1
    kind: CustomResourceDefinition
    name: eksclusters.compute.aws.crossplane.io
    uid: d920b5ec-f8e5-4178-9562-797cd50f0c13
  - apiVersion: apiextensions.k8s.io/v1beta1
    kind: CustomResourceDefinition
    name: rdsinstances.database.aws.crossplane.io
    uid: 4c150fca-463b-4daf-9f82-ade3a7349ad6
  - apiVersion: apiextensions.k8s.io/v1beta1
    kind: CustomResourceDefinition
    name: resourcerecordsets.route53.aws.crossplane.io
    uid: 3af14ad5-d762-482d-949f-3c86730fd1b2
  - apiVersion: apiextensions.k8s.io/v1beta1
    kind: CustomResourceDefinition
    name: replicationgroups.cache.aws.crossplane.io
    uid: 59690a42-a19b-4348-95eb-a179e2f12a54
  - apiVersion: apiextensions.k8s.io/v1beta1
    kind: CustomResourceDefinition
    name: rdsinstanceclasses.database.aws.crossplane.io
    uid: a9efb6ee-5ceb-4cba-9c63-945d81fc552e
  - apiVersion: apiextensions.k8s.io/v1beta1
    kind: CustomResourceDefinition
    name: snstopics.notification.aws.crossplane.io
    uid: c8a1e974-4663-49a4-874e-f2bb1f139058
  - apiVersion: apiextensions.k8s.io/v1beta1
    kind: CustomResourceDefinition
    name: routetables.ec2.aws.crossplane.io
    uid: 590cfa06-b5dc-455b-aee6-41a9c137c6c2
  - apiVersion: apiextensions.k8s.io/v1beta1
    kind: CustomResourceDefinition
    name: hostedzones.route53.aws.crossplane.io
    uid: 88e63ce3-7187-48a5-9408-94dfdf436c48
  - apiVersion: apiextensions.k8s.io/v1beta1
    kind: CustomResourceDefinition
    name: snssubscriptions.notification.aws.crossplane.io
    uid: 5c343211-58be-49a7-8a68-0547d174603c
  - apiVersion: apiextensions.k8s.io/v1beta1
    kind: CustomResourceDefinition
    name: iamrolepolicyattachments.identity.aws.crossplane.io
    uid: 8374cbc1-f32a-4ac1-a56f-6eea5db90add
  - apiVersion: apiextensions.k8s.io/v1beta1
    kind: CustomResourceDefinition
    name: cachesubnetgroups.cache.aws.crossplane.io
    uid: 763bf3ad-e1c2-42e6-b093-1957084f5be1
  - apiVersion: apiextensions.k8s.io/v1beta1
    kind: CustomResourceDefinition
    name: internetgateways.ec2.aws.crossplane.io
    uid: 3fac5e19-d987-4d23-991b-0e25190fd247
  - apiVersion: apiextensions.k8s.io/v1beta1
    kind: CustomResourceDefinition
    name: subnets.ec2.aws.crossplane.io
    uid: 15bb6f3e-7345-469e-a514-5a8b4b08ef62
  - apiVersion: apiextensions.k8s.io/v1beta1
    kind: CustomResourceDefinition
    name: certificateauthorities.acmpca.aws.crossplane.io
    uid: 754ff4b6-b853-44cb-9c0a-bb486b96df65
  permissionRequests:
  - apiGroups:
    - crossplane.io
    resources:
    - '*'
    verbs:
    - '*'
```  

</details>


[contribution process]: https://git.io/fj2m9
