### PR TITLE
Deprecate package API types

### DIFF
--- a/apis/packages/v1alpha1/stackdefinition.go
+++ b/apis/packages/v1alpha1/stackdefinition.go
@@ -101,6 +101,7 @@ type StackDefinitionStatus struct {
 // +kubebuilder:object:root=true
 
 // StackDefinition is the Schema for the StackDefinitions API
+// Deprecated: use configuration.pkg.crossplane.io and composition instead
 // +kubebuilder:resource:categories=crossplane
 type StackDefinition struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/apis/packages/v1alpha1/types.go
+++ b/apis/packages/v1alpha1/types.go
@@ -34,6 +34,7 @@ import (
 // +kubebuilder:object:root=true
 
 // A PackageInstall requests a package be installed to Crossplane.
+// Deprecated: use configuration.pkg.crossplane.io and composition instead
 // +kubebuilder:resource:categories=crossplane
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="READY",type="string",JSONPath=".status.conditionedStatus.conditions[?(@.type=='Ready')].status"
@@ -352,6 +353,7 @@ type PackageInstaller interface {
 // +kubebuilder:object:root=true
 
 // ClusterPackageInstall is the CRD type for a request to add a package to Crossplane.
+// Deprecated: use provider.pkg.crossplane.io instead
 // +kubebuilder:resource:categories=crossplane
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="READY",type="string",JSONPath=".status.conditionedStatus.conditions[?(@.type=='Ready')].status"
@@ -379,6 +381,8 @@ type ClusterPackageInstallList struct {
 // +kubebuilder:object:root=true
 
 // A Package that has been added to Crossplane.
+// Deprecated: use configuration.pkg.crossplane.io or provider.pkg.crossplane.io
+// instead
 // +kubebuilder:resource:categories=crossplane
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="READY",type="string",JSONPath=".status.conditionedStatus.conditions[?(@.type=='Ready')].status"


### PR DESCRIPTION


<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #1669 

Deprecates old package API types in favor of the v2 package manager API
types.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

`make generate`
`make reviewable`

[contribution process]: https://git.io/fj2m9
