### PR TITLE
Emit events for Package on successful and unsuccessful installations

### DIFF
--- a/pkg/controller/pkg/manager/reconciler.go
+++ b/pkg/controller/pkg/manager/reconciler.go
@@ -56,6 +56,8 @@ const (
 	errUpdateStatus                  = "cannot update package status"
 	errUpdateInactivePackageRevision = "cannot update inactive package revision"
 	errUpdateActivePackageRevision   = "cannot update active package revision"
+
+	errUnhealthyPackageRevision = "current package revision is unhealthy"
 )
 
 // Event reasons.
@@ -321,8 +323,10 @@ func (r *Reconciler) Reconcile(req reconcile.Request) (reconcile.Result, error) 
 		// Update Package status to match that of revision.
 		if pr.GetCondition(v1alpha1.TypeHealthy).Status == corev1.ConditionTrue {
 			p.SetConditions(v1alpha1.Healthy())
+			r.record.Event(p, event.Normal(reasonInstall, "Successfully installed package revision"))
 		} else {
 			p.SetConditions(v1alpha1.Unhealthy())
+			r.record.Event(p, event.Warning(reasonInstall, errors.New(errUnhealthyPackageRevision)))
 		}
 		return reconcile.Result{}, errors.Wrap(r.client.Status().Update(ctx, p), errUpdateStatus)
 	}

--- a/pkg/controller/pkg/manager/reconciler.go
+++ b/pkg/controller/pkg/manager/reconciler.go
@@ -231,7 +231,7 @@ func (r *Reconciler) Reconcile(req reconcile.Request) (reconcile.Result, error) 
 	}
 
 	if hash == "" {
-		r.record.Event(p, event.Normal(reasonUnpack, "waiting for unpack to complete"))
+		r.record.Event(p, event.Normal(reasonUnpack, "Waiting for unpack to complete"))
 		return reconcile.Result{RequeueAfter: veryShortWait}, errors.Wrap(r.client.Status().Update(ctx, p), errUpdateStatus)
 	}
 


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Updates package controller to emit events on successful and unsuccessful installations.

Fixes #1747 

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

Installed same package mentioned in #1747 and observed the following events:

```
Events:
  Type    Reason                  Age                    From                                 Message
  ----    ------                  ----                   ----                                 -------
  Normal  UnpackPackage           9m45s (x2 over 9m45s)  packages/provider.pkg.crossplane.io  Waiting for unpack to complete
  Normal  InstallPackageRevision  8m35s (x2 over 8m35s)  packages/provider.pkg.crossplane.io  Successfully installed package revision

```

[contribution process]: https://git.io/fj2m9
