### PR TITLE
Bind crossplane-admin to correct group

### DIFF
--- a/cluster/charts/crossplane-types/templates/rbac-manager-managed-clusterroles.yaml
+++ b/cluster/charts/crossplane-types/templates/rbac-manager-managed-clusterroles.yaml
@@ -11,7 +11,7 @@ roleRef:
 subjects:
 - apiGroup: rbac.authorization.k8s.io
   kind: Group
-  name: {{ template "name" . }}:master
+  name: {{ template "name" . }}:masters
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/cluster/charts/crossplane/templates/rbac-manager-managed-clusterroles.yaml
+++ b/cluster/charts/crossplane/templates/rbac-manager-managed-clusterroles.yaml
@@ -11,7 +11,7 @@ roleRef:
 subjects:
 - apiGroup: rbac.authorization.k8s.io
   kind: Group
-  name: {{ template "name" . }}:master
+  name: {{ template "name" . }}:masters
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole


### PR DESCRIPTION


<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

The crossplane-admin is intended to be bound to the crossplane:masters
convenience group, but is currently bound to the crossplane:master
group. This fixes the cluster role binding.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

Installed chart with `helm`.

[contribution process]: https://git.io/fj2m9
