### PR TITLE
Remove cargo-culted reconciler scaffold from RBAC manager

### DIFF
--- a/pkg/controller/rbac/definition/reconciler.go
+++ b/pkg/controller/rbac/definition/reconciler.go
@@ -32,7 +32,6 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/logging"
 	"github.com/crossplane/crossplane-runtime/pkg/meta"
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
-	"github.com/crossplane/crossplane-runtime/pkg/resource/unstructured"
 
 	"github.com/crossplane/crossplane/apis/apiextensions/v1alpha1"
 )
@@ -117,15 +116,11 @@ func WithClusterRoleRenderer(rr ClusterRoleRenderer) ReconcilerOption {
 
 // NewReconciler returns a Reconciler of CompositeResourceDefinitions.
 func NewReconciler(mgr manager.Manager, opts ...ReconcilerOption) *Reconciler {
-	kube := unstructured.NewClient(mgr.GetClient())
-
 	r := &Reconciler{
-		mgr: mgr,
-
 		// TODO(negz): Is Updating appropriate here? Probably.
 		client: resource.ClientApplicator{
-			Client:     kube,
-			Applicator: resource.NewAPIUpdatingApplicator(kube),
+			Client:     mgr.GetClient(),
+			Applicator: resource.NewAPIUpdatingApplicator(mgr.GetClient()),
 		},
 
 		rbac: ClusterRoleRenderFn(RenderClusterRoles),
@@ -143,7 +138,6 @@ func NewReconciler(mgr manager.Manager, opts ...ReconcilerOption) *Reconciler {
 // A Reconciler reconciles CompositeResourceDefinitions.
 type Reconciler struct {
 	client resource.ClientApplicator
-	mgr    manager.Manager
 	rbac   ClusterRoleRenderer
 
 	log    logging.Logger

--- a/pkg/controller/rbac/namespace/reconciler.go
+++ b/pkg/controller/rbac/namespace/reconciler.go
@@ -33,7 +33,6 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/logging"
 	"github.com/crossplane/crossplane-runtime/pkg/meta"
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
-	"github.com/crossplane/crossplane-runtime/pkg/resource/unstructured"
 )
 
 const (
@@ -118,15 +117,11 @@ func WithRoleRenderer(rr RoleRenderer) ReconcilerOption {
 
 // NewReconciler returns a Reconciler of Namespaces.
 func NewReconciler(mgr manager.Manager, opts ...ReconcilerOption) *Reconciler {
-	kube := unstructured.NewClient(mgr.GetClient())
-
 	r := &Reconciler{
-		mgr: mgr,
-
 		// TODO(negz): Is Updating appropriate here? Probably.
 		client: resource.ClientApplicator{
-			Client:     kube,
-			Applicator: resource.NewAPIUpdatingApplicator(kube),
+			Client:     mgr.GetClient(),
+			Applicator: resource.NewAPIUpdatingApplicator(mgr.GetClient()),
 		},
 
 		rbac: RoleRenderFn(RenderRoles),
@@ -144,7 +139,6 @@ func NewReconciler(mgr manager.Manager, opts ...ReconcilerOption) *Reconciler {
 // A Reconciler reconciles Namespaces.
 type Reconciler struct {
 	client resource.ClientApplicator
-	mgr    manager.Manager
 	rbac   RoleRenderer
 
 	log    logging.Logger

--- a/pkg/controller/rbac/provider/binding/reconciler.go
+++ b/pkg/controller/rbac/provider/binding/reconciler.go
@@ -34,7 +34,6 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/logging"
 	"github.com/crossplane/crossplane-runtime/pkg/meta"
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
-	"github.com/crossplane/crossplane-runtime/pkg/resource/unstructured"
 	"github.com/crossplane/crossplane/apis/pkg/v1alpha1"
 	"github.com/crossplane/crossplane/pkg/controller/rbac/provider/roles"
 )
@@ -100,15 +99,11 @@ func WithClientApplicator(ca resource.ClientApplicator) ReconcilerOption {
 
 // NewReconciler returns a Reconciler of ProviderRevisions.
 func NewReconciler(mgr manager.Manager, opts ...ReconcilerOption) *Reconciler {
-	kube := unstructured.NewClient(mgr.GetClient())
-
 	r := &Reconciler{
-		mgr: mgr,
-
 		// TODO(negz): Is Updating appropriate here? Probably.
 		client: resource.ClientApplicator{
-			Client:     kube,
-			Applicator: resource.NewAPIUpdatingApplicator(kube),
+			Client:     mgr.GetClient(),
+			Applicator: resource.NewAPIUpdatingApplicator(mgr.GetClient()),
 		},
 
 		log:    logging.NewNopLogger(),
@@ -124,7 +119,6 @@ func NewReconciler(mgr manager.Manager, opts ...ReconcilerOption) *Reconciler {
 // A Reconciler reconciles ProviderRevisions.
 type Reconciler struct {
 	client resource.ClientApplicator
-	mgr    manager.Manager
 
 	log    logging.Logger
 	record event.Recorder

--- a/pkg/controller/rbac/provider/roles/reconciler.go
+++ b/pkg/controller/rbac/provider/roles/reconciler.go
@@ -33,7 +33,6 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/logging"
 	"github.com/crossplane/crossplane-runtime/pkg/meta"
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
-	"github.com/crossplane/crossplane-runtime/pkg/resource/unstructured"
 	"github.com/crossplane/crossplane/apis/pkg/v1alpha1"
 )
 
@@ -118,15 +117,11 @@ func WithClusterRoleRenderer(rr ClusterRoleRenderer) ReconcilerOption {
 
 // NewReconciler returns a Reconciler of ProviderRevisions.
 func NewReconciler(mgr manager.Manager, opts ...ReconcilerOption) *Reconciler {
-	kube := unstructured.NewClient(mgr.GetClient())
-
 	r := &Reconciler{
-		mgr: mgr,
-
 		// TODO(negz): Is Updating appropriate here? Probably.
 		client: resource.ClientApplicator{
-			Client:     kube,
-			Applicator: resource.NewAPIUpdatingApplicator(kube),
+			Client:     mgr.GetClient(),
+			Applicator: resource.NewAPIUpdatingApplicator(mgr.GetClient()),
 		},
 
 		rbac: ClusterRoleRenderFn(RenderClusterRoles),
@@ -144,7 +139,6 @@ func NewReconciler(mgr manager.Manager, opts ...ReconcilerOption) *Reconciler {
 // A Reconciler reconciles ProviderRevisions.
 type Reconciler struct {
 	client resource.ClientApplicator
-	mgr    manager.Manager
 	rbac   ClusterRoleRenderer
 
 	log    logging.Logger


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
The RBAC manager controllers never use the mgr, and don't need a special Kubernetes client.

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested
I've just run the tests, and made sure Crossplane builds and starts when deployed via Helm. This change only removes an unused variable and and unused layer of client indirection, so I'm pretty confident it won't break anything.

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
