### PR TITLE
Add an explicit 'None' readiness check

### DIFF
--- a/apis/apiextensions/v1alpha1/composition_types.go
+++ b/apis/apiextensions/v1alpha1/composition_types.go
@@ -103,17 +103,19 @@ const (
 	ReadinessCheckNonEmpty     TypeReadinessCheck = "NonEmpty"
 	ReadinessCheckMatchString  TypeReadinessCheck = "MatchString"
 	ReadinessCheckMatchInteger TypeReadinessCheck = "MatchInteger"
+	ReadinessCheckNone         TypeReadinessCheck = "None"
 )
 
 // ReadinessCheck is used to indicate how to tell whether a resource is ready
 // for consumption
 type ReadinessCheck struct {
-	// FieldPath shows the path of the field whose value will be used.
-	FieldPath string `json:"fieldPath"`
-
 	// Type indicates the type of probe you'd like to use.
-	// +kubebuilder:validation:Enum="MatchString";"MatchInteger";"NonEmpty"
+	// +kubebuilder:validation:Enum="MatchString";"MatchInteger";"NonEmpty";"None"
 	Type TypeReadinessCheck `json:"type"`
+
+	// FieldPath shows the path of the field whose value will be used.
+	// +optional
+	FieldPath string `json:"fieldPath,omitempty"`
 
 	// MatchString is the value you'd like to match if you're using "MatchString" type.
 	// +optional

--- a/cluster/charts/crossplane/crds/apiextensions.crossplane.io_compositions.yaml
+++ b/cluster/charts/crossplane/crds/apiextensions.crossplane.io_compositions.yaml
@@ -145,9 +145,9 @@ spec:
                           - MatchString
                           - MatchInteger
                           - NonEmpty
+                          - None
                           type: string
                       required:
-                      - fieldPath
                       - type
                       type: object
                     type: array

--- a/pkg/controller/apiextensions/composite/composed/api.go
+++ b/pkg/controller/apiextensions/composite/composed/api.go
@@ -193,6 +193,8 @@ func (*DefaultReadinessChecker) IsReady(_ context.Context, cd resource.Composed,
 	for i, check := range t.ReadinessChecks {
 		var ready bool
 		switch check.Type {
+		case v1alpha1.ReadinessCheckNone:
+			return true, nil
 		case v1alpha1.ReadinessCheckNonEmpty:
 			_, err := paved.GetValue(check.FieldPath)
 			if resource.Ignore(fieldpath.IsNotFound, err) != nil {

--- a/pkg/controller/apiextensions/composite/composed/api.go
+++ b/pkg/controller/apiextensions/composite/composed/api.go
@@ -169,12 +169,8 @@ func (cdf *APIConnectionDetailsFetcher) Fetch(ctx context.Context, cd resource.C
 	return conn, nil
 }
 
-// DefaultReadinessChecker is a readiness checker which returns whether the composed
-// resource is ready or not.
-type DefaultReadinessChecker struct{}
-
 // IsReady returns whether the composed resource is ready.
-func (*DefaultReadinessChecker) IsReady(_ context.Context, cd resource.Composed, t v1alpha1.ComposedTemplate) (bool, error) { // nolint:gocyclo
+func IsReady(_ context.Context, cd resource.Composed, t v1alpha1.ComposedTemplate) (bool, error) { // nolint:gocyclo
 	// NOTE(muvaf): The cyclomatic complexity of this function comes from the
 	// mandatory repetitiveness of the switch clause, which is not really complex
 	// in reality. Though beware of adding additional complexity besides that.

--- a/pkg/controller/apiextensions/composite/composed/api_test.go
+++ b/pkg/controller/apiextensions/composite/composed/api_test.go
@@ -399,8 +399,7 @@ func TestIsReady(t *testing.T) {
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			c := &DefaultReadinessChecker{}
-			ready, err := c.IsReady(context.Background(), tc.args.cd, tc.args.t)
+			ready, err := IsReady(context.Background(), tc.args.cd, tc.args.t)
 			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\nIsReady(...): -want, +got:\n%s", tc.reason, diff)
 			}

--- a/pkg/controller/apiextensions/composite/composed/api_test.go
+++ b/pkg/controller/apiextensions/composite/composed/api_test.go
@@ -20,8 +20,6 @@ import (
 	"context"
 	"testing"
 
-	runtimecomposed "github.com/crossplane/crossplane-runtime/pkg/resource/unstructured/composed"
-
 	"github.com/google/go-cmp/cmp"
 	"github.com/pkg/errors"
 	v1 "k8s.io/api/core/v1"
@@ -37,6 +35,7 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/reconciler/managed"
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
 	"github.com/crossplane/crossplane-runtime/pkg/resource/fake"
+	runtimecomposed "github.com/crossplane/crossplane-runtime/pkg/resource/unstructured/composed"
 	"github.com/crossplane/crossplane-runtime/pkg/test"
 
 	"github.com/crossplane/crossplane/apis/apiextensions/v1alpha1"
@@ -266,6 +265,16 @@ func TestIsReady(t *testing.T) {
 			reason: "If no custom check is given, Ready condition should be used",
 			args: args{
 				cd: runtimecomposed.New(runtimecomposed.WithConditions(runtimev1alpha1.Available())),
+			},
+			want: want{
+				ready: true,
+			},
+		},
+		"ExplictNone": {
+			reason: "If the only readiness check is explicitly 'None' the resource is always ready.",
+			args: args{
+				cd: runtimecomposed.New(),
+				t:  v1alpha1.ComposedTemplate{ReadinessChecks: []v1alpha1.ReadinessCheck{{Type: v1alpha1.ReadinessCheckNone}}},
 			},
 			want: want{
 				ready: true,


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
The default behaviour when no readiness checks are supplied is to derive a composed resource's readiness from its 'Ready' status condition. A small subset of composable resources (e.g. ProviderConfigs) do not have status conditions, and do not have _any_ status from which we could reasonably determine their readiness. This commit introduces a new 'None' readiness check that can be used to 'turn off' readiness checking, and thus indicate that a composed resource should always be considered ready.

For example:

```yaml
spec:
  resources:
  - base:
    # ...
  - readinessChecks:
    - type: None
```

It's worth noting that this functionality is possible to emulate with the current implementation by writing something like the below example, but I feel this approach is more explicit and readable.

```yaml
spec:
  resources:
  - base:
    # ...
  - readinessChecks:
    - type: NonEmpty
      fieldPath: metadata.name
```

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
