### PR TITLE
Allow providers RBAC access to KubernetesTarget

### DIFF
--- a/pkg/controller/rbac/provider/roles/roles.go
+++ b/pkg/controller/rbac/provider/roles/roles.go
@@ -24,6 +24,7 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/meta"
 
 	"github.com/crossplane/crossplane/apis/pkg/v1alpha1"
+	wlv1alpha1 "github.com/crossplane/crossplane/apis/workload/v1alpha1"
 )
 
 const (
@@ -42,6 +43,7 @@ const (
 	suffixStatus = "/status"
 
 	pluralSecrets = "secrets"
+	pluralTargets = "kubernetestargets"
 )
 
 var (
@@ -59,6 +61,13 @@ var rulesSystemExtra = []rbacv1.PolicyRule{
 	{
 		APIGroups: []string{""},
 		Resources: []string{pluralSecrets},
+		Verbs:     verbsEdit,
+	},
+	// TODO(negz): KubernetesTarget is deprecated - this should be removed when
+	// it is per https://github.com/crossplane/crossplane/issues/1755
+	{
+		APIGroups: []string{wlv1alpha1.Group},
+		Resources: []string{pluralTargets},
 		Verbs:     verbsEdit,
 	},
 }


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
This was producing a lot of RBAC access errors in the provider logs. As far as I can tell, it was also preventing the providers from working as expected - I was surprised to find that when installing provider-gcp via the new package manager it wouldn't reconcile anything until I fixed this issue.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested
```yaml
apiVersion: pkg.crossplane.io/v1alpha1
kind: Provider
metadata:
  name: provider-gcp-master
spec:
  package: crossplane/provider-gcp:master
```

I've applied the above provider, and confirmed that the GCP example under `docs/snippets/compose` works with this change (but not without it).

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
