### PR TITLE
RBAC Manager Tweaks

### DIFF
--- a/pkg/controller/rbac/definition/roles_test.go
+++ b/pkg/controller/rbac/definition/roles_test.go
@@ -63,15 +63,30 @@ func TestRenderClusterRoles(t *testing.T) {
 			want: []rbacv1.ClusterRole{
 				{
 					ObjectMeta: metav1.ObjectMeta{
+						Name:            namePrefix + name + nameSuffixSystem,
+						OwnerReferences: []metav1.OwnerReference{owner},
+						Labels: map[string]string{
+							keyAggregateToSystem: valTrue,
+						},
+					},
+					Rules: []rbacv1.PolicyRule{
+						{
+							APIGroups: []string{group},
+							Resources: []string{pluralXR, pluralXR + suffixStatus},
+							Verbs:     verbsEdit,
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
 						Name:            namePrefix + name + nameSuffixEdit,
 						OwnerReferences: []metav1.OwnerReference{owner},
 						Labels: map[string]string{
-							keyAggregateToCrossplane: valTrue,
-							keyAggregateToAdmin:      valTrue,
-							keyAggregateToNSAdmin:    valTrue,
-							keyAggregateToEdit:       valTrue,
-							keyAggregateToNSEdit:     valTrue,
-							keyXRD:                   name,
+							keyAggregateToAdmin:   valTrue,
+							keyAggregateToNSAdmin: valTrue,
+							keyAggregateToEdit:    valTrue,
+							keyAggregateToNSEdit:  valTrue,
+							keyXRD:                name,
 						},
 					},
 					Rules: []rbacv1.PolicyRule{
@@ -134,15 +149,35 @@ func TestRenderClusterRoles(t *testing.T) {
 			want: []rbacv1.ClusterRole{
 				{
 					ObjectMeta: metav1.ObjectMeta{
+						Name:            namePrefix + name + nameSuffixSystem,
+						OwnerReferences: []metav1.OwnerReference{owner},
+						Labels: map[string]string{
+							keyAggregateToSystem: valTrue,
+						},
+					},
+					Rules: []rbacv1.PolicyRule{
+						{
+							APIGroups: []string{group},
+							Resources: []string{pluralXR, pluralXR + suffixStatus},
+							Verbs:     verbsEdit,
+						},
+						{
+							APIGroups: []string{group},
+							Resources: []string{pluralXRC, pluralXRC + suffixStatus},
+							Verbs:     verbsEdit,
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
 						Name:            namePrefix + name + nameSuffixEdit,
 						OwnerReferences: []metav1.OwnerReference{owner},
 						Labels: map[string]string{
-							keyAggregateToCrossplane: valTrue,
-							keyAggregateToAdmin:      valTrue,
-							keyAggregateToNSAdmin:    valTrue,
-							keyAggregateToEdit:       valTrue,
-							keyAggregateToNSEdit:     valTrue,
-							keyXRD:                   name,
+							keyAggregateToAdmin:   valTrue,
+							keyAggregateToNSAdmin: valTrue,
+							keyAggregateToEdit:    valTrue,
+							keyAggregateToNSEdit:  valTrue,
+							keyXRD:                name,
 						},
 					},
 					Rules: []rbacv1.PolicyRule{

--- a/pkg/controller/rbac/provider/roles/roles.go
+++ b/pkg/controller/rbac/provider/roles/roles.go
@@ -24,6 +24,7 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/meta"
 
 	"github.com/crossplane/crossplane/apis/pkg/v1alpha1"
+	wlv1alpha1 "github.com/crossplane/crossplane/apis/workload/v1alpha1"
 )
 
 const (
@@ -42,6 +43,7 @@ const (
 	suffixStatus = "/status"
 
 	pluralSecrets = "secrets"
+	pluralTargets = "kubernetestargets"
 )
 
 var (
@@ -59,6 +61,13 @@ var rulesSystemExtra = []rbacv1.PolicyRule{
 	{
 		APIGroups: []string{""},
 		Resources: []string{pluralSecrets},
+		Verbs:     verbsEdit,
+	},
+	// TODO(negz): KubernetesTarget is deprecated - this should be removed when
+	// it is per https://github.com/crossplane/crossplane/issues/1755
+	{
+		APIGroups: []string{wlv1alpha1.Group},
+		Resources: []string{pluralTargets},
 		Verbs:     verbsEdit,
 	},
 }

--- a/pkg/controller/rbac/provider/roles/roles.go
+++ b/pkg/controller/rbac/provider/roles/roles.go
@@ -42,6 +42,7 @@ const (
 
 	suffixStatus = "/status"
 
+	pluralEvents  = "events"
 	pluralSecrets = "secrets"
 	pluralTargets = "kubernetestargets"
 )
@@ -60,7 +61,7 @@ var (
 var rulesSystemExtra = []rbacv1.PolicyRule{
 	{
 		APIGroups: []string{""},
-		Resources: []string{pluralSecrets},
+		Resources: []string{pluralSecrets, pluralEvents},
 		Verbs:     verbsEdit,
 	},
 	// TODO(negz): KubernetesTarget is deprecated - this should be removed when
@@ -134,9 +135,7 @@ func RenderClusterRoles(pr *v1alpha1.ProviderRevision, crds []v1beta1.CustomReso
 	// directly to the service account tha provider runs as.
 	system := &rbacv1.ClusterRole{
 		ObjectMeta: metav1.ObjectMeta{Name: SystemClusterRoleName(pr.GetName())},
-		// TODO(negz): Require providers to explicitly ask for access to Secrets
-		// via their permissionRequests.
-		Rules: append(withVerbs(rules, verbsSystem), rulesSystemExtra...),
+		Rules:      append(withVerbs(rules, verbsSystem), rulesSystemExtra...),
 	}
 
 	roles := []rbacv1.ClusterRole{*edit, *view, *system}


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
This PR addresses a few RBAC manager issues that I've come across while testing composition end to end. Namely:

* All providers need access to work with events.
* Most providers need access to reconcile `KubernetesTarget` resources until we deprecate them. It seems that this lack of RBAC access might have been stalling the entire provider - i.e. preventing it from reconciling any resource. I haven't looked into why this was, but I have confirmed everything works as expected once access is allowed.
* Crossplane needs access to update the status subresource of XRs and XRCs. This PR introduces a new `crossplane:composite:...:aggregate-to-crossplane` role that allows that.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

```yaml
apiVersion: pkg.crossplane.io/v1alpha1
kind: Provider
metadata:
  name: provider-gcp-master
spec:
  package: crossplane/provider-gcp:master
```

I've tested that the GCP `docs/snippets/compose` example works as expected when using the above provider.

[contribution process]: https://git.io/fj2m9
