### PR TITLE
Custom deletion priority for composed resources

### DIFF
--- a/apis/apiextensions/v1alpha1/composition_types.go
+++ b/apis/apiextensions/v1alpha1/composition_types.go
@@ -93,6 +93,10 @@ type ComposedTemplate struct {
 	// default readiness check is to have the "Ready" condition to be "True".
 	// +optional
 	ReadinessChecks []ReadinessCheck `json:"readinessChecks,omitempty"`
+
+	// DeletionPriority specifies the deletion priority level of the resource. The
+	// deletion order is from high to low. Default deletion priority is 0.
+	DeletionPriority int64 `json:"deletionPriority,omitempty"`
 }
 
 // TypeReadinessCheck is used for readiness check types

--- a/cluster/charts/crossplane/crds/apiextensions.crossplane.io_compositions.yaml
+++ b/cluster/charts/crossplane/crds/apiextensions.crossplane.io_compositions.yaml
@@ -75,6 +75,10 @@ spec:
                           type: string
                       type: object
                     type: array
+                  deletionPriority:
+                    description: DeletionPriority specifies the deletion priority level of the resource. The deletion order is from high to low. Default deletion priority is 0.
+                    format: int64
+                    type: integer
                   patches:
                     description: Patches will be applied as overlay to the base resource.
                     items:

--- a/pkg/controller/apiextensions/composite/api.go
+++ b/pkg/controller/apiextensions/composite/api.go
@@ -48,6 +48,8 @@ const (
 	errUpdateComposite          = "cannot update composite resource"
 	errCompositionNotCompatible = "referenced composition is not compatible with this composite resource"
 	errGetXRD                   = "cannot get composite resource definition"
+	errGetComposed              = "cannot get composed resource"
+	errDeleteComposed           = "cannot delete composed resource"
 )
 
 // Event reasons.
@@ -329,7 +331,7 @@ func (d *APIPrioritizedDeleter) Delete(ctx context.Context, cr resource.Composit
 		nn := types.NamespacedName{Name: ref.Name, Namespace: ref.Namespace}
 		err := d.client.Get(ctx, nn, u)
 		if resource.IgnoreNotFound(err) != nil {
-			return nil, errors.Wrap(err, "cannot get resource")
+			return nil, errors.Wrap(err, errGetComposed)
 		}
 		if kerrors.IsNotFound(err) {
 			continue
@@ -346,7 +348,7 @@ func (d *APIPrioritizedDeleter) Delete(ctx context.Context, cr resource.Composit
 	for _, u := range del {
 		err := d.client.Delete(ctx, u)
 		if resource.IgnoreNotFound(err) != nil {
-			return nil, errors.Wrap(err, "cannot delete composed resource")
+			return nil, errors.Wrap(err, errDeleteComposed)
 		}
 	}
 	return del, nil


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

This PR introduces the notion of deletion priority we had in template stacks. Its main use case is the hard dependency of composed resources between each other. For example, we don't want the `EKSCluster` we have in composition to be deleted before `Release` resource of provider-helm because we'd like Helm to delete that release.

Fixes https://github.com/crossplane/crossplane/issues/1737 by allowing user to specify a negative deletion priority for `ProviderConfig` object they have in their `Composition`.
Fixes https://github.com/crossplane/crossplane/issues/1782 by allowing user to assign a deletion priority to Helm release that is higher than the priority of the cluster it points to.
Fixes https://github.com/crossplane/crossplane/issues/1612 by making sure all composed resources are gone before removing the finalizer on composite resource.

@negz has been investigating two mechanisms to fix the first two issues while this feature seems to be solving both. However, this approach applies only to composition scenarios while the secret locking & [`ProviderConfigUsage`](https://github.com/crossplane/crossplane-runtime/pull/206) work on managed resource level. See discussion in https://github.com/crossplane/crossplane/issues/1737#issuecomment-699966637

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Create the following YAML:
```yaml
apiVersion: apiextensions.crossplane.io/v1alpha1
kind: CompositeResourceDefinition
metadata:
  name: compositepostgresqlinstances.database.example.org
spec:
  claimNames:
    kind: PostgreSQLInstance
    plural: postgresqlinstances
  connectionSecretKeys:
    - username
    - password
    - endpoint
    - port
  crdSpecTemplate:
    group: database.example.org
    version: v1alpha1
    names:
      kind: CompositePostgreSQLInstance
      plural: compositepostgresqlinstances
    validation:
      openAPIV3Schema:
        type: object
        properties:
          spec:
            type: object
            properties:
              parameters:
                type: object
                properties:
                  storageGB:
                    type: integer
                required:
                  - storageGB
            required:
              - parameters
---
apiVersion: apiextensions.crossplane.io/v1alpha1
kind: Composition
metadata:
  name: compositepostgresqlinstances.gcp.database.example.org
  labels:
    provider: gcp
    guide: quickstart
spec:
  writeConnectionSecretsToNamespace: crossplane-system
  compositeTypeRef:
    apiVersion: database.example.org/v1alpha1
    kind: CompositePostgreSQLInstance
  resources:
    - base:
        apiVersion: database.gcp.crossplane.io/v1beta1
        kind: CloudSQLInstance
        spec:
          forProvider:
            databaseVersion: POSTGRES_9_6
            region: us-central1
            settings:
              tier: db-custom-1-3840
              dataDiskType: PD_SSD
              ipConfiguration:
                ipv4Enabled: true
                authorizedNetworks:
                  - value: "0.0.0.0/0"
          writeConnectionSecretToRef:
            namespace: crossplane-system
          providerConfigRef:
            name: example
          reclaimPolicy: Delete
      patches:
        - fromFieldPath: "metadata.uid"
          toFieldPath: "spec.writeConnectionSecretToRef.name"
          transforms:
            - type: string
              string:
                fmt: "%s-postgresql"
        - fromFieldPath: "spec.parameters.storageGB"
          toFieldPath: "spec.forProvider.settings.dataDiskSizeGb"
      connectionDetails:
        - fromConnectionSecretKey: username
        - fromConnectionSecretKey: password
        - fromConnectionSecretKey: endpoint
        - name: port
          value: "5432"
      # The default deletion priority is 0, so CloudSQLInstance will be deleted
      # before Network resource.
      deletionPriority: 1
    - base:
        apiVersion: compute.gcp.crossplane.io/v1beta1
        kind: Network
        spec:
          forProvider:
            autoCreateSubnetworks: false
            routingConfig:
              routingMode: REGIONAL
          reclaimPolicy: Delete
          providerConfigRef:
            name: example
```

Then request a claim via:
```yaml
apiVersion: database.example.org/v1alpha1
kind: PostgreSQLInstance
metadata:
  name: my-db
  namespace: crossplane-system
spec:
  parameters:
    storageGB: 20
  compositionSelector:
    matchLabels:
      provider: gcp
  writeConnectionSecretToRef:
    name: db-conn
```

Now delete `my-db` claim and see that `Network` is not deleted until `CloudSQLInstance` is gone.
<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
