### PR TITLE
Add oam-kubernetes-runtime as optional crossplane helm chart dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,7 @@ gitlab/
 # ignore vscode files (debug config etc...)
 /.vscode
 /.idea
+
+# helm chart dependencies
+**/charts/*.tgz
+**/charts/**/requirements.lock

--- a/cluster/charts/crossplane/README.md
+++ b/cluster/charts/crossplane/README.md
@@ -80,6 +80,7 @@ and their default values.
 | `resourcesRBACManager.requests.memory` | Memory resource requests for RBAC Manager | `256Mi` |
 | `rbacManager.deploy` | Deploy RBAC Manager and its required roles | `true` |
 | `rbacManager.managementPolicy`| The extent to which the RBAC manager will manage permissions. `All` indicates to manage all Crossplane controller and user roles. `Basic` indicates to only manage Crossplane controller roles and the `crossplane-admin`, `crossplane-edit`, and `crossplane-view` user roles. | `All` |
+| `alpha.oam.enabled` | Deploy the `crossplane/oam-kubernetes-runtime` Helm chart | `false` |
 
 ### Command Line
 

--- a/cluster/charts/crossplane/requirements.yaml
+++ b/cluster/charts/crossplane/requirements.yaml
@@ -1,0 +1,5 @@
+dependencies:
+- name: oam-kubernetes-runtime
+  version: 0.1.1-1.g8cde76d
+  repository: "https://charts.crossplane.io/master"
+  condition: alpha.oam.enabled

--- a/cluster/charts/crossplane/values.yaml.tmpl
+++ b/cluster/charts/crossplane/values.yaml.tmpl
@@ -34,3 +34,7 @@ resourcesRBACManager:
   requests:
     cpu: 100m
     memory: 256Mi
+
+oam:
+  alpha:
+    enabled: false

--- a/cluster/local/integration_tests.sh
+++ b/cluster/local/integration_tests.sh
@@ -67,7 +67,7 @@ docker tag "${BUILD_IMAGE}" "${CROSSPLANE_IMAGE}"
 
 echo_step "installing helm package(s) into \"${CROSSPLANE_NAMESPACE}\" namespace"
 "${KUBECTL}" create ns "${CROSSPLANE_NAMESPACE}"
-"${HELM3}" install "${PROJECT_NAME}" --namespace "${CROSSPLANE_NAMESPACE}" "${projectdir}/cluster/charts/${PROJECT_NAME}" --set image.pullPolicy=Never,imagePullSecrets=''
+"${HELM3}" install "${PROJECT_NAME}" --namespace "${CROSSPLANE_NAMESPACE}" "${projectdir}/cluster/charts/${PROJECT_NAME}" --set image.pullPolicy=Never,imagePullSecrets='',alpha.oam.enabled=true
 
 echo_step "waiting for deployment ${PROJECT_NAME} rollout to finish"
 "${KUBECTL}" -n "${CROSSPLANE_NAMESPACE}" rollout status "deploy/${PROJECT_NAME}" --timeout=2m
@@ -83,7 +83,7 @@ echo
 echo -------- deployments
 "${KUBECTL}" -n "${CROSSPLANE_NAMESPACE}" get deployments
 
-MUST_HAVE_DEPLOYMENTS="crossplane crossplane-rbac-manager"
+MUST_HAVE_DEPLOYMENTS="crossplane crossplane-rbac-manager oam-kubernetes-runtime-crossplane"
 for name in $MUST_HAVE_DEPLOYMENTS; do
     echo_sub_step "inspecting deployment '${name}'"
     dep_stat=$("${KUBECTL}" -n "${CROSSPLANE_NAMESPACE}" get deployments/"${name}")

--- a/docs/getting-started/install-configure.md
+++ b/docs/getting-started/install-configure.md
@@ -75,7 +75,7 @@ kubectl create namespace crossplane-system
 
 helm repo add crossplane-alpha https://charts.crossplane.io/alpha
 
-helm install crossplane --namespace crossplane-system crossplane-alpha/crossplane
+helm install crossplane --namespace crossplane-system crossplane-alpha/crossplane --set alpha.oam.enabled=true
 ```
 
 </div>
@@ -88,12 +88,12 @@ kubectl create namespace crossplane-system
 helm repo add crossplane-master https://charts.crossplane.io/master/
 helm search repo crossplane-master --devel
 
-helm install crossplane --namespace crossplane-system crossplane-master/crossplane --devel --version <version>
+helm install crossplane --namespace crossplane-system crossplane-master/crossplane --devel --version <version> --set alpha.oam.enabled=true
 ```
 
 For example:
 ```
-helm install crossplane --namespace crossplane-system crossplane-master/crossplane --version 0.11.0-rc.100.gbc5d311 --devel
+helm install crossplane --namespace crossplane-system crossplane-master/crossplane --version 0.11.0-rc.100.gbc5d311 --devel --set alpha.oam.enabled=true
 ```
 
 </div>

--- a/docs/getting-started/run-applications.md
+++ b/docs/getting-started/run-applications.md
@@ -72,43 +72,6 @@ by this guide:
 kubectl apply -f https://raw.githubusercontent.com/crossplane/crossplane/master/docs/snippets/run/definitions.yaml
 ```
 
-Now that we've defined our workloads and traits, we must install Crossplane's OAM addon. This addon
-packages the controllers that reconcile core OAM workloads and traits.
-
-<ul class="nav nav-tabs">
-<li class="active"><a href="#install-tab-helm3" data-toggle="tab">Helm 3</a></li>
-<li><a href="#install-tab-helm2" data-toggle="tab">Helm 2</a></li>
-</ul>
-<br>
-<div class="tab-content">
-<div class="tab-pane fade in active" id="install-tab-helm3" markdown="1">
-Use Helm 3 to install the latest official `alpha` release of Crossplane OAM
-Addon, suitable for community use and testing:
-
-```console
-kubectl create namespace crossplane-system
-helm repo add crossplane-alpha https://charts.crossplane.io/alpha
-helm install addon-oam-kubernetes-local --namespace crossplane-system crossplane-alpha/oam-core-resources
-```
-
-> Note that the OAM Addon requires at least Kubernetes 1.16.
-
-</div>
-<div class="tab-pane fade" id="install-tab-helm2" markdown="1">
-Use Helm 2 to install the latest official `alpha` release of the Crossplane OAM
-Addon, suitable for community use and testing:
-
-```console
-kubectl create namespace crossplane-system
-helm repo add crossplane-alpha https://charts.crossplane.io/alpha
-helm install --name addon-oam-kubernetes-local --namespace crossplane-system crossplane-alpha/oam-core-resources
-```
-
-> Note that the OAM Addon requires at least Kubernetes 1.16.
-
-</div>
-</div>
-
 ## Application Developer
 
 ### Publish Application Components

--- a/docs/reference/install.md
+++ b/docs/reference/install.md
@@ -87,6 +87,7 @@ and their default values.
 | `resourcesRBACManager.requests.memory` | Memory resource requests for RBAC Manager | `256Mi` |
 | `rbacManager.deploy` | Deploy RBAC Manager and its required roles | `true` |
 | `rbacManager.managementPolicy`| The extent to which the RBAC manager will manage permissions. `All` indicates to manage all Crossplane controller and user roles. `Basic` indicates to only manage Crossplane controller roles and the `crossplane-admin`, `crossplane-edit`, and `crossplane-view` user roles. | `All` |
+| `alpha.oam.enabled` | Deploy the `crossplane/oam-kubernetes-runtime` Helm chart | `false` |
 
 ### Command Line
 


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Adds `oam-kubernetes-runtime` as an optional helm chart dependency that can be installed by specifying `oam.enabled=true`. Keeping in draft to ensure other maintainers understand this functionality and any implications (particularly on how we version the dependency) before merge.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

`make build`
`make e2e.run`

[contribution process]: https://git.io/fj2m9
