### PR TITLE
Bump golangci-lint timeout in gh actions

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,5 +1,5 @@
 run:
-  deadline: 2m
+  timeout: 10m
 
   skip-files:
   - "zz_generated\\..+\\.go$"


### PR DESCRIPTION


<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Bumps the timeout for golangci-lint from the default 1m duration to
match the build submodule lint timeout, which is 10m.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

I have noticed this happening across a number of our repos since the GH action was added. Will bump them to match as well :+1: 

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

n/a

[contribution process]: https://git.io/fj2m9
