### PR TITLE
docs: add alternative command for Kubernetes 1.15 and earlier versions

### DIFF
--- a/docs/getting-started/install-configure.md
+++ b/docs/getting-started/install-configure.md
@@ -70,12 +70,19 @@ For Windows use the following:
 <div class="tab-pane fade in active" id="install-tab-helm3" markdown="1">
 Use Helm 3 to install the latest official `alpha` release of Crossplane, suitable for community use and testing:
 
+> OAM is available only for 1.16 and later versions of Kubernetes.
+
 ```
 kubectl create namespace crossplane-system
 
 helm repo add crossplane-alpha https://charts.crossplane.io/alpha
 
+# Kubernetes 1.16 and later versions
 helm install crossplane --namespace crossplane-system crossplane-alpha/crossplane --set alpha.oam.enabled=true
+```
+```
+# Kubernetes 1.15 and earlier versions
+helm install crossplane --namespace crossplane-system crossplane-alpha/crossplane
 ```
 
 </div>
@@ -88,7 +95,12 @@ kubectl create namespace crossplane-system
 helm repo add crossplane-master https://charts.crossplane.io/master/
 helm search repo crossplane-master --devel
 
+# Kubernetes 1.16 and later versions
 helm install crossplane --namespace crossplane-system crossplane-master/crossplane --devel --version <version> --set alpha.oam.enabled=true
+```
+```
+# Kubernetes 1.15 and earlier versions
+helm install crossplane --namespace crossplane-system crossplane-master/crossplane --devel --version <version>
 ```
 
 For example:


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

OAM works only in Kubernetes 1.16 and later versions due to server-side apply calls. Since the default install command enables the installation of OAM, this could lead to broken installation of Crossplane in earlier versions of Kubernetes.

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Manually.

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
