### PR TITLE
Join package root to ignore paths in crank build

### DIFF
--- a/cmd/crank/build.go
+++ b/cmd/crank/build.go
@@ -70,7 +70,7 @@ func (c *buildCmd) Run(child *buildChild) error {
 		return errors.New("cannot build object scheme for package parser")
 	}
 	img, err := xpkg.Build(context.Background(),
-		parser.NewFsBackend(child.fs, parser.FsDir(root), parser.FsFilters(buildFilters(c.Ignore)...)),
+		parser.NewFsBackend(child.fs, parser.FsDir(root), parser.FsFilters(buildFilters(root, c.Ignore)...)),
 		parser.New(metaScheme, objScheme),
 		child.linter)
 	if err != nil {
@@ -92,13 +92,13 @@ func (c *buildCmd) Run(child *buildChild) error {
 
 // default build filters skip directories and files without YAML extension in
 // addition to any paths specified.
-func buildFilters(skips []string) []parser.FilterFn {
+func buildFilters(root string, skips []string) []parser.FilterFn {
 	numOpts := len(skips) + 2
 	opts := make([]parser.FilterFn, numOpts)
 	opts[0] = parser.SkipDirs()
 	opts[1] = parser.SkipNotYAML()
 	for i, s := range skips {
-		opts[i+2] = parser.SkipPath(s)
+		opts[i+2] = parser.SkipPath(filepath.Join(root, s))
 	}
 	return opts
 }


### PR DESCRIPTION


<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Updates crank build to join package root path to any ignore patterns
passed such that full path does not have to be specified. This makes the
command work as the description for the --ignore flag indicates.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

Manually tested against `provider-aws` with invalid YAML files ignored with relative path patterns.

[contribution process]: https://git.io/fj2m9
