### PR TITLE
Lint configuration revisions with configuration linter

### DIFF
--- a/pkg/controller/pkg/revision/reconciler.go
+++ b/pkg/controller/pkg/revision/reconciler.go
@@ -235,7 +235,7 @@ func SetupConfigurationRevision(mgr ctrl.Manager, l logging.Logger, cache xpkg.C
 		WithNewPackageRevisionFn(nr),
 		WithParser(parser.New(metaScheme, objScheme)),
 		WithParserBackend(NewImageBackend(cache, xpkg.NewK8sFetcher(clientset, namespace))),
-		WithLinter(xpkg.NewProviderLinter()),
+		WithLinter(xpkg.NewConfigurationLinter()),
 		WithLogger(l.WithValues("controller", name)),
 		WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name))),
 	)


### PR DESCRIPTION


<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

The configuration revision controller was unintentionally updated to use
the provider linter rather than the configuration linter. This changes
it to use the configuration linter.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

Installed valid `Configuration` package. Previously was failing with
```
16s         Warning   LintPackage               configurationrevision/some-aws-stuff-2d5107bcde82   package meta type is not Provider
```

[contribution process]: https://git.io/fj2m9
