### PR TITLE
Add version flag to crank

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ NPROCS ?= 1
 GO_TEST_PARALLEL := $(shell echo $$(( $(NPROCS) / 2 )))
 
 GO_STATIC_PACKAGES = $(GO_PROJECT)/cmd/crossplane $(GO_PROJECT)/cmd/crank
-GO_LDFLAGS += -X $(GO_PROJECT)/pkg/version.Version=$(VERSION)
+GO_LDFLAGS += -X main.version=$(VERSION)
 GO_SUBDIRS += cmd pkg apis
 GO111MODULE = on
 -include build/makelib/golang.mk

--- a/cmd/crank/main.go
+++ b/cmd/crank/main.go
@@ -17,13 +17,36 @@ limitations under the License.
 package main
 
 import (
+	"fmt"
+
 	"github.com/alecthomas/kong"
 	"github.com/spf13/afero"
 )
 
 var _ = kong.Must(&cli)
 
+// version is set at build time.
+var version string
+
+type versionFlag string
+
+// Decode overrides the default string decoder to be a no-op.
+func (v versionFlag) Decode(ctx *kong.DecodeContext) error { return nil } // nolint:unparam
+
+// IsBool indicates that this string flag should be treated as a boolean value.
+func (v versionFlag) IsBool() bool { return true }
+
+// BeforeApply indicates that we want to execute the logic before running any
+// commands.
+func (v versionFlag) BeforeApply(app *kong.Kong) error { // nolint:unparam
+	fmt.Fprintln(app.Stdout, version)
+	app.Exit(0)
+	return nil
+}
+
 var cli struct {
+	Version versionFlag `short:"v" name:"version" help:"Print version and quit."`
+
 	Build   buildCmd   `cmd:"" help:"Build Crossplane packages."`
 	Install installCmd `cmd:"" help:"Install Crossplane packages."`
 	Push    pushCmd    `cmd:"" help:"Push Crossplane packages."`


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Adds a version flag to `crank` and sets it at build time. Supplying `-v` or `--version` in any command sequence will override behavior to print version and exit.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

`make build`
`crank -v`
`crank --version`
`crank build configuration -v`
etc... all output:
```
v0.13.0-rc.323.g0953f75f-dirty
```

[contribution process]: https://git.io/fj2m9
