### PR TITLE
Reflect recent ProviderConfig changes

### DIFF
--- a/docs/cloud-providers/aws/aws-provider.md
+++ b/docs/cloud-providers/aws/aws-provider.md
@@ -40,10 +40,10 @@ Once the script is successfully executed, Crossplane will use the specified aws
 account and region in the given named profile to create subsequent AWS managed
 resources.
 
-You can confirm the existense of the  AWS `ProviderConfig` by running:
+You can confirm the existence of the  AWS `ProviderConfig` by running:
 
 ```bash
-kubectl get providerconfig aws-provider
+kubectl get providerconfig default
 ```
 
 ## Optional: Setup AWS Provider Manually
@@ -68,9 +68,9 @@ setup cloud provider in the next section.
 
 Crossplane uses the AWS user credentials that were configured in the previous
 step to create resources in AWS. These credentials will be stored as a
-[secret][kubernetes secret] in Kubernetes, and will be used by an AWS `ProviderConfig`
-instance. The default AWS region is also pulled from the cli configuration, and
-added to the AWS provider.
+[secret][kubernetes secret] in Kubernetes, and will be used by an AWS
+`ProviderConfig` instance. The default AWS region is also pulled from the cli
+configuration, and added to the AWS provider.
 
 To store the credentials as a secret, run:
 
@@ -79,8 +79,7 @@ To store the credentials as a secret, run:
 BASE64ENCODED_AWS_ACCOUNT_CREDS=$(echo -e "[default]\naws_access_key_id = $(aws configure get aws_access_key_id --profile $aws_profile)\naws_secret_access_key = $(aws configure get aws_secret_access_key --profile $aws_profile)" | base64  | tr -d "\n")
 ```
 
-At this point, the region and the encoded credentials are stored in respective
-variables. Next, we'll need to create an instance of AWS provider:
+Next, we'll need to create an AWS provider configuration:
 
 ```bash
 cat > provider.yaml <<EOF
@@ -97,12 +96,14 @@ data:
 apiVersion: aws.crossplane.io/v1beta1
 kind: ProviderConfig
 metadata:
-  name: aws-provider
+  name: default
 spec:
-  credentialsSecretRef:
-    namespace: crossplane-system
-    name: aws-account-creds
-    key: credentials
+  credentials:
+    source: Secret
+    secretRef:
+      namespace: crossplane-system
+      name: aws-account-creds
+      key: credentials
 EOF
 
 # apply it to the cluster:
@@ -116,11 +117,12 @@ The output will look like the following:
 
 ```bash
 secret/aws-user-creds created
-provider.aws.crossplane.io/aws-provider created
+provider.aws.crossplane.io/default created
 ```
 
-The `aws-provider` resource will be used in other resources that we will create,
-to provide access information to the configured AWS account.
+Crossplane resources use the `ProviderConfig` named `default` if no specific
+`ProviderConfig` is specified, so this `ProviderConfig` will be the default for
+all AWS resources.
 
 <!-- Named Links -->
 

--- a/docs/cloud-providers/azure/azure-provider.md
+++ b/docs/cloud-providers/azure/azure-provider.md
@@ -53,6 +53,7 @@ Operation failed with status: 'Conflict'. Details: 409 Client Error: Conflict fo
 Finally, you need to grant admin permissions on the Azure Active Directory to
 the service principal because it will need to create other service principals
 for your `AKSCluster`:
+
 ```bash
 # grant admin consent to the service princinpal you created
 az ad app permission admin-consent --id "${AZURE_CLIENT_ID}"
@@ -99,12 +100,14 @@ data:
 apiVersion: azure.crossplane.io/v1beta1
 kind: ProviderConfig
 metadata:
-  name: azure-provider
+  name: default
 spec:
-  credentialsSecretRef:
-    namespace: crossplane-system
-    name: azure-account-creds
-    key: credentials
+  credentials
+    source: Secret
+    secretRef:
+      namespace: crossplane-system
+      name: azure-account-creds
+      key: credentials
 EOF
 
 # apply it to the cluster:
@@ -118,8 +121,9 @@ The output will look like the following:
 
 ```bash
 secret/azure-user-creds created
-provider.azure.crossplane.io/azure-provider created
+provider.azure.crossplane.io/default created
 ```
 
-The `azure-provider` resource will be used in other resources that we will
-create, to provide access information to the configured Azure account.
+Crossplane resources use the `ProviderConfig` named `default` if no specific
+`ProviderConfig` is specified, so this `ProviderConfig` will be the default for
+all Azure resources.

--- a/docs/getting-started/compose-infrastructure.md
+++ b/docs/getting-started/compose-infrastructure.md
@@ -155,8 +155,6 @@ spec:
             publiclyAccessible: true
           writeConnectionSecretToRef:
             namespace: crossplane-system
-          providerConfigRef:
-            name: aws-provider
       patches:
         - fromFieldPath: "metadata.uid"
           toFieldPath: "spec.writeConnectionSecretToRef.name"
@@ -209,8 +207,6 @@ spec:
             cidrBlock: 192.168.0.0/16
             enableDnsSupport: true
             enableDnsHostNames: true
-          providerConfigRef:
-            name: aws-provider
     - base:
         apiVersion: ec2.aws.crossplane.io/v1beta1
         kind: Subnet
@@ -224,8 +220,6 @@ spec:
             vpcIdSelector:
               matchControllerRef: true
             availabilityZone: us-east-1a
-          providerConfigRef:
-            name: aws-provider
     - base:
         apiVersion: ec2.aws.crossplane.io/v1beta1
         kind: Subnet
@@ -239,8 +233,6 @@ spec:
             vpcIdSelector:
               matchControllerRef: true
             availabilityZone: us-east-1b
-          providerConfigRef:
-            name: aws-provider
     - base:
         apiVersion: ec2.aws.crossplane.io/v1beta1
         kind: Subnet
@@ -254,8 +246,6 @@ spec:
             vpcIdSelector:
               matchControllerRef: true
             availabilityZone: us-east-1c
-          providerConfigRef:
-            name: aws-provider
     - base:
         apiVersion: database.aws.crossplane.io/v1beta1
         kind: DBSubnetGroup
@@ -265,8 +255,6 @@ spec:
             description: An excellent formation of subnetworks.
             subnetIdSelector:
               matchControllerRef: true
-          providerConfigRef:
-            name: aws-provider
     - base:
         apiVersion: ec2.aws.crossplane.io/v1beta1
         kind: InternetGateway
@@ -275,8 +263,6 @@ spec:
             region: us-east-1
             vpcIdSelector:
               matchControllerRef: true
-          providerConfigRef:
-            name: aws-provider
     - base:
         apiVersion: ec2.aws.crossplane.io/v1alpha4
         kind: RouteTable
@@ -299,8 +285,6 @@ spec:
               - subnetIdSelector:
                   matchLabels:
                     zone: us-east-1c
-          providerConfigRef:
-            name: aws-provider
     - base:
         apiVersion: ec2.aws.crossplane.io/v1beta1
         kind: SecurityGroup
@@ -318,8 +302,6 @@ spec:
                 ipRanges:
                   - cidrIp: 0.0.0.0/0
                     description: Everywhere
-          providerConfigRef:
-            name: aws-provider
     - base:
         apiVersion: database.aws.crossplane.io/v1beta1
         kind: RDSInstance
@@ -338,8 +320,6 @@ spec:
             publiclyAccessible: true
           writeConnectionSecretToRef:
             namespace: crossplane-system
-          providerConfigRef:
-            name: aws-provider
       patches:
         - fromFieldPath: "metadata.uid"
           toFieldPath: "spec.writeConnectionSecretToRef.name"
@@ -393,8 +373,6 @@ spec:
                   - value: "0.0.0.0/0"
           writeConnectionSecretToRef:
             namespace: crossplane-system
-          providerConfigRef:
-            name: gcp-provider
       patches:
         - fromFieldPath: "metadata.uid"
           toFieldPath: "spec.writeConnectionSecretToRef.name"
@@ -444,8 +422,6 @@ spec:
         kind: ResourceGroup
         spec:
           location: West US 2
-          providerConfigRef:
-            name: azure-provider
     - base:
         apiVersion: database.azure.crossplane.io/v1beta1
         kind: PostgreSQLServer
@@ -463,8 +439,6 @@ spec:
               family: Gen5
           writeConnectionSecretToRef:
             namespace: crossplane-system
-          providerConfigRef:
-            name: azure-provider
       patches:
         - fromFieldPath: "metadata.uid"
           toFieldPath: "spec.writeConnectionSecretToRef.name"
@@ -496,8 +470,6 @@ spec:
             properties:
               startIpAddress: 0.0.0.0
               endIpAddress: 255.255.255.254
-          providerConfigRef:
-            name: azure-provider
 ```
 
 ```console
@@ -533,8 +505,6 @@ spec:
             masterUsername: "myuser"
           writeConnectionSecretToRef:
             namespace: crossplane-system
-          providerConfigRef:
-            name: alibaba-provider
       patches:
         - fromFieldPath: "metadata.uid"
           toFieldPath: "spec.writeConnectionSecretToRef.name"

--- a/docs/getting-started/provision-infrastructure.md
+++ b/docs/getting-started/provision-infrastructure.md
@@ -46,8 +46,6 @@ spec:
   writeConnectionSecretToRef:
     namespace: crossplane-system
     name: aws-rdspostgresql-conn
-  providerConfigRef:
-    name: aws-provider
   reclaimPolicy: Delete
 ```
 
@@ -64,6 +62,7 @@ kubectl get rdsinstance rdspostgresql
 
 When provisioning is complete, you should see `READY: True` in the output. You
 can take a look at its connection secret that is referenced under `spec.writeConnectionSecretToRef`:
+
 ```console
 kubectl describe secret aws-rdspostgresql-conn -n crossplane-system -o yaml
 ```
@@ -96,8 +95,6 @@ spec:
   writeConnectionSecretToRef:
     namespace: crossplane-system
     name: cloudsqlpostgresql-conn
-  providerConfigRef:
-    name: gcp-provider
 ```
 
 ```console
@@ -113,6 +110,7 @@ kubectl get cloudsqlinstance cloudsqlpostgresql
 
 When provisioning is complete, you should see `READY: True` in the output. You
 can take a look at its connection secret that is referenced under `spec.writeConnectionSecretToRef`:
+
 ```console
 kubectl describe secret cloudsqlpostgresql-conn -n crossplane-system -o yaml
 ```
@@ -141,8 +139,6 @@ metadata:
   name: sqlserverpostgresql-rg
 spec:
   location: West US 2
-  providerConfigRef:
-    name: azure-provider
 ---
 apiVersion: database.azure.crossplane.io/v1beta1
 kind: PostgreSQLServer
@@ -165,8 +161,6 @@ spec:
   writeConnectionSecretToRef:
     namespace: crossplane-system
     name: sqlserverpostgresql-conn
-  providerConfigRef:
-    name: azure-provider
 ```
 
 ```console
@@ -183,6 +177,7 @@ kubectl get postgresqlserver sqlserverpostgresql
 
 When provisioning is complete, you should see `READY: True` in the output. You
 can take a look at its connection secret that is referenced under `spec.writeConnectionSecretToRef`:
+
 ```console
 kubectl describe secret sqlserverpostgresql-conn -n crossplane-system
 ```
@@ -216,8 +211,6 @@ spec:
   writeConnectionSecretToRef:
     namespace: crossplane-system
     name: alibaba-rdspostgresql-conn
-  providerConfigRef:
-    name: alibaba-provider
 ```
 
 ```console
@@ -233,6 +226,7 @@ kubectl get rdsinstance rdspostgresql
 
 When provisioning is complete, you should see `READY: True` in the output. You
 can take a look at its connection secret that is referenced under `spec.writeConnectionSecretToRef`:
+
 ```console
 kubectl describe secret alibaba-rdspostgresql-conn -n crossplane-system
 ```

--- a/docs/introduction/composition.md
+++ b/docs/introduction/composition.md
@@ -309,8 +309,6 @@ spec:
       kind: ResourceGroup
       spec:
         reclaimPolicy: Delete
-        providerConfigRef:
-          name: example
     # Patches copy or "overlay" the value of a field path within the composite
     # resource (the CompositeMySQLInstance) to a field path within the composed
     # resource (the ResourceGroup). In the below example any labels and
@@ -362,8 +360,6 @@ spec:
           storageProfile:
             backupRetentionDays: 7
             geoRedundantBackup: Disabled
-        providerConfigRef:
-          name: example
         writeConnectionSecretToRef:
           namespace: crossplane-system
         reclaimPolicy: Delete
@@ -437,8 +433,6 @@ spec:
             endIpAddress: 10.10.255.254
             virtualNetworkSubnetIdSelector:
               name: sample-subnet
-        providerConfigRef:
-          name: example
         reclaimPolicy: Delete
     patches:
     - fromFieldPath: "metadata.labels"

--- a/docs/introduction/managed-resources.md
+++ b/docs/introduction/managed-resources.md
@@ -41,7 +41,7 @@ spec:
       name: mysql-secret
       namespace: crossplane-system
   providerConfigRef:
-    name: mycreds
+    name: default
   reclaimPolicy: Delete
 ```
 
@@ -57,7 +57,8 @@ under `spec` should look like.
 * `providerConfigRef`: Reference to the `ProviderConfig` resource that will
   provide information regarding authentication of Crossplane to the provider.
   `ProviderConfig` resources refer to `Secret` and potentially contain other
-  information regarding authentication.
+  information regarding authentication. The `providerConfigRef` is defaulted to
+  a `ProviderConfig` named `default` if omitted.
 
 * `reclaimPolicy`: Enum to specify whether the actual cloud resource should be
   deleted when this managed resource is deleted in Kubernetes API server.
@@ -238,7 +239,7 @@ metadata:
     crossplane.io/external-name: existing-network
 spec:
   providerConfigRef:
-    name: gcp-creds
+    name: default
 ```
 
 Crossplane will check whether a GCP Network called `existing-network` exists,

--- a/docs/introduction/managed-resources.md
+++ b/docs/introduction/managed-resources.md
@@ -9,16 +9,17 @@ indent: true
 
 ## Overview
 
-Managed resources are the Crossplane representation of the cloud [provider][provider]
-resources and they are considered primitive low level custom resources that can
-be used directly to provision external cloud resources for an application or as
-part of an infrastructure composition.
+Managed resources are the Crossplane representation of the cloud
+[provider][provider] resources and they are considered primitive low level
+custom resources that can be used directly to provision external cloud resources
+for an application or as part of an infrastructure composition.
 
 For example, `RDSInstance` in AWS Provider corresponds to an actual RDS Instance
-in AWS. There is a one-to-one relationship and the changes on managed resources are
-reflected directly on the corresponding resource in the provider.
+in AWS. There is a one-to-one relationship and the changes on managed resources
+are reflected directly on the corresponding resource in the provider.
 
-You can browse [API Reference][api-reference] to discover all available managed resources.
+You can browse [API Reference][api-reference] to discover all available managed
+resources.
 
 ## Syntax
 
@@ -45,44 +46,46 @@ spec:
 ```
 
 In Kubernetes, `spec` top field represents the desired state of the user.
-Crossplane adheres to that and has its own conventions about how the fields under
-`spec` should look like.
+Crossplane adheres to that and has its own conventions about how the fields
+under `spec` should look like.
 
 * `writeConnectionSecretToRef`: A reference to the secret that you want this
-  managed resource to write its connection secret that you'd be able to mount
-  to your pods in the same namespace. For `RDSInstance`, this secret would contain
+  managed resource to write its connection secret that you'd be able to mount to
+  your pods in the same namespace. For `RDSInstance`, this secret would contain
   `endpoint`, `username` and `password`.
-  
-* `providerConfigRef`: Reference to the `ProviderConfig` resource that will provide information
-  regarding authentication of Crossplane to the provider. `ProviderConfig` resources
-  refer to `Secret` and potentially contain other information regarding authentication.
+
+* `providerConfigRef`: Reference to the `ProviderConfig` resource that will
+  provide information regarding authentication of Crossplane to the provider.
+  `ProviderConfig` resources refer to `Secret` and potentially contain other
+  information regarding authentication.
 
 * `reclaimPolicy`: Enum to specify whether the actual cloud resource should be
-  deleted when this managed resource is deleted in Kubernetes API server. Possible
-  values are `Delete` and `Retain`.
-  
+  deleted when this managed resource is deleted in Kubernetes API server.
+  Possible values are `Delete` and `Retain`.
+
 * `forProvider`: While the rest of the fields relate to how Crossplane should
   behave, the fields under `forProvider` are solely used to configure the actual
-  external resource. In most of the cases, the field names correspond to the what
-  exists in provider's API Reference.
-  
+  external resource. In most of the cases, the field names correspond to the
+  what exists in provider's API Reference.
+
   The objects under `forProvider` field can get huge depending on the provider
-  API. For example, GCP `ServiceAccount` has only a few fields while GCP `CloudSQLInstance`
-  has over 100 fields that you can configure.
+  API. For example, GCP `ServiceAccount` has only a few fields while GCP
+  `CloudSQLInstance` has over 100 fields that you can configure.
 
 ### Versioning
 
-Crossplane closely follows the [Kubernetes API versioning conventions][api-versioning]
-for the CRDs that it deploys. In short, for `vXbeta` and `vX` versions, you can
-expect that either automatic migration or instructions for manual migration will
-be provided when a new version of that CRD schema is released.
+Crossplane closely follows the [Kubernetes API versioning
+conventions][api-versioning] for the CRDs that it deploys. In short, for
+`vXbeta` and `vX` versions, you can expect that either automatic migration or
+instructions for manual migration will be provided when a new version of that
+CRD schema is released.
 
 ### Grouping
 
-In general, managed resources are high fidelity resources meaning they will provide
-parameters and behaviors that are provided by the external resource API. This applies
-to grouping of resources, too. For example, `Queue` appears under `sqs` API group
-in AWS,so, its `APIVersion` and `Kind` look like the following:
+In general, managed resources are high fidelity resources meaning they will
+provide parameters and behaviors that are provided by the external resource API.
+This applies to grouping of resources, too. For example, `Queue` appears under
+`sqs` API group in AWS,so, its `APIVersion` and `Kind` look like the following:
 
 ```yaml
 apiVersion: sqs.aws.crossplane.io/v1beta1
@@ -93,40 +96,40 @@ kind: Queue
 
 As a general rule, managed resource controllers try not to make any decision
 that is not specified by the user in the desired state since managed resources
-are the lowest level primitives that operate directly on the cloud provider APIs.
+are the lowest level primitives that operate directly on the cloud provider
+APIs.
 
 ### Continuous Reconciliation
 
 Crossplane providers continuously reconcile the managed resource to achieve the
-desired state. The parameters under `spec` are considered the one and only source
-of truth for the external resource. This means that if someone changed a
-configuration in the UI of the provider, like AWS Console, Crossplane will change
-it back to what's given under `spec`.
+desired state. The parameters under `spec` are considered the one and only
+source of truth for the external resource. This means that if someone changed a
+configuration in the UI of the provider, like AWS Console, Crossplane will
+change it back to what's given under `spec`.
 
 #### Immutable Properties
 
-There are configuration parameters in external resources that cloud providers do not
-allow to be changed. If the corresponding field in the managed resource is changed
-by the user, Crossplane submits the new desired state to the provider and returns
-the error, if any. For example, in AWS, you cannot change the region of
-an `RDSInstance`.
+There are configuration parameters in external resources that cloud providers do
+not allow to be changed. If the corresponding field in the managed resource is
+changed by the user, Crossplane submits the new desired state to the provider
+and returns the error, if any. For example, in AWS, you cannot change the region
+of an `RDSInstance`.
 
-Some infrastructure tools such as Terraform delete and recreate the resource
-to accommodate those changes but Crossplane does not take that route. Unless
-the managed resource is deleted and its `reclaimPolicy` is `Delete`, its controller
+Some infrastructure tools such as Terraform delete and recreate the resource to
+accommodate those changes but Crossplane does not take that route. Unless the
+managed resource is deleted and its `reclaimPolicy` is `Delete`, its controller
 never deletes the external resource in the provider.
 
-> Immutable fields are marked as `immutable` in Crossplane codebase
-but Kubernetes does not yet have immutable field notation in CRDs.
+> Immutable fields are marked as `immutable` in Crossplane codebase but
+Kubernetes does not yet have immutable field notation in CRDs.
 
 ### External Name
 
 By default the name of the managed resource is used as the name of the external
-cloud resource that will show up in your cloud console.
-To specify a different external name, Crossplane has a special annotation to
-represent the name of the external resource. For example, I would like to
-have a `CloudSQLInstance` with an external name that is different than its
-managed resource name:
+cloud resource that will show up in your cloud console. To specify a different
+external name, Crossplane has a special annotation to represent the name of the
+external resource. For example, I would like to have a `CloudSQLInstance` with
+an external name that is different than its managed resource name:
 
 ```yaml
 apiVersion: database.gcp.crossplane.io/v1beta1
@@ -139,51 +142,53 @@ spec:
   ...
 ```
 
-When you create this managed resource, you will see that the name of `CloudSQLInstance`
-in GCP console will be `my-special-db`.
+When you create this managed resource, you will see that the name of
+`CloudSQLInstance` in GCP console will be `my-special-db`.
 
-If the annotation is not given, Crossplane will fill it with the name of the managed
-resource by default. In cases where provider doesn't allow you to name the resource,
-like AWS VPC, the controller creates the resource and sets external annotation
-to be the name that the cloud provider chose. So, you would see something like
-`vpc-28dsnh3` as the value of `crossplane.io/external-name` annotation of your
-AWS `VPC` resource even if you added your own custom external name during creation.
+If the annotation is not given, Crossplane will fill it with the name of the
+managed resource by default. In cases where provider doesn't allow you to name
+the resource, like AWS VPC, the controller creates the resource and sets
+external annotation to be the name that the cloud provider chose. So, you would
+see something like `vpc-28dsnh3` as the value of `crossplane.io/external-name`
+annotation of your AWS `VPC` resource even if you added your own custom external
+name during creation.
 
 ### Late Initialization
 
-For some of the optional fields, users rely on the default that the cloud provider
-chooses for them. Since Crossplane treats the managed resource as the source of
-the truth, values of those fields need to exist in `spec` of the managed resource.
-So, in each reconciliation, Crossplane will fill the value of a field that is
-left empty by the user but is assigned a value by the provider. For example,
-there could be two fields like `region` and `availabilityZone` and you might want
-to give only `region` and leave the availability zone to be chosen by the cloud
-provider. In that case, if the provider assigns an availability zone, Crossplane
-gets that value and fills `availabilityZone`. Note that if the field is already
-filled, the controller won't override its value.
+For some of the optional fields, users rely on the default that the cloud
+provider chooses for them. Since Crossplane treats the managed resource as the
+source of the truth, values of those fields need to exist in `spec` of the
+managed resource. So, in each reconciliation, Crossplane will fill the value of
+a field that is left empty by the user but is assigned a value by the provider.
+For example, there could be two fields like `region` and `availabilityZone` and
+you might want to give only `region` and leave the availability zone to be
+chosen by the cloud provider. In that case, if the provider assigns an
+availability zone, Crossplane gets that value and fills `availabilityZone`. Note
+that if the field is already filled, the controller won't override its value.
 
 ### Deletion
 
-When a deletion request is made for a managed resource, its controller starts the
-deletion process immediately. However, the managed resource is kept in the Kubernetes
-API (via a finalizer) until the controller confirms the external resource in the
-cloud is gone. So you can be sure that if the managed resource is deleted, then
-the external cloud resource is also deleted. Any errors that happen during
-deletion will be added to the `status` of the managed resource, so you can
-troubleshoot any issues.
+When a deletion request is made for a managed resource, its controller starts
+the deletion process immediately. However, the managed resource is kept in the
+Kubernetes API (via a finalizer) until the controller confirms the external
+resource in the cloud is gone. So you can be sure that if the managed resource
+is deleted, then the external cloud resource is also deleted. Any errors that
+happen during deletion will be added to the `status` of the managed resource, so
+you can troubleshoot any issues.
 
 ## Dependencies
 
-In many cases, an external resource refers to another one for a specific configuration.
-For example, you could want your Azure Kubernetes cluster in a specific
-Virtual Network. External resources have specific fields for these relations, however,
-they usually require the information to be supplied in different formats. In Azure
-MySQL, you might be required to enter only the name of the Virtual Network while in
-Azure Kubernetes, it could be required to enter a string in a specific format
-that includes other information such as resource group name.
+In many cases, an external resource refers to another one for a specific
+configuration. For example, you could want your Azure Kubernetes cluster in a
+specific Virtual Network. External resources have specific fields for these
+relations, however, they usually require the information to be supplied in
+different formats. In Azure MySQL, you might be required to enter only the name
+of the Virtual Network while in Azure Kubernetes, it could be required to enter
+a string in a specific format that includes other information such as resource
+group name.
 
-In Crossplane, users have 3 fields to refer to another resource. Here is an example
-from Azure MySQL managed resource referring to a Azure Resource Group:
+In Crossplane, users have 3 fields to refer to another resource. Here is an
+example from Azure MySQL managed resource referring to a Azure Resource Group:
 
 ```yaml
 spec:
@@ -196,31 +201,33 @@ spec:
         app: prod
 ```
 
-In this example, the user provided only a set of labels to select a `ResourceGroup`
-managed resource that already exists in the cluster via `resourceGroupNameSelector`.
-Then after a specific `ResourceGroup` is selected, `resourceGroupNameRef` is filled
-with the name of that `ResourceGroup` managed resource. Then in the last step,
-Crossplane fills the actual `resourceGroupName` field with whatever format Azure
-accepts it. Once a dependency is resolved, the controller never changes it.
+In this example, the user provided only a set of labels to select a
+`ResourceGroup` managed resource that already exists in the cluster via
+`resourceGroupNameSelector`. Then after a specific `ResourceGroup` is selected,
+`resourceGroupNameRef` is filled with the name of that `ResourceGroup` managed
+resource. Then in the last step, Crossplane fills the actual `resourceGroupName`
+field with whatever format Azure accepts it. Once a dependency is resolved, the
+controller never changes it.
 
-Users are able to specify any of these three fields: 
- - Selector to select via labels
- - Reference to point to a determined managed resource 
- - Actual value that will be submitted to the provider
+Users are able to specify any of these three fields:
 
-It's important to note that in case a reference exists, the managed resource does
-not create the external resource until the referenced object is ready. In this
-example, creation call of Azure MySQL Server will not be made until referenced
-`ResourceGroup` has its `status.condition` named `Ready` to be true.
+- Selector to select via labels
+- Reference to point to a determined managed resource
+- Actual value that will be submitted to the provider
+
+It's important to note that in case a reference exists, the managed resource
+does not create the external resource until the referenced object is ready. In
+this example, creation call of Azure MySQL Server will not be made until
+referenced `ResourceGroup` has its `status.condition` named `Ready` to be true.
 
 ## Importing Existing Resources
 
 If you have some resources that are already provisioned in the cloud provider,
-you can import them as managed resources and let Crossplane manage them. What you
-need to do is to enter the name of the external resource as well as the required
-fields on the managed resource. For example, let's say I have a GCP Network
-provisioned from GCP console and I would like to migrate it to Crossplane. Here
-is the YAML that I need to create:
+you can import them as managed resources and let Crossplane manage them. What
+you need to do is to enter the name of the external resource as well as the
+required fields on the managed resource. For example, let's say I have a GCP
+Network provisioned from GCP console and I would like to migrate it to
+Crossplane. Here is the YAML that I need to create:
 
 ```yaml
 apiVersion: compute.gcp.crossplane.io/v1beta1
@@ -234,14 +241,14 @@ spec:
     name: gcp-creds
 ```
 
-Crossplane will check whether a GCP Network called `existing-network` exists, and
-if it does, then the optional fields under `forProvider` will be filled with the
-values that are fetched from the provider.
+Crossplane will check whether a GCP Network called `existing-network` exists,
+and if it does, then the optional fields under `forProvider` will be filled with
+the values that are fetched from the provider.
 
 Note that if a resource has required fields, you must fill those fields or the
 creation of the managed resource will be rejected. So, in those cases, you will
-need to enter the name of the resource as well as the required fields as indicated
-in the [API Reference][api-reference] documentation.
+need to enter the name of the resource as well as the required fields as
+indicated in the [API Reference][api-reference] documentation.
 
 ## Backup and Restore
 
@@ -249,11 +256,12 @@ Crossplane adheres to Kubernetes conventions as much as possible and one of the
 advantages we gain is backup & restore ability with tools that work with native
 Kubernetes types, like [Velero][velero].
 
-If you'd like to backup and restore manually, you can simply export them and save
-YAMLs in your file system. When you reload them, as we've discovered in import
-section, their `crosssplane.io/external-name` annotation and required fields are
-there and those are enough to import a resource. The tool you're using needs to
-store `annotations` and `spec` fields, which most tools do including Velero.
+If you'd like to backup and restore manually, you can simply export them and
+save YAMLs in your file system. When you reload them, as we've discovered in
+import section, their `crosssplane.io/external-name` annotation and required
+fields are there and those are enough to import a resource. The tool you're
+using needs to store `annotations` and `spec` fields, which most tools do
+including Velero.
 
 [api-versioning]: https://kubernetes.io/docs/reference/using-api/api-overview/#api-versioning
 [velero]: https://velero.io/

--- a/docs/introduction/providers.md
+++ b/docs/introduction/providers.md
@@ -90,10 +90,12 @@ kind: ProviderConfig
 metadata:
   name: aws-provider
 spec:
-  credentialsSecretRef:
-    namespace: crossplane-system
-    name: aws-creds
-    key: key
+  credentials:
+    source: Secret
+    secretRef:
+      namespace: crossplane-system
+      name: aws-creds
+      key: key
 ```
 
 You can see that there is a reference to a key in a specific `Secret`. The value
@@ -118,7 +120,8 @@ spec:
 The AWS provider controller will use that provider for this instance of
 `RDSInstance`. Since every resource has its own reference to a `ProviderConfig`,
 you can have multiple `ProviderConfig` resources in your cluster referenced by
-different resources.
+different resources. When no `providerConfigRef` is specified, the `RDSInstance`
+will attempt to use a `ProviderConfig` named `default`.
 
 <!-- Named Links -->
 

--- a/docs/introduction/providers.md
+++ b/docs/introduction/providers.md
@@ -16,30 +16,35 @@ contain many Custom Resource Definitions and their controllers.
 Here is the list of current providers:
 
 ### AWS Provider
+
 * [GitHub][provider-aws]
 * [API Reference][aws-reference]
 
 ### GCP Provider
+
 * [GitHub][provider-gcp]
 * [API Reference][gcp-reference]
 
 ### Azure Provider
+
 * [GitHub][provider-azure]
 * [API Reference][azure-reference]
 
 ### Rook Provider
+
 * [GitHub][provider-rook]
 * [API Reference][rook-reference]
 
 ### Alibaba Cloud Provider
+
 * [GitHub][provider-alibaba]
 * [API Reference][alibaba-reference]
 
 ## Installing Providers
 
 The core Crossplane controller can install provider controllers and CRDs for you
-through its own provider packaging mechanism, which is triggered by the application
-of a `Provider` resource. For example, in order to request
+through its own provider packaging mechanism, which is triggered by the
+application of a `Provider` resource. For example, in order to request
 installation of the `provider-aws` package, apply the following resource to the
 cluster where Crossplane is running:
 
@@ -53,30 +58,31 @@ spec:
 ```
 
 The field `spec.package` is where you refer to the container image of the
-provider. Crossplane Package Manager will unpack that container, register
-CRDs and set up necessary RBAC rules and then start the controllers.
+provider. Crossplane Package Manager will unpack that container, register CRDs
+and set up necessary RBAC rules and then start the controllers.
 
-There are a few other ways to to trigger the installation of provider
-packages:
+There are a few other ways to to trigger the installation of provider packages:
 
-* As part of Crossplane Helm chart by adding the following
-  statement to your `helm install` command: `--set clusterPackages.gcp.deploy=true`
-  It will install the default version hard-coded in that release of Crossplane
-  Helm chart but if you'd like to specif an exact version, you can add:
-  `--set clusterPackages.gcp.version=master`.
-* Using [Crossplane kubectl plugin][crossplane-cli]:
-  `kubectl crossplane package install --cluster -n crossplane-system 'crossplane/provider-gcp:master' provider-gcp`
+* As part of Crossplane Helm chart by adding the following statement to your
+  `helm install` command: `--set clusterPackages.gcp.deploy=true` It will
+  install the default version hard-coded in that release of Crossplane Helm
+  chart but if you'd like to specif an exact version, you can add: `--set
+  clusterPackages.gcp.version=master`.
+* Using [Crossplane kubectl plugin][crossplane-cli]: `kubectl crossplane package
+  install --cluster -n crossplane-system 'crossplane/provider-gcp:master'
+  provider-gcp`
 
 You can uninstall a provider by deleting the `ClusterPackageInstall` resource
 you've created.
 
 ## Configuring Providers
 
-In order to authenticate with the external provider API, the provider controllers
-need to have access to credentials. It could be an IAM User for AWS, a Service
-Account for GCP or a Service Principal for Azure. Every provider has a type called
-`ProviderConfig` that has information about how to authenticate to the provider API.
-An example `ProviderConfig` resource for AWS looks like the following:
+In order to authenticate with the external provider API, the provider
+controllers need to have access to credentials. It could be an IAM User for AWS,
+a Service Account for GCP or a Service Principal for Azure. Every provider has a
+type called `ProviderConfig` that has information about how to authenticate to
+the provider API. An example `ProviderConfig` resource for AWS looks like the
+following:
 
 ```yaml
 apiVersion: aws.crossplane.io/v1beta1
@@ -93,9 +99,11 @@ spec:
 You can see that there is a reference to a key in a specific `Secret`. The value
 of that key should contain the credentials that the controller will use. The
 documentation of each provider should give you an idea of how that credentials
-blob should look like. See [Getting Started][getting-started] guide for more details.
+blob should look like. See [Getting Started][getting-started] guide for more
+details.
 
-The following is an example usage of Azure `ProviderConfig`, referenced by a `RDSInstance`:
+The following is an example usage of Azure `ProviderConfig`, referenced by a
+`RDSInstance`:
 
 ```yaml
 apiVersion: database.aws.crossplane.io/v1beta1
@@ -107,10 +115,10 @@ spec:
   ...
 ```
 
-The AWS provider controller will use that provider for this instance of `RDSInstance`.
-Since every resource has its own reference to a `ProviderConfig`, you can have multiple
-`ProviderConfig` resources in your cluster referenced by different resources.
-
+The AWS provider controller will use that provider for this instance of
+`RDSInstance`. Since every resource has its own reference to a `ProviderConfig`,
+you can have multiple `ProviderConfig` resources in your cluster referenced by
+different resources.
 
 <!-- Named Links -->
 

--- a/docs/snippets/compose/composition-alibaba.yaml
+++ b/docs/snippets/compose/composition-alibaba.yaml
@@ -24,8 +24,6 @@ spec:
             masterUsername: "myuser"
           writeConnectionSecretToRef:
             namespace: crossplane-system
-          providerConfigRef:
-            name: alibaba-provider
       patches:
         - fromFieldPath: "metadata.uid"
           toFieldPath: "spec.writeConnectionSecretToRef.name"

--- a/docs/snippets/compose/composition-aws-with-vpc.yaml
+++ b/docs/snippets/compose/composition-aws-with-vpc.yaml
@@ -22,8 +22,6 @@ spec:
             cidrBlock: 192.168.0.0/16
             enableDnsSupport: true
             enableDnsHostNames: true
-          providerConfigRef:
-            name: aws-provider
     - base:
         apiVersion: ec2.aws.crossplane.io/v1beta1
         kind: Subnet
@@ -37,8 +35,6 @@ spec:
             vpcIdSelector:
               matchControllerRef: true
             availabilityZone: us-east-1a
-          providerConfigRef:
-            name: aws-provider
     - base:
         apiVersion: ec2.aws.crossplane.io/v1beta1
         kind: Subnet
@@ -52,8 +48,6 @@ spec:
             vpcIdSelector:
               matchControllerRef: true
             availabilityZone: us-east-1b
-          providerConfigRef:
-            name: aws-provider
     - base:
         apiVersion: ec2.aws.crossplane.io/v1beta1
         kind: Subnet
@@ -67,8 +61,6 @@ spec:
             vpcIdSelector:
               matchControllerRef: true
             availabilityZone: us-east-1c
-          providerConfigRef:
-            name: aws-provider
     - base:
         apiVersion: database.aws.crossplane.io/v1beta1
         kind: DBSubnetGroup
@@ -78,8 +70,6 @@ spec:
             description: An excellent formation of subnetworks.
             subnetIdSelector:
               matchControllerRef: true
-          providerConfigRef:
-            name: aws-provider
     - base:
         apiVersion: ec2.aws.crossplane.io/v1beta1
         kind: InternetGateway
@@ -88,8 +78,6 @@ spec:
             region: us-east-1
             vpcIdSelector:
               matchControllerRef: true
-          providerConfigRef:
-            name: aws-provider
     - base:
         apiVersion: ec2.aws.crossplane.io/v1alpha4
         kind: RouteTable
@@ -112,8 +100,6 @@ spec:
               - subnetIdSelector:
                   matchLabels:
                     zone: us-east-1c
-          providerConfigRef:
-            name: aws-provider
     - base:
         apiVersion: ec2.aws.crossplane.io/v1beta1
         kind: SecurityGroup
@@ -131,8 +117,6 @@ spec:
                 ipRanges:
                   - cidrIp: 0.0.0.0/0
                     description: Everywhere
-          providerConfigRef:
-            name: aws-provider
     - base:
         apiVersion: database.aws.crossplane.io/v1beta1
         kind: RDSInstance
@@ -151,8 +135,6 @@ spec:
             publiclyAccessible: true
           writeConnectionSecretToRef:
             namespace: crossplane-system
-          providerConfigRef:
-            name: aws-provider
       patches:
         - fromFieldPath: "metadata.uid"
           toFieldPath: "spec.writeConnectionSecretToRef.name"

--- a/docs/snippets/compose/composition-aws.yaml
+++ b/docs/snippets/compose/composition-aws.yaml
@@ -27,8 +27,6 @@ spec:
             publiclyAccessible: true
           writeConnectionSecretToRef:
             namespace: crossplane-system
-          providerConfigRef:
-            name: aws-provider
       patches:
         - fromFieldPath: "metadata.uid"
           toFieldPath: "spec.writeConnectionSecretToRef.name"

--- a/docs/snippets/compose/composition-azure.yaml
+++ b/docs/snippets/compose/composition-azure.yaml
@@ -17,8 +17,6 @@ spec:
         kind: ResourceGroup
         spec:
           location: West US 2
-          providerConfigRef:
-            name: azure-provider
     - base:
         apiVersion: database.azure.crossplane.io/v1beta1
         kind: PostgreSQLServer
@@ -36,8 +34,6 @@ spec:
               family: Gen5
           writeConnectionSecretToRef:
             namespace: crossplane-system
-          providerConfigRef:
-            name: azure-provider
       patches:
         - fromFieldPath: "metadata.uid"
           toFieldPath: "spec.writeConnectionSecretToRef.name"
@@ -69,5 +65,3 @@ spec:
             properties:
               startIpAddress: 0.0.0.0
               endIpAddress: 255.255.255.254
-          providerConfigRef:
-            name: azure-provider

--- a/docs/snippets/compose/composition-gcp.yaml
+++ b/docs/snippets/compose/composition-gcp.yaml
@@ -28,8 +28,6 @@ spec:
                   - value: "0.0.0.0/0"
           writeConnectionSecretToRef:
             namespace: crossplane-system
-          providerConfigRef:
-            name: gcp-provider
       patches:
         - fromFieldPath: "metadata.uid"
           toFieldPath: "spec.writeConnectionSecretToRef.name"

--- a/docs/snippets/configure/aws/provider.yaml
+++ b/docs/snippets/configure/aws/provider.yaml
@@ -11,9 +11,11 @@ type: Opaque
 apiVersion: aws.crossplane.io/v1beta1
 kind: ProviderConfig
 metadata:
-  name: aws-provider
+  name: default
 spec:
-  credentialsSecretRef:
-    namespace: crossplane-system
-    name: aws-account-creds
-    key: credentials
+  credentials:
+    source: Secret
+    secretRef:
+      namespace: crossplane-system
+      name: aws-account-creds
+      key: credentials

--- a/docs/snippets/provision/alibaba.yaml
+++ b/docs/snippets/provision/alibaba.yaml
@@ -13,5 +13,3 @@ spec:
   writeConnectionSecretToRef:
     namespace: crossplane-system
     name: alibaba-rdspostgresql-conn
-  providerConfigRef:
-    name: alibaba-provider

--- a/docs/snippets/provision/aws.yaml
+++ b/docs/snippets/provision/aws.yaml
@@ -14,5 +14,3 @@ spec:
   writeConnectionSecretToRef:
     namespace: crossplane-system
     name: aws-rdspostgresql-conn
-  providerConfigRef:
-    name: aws-provider

--- a/docs/snippets/provision/azure.yaml
+++ b/docs/snippets/provision/azure.yaml
@@ -4,8 +4,6 @@ metadata:
   name: sqlserverpostgresql-rg
 spec:
   location: West US 2
-  providerConfigRef:
-    name: azure-provider
 ---
 apiVersion: database.azure.crossplane.io/v1beta1
 kind: PostgreSQLServer
@@ -28,5 +26,3 @@ spec:
   writeConnectionSecretToRef:
     namespace: crossplane-system
     name: sqlserverpostgresql-conn
-  providerConfigRef:
-    name: azure-provider

--- a/docs/snippets/provision/gcp.yaml
+++ b/docs/snippets/provision/gcp.yaml
@@ -13,5 +13,3 @@ spec:
   writeConnectionSecretToRef:
     namespace: crossplane-system
     name: cloudsqlpostgresql-conn
-  providerConfigRef:
-    name: gcp-provider


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Specifically, the change of schema introduced by crossplane/crossplane-runtime#212, and the fact that resources default to using the ProviderConfig named 'default'.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested
By running through all of the examples under `docs/snippets/compose`.

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
