### PR TITLE
Fix crash caused by invalid transform in composition

### DIFF
--- a/apis/apiextensions/v1alpha1/composition_types.go
+++ b/apis/apiextensions/v1alpha1/composition_types.go
@@ -21,10 +21,9 @@ import (
 	"fmt"
 	"reflect"
 
-	"k8s.io/apimachinery/pkg/runtime"
-
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 
 	"github.com/crossplane/crossplane-runtime/apis/core/v1alpha1"
 	"github.com/crossplane/crossplane-runtime/pkg/fieldpath"
@@ -235,7 +234,10 @@ func (t *Transform) Transform(input interface{}) (interface{}, error) {
 	default:
 		return nil, errors.New(errTypeNotSupported(string(t.Type)))
 	}
-	if transformer == nil {
+	// An interface equals nil only if both the type and value are nil. Above,
+	// even if t.<Type> is nil, its type is assigned to "transformer" but we're
+	// interested in whether only the value is nil or not.
+	if reflect.ValueOf(transformer).IsNil() {
 		return nil, errors.New(errConfigMissing(string(t.Type)))
 	}
 	out, err := transformer.Resolve(input)

--- a/pkg/controller/apiextensions/composite/reconciler.go
+++ b/pkg/controller/apiextensions/composite/reconciler.go
@@ -18,6 +18,7 @@ package composite
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/google/go-cmp/cmp"
@@ -56,8 +57,8 @@ const (
 	errSelectComp   = "cannot select Composition"
 	errGetComp      = "cannot get Composition"
 	errConfigure    = "cannot configure composite resource"
-	errReconcile    = "cannot reconcile composed infrastructure resource"
 	errPublish      = "cannot publish connection details"
+	errFmtCompose   = "cannot compose resource at index %d"
 )
 
 // Event reasons.
@@ -273,8 +274,8 @@ func (r *Reconciler) Reconcile(req reconcile.Request) (reconcile.Result, error) 
 
 		obs, err := r.resource.Compose(ctx, cr, composed.New(composed.FromReference(ref)), tmpl)
 		if err != nil {
-			log.Debug(errReconcile, "error", err)
-			r.record.Event(cr, event.Warning(reasonCompose, err))
+			log.Debug(fmt.Sprintf(errFmtCompose, i), "error", err)
+			r.record.Event(cr, event.Warning(reasonCompose, errors.Wrap(err, fmt.Sprintf(errFmtCompose, i))))
 			return reconcile.Result{RequeueAfter: shortWait}, nil
 		}
 


### PR DESCRIPTION
### Description of your changes

We need to check the value of the interface instead of itself directly because interfaces are `nil` only if both their type and value are `nil`. In this case, we assign a `nil` struct but the resulting interface is not `nil` since it carries the type information of that struct even though that struct was `nil`. This PR lets the code check only the value of the interface against `nil`.

Fixes https://github.com/crossplane/crossplane/issues/1815

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Used the example in #1815 . Instead of crash, we get the following error in events:
```
  Warning  ComposeResources   28s (x2 over 58s)    defined/compositeresourcedefinition.apiextensions.crossplane.io  cannot compose resource at index 1: cannot apply overlay: cannot apply the patch at index 0: transform at index 0 returned error: given type string requires configuration
```

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
