### PR TITLE
Default to current for crank install version

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -3,7 +3,7 @@
 set -eu
 
 CHANNEL=${CHANNEL:-alpha}
-VERSION=${VERSION:-v0.13.0}
+VERSION=${VERSION:-current}
 
 os=$(uname -s)
 arch=$(uname -m)
@@ -22,7 +22,7 @@ unsupported_arch() {
 
 case $OS in
   CYGWIN* | MINGW64*)
-    if [ $ARCH == "amd64" ]
+    if [ $ARCH = "amd64" ]
     then
       OS_ARCH=windows_amd64
       BIN=crank.exe


### PR DESCRIPTION

<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Updates the install.sh script to default to current rather than a pinned
stable version of crossplane. This means that if CHANNEL is master and
no VERSION is supplied then we will get latest master build. If CHANNEL
is alpha and no VERSION is supplied then we will get latest stable.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

Fixes #1820 

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

Tested running locally.

[contribution process]: https://git.io/fj2m9
