### PR TITLE
Get kubectl-crossplane installed as a plugin

### DIFF
--- a/docs/introduction/packages.md
+++ b/docs/introduction/packages.md
@@ -196,7 +196,7 @@ This is the package image that we built, pushed, and are asking Crossplane to
 install. The tag we specify here is important. Crossplane will periodically
 check if the installed image matches the digest of the image in the remote
 registry. If it does not, Crossplane will create a new _Revision_ (either
-`ProviderRevision` or `ConfigurationRevision`). If you do not for Crossplane to
+`ProviderRevision` or `ConfigurationRevision`). If you do not wish Crossplane to
 ever update your packages without explicitly instructing it to do so, you should
 consider specifying a tag which you know will not have the underlying contents
 change unexpectedly (e.g. a specific semantic version, such as `v0.1.0`) or, for
@@ -220,7 +220,7 @@ until the other cedes control.
 
 An `Inactive` package revision attempts to become the _owner_ of all resource it
 installs. There can be an arbitrary number of owners of a resource, so multiple
-`Inactive` revisions and a single `Active` revisions can exist for a resource.
+`Inactive` revisions and a single `Active` revision can exist for a resource.
 Importantly, an `Inactive` package revision will not perform any auxiliary
 actions (such as creating a `Deployment` in the case of a `Provider`), meaning
 we will not encounter a situation where two revisions are fighting over
@@ -245,7 +245,7 @@ become `Inactive`, and the oldest `Inactive` revision will be garbage collected.
 > enough times (but do not make `Active` the new revisions), it is possible that
 > activating a newer revision could cause the previously `Active` revision to
 > immediately be garbage collected if it is outside the
-> `spec.revisionHistoryLimit`. 
+> `spec.revisionHistoryLimit`.
 
 <!-- Named Links -->
 

--- a/install.sh
+++ b/install.sh
@@ -57,5 +57,12 @@ if ! curl -sLo kubectl-crossplane "${url}"; then
   exit 1
 fi
 
-echo "Crossplane CLI installed successfully! Visit https://crossplane.io to get started. 🚀"
-echo "\n\nHave a nice day! 👋\n"
+chmod +x kubectl-crossplane
+
+echo "kubectl plugin downloaded successfully! Run the following commands to finish installing it:"
+echo 
+echo sudo mv kubectl-crossplane $(dirname $(which kubectl))
+echo kubectl crossplane --help
+echo
+echo "Visit https://crossplane.io to get started. 🚀"
+echo "Have a nice day! 👋\n"


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
This change gets the `kubectl crossplane` plugin installed, but does not completely automate it in order to avoid the user having to run a script that uses `sudo`.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [ ] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested
```
CHANNEL=master sh install.sh
```
<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
