### PR TITLE
Bump oam-kubernetes-runtime chart to v0.2.2

### DIFF
--- a/cluster/charts/crossplane/requirements.yaml
+++ b/cluster/charts/crossplane/requirements.yaml
@@ -1,5 +1,5 @@
 dependencies:
 - name: oam-kubernetes-runtime
-  version: 0.2.1
+  version: 0.2.2
   repository: "https://charts.crossplane.io/alpha"
   condition: alpha.oam.enabled


### PR DESCRIPTION


<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Picks up a fix that gives OAM controllers RBAC to emit events.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

`make build`
`make e2e.run`

[contribution process]: https://git.io/fj2m9
