### PR TITLE
Explicitly avoid leaking file descriptors when caching packages

### DIFF
--- a/pkg/xpkg/cache.go
+++ b/pkg/xpkg/cache.go
@@ -81,7 +81,10 @@ func (c *ImageCache) Store(tag, id string, img v1.Image) error {
 	if err != nil {
 		return err
 	}
-	return tarball.Write(ref, img, cf)
+	if err := tarball.Write(ref, img, cf); err != nil {
+		return err
+	}
+	return cf.Close()
 }
 
 // Delete removes an image from the ImageCache.

--- a/pkg/xpkg/cache.go
+++ b/pkg/xpkg/cache.go
@@ -17,6 +17,7 @@ limitations under the License.
 package xpkg
 
 import (
+	"io"
 	"os"
 	"sync"
 
@@ -66,7 +67,7 @@ func (c *ImageCache) Get(tag, id string) (v1.Image, error) {
 		}
 		t = &nt
 	}
-	return tarball.ImageFromPath(BuildPath(c.dir, id), t)
+	return tarball.Image(fsOpener(BuildPath(c.dir, id), c.fs), t)
 }
 
 // Store saves an image to the ImageCache.
@@ -96,6 +97,12 @@ func (c *ImageCache) Delete(id string) error {
 		return nil
 	}
 	return err
+}
+
+func fsOpener(path string, fs afero.Fs) tarball.Opener {
+	return func() (io.ReadCloser, error) {
+		return fs.Open(path)
+	}
 }
 
 // NopCache is a cache implementation that does not store anything and always

--- a/pkg/xpkg/cache_test.go
+++ b/pkg/xpkg/cache_test.go
@@ -1,0 +1,172 @@
+/*
+Copyright 2020 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package xpkg
+
+import (
+	"os"
+	"syscall"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-containerregistry/pkg/name"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/empty"
+	"github.com/google/go-containerregistry/pkg/v1/tarball"
+	"github.com/spf13/afero"
+
+	"github.com/crossplane/crossplane-runtime/pkg/test"
+)
+
+func TestGet(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	cf, _ := fs.Create("/cache/exists.xpkg")
+	_ = tarball.Write(name.Tag{}, empty.Image, cf)
+
+	type args struct {
+		cache Cache
+		tag   string
+		id    string
+	}
+	cases := map[string]struct {
+		reason string
+		args   args
+		want   error
+	}{
+		"Success": {
+			reason: "Should not return an error if package exists at path.",
+			args: args{
+				cache: NewImageCache("/cache", fs),
+				tag:   "",
+				id:    "exists",
+			},
+		},
+		"ErrNotExist": {
+			reason: "Should return error if package does not exist at path.",
+			args: args{
+				cache: NewImageCache("/cache", fs),
+				tag:   "",
+				id:    "not-exist",
+			},
+			want: &os.PathError{Op: "open", Path: "/cache/not-exist.xpkg", Err: afero.ErrFileNotFound},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			_, err := tc.args.cache.Get(tc.args.tag, tc.args.id)
+
+			if diff := cmp.Diff(tc.want, err, test.EquateErrors()); diff != "" {
+				t.Errorf("\n%s\nGet(...): -want err, +got err:\n%s", tc.reason, diff)
+			}
+		})
+	}
+}
+
+func TestStore(t *testing.T) {
+	fs := afero.NewMemMapFs()
+
+	type args struct {
+		cache Cache
+		tag   string
+		id    string
+		img   v1.Image
+	}
+	cases := map[string]struct {
+		reason string
+		args   args
+		want   error
+	}{
+		"Success": {
+			reason: "Should not return an error if package is created at path.",
+			args: args{
+				cache: NewImageCache("/cache", fs),
+				tag:   "crossplane/exist-xpkg:latest",
+				id:    "exists-1234567",
+				img:   empty.Image,
+			},
+		},
+		"ErrFailedCreate": {
+			reason: "Should return an error if file creation fails.",
+			args: args{
+				cache: NewImageCache("/cache", afero.NewReadOnlyFs(fs)),
+				tag:   "crossplane/exist-xpkg:latest",
+				id:    "exists-1234567",
+				img:   empty.Image,
+			},
+			want: syscall.EPERM,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			err := tc.args.cache.Store(tc.args.tag, tc.args.id, tc.args.img)
+
+			if diff := cmp.Diff(tc.want, err, test.EquateErrors()); diff != "" {
+				t.Errorf("\n%s\nStore(...): -want err, +got err:\n%s", tc.reason, diff)
+			}
+		})
+	}
+}
+
+func TestDelete(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	cf, _ := fs.Create("/cache/exists.xpkg")
+	_ = tarball.Write(name.Tag{}, empty.Image, cf)
+
+	type args struct {
+		cache Cache
+		id    string
+	}
+	cases := map[string]struct {
+		reason string
+		args   args
+		want   error
+	}{
+		"Success": {
+			reason: "Should not return an error if package is deleted at path.",
+			args: args{
+				cache: NewImageCache("/cache", fs),
+				id:    "exists",
+			},
+		},
+		"SuccessNotExist": {
+			reason: "Should not return an error if package does not exist.",
+			args: args{
+				cache: NewImageCache("/cache", fs),
+				id:    "not-exist",
+			},
+		},
+		"ErrFailedDelete": {
+			reason: "Should return an error if file deletion fails.",
+			args: args{
+				cache: NewImageCache("/cache", afero.NewReadOnlyFs(fs)),
+				id:    "exists-1234567",
+			},
+			want: syscall.EPERM,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			err := tc.args.cache.Delete(tc.args.id)
+
+			if diff := cmp.Diff(tc.want, err, test.EquateErrors()); diff != "" {
+				t.Errorf("\n%s\nStore(...): -want err, +got err:\n%s", tc.reason, diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

File descriptors can be leaked when a file is opened and not subsequently
closed. In the case of the package manager, there would likely need to be a
large number of packages installed before this became an issue as there
should only be one open per revision when it is initially stored. Files
are opened and closed correctly currently on Get calls.

_Note that I don't believe we are actually leaking file descriptors because os.File is implicitly closed when garbage collected. See testing below for more information._

Also adds some unit tests for cache package.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

I ran this and installed 4 packages and compared `lsof` output vs current `master`, and it didn't appear that we were leaking file descriptors. However, it is better practice to close explicitly.

[contribution process]: https://git.io/fj2m9
