### PR TITLE
Display Established and Offered status for XRD

### DIFF
--- a/apis/apiextensions/v1alpha1/xrd_types.go
+++ b/apis/apiextensions/v1alpha1/xrd_types.go
@@ -139,6 +139,8 @@ type CompositeResourceDefinitionStatus struct {
 // An CompositeResourceDefinition defines a new kind of composite infrastructure
 // resource. The new resource is composed of other composite or managed
 // infrastructure resources.
+// +kubebuilder:printcolumn:name="ESTABLISHED",type="string",JSONPath=".status.conditions[?(@.type=='Established')].status"
+// +kubebuilder:printcolumn:name="OFFERED",type="string",JSONPath=".status.conditions[?(@.type=='Offered')].status"
 // +kubebuilder:printcolumn:name="AGE",type="date",JSONPath=".metadata.creationTimestamp"
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:scope=Cluster,categories=crossplane,shortName=xrd

--- a/cluster/charts/crossplane/crds/apiextensions.crossplane.io_compositeresourcedefinitions.yaml
+++ b/cluster/charts/crossplane/crds/apiextensions.crossplane.io_compositeresourcedefinitions.yaml
@@ -9,6 +9,12 @@ metadata:
   name: compositeresourcedefinitions.apiextensions.crossplane.io
 spec:
   additionalPrinterColumns:
+  - JSONPath: .status.conditions[?(@.type=='Established')].status
+    name: ESTABLISHED
+    type: string
+  - JSONPath: .status.conditions[?(@.type=='Offered')].status
+    name: OFFERED
+    type: string
   - JSONPath: .metadata.creationTimestamp
     name: AGE
     type: date


### PR DESCRIPTION


<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Adds printer columns for established and offered conditions of an XRD so
that it can easily be determined if the XRD was reconciled
appropriately.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>
I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

Installed Crossplane and installed a configuration package with an XRD:

```
NAME                                ESTABLISHED   OFFERED   AGE
compositeinfras.metal.equinix.com   True          True      36s
```

[contribution process]: https://git.io/fj2m9
