### PR TITLE
Aggregate edit and view roles to admin

### DIFF
--- a/cluster/charts/crossplane/templates/rbac-manager-managed-clusterroles.yaml
+++ b/cluster/charts/crossplane/templates/rbac-manager-managed-clusterroles.yaml
@@ -26,6 +26,8 @@ aggregationRule:
   clusterRoleSelectors:
   - matchLabels:
       rbac.crossplane.io/aggregate-to-admin: "true"
+      rbac.crossplane.io/aggregate-to-edit: "true"
+      rbac.crossplane.io/aggregate-to-view: "true"
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole


### PR DESCRIPTION


<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

This updates the crossplane-admin role to be given any roles that are
given to the edit or view roles. We still explicitly aggregate to the
admin when the RBAC manager creates roles, so these aggregation lables
are convenience for if a user want to manually create a role for edit or
view that should roll up to admin.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

Fixes #1852 

Keeping this in draft for discussion. I actually don't love this change as I generally prefer being explicit about the aggregation of a role. If we do go this route, it might be worth examining if we want to clean up some of the logic in the code that explicitly labels edit roles with the aggregate to admin and/or assigning the base role of the admin explicitly then _only_ aggregating edit and view to admin.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

`make e2e.run`

[contribution process]: https://git.io/fj2m9
