### PR TITLE
Enable leader election for controller managers

### DIFF
--- a/cluster/charts/crossplane/README.md
+++ b/cluster/charts/crossplane/README.md
@@ -67,8 +67,9 @@ and their default values.
 | `image.tag` | Image tag | `master` |
 | `image.pullPolicy` | Image pull policy | `Always` |
 | `imagePullSecrets` | Names of image pull secrets to use | `dockerhub` |
-| `replicas` | The number of replicas to run for the Crossplane and RBAC Manager (if enabled) pods | `1` |
+| `replicas` | The number of replicas to run for the Crossplane pods | `1` |
 | `deploymentStrategy` | The deployment strategy for the Crossplane and RBAC Manager (if enabled) pods | `RollingUpdate` |
+| `leaderElection` | Enable leader election for Crossplane Managers pod | `true` |
 | `priorityClassName` | Priority class name for Crossplane and RBAC Manager (if enabled) pods | `""` |
 | `resourcesCrossplane.limits.cpu` | CPU resource limits for Crossplane | `100m` |
 | `resourcesCrossplane.limits.memory` | Memory resource limits for Crossplane | `512Mi` |
@@ -82,6 +83,8 @@ and their default values.
 | `resourcesRBACManager.requests.cpu` | CPU resource requests for RBAC Manager | `100m` |
 | `resourcesRBACManager.requests.memory` | Memory resource requests for RBAC Manager | `256Mi` |
 | `rbacManager.deploy` | Deploy RBAC Manager and its required roles | `true` |
+| `rbacManager.replicas` | The number of replicas to run for the RBAC Manager pods | `1` |
+| `rbacManager.leaderElection` | Enable leader election for RBAC Managers pod | `true` |
 | `rbacManager.managementPolicy`| The extent to which the RBAC manager will manage permissions. `All` indicates to manage all Crossplane controller and user roles. `Basic` indicates to only manage Crossplane controller roles and the `crossplane-admin`, `crossplane-edit`, and `crossplane-view` user roles. | `All` |
 | `alpha.oam.enabled` | Deploy the `crossplane/oam-kubernetes-runtime` Helm chart | `false` |
 

--- a/cluster/charts/crossplane/templates/clusterrole.yaml
+++ b/cluster/charts/crossplane/templates/clusterrole.yaml
@@ -77,3 +77,14 @@ rules:
   - patch
   - delete
   - watch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - create
+  - update
+  - patch
+  - watch

--- a/cluster/charts/crossplane/templates/deployment.yaml
+++ b/cluster/charts/crossplane/templates/deployment.yaml
@@ -47,6 +47,8 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
+          - name: LEADER_ELECTION
+            value: "{{ .Values.leaderElection }}"
         volumeMounts:
           - mountPath: /cache
             name: package-cache

--- a/cluster/charts/crossplane/templates/rbac-manager-clusterrole.yaml
+++ b/cluster/charts/crossplane/templates/rbac-manager-clusterrole.yaml
@@ -77,4 +77,15 @@ rules:
   - clusterrolebindings
   verbs:
   - "*"
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - create
+  - update
+  - patch
+  - watch
 {{- end}}

--- a/cluster/charts/crossplane/templates/rbac-manager-deployment.yaml
+++ b/cluster/charts/crossplane/templates/rbac-manager-deployment.yaml
@@ -9,7 +9,7 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
-  replicas: {{ .Values.replicas }}
+  replicas: {{ .Values.rbacManager.replicas }}
   selector:
     matchLabels:
       app: {{ template "name" . }}-rbac-manager
@@ -43,4 +43,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        env:
+          - name: LEADER_ELECTION
+            value: "{{ .Values.rbacManager.leaderElection }}"
 {{- end}}

--- a/cluster/charts/crossplane/values.yaml.tmpl
+++ b/cluster/charts/crossplane/values.yaml.tmpl
@@ -7,6 +7,7 @@ image:
   tag: %%VERSION%%
   pullPolicy: Always
 
+leaderElection: true
 args: {}
 
 provider:
@@ -17,7 +18,9 @@ imagePullSecrets:
 
 rbacManager:
   deploy: true
+  replicas: 1
   managementPolicy: All
+  leaderElection: true
   args: {}
 
 priorityClassName: ""

--- a/cluster/local/integration_tests.sh
+++ b/cluster/local/integration_tests.sh
@@ -67,7 +67,7 @@ docker tag "${BUILD_IMAGE}" "${CROSSPLANE_IMAGE}"
 
 echo_step "installing helm package(s) into \"${CROSSPLANE_NAMESPACE}\" namespace"
 "${KUBECTL}" create ns "${CROSSPLANE_NAMESPACE}"
-"${HELM3}" install "${PROJECT_NAME}" --namespace "${CROSSPLANE_NAMESPACE}" "${projectdir}/cluster/charts/${PROJECT_NAME}" --set image.pullPolicy=Never,imagePullSecrets='',alpha.oam.enabled=true
+"${HELM3}" install "${PROJECT_NAME}" --namespace "${CROSSPLANE_NAMESPACE}" "${projectdir}/cluster/charts/${PROJECT_NAME}" --set replicas=2,rbacManager.replicas=2,image.pullPolicy=Never,imagePullSecrets='',alpha.oam.enabled=true
 
 echo_step "waiting for deployment ${PROJECT_NAME} rollout to finish"
 "${KUBECTL}" -n "${CROSSPLANE_NAMESPACE}" rollout status "deploy/${PROJECT_NAME}" --timeout=2m

--- a/pkg/controller/rbac/provider/roles/roles.go
+++ b/pkg/controller/rbac/provider/roles/roles.go
@@ -41,8 +41,9 @@ const (
 
 	suffixStatus = "/status"
 
-	pluralEvents  = "events"
-	pluralSecrets = "secrets"
+	pluralEvents     = "events"
+	pluralConfigmaps = "configmaps"
+	pluralSecrets    = "secrets"
 )
 
 var (
@@ -59,7 +60,7 @@ var (
 var rulesSystemExtra = []rbacv1.PolicyRule{
 	{
 		APIGroups: []string{""},
-		Resources: []string{pluralSecrets, pluralEvents},
+		Resources: []string{pluralSecrets, pluralConfigmaps, pluralEvents},
 		Verbs:     verbsEdit,
 	},
 }


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

This PR enables leader election for Crossplane and RBAC controller manager. ~~Note that this has a hard dependency on https://github.com/crossplane/crossplane-runtime/pull/220 and a new release of `crossplane-runtime`~~.

~~But it demonstrates, currently as it stands, the idea of how leader election can be enabled from a central place for any and all controller manager within crossplane ecosystem.~~

Note that this PR still uses controller-runtime v0.6.x which doesn't have [Lease API](https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#lease-v1-coordination-k8s-io). Originally we wanted to enable it right out of the bat, but controller-runtime is still in alpha state.


<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Partial fix for #5 

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Manually ran the following steps and checked for various points:

- ran `./cluster/local/kind.sh up`
- ran `./cluster/local/kind.sh helm-install` (with additional `--set replicas=2`)
- watched for both pods to come up
- tailed logs of both pods on separate windows, simultaneously
- ran `kubectl crossplane install provider crossplane/provider-aws:v0.13.0`
- looked for the logs of two pods and only **one** of them should pick up this operation

```bash
☸ kind-kind (crossplane-system) ➜ k get pods
NAME                                        READY   STATUS    RESTARTS   AGE
crossplane-8566f7fdcd-ql45n                 1/1     Running   0          5m43s
crossplane-8566f7fdcd-s4c97                 1/1     Running   0          5m43s
crossplane-rbac-manager-84b5dc7cd5-dv2r5    1/1     Running   0          5m43s
provider-aws-2302358baab6-868cb8b97-n6svh   1/1     Running   0          4m32s


☸ kind-kind (crossplane-system) ➜ k logs -f crossplane-8566f7fdcd-ql45n
I1029 17:09:49.160081       1 leaderelection.go:242] attempting to acquire leader lease  crossplane-system/crossplane-leader-election-core...
I1029 17:10:06.566954       1 leaderelection.go:252] successfully acquired lease crossplane-system/crossplane-leader-election-core
E1029 17:10:40.827300       1 aws_credentials.go:77] while getting AWS credentials NoCredentialProviders: no valid providers in chain. Deprecated.
        For verbose messaging see aws.Config.CredentialsChainVerboseErrors


☸ kind-kind (crossplane-system) ➜ k logs -f crossplane-8566f7fdcd-s4c97
I1029 17:09:49.160044       1 leaderelection.go:242] attempting to acquire leader lease  crossplane-system/crossplane-leader-election-core...
E1029 17:10:06.570526       1 leaderelection.go:356] Failed to update lock: Operation cannot be fulfilled on configmaps "crossplane-leader-election-core": the object has been modified; please apply your changes to the latest version and try again

```

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
