### PR TITLE
PreserveUnknownFields on RawExtension fields

### DIFF
--- a/apis/apiextensions/v1alpha1/composition_types.go
+++ b/apis/apiextensions/v1alpha1/composition_types.go
@@ -76,6 +76,7 @@ type TypeReference struct {
 // should be processed.
 type ComposedTemplate struct {
 	// Base is the target resource that the patches will be applied on.
+	// +kubebuilder:pruning:PreserveUnknownFields
 	Base runtime.RawExtension `json:"base"`
 
 	// Patches will be applied as overlay to the base resource.

--- a/apis/apiextensions/v1alpha1/xrd_types.go
+++ b/apis/apiextensions/v1alpha1/xrd_types.go
@@ -124,6 +124,7 @@ type CustomResourceDefinitionVersion struct {
 type CustomResourceValidation struct {
 	// openAPIV3Schema is the OpenAPI v3 schema to use for validation and pruning.
 	// +optional
+	// +kubebuilder:pruning:PreserveUnknownFields
 	OpenAPIV3Schema runtime.RawExtension `json:"openAPIV3Schema,omitempty"`
 }
 

--- a/cluster/charts/crossplane/crds/apiextensions.crossplane.io_compositeresourcedefinitions.yaml
+++ b/cluster/charts/crossplane/crds/apiextensions.crossplane.io_compositeresourcedefinitions.yaml
@@ -151,6 +151,7 @@ spec:
                       openAPIV3Schema:
                         description: openAPIV3Schema is the OpenAPI v3 schema to use for validation and pruning.
                         type: object
+                        x-kubernetes-preserve-unknown-fields: true
                     type: object
                   version:
                     description: 'version is the API version of the defined custom resource. The custom resources are served under `/apis/<group>/<version>/...`. Must match the name of the first item in the `versions` list if `version` and `versions` are both specified. Optional if `versions` is specified. Deprecated: use `versions` instead.'

--- a/cluster/charts/crossplane/crds/apiextensions.crossplane.io_compositions.yaml
+++ b/cluster/charts/crossplane/crds/apiextensions.crossplane.io_compositions.yaml
@@ -59,6 +59,7 @@ spec:
                     base:
                       description: Base is the target resource that the patches will be applied on.
                       type: object
+                      x-kubernetes-preserve-unknown-fields: true
                     connectionDetails:
                       description: ConnectionDetails lists the propagation secret keys from this target resource to the composition instance connection secret.
                       items:


### PR DESCRIPTION

<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Adds CRD generation directive to specify preserve unknown fields in
RawExtension types so that information provided is not stripped during
pruning, which is default for v1 CRDs.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

Follow-up to #1850 
xref #1435 

See https://github.com/kubernetes/kubernetes/issues/88252 for more info about why this change is needed.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

Applied an XRD and Composition, then created an instance of the XR. Before the change of the XRD preserve unknown fields, validation failed because the `openAPIV3Schema` was being stripped of the XRD. Before the change of the Composition preserve unknown fields, rendering resources failed because `base` was getting stripped off resource templates. After both changes, full composition workflow worked as expected.

[contribution process]: https://git.io/fj2m9
