### PR TITLE
Cache the Go build cache during CI runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,6 +81,17 @@ jobs:
         with:
           go-version: ${{ env.GO_VERSION }}
 
+      - name: Find the Go build Cache
+        id: go
+        run: echo "::set-output name=cache::$(go env GOCACHE)"
+
+      - name: Cache the Go build Cache
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.go.outputs.cache }}
+          key: ${{ runner.os }}-build-${{ hashFiles('**/go.sum') }}
+          restore-keys: ${{ runner.os }}-build-
+
       - name: Cache Go Dependencies
         uses: actions/cache@v2
         with:
@@ -112,6 +123,17 @@ jobs:
         uses: actions/setup-go@v2
         with:
           go-version: ${{ env.GO_VERSION }}
+
+      - name: Find the Go build Cache
+        id: go
+        run: echo "::set-output name=cache::$(go env GOCACHE)"
+
+      - name: Cache the Go build Cache
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.go.outputs.cache }}
+          key: ${{ runner.os }}-build-${{ hashFiles('**/go.sum') }}
+          restore-keys: ${{ runner.os }}-build-
 
       - name: Cache Go Dependencies
         uses: actions/cache@v2
@@ -161,6 +183,17 @@ jobs:
         uses: actions/setup-go@v2
         with:
           go-version: ${{ env.GO_VERSION }}
+
+      - name: Find the Go build Cache
+        id: go
+        run: echo "::set-output name=cache::$(go env GOCACHE)"
+
+      - name: Cache the Go build Cache
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.go.outputs.cache }}
+          key: ${{ runner.os }}-build-${{ hashFiles('**/go.sum') }}
+          restore-keys: ${{ runner.os }}-build-
 
       - name: Cache Go Dependencies
         uses: actions/cache@v2
@@ -212,6 +245,17 @@ jobs:
         uses: actions/setup-go@v2
         with:
           go-version: ${{ env.GO_VERSION }}
+
+      - name: Find the Go build Cache
+        id: go
+        run: echo "::set-output name=cache::$(go env GOCACHE)"
+
+      - name: Cache the Go build Cache
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.go.outputs.cache }}
+          key: ${{ runner.os }}-build-${{ hashFiles('**/go.sum') }}
+          restore-keys: ${{ runner.os }}-build-
 
       - name: Cache Go Dependencies
         uses: actions/cache@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,17 @@ jobs:
         with:
           submodules: true
 
+      - name: Find the Go Build Cache
+        id: go
+        run: echo "::set-output name=cache::$(go env GOCACHE)"
+
+      - name: Cache the Go Build Cache
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.go.outputs.cache }}
+          key: ${{ runner.os }}-build-lint-${{ hashFiles('**/go.sum') }}
+          restore-keys: ${{ runner.os }}-build-lint-
+
       - name: Cache Go Dependencies
         uses: actions/cache@v2
         with:
@@ -81,16 +92,16 @@ jobs:
         with:
           go-version: ${{ env.GO_VERSION }}
 
-      - name: Find the Go build Cache
+      - name: Find the Go Build Cache
         id: go
         run: echo "::set-output name=cache::$(go env GOCACHE)"
 
-      - name: Cache the Go build Cache
+      - name: Cache the Go Build Cache
         uses: actions/cache@v2
         with:
           path: ${{ steps.go.outputs.cache }}
-          key: ${{ runner.os }}-build-${{ hashFiles('**/go.sum') }}
-          restore-keys: ${{ runner.os }}-build-
+          key: ${{ runner.os }}-build-check-diff-${{ hashFiles('**/go.sum') }}
+          restore-keys: ${{ runner.os }}-build-check-diff-
 
       - name: Cache Go Dependencies
         uses: actions/cache@v2
@@ -124,16 +135,16 @@ jobs:
         with:
           go-version: ${{ env.GO_VERSION }}
 
-      - name: Find the Go build Cache
+      - name: Find the Go Build Cache
         id: go
         run: echo "::set-output name=cache::$(go env GOCACHE)"
 
-      - name: Cache the Go build Cache
+      - name: Cache the Go Build Cache
         uses: actions/cache@v2
         with:
           path: ${{ steps.go.outputs.cache }}
-          key: ${{ runner.os }}-build-${{ hashFiles('**/go.sum') }}
-          restore-keys: ${{ runner.os }}-build-
+          key: ${{ runner.os }}-build-unit-tests-${{ hashFiles('**/go.sum') }}
+          restore-keys: ${{ runner.os }}-build-unit-tests-
 
       - name: Cache Go Dependencies
         uses: actions/cache@v2
@@ -184,16 +195,16 @@ jobs:
         with:
           go-version: ${{ env.GO_VERSION }}
 
-      - name: Find the Go build Cache
+      - name: Find the Go Build Cache
         id: go
         run: echo "::set-output name=cache::$(go env GOCACHE)"
 
-      - name: Cache the Go build Cache
+      - name: Cache the Go Build Cache
         uses: actions/cache@v2
         with:
           path: ${{ steps.go.outputs.cache }}
-          key: ${{ runner.os }}-build-${{ hashFiles('**/go.sum') }}
-          restore-keys: ${{ runner.os }}-build-
+          key: ${{ runner.os }}-build-e2e-tests-${{ hashFiles('**/go.sum') }}
+          restore-keys: ${{ runner.os }}-build-e2e-tests-
 
       - name: Cache Go Dependencies
         uses: actions/cache@v2
@@ -246,16 +257,16 @@ jobs:
         with:
           go-version: ${{ env.GO_VERSION }}
 
-      - name: Find the Go build Cache
+      - name: Find the Go Build Cache
         id: go
         run: echo "::set-output name=cache::$(go env GOCACHE)"
 
-      - name: Cache the Go build Cache
+      - name: Cache the Go Build Cache
         uses: actions/cache@v2
         with:
           path: ${{ steps.go.outputs.cache }}
-          key: ${{ runner.os }}-build-${{ hashFiles('**/go.sum') }}
-          restore-keys: ${{ runner.os }}-build-
+          key: ${{ runner.os }}-build-publish-artifacts-${{ hashFiles('**/go.sum') }}
+          restore-keys: ${{ runner.os }}-build-publish-artifacts-
 
       - name: Cache Go Dependencies
         uses: actions/cache@v2


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
This PR causes GitHub to cache the Go build cache for each job. The cache is invalidated whenever `go.sum` changes. This will get us a small speedup under certain circumstances, for example:

* [This build](https://github.com/negz/crossplane/actions/runs/323897602) with a build cache miss took 8 minutes.
* [This build](https://github.com/negz/crossplane/actions/runs/323916743) with a build cache hit took 6 minutes.

The speedup is particularly obvious if you take a look at the parts of each build during which we're actually building Go code; i.e. the cold cache "Build Artifacts" job took 5.5 minutes, while its hot cache equivalent took 1.5 minutes. Note though that this build speedup is at the cost of a small network penalty; it adds an additional 10-20 seconds to each job in order to either persist or restore the build cache to or from GitHub's cache system.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [ ] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
See experiment above.

[contribution process]: https://git.io/fj2m9
