### PR TITLE
Fix a typo in code example

### DIFF
--- a/docs/introduction/managed-resources.md
+++ b/docs/introduction/managed-resources.md
@@ -235,7 +235,7 @@ apiVersion: compute.gcp.crossplane.io/v1beta1
 kind: Network
 metadata:
   name: foo-network
-  annotation:
+  annotations:
     crossplane.io/external-name: existing-network
 spec:
   providerConfigRef:


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

This is just a single character change in the code example from the documentation, but it costed me some time when I was trying to import existing resources 😅
Adjusted the object according to [the Kubernetes docs](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/), which works.

Fixes potential issues for people, who copy-paste code examples

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

1. You need to have an existing cloud resource. In my case AWS IAM policy: `test-policy`
2. Create a `IAMPolicy` specification **with wrong** `annotation` keyword. For example:
```
---
apiVersion: identity.aws.crossplane.io/v1alpha1
kind: IAMPolicy
metadata:
  name: my-test-policy-crossplane
  annotation:
    crossplane.io/external-name: "arn:aws:iam::<REDACTED>:policy/test-policy"
spec:
  deletionPolicy: Orphan
  forProvider:
    description: "Test policy"
    name: test-policy
      {
          "Version": "2012-10-17",
          "Statement": [
              {
                  "Sid": "Test",
                  "Effect": "Allow",
                  "Action": "s3:ListBucket",
                  "Resource": "*"
              }
          ]
      }
```
3. You will get this error
```EntityAlreadyExists: A policy called test-policy already exists. Duplicate names are not allowed.```
5. Change the keyword to `annotations` and it works now

[contribution process]: https://git.io/fj2m9
