### PR TITLE
Replace image identfier in helm provider names

### DIFF
--- a/cluster/charts/crossplane/templates/provider.yaml
+++ b/cluster/charts/crossplane/templates/provider.yaml
@@ -3,7 +3,7 @@
 apiVersion: pkg.crossplane.io/v1alpha1
 kind: Provider
 metadata:
-  name: {{ . | trim | replace "/" "-" | replace ":" "-" }}
+  name: {{ regexReplaceAll "(:|@).*" . "" | trim | replace "/" "-" }}
 spec:
   package: {{ . | trim }}
 ---


### PR DESCRIPTION


<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Replaces all characters following a : or @ in a provider image that is
passed via provider.packages when setting the provider name. This more
closely aligns with the behavior of crank and does not include version
information in the provider name as the provider may be updated to a
different version in the future.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

xref #1875 (partial fix, the underlying behavior still exists, but this addresses a specific instance)

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

`helm template cluster/charts/crossplane --set provider.packages={crossplane/provider-gcp:v0.13.0}`

```
apiVersion: pkg.crossplane.io/v1alpha1
kind: Provider
metadata:
  name: crossplane-provider-gcp
spec:
  package: crossplane/provider-gcp:v0.13.0

```

[contribution process]: https://git.io/fj2m9
