### PR TITLE
Add credentials for publishing docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -314,4 +314,6 @@ jobs:
           CHANNEL: master
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_USR }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_PSW }}
+          DOCS_GIT_USR: ${{ secrets.UPBOUND_BOT_GITHUB_USR }}
+          DOCS_GIT_PSW: ${{ secrets.UPBOUND_BOT_GITHUB_PSW }}
         

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -46,4 +46,6 @@ jobs:
           CHANNEL: ${{ github.event.inputs.channel }}
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_USR }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_PSW }}
+          DOCS_GIT_USR: ${{ secrets.UPBOUND_BOT_GITHUB_USR }}
+          DOCS_GIT_PSW: ${{ secrets.UPBOUND_BOT_GITHUB_PSW }}
         

--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ IMAGES = crossplane
 
 SOURCE_DOCS_DIR = docs
 DEST_DOCS_DIR = docs
-DOCS_GIT_REPO = https://$(GIT_API_TOKEN)@github.com/crossplane/crossplane.github.io.git
+DOCS_GIT_REPO = https://$(DOCS_GIT_USR):$(DOCS_GIT_PSW)@github.com/crossplane/crossplane.github.io.git
 -include build/makelib/docs.mk
 
 # ====================================================================================


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes https://github.com/crossplane/crossplane/issues/1889

The UPBOUND_BOT_GITHUB secrets have access to push to our docsu repo at https://github.com/crossplane/crossplane.github.io/. We don't gate the promote job on the presence of these secrets because they're not required to publish; i.e. if they're missing we'll still publish to Docker and S3.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [ ] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
