### PR TITLE
Make package friendly indentifier a valid DNS label name

### DIFF
--- a/pkg/xpkg/name.go
+++ b/pkg/xpkg/name.go
@@ -54,7 +54,8 @@ func truncate(str string, num int) string {
 // FriendlyID builds a maximum 63 character string made up of the name of a
 // package and its image digest.
 func FriendlyID(name, hash string) string {
-	return strings.Join([]string{truncate(name, 50), truncate(hash, 12)}, "-")
+	id := strings.ReplaceAll(strings.Join([]string{truncate(name, 50), truncate(hash, 12)}, "-"), ".", "-")
+	return id
 }
 
 // BuildPath builds a path for a compiled Crossplane package. If file name has

--- a/pkg/xpkg/name.go
+++ b/pkg/xpkg/name.go
@@ -52,7 +52,8 @@ func truncate(str string, num int) string {
 }
 
 // FriendlyID builds a maximum 63 character string made up of the name of a
-// package and its image digest.
+// package and its image digest. It expects the first string to be a valid DNS
+// subdomain name and the second to be a valid OCI image digest.
 func FriendlyID(name, hash string) string {
 	id := strings.ReplaceAll(strings.Join([]string{truncate(name, 50), truncate(hash, 12)}, "-"), ".", "-")
 	return id

--- a/pkg/xpkg/name_test.go
+++ b/pkg/xpkg/name_test.go
@@ -65,6 +65,14 @@ func TestFriendlyID(t *testing.T) {
 			},
 			want: "provider-aws-plusabunchofothernonsensethatisgoingt-123456789123",
 		},
+		"ReplacePeriod": {
+			reason: "All period characters should be replaced with a dash.",
+			args: args{
+				pkg:  "provider.aws-plusabunchofothernonsensethatisgoingtogetslicedoff",
+				hash: "1234.567891234567",
+			},
+			want: "provider-aws-plusabunchofothernonsensethatisgoingt-1234-5678912",
+		},
 	}
 
 	for name, tc := range cases {


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Updates FriendlyID to replace all periods in returned identifier such
that a valid DNS subdomain name is converted to a valid DNS label. This
is important for the case in which the identifier is used as the name
for a automounted service account volume name, which must adhere to DNS
label standards.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

 _Note: this function does not convert any arbitrary strings into a valid DNS label name. It assumes the passed values are already a valid DNS subdomain name and a valid OCI image digest. See https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names for more info._

Fixes #1875 

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

Unit tests.

[contribution process]: https://git.io/fj2m9
