### PR TITLE
Make HEAD request when fetching a package digest

### DIFF
--- a/pkg/controller/pkg/manager/revisioner.go
+++ b/pkg/controller/pkg/manager/revisioner.go
@@ -28,7 +28,7 @@ import (
 )
 
 const (
-	errFetchPackage = "failed to fetch package from remote"
+	errFetchPackage = "failed to fetch package digest from remote"
 )
 
 // Revisioner extracts a revision name for a package source.
@@ -63,15 +63,11 @@ func (r *PackageRevisioner) Revision(ctx context.Context, p v1alpha1.Package) (s
 	if err != nil {
 		return "", err
 	}
-	img, err := r.fetcher.Fetch(ctx, ref, v1alpha1.RefNames(p.GetPackagePullSecrets()))
-	if err != nil {
+	d, err := r.fetcher.Head(ctx, ref, v1alpha1.RefNames(p.GetPackagePullSecrets()))
+	if err != nil || d == nil {
 		return "", errors.Wrap(err, errFetchPackage)
 	}
-	h, err := img.Digest()
-	if err != nil {
-		return "", err
-	}
-	return xpkg.FriendlyID(p.GetName(), h.Hex), nil
+	return xpkg.FriendlyID(p.GetName(), d.Digest.Hex), nil
 }
 
 // NopRevisioner returns an empty revision name.

--- a/pkg/controller/pkg/manager/revisioner_test.go
+++ b/pkg/controller/pkg/manager/revisioner_test.go
@@ -115,7 +115,7 @@ func TestPackageRevisioner(t *testing.T) {
 			reason: "Should return an error if we fail to fetch package image.",
 			args: args{
 				f: &fake.MockFetcher{
-					MockFetch: fake.NewMockFetchFn(nil, errBoom),
+					MockHead: fake.NewMockHeadFn(nil, errBoom),
 				},
 				pkg: &v1alpha1.Provider{
 					Spec: v1alpha1.ProviderSpec{

--- a/pkg/xpkg/fake/mocks.go
+++ b/pkg/xpkg/fake/mocks.go
@@ -69,6 +69,7 @@ var _ xpkg.Fetcher = &MockFetcher{}
 // MockFetcher is a mock fetcher.
 type MockFetcher struct {
 	MockFetch func() (v1.Image, error)
+	MockHead  func() (*v1.Descriptor, error)
 }
 
 // NewMockFetchFn creates a new MockFetch function for MockFetcher.
@@ -79,4 +80,14 @@ func NewMockFetchFn(img v1.Image, err error) func() (v1.Image, error) {
 // Fetch calls the underlying MockFetch.
 func (m *MockFetcher) Fetch(ctx context.Context, ref name.Reference, secrets []string) (v1.Image, error) {
 	return m.MockFetch()
+}
+
+// NewMockHeadFn creates a new MockHead function for MockFetcher.
+func NewMockHeadFn(d *v1.Descriptor, err error) func() (*v1.Descriptor, error) {
+	return func() (*v1.Descriptor, error) { return d, err }
+}
+
+// Head calls the underlying MockHead.
+func (m *MockFetcher) Head(ctx context.Context, ref name.Reference, secrets []string) (*v1.Descriptor, error) {
+	return m.MockHead()
 }


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Updates the package manager controller to make a `HEAD` request instead of `GET` to acquire an image digest.

Fixes #1903 

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

Followed a typical package installation flow:
1. Install Crossplane
2. Install `provider-aws`: `k crossplane install provider crossplane/provider-aws:master`
3. See successful package install with correct digest

```
🤖 (crossplane) k get pkg
NAME                                      INSTALLED   HEALTHY   PACKAGE                          AGE
provider.pkg.crossplane.io/provider-aws   True        True      crossplane/provider-aws:master   119s

🤖 (crossplane) k get providerrevision
NAME                        HEALTHY   REVISION   IMAGE                            STATE    AGE
provider-aws-4ef40e146f8b   True      1          crossplane/provider-aws:master   Active   117s

🤖 (crossplane) k get pods -n crossplane-system
NAME                                                 READY   STATUS    RESTARTS   AGE
crossplane-5dd4f6f599-d877q                          1/1     Running   0          3m20s
crossplane-rbac-manager-55d4b59c7-mnzj6              1/1     Running   0          3m20s
oam-kubernetes-runtime-crossplane-67f4689d7f-4bjb8   1/1     Running   0          3m20s
provider-aws-4ef40e146f8b-7866d6b44c-d95n4           1/1     Running   0          113s
```


[contribution process]: https://git.io/fj2m9
