### PR TITLE
Remove kubernetes 1.15 support

### DIFF
--- a/cluster/charts/crossplane/README.md
+++ b/cluster/charts/crossplane/README.md
@@ -6,7 +6,7 @@ resources and controllers needed to deploy and configure Crossplane.
 
 ## Pre-requisites
 
-* [Kubernetes cluster], minimum version `v1.15.0+`
+* [Kubernetes cluster], minimum version `v1.16.0+`
 * [Helm], minimum version `v3.0.0+`.
 
 ## Installation

--- a/docs/getting-started/install-configure.md
+++ b/docs/getting-started/install-configure.md
@@ -71,20 +71,12 @@ For Windows use the following:
 <div class="tab-pane fade in active" id="install-tab-helm3" markdown="1">
 Use Helm 3 to install the latest official `alpha` release of Crossplane, suitable for community use and testing:
 
-> OAM is available only for 1.16 and later versions of Kubernetes.
-
 ```console
 kubectl create namespace crossplane-system
 
 helm repo add crossplane-alpha https://charts.crossplane.io/alpha
 
-# Kubernetes 1.16 and later versions
 helm install crossplane --namespace crossplane-system crossplane-alpha/crossplane --set alpha.oam.enabled=true
-```
-
-```console
-# Kubernetes 1.15 and earlier versions
-helm install crossplane --namespace crossplane-system crossplane-alpha/crossplane
 ```
 
 </div>
@@ -97,13 +89,7 @@ kubectl create namespace crossplane-system
 helm repo add crossplane-master https://charts.crossplane.io/master/
 helm search repo crossplane-master --devel
 
-# Kubernetes 1.16 and later versions
 helm install crossplane --namespace crossplane-system crossplane-master/crossplane --devel --version <version> --set alpha.oam.enabled=true
-```
-
-```console
-# Kubernetes 1.15 and earlier versions
-helm install crossplane --namespace crossplane-system crossplane-master/crossplane --devel --version <version>
 ```
 
 For example:

--- a/docs/reference/install.md
+++ b/docs/reference/install.md
@@ -13,7 +13,7 @@ resources and controllers needed to deploy and configure Crossplane.
 
 ## Pre-requisites
 
-* [Kubernetes cluster], minimum version `v1.15.0+`
+* [Kubernetes cluster], minimum version `v1.16.0+`
 * [Helm], minimum version `v3.0.0+`.
 
 ## Installation


### PR DESCRIPTION

<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Removes k8s v1.15 support from Crossplane as it will no longer be
compatible with the switch to v1 CRDs in Crossplane v0.14.0.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>


I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

n/a

[contribution process]: https://git.io/fj2m9
