### PR TITLE
Reconcile XRCs when XR connection secrets change

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -107,6 +107,7 @@ github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMn
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa/go.mod h1:zn76sxSg3SzpJ0PPJaLDCu+Bu0Lg3sKTORVIj19EIF8=
+github.com/containerd/containerd v1.3.0 h1:xjvXQWABwS2uiv3TWgQt5Uth60Gu86LTGZXMJkjc7rY=
 github.com/containerd/containerd v1.3.0/go.mod h1:bC6axHOhabU15QhwfG7w5PipXdVtMXFTttgp+kVtyUA=
 github.com/coreos/bbolt v1.3.1-coreos.6/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
@@ -449,6 +450,7 @@ github.com/onsi/gomega v1.8.1/go.mod h1:Ho0h+IUsWyvy1OpqCwxlQ/21gkhVunqlU8fDGcoT
 github.com/onsi/gomega v1.9.0/go.mod h1:Ho0h+IUsWyvy1OpqCwxlQ/21gkhVunqlU8fDGcoTdcA=
 github.com/onsi/gomega v1.10.1 h1:o0+MgICZLuZ7xjH7Vx6zS/zcu93/BEp1VwkIW1mEXCE=
 github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1ybHNo=
+github.com/opencontainers/go-digest v1.0.0-rc1 h1:WzifXhOVOEOuFYOJAW6aQqW0TooG2iki3E3Ii+WN7gQ=
 github.com/opencontainers/go-digest v1.0.0-rc1/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=
 github.com/opencontainers/image-spec v1.0.1 h1:JMemWkRwHx4Zj+fVxWoMCFm/8sYGGrUVojFA6h/TRcI=
 github.com/opencontainers/image-spec v1.0.1/go.mod h1:BtxoFyWECRxE4U/7sNtV5W15zMzWCbyJoFRP3s7yZA0=

--- a/pkg/controller/apiextensions/offered/reconciler.go
+++ b/pkg/controller/apiextensions/offered/reconciler.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
 	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	kmeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -393,6 +394,7 @@ func (r *Reconciler) Reconcile(req reconcile.Request) (reconcile.Result, error) 
 	if err := r.claim.Start(claim.ControllerName(d.GetName()), o,
 		controller.For(cm, &handler.EnqueueRequestForObject{}),
 		controller.For(cp, &EnqueueRequestForClaim{}),
+		controller.For(&corev1.Secret{}, &EnqueueRequestForControllersClaim{r.client}),
 	); err != nil {
 		log.Debug(errStartController, "error", err)
 		r.record.Event(d, event.Warning(reasonOfferXRC, errors.Wrap(err, errStartController)))

--- a/pkg/controller/apiextensions/offered/watch.go
+++ b/pkg/controller/apiextensions/offered/watch.go
@@ -17,9 +17,15 @@ limitations under the License.
 package offered
 
 import (
+	"context"
+
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/workqueue"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -45,31 +51,31 @@ type adder interface {
 	Add(item interface{})
 }
 
-// EnqueueRequestForClaim enqueues a reconcile.Request for the
-// NamespacedName of a ClaimReferencer's ClaimReference.
+// EnqueueRequestForClaim enqueues a reconcile.Request for the NamespacedName of
+// a composite resource's ClaimReference.
 type EnqueueRequestForClaim struct{}
 
 // Create adds a NamespacedName for the supplied CreateEvent if its Object is a
-// ClaimReferencer.
+// composite resource.
 func (e *EnqueueRequestForClaim) Create(evt event.CreateEvent, q workqueue.RateLimitingInterface) {
 	addClaim(evt.Object, q)
 }
 
 // Update adds a NamespacedName for the supplied UpdateEvent if its Objects are
-// ClaimReferencers.
+// composite resources.
 func (e *EnqueueRequestForClaim) Update(evt event.UpdateEvent, q workqueue.RateLimitingInterface) {
 	addClaim(evt.ObjectOld, q)
 	addClaim(evt.ObjectNew, q)
 }
 
 // Delete adds a NamespacedName for the supplied DeleteEvent if its Object is a
-// ClaimReferencer.
+// composite resource.
 func (e *EnqueueRequestForClaim) Delete(evt event.DeleteEvent, q workqueue.RateLimitingInterface) {
 	addClaim(evt.Object, q)
 }
 
 // Generic adds a NamespacedName for the supplied GenericEvent if its Object is
-// a ClaimReferencer.
+// a composite resource.
 func (e *EnqueueRequestForClaim) Generic(evt event.GenericEvent, q workqueue.RateLimitingInterface) {
 	addClaim(evt.Object, q)
 }
@@ -80,6 +86,64 @@ func addClaim(obj runtime.Object, queue adder) {
 		return
 	}
 	cp := &composite.Unstructured{Unstructured: *u}
+	if cp.GetClaimReference() != nil {
+		queue.Add(reconcile.Request{NamespacedName: meta.NamespacedNameOf(cp.GetClaimReference())})
+	}
+}
+
+// EnqueueRequestForControllersClaim enqueues a reconcile.Request for the
+// NamespacedName of a Secret's controller's ClaimReference. The controller must
+// be a composite resource.
+type EnqueueRequestForControllersClaim struct{ client client.Reader }
+
+// Create adds a NamespacedName for the supplied CreateEvent if its Object is
+// the connection secret of a claimed composite resource.
+func (e *EnqueueRequestForControllersClaim) Create(evt event.CreateEvent, q workqueue.RateLimitingInterface) {
+	e.addClaim(evt.Object, q)
+}
+
+// Update adds a NamespacedName for the supplied UpdateEvent if its Objects are
+// the connection secret of a claimed composite resource.
+func (e *EnqueueRequestForControllersClaim) Update(evt event.UpdateEvent, q workqueue.RateLimitingInterface) {
+	e.addClaim(evt.ObjectOld, q)
+	e.addClaim(evt.ObjectNew, q)
+}
+
+// Delete adds a NamespacedName for the supplied DeleteEvent if its Object is
+// the connection secret of a claimed composite resource.
+func (e *EnqueueRequestForControllersClaim) Delete(evt event.DeleteEvent, q workqueue.RateLimitingInterface) {
+	e.addClaim(evt.Object, q)
+}
+
+// Generic adds a NamespacedName for the supplied GenericEvent if its Object is
+// the connection secret of a claimed composite resource.
+func (e *EnqueueRequestForControllersClaim) Generic(evt event.GenericEvent, q workqueue.RateLimitingInterface) {
+	e.addClaim(evt.Object, q)
+}
+
+func (e *EnqueueRequestForControllersClaim) addClaim(obj runtime.Object, queue adder) {
+	s, ok := obj.(*corev1.Secret)
+	if !ok {
+		return
+	}
+
+	if s.Type != resource.SecretTypeConnection {
+		return
+	}
+
+	ref := v1.GetControllerOf(s)
+	if ref == nil {
+		return
+	}
+
+	nn := types.NamespacedName{Name: ref.Name}
+	cp := &composite.Unstructured{}
+	cp.SetAPIVersion(ref.APIVersion)
+	cp.SetKind(ref.Kind)
+	if err := e.client.Get(context.TODO(), nn, cp); err != nil {
+		return
+	}
+
 	if cp.GetClaimReference() != nil {
 		queue.Add(reconcile.Request{NamespacedName: meta.NamespacedNameOf(cp.GetClaimReference())})
 	}


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes https://github.com/crossplane/crossplane/issues/1917

Enqueueing an XRC reconcile when an XR connection secret changes ensures we always propagate XR connection secrets to XRC connection secrets when they change.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
I've tested this by building and installing https://github.com/upbound/platform-ref-aws/tree/6137abb642d9ad6e336f29c94f08ebece1f98ee9 and confirming that as the underlying EKS cluster's connection secret changes over time, the `Cluster` claim's connection secret changes to match it - I can use the claim's connection secret to connect to the EKS cluster long after the EKS token should have rotated;

```console
$ kubectl get cluster.eks
NAME                                   READY   SYNCED   AGE
platform-ref-aws-cluster-q4hdw-k6t8r   True    True     29m

$ kubectl get -o json secret platform-ref-aws-cluster |jq -r '.data.kubeconfig|@base64d'> claim.kcfg
$ kubectl --kubeconfig claim.kcfg -n kube-system get po
NAME                       READY   STATUS    RESTARTS   AGE
aws-node-9v26x             1/1     Running   0          14m
aws-node-s2dt7             1/1     Running   0          14m
aws-node-st6gj             1/1     Running   0          14m
coredns-5946c5d67c-bjkb8   1/1     Running   0          18m
coredns-5946c5d67c-xgzk6   1/1     Running   0          18m
kube-proxy-9jb7r           1/1     Running   0          14m
kube-proxy-r827r           1/1     Running   0          14m
kube-proxy-wmkr5           1/1     Running   0          14m
```


[contribution process]: https://git.io/fj2m9
