### PR TITLE
Remove status subresource from ControllerConfig

### DIFF
--- a/apis/pkg/v1alpha1/config.go
+++ b/apis/pkg/v1alpha1/config.go
@@ -108,7 +108,6 @@ type ControllerConfigSpec struct {
 // +genclient:nonNamespaced
 
 // ControllerConfig is the CRD type for a packaged controller configuration.
-// +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="AGE",type="date",JSONPath=".metadata.creationTimestamp"
 // +kubebuilder:resource:scope=Cluster
 type ControllerConfig struct {

--- a/cluster/charts/crossplane/crds/pkg.crossplane.io_controllerconfigs.yaml
+++ b/cluster/charts/crossplane/crds/pkg.crossplane.io_controllerconfigs.yaml
@@ -711,8 +711,7 @@ spec:
         type: object
     served: true
     storage: true
-    subresources:
-      status: {}
+    subresources: {}
 status:
   acceptedNames:
     kind: ""


### PR DESCRIPTION


<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

The ControllerConfig resource does not have any status so we do not need
to have a status subresource.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

`make e2e.run`

[contribution process]: https://git.io/fj2m9
