### PR TITLE
Add Unknown health condition for package revisions

### DIFF
--- a/apis/pkg/v1alpha1/conditions.go
+++ b/apis/pkg/v1alpha1/conditions.go
@@ -34,11 +34,12 @@ const (
 
 // Reasons a package is or is not installed.
 const (
-	ReasonUnpacking runtimev1alpha1.ConditionReason = "UnpackingPackage"
-	ReasonInactive  runtimev1alpha1.ConditionReason = "InactivePackageRevision"
-	ReasonActive    runtimev1alpha1.ConditionReason = "ActivePackageRevision"
-	ReasonUnhealthy runtimev1alpha1.ConditionReason = "UnhealthyPackageRevision"
-	ReasonHealthy   runtimev1alpha1.ConditionReason = "HealthyPackageRevision"
+	ReasonUnpacking     runtimev1alpha1.ConditionReason = "UnpackingPackage"
+	ReasonInactive      runtimev1alpha1.ConditionReason = "InactivePackageRevision"
+	ReasonActive        runtimev1alpha1.ConditionReason = "ActivePackageRevision"
+	ReasonUnhealthy     runtimev1alpha1.ConditionReason = "UnhealthyPackageRevision"
+	ReasonHealthy       runtimev1alpha1.ConditionReason = "HealthyPackageRevision"
+	ReasonUnknownHealth runtimev1alpha1.ConditionReason = "UnknownPackageRevisionHealth"
 )
 
 // Unpacking indicates that the package manager is waiting for a package
@@ -91,5 +92,15 @@ func Healthy() runtimev1alpha1.Condition {
 		Status:             corev1.ConditionTrue,
 		LastTransitionTime: metav1.Now(),
 		Reason:             ReasonHealthy,
+	}
+}
+
+// UnknownHealth indicates that the health of the current revision is unknown.
+func UnknownHealth() runtimev1alpha1.Condition {
+	return runtimev1alpha1.Condition{
+		Type:               TypeHealthy,
+		Status:             corev1.ConditionUnknown,
+		LastTransitionTime: metav1.Now(),
+		Reason:             ReasonUnknownHealth,
 	}
 }

--- a/pkg/controller/pkg/manager/reconciler.go
+++ b/pkg/controller/pkg/manager/reconciler.go
@@ -65,7 +65,8 @@ const (
 	errUpdateStatus                  = "cannot update package status"
 	errUpdateInactivePackageRevision = "cannot update inactive package revision"
 
-	errUnhealthyPackageRevision = "current package revision is unhealthy"
+	errUnhealthyPackageRevision     = "current package revision is unhealthy"
+	errUnknownPackageRevisionHealth = "current package revision health is unknown"
 )
 
 // Event reasons.
@@ -324,6 +325,10 @@ func (r *Reconciler) Reconcile(req reconcile.Request) (reconcile.Result, error) 
 	if pr.GetCondition(v1alpha1.TypeHealthy).Status == corev1.ConditionFalse {
 		p.SetConditions(v1alpha1.Unhealthy())
 		r.record.Event(p, event.Warning(reasonInstall, errors.New(errUnhealthyPackageRevision)))
+	}
+	if pr.GetCondition(v1alpha1.TypeHealthy).Status == corev1.ConditionUnknown {
+		p.SetConditions(v1alpha1.UnknownHealth())
+		r.record.Event(p, event.Warning(reasonInstall, errors.New(errUnknownPackageRevisionHealth)))
 	}
 
 	// Create the non-existent package revision.

--- a/pkg/controller/pkg/manager/reconciler_test.go
+++ b/pkg/controller/pkg/manager/reconciler_test.go
@@ -150,6 +150,7 @@ func TestReconcile(t *testing.T) {
 								want.SetGroupVersionKind(v1alpha1.ConfigurationGroupVersionKind)
 								want.SetCurrentRevision("test-1234567")
 								want.SetActivationPolicy(&v1alpha1.AutomaticActivation)
+								want.SetConditions(v1alpha1.UnknownHealth())
 								want.SetConditions(v1alpha1.Active())
 								if diff := cmp.Diff(want, o); diff != "" {
 									t.Errorf("-want, +got:\n%s", diff)
@@ -198,6 +199,7 @@ func TestReconcile(t *testing.T) {
 								want.SetCurrentRevision("test-1234567")
 								want.SetActivationPolicy(&v1alpha1.AutomaticActivation)
 								want.SetPackagePullPolicy(&pullAlways)
+								want.SetConditions(v1alpha1.UnknownHealth())
 								want.SetConditions(v1alpha1.Active())
 								if diff := cmp.Diff(want, o); diff != "" {
 									t.Errorf("-want, +got:\n%s", diff)
@@ -244,6 +246,7 @@ func TestReconcile(t *testing.T) {
 								want.SetGroupVersionKind(v1alpha1.ConfigurationGroupVersionKind)
 								want.SetActivationPolicy(&v1alpha1.ManualActivation)
 								want.SetCurrentRevision("test-1234567")
+								want.SetConditions(v1alpha1.UnknownHealth())
 								want.SetConditions(v1alpha1.Inactive())
 								if diff := cmp.Diff(want, o); diff != "" {
 									t.Errorf("-want, +got:\n%s", diff)


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->


Adds an `Unknown` condition for a package revision's health and sets it when the revision is initially created and has not attempted to install its contents yet.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

1. Installed Crossplane
2. Installed `provider-aws` and saw the following progression:

```
NAME             INSTALLED   HEALTHY   PACKAGE                          AGE
provider-aws                           crossplane/provider-aws:master   0s
provider-aws     True        Unknown   crossplane/provider-aws:master   10s
provider-aws     True        True      crossplane/provider-aws:master   24s
```

[contribution process]: https://git.io/fj2m9
