### PR TITLE
Initial commit of Tilt for local development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,13 @@ gitlab/
 # helm chart dependencies
 **/charts/*.tgz
 **/charts/**/requirements.lock
+**/charts/**/charts
+**/charts/**/tmpcharts
 
 # Crossplane packages
 *.xpkg
+
+# Tilt
+tilt-providers.json
+tild.d/
+tilt_modules/

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,6 +3,9 @@ run:
 
   skip-files:
   - "zz_generated\\..+\\.go$"
+  
+  skip-dirs:
+  - "tilt_modules"
 
 output:
   # colored-line-number|line-number|json|tab|checkstyle|code-climate, default is "colored-line-number"

--- a/.tiltignore
+++ b/.tiltignore
@@ -1,0 +1,2 @@
+**/charts/**/charts
+**/charts/**/tmpcharts

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,6 +64,34 @@ kubectl -n crossplane-system scale deploy crossplane --replicas=0
 make run
 ```
 
+Alternatively you can use [Tilt] to automate almost all of the tasks needed for
+local developement. Note that you'd still need to have a local cluster ('kind' is
+still recommended here). The `Tiltfile` contains all the steps to watch and run TODO:
+
+```bash
+# Prepare local '.work/' folder required by local toolings
+make local.prepare
+
+# Start a new kind cluster. Customized to be used with Tilt.
+USE_TILT=true make kind.up
+
+# Update helm chart dependency. This is needed once or when
+# 'cluster/charts/crossplane/charts' folder is missing or
+# any of the dependencies of Crossplane chart have been changed.
+#
+# Note that this has to be done outside of Tilt:
+# https://docs.tilt.dev/helm.html#sub-charts-and-requirementstxt
+make local.helmdep
+
+# Start Tilt and open its UI http://localhost:10350/ in your browser.
+# At this point Tilt starts watching your local folder for any changes
+# and executes required tasks (building Crossplane, creating a docker
+# image, deploying to kind cluster, etc). You can just go back and forth
+# between your editor and the Tilt UI to get immediate and fast feedback
+# of result of your changes.
+make tilt.up
+```
+
 > Note that local development using minikube and microk8s is also possible.
 > Simply use the `minikube.sh` or `microk8s.sh` variants of the above `kind.sh`
 > script to do so. Their arguments and functionality are identical.
@@ -150,6 +178,7 @@ us][Slack] if you have any questions about contributing!
 [code of conduct]: https://github.com/cncf/foundation/blob/master/code-of-conduct.md
 [build submodule]: https://github.com/upbound/build/
 [`kind`]: https://kind.sigs.k8s.io/
+[Tilt]: https://tilt.dev/
 [Crossplane release cycle]: docs/reference/release-cycle.md
 [good git commit hygiene]: https://www.futurelearn.com/info/blog/telling-stories-with-your-git-history
 [Developer Certificate of Origin]: https://github.com/apps/dco

--- a/Makefile
+++ b/Makefile
@@ -69,6 +69,11 @@ DOCS_GIT_REPO = https://$(DOCS_GIT_USR):$(DOCS_GIT_PSW)@github.com/crossplane/cr
 -include build/makelib/docs.mk
 
 # ====================================================================================
+# Setup Local development tools
+
+-include build/makelib/local.mk
+
+# ====================================================================================
 # Targets
 
 # run `make help` to see the targets and options

--- a/Tiltfile
+++ b/Tiltfile
@@ -1,0 +1,269 @@
+# Tilt >= v0.17.8 is required to handle escaping of colons in selector names and proper
+# teardown of resources
+load('ext://min_tilt_version', 'min_tilt_version')
+min_tilt_version('0.17.8')
+
+# We require at minimum CRD support, so need at least Kubernetes v1.16
+load('ext://min_k8s_version', 'min_k8s_version')
+min_k8s_version('1.16')
+
+# Load the extension for live updating
+load('ext://restart_process', 'docker_build_with_restart')
+
+# Load the provider helpers
+load('cluster/local/provider.Tiltfile', 'build_provider', 'deploy_provider')
+
+# For consistency we're going to always create 'crossplane-system' namespace and use it
+load('ext://namespace', 'namespace_create')
+namespace = "crossplane-system"
+namespace_create(namespace)
+
+####################################################################################
+# Crossplane Core
+####################################################################################
+# Main function to make sure inital build steps runs in sequence
+def main():
+    generate_crds()
+    build_crossplane()
+    deploy_crossplane()
+
+# Build crossplane binary and docker image. Binary is built for linux-amd64 (to be
+# only used inside a container.) The binary is stored in crossplane cloned folder
+# at _output/tilt/
+def build_crossplane():
+    # Build crossplane
+    local_resource(
+        'build-crossplane',
+        'CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o _output/tilt/crossplane ./cmd/crossplane',
+        deps = [
+            'go.mod',
+            'go.sum',
+            'cmd/crossplane',
+            'apis',
+            'internal'
+        ],
+        ignore = [
+            'apis/**/zz_generated.*',
+            'internal/client/clientset'
+        ]
+    )
+
+    dockerfile_contents = '\n'.join([
+        'FROM alpine:3.7',
+        'RUN apk --no-cache add ca-certificates bash',
+        'ADD _output/tilt/crossplane /usr/local/bin/crossplane',
+        'EXPOSE 8080',
+        'ENTRYPOINT ["crossplane"]'
+    ])
+
+    # Build crossplane docker image
+    docker_build_with_restart(
+        'crossplane/crossplane',
+        '.',
+        dockerfile_contents = dockerfile_contents,
+        only = [
+            '_output/tilt/crossplane',
+        ],
+        live_update = [
+            sync('_output/tilt/crossplane', '/usr/local/bin/crossplane')
+        ],
+        entrypoint = [
+            'crossplane'
+        ]
+    )
+
+# Regenerate CRDs if content of 'api/' folder changes. Note that all the 'zz_generated.*'
+# files are excluded from retriggering the build again, otherwise we would end up in an
+# infinite loop of building. But 'zz_generated.*' files will be included in the final
+# image and will get live reloaded into running pod.
+def generate_crds():
+    # Generate crossplane CRDs out of API definition
+    _packages = ' '.join([
+        'github.com/crossplane/crossplane/cmd/...',
+        'github.com/crossplane/crossplane/internal/...',
+        'github.com/crossplane/crossplane/apis/...'
+    ])
+    local_resource(
+        'gen-crds',
+        'CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go generate -tags "generate" ' + _packages,
+        deps = [
+            'apis'
+        ],
+        ignore = [
+            'apis/**/zz_generated.*'
+        ]
+    )
+
+    # Find all the CRDs manifest files
+    #
+    # NOTE(khos2ow): we don't need to manually apply generated CRDs
+    # here. They will get re-applied through helm (see below).
+    crds_folder = 'cluster/charts/crossplane/crds'
+    files = listdir(crds_folder)
+
+    # Extract name of the CRDs to show on Tilt UI
+    crds_name = []
+    for f in files:
+        crds_name.append(read_yaml(f)['metadata']['name'] + ':customresourcedefinition')
+
+    crds_name.append('lock:lock')
+
+    # Group CRDs together for easy access on Tilt UI
+    k8s_resource(
+        new_name = 'crds',
+        objects = crds_name,
+        resource_deps = [
+            'crossplane'
+        ]
+    )
+
+def deploy_crossplane():
+    # Deploy the built chart with just built crossplane image
+    k8s_yaml(helm(
+        'cluster/charts/crossplane',
+        name = 'crossplane',
+        namespace = namespace,
+        set = [
+            # NOTE(khos2ow): modifying security context to be able to
+            # live reload the changes into pods.
+            #
+            # DO NOT SET THESE VALUES IN PRODUCTION!!
+            #
+            'securityContextCrossplane.runAsUser=0',
+            'securityContextCrossplane.runAsGroup=0',
+            'securityContextCrossplane.readOnlyRootFilesystem=false',
+            'securityContextRBACManager.readOnlyRootFilesystem=false',
+
+            # NOTE(khos2ow): explicitly disabling leader election for
+            # development setup, because it will take a bit of time to
+            # completely acquire a lock and that causes a race condition
+            # on deploying proviers down below (if any).
+            'leaderElection=false',
+            'rbacManager.leaderElection=false'
+        ]
+    ))
+
+    # Group service accounts and cluster roles together for easy access on Tilt UI
+    k8s_resource(
+        new_name = 'roles-accounts',
+        objects = [
+            'crossplane:serviceaccount',
+            'rbac-manager:serviceaccount',
+            'crossplane:clusterrole',
+            'crossplane:clusterrolebinding',
+            'crossplane\\:system\\:aggregate-to-crossplane:clusterrole',
+            'crossplane-rbac-manager:clusterrole',
+            'crossplane-rbac-manager:clusterrolebinding',
+            'crossplane-admin:clusterrolebinding',
+            'crossplane-admin:clusterrole',
+            'crossplane-edit:clusterrole',
+            'crossplane-view:clusterrole',
+            'crossplane-browse:clusterrole',
+            'crossplane\\:aggregate-to-admin:clusterrole',
+            'crossplane\\:aggregate-to-edit:clusterrole',
+            'crossplane\\:aggregate-to-view:clusterrole',
+            'crossplane\\:aggregate-to-ns-admin:clusterrole',
+            'crossplane\\:aggregate-to-ns-edit:clusterrole',
+            'crossplane\\:aggregate-to-ns-view:clusterrole'
+        ]
+    )
+
+main()
+
+####################################################################################
+# Crossplane Providers
+#
+# Users can use tilt-providers.json to build and deploy additional providers
+# into the cluster. There are two ways of doing so:
+#
+# 1. deploy existing official providers (from DockerHub)
+# 2. build and deploy local clone of a provider from filesystem
+#
+# Example content of tilt-providers.json:
+# 
+# {
+#     "provider-foo": {
+#         "enabled": true,
+#         "context": "/path/to/provider-cloned-folder"
+#     },
+#     "provider-bar": {
+#         "enabled": false,
+#         "package_owner": "crossplane",
+#         "package_ref": "alpha"
+#     }
+# }
+#
+# Example content of tilt-settings.json:
+#
+# {
+#     "args": [],                        // args to pass to pod
+#     "debug": false,                    // enable debug mode
+#     "namespace": "crossplane-system"   // namespace to deploy provider into
+# }
+#
+# Note that `context` can also be relative to crossplane local cloned folder.
+####################################################################################
+def build_deploy_providers():
+    settings = {
+        'args': [],
+        'debug': False,
+        'namespace': 'crossplane-system'
+    }
+    settings.update(read_json(
+        'tilt-settings.json',
+        default = {}
+    ))
+
+    # Make sure these value are set as follow (they are needed like this)
+    settings['core_path'] = os.getcwd()
+    settings['resource_deps'] = [
+        'crossplane',
+        'crossplane-rbac-manager',
+        'crds'
+    ]
+
+    providers = {}
+    providers.update(read_json(
+        'tilt-providers.json',
+        default = {}
+    ))
+
+    for name in providers:
+        provider = providers.get(name)
+        provider['short_name'] = name.replace('provider-', '')
+
+        if provider.get('enabled') != True :
+            continue
+
+        if provider.get('context') != None :
+            config_file = os.path.join(provider.get('context'), 'tilt-provider.json')
+            if os.path.exists(config_file) == False:
+                continue
+
+            provider_config = {}
+            provider_config.update(read_json(
+                config_file,
+                default = {}
+            ))
+
+            for key in provider_config:
+                provider[key] = provider_config[key]
+            
+            settings['local_image'] = True
+            build_provider(name, provider, settings)
+
+        deploy_provider(name, provider, settings)
+
+build_deploy_providers()
+
+####################################################################################
+# Custom Tiltfiles
+#
+# Users may define their own Tilt customizations in tilt.d. This directory is
+# excluded from git and these files will not be checked in to version control.
+####################################################################################
+def include_custom_files():
+    for f in listdir("tilt.d"):
+        include(f)
+
+include_custom_files()

--- a/cluster/local/README.md
+++ b/cluster/local/README.md
@@ -2,5 +2,91 @@
 
 This directory contains scripts that automate common local development flows for
 Crossplane, allowing you to deploy your local build of Crossplane to a `kind`
-cluster. Run [kind.sh](./kind.sh) to setup a single-node kind Kubernetes
-cluster.
+cluster. [kind-with-registry.sh] is being used to setup a single-node
+kind Kubernetes cluster.
+
+## Using Tilt
+
+[Tilt] can be used to reduce the repetative tasks you might have to do to keep your
+local deployment up to date. It watches required folders locally and takes action
+accordingly (e.g. build crossplane binary and image, deploy it on local cluster, etc).
+
+In order to use tilt, the following steps are needed:
+
+1. Prepare local `.work/` folder (only once)
+
+   ```sh
+   make local.prepare
+   ```
+
+2. Spin up a kind cluster:
+
+    ```sh
+    USE_TILT=true make kind.up
+    ```
+
+3. Update helm chart dependency, this must be done [outside of Tilt]:
+
+    ```sh
+    make local.helmdep
+    ```
+
+    This is needed once or when `cluster/charts/crossplane/charts` is missing or any of the
+    dependencies of Crossplane chart have been changed, otherwise you'd see this error:
+
+    ```text
+    Error: found in Chart.yaml, but missing in charts/ directory
+    ```
+
+4. Use tilt!
+
+    ```sh
+    make tilt.up
+    ```
+
+    If you've encountered `Error: notify.Add(...): no space left on device` check out
+    [this comment] for a solution.
+
+To see all available options for local developement look at [build/makelib/local.mk].
+
+### Working with Providers
+
+If you are working on a Crossplane provider and you want it to get deployed with Tilt
+you can add the provider details to a `gitignore`-d file called `tilt-providers.json`
+in the root of `crossplane/crossplane` repository.
+
+```json
+{
+    "provider-aws": {
+        "enabled": true,
+        "context": "/path/to/local/clone/provider-aws"
+    },
+    "provider-gcp": {
+        "enabled": true,
+        "package_owner": "crossplane",
+        "package_ref": "alpha"
+    }
+}
+```
+
+You also would be able to set some of the configuration options for the overall state of the deployment in `tilt-settings.json`.
+
+```json
+{
+    "args": [],
+    "debug": false,
+    "namespace": "crossplane-system"
+}
+```
+
+This will deploy two providers as part of running Tilt:
+
+- `provider-gcp` from `crossplane` Dockerhub namespace of `alpha` channel
+- `provider-aws` built locally from `/path/to/local/clone/provider-aws`
+  - note that `context` can also be relative to crossplane local cloned folder
+
+[kind-with-registry.sh]: ./kind-with-registry.sh
+[Tilt]: https://tilt.dev
+[outside of Tilt]: https://docs.tilt.dev/helm.html#sub-charts-and-requirementstxt
+[this comment]: https://github.com/tilt-dev/tilt/issues/2079#issuecomment-632226113
+[build/makelib/local.mk]: build/makelib/local.mk

--- a/cluster/local/kind-with-registry.sh
+++ b/cluster/local/kind-with-registry.sh
@@ -1,0 +1,92 @@
+#!/bin/sh
+#
+# Adapted from:
+# https://github.com/kubernetes-sigs/kind/commits/master/site/static/examples/kind-with-registry.sh
+#
+# Copyright 2020 The Kubernetes Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Copied from:
+# https://github.com/tilt-dev/kind-local/blob/master/kind-with-registry.sh
+
+set -o errexit
+
+# desired cluster name; default is "kind"
+KIND_CLUSTER_NAME="${KIND_CLUSTER_NAME:-kind}"
+KUBECONFIG="${KUBECONFIG:-}"
+
+kind_kubeconfig=""
+
+if [ -n "$KUBECONFIG" ] && [ -r "$KUBECONFIG" ]; then
+  kind_kubeconfig="--kubeconfig ${KUBECONFIG}"
+fi
+
+kind_version=$(kind version)
+kind_network='kind'
+reg_name='kind-registry'
+reg_port='5000'
+case "${kind_version}" in
+  "kind v0.7."* | "kind v0.6."* | "kind v0.5."*)
+    kind_network='bridge'
+    ;;
+esac
+
+# create registry container unless it already exists
+running="$(docker inspect -f '{{.State.Running}}' "${reg_name}" 2>/dev/null || true)"
+if [ "${running}" != 'true' ]; then
+  docker run \
+    -d --restart=always -p "${reg_port}:5000" --name "${reg_name}" \
+    registry:2
+fi
+
+reg_host="${reg_name}"
+if [ "${kind_network}" = "bridge" ]; then
+    reg_host="$(docker inspect -f '{{.NetworkSettings.IPAddress}}' "${reg_name}")"
+fi
+echo "Registry Host: ${reg_host}"
+
+# create a cluster with the local registry enabled in containerd
+cat <<EOF | kind create cluster --name "${KIND_CLUSTER_NAME}" ${kind_kubeconfig} --config=-
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+containerdConfigPatches:
+- |-
+  [plugins."io.containerd.grpc.v1.cri".registry.mirrors."localhost:${reg_port}"]
+    endpoint = ["http://${reg_host}:5000"]
+EOF
+
+cat <<EOF | kubectl apply -f -
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: local-registry-hosting
+  namespace: kube-public
+data:
+  localRegistryHosting.v1: |
+    host: "localhost:${reg_port}"
+    help: "https://kind.sigs.k8s.io/docs/user/local-registry/"
+EOF
+
+if [ "${kind_network}" != "bridge" ]; then
+  containers=$(docker network inspect ${kind_network} -f "{{range .Containers}}{{.Name}} {{end}}")
+  needs_connect="true"
+  for c in $containers; do
+    if [ "$c" = "${reg_name}" ]; then
+      needs_connect="false"
+    fi
+  done
+  if [ "${needs_connect}" = "true" ]; then
+    docker network connect "${kind_network}" "${reg_name}" || true
+  fi
+fi

--- a/cluster/local/provider.Tiltfile
+++ b/cluster/local/provider.Tiltfile
@@ -1,0 +1,196 @@
+####################################################################################
+# Crossplane Providers helper functions
+#
+# These are helper functions to build, deploy, and live-reload providers.
+# Note that these functions are shared with both:
+#
+# 1) core crossplane repo
+# 2) any standalone provider
+####################################################################################
+
+# Register CRDs which expose `image` for Tilt to be able to find them and
+# build the corresponding docker image for it.
+# https://docs.tilt.dev/custom_resource.html#does-it-contain-images
+k8s_kind('ControllerConfig', image_json_path = '{.spec.image}')
+
+# Build a crossplane provider
+#
+# 1. build and apply CRDs
+# 2. build and deploy controller manager
+def build_provider(name, provider, settings):
+    _generate_crds(provider, settings)
+    _build_controller(name, provider, settings)
+
+# Generate and apply crossplane provider's CRDs
+def _generate_crds(provider, settings):
+    context = provider.get('context')
+
+    # Prefix each dependency with context so Tilt can watch the correct paths
+    # for changes. At the same time keep track of 'zz_generated.*' files to
+    # ignore (this is needed to prevent being stuck in an infinite loop.)
+    crd_deps = []
+    ignore_deps = []
+    for d in provider.get('crd_deps', []):
+        crd_deps.append(context + '/' + d)
+        ignore_deps.append(context + '/' + d + '/**/zz_generated.*')
+        
+    # Generate crossplane provider CRDs out of API definition
+    local_resource(
+        'gen-crds-' + provider['short_name'],
+        'cd ' + context + ' && make generate',
+        deps = crd_deps,
+        ignore = ignore_deps
+    )
+
+    # Find all the CRDs manifests files
+    crds_folder = context + '/' + provider.get('crds_folder', 'package/crds')
+    files = listdir(crds_folder)
+
+    # Extract name of the CRDs to show on Tilt UI
+    crds_name = []
+    for f in files:
+        crds_name.append(read_yaml(f)['metadata']['name'] + ':customresourcedefinition')
+
+    # Apply CRD manifests
+    k8s_yaml(files)
+    k8s_resource(
+        new_name = 'crds-' + provider['short_name'],
+        objects = crds_name,
+        resource_deps = settings.get('resource_deps')
+    )
+
+# Build crossplane provider binary and docker image. Binary is built for
+# linux-amd64 (to be only used inside a container.) The binary is stored
+# in crossplane cloned folder at _output/tilt/
+def _build_controller(name, provider, settings):
+    context = provider.get('context')
+    go_main = provider.get('go_main')
+    core_path = settings.get('core_path')
+
+    # Prefix each live reload dependency with context so Tilt
+    # can watch the correct paths for changes
+    cmd_deps = []
+    ignore_deps = []
+    for d in provider.get('cmd_deps', []):
+        cmd_deps.append(context + '/' + d)
+        ignore_deps.append(context + '/' + d + '/**/zz_generated.*')
+
+    # Build crossplane provider
+    build_output = '_output/tilt/' + name
+    local_resource(
+        'build-' + provider['short_name'],
+        'cd ' + context + ' && CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o ' + core_path + '/' + build_output + ' ' + go_main,
+        deps = cmd_deps,
+        ignore = ignore_deps
+    )
+
+    # Build crossplane provider docker image
+    dockerfile_contents = '\n'.join([
+        'FROM alpine:3.7',
+        'RUN apk --no-cache add ca-certificates bash',
+        'ADD ' + build_output + ' /usr/local/bin/crossplane-provider',
+        # TODO(khos2ow): change this URL right before
+        # merging the PR in crossplane/crossplane!
+        #
+        # https://github.com/crossplane/crossplane/pull/1925
+        'ADD https://raw.githubusercontent.com/khos2ow/crossplane/tilt/cluster/local/tilt_start.sh /usr/local/bin',
+        'ADD https://raw.githubusercontent.com/khos2ow/crossplane/tilt/cluster/local/tilt_restart.sh /usr/local/bin',
+        'RUN chmod +x /usr/local/bin/tilt_start.sh /usr/local/bin/tilt_restart.sh',
+        'EXPOSE 8080',
+        'ENTRYPOINT ["tilt_start.sh", "crossplane-provider"]'
+    ])
+
+    package_owner = provider.get('package_owner', 'crossplane')
+
+    docker_build(
+        provider.get('image_name', package_owner + '/' + name + '-controller'),
+        '.',
+        dockerfile_contents = dockerfile_contents,
+        only = [
+            build_output,
+        ],
+        live_update = [
+            sync(build_output, '/usr/local/bin/crossplane-provider'),
+            run('tilt_restart.sh'),
+        ]
+    )
+
+# Deploy crossplane provider into the cluster. If local_image is set to 'True' an
+# additional 'ControllerConfig' also gets deployed with override 'spec.image' for
+# Tilt to be able to inject the locally built provider image into the Deployment.
+def deploy_provider(name, provider, settings):
+    package_owner = provider.get('package_owner', 'crossplane')
+    package_ref = provider.get('package_ref', 'master')
+    package_name = provider.get('package_name', package_owner + '/' + name + ':' + package_ref)
+
+    package_revision = local(
+        'docker pull ' + package_name + ' | grep "Digest:" | cut -d: -f3 | head -c 12',
+        quiet = True
+    )
+    provider['package_revision'] = str(package_revision)
+
+    spec = {
+        'package': package_name
+    }
+
+    if settings.get('local_image', False) == True:
+        _deploy_controller_config(name, provider, settings)
+
+        spec['controllerConfigRef'] = {
+            'name': provider['short_name']
+        }
+
+    k8s_yaml(encode_yaml({
+        'apiVersion': 'pkg.crossplane.io/v1',
+        'kind': 'Provider',
+        'metadata': {
+            'name': name,
+            'namespace': settings.get('namespace'),
+        },
+        'spec': spec
+    }))
+    k8s_resource(
+        new_name = name,
+        objects = [
+            name + ':provider:' + settings.get('namespace'),
+        ],
+        resource_deps = settings.get('resource_deps')
+    )
+
+# Deploy a ControllerConfig with overrided spec.image
+def _deploy_controller_config(name, provider, settings):
+    package_owner = provider.get('package_owner', 'crossplane')
+    image_name = provider.get('image_name', package_owner + '/' + name + '-controller:master')
+
+    args = settings.get('args', [])
+    if settings.get('debug') == True:
+        args.append('--debug')
+
+    k8s_yaml(encode_yaml({
+        'apiVersion': 'pkg.crossplane.io/v1alpha1',
+        'kind': 'ControllerConfig',
+        'metadata': {
+            'name': provider['short_name'],
+            'namespace': settings.get('namespace'),
+        },
+        'spec': {
+            'image': image_name,
+            'args': args,
+            'podSecurityContext': {
+                'runAsUser': 0,
+                'runAsGroup': 0
+            },
+            'securityContext': {
+                'runAsUser': 0,
+                'runAsGroup': 0,
+                'readOnlyRootFilesystem': False
+            }
+        }
+    }))
+    k8s_resource(
+        workload = provider['short_name'],
+        resource_deps = settings.get('resource_deps'),
+        extra_pod_selectors = [{
+            'pkg.crossplane.io/revision': name + '-' + provider.get('package_revision')
+        }]
+    )

--- a/cluster/local/tilt_restart.sh
+++ b/cluster/local/tilt_restart.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+#
+# A helper script to restart a given process as part of a Live Update.
+#
+# Further reading:
+# https://docs.tilt.dev/live_update_reference.html#restarting-your-process
+#
+# Usage:
+#   Copy start.sh and restart.sh to your container working dir.
+#
+#   Make your container entrypoint:
+#   ./start.sh path-to-binary [args]
+#
+#   To restart the container:
+#   ./restart.sh
+#
+# Copied from: https://github.com/tilt-dev/rerun-process-wrapper/blob/master/restart.sh
+
+set -u
+
+touch restart.txt
+PID="$(cat process.txt)"
+if [ $? -ne 0 ]; then
+  echo "unable to read process.txt. was your process started with start.sh?"
+  exit 1
+fi
+kill "$PID"

--- a/cluster/local/tilt_start.sh
+++ b/cluster/local/tilt_start.sh
@@ -1,0 +1,46 @@
+#!/bin/sh
+#
+# A helper script to restart a given process as part of a Live Update.
+#
+# Further reading:
+# https://docs.tilt.dev/live_update_reference.html#restarting-your-process
+#
+# Usage:
+#   Copy start.sh and restart.sh to your container working dir.
+#
+#   Make your container entrypoint:
+#   ./start.sh path-to-binary [args]
+#
+#   To restart the container:
+#   ./restart.sh
+#
+# Copied from: https://github.com/tilt-dev/rerun-process-wrapper/blob/master/start.sh
+
+set -eu
+
+process_id=""
+
+trap quit TERM INT
+
+quit() {
+  if [ -n "$process_id" ]; then
+    kill $process_id
+  fi
+}
+
+while true; do
+    rm -f restart.txt
+
+    "$@" &
+    process_id=$!
+    echo "$process_id" > process.txt
+    set +e
+    wait $process_id
+    EXIT_CODE=$?
+    set -e
+    if [ ! -f restart.txt ]; then
+        echo "Exiting with code $EXIT_CODE"
+        exit $EXIT_CODE
+    fi
+    echo "Restarting"
+done


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

This PR introduces usage of [Tilt](https://github.com/tilt-dev/tilt). Using Tilt will improve developer's experience significantly while working on Crossplane. The workflow will be as simple as:

- spin up a local cluster (using new `kind-with-registry.sh` script)
- `tilt up` on the root of repository
    
Tilt will watch the changes in required folders (e.g. `cmd`, `pkg`, ... and ignore for example `docs`, `hacks`, ...) and build and live-reload the resources needed to be deployed.

~~Note that as of now, this will only work on `crossplane/crossplane`, consecutively I'll try to add the support for providers as well. So that one can clone Crossplane and provider locally and _bundle_ them up together for local rapid deployment.~~

Consecutively if you are working on a Crossplane provider and you want it to get deployed with Tilt you can add the Provider detail to a `gitignore`-d file called `tilt-providers.json` in the root of `crossplane/crossplane` repository. Example:

`tilt-providers.json`:

```json
{
    "provider-aws": {
        "enabled": true,
        "context": "/path/to/local/clone/provider-aws"
    },
    "provider-gcp": {
        "enabled": false,
        "package_owner": "crossplane",
        "package_ref": "alpha"
    }
}
```

You also would be able to set some configurations of overall state of deployment in `tilt-settings.json`.

`tilt-settings.json`:

```json/text
{
    "args": [],                        // args to pass to pod
    "debug": false,                    // enable debug mode
    "namespace": "crossplane-system"   // namespace to deploy provider into
}
```

This will deploy two providers as part of running Tilt:

- `provider-gcp` from `crossplane` Dockerhub namespace of `alpha` channel
- `provider-aws` built locally from `/path/to/local/clone/provider-aws`
  - note that `context` can also be relative to crossplane local cloned folder

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

**NOTE:** this PR depends on https://github.com/upbound/build/pull/127 and must be merged after that one.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
