### PR TITLE
Allow XRs and XRCs to record when they last published connection details

### DIFF
--- a/apis/apiextensions/v1alpha1/ccrd/crd_test.go
+++ b/apis/apiextensions/v1alpha1/ccrd/crd_test.go
@@ -28,7 +28,6 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/pkg/errors"
 	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-	v1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -255,7 +254,7 @@ func TestForCompositeResource(t *testing.T) {
 									},
 									"connectionDetails": {
 										Type: "object",
-										Properties: map[string]v1.JSONSchemaProps{
+										Properties: map[string]extv1.JSONSchemaProps{
 											"lastPublishedTime": {Type: "string", Format: "date-time"},
 										},
 									},
@@ -558,7 +557,7 @@ func TestForCompositeResourceClaim(t *testing.T) {
 										},
 										"connectionDetails": {
 											Type: "object",
-											Properties: map[string]v1.JSONSchemaProps{
+											Properties: map[string]extv1.JSONSchemaProps{
 												"lastPublishedTime": {Type: "string", Format: "date-time"},
 											},
 										},

--- a/apis/apiextensions/v1alpha1/ccrd/crd_test.go
+++ b/apis/apiextensions/v1alpha1/ccrd/crd_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/pkg/errors"
 	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	v1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -250,6 +251,12 @@ func TestForCompositeResource(t *testing.T) {
 													"type":               {Type: "string"},
 												},
 											},
+										},
+									},
+									"connectionDetails": {
+										Type: "object",
+										Properties: map[string]v1.JSONSchemaProps{
+											"lastPublishedTime": {Type: "string", Format: "date-time"},
 										},
 									},
 								},
@@ -547,6 +554,12 @@ func TestForCompositeResourceClaim(t *testing.T) {
 														"type":               {Type: "string"},
 													},
 												},
+											},
+										},
+										"connectionDetails": {
+											Type: "object",
+											Properties: map[string]v1.JSONSchemaProps{
+												"lastPublishedTime": {Type: "string", Format: "date-time"},
 											},
 										},
 									},

--- a/apis/apiextensions/v1alpha1/ccrd/schemas.go
+++ b/apis/apiextensions/v1alpha1/ccrd/schemas.go
@@ -16,14 +16,14 @@ limitations under the License.
 
 package ccrd
 
-import v1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+import extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 
 // TODO(negz): Add descriptions to schema fields.
 
 // BaseProps is a partial OpenAPIV3Schema for the spec fields that Crossplane
 // expects to be present for all CRDs that it creates.
-func BaseProps() map[string]v1.JSONSchemaProps {
-	return map[string]v1.JSONSchemaProps{
+func BaseProps() map[string]extv1.JSONSchemaProps {
+	return map[string]extv1.JSONSchemaProps{
 		"apiVersion": {
 			Type: "string",
 		},
@@ -37,11 +37,11 @@ func BaseProps() map[string]v1.JSONSchemaProps {
 		},
 		"spec": {
 			Type:       "object",
-			Properties: map[string]v1.JSONSchemaProps{},
+			Properties: map[string]extv1.JSONSchemaProps{},
 		},
 		"status": {
 			Type:       "object",
-			Properties: map[string]v1.JSONSchemaProps{},
+			Properties: map[string]extv1.JSONSchemaProps{},
 		},
 	}
 }
@@ -49,24 +49,24 @@ func BaseProps() map[string]v1.JSONSchemaProps {
 // CompositeResourceSpecProps is a partial OpenAPIV3Schema for the spec fields
 // that Crossplane expects to be present for all defined infrastructure
 // resources.
-func CompositeResourceSpecProps() map[string]v1.JSONSchemaProps {
-	return map[string]v1.JSONSchemaProps{
+func CompositeResourceSpecProps() map[string]extv1.JSONSchemaProps {
+	return map[string]extv1.JSONSchemaProps{
 		"compositionRef": {
 			Type:     "object",
 			Required: []string{"name"},
-			Properties: map[string]v1.JSONSchemaProps{
+			Properties: map[string]extv1.JSONSchemaProps{
 				"name": {Type: "string"},
 			},
 		},
 		"compositionSelector": {
 			Type:     "object",
 			Required: []string{"matchLabels"},
-			Properties: map[string]v1.JSONSchemaProps{
+			Properties: map[string]extv1.JSONSchemaProps{
 				"matchLabels": {
 					Type: "object",
-					AdditionalProperties: &v1.JSONSchemaPropsOrBool{
+					AdditionalProperties: &extv1.JSONSchemaPropsOrBool{
 						Allows: true,
-						Schema: &v1.JSONSchemaProps{Type: "string"},
+						Schema: &extv1.JSONSchemaProps{Type: "string"},
 					},
 				},
 			},
@@ -74,7 +74,7 @@ func CompositeResourceSpecProps() map[string]v1.JSONSchemaProps {
 		"claimRef": {
 			Type:     "object",
 			Required: []string{"apiVersion", "kind", "namespace", "name"},
-			Properties: map[string]v1.JSONSchemaProps{
+			Properties: map[string]extv1.JSONSchemaProps{
 				"apiVersion": {Type: "string"},
 				"kind":       {Type: "string"},
 				"namespace":  {Type: "string"},
@@ -83,10 +83,10 @@ func CompositeResourceSpecProps() map[string]v1.JSONSchemaProps {
 		},
 		"resourceRefs": {
 			Type: "array",
-			Items: &v1.JSONSchemaPropsOrArray{
-				Schema: &v1.JSONSchemaProps{
+			Items: &extv1.JSONSchemaPropsOrArray{
+				Schema: &extv1.JSONSchemaProps{
 					Type: "object",
-					Properties: map[string]v1.JSONSchemaProps{
+					Properties: map[string]extv1.JSONSchemaProps{
 						"apiVersion": {Type: "string"},
 						"name":       {Type: "string"},
 						"kind":       {Type: "string"},
@@ -99,7 +99,7 @@ func CompositeResourceSpecProps() map[string]v1.JSONSchemaProps {
 		"writeConnectionSecretToRef": {
 			Type:     "object",
 			Required: []string{"name", "namespace"},
-			Properties: map[string]v1.JSONSchemaProps{
+			Properties: map[string]extv1.JSONSchemaProps{
 				"name":      {Type: "string"},
 				"namespace": {Type: "string"},
 			},
@@ -110,24 +110,24 @@ func CompositeResourceSpecProps() map[string]v1.JSONSchemaProps {
 // CompositeResourceClaimSpecProps is a partial OpenAPIV3Schema for the spec
 // fields that Crossplane expects to be present for all published infrastructure
 // resources.
-func CompositeResourceClaimSpecProps() map[string]v1.JSONSchemaProps {
-	return map[string]v1.JSONSchemaProps{
+func CompositeResourceClaimSpecProps() map[string]extv1.JSONSchemaProps {
+	return map[string]extv1.JSONSchemaProps{
 		"compositionRef": {
 			Type:     "object",
 			Required: []string{"name"},
-			Properties: map[string]v1.JSONSchemaProps{
+			Properties: map[string]extv1.JSONSchemaProps{
 				"name": {Type: "string"},
 			},
 		},
 		"compositionSelector": {
 			Type:     "object",
 			Required: []string{"matchLabels"},
-			Properties: map[string]v1.JSONSchemaProps{
+			Properties: map[string]extv1.JSONSchemaProps{
 				"matchLabels": {
 					Type: "object",
-					AdditionalProperties: &v1.JSONSchemaPropsOrBool{
+					AdditionalProperties: &extv1.JSONSchemaPropsOrBool{
 						Allows: true,
-						Schema: &v1.JSONSchemaProps{Type: "string"},
+						Schema: &extv1.JSONSchemaProps{Type: "string"},
 					},
 				},
 			},
@@ -135,7 +135,7 @@ func CompositeResourceClaimSpecProps() map[string]v1.JSONSchemaProps {
 		"resourceRef": {
 			Type:     "object",
 			Required: []string{"apiVersion", "kind", "name"},
-			Properties: map[string]v1.JSONSchemaProps{
+			Properties: map[string]extv1.JSONSchemaProps{
 				"apiVersion": {Type: "string"},
 				"kind":       {Type: "string"},
 				"name":       {Type: "string"},
@@ -144,7 +144,7 @@ func CompositeResourceClaimSpecProps() map[string]v1.JSONSchemaProps {
 		"writeConnectionSecretToRef": {
 			Type:     "object",
 			Required: []string{"name"},
-			Properties: map[string]v1.JSONSchemaProps{
+			Properties: map[string]extv1.JSONSchemaProps{
 				"name": {Type: "string"},
 			},
 		},
@@ -154,16 +154,16 @@ func CompositeResourceClaimSpecProps() map[string]v1.JSONSchemaProps {
 // CompositeResourceStatusProps is a partial OpenAPIV3Schema for the status
 // fields that Crossplane expects to be present for all defined or published
 // infrastructure resources.
-func CompositeResourceStatusProps() map[string]v1.JSONSchemaProps {
-	return map[string]v1.JSONSchemaProps{
+func CompositeResourceStatusProps() map[string]extv1.JSONSchemaProps {
+	return map[string]extv1.JSONSchemaProps{
 		"conditions": {
 			Description: "Conditions of the resource.",
 			Type:        "array",
-			Items: &v1.JSONSchemaPropsOrArray{
-				Schema: &v1.JSONSchemaProps{
+			Items: &extv1.JSONSchemaPropsOrArray{
+				Schema: &extv1.JSONSchemaProps{
 					Type:     "object",
 					Required: []string{"lastTransitionTime", "reason", "status", "type"},
-					Properties: map[string]v1.JSONSchemaProps{
+					Properties: map[string]extv1.JSONSchemaProps{
 						"lastTransitionTime": {Type: "string", Format: "date-time"},
 						"message":            {Type: "string"},
 						"reason":             {Type: "string"},
@@ -175,7 +175,7 @@ func CompositeResourceStatusProps() map[string]v1.JSONSchemaProps {
 		},
 		"connectionDetails": {
 			Type: "object",
-			Properties: map[string]v1.JSONSchemaProps{
+			Properties: map[string]extv1.JSONSchemaProps{
 				"lastPublishedTime": {Type: "string", Format: "date-time"},
 			},
 		},
@@ -184,8 +184,8 @@ func CompositeResourceStatusProps() map[string]v1.JSONSchemaProps {
 
 // CompositeResourcePrinterColumns returns the set of default printer columns
 // that should exist in all generated composite resource CRDs.
-func CompositeResourcePrinterColumns() []v1.CustomResourceColumnDefinition {
-	return []v1.CustomResourceColumnDefinition{
+func CompositeResourcePrinterColumns() []extv1.CustomResourceColumnDefinition {
+	return []extv1.CustomResourceColumnDefinition{
 		{
 			Name:     "READY",
 			Type:     "string",
@@ -201,8 +201,8 @@ func CompositeResourcePrinterColumns() []v1.CustomResourceColumnDefinition {
 
 // CompositeResourceClaimPrinterColumns returns the set of default printer
 // columns that should exist in all generated composite resource claim CRDs.
-func CompositeResourceClaimPrinterColumns() []v1.CustomResourceColumnDefinition {
-	return []v1.CustomResourceColumnDefinition{
+func CompositeResourceClaimPrinterColumns() []extv1.CustomResourceColumnDefinition {
+	return []extv1.CustomResourceColumnDefinition{
 		{
 			Name:     "READY",
 			Type:     "string",

--- a/apis/apiextensions/v1alpha1/ccrd/schemas.go
+++ b/apis/apiextensions/v1alpha1/ccrd/schemas.go
@@ -173,6 +173,12 @@ func CompositeResourceStatusProps() map[string]v1.JSONSchemaProps {
 				},
 			},
 		},
+		"connectionDetails": {
+			Type: "object",
+			Properties: map[string]v1.JSONSchemaProps{
+				"lastPublishedTime": {Type: "string", Format: "date-time"},
+			},
+		},
 	}
 }
 

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/alecthomas/kong v0.2.11
 	github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751 // indirect
 	github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d // indirect
-	github.com/crossplane/crossplane-runtime v0.10.0
+	github.com/crossplane/crossplane-runtime v0.10.1-0.20201105085105-31eef9b01ece
 	github.com/docker/cli v0.0.0-20200915230204-cd8016b6bcc5 // indirect
 	github.com/docker/docker v17.12.0-ce-rc1.0.20200926000217-2617742802f6+incompatible // indirect
 	github.com/go-logr/zapr v0.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -129,8 +129,8 @@ github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsr
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
 github.com/creack/pty v1.1.9 h1:uDmaGzcdjhF4i/plgjmEsriH11Y0o7RKapEf/LDaM3w=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
-github.com/crossplane/crossplane-runtime v0.10.0 h1:H8YvMcrm1uzZYpwU/BpxjRQfceVulxgYJMx4rmX38Hg=
-github.com/crossplane/crossplane-runtime v0.10.0/go.mod h1:cJl5ZZONisre4v6wTmbrC8Jh3AI+erq/lNaxZzv9tnU=
+github.com/crossplane/crossplane-runtime v0.10.1-0.20201105085105-31eef9b01ece h1:aHwkWc13UDr0IJHO+AOSQS96+5pxrGhkZpHKuLctjjA=
+github.com/crossplane/crossplane-runtime v0.10.1-0.20201105085105-31eef9b01ece/go.mod h1:cJl5ZZONisre4v6wTmbrC8Jh3AI+erq/lNaxZzv9tnU=
 github.com/davecgh/go-spew v0.0.0-20151105211317-5215b55f46b2/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/pkg/controller/apiextensions/claim/api_test.go
+++ b/pkg/controller/apiextensions/claim/api_test.go
@@ -1,0 +1,238 @@
+/*
+Copyright 2020 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package claim
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/crossplane/crossplane-runtime/apis/core/v1alpha1"
+	"github.com/crossplane/crossplane-runtime/pkg/resource"
+	"github.com/crossplane/crossplane-runtime/pkg/resource/fake"
+	"github.com/crossplane/crossplane-runtime/pkg/test"
+)
+
+var _ ConnectionPropagator = &APIConnectionPropagator{}
+
+func TestPropagateConnection(t *testing.T) {
+	errBoom := errors.New("boom")
+
+	mgcsns := "coolnamespace"
+	mgcsname := "coolmanagedsecret"
+	mgcsdata := map[string][]byte{"cool": {1}}
+
+	cmcsns := "coolnamespace"
+	cmcsname := "coolclaimsecret"
+
+	cp := &fake.Composite{
+		ConnectionSecretWriterTo: fake.ConnectionSecretWriterTo{
+			Ref: &v1alpha1.SecretReference{Namespace: mgcsns, Name: mgcsname},
+		},
+	}
+
+	cm := &fake.CompositeClaim{
+		ObjectMeta: metav1.ObjectMeta{Namespace: cmcsns},
+		LocalConnectionSecretWriterTo: fake.LocalConnectionSecretWriterTo{
+			Ref: &v1alpha1.LocalSecretReference{Name: cmcsname},
+		},
+	}
+
+	type fields struct {
+		client resource.ClientApplicator
+		typer  runtime.ObjectTyper
+	}
+
+	type args struct {
+		ctx  context.Context
+		to   resource.LocalConnectionSecretOwner
+		from resource.ConnectionSecretOwner
+	}
+	type want struct {
+		propagated bool
+		err        error
+	}
+
+	cases := map[string]struct {
+		reason string
+		fields fields
+		args   args
+		want   want
+	}{
+		"ClaimDoesNotWantConnectionSecret": {
+			reason: "The composite resource's secret should not be propagated if the claim does not want to write one",
+			args: args{
+				to:   &fake.CompositeClaim{},
+				from: cp,
+			},
+			want: want{
+				err: nil,
+			},
+		},
+		"ManagedDoesNotExposeConnectionSecret": {
+			reason: "The composite resource's secret should not be propagated if it does not have one",
+			args: args{
+				to:   cm,
+				from: &fake.Managed{},
+			},
+			want: want{
+				err: nil,
+			},
+		},
+		"GetManagedSecretError": {
+			reason: "Errors getting the composite resource's connection secret should be returned",
+			fields: fields{
+				client: resource.ClientApplicator{
+					Client: &test.MockClient{MockGet: test.NewMockGetFn(errBoom)},
+				},
+			},
+			args: args{
+				to:   cm,
+				from: cp,
+			},
+			want: want{
+				err: errors.Wrap(errBoom, errGetSecret),
+			},
+		},
+		"ManagedResourceDoesNotControlSecret": {
+			reason: "The composite resource must control its connection secret before it can be propagated",
+			fields: fields{
+				client: resource.ClientApplicator{
+					// Simulate getting a secret that is not controlled by the
+					// composite resource by not modifying the secret passed to
+					// the client, and not returning an error. We thus proceed
+					// with our original empty secret, which has no controller
+					// reference.
+					Client: &test.MockClient{MockGet: test.NewMockGetFn(nil)},
+				},
+			},
+			args: args{
+				to:   cm,
+				from: cp,
+			},
+			want: want{
+				err: errors.New(errSecretConflict),
+			},
+		},
+		"ApplyClaimSecretError": {
+			reason: "Errors applying the claim connection secret should be returned",
+			fields: fields{
+				client: resource.ClientApplicator{
+					Client: &test.MockClient{MockGet: test.NewMockGetFn(nil, func(o runtime.Object) error {
+						s := resource.ConnectionSecretFor(cp, fake.GVK(cp))
+						*o.(*corev1.Secret) = *s
+						return nil
+					})},
+					Applicator: resource.ApplyFn(func(_ context.Context, _ runtime.Object, _ ...resource.ApplyOption) error { return errBoom }),
+				},
+				typer: fake.SchemeWith(cp, cm),
+			},
+			args: args{
+				to:   cm,
+				from: cp,
+			},
+			want: want{
+				err: errors.Wrap(errBoom, errCreateOrUpdateSecret),
+			},
+		},
+		"SuccessfulNoOp": {
+			reason: "The claim secret should not be updated if it would not change",
+			fields: fields{
+				client: resource.ClientApplicator{
+					Client: &test.MockClient{
+						MockGet: test.NewMockGetFn(nil, func(o runtime.Object) error {
+							// The managed secret has some data when we get it.
+							s := resource.ConnectionSecretFor(cp, fake.GVK(cp))
+							s.Data = mgcsdata
+
+							*o.(*corev1.Secret) = *s
+							return nil
+						}),
+					},
+					Applicator: resource.ApplyFn(func(ctx context.Context, o runtime.Object, _ ...resource.ApplyOption) error {
+						// Simulate a no-op change by not allowing the update.
+						return resource.AllowUpdateIf(func(_, _ runtime.Object) bool { return false })(ctx, o, o)
+					}),
+				},
+				typer: fake.SchemeWith(cp, cm),
+			},
+			args: args{
+				to:   cm,
+				from: cp,
+			},
+			want: want{
+				propagated: false,
+			},
+		},
+		"SuccessfulPublish": {
+			reason: "Successful propagation should update the claim secret with the appropriate values",
+			fields: fields{
+				client: resource.ClientApplicator{
+					Client: &test.MockClient{
+						MockGet: test.NewMockGetFn(nil, func(o runtime.Object) error {
+							// The managed secret has some data when we get it.
+							s := resource.ConnectionSecretFor(cp, fake.GVK(cp))
+							s.Data = mgcsdata
+
+							*o.(*corev1.Secret) = *s
+							return nil
+						}),
+					},
+					Applicator: resource.ApplyFn(func(_ context.Context, o runtime.Object, _ ...resource.ApplyOption) error {
+						// Ensure the managed secret's data is copied to the
+						// claim secret, and that the claim secret is annotated
+						// to allow constant propagation from the managed
+						// secret.
+						want := resource.LocalConnectionSecretFor(cm, fake.GVK(cm))
+						want.Data = mgcsdata
+						if diff := cmp.Diff(want, o); diff != "" {
+							t.Errorf("-want, +got: %s", diff)
+						}
+
+						return nil
+					}),
+				},
+				typer: fake.SchemeWith(cp, cm),
+			},
+			args: args{
+				to:   cm,
+				from: cp,
+			},
+			want: want{
+				propagated: true,
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			api := &APIConnectionPropagator{client: tc.fields.client, typer: tc.fields.typer}
+			got, err := api.PropagateConnection(tc.args.ctx, tc.args.to, tc.args.from)
+			if diff := cmp.Diff(tc.want.propagated, got); diff != "" {
+				t.Errorf("\n%s\napi.PropagateConnection(...): -want, +got:\n%s", tc.reason, diff)
+			}
+			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
+				t.Errorf("\n%s\napi.PropagateConnection(...): -want error, +got error:\n%s", tc.reason, diff)
+			}
+		})
+	}
+}

--- a/pkg/controller/apiextensions/claim/reconciler.go
+++ b/pkg/controller/apiextensions/claim/reconciler.go
@@ -458,11 +458,12 @@ func (r *Reconciler) Reconcile(req reconcile.Request) (reconcile.Result, error) 
 	}
 	if propagated {
 		cm.SetConnectionDetailsLastPublishedTime(&metav1.Time{Time: time.Now()})
+		log.Debug("Successfully propagated connection details from composite resource")
+		record.Event(cm, event.Normal(reasonPropagate, "Successfully propagated connection details from composite resource"))
 	}
 
 	// We have a watch on both the claim and its composite, so there's no
 	// need to requeue here.
-	record.Event(cm, event.Normal(reasonPropagate, "Successfully propagated connection details from composite resource"))
 	cm.SetConditions(v1alpha1.Available())
 	return reconcile.Result{Requeue: false}, errors.Wrap(r.client.Status().Update(ctx, cm), errUpdateClaimStatus)
 }

--- a/pkg/controller/apiextensions/composite/reconciler.go
+++ b/pkg/controller/apiextensions/composite/reconciler.go
@@ -315,6 +315,8 @@ func (r *Reconciler) Reconcile(req reconcile.Request) (reconcile.Result, error) 
 	}
 	if published {
 		cr.SetConnectionDetailsLastPublishedTime(&metav1.Time{Time: time.Now()})
+		log.Debug("Successfully published connection details")
+		r.record.Event(cr, event.Normal(reasonPublish, "Successfully published connection details"))
 	}
 
 	// TODO(muvaf): Report which resources are not ready.
@@ -328,7 +330,6 @@ func (r *Reconciler) Reconcile(req reconcile.Request) (reconcile.Result, error) 
 		wait = shortWait
 	}
 
-	r.record.Event(cr, event.Normal(reasonPublish, "Successfully published connection details"))
 	r.record.Event(cr, event.Normal(reasonCompose, "Successfully composed resources"))
 	return reconcile.Result{RequeueAfter: wait}, errors.Wrap(r.client.Status().Update(ctx, cr), errUpdateStatus)
 }


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes https://github.com/crossplane/crossplane/issues/1917
Closes https://github.com/crossplane/crossplane/pull/1918

In addition to being useful debug information, this allows a controller to watch for changes to connection details indirectly by watching the resource those connection details pertain to; i.e. the XRC controller will have a reconcile queued when the XR's connection details change. It's possible today for the XRC controller to instead watch the XR's connection secret directly, but this functionality could be useful if and when connection details are published to an external system (e.g. Vault).

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
I've tested this by installing a Configuration built from https://github.com/upbound/platform-ref-aws/tree/6137ab and verifying that:

* The `CompositeCluster` XR has its `status.connectionDetails.lastPublishedTime` updated only when new connection details are published.
* The `Cluster` XRC has its `status.connectionDetails.lastPublishedTime` updated only when new connection details are propagated from the aforementioned XR.
* Reconciles are queued for the `Cluster` XRC (triggering connection secret propagation) whenever the XR's connection secret changes. This is because the XRC controller queues a reconcile for the referenced XRC when an XR changes.
* I can use the `Cluster` XRC's connection secret to connect to the underlying EKS cluster after the underlying EKS managed resource's connection secret should have rotated.

Using the claim's secret to connect to the EKS cluster ~20 mins after its creation:
```console
$ kubectl get -o json secret platform-ref-aws-cluster |jq -r '.data.kubeconfig|@base64d'> claim.kcfg
$ kubectl --kubeconfig claim.kcfg -n kube-system get po
NAME                       READY   STATUS    RESTARTS   AGE
aws-node-5v9cn             1/1     Running   0          11m
aws-node-9jc7q             1/1     Running   0          11m
aws-node-lr478             1/1     Running   0          11m
coredns-5946c5d67c-scn4r   1/1     Running   0          17m
coredns-5946c5d67c-v5sfk   1/1     Running   0          17m
kube-proxy-78s4p           1/1     Running   0          11m
kube-proxy-fc9nd           1/1     Running   0          11m
kube-proxy-q792w           1/1     Running   0          11m
```

The new status field, as shown by `kubectl describe`:
```console
$ kubectl describe compositecluster                                                                                                                             
Name:         platform-ref-aws-cluster-v88bb                                                                                                                                       
Namespace:                                                                                                                                                                         
Labels:       crossplane.io/claim-name=platform-ref-aws-cluster                          
              crossplane.io/claim-namespace=default                                                                                                                                
              crossplane.io/composite=platform-ref-aws-cluster-v88bb                     
Annotations:  <none>                                                                                                                                                               
API Version:  aws.platformref.crossplane.io/v1alpha1                                     
Kind:         CompositeCluster                                                                                                                                                     
Metadata:                                                                                
  Creation Timestamp:  2020-11-05T05:06:54Z                                                                                                                                        
  Generate Name:       platform-ref-aws-cluster-                                         
  Generation:          5                                                                                                                                                           
  Resource Version:    12021                                                             
  Self Link:           /apis/aws.platformref.crossplane.io/v1alpha1/compositeclusters/platform-ref-aws-cluster-v88bb                                                               
  UID:                 18bb03ee-a4af-4b15-a3b8-6f70d5682c61                                                                                                                        
Spec:                                                                                                                                                                              
  Claim Ref:                                                                                                                                                                       
    API Version:  aws.platformref.crossplane.io/v1alpha1                                                                                                                           
    Kind:         Cluster                                                                                                                                                          
    Name:         platform-ref-aws-cluster                                               
    Namespace:    default                                                                
  Composition Ref:                                                                                                                                                                 
    Name:  compositeclusters.aws.platformref.crossplane.io                                                                                                                         
  Id:      platform-ref-aws-cluster                                                                                                                                                
  Parameters:                                                                            
    Network Ref:                                                                                                                                                                   
      Id:  platform-ref-aws-network                                                      
    Nodes:                                                                                                                                                                         
      Count:  3                                                                          
      Size:   small                                                                                                                                                                
    Services:                                                                            
      Operators:                                                                                                                                                                   
        Prometheus:                                                                                                                                                                
          Version:  10.0.2                                                                                                                                                         
  Resource Refs:                                                                                                                                                                   
    API Version:  aws.platformref.crossplane.io/v1alpha1                                                                                                                           
    Kind:         EKS                                                                                                                                                              
    Name:         platform-ref-aws-cluster-v88bb-gmztd                                                                                                                             
    UID:          f211d461-719a-4518-9531-4b07aa6b73e1                                   
    API Version:  aws.platformref.crossplane.io/v1alpha1                                                                                                                           
    Kind:         Services                                                               
    Name:         platform-ref-aws-cluster-v88bb-4dxbt                                   
    UID:          e80e5ea1-9195-4ad1-aed5-a021814f09aa                                                                                                                             
  Write Connection Secret To Ref:                                                                                                                                                  
    Name:       18bb03ee-a4af-4b15-a3b8-6f70d5682c61                                     
    Namespace:  crossplane-system                                                        
Status:                      
  Conditions:                              
    Last Transition Time:  2020-11-05T05:24:29Z                                          
    Reason:                Creating                                                      
    Status:                False
    Type:                  Ready                                                         
  Connection Details:                                                                    
    Last Published Time:  2020-11-05T05:23:58Z                                           
Events:                                  
  Type    Reason                   Age                   From                                                             Message                                                  
  ----    ------                   ----                  ----                                                             -------                                                  
  Normal  PublishConnectionSecret  16m (x8 over 17m)     defined/compositeresourcedefinition.apiextensions.crossplane.io  Successfully published connection details                
  Normal  ComposeResources         16m (x8 over 17m)     defined/compositeresourcedefinition.apiextensions.crossplane.io  Successfully composed resources                          
  Normal  SelectComposition        2m51s (x67 over 17m)  defined/compositeresourcedefinition.apiextensions.crossplane.io  Successfully selected composition 
```

[contribution process]: https://git.io/fj2m9
