### PR TITLE
Apply RBAC roles less frequently

### DIFF
--- a/pkg/controller/rbac/namespace/roles.go
+++ b/pkg/controller/rbac/namespace/roles.go
@@ -17,6 +17,7 @@ limitations under the License.
 package namespace
 
 import (
+	"sort"
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
@@ -53,6 +54,10 @@ const (
 // RenderRoles for the supplied namespace by aggregating rules from the supplied
 // cluster roles.
 func RenderRoles(ns *corev1.Namespace, crs []rbacv1.ClusterRole) []rbacv1.Role {
+	// Our list of CRs has no guaranteed order, so we sort them in order to
+	// ensure we don't reorder our RBAC rules on each update.
+	sort.Slice(crs, func(i, j int) bool { return crs[i].GetName() < crs[j].GetName() })
+
 	admin := &rbacv1.Role{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace:   ns.GetName(),

--- a/pkg/controller/rbac/provider/roles/reconciler_test.go
+++ b/pkg/controller/rbac/provider/roles/reconciler_test.go
@@ -147,7 +147,31 @@ func TestReconcile(t *testing.T) {
 				r: reconcile.Result{RequeueAfter: shortWait},
 			},
 		},
-		"Successful": {
+		"SuccessfulNoOp": {
+			reason: "We should not requeue when no ClusterRoles need applying.",
+			args: args{
+				mgr: &fake.Manager{},
+				opts: []ReconcilerOption{
+					WithClientApplicator(resource.ClientApplicator{
+						Client: &test.MockClient{
+							MockGet:  test.NewMockGetFn(nil),
+							MockList: test.NewMockListFn(nil),
+						},
+						Applicator: resource.ApplyFn(func(ctx context.Context, o runtime.Object, ao ...resource.ApplyOption) error {
+							// Simulate a no-op change by not allowing the update.
+							return resource.AllowUpdateIf(func(_, _ runtime.Object) bool { return false })(ctx, o, o)
+						}),
+					}),
+					WithClusterRoleRenderer(ClusterRoleRenderFn(func(*v1alpha1.ProviderRevision, []extv1.CustomResourceDefinition) []rbacv1.ClusterRole {
+						return []rbacv1.ClusterRole{{}}
+					})),
+				},
+			},
+			want: want{
+				r: reconcile.Result{Requeue: false},
+			},
+		},
+		"SuccessfulApply": {
 			reason: "We should not requeue when we successfully apply our ClusterRoles.",
 			args: args{
 				mgr: &fake.Manager{},
@@ -193,6 +217,68 @@ func TestReconcile(t *testing.T) {
 			}
 			if diff := cmp.Diff(tc.want.r, got, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\nr.Reconcile(...): -want, +got:\n%s", tc.reason, diff)
+			}
+		})
+	}
+}
+
+func TestClusterRolesDiffer(t *testing.T) {
+	cases := map[string]struct {
+		current runtime.Object
+		desired runtime.Object
+		want    bool
+	}{
+		"Equal": {
+			current: &rbacv1.ClusterRole{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{"a": "a"},
+				},
+				Rules: []rbacv1.PolicyRule{{}},
+			},
+			desired: &rbacv1.ClusterRole{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{"a": "a"},
+				},
+				Rules: []rbacv1.PolicyRule{{}},
+			},
+			want: false,
+		},
+		"LabelsDiffer": {
+			current: &rbacv1.ClusterRole{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{"a": "a"},
+				},
+				Rules: []rbacv1.PolicyRule{{}},
+			},
+			desired: &rbacv1.ClusterRole{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{"b": "b"},
+				},
+				Rules: []rbacv1.PolicyRule{{}},
+			},
+			want: true,
+		},
+		"RulesDiffer": {
+			current: &rbacv1.ClusterRole{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{"a": "a"},
+				},
+				Rules: []rbacv1.PolicyRule{{}},
+			},
+			desired: &rbacv1.ClusterRole{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{"a": "a"},
+				},
+			},
+			want: true,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got := ClusterRolesDiffer(tc.current, tc.desired)
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("ClusterRolesDiffer(...): -want, +got\n:%s", diff)
 			}
 		})
 	}

--- a/pkg/controller/rbac/provider/roles/roles.go
+++ b/pkg/controller/rbac/provider/roles/roles.go
@@ -17,6 +17,8 @@ limitations under the License.
 package roles
 
 import (
+	"sort"
+
 	rbacv1 "k8s.io/api/rbac/v1"
 	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -73,6 +75,10 @@ func SystemClusterRoleName(revisionName string) string {
 
 // RenderClusterRoles returns ClusterRoles for the supplied ProviderRevision.
 func RenderClusterRoles(pr *v1alpha1.ProviderRevision, crds []extv1.CustomResourceDefinition) []rbacv1.ClusterRole {
+	// Our list of CRDs has no guaranteed order, so we sort them in order to
+	// ensure we don't reorder our RBAC rules on each update.
+	sort.Slice(crds, func(i, j int) bool { return crds[i].GetName() < crds[j].GetName() })
+
 	groups := make([]string, 0)            // Allows deterministic iteration over groups.
 	resources := make(map[string][]string) // Resources by group.
 	for _, crd := range crds {


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Partial fix for https://github.com/crossplane/crossplane/issues/1929

This PR ensures that we don't update RBAC Roles and ClusterRoles unless our update would meaningfully change the role. Based on my testing this should be a partial fix for the above issue. Each time a CRD or XRD is updated by the ProviderRevision or ConfigurationRevision controllers the RBAC controller has a reconcile queued. That can be up to 40 reconciles for a provider like AWS that owns 40 CRDs, though the reconcile workqueue appears to do some deduping for us here. With this PR in place updates to CRDs and XRDs won't result in a fanout of updates to RBAC ClusterRoles and Roles unless something meaningfully changed (i.e. unless we'd change rules, annotations, or labels).

@hasheddan is working on a corresponding PR that will prevent the package revision controllers from updating the objects owned by provider and configuration revisions unless something meaningful about them has changed. I expect the two PRs combined should eliminate the API server load issues being caused by RBAC manager churn.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
I've tested this by installing provider-aws:master on a Kubernetes 1.19 kind cluster running this PR. I see that every 60 seconds all CRDs change. This triggers a lot of reconciles (around 12 reconciles every 60 seconds, when the ProviderRevision controller updates its 40 AWS CRDs), but those reconciles don't interact with the API server. They generate new RBAC roles, then read the existing RBAC roles from cache and determine that nothing has changed.

[contribution process]: https://git.io/fj2m9
