### PR TITLE
Only requeue package revision controller on changes to installed objects

### DIFF
--- a/pkg/controller/pkg/revision/reconciler_test.go
+++ b/pkg/controller/pkg/revision/reconciler_test.go
@@ -605,7 +605,7 @@ func TestReconcile(t *testing.T) {
 				},
 			},
 			want: want{
-				r: reconcile.Result{RequeueAfter: longWait},
+				r: reconcile.Result{Requeue: false},
 			},
 		},
 		"SuccessfulActiveRevisionIgnoreConstraints": {
@@ -651,7 +651,7 @@ func TestReconcile(t *testing.T) {
 				},
 			},
 			want: want{
-				r: reconcile.Result{RequeueAfter: longWait},
+				r: reconcile.Result{Requeue: false},
 			},
 		},
 		"ErrEstablishActiveRevision": {
@@ -741,7 +741,7 @@ func TestReconcile(t *testing.T) {
 				},
 			},
 			want: want{
-				r: reconcile.Result{RequeueAfter: longWait},
+				r: reconcile.Result{Requeue: false},
 			},
 		},
 		"ErrEstablishInactiveRevision": {


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Updates the package revision controller to only requeue when an installed object changes or when the `____Revision` itself is modified.

Fixes #1923 

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

manual testing steps to be added

[contribution process]: https://git.io/fj2m9
