### PR TITLE
Do not allow access to ControllerConfig in managed roles

### DIFF
--- a/cluster/charts/crossplane/templates/rbac-manager-managed-clusterroles.yaml
+++ b/cluster/charts/crossplane/templates/rbac-manager-managed-clusterroles.yaml
@@ -103,8 +103,11 @@ rules:
 # Crossplane administrators have full access to built in Crossplane types.
 - apiGroups:
   - apiextensions.crossplane.io
-  - pkg.crossplane.io
   resources: ["*"]
+  verbs: ["*"]
+- apiGroups:
+  - pkg.crossplane.io
+  resources: [Provider, Configuration, ProviderRevision, ConfigurationRevision]
   verbs: ["*"]
 # Crossplane administrators have access to view CRDs in order to debug XRDs.
 - apiGroups: [apiextensions.k8s.io]
@@ -138,8 +141,11 @@ rules:
 # Crossplane editors have full access to built in Crossplane types.
 - apiGroups:
   - apiextensions.crossplane.io
-  - pkg.crossplane.io
   resources: ["*"]
+  verbs: ["*"]
+- apiGroups:
+  - pkg.crossplane.io
+  resources: [Provider, Configuration, ProviderRevision, ConfigurationRevision]
   verbs: ["*"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -164,8 +170,11 @@ rules:
 # Crossplane viewers have read-only access to built in Crossplane types.
 - apiGroups:
   - apiextensions.crossplane.io
-  - pkg.crossplane.io
   resources: ["*"]
+  verbs: [get, list, watch]
+- apiGroups:
+  - pkg.crossplane.io
+  resources: [Provider, Configuration, ProviderRevision, ConfigurationRevision]
   verbs: [get, list, watch]
 ---
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION


<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

The ability to create a ControllerConfig is highly previliged because it
essentially allows for creating arbitrary Deployments in a cluster. This
removes that privilege and requires that a user with higher-level
permissions grants the permissions to other users explicitly.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

`make build`
`make e2e.run`

[contribution process]: https://git.io/fj2m9
