### PR TITLE
Fix odd number of args for kv paris in debug logs

### DIFF
--- a/pkg/controller/rbac/namespace/reconciler.go
+++ b/pkg/controller/rbac/namespace/reconciler.go
@@ -205,7 +205,7 @@ func (r *Reconciler) Reconcile(req reconcile.Request) (reconcile.Result, error) 
 			return reconcile.Result{RequeueAfter: shortWait}, nil
 		}
 
-		log.Debug("Applied RBAC Role", "role-name")
+		log.Debug("Applied RBAC Role")
 	}
 
 	r.record.Event(ns, event.Normal(reasonApplyRoles, "Applied RBAC Roles"))


### PR DESCRIPTION


<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->


Fixes a debug logging statement that passes an odd number of arguments,
causing panic at runtime when debug flag is supplied.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

Ran RBAC manager with `-d` flag.

[contribution process]: https://git.io/fj2m9
