### PR TITLE
Do not watch CRDs in RBAC manager provider revision controller

### DIFF
--- a/pkg/controller/rbac/provider/roles/reconciler.go
+++ b/pkg/controller/rbac/provider/roles/reconciler.go
@@ -28,10 +28,8 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	kcontroller "sigs.k8s.io/controller-runtime/pkg/controller"
-	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
-	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	"github.com/crossplane/crossplane-runtime/pkg/event"
 	"github.com/crossplane/crossplane-runtime/pkg/logging"
@@ -80,7 +78,6 @@ func Setup(mgr ctrl.Manager, log logging.Logger) error {
 		Named(name).
 		For(&v1alpha1.ProviderRevision{}).
 		Owns(&rbacv1.ClusterRole{}).
-		Watches(&source.Kind{Type: &extv1.CustomResourceDefinition{}}, &handler.EnqueueRequestForOwner{OwnerType: &v1alpha1.ProviderRevision{}}).
 		WithOptions(kcontroller.Options{MaxConcurrentReconciles: maxConcurrency}).
 		Complete(NewReconciler(mgr,
 			WithLogger(log.WithValues("controller", name)),


### PR DESCRIPTION


<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

The ProviderRevision controller updates the CRDs every minute, which can
enqueue many requests for the RBAC manager provider revision controller.
In practice, the addition or removal of a CRD for a package will always
be reflected in the ProviderRevision, so the RBAC manager will have a
reconcile triggered within 60 seconds if any changes are made.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

`make build`
`make e2e.run`

[contribution process]: https://git.io/fj2m9
