### PR TITLE
Do not append hash when xpkg name provided

### DIFF
--- a/cmd/crank/build.go
+++ b/cmd/crank/build.go
@@ -52,15 +52,6 @@ func (c *buildCmd) Run(child *buildChild) error {
 		return err
 	}
 
-	pkgName := child.name
-	if pkgName == "" {
-		metaPath := filepath.Join(root, xpkg.MetaFile)
-		pkgName, err = xpkg.ParseNameFromMeta(child.fs, metaPath)
-		if err != nil {
-			return errors.Wrap(err, errGetNameFromMeta)
-		}
-	}
-
 	metaScheme, err := xpkg.BuildMetaScheme()
 	if err != nil {
 		return errors.New("cannot build meta scheme for package parser")
@@ -82,7 +73,17 @@ func (c *buildCmd) Run(child *buildChild) error {
 		return errors.Wrap(err, errImageDigest)
 	}
 
-	f, err := child.fs.Create(xpkg.BuildPath(root, xpkg.FriendlyID(pkgName, hash.Hex)))
+	pkgName := child.name
+	if pkgName == "" {
+		metaPath := filepath.Join(root, xpkg.MetaFile)
+		pkgName, err = xpkg.ParseNameFromMeta(child.fs, metaPath)
+		if err != nil {
+			return errors.Wrap(err, errGetNameFromMeta)
+		}
+		pkgName = xpkg.FriendlyID(pkgName, hash.Hex)
+	}
+
+	f, err := child.fs.Create(xpkg.BuildPath(root, pkgName))
 	if err != nil {
 		return errors.Wrap(err, errCreatePackage)
 	}


### PR DESCRIPTION


<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Currently, if a custom name is used when building an xpkg rather than
assuming the name in the crossplane.yaml, the digest of the package is
appended to the custom name. We should assume that a user wants to use
the custom name exactly as they have provided and not append a hash in
that case. This updates to make that change.

When the name in crossplane.yaml is used, the image hash will still be
appended.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

Tested on `config-nop` package directory:

- `k crossplane build configuration --name test` --> `test.xpkg`
- `k crossplane build configuration --name test.xpkg` --> `test.xpkg`
- `k crossplane build configuration --name test.blah` --> `test.xpkg`
- `k crossplane build configuration` --> `config-nop-6122c6b73a32.xpkg`


[contribution process]: https://git.io/fj2m9
