### PR TITLE
Exposing metrics for core and rbac

### DIFF
--- a/cluster/charts/crossplane/README.md
+++ b/cluster/charts/crossplane/README.md
@@ -94,6 +94,7 @@ securityContextRBACManager:
 | `rbacManager.leaderElection` | Enable leader election for RBAC Managers pod | `true` |
 | `rbacManager.managementPolicy`| The extent to which the RBAC manager will manage permissions. `All` indicates to manage all Crossplane controller and user roles. `Basic` indicates to only manage Crossplane controller roles and the `crossplane-admin`, `crossplane-edit`, and `crossplane-view` user roles. | `All` |
 | `alpha.oam.enabled` | Deploy the `crossplane/oam-kubernetes-runtime` Helm chart | `false` |
+| `metrics.enabled` | Expose Crossplane and RBAC Manager metrics endpoint | `false` |
 
 ### Command Line
 

--- a/cluster/charts/crossplane/templates/deployment.yaml
+++ b/cluster/charts/crossplane/templates/deployment.yaml
@@ -17,6 +17,12 @@ spec:
     type: {{ .Values.deploymentStrategy }}
   template:
     metadata:
+      {{- if .Values.metrics.enabled }}
+      annotations:
+        prometheus.io/path: /metrics
+        prometheus.io/port: "8080"
+        prometheus.io/scrape: "true"
+      {{- end }}
       labels:
         app: {{ template "name" . }}
         release: {{ .Release.Name }}
@@ -37,6 +43,11 @@ spec:
         name: {{ .Chart.Name }}
         resources:
           {{- toYaml .Values.resourcesCrossplane | nindent 12 }}
+        {{- if .Values.metrics.enabled }}
+        ports:
+        - name: metrics
+          containerPort: 8080
+        {{- end }}
         securityContext:
           {{- toYaml .Values.securityContextCrossplane | nindent 12 }}
         env:
@@ -59,4 +70,3 @@ spec:
           medium: {{ .Values.packageCache.medium }}
           sizeLimit: {{ .Values.packageCache.sizeLimit }}
         {{- end }}
-        

--- a/cluster/charts/crossplane/templates/rbac-manager-deployment.yaml
+++ b/cluster/charts/crossplane/templates/rbac-manager-deployment.yaml
@@ -18,6 +18,12 @@ spec:
     type: {{ .Values.deploymentStrategy }}
   template:
     metadata:
+      {{- if .Values.metrics.enabled }}
+      annotations:
+        prometheus.io/path: /metrics
+        prometheus.io/port: "8080"
+        prometheus.io/scrape: "true"
+      {{- end }}
       labels:
         app: {{ template "name" . }}-rbac-manager
         release: {{ .Release.Name }}
@@ -40,6 +46,11 @@ spec:
         name: {{ .Chart.Name }}
         resources:
           {{- toYaml .Values.resourcesRBACManager | nindent 12 }}
+        {{- if .Values.metrics.enabled }}
+        ports:
+        - name: metrics
+          containerPort: 8080
+        {{- end }}
         securityContext:
           {{- toYaml .Values.securityContextRBACManager | nindent 12 }}
         env:

--- a/cluster/charts/crossplane/values.yaml.tmpl
+++ b/cluster/charts/crossplane/values.yaml.tmpl
@@ -59,3 +59,6 @@ securityContextRBACManager:
 alpha:
   oam:
     enabled: false
+
+metrics:
+  enabled: false


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

Exposing metrics for Core and RBAC controller manager by tapping to existing metrics server provided by `controller-runtime` . As a result new `/metrics` endpoint is available under `:8080` port which can be used by Prometheus to scrape metrics.

This functionality is being gated by `metrics.enabled` variable of crossplane Helm chart.

Note that required annotations are added to Deployments, so scraping of metrics is already happening if Prometheus exists.

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #314 (and maybe #1846)

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Following steps:

- spin up a cluster with `./cluster/local/kind.sh up`
- deploy to it `./cluster/local/kind.sh helm-install`
- `k -n crossplane-system port-forward $CROSSPLANE_POD 8080` and open http://localhost:8080/metrics in browser
  - note that we're reusing port `8080` for this and not a new port

additionally:

- install Promethues
  ```yaml
  helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
  helm repo update
  helm upgrade --install promethues --namespace crossplane-system --set service.type=NodePort prometheus-community/prometheus
  ```
- `k -n crossplane-system port-forward $PROMETHESU_POD 9090`
- open http://localhost:9090 in the browser and look for existence of any of the newly generated keys in the `crossplane-xx` and `crossplane-rbac-yy` pods:
  - `workqueue_work_duration_seconds_bucket`
    ```
    workqueue_work_duration_seconds_bucket{app="crossplane",instance="10.244.0.14:8080",job="kubernetes-pods",kubernetes_namespace="crossplane-system",kubernetes_pod_name="crossplane-bb67d8d5b-jn4gv",le="+Inf",name="defined/compositeresourcedefinition.apiextensions.crossplane.io",pod_template_hash="bb67d8d5b",release="crossplane"} | 0

    workqueue_work_duration_seconds_bucket{app="crossplane",instance="10.244.0.14:8080",job="kubernetes-pods",kubernetes_namespace="crossplane-system",kubernetes_pod_name="crossplane-bb67d8d5b-jn4gv",le="+Inf",name="offered/compositeresourcedefinition.apiextensions.crossplane.io",pod_template_hash="bb67d8d5b",release="crossplane"} | 0
    ```
  - etc
<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
