### PR TITLE
Recognize v1beta1 apiextensions types in package manager and CLI

### DIFF
--- a/pkg/xpkg/lint.go
+++ b/pkg/xpkg/lint.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/crossplane/crossplane-runtime/pkg/parser"
 	apiextensionsv1alpha1 "github.com/crossplane/crossplane/apis/apiextensions/v1alpha1"
+	apiextensionsv1beta1 "github.com/crossplane/crossplane/apis/apiextensions/v1beta1"
 	pkgmeta "github.com/crossplane/crossplane/apis/pkg/meta/v1alpha1"
 	"github.com/crossplane/crossplane/pkg/version"
 )
@@ -127,16 +128,20 @@ func IsCRD(o runtime.Object) error {
 
 // IsXRD checks that an object is a CompositeResourceDefinition.
 func IsXRD(o runtime.Object) error {
-	if _, ok := o.(*apiextensionsv1alpha1.CompositeResourceDefinition); !ok {
+	switch o.(type) {
+	case *apiextensionsv1alpha1.CompositeResourceDefinition, *apiextensionsv1beta1.CompositeResourceDefinition:
+		return nil
+	default:
 		return errors.New(errNotXRD)
 	}
-	return nil
 }
 
 // IsComposition checks that an object is a Composition.
 func IsComposition(o runtime.Object) error {
-	if _, ok := o.(*apiextensionsv1alpha1.Composition); !ok {
+	switch o.(type) {
+	case *apiextensionsv1alpha1.Composition, *apiextensionsv1beta1.Composition:
+		return nil
+	default:
 		return errors.New(errNotComposition)
 	}
-	return nil
 }

--- a/pkg/xpkg/lint_test.go
+++ b/pkg/xpkg/lint_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/parser"
 	"github.com/crossplane/crossplane-runtime/pkg/test"
 	apiextensionsv1alpha1 "github.com/crossplane/crossplane/apis/apiextensions/v1alpha1"
+	apiextensionsv1beta1 "github.com/crossplane/crossplane/apis/apiextensions/v1beta1"
 	pkgmeta "github.com/crossplane/crossplane/apis/pkg/meta/v1alpha1"
 	"github.com/crossplane/crossplane/pkg/version"
 	"github.com/crossplane/crossplane/pkg/version/fake"
@@ -58,28 +59,42 @@ kind: Configuration
 metadata:
   name: test`)
 
-	xrdBytes = []byte(`apiVersion: apiextentions.crossplane.io/v1alpha1
+	v1alpha1xrdBytes = []byte(`apiVersion: apiextentions.crossplane.io/v1alpha1
 kind: CompositeResourceDefinition
 metadata:
   name: test`)
 
-	compBytes = []byte(`apiVersion: apiextentions.crossplane.io/v1alpha1
+	v1beta1xrdBytes = []byte(`apiVersion: apiextentions.crossplane.io/v1beta1
+kind: CompositeResourceDefinition
+metadata:
+  name: test`)
+
+	v1alpha1compBytes = []byte(`apiVersion: apiextentions.crossplane.io/v1alpha1
 kind: Composition
 metadata:
   name: test`)
 
-	v1beta1crd = &apiextensions.CustomResourceDefinition{}
-	_          = yaml.Unmarshal(v1beta1CRDBytes, v1beta1crd)
-	v1crd      = &apiextensions.CustomResourceDefinition{}
-	_          = yaml.Unmarshal(v1CRDBytes, v1crd)
-	provMeta   = &pkgmeta.Provider{}
-	_          = yaml.Unmarshal(provBytes, provMeta)
-	confMeta   = &pkgmeta.Configuration{}
-	_          = yaml.Unmarshal(confBytes, confMeta)
-	xrd        = &apiextensionsv1alpha1.CompositeResourceDefinition{}
-	_          = yaml.Unmarshal(xrdBytes, xrd)
-	comp       = &apiextensionsv1alpha1.Composition{}
-	_          = yaml.Unmarshal(compBytes, comp)
+	v1beta1compBytes = []byte(`apiVersion: apiextentions.crossplane.io/v1alpha1
+kind: Composition
+metadata:
+  name: test`)
+
+	v1beta1crd   = &apiextensions.CustomResourceDefinition{}
+	_            = yaml.Unmarshal(v1beta1CRDBytes, v1beta1crd)
+	v1crd        = &apiextensions.CustomResourceDefinition{}
+	_            = yaml.Unmarshal(v1CRDBytes, v1crd)
+	provMeta     = &pkgmeta.Provider{}
+	_            = yaml.Unmarshal(provBytes, provMeta)
+	confMeta     = &pkgmeta.Configuration{}
+	_            = yaml.Unmarshal(confBytes, confMeta)
+	v1alpha1xrd  = &apiextensionsv1alpha1.CompositeResourceDefinition{}
+	_            = yaml.Unmarshal(v1alpha1xrdBytes, v1alpha1xrd)
+	v1beta1xrd   = &apiextensionsv1beta1.CompositeResourceDefinition{}
+	_            = yaml.Unmarshal(v1beta1xrdBytes, v1alpha1xrd)
+	v1alpha1comp = &apiextensionsv1alpha1.Composition{}
+	_            = yaml.Unmarshal(v1alpha1compBytes, v1alpha1comp)
+	v1beta1comp  = &apiextensionsv1alpha1.Composition{}
+	_            = yaml.Unmarshal(v1beta1compBytes, v1alpha1comp)
 
 	meta, _ = BuildMetaScheme()
 	obj, _  = BuildObjectScheme()
@@ -368,9 +383,13 @@ func TestIsXRD(t *testing.T) {
 		obj    runtime.Object
 		err    error
 	}{
-		"Successful": {
+		"v1alpha1": {
 			reason: "Should not return error if object is XRD.",
-			obj:    xrd,
+			obj:    v1alpha1xrd,
+		},
+		"v1beta1": {
+			reason: "Should not return error if object is XRD.",
+			obj:    v1beta1xrd,
 		},
 		"ErrNotConfiguration": {
 			reason: "Should return error if object is not XRD.",
@@ -396,9 +415,13 @@ func TestIsComposition(t *testing.T) {
 		obj    runtime.Object
 		err    error
 	}{
-		"Successful": {
+		"v1alpha1": {
 			reason: "Should not return error if object is composition.",
-			obj:    comp,
+			obj:    v1alpha1comp,
+		},
+		"v1beta1": {
+			reason: "Should not return error if object is composition.",
+			obj:    v1beta1comp,
 		},
 		"ErrNotComposition": {
 			reason: "Should return error if object is not composition.",

--- a/pkg/xpkg/scheme.go
+++ b/pkg/xpkg/scheme.go
@@ -22,6 +22,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 
 	apiextensionsv1alpha1 "github.com/crossplane/crossplane/apis/apiextensions/v1alpha1"
+	apiextensionsv1beta1 "github.com/crossplane/crossplane/apis/apiextensions/v1beta1"
 	pkgmeta "github.com/crossplane/crossplane/apis/pkg/meta/v1alpha1"
 )
 
@@ -40,6 +41,9 @@ func BuildMetaScheme() (*runtime.Scheme, error) {
 func BuildObjectScheme() (*runtime.Scheme, error) {
 	objScheme := runtime.NewScheme()
 	if err := apiextensionsv1alpha1.AddToScheme(objScheme); err != nil {
+		return nil, err
+	}
+	if err := apiextensionsv1beta1.AddToScheme(objScheme); err != nil {
 		return nil, err
 	}
 	if err := extv1beta1.AddToScheme(objScheme); err != nil {


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Update package schemes to recognize both v1beta1 and v1alpha1 apiextensions types such that they will be packaged and installed successfully by the CLI and package manager.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

Built a `Configuration` package with a `v1beta1` `Composition`. Confirmed that build and install fails with latest Crossplane and works with fixes in this PR.

[contribution process]: https://git.io/fj2m9
