### PR TITLE
Block owner deletion for package revisions

### DIFF
--- a/pkg/controller/pkg/manager/reconciler_test.go
+++ b/pkg/controller/pkg/manager/reconciler_test.go
@@ -378,10 +378,11 @@ func TestReconcile(t *testing.T) {
 							want.SetLabels(map[string]string{"pkg.crossplane.io/package": "test"})
 							want.SetName("test-1234567")
 							want.SetOwnerReferences([]metav1.OwnerReference{{
-								APIVersion: v1beta1.SchemeGroupVersion.String(),
-								Kind:       v1beta1.ConfigurationKind,
-								Name:       "test",
-								Controller: &trueVal,
+								APIVersion:         v1beta1.SchemeGroupVersion.String(),
+								Kind:               v1beta1.ConfigurationKind,
+								Name:               "test",
+								Controller:         &trueVal,
+								BlockOwnerDeletion: &trueVal,
 							}})
 							want.SetGroupVersionKind(v1beta1.ConfigurationRevisionGroupVersionKind)
 							want.SetDesiredState(v1beta1.PackageRevisionActive)
@@ -593,10 +594,11 @@ func TestReconcile(t *testing.T) {
 							want.SetLabels(map[string]string{"pkg.crossplane.io/package": "test"})
 							want.SetName("test-1234567")
 							want.SetOwnerReferences([]metav1.OwnerReference{{
-								APIVersion: v1beta1.SchemeGroupVersion.String(),
-								Kind:       v1beta1.ConfigurationKind,
-								Name:       "test",
-								Controller: &trueVal,
+								APIVersion:         v1beta1.SchemeGroupVersion.String(),
+								Kind:               v1beta1.ConfigurationKind,
+								Name:               "test",
+								Controller:         &trueVal,
+								BlockOwnerDeletion: &trueVal,
 							}})
 							want.SetGroupVersionKind(v1beta1.ConfigurationRevisionGroupVersionKind)
 							want.SetDesiredState(v1beta1.PackageRevisionActive)


### PR DESCRIPTION


<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Makes the inability to delete a package revision block deletion of its
parent package. There should never be a case in which a revision exists
but has no parent.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

Tested by running with a package revision controller that never removes its finalizer.

[contribution process]: https://git.io/fj2m9
