### PR TITLE
Move securityContext items into chart's input values

### DIFF
--- a/cluster/charts/crossplane/README.md
+++ b/cluster/charts/crossplane/README.md
@@ -75,6 +75,10 @@ and their default values.
 | `resourcesCrossplane.limits.memory` | Memory resource limits for Crossplane | `512Mi` |
 | `resourcesCrossplane.requests.cpu` | CPU resource requests for Crossplane | `100m` |
 | `resourcesCrossplane.requests.memory` | Memory resource requests for Crossplane | `256Mi` |
+| `securityContextCrossplane.runAsUser` | Run as user for Crossplane | `2000` |
+| `securityContextCrossplane.runAsGroup` | Run as group for Crossplane | `2000` |
+| `securityContextCrossplane.allowPrivilegeEscalation` | Allow privilege escalation for Crossplane | `false` |
+| `securityContextCrossplane.readOnlyRootFilesystem` | ReadOnly root filesystem for Crossplane | `true` |
 | `packageCache.medium` | Storage medium for package cache. `Memory` means volume will be backed by tmpfs, which can be useful for development. | `""` |
 | `packageCache.sizeLimit` | Size limit for package cache. If medium is `Memory` then maximum usage would be the minimum of this value the sum of all memory limits on containers in the Crossplane pod. | `5Mi` |
 | `packageCache.pvc` | Name of the PersistentVolumeClaim to be used as the package cache. Providing a value will cause the default emptyDir volume to not be mounted. | `""` |
@@ -82,6 +86,9 @@ and their default values.
 | `resourcesRBACManager.limits.memory` | Memory resource limits for RBAC Manager | `512Mi` |
 | `resourcesRBACManager.requests.cpu` | CPU resource requests for RBAC Manager | `100m` |
 | `resourcesRBACManager.requests.memory` | Memory resource requests for RBAC Manager | `256Mi` |
+securityContextRBACManager:
+| `securityContextRBACManager.allowPrivilegeEscalation` | Allow privilege escalation for RBAC Manager | `false` |
+| `securityContextRBACManager.readOnlyRootFilesystem` | ReadOnly root filesystem for RBAC Manager | `true` |
 | `rbacManager.deploy` | Deploy RBAC Manager and its required roles | `true` |
 | `rbacManager.replicas` | The number of replicas to run for the RBAC Manager pods | `1` |
 | `rbacManager.leaderElection` | Enable leader election for RBAC Managers pod | `true` |

--- a/cluster/charts/crossplane/templates/deployment.yaml
+++ b/cluster/charts/crossplane/templates/deployment.yaml
@@ -38,10 +38,7 @@ spec:
         resources:
           {{- toYaml .Values.resourcesCrossplane | nindent 12 }}
         securityContext:
-          runAsUser: 2000
-          runAsGroup: 2000
-          allowPrivilegeEscalation: false
-          readOnlyRootFilesystem: true
+          {{- toYaml .Values.securityContextCrossplane | nindent 12 }}
         env:
           - name: POD_NAMESPACE
             valueFrom:

--- a/cluster/charts/crossplane/templates/rbac-manager-deployment.yaml
+++ b/cluster/charts/crossplane/templates/rbac-manager-deployment.yaml
@@ -41,8 +41,7 @@ spec:
         resources:
           {{- toYaml .Values.resourcesRBACManager | nindent 12 }}
         securityContext:
-          allowPrivilegeEscalation: false
-          readOnlyRootFilesystem: true
+          {{- toYaml .Values.securityContextRBACManager | nindent 12 }}
         env:
           - name: LEADER_ELECTION
             value: "{{ .Values.rbacManager.leaderElection }}"

--- a/cluster/charts/crossplane/values.yaml.tmpl
+++ b/cluster/charts/crossplane/values.yaml.tmpl
@@ -33,6 +33,12 @@ resourcesCrossplane:
     cpu: 100m
     memory: 256Mi
 
+securityContextCrossplane:
+  runAsUser: 2000
+  runAsGroup: 2000
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+
 packageCache:
   medium: ""
   sizeLimit: 5Mi
@@ -45,6 +51,10 @@ resourcesRBACManager:
   requests:
     cpu: 100m
     memory: 256Mi
+
+securityContextRBACManager:
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
 
 alpha:
   oam:


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

The purpose of this move is to be able to override them on the fly for any platforms that restrict setting them or in situations where they need to be completely disabled, such as development environments.

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

- `make build`
- `make helm.prepare`
- `./cluster/local/kind.sh up`
- modify `cluster/charts/crossplane/values.yaml` as follow:
  ```yaml
  ...
  securityContextCrossplane:
    runAsUser: 3000
    runAsGroup: 3000
  ...
  ```
- make sure the corresponding values do exist in the deployment:
  ```bash
  $ k -n crossplane-system get deployments.apps crossplane -o yaml
  apiVersion: apps/v1
  kind: Deployment
  metadata:
    labels:
      app: crossplane
      app.kubernetes.io/managed-by: Helm
      chart: crossplane-0.0.1
      heritage: Helm
      release: crossplane
    name: crossplane
    namespace: crossplane-system
  spec:
    ...
    template:
      ...
      spec:
        containers:
        - image: crossplane/crossplane:v1.0.0-rc.0.27.g73352a7a-dirty
          ...
          securityContext:
            allowPrivilegeEscalation: false
            readOnlyRootFilesystem: true
            runAsGroup: 3000
            runAsUser: 3000
  ...
  ```  
<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
