### PR TITLE
Add AGE printer column to XRs and Claims

### DIFF
--- a/pkg/xcrd/crd_test.go
+++ b/pkg/xcrd/crd_test.go
@@ -145,6 +145,11 @@ func TestForCompositeResource(t *testing.T) {
 						Type:     "string",
 						JSONPath: ".spec.compositionRef.name",
 					},
+					{
+						Name:     "AGE",
+						Type:     "Date",
+						JSONPath: ".metadata.creationTimestamp",
+					},
 				},
 				Schema: &extv1.CustomResourceValidation{
 					OpenAPIV3Schema: &extv1.JSONSchemaProps{
@@ -463,6 +468,11 @@ func TestForCompositeResourceClaim(t *testing.T) {
 							Name:     "CONNECTION-SECRET",
 							Type:     "string",
 							JSONPath: ".spec.writeConnectionSecretToRef.name",
+						},
+						{
+							Name:     "AGE",
+							Type:     "Date",
+							JSONPath: ".metadata.creationTimestamp",
 						},
 					},
 					Schema: &extv1.CustomResourceValidation{

--- a/pkg/xcrd/schemas.go
+++ b/pkg/xcrd/schemas.go
@@ -206,6 +206,11 @@ func CompositeResourcePrinterColumns() []extv1.CustomResourceColumnDefinition {
 			Type:     "string",
 			JSONPath: ".spec.compositionRef.name",
 		},
+		{
+			Name:     "AGE",
+			Type:     "Date",
+			JSONPath: ".metadata.creationTimestamp",
+		},
 	}
 }
 
@@ -222,6 +227,11 @@ func CompositeResourceClaimPrinterColumns() []extv1.CustomResourceColumnDefiniti
 			Name:     "CONNECTION-SECRET",
 			Type:     "string",
 			JSONPath: ".spec.writeConnectionSecretToRef.name",
+		},
+		{
+			Name:     "AGE",
+			Type:     "Date",
+			JSONPath: ".metadata.creationTimestamp",
 		},
 	}
 }


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes
Add AGE printer column to XRs.
It's convenient to see the age when listing XRs in a cluster. Also, all
other Crossplane resoruces have this printer column already.
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->


I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
