### PR TITLE
Add GH action workflows for building and publishing docs packages

### DIFF
--- a/.github/workflows/configurations.yml
+++ b/.github/workflows/configurations.yml
@@ -1,0 +1,164 @@
+name: Configurations
+
+on:
+  push:
+    branches:
+      - master
+      - release-*
+  workflow_dispatch: {}
+
+env:
+  DOCKER_USR: ${{ secrets.UPBOUND_ROBOT_USR }}
+
+jobs:
+  getting-started-with-aws:
+    runs-on: ubuntu-18.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          submodules: true
+      # The tagger step uses the same logic in the build submodule to generate package tag
+      # https://github.com/upbound/build/blob/4f64913157a952dbe77cd9e05457d9abe695a1d4/makelib/common.mk#L193
+      - name: Set tag
+        run: echo "::set-output name=VERSION_TAG::$(git describe --dirty --always --tags | sed 's/-/./2' | sed 's/-/./2' )"
+        id: tagger
+      - name: Login to Docker
+        uses: docker/login-action@v1
+        if: env.DOCKER_USR != ''
+        with:
+          registry: registry.upbound.io
+          username: ${{ secrets.UPBOUND_ROBOT_USR }}
+          password: ${{ secrets.UPBOUND_ROBOT_PSW }}
+      - name: Build
+        uses: crossplane-contrib/xpkg-action@v0.1.0
+        with:
+          command: build configuration -f docs/snippets/package/aws --name=getting-started-with-aws.xpkg
+      - name: Push
+        uses: crossplane-contrib/xpkg-action@v0.1.0
+        with:
+          command: push configuration -f docs/snippets/package/aws/getting-started-with-aws.xpkg registry.upbound.io/xp/getting-started-with-aws:${{ steps.tagger.outputs.VERSION_TAG }}
+      - name: Push Latest
+        uses: crossplane-contrib/xpkg-action@v0.1.0
+        with:
+          command: push configuration -f docs/snippets/package/aws/getting-started-with-aws.xpkg registry.upbound.io/xp/getting-started-with-aws
+  
+  getting-started-with-aws-with-vpc:
+    runs-on: ubuntu-18.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          submodules: true
+      - name: Set tag
+        run: echo "::set-output name=VERSION_TAG::$(git describe --dirty --always --tags | sed 's/-/./2' | sed 's/-/./2' )"
+        id: tagger
+      - name: Login to Docker
+        uses: docker/login-action@v1
+        if: env.DOCKER_USR != ''
+        with:
+          registry: registry.upbound.io
+          username: ${{ secrets.UPBOUND_ROBOT_USR }}
+          password: ${{ secrets.UPBOUND_ROBOT_PSW }}
+      - name: Build
+        uses: crossplane-contrib/xpkg-action@v0.1.0
+        with:
+          command: build configuration -f docs/snippets/package/aws-with-vpc --name=getting-started-with-aws-with-vpc.xpkg
+      - name: Push
+        uses: crossplane-contrib/xpkg-action@v0.1.0
+        with:
+          command: push configuration -f docs/snippets/package/aws-with-vpc/getting-started-with-aws-with-vpc.xpkg registry.upbound.io/xp/getting-started-with-aws-with-vpc:${{ steps.tagger.outputs.VERSION_TAG }}
+      - name: Push Latest
+        uses: crossplane-contrib/xpkg-action@v0.1.0
+        with:
+          command: push configuration -f docs/snippets/package/aws-with-vpc/getting-started-with-aws-with-vpc.xpkg registry.upbound.io/xp/getting-started-with-aws-with-vpc
+  
+  getting-started-with-gcp:
+    runs-on: ubuntu-18.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          submodules: true
+      - name: Set tag
+        run: echo "::set-output name=VERSION_TAG::$(git describe --dirty --always --tags | sed 's/-/./2' | sed 's/-/./2' )"
+        id: tagger
+      - name: Login to Docker
+        uses: docker/login-action@v1
+        if: env.DOCKER_USR != ''
+        with:
+          registry: registry.upbound.io
+          username: ${{ secrets.UPBOUND_ROBOT_USR }}
+          password: ${{ secrets.UPBOUND_ROBOT_PSW }}
+      - name: Build
+        uses: crossplane-contrib/xpkg-action@v0.1.0
+        with:
+          command: build configuration -f docs/snippets/package/gcp --name=getting-started-with-gcp.xpkg
+      - name: Push
+        uses: crossplane-contrib/xpkg-action@v0.1.0
+        with:
+          command: push configuration -f docs/snippets/package/aws/getting-started-with-gcp.xpkg registry.upbound.io/xp/getting-started-with-gcp:${{ steps.tagger.outputs.VERSION_TAG }}
+      - name: Push Latest
+        uses: crossplane-contrib/xpkg-action@v0.1.0
+        with:
+          command: push configuration -f docs/snippets/package/aws/getting-started-with-gcp.xpkg registry.upbound.io/xp/getting-started-with-gcp
+  
+  getting-started-with-azure:
+    runs-on: ubuntu-18.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          submodules: true
+      - name: Set tag
+        run: echo "::set-output name=VERSION_TAG::$(git describe --dirty --always --tags | sed 's/-/./2' | sed 's/-/./2' )"
+        id: tagger
+      - name: Login to Docker
+        uses: docker/login-action@v1
+        if: env.DOCKER_USR != ''
+        with:
+          registry: registry.upbound.io
+          username: ${{ secrets.UPBOUND_ROBOT_USR }}
+          password: ${{ secrets.UPBOUND_ROBOT_PSW }}
+      - name: Build
+        uses: crossplane-contrib/xpkg-action@v0.1.0
+        with:
+          command: build configuration -f docs/snippets/package/azure --name=getting-started-with-azure.xpkg
+      - name: Push
+        uses: crossplane-contrib/xpkg-action@v0.1.0
+        with:
+          command: push configuration -f docs/snippets/package/aws/getting-started-with-azure.xpkg registry.upbound.io/xp/getting-started-with-azure:${{ steps.tagger.outputs.VERSION_TAG }}
+      - name: Push Latest
+        uses: crossplane-contrib/xpkg-action@v0.1.0
+        with:
+          command: push configuration -f docs/snippets/package/aws/getting-started-with-azure.xpkg registry.upbound.io/xp/getting-started-with-azure
+  
+  getting-started-with-alibaba:
+    runs-on: ubuntu-18.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          submodules: true
+      - name: Set tag
+        run: echo "::set-output name=VERSION_TAG::$(git describe --dirty --always --tags | sed 's/-/./2' | sed 's/-/./2' )"
+        id: tagger
+      - name: Login to Docker
+        uses: docker/login-action@v1
+        if: env.DOCKER_USR != ''
+        with:
+          registry: registry.upbound.io
+          username: ${{ secrets.UPBOUND_ROBOT_USR }}
+          password: ${{ secrets.UPBOUND_ROBOT_PSW }}
+      - name: Build
+        uses: crossplane-contrib/xpkg-action@v0.1.0
+        with:
+          command: build configuration -f docs/snippets/package/alibaba --name=getting-started-with-alibaba.xpkg
+      - name: Push
+        uses: crossplane-contrib/xpkg-action@v0.1.0
+        with:
+          command: push configuration -f docs/snippets/package/aws/getting-started-with-alibaba.xpkg registry.upbound.io/xp/getting-started-with-alibaba:${{ steps.tagger.outputs.VERSION_TAG }}
+      - name: Push Latest
+        uses: crossplane-contrib/xpkg-action@v0.1.0
+        with:
+          command: push configuration -f docs/snippets/package/aws/getting-started-with-alibaba.xpkg registry.upbound.io/xp/getting-started-with-alibaba

--- a/docs/getting-started/compose-infrastructure.md
+++ b/docs/getting-started/compose-infrastructure.md
@@ -73,7 +73,7 @@ We will now install a `Configuration` that:
 > an RDS instance that will allow traffic from the internet.
 
 ```console
-kubectl crossplane install configuration crossplane/getting-started-with-aws:master
+kubectl crossplane install configuration registry.upbound.io/xp/getting-started-with-aws:latest
 ```
 
 </div>
@@ -85,28 +85,28 @@ kubectl crossplane install configuration crossplane/getting-started-with-aws:mas
 > complex ones. See the [composition] documentation for more information.
 
 ```console
-kubectl crossplane install configuration crossplane/getting-started-with-aws-with-vpc:master
+kubectl crossplane install configuration registry.upbound.io/xp/getting-started-with-aws-with-vpc:latest
 ```
 
 </div>
 <div class="tab-pane fade" id="gcp-tab-1" markdown="1">
 
 ```console
-kubectl crossplane install configuration crossplane/getting-started-with-gcp:master
+kubectl crossplane install configuration registry.upbound.io/xp/getting-started-with-gcp:latest
 ```
 
 </div>
 <div class="tab-pane fade" id="azure-tab-1" markdown="1">
 
 ```console
-kubectl crossplane install configuration crossplane/getting-started-with-azure:master
+kubectl crossplane install configuration registry.upbound.io/xp/getting-started-with-azure:latest
 ```
 
 </div>
 <div class="tab-pane fade" id="alibaba-tab-1" markdown="1">
 
 ```console
-kubectl crossplane install configuration crossplane/getting-started-with-alibaba:master
+kubectl crossplane install configuration registry.upbound.io/xp/getting-started-with-alibaba:latest
 ```
 
 </div>


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Adds a new workflow for building and pushing configuration packages we use in documentation on merges to `master` and `release-*` branches. Note that we push both a version matching the crossplane tag as well as a version tagged `latest` on every build.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

Commands have been tested manually and the new action is tested via its own workflow in its repo: https://github.com/crossplane-contrib/xpkg-action. The version tagging has been tested here and matches the strategy used in `build` submodule: https://github.com/hasheddan/action-tests

[contribution process]: https://git.io/fj2m9
