### PR TITLE
Ensure valid DNS label for FriendlyID 

### DIFF
--- a/internal/xpkg/name.go
+++ b/internal/xpkg/name.go
@@ -51,12 +51,10 @@ func truncate(str string, num int) string {
 	return t
 }
 
-// FriendlyID builds a maximum 63 character string made up of the name of a
-// package and its image digest. It expects the first string to be a valid DNS
-// subdomain name and the second to be a valid OCI image digest.
+// FriendlyID builds a valid DNS label string made up of the name of a package
+// and its image digest.
 func FriendlyID(name, hash string) string {
-	id := strings.ReplaceAll(strings.Join([]string{truncate(name, 50), truncate(hash, 12)}, "-"), ".", "-")
-	return id
+	return ToDNSLabel(strings.Join([]string{truncate(name, 50), truncate(hash, 12)}, "-"))
 }
 
 // ToDNSLabel converts the string to a valid DNS label.

--- a/internal/xpkg/name_test.go
+++ b/internal/xpkg/name_test.go
@@ -73,6 +73,14 @@ func TestFriendlyID(t *testing.T) {
 			},
 			want: "provider-aws-plusabunchofothernonsensethatisgoingt-1234-5678912",
 		},
+		"DigestIsName": {
+			reason: "A valid DNS label should be returned when package digest is a name.",
+			args: args{
+				pkg:  "provider-in-cluster",
+				hash: "provider-in-cluster",
+			},
+			want: "provider-in-cluster-provider-in",
+		},
 	}
 
 	for name, tc := range cases {


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Updates FriendlyID package revision naming function to always return a
valid DNS label made up of a concatenation of the package name and the
revision digest. This will not result in changes for the typical naming
scenario, but can guard against issues when a revision image has been
manually loaded into the cache with an unexpected name.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

This fixes the case we run into here: https://github.com/crossplane-contrib/provider-in-cluster/pull/9.. but I also just think its cleaner in gernal to always produce a valid DNS label as opposed to _usually_ producing a valid one.

[contribution process]: https://git.io/fj2m9
