### PR TITLE
Enable memory profiling in debug mode

### DIFF
--- a/cluster/charts/crossplane/README.md
+++ b/cluster/charts/crossplane/README.md
@@ -63,6 +63,7 @@ and their default values.
 
 | Parameter | Description | Default |
 | --- | --- | --- |
+| `debug` | Enable debug mode for Crossplane and RBAC Manager | `false` |
 | `image.repository` | Image | `crossplane/crossplane` |
 | `image.tag` | Image tag | `master` |
 | `image.pullPolicy` | Image pull policy | `Always` |

--- a/cluster/charts/crossplane/templates/deployment.yaml
+++ b/cluster/charts/crossplane/templates/deployment.yaml
@@ -33,11 +33,14 @@ spec:
       serviceAccountName: {{ template "name" . }}
       containers:
       - image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
-        {{- if .Values.args }}
+        {{- if or (.Values.args) (.Values.debug) }}
         args:
+        {{- end }}
+        {{- if or .Values.debug }}
+        - --debug
+        {{- end }}
         {{- range $arg := .Values.args }}
         - {{ $arg }}
-        {{- end }}
         {{- end }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         name: {{ .Chart.Name }}

--- a/cluster/charts/crossplane/templates/rbac-manager-deployment.yaml
+++ b/cluster/charts/crossplane/templates/rbac-manager-deployment.yaml
@@ -36,6 +36,9 @@ spec:
       - image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
         args:
         - rbac
+        {{- if or .Values.debug }}
+        - --debug
+        {{- end }}
         {{- if .Values.rbacManager.managementPolicy }}
         - --manage={{ .Values.rbacManager.managementPolicy }}
         {{- end }}

--- a/cluster/charts/crossplane/values.yaml.tmpl
+++ b/cluster/charts/crossplane/values.yaml.tmpl
@@ -7,6 +7,7 @@ image:
   tag: %%VERSION%%
   pullPolicy: Always
 
+debug: false
 leaderElection: true
 args: {}
 

--- a/cluster/images/crossplane/Dockerfile
+++ b/cluster/images/crossplane/Dockerfile
@@ -2,6 +2,6 @@ FROM BASEIMAGE
 RUN apk --no-cache add ca-certificates bash
 
 ADD crossplane /usr/local/bin/
-EXPOSE 8080
+EXPOSE 8080 9090
 USER 1001
 ENTRYPOINT ["crossplane"]

--- a/cmd/crossplane/main.go
+++ b/cmd/crossplane/main.go
@@ -25,6 +25,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	"github.com/crossplane/crossplane-runtime/pkg/logging"
+	"github.com/crossplane/crossplane-runtime/pkg/pprof"
 	"github.com/crossplane/crossplane/cmd/crossplane/core"
 	"github.com/crossplane/crossplane/cmd/crossplane/rbac"
 )
@@ -47,6 +48,12 @@ func main() {
 		// *very* verbose even at info level, so we only provide it a real
 		// logger when we're running in debug mode.
 		ctrl.SetLogger(zl)
+	}
+
+	if *debug {
+		server := pprof.NewServer(logging.NewLogrLogger(zl.WithName("pprof-server")))
+		server.Start()
+		defer server.Stop()
 	}
 
 	switch cmd {


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

When in debug mode, start a standalone HTTP server on port 9090
dedicated for Memory Profiling. It exposes the following endpoints:

- /debug/pprof/
- /debug/pprof/cmdline
- /debug/pprof/profile
- /debug/pprof/symbol
- /debug/pprof/trace
- /debug/pprof/goroutine
- /debug/pprof/heap
- /debug/pprof/threadcreate
- /debug/pprof/block

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
This PR is blocked by crossplane/crossplane-runtime#233
Partial fix for #1846 

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9

- run `./cluster/local/kind.sh up`
- run `HELM3_FLAGS="--set debug=true" ./cluster/local/kind.sh helm-install`
- run `kubectl -n crossplane-system port-forward CROSSPLANE_POD 9090`
- open above endpoints in the browser: e.g. http://localhost:9090/debug/pprof/symbol