### PR TITLE
Provide additional context when failing to build pkg

### DIFF
--- a/cmd/crank/build.go
+++ b/cmd/crank/build.go
@@ -91,13 +91,13 @@ func (c *buildCmd) Run(child *buildChild) error {
 	return tarball.Write(nil, img, f)
 }
 
-// default build filters skip directories and files without YAML extension in
-// addition to any paths specified.
+// default build filters skip directories, empty files, and files without YAML
+// extension in addition to any paths specified.
 func buildFilters(root string, skips []string) []parser.FilterFn {
-	numOpts := len(skips) + 2
-	opts := make([]parser.FilterFn, numOpts)
+	opts := make([]parser.FilterFn, len(skips)+3)
 	opts[0] = parser.SkipDirs()
 	opts[1] = parser.SkipNotYAML()
+	opts[2] = parser.SkipEmpty()
 	for i, s := range skips {
 		opts[i+2] = parser.SkipPath(filepath.Join(root, s))
 	}

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/alecthomas/kong v0.2.11
 	github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751 // indirect
 	github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d // indirect
-	github.com/crossplane/crossplane-runtime v0.11.1-0.20201120062856-57ef784bfe43
+	github.com/crossplane/crossplane-runtime v0.11.1-0.20201208222033-479dbc8a4560
 	github.com/docker/cli v0.0.0-20200915230204-cd8016b6bcc5 // indirect
 	github.com/docker/docker v17.12.0-ce-rc1.0.20200926000217-2617742802f6+incompatible // indirect
 	github.com/go-logr/zapr v0.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -135,8 +135,8 @@ github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsr
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
 github.com/creack/pty v1.1.9 h1:uDmaGzcdjhF4i/plgjmEsriH11Y0o7RKapEf/LDaM3w=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
-github.com/crossplane/crossplane-runtime v0.11.1-0.20201120062856-57ef784bfe43 h1:eos1bgDVzi81wPwOVgOpWmEl+dtZ45y1PLMGjPZ4Bto=
-github.com/crossplane/crossplane-runtime v0.11.1-0.20201120062856-57ef784bfe43/go.mod h1:cJl5ZZONisre4v6wTmbrC8Jh3AI+erq/lNaxZzv9tnU=
+github.com/crossplane/crossplane-runtime v0.11.1-0.20201208222033-479dbc8a4560 h1:gVbLLKZEGlZsyZwkHjizwKAJQBi1FXn174FiJmXnOqo=
+github.com/crossplane/crossplane-runtime v0.11.1-0.20201208222033-479dbc8a4560/go.mod h1:cJl5ZZONisre4v6wTmbrC8Jh3AI+erq/lNaxZzv9tnU=
 github.com/davecgh/go-spew v0.0.0-20151105211317-5215b55f46b2/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/internal/xpkg/build.go
+++ b/internal/xpkg/build.go
@@ -36,7 +36,6 @@ const (
 	errParserPackage = "failed to parse package"
 	errLintPackage   = "failed to lint package"
 	errInitBackend   = "failed to initialize package parsing backend"
-	errCopyStream    = "failed to copy stream into buffer"
 	errTarFromStream = "failed to build tarball from package stream"
 	errLayerFromTar  = "failed to convert tarball to image layer"
 )
@@ -58,9 +57,6 @@ func Build(ctx context.Context, b parser.Backend, p parser.Parser, l parser.Lint
 	}
 	if err := l.Lint(pkg); err != nil {
 		return nil, errors.Wrap(err, errLintPackage)
-	}
-	if _, err = io.Copy(buf, r); err != nil {
-		return nil, errors.Wrap(err, errCopyStream)
 	}
 
 	// Write on-disk package contents to tarball.


### PR DESCRIPTION


<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Adds additional context to where the parsing error occurred when
building a crossplane package from files on disk.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

xref https://github.com/crossplane/crossplane-runtime/pull/232 https://github.com/crossplane/crossplane-runtime/issues/229

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

Edited one of the sample configuration packages and attempted to build:

```
🤖 (crossplane) kubectl crossplane build configuration -f docs/snippets/package/aws
kubectl crossplane: error: failed to build package: failed to parse package: {path:/home/dan/code/github.com/crossplane/crossplane/docs/snippets/package/aws/composition.yaml position:1390}: no kind "Compositions" is registered for version "apiextensions.crossplane.io/v1beta1" in scheme "pkg/runtime/scheme.go:101"

```

[contribution process]: https://git.io/fj2m9
