### PR TITLE
Default to stable channel for kubectl-crossplane download

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -2,7 +2,7 @@
 
 set -eu
 
-CHANNEL=${CHANNEL:-alpha}
+CHANNEL=${CHANNEL:-stable}
 VERSION=${VERSION:-current}
 
 os=$(uname -s)


### PR DESCRIPTION


<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Updates default release channel to stable when invoking
kubectl-crossplane download script.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

Fixes #1981 

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

Stable channel does not yet exist, but will when v1.0 docs go live, at which point we will instruct folks to use this script.

[contribution process]: https://git.io/fj2m9
