### PR TITLE
Fix panic in crank with missing filters

### DIFF
--- a/cmd/crank/build.go
+++ b/cmd/crank/build.go
@@ -94,12 +94,15 @@ func (c *buildCmd) Run(child *buildChild) error {
 // default build filters skip directories, empty files, and files without YAML
 // extension in addition to any paths specified.
 func buildFilters(root string, skips []string) []parser.FilterFn {
-	opts := make([]parser.FilterFn, len(skips)+3)
-	opts[0] = parser.SkipDirs()
-	opts[1] = parser.SkipNotYAML()
-	opts[2] = parser.SkipEmpty()
+	defaultFns := []parser.FilterFn{
+		parser.SkipDirs(),
+		parser.SkipNotYAML(),
+		parser.SkipEmpty(),
+	}
+	opts := make([]parser.FilterFn, len(skips)+len(defaultFns))
+	copy(opts, defaultFns)
 	for i, s := range skips {
-		opts[i+2] = parser.SkipPath(filepath.Join(root, s))
+		opts[i+len(defaultFns)] = parser.SkipPath(filepath.Join(root, s))
 	}
 	return opts
 }


### PR DESCRIPTION

<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

FilterFns were being copied incorrectly into the slice that was passed
to the fsReader backend, causing it to call nil functions and panic
paths are ignored. This updates it to correctly copy the default
functions and path skips into the FilterFn slice.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>


I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

`kubectl crossplane build configuration --name package.xpkg --ignore "examples/*,hack/*"` with https://github.com/upbound/platform-ref-aws

[contribution process]: https://git.io/fj2m9
