### PR TITLE
Use a consistent package name in installation and pin provider semvers in docs

### DIFF
--- a/docs/getting-started/install-configure.md
+++ b/docs/getting-started/install-configure.md
@@ -203,7 +203,7 @@ for infrastructure provisioning:
 ### Install AWS Provider
 
 ```console
-kubectl crossplane install provider crossplane/provider-aws:alpha
+kubectl crossplane install provider crossplane/provider-aws:v0.16.0
 ```
 
 ### Get AWS Account Keyfile
@@ -248,7 +248,7 @@ kubectl apply -f https://raw.githubusercontent.com/crossplane/crossplane/master/
 ### Install GCP Provider
 
 ```console
-kubectl crossplane install provider crossplane/provider-gcp:alpha
+kubectl crossplane install provider crossplane/provider-gcp:v0.14.0
 ```
 
 ### Get GCP Account Keyfile
@@ -309,7 +309,7 @@ spec:
 ### Install Azure Provider
 
 ```console
-kubectl crossplane install provider crossplane/provider-azure:alpha
+kubectl crossplane install provider crossplane/provider-azure:v0.14.0
 ```
 
 ### Get Azure Principal Keyfile
@@ -369,7 +369,7 @@ kubectl apply -f https://raw.githubusercontent.com/crossplane/crossplane/master/
 ### Install Alibaba Provider
 
 ```console
-kubectl crossplane install provider crossplane/provider-alibaba:alpha
+kubectl crossplane install provider crossplane/provider-alibaba:v0.5.0
 ```
 
 ### Create a Provider Secret


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Updates the Crossplane CLI to use the same naming strategy as the
dependency resolver to reduce the liklihood that the resolver duplicates
a dependency while it is transitioning from one revision to the next.

We currently install providers based on the alpha release channel to
avoid churn on docs at release time. As we move towards more
independence in terms of maintainership for providers, we should allow
provider maintainers to update documentation to install with the latest
semantic version of their provider, which we encourage as best practice
when dealing with packages.

This also allows us to have a simpler getting started workflow with
first installing providers, then later installing configuration packages
that depend on them. This workflow is currently broken because the
configuration packages do not parse alpha as a valid semantic version.

Partially addresses #2032 

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

```
🤖 (crossplane) kubectl-crossplane install provider crossplane/provider-gcp:v0.12.0
provider.pkg.crossplane.io/crossplane-provider-gcp created
```

[contribution process]: https://git.io/fj2m9
