### PR TITLE
Build configuration packages with v1alpha1 meta types

### DIFF
--- a/docs/snippets/package/alibaba/crossplane.yaml
+++ b/docs/snippets/package/alibaba/crossplane.yaml
@@ -1,4 +1,4 @@
-apiVersion: meta.pkg.crossplane.io/v1
+apiVersion: meta.pkg.crossplane.io/v1alpha1
 kind: Configuration
 metadata:
   name: getting-started-with-alibaba

--- a/docs/snippets/package/alibaba/crossplane.yaml
+++ b/docs/snippets/package/alibaba/crossplane.yaml
@@ -10,4 +10,4 @@ spec:
     version: ">=v0.14.0-0"
   dependsOn:
     - provider: crossplane/provider-alibaba
-      version: ">=v0.4.0-0"
+      version: ">=v0.4.0"

--- a/docs/snippets/package/aws-with-vpc/crossplane.yaml
+++ b/docs/snippets/package/aws-with-vpc/crossplane.yaml
@@ -11,4 +11,4 @@ spec:
     version: ">=v0.14.0-0"
   dependsOn:
     - provider: crossplane/provider-aws
-      version: ">=v0.14.0-0"
+      version: ">=v0.14.0"

--- a/docs/snippets/package/aws-with-vpc/crossplane.yaml
+++ b/docs/snippets/package/aws-with-vpc/crossplane.yaml
@@ -1,4 +1,4 @@
-apiVersion: meta.pkg.crossplane.io/v1
+apiVersion: meta.pkg.crossplane.io/v1alpha1
 kind: Configuration
 metadata:
   name: getting-started-with-aws-with-vpc

--- a/docs/snippets/package/aws/crossplane.yaml
+++ b/docs/snippets/package/aws/crossplane.yaml
@@ -1,4 +1,4 @@
-apiVersion: meta.pkg.crossplane.io/v1
+apiVersion: meta.pkg.crossplane.io/v1alpha1
 kind: Configuration
 metadata:
   name: getting-started-with-aws

--- a/docs/snippets/package/aws/crossplane.yaml
+++ b/docs/snippets/package/aws/crossplane.yaml
@@ -11,4 +11,4 @@ spec:
     version: ">=v0.14.0-0"
   dependsOn:
     - provider: crossplane/provider-aws
-      version: ">=v0.14.0-0"
+      version: ">=v0.14.0"

--- a/docs/snippets/package/azure/crossplane.yaml
+++ b/docs/snippets/package/azure/crossplane.yaml
@@ -1,4 +1,4 @@
-apiVersion: meta.pkg.crossplane.io/v1
+apiVersion: meta.pkg.crossplane.io/v1alpha1
 kind: Configuration
 metadata:
   name: getting-started-with-azure

--- a/docs/snippets/package/azure/crossplane.yaml
+++ b/docs/snippets/package/azure/crossplane.yaml
@@ -10,4 +10,4 @@ spec:
     version: ">=v0.14.0-0"
   dependsOn:
     - provider: crossplane/provider-azure
-      version: ">=v0.13.0-0"
+      version: ">=v0.13.0"

--- a/docs/snippets/package/gcp/crossplane.yaml
+++ b/docs/snippets/package/gcp/crossplane.yaml
@@ -10,4 +10,4 @@ spec:
     version: ">=v0.14.0-0"
   dependsOn:
     - provider: crossplane/provider-gcp
-      version: ">=v0.13.0-0"
+      version: ">=v0.13.0"

--- a/docs/snippets/package/gcp/crossplane.yaml
+++ b/docs/snippets/package/gcp/crossplane.yaml
@@ -1,4 +1,4 @@
-apiVersion: meta.pkg.crossplane.io/v1
+apiVersion: meta.pkg.crossplane.io/v1alpha1
 kind: Configuration
 metadata:
   name: getting-started-with-gcp


### PR DESCRIPTION


<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Reverts update to build configuration packages with v1 meta types and
uses v1alpha1 for the time being, which are still supported in the
package manager.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

`kubectl crossplane build configuration ...`

[contribution process]: https://git.io/fj2m9
