### PR TITLE
[release-1.0]fix named link for managed resources documentation

### DIFF
--- a/docs/introduction/overview.md
+++ b/docs/introduction/overview.md
@@ -77,7 +77,7 @@ Managed resources are Kubernetes custom resources that represent infrastructure
 primitives. Managed resources with an API version of `v1beta1` or higher support
 every field that the cloud provider does for the given resource. You can find
 the Managed Resources and their API specifications for each provider on
-[doc.crds.dev] and learn more in the [managed resource documentation].
+[doc.crds.dev] and learn more in the [managed resources documentation].
 
 ## Composite Resources
 


### PR DESCRIPTION
Signed-off-by: Jiaming Hu <Jiaming.Hu@ibm.com>

<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
This PR is for a tiny fix in the overview.md. It makes the named link "managed resources documentation" works in the document.

Cherry-pick from https://github.com/crossplane/crossplane/pull/2050.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
