### PR TITLE
Build linux_arm binaries for crossplane and crank and use distroless base image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,6 +57,7 @@ HELM_CHART_LINT_ARGS_crossplane = --set nameOverride='',imagePullSecrets=''
 
 DOCKER_REGISTRY = crossplane
 IMAGES = crossplane
+OSBASEIMAGE = gcr.io/distroless/static:nonroot
 -include build/makelib/image.mk
 
 # ====================================================================================

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 PROJECT_NAME := crossplane
 PROJECT_REPO := github.com/crossplane/$(PROJECT_NAME)
 
-PLATFORMS ?= linux_amd64 linux_arm64 darwin_amd64 windows_amd64
+PLATFORMS ?= linux_amd64 linux_arm64 linux_arm darwin_amd64 windows_amd64
 # -include will silently skip missing files, which allows us
 # to load those files with a target in the Makefile. If only
 # "include" was used, the make command would fail and refuse

--- a/cluster/images/crossplane/Dockerfile
+++ b/cluster/images/crossplane/Dockerfile
@@ -1,5 +1,4 @@
 FROM BASEIMAGE
-RUN apk --no-cache add ca-certificates bash
 
 ADD crossplane /usr/local/bin/
 EXPOSE 8080

--- a/cluster/images/crossplane/Makefile
+++ b/cluster/images/crossplane/Makefile
@@ -7,6 +7,7 @@ include ../../../build/makelib/common.mk
 # ====================================================================================
 #  Options
 IMAGE = $(BUILD_REGISTRY)/crossplane-$(ARCH)
+OSBASEIMAGE = gcr.io/distroless/static:nonroot
 include ../../../build/makelib/image.mk
 
 # ====================================================================================

--- a/cluster/images/crossplane/Makefile
+++ b/cluster/images/crossplane/Makefile
@@ -1,7 +1,7 @@
 # ====================================================================================
 # Setup Project
 
-PLATFORMS := linux_amd64 linux_arm64
+PLATFORMS := linux_amd64 linux_arm64 linux_arm
 include ../../../build/makelib/common.mk
 
 # ====================================================================================


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Adds the linux_arm go target so that crossplane and the cli can be run
on 32 bit arm platforms. Also updates to use `distroless/static:nonroot`
as base image. More can be read about the static distroless image [here](https://github.com/GoogleContainerTools/distroless/blob/master/base/README.md).

xref https://github.com/crossplane/crossplane/issues/1745

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

`make build.all BUILD_ARGS="--load"`

I have successfully reproduced our current CI build process locally with docker buildx and deployed the helm chart using the amd64 image. @Knappek has tested `linux_arm` binaries on rpi.

[contribution process]: https://git.io/fj2m9
