### PR TITLE
Specify platform on docker buildx build

### DIFF
--- a/cluster/images/crossplane/Makefile
+++ b/cluster/images/crossplane/Makefile
@@ -23,6 +23,7 @@ img.build:
 	@cp $(OUTPUT_DIR)/bin/$(OS)_$(ARCH)/crossplane $(IMAGE_TEMP_DIR) || $(FAIL)
 	@cd $(IMAGE_TEMP_DIR) && $(SED_CMD) 's|BASEIMAGE|$(OSBASEIMAGE)|g' Dockerfile || $(FAIL)
 	@docker build $(BUILD_ARGS) \
+		--platform linux/$(ARCH) \
 		-t $(IMAGE) \
 		$(IMAGE_TEMP_DIR) || $(FAIL)
 	@$(OK) docker build $(IMAGE)


### PR DESCRIPTION


<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Adds --platform arg to docker buildx command so that the appropriate
baseimage is pulled for the given platform.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

Existing builds have the wrong `Architecture` though they are added to the manifest with the correct platform:

```
🤖 (crossplane) docker buildx imagetools inspect crossplane/crossplane:master
Name:      docker.io/crossplane/crossplane:master
MediaType: application/vnd.docker.distribution.manifest.list.v2+json
Digest:    sha256:7f3cbf297b74f6b3dcf78899b5aacc0cb519202f58448a3b61e1c9eb62c556bd
           
Manifests: 
  Name:      docker.io/crossplane/crossplane:master@sha256:4ee181997a2cbea0d9766697361c5bca3351781bb439d31e801759f89630971d
  MediaType: application/vnd.docker.distribution.manifest.v2+json
  Platform:  linux/amd64
             
  Name:      docker.io/crossplane/crossplane:master@sha256:238ae22e49f27426c85d2421722e65472ca035aaad5ee35630a1008e50828ae8
  MediaType: application/vnd.docker.distribution.manifest.v2+json
  Platform:  linux/arm64
             
  Name:      docker.io/crossplane/crossplane:master@sha256:84a4bc5708aa3c2bc9be038525d666c6f209c790b9e928a486fdd7f5c7a6bef6
  MediaType: application/vnd.docker.distribution.manifest.v2+json
  Platform:  linux/arm


🤖 (crossplane) skopeo inspect docker://crossplane/crossplane-arm:master
{
    "Name": "docker.io/crossplane/crossplane-arm",
    "Digest": "sha256:84a4bc5708aa3c2bc9be038525d666c6f209c790b9e928a486fdd7f5c7a6bef6",
    "RepoTags": [
        "master",
        "v1.1.0-rc.21.g2bee08be",
        "v1.1.0-rc.23.ga18b4864",
        "v1.1.0-rc.25.gfe12fb31"
    ],
    "Created": "2021-01-12T03:37:44.50386726Z",
    "DockerVersion": "",
    "Labels": null,
    "Architecture": "amd64", <--- THIS SHOULD BE ARM
    "Os": "linux",
    "Layers": [
        "sha256:5749e56bea7178768b00aac0bf087558fccd5b8e0c807610618be7568459f359",
        "sha256:10a93f44f76d9147d2b06ffc888907350f3bdcb6e5a808776f577238b8243c17"
    ],
    "Env": [
        "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
        "SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt"
    ]
}

```

After specifying correct `--platform`, the manifest does use the correct `Architecture`:

```
🤖 (crossplane) docker inspect build-c0d442a4/crossplane-arm | grep Architecture
        "Architecture": "arm",
```

[contribution process]: https://git.io/fj2m9
