### PR TITLE
Warn user that kubectl plugin might be outdated

### DIFF
--- a/cmd/crank/install.go
+++ b/cmd/crank/install.go
@@ -19,17 +19,20 @@ package main
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"strings"
 
 	"github.com/alecthomas/kong"
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 
 	v1 "github.com/crossplane/crossplane/apis/pkg/v1"
 	typedclient "github.com/crossplane/crossplane/internal/client/clientset/versioned/typed/pkg/v1"
+	"github.com/crossplane/crossplane/internal/version"
 	"github.com/crossplane/crossplane/internal/xpkg"
 
 	// Load all the auth plugins for the cloud providers.
@@ -97,7 +100,7 @@ func (c *installConfigCmd) Run(k *kong.Context) error {
 	kube := typedclient.NewForConfigOrDie(ctrl.GetConfigOrDie())
 	res, err := kube.Configurations().Create(context.Background(), cr, metav1.CreateOptions{})
 	if err != nil {
-		return errors.Wrap(err, "cannot create configuration")
+		return errors.Wrap(warnIfNotFound(err), "cannot create configuration")
 	}
 	_, err = fmt.Fprintf(k.Stdout, "%s/%s created\n", strings.ToLower(v1.ConfigurationGroupKind), res.GetName())
 	return err
@@ -141,8 +144,19 @@ func (c *installProviderCmd) Run(k *kong.Context) error {
 	kube := typedclient.NewForConfigOrDie(ctrl.GetConfigOrDie())
 	res, err := kube.Providers().Create(context.Background(), cr, metav1.CreateOptions{})
 	if err != nil {
-		return errors.Wrap(err, "cannot create provider")
+		return errors.Wrap(warnIfNotFound(err), "cannot create provider")
 	}
 	_, err = fmt.Fprintf(k.Stdout, "%s/%s created\n", strings.ToLower(v1.ProviderGroupKind), res.GetName())
 	return err
+}
+
+func warnIfNotFound(err error) error {
+	serr, ok := err.(*apierrors.StatusError)
+	if !ok {
+		return err
+	}
+	if serr.ErrStatus.Code != http.StatusNotFound {
+		return err
+	}
+	return errors.WithMessagef(err, "kubectl-crossplane plugin %s might be out of date", version.New().GetVersionString())
 }


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

When outdated kubectl crossplane plugin is used to install provider or
configuration, user will face a generic and a bit misleading error
message of "the server could not find the resource." At this point user
won't have more context of what happened when in reality they might be
using older version of crossplane CLI plugin all along.

https://crossplane.slack.com/archives/CEG3T90A1/p1610142999359200 for a bit more context

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

- deploy the latest version of crossplane using `crossplane-master` chart
- manually check out tag `v0.13.0` and apply this patch and build a new crank binary
- use the binary to install `provider-aws:master` and make sure the warning is being shown properly

[contribution process]: https://git.io/fj2m9
