### PR TITLE
Add bidirectional patches to composite resources

### DIFF
--- a/cluster/charts/crossplane/crds/apiextensions.crossplane.io_compositions.yaml
+++ b/cluster/charts/crossplane/crds/apiextensions.crossplane.io_compositions.yaml
@@ -127,6 +127,7 @@ spec:
                             enum:
                             - FromCompositeFieldPath
                             - PatchSet
+                            - ToCompositeFieldPath
                             type: string
                         type: object
                       type: array
@@ -229,6 +230,7 @@ spec:
                             enum:
                             - FromCompositeFieldPath
                             - PatchSet
+                            - ToCompositeFieldPath
                             type: string
                         type: object
                       type: array

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/docker/docker v17.12.0-ce-rc1.0.20200926000217-2617742802f6+incompatible // indirect
 	github.com/google/go-cmp v0.5.2
 	github.com/google/go-containerregistry v0.2.1
+	github.com/imdario/mergo v0.3.11
 	github.com/pkg/errors v0.9.1
 	github.com/spf13/afero v1.4.1
 	gopkg.in/alecthomas/kingpin.v2 v2.2.6

--- a/go.sum
+++ b/go.sum
@@ -410,6 +410,8 @@ github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:
 github.com/imdario/mergo v0.3.5/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/imdario/mergo v0.3.10 h1:6q5mVkdH/vYmqngx7kZQTjJ5HRsx+ImorDIEQ+beJgc=
 github.com/imdario/mergo v0.3.10/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
+github.com/imdario/mergo v0.3.11 h1:3tnifQM4i+fbajXKBHXWEH+KvNHqojZ778UH75j3bGA=
+github.com/imdario/mergo v0.3.11/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=

--- a/internal/controller/apiextensions/claim/configurator.go
+++ b/internal/controller/apiextensions/claim/configurator.go
@@ -20,9 +20,10 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/imdario/mergo"
 	"github.com/pkg/errors"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/crossplane/crossplane-runtime/pkg/fieldpath"
 	"github.com/crossplane/crossplane-runtime/pkg/meta"
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
 	"github.com/crossplane/crossplane-runtime/pkg/resource/unstructured/claim"
@@ -30,19 +31,19 @@ import (
 	"github.com/crossplane/crossplane/internal/xcrd"
 )
 
-// Label keys.
 const (
-	LabelKeyNamePrefixForComposed = "crossplane.io/composite"
-	LabelKeyClaimName             = "crossplane.io/claim-name"
-	LabelKeyClaimNamespace        = "crossplane.io/claim-namespace"
+	errUnsupportedClaimSpec = "composite resource claim spec was not an object"
+	errUnsupportedDstObject = "destination object was not valid object"
+	errUnsupportedSrcObject = "source object was not valid object"
+
+	errMergeClaimSpec   = "unable to merge claim spec"
+	errMergeClaimStatus = "unable to merge claim status"
 )
 
-const errUnsupportedClaimSpec = "composite resource claim spec was not an object"
-
-// Configure the supplied composite resource. The composite resource name is
-// derived from the supplied claim, as {name}-{random-string}. The claim's
+// ConfigureComposite configures the supplied composite resource. The composite resource name
+// is derived from the supplied claim, as {name}-{random-string}. The claim's
 // external name annotation, if any, is propagated to the composite resource.
-func Configure(_ context.Context, cm resource.CompositeClaim, cp resource.Composite) error {
+func ConfigureComposite(_ context.Context, cm resource.CompositeClaim, cp resource.Composite) error {
 	// It's possible we're being asked to configure a statically provisioned
 	// composite resource in which case we should respect its existing name and
 	// external name.
@@ -74,20 +75,21 @@ func Configure(_ context.Context, cm resource.CompositeClaim, cp resource.Compos
 		return nil
 	}
 
-	// TODO(negz): Consider nesting all user-specified spec values under a
-	// predictable object like spec.parameters so we can propagate _only_ user
-	// specified fields. Maintaining a set of keys to delete here seems error
-	// prone. Note that deleting these keys isn't always necessary; the CRD will
-	// drop them if preserveUnknownFields is false, but that is not the default
-	// for pre-v1 CRDs.
-	i, _ := fieldpath.Pave(ucm.Object).GetValue("spec")
-	spec, ok := i.(map[string]interface{})
+	icmSpec := ucm.Object["spec"]
+	spec, ok := icmSpec.(map[string]interface{})
 	if !ok {
 		return errors.New(errUnsupportedClaimSpec)
 	}
 
-	_ = fieldpath.Pave(ucp.Object).SetValue("spec", filter(spec, xcrd.FilterClaimSpecProps...))
+	// Delete base claim fields when configuring composite spec
+	baseClaimSpec := xcrd.CompositeResourceClaimSpecProps()
 
+	// keep any necessary fields between claim and composite
+	for _, field := range xcrd.KeepClaimSpecProps {
+		delete(baseClaimSpec, field)
+	}
+	claimSpecFilter := xcrd.GetPropFields(baseClaimSpec)
+	ucp.Object["spec"] = filter(spec, claimSpecFilter...)
 	return nil
 }
 
@@ -106,4 +108,94 @@ func filter(in map[string]interface{}, keys ...string) map[string]interface{} {
 		out[k] = v
 	}
 	return out
+}
+
+// APIClaimConfigurator configures the supplied claims with fields
+// from the composite. This includes late-initializing spec values
+// and updating status fields in claim.
+type APIClaimConfigurator struct {
+	client client.Client
+}
+
+// NewAPIClaimConfigurator returns a APIClaimConfigurator.
+func NewAPIClaimConfigurator(client client.Client) *APIClaimConfigurator {
+	return &APIClaimConfigurator{client: client}
+}
+
+// Configure the supplied claims with fields from the composite.
+// This includes late-initializing spec values and updating status fields in claim.
+func (c *APIClaimConfigurator) Configure(ctx context.Context, cr resource.CompositeClaim, cp resource.Composite) error {
+	ucr, ok := cr.(*claim.Unstructured)
+	if !ok {
+		return nil
+	}
+	ucp, ok := cp.(*composite.Unstructured)
+	if !ok {
+		return nil
+	}
+
+	if err := merge(ucr.Object["status"], ucp.Object["status"],
+		// Status fields from composite overwrite non-empty fields in claim
+		withMergeOptions(mergo.WithOverride),
+		withSrcFilter(xcrd.GetPropFields(xcrd.CompositeResourceStatusProps())...)); err != nil {
+		return errors.Wrap(err, errMergeClaimStatus)
+	}
+
+	if err := c.client.Status().Update(ctx, cr); err != nil {
+		return errors.Wrap(err, errUpdateClaimStatus)
+	}
+
+	if err := merge(ucr.Object["spec"], ucp.Object["spec"],
+		withSrcFilter(xcrd.GetPropFields(xcrd.CompositeResourceSpecProps())...)); err != nil {
+		return errors.Wrap(err, errMergeClaimSpec)
+	}
+
+	return errors.Wrap(c.client.Update(ctx, cr), errUpdateClaim)
+}
+
+type mergeConfig struct {
+	mergeOptions []func(*mergo.Config)
+	srcfilter    []string
+}
+
+// withMergeOptions allows custom mergo.Config options
+func withMergeOptions(opts ...func(*mergo.Config)) func(*mergeConfig) {
+	return func(config *mergeConfig) {
+		config.mergeOptions = opts
+	}
+}
+
+// withSrcFilter filters supplied keys from src map before merging
+func withSrcFilter(keys ...string) func(*mergeConfig) {
+	return func(config *mergeConfig) {
+		config.srcfilter = keys
+	}
+}
+
+// merge a src map into dst map
+func merge(dst, src interface{}, opts ...func(*mergeConfig)) error {
+	if dst == nil || src == nil {
+		// Nothing available to merge if dst or src are nil.
+		// This can occur early on in reconciliation when the
+		// status subresource has not been set yet.
+		return nil
+	}
+
+	config := &mergeConfig{}
+
+	for _, opt := range opts {
+		opt(config)
+	}
+
+	dstMap, ok := dst.(map[string]interface{})
+	if !ok {
+		return errors.New(errUnsupportedDstObject)
+	}
+
+	srcMap, ok := src.(map[string]interface{})
+	if !ok {
+		return errors.New(errUnsupportedSrcObject)
+	}
+
+	return mergo.Merge(&dstMap, filter(srcMap, config.srcfilter...), config.mergeOptions...)
 }

--- a/internal/controller/apiextensions/claim/configurator_test.go
+++ b/internal/controller/apiextensions/claim/configurator_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/crossplane/crossplane-runtime/pkg/meta"
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
@@ -35,7 +36,7 @@ import (
 	"github.com/crossplane/crossplane/internal/xcrd"
 )
 
-func TestConfigure(t *testing.T) {
+func TestCompositeConfigure(t *testing.T) {
 	ns := "spacename"
 	name := "cool"
 	now := metav1.Now()
@@ -152,6 +153,10 @@ func TestConfigure(t *testing.T) {
 							"spec": map[string]interface{}{
 								"coolness": 23,
 
+								// These should be preserved.
+								"compositionRef":      "ref",
+								"compositionSelector": "ref",
+
 								// These should be filtered out.
 								"resourceRef":                "ref",
 								"writeConnectionSecretToRef": "ref",
@@ -173,7 +178,9 @@ func TestConfigure(t *testing.T) {
 								},
 							},
 							"spec": map[string]interface{}{
-								"coolness": int64(23),
+								"coolness":            23,
+								"compositionRef":      "ref",
+								"compositionSelector": "ref",
 							},
 						},
 					},
@@ -229,7 +236,7 @@ func TestConfigure(t *testing.T) {
 							"spec": map[string]interface{}{
 								// This should be overridden with the value of
 								// the equivalent claim field.
-								"coolness": int64(42),
+								"coolness": 42,
 							},
 						},
 					},
@@ -256,7 +263,7 @@ func TestConfigure(t *testing.T) {
 								},
 							},
 							"spec": map[string]interface{}{
-								"coolness": int64(23),
+								"coolness": 23,
 							},
 						},
 					},
@@ -267,12 +274,347 @@ func TestConfigure(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			got := Configure(tc.args.ctx, tc.args.cm, tc.args.cp)
+			got := ConfigureComposite(tc.args.ctx, tc.args.cm, tc.args.cp)
 			if diff := cmp.Diff(tc.want.err, got, test.EquateErrors()); diff != "" {
-				t.Errorf("b.Bind(...): %s\n-want error, +got error:\n%s\n", tc.reason, diff)
+				t.Errorf("ConfigureComposite(...): %s\n-want error, +got error:\n%s\n", tc.reason, diff)
 			}
 			if diff := cmp.Diff(tc.want.cp, tc.args.cp); diff != "" {
-				t.Errorf("b.Bind(...): %s\n-want, +got:\n%s\n", tc.reason, diff)
+				t.Errorf("ConfigureComposite(...): %s\n-want, +got:\n%s\n", tc.reason, diff)
+			}
+		})
+	}
+
+}
+
+func TestClaimConfigure(t *testing.T) {
+	errBoom := errors.New("boom")
+	ns := "spacename"
+	name := "cool"
+
+	type args struct {
+		cm     resource.CompositeClaim
+		cp     resource.Composite
+		client client.Client
+	}
+
+	type want struct {
+		cm  resource.CompositeClaim
+		err error
+	}
+
+	cases := map[string]struct {
+		reason string
+		args   args
+		want   want
+	}{
+		"MergeStatusClaimError": {
+			reason: "Should return an error if unable to merge status of claim",
+			args: args{
+				cm: &claim.Unstructured{
+					Unstructured: unstructured.Unstructured{
+						Object: map[string]interface{}{
+							"status": "notStatus",
+						},
+					},
+				},
+				cp: &composite.Unstructured{
+					Unstructured: unstructured.Unstructured{
+						Object: map[string]interface{}{
+							"status": "notStatus",
+						},
+					},
+				},
+			},
+			want: want{
+				cm: &claim.Unstructured{
+					Unstructured: unstructured.Unstructured{
+						Object: map[string]interface{}{
+							"status": "notStatus",
+						},
+					},
+				},
+				err: errors.Wrap(errors.New(errUnsupportedDstObject), errMergeClaimStatus),
+			},
+		},
+		"MergeStatusCompositeError": {
+			reason: "Should return an error if unable to merge status from composite",
+			args: args{
+				cm: &claim.Unstructured{
+					Unstructured: unstructured.Unstructured{
+						Object: map[string]interface{}{
+							"status": map[string]interface{}{},
+						},
+					},
+				},
+				cp: &composite.Unstructured{
+					Unstructured: unstructured.Unstructured{
+						Object: map[string]interface{}{
+							"status": "notStatus",
+						},
+					},
+				},
+			},
+			want: want{
+				cm: &claim.Unstructured{
+					Unstructured: unstructured.Unstructured{
+						Object: map[string]interface{}{
+							"status": map[string]interface{}{},
+						},
+					},
+				},
+				err: errors.Wrap(errors.New(errUnsupportedSrcObject), errMergeClaimStatus),
+			},
+		},
+		"UpdateStatusError": {
+			reason: "Should return an error if unable to update status",
+			args: args{
+				client: &test.MockClient{
+					MockStatusUpdate: test.NewMockStatusUpdateFn(errBoom),
+				},
+				cm: &claim.Unstructured{
+					Unstructured: unstructured.Unstructured{
+						Object: map[string]interface{}{
+							"spec":   map[string]interface{}{},
+							"status": map[string]interface{}{},
+						},
+					},
+				},
+				cp: &composite.Unstructured{
+					Unstructured: unstructured.Unstructured{
+						Object: map[string]interface{}{
+							"spec":   map[string]interface{}{},
+							"status": map[string]interface{}{},
+						},
+					},
+				},
+			},
+			want: want{
+				cm: &claim.Unstructured{
+					Unstructured: unstructured.Unstructured{
+						Object: map[string]interface{}{
+							"spec":   map[string]interface{}{},
+							"status": map[string]interface{}{},
+						},
+					},
+				},
+				err: errors.Wrap(errBoom, errUpdateClaimStatus),
+			},
+		},
+		"MergeSpecError": {
+			reason: "Should return an error if unable to merge spec",
+			args: args{
+				client: &test.MockClient{
+					MockStatusUpdate: test.NewMockStatusUpdateFn(nil),
+				},
+				cm: &claim.Unstructured{
+					Unstructured: unstructured.Unstructured{
+						Object: map[string]interface{}{
+							"spec":   "notSpec",
+							"status": map[string]interface{}{},
+						},
+					},
+				},
+				cp: &composite.Unstructured{
+					Unstructured: unstructured.Unstructured{
+						Object: map[string]interface{}{
+							"spec":   "notSpec",
+							"status": map[string]interface{}{},
+						},
+					},
+				},
+			},
+			want: want{
+				cm: &claim.Unstructured{
+					Unstructured: unstructured.Unstructured{
+						Object: map[string]interface{}{
+							"spec":   "notSpec",
+							"status": map[string]interface{}{},
+						},
+					},
+				},
+				err: errors.Wrap(errors.New(errUnsupportedDstObject), errMergeClaimSpec),
+			},
+		},
+		"UpdateClaimError": {
+			reason: "Should return an error if unable to update claim",
+			args: args{
+				client: &test.MockClient{
+					MockUpdate:       test.NewMockUpdateFn(errBoom),
+					MockStatusUpdate: test.NewMockStatusUpdateFn(nil),
+				},
+				cm: &claim.Unstructured{
+					Unstructured: unstructured.Unstructured{
+						Object: map[string]interface{}{
+							"spec":   map[string]interface{}{},
+							"status": map[string]interface{}{},
+						},
+					},
+				},
+				cp: &composite.Unstructured{
+					Unstructured: unstructured.Unstructured{
+						Object: map[string]interface{}{
+							"spec":   map[string]interface{}{},
+							"status": map[string]interface{}{},
+						},
+					},
+				},
+			},
+			want: want{
+				cm: &claim.Unstructured{
+					Unstructured: unstructured.Unstructured{
+						Object: map[string]interface{}{
+							"spec":   map[string]interface{}{},
+							"status": map[string]interface{}{},
+						},
+					},
+				},
+				err: errors.Wrap(errBoom, errUpdateClaim),
+			},
+		},
+		"LateInitializeClaim": {
+			reason: "Empty fields in claim should be late initialized from the composite",
+			args: args{
+				client: test.NewMockClient(),
+				cm: &claim.Unstructured{
+					Unstructured: unstructured.Unstructured{
+						Object: map[string]interface{}{
+							"metadata": map[string]interface{}{
+								"namespace": ns,
+								"name":      name,
+							},
+							"spec": map[string]interface{}{
+								"someField":                  "someValue",
+								"resourceRef":                "ref",
+								"writeConnectionSecretToRef": "ref",
+							},
+							"status": map[string]interface{}{},
+						},
+					},
+				},
+				cp: &composite.Unstructured{
+					Unstructured: unstructured.Unstructured{
+						Object: map[string]interface{}{
+							"metadata": map[string]interface{}{
+								"namespace": ns,
+								"name":      name + "-12345",
+							},
+							"spec": map[string]interface{}{
+								"coolness": 23,
+
+								// These should be filtered out.
+								"resourceRefs": "ref",
+								"claimRef":     "ref",
+							},
+							"status": map[string]interface{}{},
+						},
+					},
+				},
+			},
+			want: want{
+				cm: &claim.Unstructured{
+					Unstructured: unstructured.Unstructured{
+						Object: map[string]interface{}{
+							"metadata": map[string]interface{}{
+								"namespace": ns,
+								"name":      name,
+							},
+							"spec": map[string]interface{}{
+								"someField":                  "someValue",
+								"coolness":                   23,
+								"resourceRef":                "ref",
+								"writeConnectionSecretToRef": "ref",
+							},
+							"status": map[string]interface{}{},
+						},
+					},
+				},
+			},
+		},
+		"ConfigureStatus": {
+			reason: "Status of claim should be overwritten by the composite",
+			args: args{
+				client: test.NewMockClient(),
+				cm: &claim.Unstructured{
+					Unstructured: unstructured.Unstructured{
+						Object: map[string]interface{}{
+							"metadata": map[string]interface{}{
+								"namespace": ns,
+								"name":      name,
+							},
+							"spec": map[string]interface{}{
+								"resourceRef":                "ref",
+								"writeConnectionSecretToRef": "ref",
+							},
+							"status": map[string]interface{}{
+								"previousCoolness": 23,
+								"conditions": []map[string]interface{}{
+									{
+										"type": "someCondition",
+									},
+								},
+							},
+						},
+					},
+				},
+				cp: &composite.Unstructured{
+					Unstructured: unstructured.Unstructured{
+						Object: map[string]interface{}{
+							"metadata": map[string]interface{}{
+								"namespace": ns,
+								"name":      name + "-12345",
+							},
+							"spec": map[string]interface{}{
+								"resourceRefs": "ref",
+								"claimRef":     "ref",
+							},
+							"status": map[string]interface{}{
+								"previousCoolness": 28,
+								"conditions": []map[string]interface{}{
+									{
+										"type": "otherCondition",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: want{
+				cm: &claim.Unstructured{
+					Unstructured: unstructured.Unstructured{
+						Object: map[string]interface{}{
+							"metadata": map[string]interface{}{
+								"namespace": ns,
+								"name":      name,
+							},
+							"spec": map[string]interface{}{
+								"resourceRef":                "ref",
+								"writeConnectionSecretToRef": "ref",
+							},
+							"status": map[string]interface{}{
+								"previousCoolness": 28,
+								"conditions": []map[string]interface{}{
+									{
+										"type": "someCondition",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			c := NewAPIClaimConfigurator(tc.args.client)
+			got := c.Configure(context.Background(), tc.args.cm, tc.args.cp)
+			if diff := cmp.Diff(tc.want.err, got, test.EquateErrors()); diff != "" {
+				t.Errorf("c.Configure(...): %s\n-want error, +got error:\n%s\n", tc.reason, diff)
+			}
+			if diff := cmp.Diff(tc.want.cm, tc.args.cm); diff != "" {
+				t.Errorf("c.Configure(...): %s\n-want, +got:\n%s\n", tc.reason, diff)
 			}
 		})
 	}

--- a/internal/controller/apiextensions/claim/reconciler_test.go
+++ b/internal/controller/apiextensions/claim/reconciler_test.go
@@ -218,7 +218,7 @@ func TestReconcile(t *testing.T) {
 					WithClaimFinalizer(resource.FinalizerFns{
 						AddFinalizerFn: func(ctx context.Context, obj resource.Object) error { return nil },
 					}),
-					WithCompositeConfigurator(CompositeConfiguratorFn(func(ctx context.Context, cm resource.CompositeClaim, cp resource.Composite) error { return errBoom })),
+					WithCompositeConfigurator(ConfiguratorFn(func(ctx context.Context, cm resource.CompositeClaim, cp resource.Composite) error { return errBoom })),
 				},
 			},
 			want: want{
@@ -246,7 +246,7 @@ func TestReconcile(t *testing.T) {
 					WithClaimFinalizer(resource.FinalizerFns{
 						AddFinalizerFn: func(ctx context.Context, obj resource.Object) error { return nil },
 					}),
-					WithCompositeConfigurator(CompositeConfiguratorFn(func(ctx context.Context, cm resource.CompositeClaim, cp resource.Composite) error { return nil })),
+					WithCompositeConfigurator(ConfiguratorFn(func(ctx context.Context, cm resource.CompositeClaim, cp resource.Composite) error { return nil })),
 				},
 			},
 			want: want{
@@ -275,8 +275,39 @@ func TestReconcile(t *testing.T) {
 					WithClaimFinalizer(resource.FinalizerFns{
 						AddFinalizerFn: func(ctx context.Context, obj resource.Object) error { return nil },
 					}),
-					WithCompositeConfigurator(CompositeConfiguratorFn(func(ctx context.Context, cm resource.CompositeClaim, cp resource.Composite) error { return nil })),
+					WithCompositeConfigurator(ConfiguratorFn(func(ctx context.Context, cm resource.CompositeClaim, cp resource.Composite) error { return nil })),
 					WithBinder(BinderFn(func(ctx context.Context, cm resource.CompositeClaim, cp resource.Composite) error { return errBoom })),
+				},
+			},
+			want: want{
+				r: reconcile.Result{RequeueAfter: aShortWait},
+			},
+		},
+		"ClaimConfigureError": {
+			reason: "We should requeue after a short wait if we encounter an error configuring the claim resource",
+			args: args{
+				mgr: &fake.Manager{},
+				opts: []ReconcilerOption{
+					WithClientApplicator(resource.ClientApplicator{
+						Client: &test.MockClient{
+							MockGet: test.NewMockGetFn(nil, func(obj client.Object) error {
+								if o, ok := obj.(*claim.Unstructured); ok {
+									o.SetResourceReference(&corev1.ObjectReference{})
+								}
+								return nil
+							}),
+							MockStatusUpdate: test.NewMockStatusUpdateFn(nil),
+						},
+						Applicator: resource.ApplyFn(func(c context.Context, r client.Object, ao ...resource.ApplyOption) error {
+							return nil
+						}),
+					}),
+					WithClaimFinalizer(resource.FinalizerFns{
+						AddFinalizerFn: func(ctx context.Context, obj resource.Object) error { return nil },
+					}),
+					WithCompositeConfigurator(ConfiguratorFn(func(ctx context.Context, cm resource.CompositeClaim, cp resource.Composite) error { return nil })),
+					WithBinder(BinderFn(func(ctx context.Context, cm resource.CompositeClaim, cp resource.Composite) error { return nil })),
+					WithClaimConfigurator(ConfiguratorFn(func(ctx context.Context, cm resource.CompositeClaim, cp resource.Composite) error { return errBoom })),
 				},
 			},
 			want: want{
@@ -305,8 +336,9 @@ func TestReconcile(t *testing.T) {
 					WithClaimFinalizer(resource.FinalizerFns{
 						AddFinalizerFn: func(ctx context.Context, obj resource.Object) error { return nil },
 					}),
-					WithCompositeConfigurator(CompositeConfiguratorFn(func(ctx context.Context, cm resource.CompositeClaim, cp resource.Composite) error { return nil })),
+					WithCompositeConfigurator(ConfiguratorFn(func(ctx context.Context, cm resource.CompositeClaim, cp resource.Composite) error { return nil })),
 					WithBinder(BinderFn(func(ctx context.Context, cm resource.CompositeClaim, cp resource.Composite) error { return nil })),
+					WithClaimConfigurator(ConfiguratorFn(func(ctx context.Context, cm resource.CompositeClaim, cp resource.Composite) error { return nil })),
 				},
 			},
 			want: want{
@@ -338,8 +370,9 @@ func TestReconcile(t *testing.T) {
 					WithClaimFinalizer(resource.FinalizerFns{
 						AddFinalizerFn: func(ctx context.Context, obj resource.Object) error { return nil },
 					}),
-					WithCompositeConfigurator(CompositeConfiguratorFn(func(ctx context.Context, cm resource.CompositeClaim, cp resource.Composite) error { return nil })),
+					WithCompositeConfigurator(ConfiguratorFn(func(ctx context.Context, cm resource.CompositeClaim, cp resource.Composite) error { return nil })),
 					WithBinder(BinderFn(func(ctx context.Context, cm resource.CompositeClaim, cp resource.Composite) error { return nil })),
+					WithClaimConfigurator(ConfiguratorFn(func(ctx context.Context, cm resource.CompositeClaim, cp resource.Composite) error { return nil })),
 					WithConnectionPropagator(ConnectionPropagatorFn(func(ctx context.Context, to resource.LocalConnectionSecretOwner, from resource.ConnectionSecretOwner) (propagated bool, err error) {
 						return false, errBoom
 					})),
@@ -374,8 +407,9 @@ func TestReconcile(t *testing.T) {
 					WithClaimFinalizer(resource.FinalizerFns{
 						AddFinalizerFn: func(ctx context.Context, obj resource.Object) error { return nil },
 					}),
-					WithCompositeConfigurator(CompositeConfiguratorFn(func(ctx context.Context, cm resource.CompositeClaim, cp resource.Composite) error { return nil })),
+					WithCompositeConfigurator(ConfiguratorFn(func(ctx context.Context, cm resource.CompositeClaim, cp resource.Composite) error { return nil })),
 					WithBinder(BinderFn(func(ctx context.Context, cm resource.CompositeClaim, cp resource.Composite) error { return nil })),
+					WithClaimConfigurator(ConfiguratorFn(func(ctx context.Context, cm resource.CompositeClaim, cp resource.Composite) error { return nil })),
 					WithConnectionPropagator(ConnectionPropagatorFn(func(ctx context.Context, to resource.LocalConnectionSecretOwner, from resource.ConnectionSecretOwner) (propagated bool, err error) {
 						return true, nil
 					})),

--- a/internal/controller/apiextensions/composite/composed.go
+++ b/internal/controller/apiextensions/composite/composed.go
@@ -133,6 +133,19 @@ func (r *APIDryRunRenderer) Render(ctx context.Context, cp resource.Composite, c
 	return errors.Wrap(r.client.Create(ctx, cd, client.DryRunAll), errName)
 }
 
+// RenderComposite renders the supplied composite resource using the supplied composed
+// resource and template.
+func RenderComposite(_ context.Context, cp resource.Composite, cd resource.Composed, t v1.ComposedTemplate) error {
+	onlyPatches := []v1.PatchType{v1.PatchTypeToCompositeFieldPath}
+	for i, p := range t.Patches {
+		if err := p.Apply(cp, cd, onlyPatches...); err != nil {
+			return errors.Wrapf(err, errFmtPatch, i)
+		}
+	}
+
+	return nil
+}
+
 // An APIConnectionDetailsFetcher may use the API server to read connection
 // details from a Secret.
 type APIConnectionDetailsFetcher struct {

--- a/internal/xcrd/crd_test.go
+++ b/internal/xcrd/crd_test.go
@@ -80,7 +80,42 @@ func TestForCompositeResource(t *testing.T) {
 	singular := "coolcomposite"
 	plural := "coolcomposites"
 
-	schema := `{"required":["spec"],"properties":{"spec":{"required":["storageGB","engineVersion"],"properties":{"engineVersion":{"enum":["5.6","5.7"],"type":"string"},"storageGB":{"type":"integer"}},"type":"object"}},"type":"object"}`
+	schema := `
+{
+  "required": [
+    "spec"
+  ],
+  "properties": {
+    "spec": {
+      "required": [
+        "storageGB",
+        "engineVersion"
+      ],
+      "properties": {
+        "engineVersion": {
+          "enum": [
+            "5.6",
+            "5.7"
+          ],
+          "type": "string"
+        },
+        "storageGB": {
+          "type": "integer"
+        }
+      },
+      "type": "object"
+    },
+    "status": {
+      "properties": {
+        "phase": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    }
+  },
+  "type": "object"
+}`
 
 	d := &v1.CompositeResourceDefinition{
 		ObjectMeta: metav1.ObjectMeta{
@@ -239,6 +274,7 @@ func TestForCompositeResource(t *testing.T) {
 							"status": {
 								Type: "object",
 								Properties: map[string]extv1.JSONSchemaProps{
+									"phase": {Type: "string"},
 
 									// From CompositeResourceStatusProps()
 									"conditions": {
@@ -399,7 +435,39 @@ func TestForCompositeResourceClaim(t *testing.T) {
 	claimSingular := "coolclaim"
 	claimPlural := "coolclaims"
 
-	schema := `{"properties":{"spec":{"required":["storageGB","engineVersion"],"properties":{"engineVersion":{"enum":["5.6","5.7"],"type":"string"},"storageGB":{"type":"integer"}},"type":"object"}},"type":"object"}`
+	schema := `
+{
+	"properties": {
+		"spec": {
+			"required": [
+				"storageGB",
+				"engineVersion"
+			],
+			"properties": {
+				"engineVersion": {
+					"enum": [
+						"5.6",
+						"5.7"
+					],
+					"type": "string"
+				},
+				"storageGB": {
+					"type": "integer"
+				}
+			},
+			"type": "object"
+		},
+		"status": {
+      "properties": {
+        "phase": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    }
+	},
+	"type": "object"
+}`
 
 	d := &v1.CompositeResourceDefinition{
 		ObjectMeta: metav1.ObjectMeta{
@@ -549,6 +617,7 @@ func TestForCompositeResourceClaim(t *testing.T) {
 								"status": {
 									Type: "object",
 									Properties: map[string]extv1.JSONSchemaProps{
+										"phase": {Type: "string"},
 
 										// From CompositeResourceStatusProps()
 										"conditions": {

--- a/internal/xcrd/schemas.go
+++ b/internal/xcrd/schemas.go
@@ -25,9 +25,9 @@ const (
 	LabelKeyClaimNamespace        = "crossplane.io/claim-namespace"
 )
 
-// FilterClaimSpecProps is the list of XRC resource spec properties to filter
-// out when translating an XRC into an XR.
-var FilterClaimSpecProps = []string{"resourceRef", "writeConnectionSecretToRef"}
+// KeepClaimSpecProps is the list of XRC spec properties to keep
+// when translating an XRC into an XR.
+var KeepClaimSpecProps = []string{"compositionRef", "compositionSelector"}
 
 // TODO(negz): Add descriptions to schema fields.
 
@@ -238,4 +238,15 @@ func CompositeResourceClaimPrinterColumns() []extv1.CustomResourceColumnDefiniti
 			JSONPath: ".metadata.creationTimestamp",
 		},
 	}
+}
+
+// GetPropFields returns the fields from a map of schema properties
+func GetPropFields(props map[string]extv1.JSONSchemaProps) []string {
+	propFields := make([]string, len(props))
+	i := 0
+	for k := range props {
+		propFields[i] = k
+		i++
+	}
+	return propFields
 }


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes https://github.com/crossplane/crossplane/issues/1639.

Adds new patch type `ToCompositeFieldPath`. Adds composite render to composite reconciler to apply patches which modify composite from composed. Also adds ClaimConfigurator to claim reconciler to late initialize spec values from composite and update status fields from composite. 

Fixes https://github.com/crossplane/crossplane/issues/2081, which is strongly related, previously status fields from XRD's were not persisted but status fields within claims and compositions can now be patched from composed resources.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

Tested with an XRD which creates a deployment. Patches parameters to deployment spec and status back from deployment.

Tested both Composite and CompositeClaim resource.

 <details>
    <summary>xrd-deploy.yaml</summary>
  <br></br>
<head class="lang-yaml">

    apiVersion: apiextensions.crossplane.io/v1
    kind: CompositeResourceDefinition
    metadata:
      creationTimestamp: null
      name: compositedeploys.example.com
    spec:
      claimNames:
        kind: Deploy
        plural: deploys
        singular: deploy
      group: example.com
      names:
        kind: CompositeDeploy
        plural: compositedeploys
        singular: compositedeploy
      versions:
        - name: v1alpha1
          referenceable: true
          served: true
          schema:
            openAPIV3Schema:
              properties:
                spec:
                  type: object
                  properties:
                    parameters:
                      type: object
                      properties:
                        namespace:
                          type: string
                        image:
                          type: string
                        replicas:
                          type: integer
                status:
                  type: object
                  properties:
                    readyReplicas:
                      type: integer
                    updatedReplicas:
                      type: integer
</head>
</details>

<details>
    <summary>composition-deploy.yaml</summary>
  <br></br>
<head class="lang-yaml">

    apiVersion: apiextensions.crossplane.io/v1
    kind: Composition
    metadata:
      name: compositedeploys
    spec:
      compositeTypeRef:
        apiVersion: example.com/v1alpha1
        kind: CompositeDeploy
      resources:
        - base:
            apiVersion: apps/v1
            kind: Deployment
            metadata:
              name: xrd-test
              namespace: default
            spec:
              replicas: 1
              template:
                spec:
                  containers:
                    - name: default
                      image: busybox:latest
                      command:
                        - /bin/sh
                        - "-c"
                      args:
                        - "echo starting...; sleep infinity"
          patches:
            - fromFieldPath: metadata.name
              toFieldPath: metadata.name
              type: FromCompositeFieldPath
            - fromFieldPath: metadata.name
              toFieldPath: spec.selector.matchLabels[app]
              type: FromCompositeFieldPath
            - fromFieldPath: metadata.name
              toFieldPath: spec.template.metadata.labels[app]
              type: FromCompositeFieldPath
    
            # inputs
            - fromFieldPath: spec.parameters.namespace
              toFieldPath: metadata.namespace
              type: FromCompositeFieldPath
            - fromFieldPath: spec.parameters.image
              toFieldPath: spec.template.spec.containers[0].image
              type: FromCompositeFieldPath
            - fromFieldPath: spec.parameters.replicas
              toFieldPath: spec.replicas
              type: FromCompositeFieldPath
    
            # outputs
            - fromFieldPath: spec.replicas
              toFieldPath: spec.parameters.replicas
              type: ToCompositeFieldPath
            - fromFieldPath: status.readyReplicas
              toFieldPath: status.readyReplicas
              type: ToCompositeFieldPath
            - fromFieldPath: status.updatedReplicas
              toFieldPath: status.updatedReplicas
              type: ToCompositeFieldPath
          readinessChecks:
            - type: MatchString
              fieldPath: status.conditions[0].status
              matchString: "True"
</head>
</details>

 <details>
    <summary>composite-deploy.yaml</summary>
  <br></br>
<head class="lang-yaml">

    apiVersion: example.com/v1alpha1
    kind: CompositeDeploy
    metadata:
      name: composite-test
    spec:
      parameters:
        namespace: default
        image: busybox:1
        replicas: 1
</head>
</details>

 <details>
    <summary>claim-deploy.yaml</summary>
  <br></br>
<head class="lang-yaml">

    apiVersion: example.com/v1alpha1
    kind: Deploy
    metadata:
      name: claim-test
    spec:
      parameters:
        namespace: default
        image: busybox:1
        replicas: 2
</head>
</details>

[contribution process]: https://git.io/fj2m9
