### PR TITLE
Make dependency status fields optional in revisions

### DIFF
--- a/apis/pkg/v1/revision_types.go
+++ b/apis/pkg/v1/revision_types.go
@@ -90,9 +90,9 @@ type PackageRevisionStatus struct {
 	ObjectRefs []xpv1.TypedReference `json:"objectRefs,omitempty"`
 
 	// Dependency information.
-	FoundDependencies     int64 `json:"foundDependencies"`
-	InstalledDependencies int64 `json:"installedDependencies"`
-	InvalidDependencies   int64 `json:"invalidDependencies"`
+	FoundDependencies     int64 `json:"foundDependencies,omitempty"`
+	InstalledDependencies int64 `json:"installedDependencies,omitempty"`
+	InvalidDependencies   int64 `json:"invalidDependencies,omitempty"`
 
 	// PermissionRequests made by this package. The package declares that its
 	// controller needs these permissions to run. The RBAC manager is

--- a/apis/pkg/v1beta1/revision_types.go
+++ b/apis/pkg/v1beta1/revision_types.go
@@ -90,9 +90,9 @@ type PackageRevisionStatus struct {
 	ObjectRefs []xpv1.TypedReference `json:"objectRefs,omitempty"`
 
 	// Dependency information.
-	FoundDependencies     int64 `json:"foundDependencies"`
-	InstalledDependencies int64 `json:"installedDependencies"`
-	InvalidDependencies   int64 `json:"invalidDependencies"`
+	FoundDependencies     int64 `json:"foundDependencies,omitempty"`
+	InstalledDependencies int64 `json:"installedDependencies,omitempty"`
+	InvalidDependencies   int64 `json:"invalidDependencies,omitempty"`
 
 	// PermissionRequests made by this package. The package declares that its
 	// controller needs these permissions to run. The RBAC manager is

--- a/cluster/charts/crossplane/crds/pkg.crossplane.io_configurationrevisions.yaml
+++ b/cluster/charts/crossplane/crds/pkg.crossplane.io_configurationrevisions.yaml
@@ -209,10 +209,6 @@ spec:
                   - verbs
                   type: object
                 type: array
-            required:
-            - foundDependencies
-            - installedDependencies
-            - invalidDependencies
             type: object
         type: object
     served: true
@@ -410,10 +406,6 @@ spec:
                   - verbs
                   type: object
                 type: array
-            required:
-            - foundDependencies
-            - installedDependencies
-            - invalidDependencies
             type: object
         type: object
     served: true

--- a/cluster/charts/crossplane/crds/pkg.crossplane.io_providerrevisions.yaml
+++ b/cluster/charts/crossplane/crds/pkg.crossplane.io_providerrevisions.yaml
@@ -209,10 +209,6 @@ spec:
                   - verbs
                   type: object
                 type: array
-            required:
-            - foundDependencies
-            - installedDependencies
-            - invalidDependencies
             type: object
         type: object
     served: true
@@ -410,10 +406,6 @@ spec:
                   - verbs
                   type: object
                 type: array
-            required:
-            - foundDependencies
-            - installedDependencies
-            - invalidDependencies
             type: object
         type: object
     served: true


### PR DESCRIPTION


<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

In rare edge cases, having required status fields can cause problems
when trying to clean up old objects by manually removing finalizers.
kubectl is not able to edit the status subresource, meaning that if
these fields are not set then a user is stuck trying to remove the
finalizer because the patch is technically invalid. This would only be
the case if a user was updating from a pre-v1.0.0 Crossplane version and
had manually upgraded the revision CRDs to v1.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

_**Note: this is technically an API change, but it is backwards compatible.**_

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

See https://crossplane.slack.com/archives/CEG3T90A1/p1611152392084200 for context on how this addresses the described issue.

[contribution process]: https://git.io/fj2m9
