### PR TITLE
add configuration.packages to helm chart

### DIFF
--- a/cluster/charts/crossplane/README.md
+++ b/cluster/charts/crossplane/README.md
@@ -79,6 +79,8 @@ and their default values.
 | `securityContextCrossplane.runAsGroup` | Run as group for Crossplane | `2000` |
 | `securityContextCrossplane.allowPrivilegeEscalation` | Allow privilege escalation for Crossplane | `false` |
 | `securityContextCrossplane.readOnlyRootFilesystem` | ReadOnly root filesystem for Crossplane | `true` |
+| `provider.packages` | Provider packages to be installed | `[]` |
+| `configuration.packages` | Configuration packages to be installed | `[]` |
 | `packageCache.medium` | Storage medium for package cache. `Memory` means volume will be backed by tmpfs, which can be useful for development. | `""` |
 | `packageCache.sizeLimit` | Size limit for package cache. If medium is `Memory` then maximum usage would be the minimum of this value the sum of all memory limits on containers in the Crossplane pod. | `5Mi` |
 | `packageCache.pvc` | Name of the PersistentVolumeClaim to be used as the package cache. Providing a value will cause the default emptyDir volume to not be mounted. | `""` |

--- a/cluster/charts/crossplane/templates/configuration.yaml
+++ b/cluster/charts/crossplane/templates/configuration.yaml
@@ -1,0 +1,11 @@
+{{- range $.Values.configuration.packages }}
+{{ if ne . "" }}
+apiVersion: pkg.crossplane.io/v1
+kind: Configuration
+metadata:
+  name: {{ regexReplaceAll "(:|@).*" . "" | trim | replace "/" "-" }}
+spec:
+  package: {{ . | trim }}
+---
+{{ end }}
+{{- end }}

--- a/cluster/charts/crossplane/values.yaml.tmpl
+++ b/cluster/charts/crossplane/values.yaml.tmpl
@@ -13,6 +13,9 @@ args: {}
 provider:
   packages: []
 
+configuration:
+  packages: []
+
 imagePullSecrets:
 - dockerhub
 


### PR DESCRIPTION
Signed-off-by: Chee Wai Ooi <cheewaio@ca.ibm.com>

<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #2083 

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

```
bash-3.2$ helm install crossplane --namespace crossplane-system --set configuration.packages[0]='crossplane/my-org-infra:v0.1.0' /tmp/crossplane-1.1.0-rc.35.gdc2c4597-dirty.tgz
NAME: crossplane
LAST DEPLOYED: Wed Jan 20 13:34:12 2021
NAMESPACE: crossplane-system
STATUS: deployed
REVISION: 1
TEST SUITE: None
NOTES:
Release: crossplane

Chart Name: crossplane
Chart Description: Crossplane is an open source Kubernetes add-on that extends any cluster with the ability to provision and manage cloud infrastructure, services, and applications using kubectl, GitOps, or any tool that works with the Kubernetes API.
Chart Version: 1.1.0-rc.35.gdc2c4597-dirty
Chart Application Version: 1.1.0-rc.35.gdc2c4597-dirty

Kube Version: v1.16.15
bash-3.2$ kubectl get configuration
NAME                      INSTALLED   HEALTHY   PACKAGE                          AGE
crossplane-my-org-infra                         crossplane/my-org-infra:v0.1.0   33s
```

[contribution process]: https://git.io/fj2m9
