### PR TITLE
Give Crossplane and installed providers access to Lease API for leader election

### DIFF
--- a/cluster/charts/crossplane/templates/clusterrole.yaml
+++ b/cluster/charts/crossplane/templates/clusterrole.yaml
@@ -79,8 +79,10 @@ rules:
   - watch
 - apiGroups:
   - ""
+  - coordination.k8s.io
   resources:
   - configmaps
+  - leases
   verbs:
   - get
   - list
@@ -88,3 +90,4 @@ rules:
   - update
   - patch
   - watch
+  - delete

--- a/cluster/charts/crossplane/templates/rbac-manager-clusterrole.yaml
+++ b/cluster/charts/crossplane/templates/rbac-manager-clusterrole.yaml
@@ -79,8 +79,10 @@ rules:
   - "*"
 - apiGroups:
   - ""
+  - coordination.k8s.io
   resources:
   - configmaps
+  - leases
   verbs:
   - get
   - list
@@ -88,4 +90,5 @@ rules:
   - update
   - patch
   - watch
+  - delete
 {{- end}}

--- a/internal/controller/rbac/provider/roles/roles.go
+++ b/internal/controller/rbac/provider/roles/roles.go
@@ -45,6 +45,7 @@ const (
 	pluralEvents     = "events"
 	pluralConfigmaps = "configmaps"
 	pluralSecrets    = "secrets"
+	pluralLeases     = "leases"
 )
 
 var (
@@ -59,11 +60,12 @@ var (
 //
 // * Secrets for provider credentials and connection secrets.
 // * ConfigMaps for leader election.
+// * Leases for leader election.
 // * Events for debugging.
 var rulesSystemExtra = []rbacv1.PolicyRule{
 	{
-		APIGroups: []string{""},
-		Resources: []string{pluralSecrets, pluralConfigmaps, pluralEvents},
+		APIGroups: []string{"", "coordination/v1"},
+		Resources: []string{pluralSecrets, pluralConfigmaps, pluralEvents, pluralLeases},
 		Verbs:     verbsEdit,
 	},
 }


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Adds RBAC permissions for Crossplane / RBAC manager and provider to be able to perform leader election using the Kubernetes Lease API, which is used by default in controller-runtime v0.7.0+.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

Ran locally and verified install + provider install:

```
🤖 (crossplane) k get pkg

NAME                                      INSTALLED   HEALTHY   PACKAGE                           AGE
provider.pkg.crossplane.io/provider-aws   True        True      crossplane/provider-aws:v0.16.0   33s
```

```
🤖 (crossplane) k get pods -n crossplane-system
NAME                                         READY   STATUS    RESTARTS   AGE
crossplane-5cb4c69d4f-zk9px                  1/1     Running   0          2m23s
crossplane-rbac-manager-dc5988cd8-kqqqp      1/1     Running   0          2m23s
provider-aws-6b36ca882d8e-6bf947b897-zlk5m   1/1     Running   0          68s
```

```
🤖 (crossplane) k logs -n crossplane-system crossplane-5cb4c69d4f-zk9px
I0127 22:42:11.833353       1 leaderelection.go:243] attempting to acquire leader lease crossplane-system/crossplane-leader-election-core...
I0127 22:42:11.943696       1 leaderelection.go:253] successfully acquired lease crossplane-system/crossplane-leader-election-core
```

[contribution process]: https://git.io/fj2m9
