### PR TITLE
support for nodeSelector, tolerations, affinity in helm chart

### DIFF
--- a/cluster/charts/crossplane/README.md
+++ b/cluster/charts/crossplane/README.md
@@ -63,6 +63,7 @@ and their default values.
 
 | Parameter | Description | Default |
 | --- | --- | --- |
+| `affinity` | Enable affinity for Crossplane pod | `{}` |
 | `image.repository` | Image | `crossplane/crossplane` |
 | `image.tag` | Image tag | `master` |
 | `image.pullPolicy` | Image pull policy | `Always` |
@@ -70,6 +71,7 @@ and their default values.
 | `replicas` | The number of replicas to run for the Crossplane pods | `1` |
 | `deploymentStrategy` | The deployment strategy for the Crossplane and RBAC Manager (if enabled) pods | `RollingUpdate` |
 | `leaderElection` | Enable leader election for Crossplane Managers pod | `true` |
+| `nodeSelector` | Enable nodeSelector for Crossplane pod | `{}` |
 | `priorityClassName` | Priority class name for Crossplane and RBAC Manager (if enabled) pods | `""` |
 | `resourcesCrossplane.limits.cpu` | CPU resource limits for Crossplane | `100m` |
 | `resourcesCrossplane.limits.memory` | Memory resource limits for Crossplane | `512Mi` |
@@ -84,17 +86,20 @@ and their default values.
 | `packageCache.medium` | Storage medium for package cache. `Memory` means volume will be backed by tmpfs, which can be useful for development. | `""` |
 | `packageCache.sizeLimit` | Size limit for package cache. If medium is `Memory` then maximum usage would be the minimum of this value the sum of all memory limits on containers in the Crossplane pod. | `5Mi` |
 | `packageCache.pvc` | Name of the PersistentVolumeClaim to be used as the package cache. Providing a value will cause the default emptyDir volume to not be mounted. | `""` |
+| `tolerations` | Enable tolerations for Crossplane pod | `{}` |
 | `resourcesRBACManager.limits.cpu` | CPU resource limits for RBAC Manager | `100m` |
 | `resourcesRBACManager.limits.memory` | Memory resource limits for RBAC Manager | `512Mi` |
 | `resourcesRBACManager.requests.cpu` | CPU resource requests for RBAC Manager | `100m` |
 | `resourcesRBACManager.requests.memory` | Memory resource requests for RBAC Manager | `256Mi` |
-securityContextRBACManager:
 | `securityContextRBACManager.allowPrivilegeEscalation` | Allow privilege escalation for RBAC Manager | `false` |
 | `securityContextRBACManager.readOnlyRootFilesystem` | ReadOnly root filesystem for RBAC Manager | `true` |
+| `rbacManager.affinity` | Enable affinity for RBAC Managers pod | `{}` |
 | `rbacManager.deploy` | Deploy RBAC Manager and its required roles | `true` |
+| `rbacManager.nodeSelector` | Enable nodeSelector for RBAC Managers pod | `{}` |
 | `rbacManager.replicas` | The number of replicas to run for the RBAC Manager pods | `1` |
 | `rbacManager.leaderElection` | Enable leader election for RBAC Managers pod | `true` |
 | `rbacManager.managementPolicy`| The extent to which the RBAC manager will manage permissions. `All` indicates to manage all Crossplane controller and user roles. `Basic` indicates to only manage Crossplane controller roles and the `crossplane-admin`, `crossplane-edit`, and `crossplane-view` user roles. | `All` |
+| `rbacManager.tolerations` | Enable tolerations for RBAC Managers pod | `{}` |
 | `alpha.oam.enabled` | Deploy the `crossplane/oam-kubernetes-runtime` Helm chart | `false` |
 | `metrics.enabled` | Expose Crossplane and RBAC Manager metrics endpoint | `false` |
 

--- a/cluster/charts/crossplane/templates/deployment.yaml
+++ b/cluster/charts/crossplane/templates/deployment.yaml
@@ -70,3 +70,12 @@ spec:
           medium: {{ .Values.packageCache.medium }}
           sizeLimit: {{ .Values.packageCache.sizeLimit }}
         {{- end }}
+      {{- if .Values.nodeSelector }}
+      nodeSelector: {{ toYaml .Values.nodeSelector | nindent 8 }}
+      {{- end }}
+      {{- if .Values.tolerations }}
+      tolerations: {{ toYaml .Values.tolerations | nindent 8 }}
+      {{- end }}
+      {{- if .Values.affinity }}
+      affinity: {{ toYaml .Values.affinity | nindent 8 }}
+      {{- end }}

--- a/cluster/charts/crossplane/templates/rbac-manager-deployment.yaml
+++ b/cluster/charts/crossplane/templates/rbac-manager-deployment.yaml
@@ -57,4 +57,13 @@ spec:
         env:
           - name: LEADER_ELECTION
             value: "{{ .Values.rbacManager.leaderElection }}"
+      {{- if .Values.rbacManager.nodeSelector }}
+      nodeSelector: {{ toYaml .Values.rbacManager.nodeSelector | nindent 8 }}
+      {{- end }}
+      {{- if .Values.rbacManager.tolerations }}
+      tolerations: {{ toYaml .Values.rbacManager.tolerations | nindent 8 }}
+      {{- end }}
+      {{- if .Values.rbacManager.affinity }}
+      affinity: {{ toYaml .Values.rbacManager.affinity | nindent 8 }}
+      {{- end }}
 {{- end}}

--- a/cluster/charts/crossplane/values.yaml.tmpl
+++ b/cluster/charts/crossplane/values.yaml.tmpl
@@ -7,6 +7,10 @@ image:
   tag: %%VERSION%%
   pullPolicy: Always
 
+nodeSelector: {}
+tolerations: {}
+affinity: {}
+
 leaderElection: true
 args: {}
 
@@ -25,6 +29,9 @@ rbacManager:
   managementPolicy: All
   leaderElection: true
   args: {}
+  nodeSelector: {}
+  tolerations: {}
+  affinity: {}
 
 priorityClassName: ""
 

--- a/docs/reference/install.md
+++ b/docs/reference/install.md
@@ -73,29 +73,45 @@ and their default values.
 
 | Parameter | Description | Default |
 | --- | --- | --- |
+| `affinity` | Enable affinity for Crossplane pod | `{}` |
 | `image.repository` | Image | `crossplane/crossplane` |
 | `image.tag` | Image tag | `master` |
 | `image.pullPolicy` | Image pull policy | `Always` |
 | `imagePullSecrets` | Names of image pull secrets to use | `dockerhub` |
-| `replicas` | The number of replicas to run for the Crossplane and RBAC Manager (if enabled) pods | `1` |
+| `replicas` | The number of replicas to run for the Crossplane pods | `1` |
 | `deploymentStrategy` | The deployment strategy for the Crossplane and RBAC Manager (if enabled) pods | `RollingUpdate` |
+| `leaderElection` | Enable leader election for Crossplane Managers pod | `true` |
+| `nodeSelector` | Enable nodeSelector for Crossplane pod | `{}` |
 | `priorityClassName` | Priority class name for Crossplane and RBAC Manager (if enabled) pods | `""` |
 | `resourcesCrossplane.limits.cpu` | CPU resource limits for Crossplane | `100m` |
 | `resourcesCrossplane.limits.memory` | Memory resource limits for Crossplane | `512Mi` |
 | `resourcesCrossplane.requests.cpu` | CPU resource requests for Crossplane | `100m` |
 | `resourcesCrossplane.requests.memory` | Memory resource requests for Crossplane | `256Mi` |
+| `securityContextCrossplane.runAsUser` | Run as user for Crossplane | `2000` |
+| `securityContextCrossplane.runAsGroup` | Run as group for Crossplane | `2000` |
+| `securityContextCrossplane.allowPrivilegeEscalation` | Allow privilege escalation for Crossplane | `false` |
+| `securityContextCrossplane.readOnlyRootFilesystem` | ReadOnly root filesystem for Crossplane | `true` |
+| `provider.packages` | The list of Provider packages to install together with Crossplane | `[]` |
+| `configuration.packages` | The list of Configuration packages to install together with Crossplane | `[]` |
 | `packageCache.medium` | Storage medium for package cache. `Memory` means volume will be backed by tmpfs, which can be useful for development. | `""` |
 | `packageCache.sizeLimit` | Size limit for package cache. If medium is `Memory` then maximum usage would be the minimum of this value the sum of all memory limits on containers in the Crossplane pod. | `5Mi` |
 | `packageCache.pvc` | Name of the PersistentVolumeClaim to be used as the package cache. Providing a value will cause the default emptyDir volume to not be mounted. | `""` |
+| `tolerations` | Enable tolerations for Crossplane pod | `{}` |
 | `resourcesRBACManager.limits.cpu` | CPU resource limits for RBAC Manager | `100m` |
 | `resourcesRBACManager.limits.memory` | Memory resource limits for RBAC Manager | `512Mi` |
 | `resourcesRBACManager.requests.cpu` | CPU resource requests for RBAC Manager | `100m` |
 | `resourcesRBACManager.requests.memory` | Memory resource requests for RBAC Manager | `256Mi` |
+| `securityContextRBACManager.allowPrivilegeEscalation` | Allow privilege escalation for RBAC Manager | `false` |
+| `securityContextRBACManager.readOnlyRootFilesystem` | ReadOnly root filesystem for RBAC Manager | `true` |
+| `rbacManager.affinity` | Enable affinity for RBAC Managers pod | `{}` |
 | `rbacManager.deploy` | Deploy RBAC Manager and its required roles | `true` |
+| `rbacManager.nodeSelector` | Enable nodeSelector for RBAC Managers pod | `{}` |
+| `rbacManager.replicas` | The number of replicas to run for the RBAC Manager pods | `1` |
+| `rbacManager.leaderElection` | Enable leader election for RBAC Managers pod | `true` |
 | `rbacManager.managementPolicy`| The extent to which the RBAC manager will manage permissions. `All` indicates to manage all Crossplane controller and user roles. `Basic` indicates to only manage Crossplane controller roles and the `crossplane-admin`, `crossplane-edit`, and `crossplane-view` user roles. | `All` |
+| `rbacManager.tolerations` | Enable tolerations for RBAC Managers pod | `{}` |
 | `alpha.oam.enabled` | Deploy the `crossplane/oam-kubernetes-runtime` Helm chart | `false` |
-| `provider.packages` | The list of Provider packages to install together with Crossplane | `[]` |
-| `configuration.packages` | The list of Configuration packages to install together with Crossplane | `[]` |
+| `metrics.enabled` | Expose Crossplane and RBAC Manager metrics endpoint | `false` |
 
 ### Command Line
 


### PR DESCRIPTION
Signed-off-by: smcavallo <smcavallo@hotmail.com>

<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes
See - https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/
Allows for setting nodeSelector, tolerations, affinity in helm chart
Useful for keeping crossplane pods on kubernetes nodes of a specific architecture or while designing a deployment for high availability

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #

I have:

- [X] Read and followed Crossplane's [contribution process].
- [X] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
Below command results in no change in behavior
`helm template --values=values.yaml .`

when added to values.yaml
```
nodeSelector:
  kubernetes.io/os: linux
  kubernetes.io/arch: amd64
tolerations: {}
affinity: {}
```
the same command results in
```
---
# Source: crossplane/templates/deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: crossplane
  labels:
    app: crossplane
    chart: crossplane-0.0.1
    release: RELEASE-NAME
    heritage: Helm
spec:
  replicas: 1
  selector:
    matchLabels:
      app: crossplane
      release: RELEASE-NAME
  strategy:
    type: RollingUpdate
  template:
    metadata:
      labels:
        app: crossplane
        release: RELEASE-NAME
    spec:
      serviceAccountName: crossplane
      containers:
      - image: crossplane/crossplane:asdfasdf
        imagePullPolicy: Always
        name: crossplane
        resources:
            limits:
              cpu: 100m
              memory: 512Mi
            requests:
              cpu: 100m
              memory: 256Mi
        securityContext:
            allowPrivilegeEscalation: false
            readOnlyRootFilesystem: true
            runAsGroup: 2000
            runAsUser: 2000
        env:
          - name: POD_NAMESPACE
            valueFrom:
              fieldRef:
                fieldPath: metadata.namespace
          - name: LEADER_ELECTION
            value: "true"
        volumeMounts:
          - mountPath: /cache
            name: package-cache
      volumes:
      - name: package-cache
        emptyDir:
          medium:
          sizeLimit: 5Mi
      nodeSelector:
        kubernetes.io/arch: amd64
        kubernetes.io/os: linux
```


[contribution process]: https://git.io/fj2m9
