### PR TITLE
Do not build with cloud provider keychains for pkg manager

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,7 @@ GO_TEST_PARALLEL := $(shell echo $$(( $(NPROCS) / 2 )))
 GO_STATIC_PACKAGES = $(GO_PROJECT)/cmd/crossplane $(GO_PROJECT)/cmd/crank
 GO_LDFLAGS += -X $(GO_PROJECT)/internal/version.version=$(VERSION)
 GO_SUBDIRS += cmd internal apis
+# disables credential providers for pulling package images
 GO_TAGS += disable_gcp disable_aws disable_azure
 GO111MODULE = on
 -include build/makelib/golang.mk

--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,7 @@ GO_TEST_PARALLEL := $(shell echo $$(( $(NPROCS) / 2 )))
 GO_STATIC_PACKAGES = $(GO_PROJECT)/cmd/crossplane $(GO_PROJECT)/cmd/crank
 GO_LDFLAGS += -X $(GO_PROJECT)/internal/version.version=$(VERSION)
 GO_SUBDIRS += cmd internal apis
+GO_TAGS += disable_gcp disable_aws disable_azure
 GO111MODULE = on
 -include build/makelib/golang.mk
 


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Currently Crossplane does not allow for configuring a pod to use the
cloud provider keychain to fetch package images. Including the
functionality results in confusing errors being logged by the
anonymously imported cloud provider credential providers in k8schain.
This updates the build to exclude modules.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

In addition to this, we don't formally document the ability to use these credential providers, and they can cause issues, such as those described in https://github.com/kubernetes/kubernetes/pull/100686. `go-containerregistry` maintains a fork of these providers so that they don't have to take a dependency on k/k (https://github.com/vdemeester/k8s-pkg-credentialprovider), but this makes any modifications subject to long release cycles and lots of rounds of approval.

I would prefer to eliminate this dependency until we officially document support for it (if ever).


I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

Tested and confirmed that this eliminates the spurious logs _and_ eliminates issues with http client getting hung in network proxies.

[contribution process]: https://git.io/fj2m9
