### PR TITLE
fromFieldPath in secret

### DIFF
--- a/apis/apiextensions/v1/composition_types.go
+++ b/apis/apiextensions/v1/composition_types.go
@@ -543,6 +543,16 @@ func (s *ConvertTransform) Resolve(input interface{}) (interface{}, error) {
 	return f(input)
 }
 
+// A ConnectionDetailType is a type of connection detail.
+type ConnectionDetailType string
+
+// ConnectionDetailType types.
+const (
+	ConnectionDetailFromConnectionSecretKey ConnectionDetailType = "FromConnectionSecretKey" // Default
+	ConnectionDetailFromFieldPath           ConnectionDetailType = "FromFieldPath"
+	ConnectionDetailValue                   ConnectionDetailType = "Value"
+)
+
 // ConnectionDetail includes the information about the propagation of the connection
 // information from one secret to another.
 type ConnectionDetail struct {
@@ -552,15 +562,22 @@ type ConnectionDetail struct {
 	// +optional
 	Name *string `json:"name,omitempty"`
 
+	// Type sets the connection detail fetching behaviour to be used. Each connection detail type may require
+	// its' own fields to be set on the ConnectionDetail object.
+	// +optional
+	// +kubebuilder:validation:Enum=FromConnectionSecretKey;FromFieldPath;Value
+	// +kubebuilder:default=FromConnectionSecretKey
+	Type ConnectionDetailType `json:"type,omitempty"`
+
 	// FromConnectionSecretKey is the key that will be used to fetch the value
 	// from the given target resource's secret
 	// +optional
 	FromConnectionSecretKey *string `json:"fromConnectionSecretKey,omitempty"`
 
-	// FromResourceFieldPath is the path of the field on the composed resource whose value
-	// to be used as input. Name must be specified.
+	// FromFieldPath is the path of the field on the composed resource whose value
+	// to be used as input. Name must be specified if the type is FromFieldPath is specified.
 	// +optional
-	FromResourceFieldPath *string `json:"fromResourceFieldPath,omitempty"`
+	FromFieldPath *string `json:"fromFieldPath,omitempty"`
 
 	// Value that will be propagated to the connection secret of the composition
 	// instance. Typically you should use FromConnectionSecretKey instead, but

--- a/apis/apiextensions/v1/composition_types.go
+++ b/apis/apiextensions/v1/composition_types.go
@@ -208,7 +208,7 @@ type Patch struct {
 	// +kubebuilder:default=FromCompositeFieldPath
 	Type PatchType `json:"type,omitempty"`
 
-	// FromFieldPath is the path of the field on the upstream resource whose value
+	// FromFieldPath is the path of the field on the composed resource whose value
 	// to be used as input. Required when type is FromCompositeFieldPath.
 	// +optional
 	FromFieldPath *string `json:"fromFieldPath,omitempty"`
@@ -553,9 +553,14 @@ type ConnectionDetail struct {
 	Name *string `json:"name,omitempty"`
 
 	// FromConnectionSecretKey is the key that will be used to fetch the value
-	// from the given target resource.
+	// from the given target resource's secret
 	// +optional
 	FromConnectionSecretKey *string `json:"fromConnectionSecretKey,omitempty"`
+
+	// FromResourceFieldPath is the path of the field on the composed resource whose value
+	// to be used as input. Name must be specified.
+	// +optional
+	FromResourceFieldPath *string `json:"fromResourceFieldPath,omitempty"`
 
 	// Value that will be propagated to the connection secret of the composition
 	// instance. Typically you should use FromConnectionSecretKey instead, but

--- a/apis/apiextensions/v1/zz_generated.deepcopy.go
+++ b/apis/apiextensions/v1/zz_generated.deepcopy.go
@@ -361,8 +361,8 @@ func (in *ConnectionDetail) DeepCopyInto(out *ConnectionDetail) {
 		*out = new(string)
 		**out = **in
 	}
-	if in.FromResourceFieldPath != nil {
-		in, out := &in.FromResourceFieldPath, &out.FromResourceFieldPath
+	if in.FromFieldPath != nil {
+		in, out := &in.FromFieldPath, &out.FromFieldPath
 		*out = new(string)
 		**out = **in
 	}

--- a/apis/apiextensions/v1/zz_generated.deepcopy.go
+++ b/apis/apiextensions/v1/zz_generated.deepcopy.go
@@ -361,6 +361,11 @@ func (in *ConnectionDetail) DeepCopyInto(out *ConnectionDetail) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.FromResourceFieldPath != nil {
+		in, out := &in.FromResourceFieldPath, &out.FromResourceFieldPath
+		*out = new(string)
+		**out = **in
+	}
 	if in.Value != nil {
 		in, out := &in.Value, &out.Value
 		*out = new(string)

--- a/cluster/charts/crossplane/crds/apiextensions.crossplane.io_compositions.yaml
+++ b/cluster/charts/crossplane/crds/apiextensions.crossplane.io_compositions.yaml
@@ -65,7 +65,7 @@ spec:
                         description: Patch objects are applied between composite and composed resources. Their behaviour depends on the Type selected. The default Type, FromCompositeFieldPath, copies a value from the composite resource to the composed resource, applying any defined transformers.
                         properties:
                           fromFieldPath:
-                            description: FromFieldPath is the path of the field on the upstream resource whose value to be used as input. Required when type is FromCompositeFieldPath.
+                            description: FromFieldPath is the path of the field on the composed resource whose value to be used as input. Required when type is FromCompositeFieldPath.
                             type: string
                           patchSetName:
                             description: PatchSetName to include patches from. Required when type is PatchSet.
@@ -152,7 +152,10 @@ spec:
                         description: ConnectionDetail includes the information about the propagation of the connection information from one secret to another.
                         properties:
                           fromConnectionSecretKey:
-                            description: FromConnectionSecretKey is the key that will be used to fetch the value from the given target resource.
+                            description: FromConnectionSecretKey is the key that will be used to fetch the value from the given target resource's secret
+                            type: string
+                          fromResourceFieldPath:
+                            description: FromResourceFieldPath is the path of the field on the composed resource whose value to be used as input. Name must be specified.
                             type: string
                           name:
                             description: Name of the connection secret key that will be propagated to the connection secret of the composition instance. Leave empty if you'd like to use the same key name.
@@ -168,7 +171,7 @@ spec:
                         description: Patch objects are applied between composite and composed resources. Their behaviour depends on the Type selected. The default Type, FromCompositeFieldPath, copies a value from the composite resource to the composed resource, applying any defined transformers.
                         properties:
                           fromFieldPath:
-                            description: FromFieldPath is the path of the field on the upstream resource whose value to be used as input. Required when type is FromCompositeFieldPath.
+                            description: FromFieldPath is the path of the field on the composed resource whose value to be used as input. Required when type is FromCompositeFieldPath.
                             type: string
                           patchSetName:
                             description: PatchSetName to include patches from. Required when type is PatchSet.

--- a/cluster/charts/crossplane/crds/apiextensions.crossplane.io_compositions.yaml
+++ b/cluster/charts/crossplane/crds/apiextensions.crossplane.io_compositions.yaml
@@ -154,11 +154,19 @@ spec:
                           fromConnectionSecretKey:
                             description: FromConnectionSecretKey is the key that will be used to fetch the value from the given target resource's secret
                             type: string
-                          fromResourceFieldPath:
-                            description: FromResourceFieldPath is the path of the field on the composed resource whose value to be used as input. Name must be specified.
+                          fromFieldPath:
+                            description: FromFieldPath is the path of the field on the composed resource whose value to be used as input. Name must be specified if the type is FromFieldPath is specified.
                             type: string
                           name:
                             description: Name of the connection secret key that will be propagated to the connection secret of the composition instance. Leave empty if you'd like to use the same key name.
+                            type: string
+                          type:
+                            default: FromConnectionSecretKey
+                            description: Type sets the connection detail fetching behaviour to be used. Each connection detail type may require its' own fields to be set on the ConnectionDetail object.
+                            enum:
+                            - FromConnectionSecretKey
+                            - FromFieldPath
+                            - Value
                             type: string
                           value:
                             description: Value that will be propagated to the connection secret of the composition instance. Typically you should use FromConnectionSecretKey instead, but an explicit value may be set to inject a fixed, non-sensitive connection secret values, for example a well-known port. Supercedes FromConnectionSecretKey when set.

--- a/internal/controller/apiextensions/composite/composed_test.go
+++ b/internal/controller/apiextensions/composite/composed_test.go
@@ -18,6 +18,7 @@ package composite
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -189,9 +190,11 @@ func TestFetch(t *testing.T) {
 				t: v1.ComposedTemplate{ConnectionDetails: []v1.ConnectionDetail{
 					{
 						FromConnectionSecretKey: pointer.StringPtr("bar"),
+						Type:                    v1.ConnectionDetailFromConnectionSecretKey,
 					},
 					{
 						Name:  pointer.StringPtr("fixed"),
+						Type:  v1.ConnectionDetailValue,
 						Value: pointer.StringPtr("value"),
 					},
 				}},
@@ -233,25 +236,21 @@ func TestFetch(t *testing.T) {
 				t: v1.ComposedTemplate{ConnectionDetails: []v1.ConnectionDetail{
 					{
 						FromConnectionSecretKey: pointer.StringPtr("bar"),
+						Type:                    v1.ConnectionDetailFromConnectionSecretKey,
 					},
 					{
 						FromConnectionSecretKey: pointer.StringPtr("none"),
+						Type:                    v1.ConnectionDetailFromConnectionSecretKey,
 					},
 					{
 						Name:                    pointer.StringPtr("convfoo"),
 						FromConnectionSecretKey: pointer.StringPtr("foo"),
+						Type:                    v1.ConnectionDetailFromConnectionSecretKey,
 					},
 					{
 						Name:  pointer.StringPtr("fixed"),
 						Value: pointer.StringPtr("value"),
-					},
-					{
-						// Entries with only a name are silently ignored.
-						Name: pointer.StringPtr("missingvalue"),
-					},
-					{
-						// Entries with only a value are silently ignored.
-						Value: pointer.StringPtr("missingname"),
+						Type:  v1.ConnectionDetailValue,
 					},
 				}},
 			},
@@ -261,6 +260,140 @@ func TestFetch(t *testing.T) {
 					"bar":     s.Data["bar"],
 					"fixed":   []byte("value"),
 				},
+			},
+		},
+		"ConnectionDetailValueNotSet": {
+			reason: "Should error if Value type value is not set",
+			args: args{
+				kube: &test.MockClient{MockGet: func(_ context.Context, key client.ObjectKey, obj client.Object) error {
+					if sobj, ok := obj.(*corev1.Secret); ok {
+						if key.Name == sref.Name && key.Namespace == sref.Namespace {
+							s.DeepCopyInto(sobj)
+							return nil
+						}
+					}
+					t.Errorf("wrong secret is queried")
+					return errBoom
+				}},
+				cd: &fake.Composed{
+					ConnectionSecretWriterTo: fake.ConnectionSecretWriterTo{Ref: sref},
+				},
+				t: v1.ComposedTemplate{ConnectionDetails: []v1.ConnectionDetail{
+					{
+						Name: pointer.StringPtr("missingvalue"),
+						Type: v1.ConnectionDetailValue,
+					},
+				}},
+			},
+			want: want{
+				err: fmt.Errorf(errConnDetailVal, v1.ConnectionDetailValue),
+			},
+		},
+		"ErrConnectionDetailNameNotSet": {
+			reason: "Should error if Value type name is not set",
+			args: args{
+				kube: &test.MockClient{MockGet: func(_ context.Context, key client.ObjectKey, obj client.Object) error {
+					if sobj, ok := obj.(*corev1.Secret); ok {
+						if key.Name == sref.Name && key.Namespace == sref.Namespace {
+							s.DeepCopyInto(sobj)
+							return nil
+						}
+					}
+					t.Errorf("wrong secret is queried")
+					return errBoom
+				}},
+				cd: &fake.Composed{
+					ConnectionSecretWriterTo: fake.ConnectionSecretWriterTo{Ref: sref},
+				},
+				t: v1.ComposedTemplate{ConnectionDetails: []v1.ConnectionDetail{
+					{
+						Value: pointer.StringPtr("missingname"),
+						Type:  v1.ConnectionDetailValue,
+					},
+				}},
+			},
+			want: want{
+				err: fmt.Errorf(errConnDetailKey, v1.ConnectionDetailValue),
+			},
+		},
+		"ErrConnectionDetailFromConnectionSecretKeyNotSet": {
+			reason: "Should error if ConnectionDetailFromConnectionSecretKey type FromConnectionSecretKey is not set",
+			args: args{
+				kube: &test.MockClient{MockGet: func(_ context.Context, key client.ObjectKey, obj client.Object) error {
+					if sobj, ok := obj.(*corev1.Secret); ok {
+						if key.Name == sref.Name && key.Namespace == sref.Namespace {
+							s.DeepCopyInto(sobj)
+							return nil
+						}
+					}
+					t.Errorf("wrong secret is queried")
+					return errBoom
+				}},
+				cd: &fake.Composed{
+					ConnectionSecretWriterTo: fake.ConnectionSecretWriterTo{Ref: sref},
+				},
+				t: v1.ComposedTemplate{ConnectionDetails: []v1.ConnectionDetail{
+					{
+						Type: v1.ConnectionDetailFromConnectionSecretKey,
+					},
+				}},
+			},
+			want: want{
+				err: fmt.Errorf(errConnDetailKey, v1.ConnectionDetailFromConnectionSecretKey),
+			},
+		},
+		"ErrConnectionDetailFromFieldPathNotSet": {
+			reason: "Should error if ConnectionDetailFromFieldPath type FromFieldPath is not set",
+			args: args{
+				kube: &test.MockClient{MockGet: func(_ context.Context, key client.ObjectKey, obj client.Object) error {
+					if sobj, ok := obj.(*corev1.Secret); ok {
+						if key.Name == sref.Name && key.Namespace == sref.Namespace {
+							s.DeepCopyInto(sobj)
+							return nil
+						}
+					}
+					t.Errorf("wrong secret is queried")
+					return errBoom
+				}},
+				cd: &fake.Composed{
+					ConnectionSecretWriterTo: fake.ConnectionSecretWriterTo{Ref: sref},
+				},
+				t: v1.ComposedTemplate{ConnectionDetails: []v1.ConnectionDetail{
+					{
+						Type: v1.ConnectionDetailFromFieldPath,
+						Name: pointer.StringPtr("missingname"),
+					},
+				}},
+			},
+			want: want{
+				err: fmt.Errorf(errConnDetailPath, v1.ConnectionDetailFromFieldPath),
+			},
+		},
+		"ErrConnectionDetailFromFieldPathNameNotSet": {
+			reason: "Should error if ConnectionDetailFromFieldPath type Name is not set",
+			args: args{
+				kube: &test.MockClient{MockGet: func(_ context.Context, key client.ObjectKey, obj client.Object) error {
+					if sobj, ok := obj.(*corev1.Secret); ok {
+						if key.Name == sref.Name && key.Namespace == sref.Namespace {
+							s.DeepCopyInto(sobj)
+							return nil
+						}
+					}
+					t.Errorf("wrong secret is queried")
+					return errBoom
+				}},
+				cd: &fake.Composed{
+					ConnectionSecretWriterTo: fake.ConnectionSecretWriterTo{Ref: sref},
+				},
+				t: v1.ComposedTemplate{ConnectionDetails: []v1.ConnectionDetail{
+					{
+						Type:          v1.ConnectionDetailFromFieldPath,
+						FromFieldPath: pointer.StringPtr("fieldpath"),
+					},
+				}},
+			},
+			want: want{
+				err: fmt.Errorf(errConnDetailKey, v1.ConnectionDetailFromFieldPath),
 			},
 		},
 		"SuccessFieldPath": {
@@ -284,9 +417,9 @@ func TestFetch(t *testing.T) {
 				},
 				t: v1.ComposedTemplate{ConnectionDetails: []v1.ConnectionDetail{
 					{
-						// Entries with only a name are silently ignored.
 						Name:          pointer.StringPtr("name"),
-						FromResourceFieldPath: pointer.StringPtr("objectMeta.name"),
+						FromFieldPath: pointer.StringPtr("objectMeta.name"),
+						Type:          v1.ConnectionDetailFromFieldPath,
 					},
 				}},
 			},
@@ -317,9 +450,9 @@ func TestFetch(t *testing.T) {
 				},
 				t: v1.ComposedTemplate{ConnectionDetails: []v1.ConnectionDetail{
 					{
-						// Entries with only a name are silently ignored.
 						Name:          pointer.StringPtr("generation"),
-						FromResourceFieldPath: pointer.StringPtr("objectMeta.generation"),
+						FromFieldPath: pointer.StringPtr("objectMeta.generation"),
+						Type:          v1.ConnectionDetailFromFieldPath,
 					},
 				}},
 			},


### PR DESCRIPTION
### Description of your changes
Fixes #1609 

This PR adds a FromFieldPath value in the ConnectionDetail struct and also cleans up and adds functionality to parse the fieldPath into a value from CR.

I have:

- [X] Read and followed Crossplane's [contribution process].
- [X] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Manual testing, unit testing needs to be added.

[contribution process]: https://git.io/fj2m9
