### PR TITLE
Return consistent connection secret errors

### DIFF
--- a/internal/controller/apiextensions/composite/composed.go
+++ b/internal/controller/apiextensions/composite/composed.go
@@ -40,17 +40,18 @@ import (
 
 // Error strings
 const (
-	errApply          = "cannot apply composed resource"
-	errFetchSecret    = "cannot fetch connection secret"
-	errReadiness      = "cannot check whether composed resource is ready"
-	errUnmarshal      = "cannot unmarshal base template"
-	errFmtPatch       = "cannot apply the patch at index %d"
-	errGetSecret      = "cannot get connection secret of composed resource"
-	errNamePrefix     = "name prefix is not found in labels"
-	errName           = "cannot use dry-run create to name composed resource"
-	errConnDetailKey  = "connection detail of type %s key is not set"
-	errConnDetailVal  = "connection detail of type %s value is not set"
-	errConnDetailPath = "connection detail of type %s fromFieldPath is not set"
+	errApply       = "cannot apply composed resource"
+	errFetchSecret = "cannot fetch connection secret"
+	errReadiness   = "cannot check whether composed resource is ready"
+	errUnmarshal   = "cannot unmarshal base template"
+	errGetSecret   = "cannot get connection secret of composed resource"
+	errNamePrefix  = "name prefix is not found in labels"
+	errName        = "cannot use dry-run create to name composed resource"
+
+	errFmtPatch          = "cannot apply the patch at index %d"
+	errFmtConnDetailKey  = "connection detail of type %q key is not set"
+	errFmtConnDetailVal  = "connection detail of type %q value is not set"
+	errFmtConnDetailPath = "connection detail of type %q fromFieldPath is not set"
 )
 
 // Observation is the result of composed reconciliation.
@@ -186,15 +187,15 @@ func (cdf *APIConnectionDetailsFetcher) FetchConnectionDetails(ctx context.Conte
 			// Name, Value must be set if value type
 			switch {
 			case d.Name == nil:
-				return nil, fmt.Errorf(errConnDetailKey, d.Type)
+				return nil, errors.Errorf(errFmtConnDetailKey, d.Type)
 			case d.Value == nil:
-				return nil, fmt.Errorf(errConnDetailVal, d.Type)
+				return nil, errors.Errorf(errFmtConnDetailVal, d.Type)
 			default:
 				conn[*d.Name] = []byte(*d.Value)
 			}
 		case v1.ConnectionDetailFromConnectionSecretKey:
 			if d.FromConnectionSecretKey == nil {
-				return nil, fmt.Errorf(errConnDetailKey, d.Type)
+				return nil, errors.Errorf(errFmtConnDetailKey, d.Type)
 			}
 			if data[*d.FromConnectionSecretKey] == nil {
 				// We don't consider this an error because it's possible the
@@ -211,9 +212,9 @@ func (cdf *APIConnectionDetailsFetcher) FetchConnectionDetails(ctx context.Conte
 		case v1.ConnectionDetailFromFieldPath:
 			switch {
 			case d.Name == nil:
-				return nil, fmt.Errorf(errConnDetailKey, d.Type)
+				return nil, errors.Errorf(errFmtConnDetailKey, d.Type)
 			case d.FromFieldPath == nil:
-				return nil, fmt.Errorf(errConnDetailPath, d.Type)
+				return nil, errors.Errorf(errFmtConnDetailPath, d.Type)
 			default:
 				_ = extractFieldPathValue(cd, d, conn)
 			}

--- a/internal/controller/apiextensions/composite/composed_test.go
+++ b/internal/controller/apiextensions/composite/composed_test.go
@@ -18,7 +18,6 @@ package composite
 
 import (
 	"context"
-	"fmt"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -286,7 +285,7 @@ func TestFetch(t *testing.T) {
 				}},
 			},
 			want: want{
-				err: fmt.Errorf(errConnDetailVal, v1.ConnectionDetailValue),
+				err: errors.Errorf(errFmtConnDetailVal, v1.ConnectionDetailValue),
 			},
 		},
 		"ErrConnectionDetailNameNotSet": {
@@ -313,7 +312,7 @@ func TestFetch(t *testing.T) {
 				}},
 			},
 			want: want{
-				err: fmt.Errorf(errConnDetailKey, v1.ConnectionDetailValue),
+				err: errors.Errorf(errFmtConnDetailKey, v1.ConnectionDetailValue),
 			},
 		},
 		"ErrConnectionDetailFromConnectionSecretKeyNotSet": {
@@ -339,7 +338,7 @@ func TestFetch(t *testing.T) {
 				}},
 			},
 			want: want{
-				err: fmt.Errorf(errConnDetailKey, v1.ConnectionDetailFromConnectionSecretKey),
+				err: errors.Errorf(errFmtConnDetailKey, v1.ConnectionDetailFromConnectionSecretKey),
 			},
 		},
 		"ErrConnectionDetailFromFieldPathNotSet": {
@@ -366,7 +365,7 @@ func TestFetch(t *testing.T) {
 				}},
 			},
 			want: want{
-				err: fmt.Errorf(errConnDetailPath, v1.ConnectionDetailFromFieldPath),
+				err: errors.Errorf(errFmtConnDetailPath, v1.ConnectionDetailFromFieldPath),
 			},
 		},
 		"ErrConnectionDetailFromFieldPathNameNotSet": {
@@ -393,7 +392,7 @@ func TestFetch(t *testing.T) {
 				}},
 			},
 			want: want{
-				err: fmt.Errorf(errConnDetailKey, v1.ConnectionDetailFromFieldPath),
+				err: errors.Errorf(errFmtConnDetailKey, v1.ConnectionDetailFromFieldPath),
 			},
 		},
 		"SuccessFieldPath": {


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Some trivial tweaks to the errors we return when handling connection secrets. I didn't notice these until after I'd merged https://github.com/crossplane/crossplane/pull/2120 and was rebasing my branch on the changes. 

* Use the errors package rather than fmt.Errorf (adds stack trace)
* Use %q (quoted values) in error format strings
* Distinguish errFmt strings from plain old err strings

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

Just the unit tests - it's a trivial change.

[contribution process]: https://git.io/fj2m9
