### PR TITLE
Fix liquid template rendering in vault guide

### DIFF
--- a/docs/guides/vault-injection.md
+++ b/docs/guides/vault-injection.md
@@ -227,6 +227,7 @@ injected into the container filesystem by assuming role `crossplane-providers`.
 There is also so template formatting added to make sure the secret data is
 presented in a form that `provider-gcp` is expecting.
 
+{% raw  %}
 ```console
 echo "apiVersion: pkg.crossplane.io/v1alpha1
 kind: ControllerConfig
@@ -252,6 +253,7 @@ spec:
   controllerConfigRef:
     name: vault-config" | kubectl apply -f -
 ```
+{% endraw %}
 
 ## Configure provider-gcp
 


### PR DESCRIPTION


<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes an issue where the vault injection template was being rendered
incorrectly due to jekyll interpreting it as a liquid template.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

See https://crossplane.io/docs/master/guides/vault-injection.html#install-provider-gcp

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

Rendered locally:

![raw-liquid](https://user-images.githubusercontent.com/31777345/107701449-8819bf80-6c7e-11eb-8dd3-129c52543af3.png)


[contribution process]: https://git.io/fj2m9
