### PR TITLE
Cleanup Composition 'Type' discriminator fields

### DIFF
--- a/apis/apiextensions/v1/composition_types.go
+++ b/apis/apiextensions/v1/composition_types.go
@@ -562,7 +562,7 @@ type ConnectionDetailType string
 const (
 	ConnectionDetailTypeFromConnectionSecretKey ConnectionDetailType = "FromConnectionSecretKey" // Default
 	ConnectionDetailTypeFromFieldPath           ConnectionDetailType = "FromFieldPath"
-	ConnectionDetailTypeValue                   ConnectionDetailType = "Value"
+	ConnectionDetailTypeFromValue               ConnectionDetailType = "FromValue"
 )
 
 // ConnectionDetail includes the information about the propagation of the connection
@@ -578,7 +578,7 @@ type ConnectionDetail struct {
 	// connection detail type may require its' own fields to be set on the
 	// ConnectionDetail object.
 	// +optional
-	// +kubebuilder:validation:Enum=FromConnectionSecretKey;FromFieldPath;Value
+	// +kubebuilder:validation:Enum=FromConnectionSecretKey;FromFieldPath;FromValue
 	// +kubebuilder:default=FromConnectionSecretKey
 	Type ConnectionDetailType `json:"type,omitempty"`
 

--- a/apis/apiextensions/v1/composition_types.go
+++ b/apis/apiextensions/v1/composition_types.go
@@ -560,7 +560,8 @@ type ConnectionDetailType string
 
 // ConnectionDetailType types.
 const (
-	ConnectionDetailTypeFromConnectionSecretKey ConnectionDetailType = "FromConnectionSecretKey" // Default
+	ConnectionDetailTypeUnknown                 ConnectionDetailType = "Unknown"
+	ConnectionDetailTypeFromConnectionSecretKey ConnectionDetailType = "FromConnectionSecretKey"
 	ConnectionDetailTypeFromFieldPath           ConnectionDetailType = "FromFieldPath"
 	ConnectionDetailTypeFromValue               ConnectionDetailType = "FromValue"
 )
@@ -575,12 +576,12 @@ type ConnectionDetail struct {
 	Name *string `json:"name,omitempty"`
 
 	// Type sets the connection detail fetching behaviour to be used. Each
-	// connection detail type may require its' own fields to be set on the
-	// ConnectionDetail object.
+	// connection detail type may require its own fields to be set on the
+	// ConnectionDetail object. If the type is omitted Crossplane will attempt
+	// to infer it based on which other fields were specified.
 	// +optional
 	// +kubebuilder:validation:Enum=FromConnectionSecretKey;FromFieldPath;FromValue
-	// +kubebuilder:default=FromConnectionSecretKey
-	Type ConnectionDetailType `json:"type,omitempty"`
+	Type *ConnectionDetailType `json:"type,omitempty"`
 
 	// FromConnectionSecretKey is the key that will be used to fetch the value
 	// from the given target resource's secret.

--- a/apis/apiextensions/v1/composition_types.go
+++ b/apis/apiextensions/v1/composition_types.go
@@ -166,15 +166,15 @@ type ComposedTemplate struct {
 	ReadinessChecks []ReadinessCheck `json:"readinessChecks,omitempty"`
 }
 
-// TypeReadinessCheck is used for readiness check types.
-type TypeReadinessCheck string
+// ReadinessCheckType is used for readiness check types.
+type ReadinessCheckType string
 
 // The possible values for readiness check type.
 const (
-	ReadinessCheckNonEmpty     TypeReadinessCheck = "NonEmpty"
-	ReadinessCheckMatchString  TypeReadinessCheck = "MatchString"
-	ReadinessCheckMatchInteger TypeReadinessCheck = "MatchInteger"
-	ReadinessCheckNone         TypeReadinessCheck = "None"
+	ReadinessCheckTypeNonEmpty     ReadinessCheckType = "NonEmpty"
+	ReadinessCheckTypeMatchString  ReadinessCheckType = "MatchString"
+	ReadinessCheckTypeMatchInteger ReadinessCheckType = "MatchInteger"
+	ReadinessCheckTypeNone         ReadinessCheckType = "None"
 )
 
 // ReadinessCheck is used to indicate how to tell whether a resource is ready
@@ -182,7 +182,7 @@ const (
 type ReadinessCheck struct {
 	// Type indicates the type of probe you'd like to use.
 	// +kubebuilder:validation:Enum="MatchString";"MatchInteger";"NonEmpty";"None"
-	Type TypeReadinessCheck `json:"type"`
+	Type ReadinessCheckType `json:"type"`
 
 	// FieldPath shows the path of the field whose value will be used.
 	// +optional
@@ -346,6 +346,7 @@ const (
 type Transform struct {
 
 	// Type of the transform to be run.
+	// +kubebuilder:validation:Enum=map;math;string;convert
 	Type TransformType `json:"type"`
 
 	// Math is used to transform the input via mathematical operations such as
@@ -559,9 +560,9 @@ type ConnectionDetailType string
 
 // ConnectionDetailType types.
 const (
-	ConnectionDetailFromConnectionSecretKey ConnectionDetailType = "FromConnectionSecretKey" // Default
-	ConnectionDetailFromFieldPath           ConnectionDetailType = "FromFieldPath"
-	ConnectionDetailValue                   ConnectionDetailType = "Value"
+	ConnectionDetailTypeFromConnectionSecretKey ConnectionDetailType = "FromConnectionSecretKey" // Default
+	ConnectionDetailTypeFromFieldPath           ConnectionDetailType = "FromFieldPath"
+	ConnectionDetailTypeValue                   ConnectionDetailType = "Value"
 )
 
 // ConnectionDetail includes the information about the propagation of the connection
@@ -573,20 +574,22 @@ type ConnectionDetail struct {
 	// +optional
 	Name *string `json:"name,omitempty"`
 
-	// Type sets the connection detail fetching behaviour to be used. Each connection detail type may require
-	// its' own fields to be set on the ConnectionDetail object.
+	// Type sets the connection detail fetching behaviour to be used. Each
+	// connection detail type may require its' own fields to be set on the
+	// ConnectionDetail object.
 	// +optional
 	// +kubebuilder:validation:Enum=FromConnectionSecretKey;FromFieldPath;Value
 	// +kubebuilder:default=FromConnectionSecretKey
 	Type ConnectionDetailType `json:"type,omitempty"`
 
 	// FromConnectionSecretKey is the key that will be used to fetch the value
-	// from the given target resource's secret
+	// from the given target resource's secret.
 	// +optional
 	FromConnectionSecretKey *string `json:"fromConnectionSecretKey,omitempty"`
 
-	// FromFieldPath is the path of the field on the composed resource whose value
-	// to be used as input. Name must be specified if the type is FromFieldPath is specified.
+	// FromFieldPath is the path of the field on the composed resource whose
+	// value to be used as input. Name must be specified if the type is
+	// FromFieldPath is specified.
 	// +optional
 	FromFieldPath *string `json:"fromFieldPath,omitempty"`
 

--- a/apis/apiextensions/v1/composition_types.go
+++ b/apis/apiextensions/v1/composition_types.go
@@ -219,14 +219,15 @@ type Patch struct {
 	// +kubebuilder:default=FromCompositeFieldPath
 	Type PatchType `json:"type,omitempty"`
 
-	// FromFieldPath is the path of the field on the composed resource whose value
-	// to be used as input. Required when type is FromCompositeFieldPath.
+	// FromFieldPath is the path of the field on the resource whose value is
+	// to be used as input. Required when type is FromCompositeFieldPath or
+	// ToCompositeFieldPath.
 	// +optional
 	FromFieldPath *string `json:"fromFieldPath,omitempty"`
 
-	// ToFieldPath is the path of the field on the base resource whose value will
+	// ToFieldPath is the path of the field on the resource whose value will
 	// be changed with the result of transforms. Leave empty if you'd like to
-	// propagate to the same path on the target resource.
+	// propagate to the same path as fromFieldPath.
 	// +optional
 	ToFieldPath *string `json:"toFieldPath,omitempty"`
 

--- a/apis/apiextensions/v1/zz_generated.deepcopy.go
+++ b/apis/apiextensions/v1/zz_generated.deepcopy.go
@@ -361,6 +361,11 @@ func (in *ConnectionDetail) DeepCopyInto(out *ConnectionDetail) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.Type != nil {
+		in, out := &in.Type, &out.Type
+		*out = new(ConnectionDetailType)
+		**out = **in
+	}
 	if in.FromConnectionSecretKey != nil {
 		in, out := &in.FromConnectionSecretKey, &out.FromConnectionSecretKey
 		*out = new(string)

--- a/apis/apiextensions/v1beta1/composition_types.go
+++ b/apis/apiextensions/v1beta1/composition_types.go
@@ -253,6 +253,7 @@ type ConnectionDetailType string
 
 // ConnectionDetailType types.
 const (
+	ConnectionDetailTypeUnknown                 ConnectionDetailType = "Unknown"
 	ConnectionDetailTypeFromConnectionSecretKey ConnectionDetailType = "FromConnectionSecretKey" // Default
 	ConnectionDetailTypeFromFieldPath           ConnectionDetailType = "FromFieldPath"
 	ConnectionDetailTypeFromValue               ConnectionDetailType = "FromValue"
@@ -268,11 +269,11 @@ type ConnectionDetail struct {
 	Name *string `json:"name,omitempty"`
 
 	// Type sets the connection detail fetching behaviour to be used. Each
-	// connection detail type may require its' own fields to be set on the
-	// ConnectionDetail object.
+	// connection detail type may require its own fields to be set on the
+	// ConnectionDetail object. If the type is omitted Crossplane will attempt
+	// to infer it based on which other fields were specified.
 	// +optional
 	// +kubebuilder:validation:Enum=FromConnectionSecretKey;FromFieldPath;FromValue
-	// +kubebuilder:default=FromConnectionSecretKey
 	Type ConnectionDetailType `json:"type,omitempty"`
 
 	// FromConnectionSecretKey is the key that will be used to fetch the value

--- a/apis/apiextensions/v1beta1/composition_types.go
+++ b/apis/apiextensions/v1beta1/composition_types.go
@@ -255,7 +255,7 @@ type ConnectionDetailType string
 const (
 	ConnectionDetailTypeFromConnectionSecretKey ConnectionDetailType = "FromConnectionSecretKey" // Default
 	ConnectionDetailTypeFromFieldPath           ConnectionDetailType = "FromFieldPath"
-	ConnectionDetailTypeValue                   ConnectionDetailType = "Value"
+	ConnectionDetailTypeFromValue               ConnectionDetailType = "FromValue"
 )
 
 // ConnectionDetail includes the information about the propagation of the connection
@@ -271,7 +271,7 @@ type ConnectionDetail struct {
 	// connection detail type may require its' own fields to be set on the
 	// ConnectionDetail object.
 	// +optional
-	// +kubebuilder:validation:Enum=FromConnectionSecretKey;FromFieldPath;Value
+	// +kubebuilder:validation:Enum=FromConnectionSecretKey;FromFieldPath;FromValue
 	// +kubebuilder:default=FromConnectionSecretKey
 	Type ConnectionDetailType `json:"type,omitempty"`
 

--- a/apis/apiextensions/v1beta1/composition_types.go
+++ b/apis/apiextensions/v1beta1/composition_types.go
@@ -158,14 +158,15 @@ type Patch struct {
 	// +kubebuilder:default=FromCompositeFieldPath
 	Type PatchType `json:"type,omitempty"`
 
-	// FromFieldPath is the path of the field on the composed resource whose value
-	// to be used as input. Required when type is FromCompositeFieldPath.
+	// FromFieldPath is the path of the field on the resource whose value is
+	// to be used as input. Required when type is FromCompositeFieldPath or
+	// ToCompositeFieldPath.
 	// +optional
 	FromFieldPath *string `json:"fromFieldPath,omitempty"`
 
-	// ToFieldPath is the path of the field on the base resource whose value will
+	// ToFieldPath is the path of the field on the resource whose value will
 	// be changed with the result of transforms. Leave empty if you'd like to
-	// propagate to the same path on the target resource.
+	// propagate to the same path as fromFieldPath.
 	// +optional
 	ToFieldPath *string `json:"toFieldPath,omitempty"`
 

--- a/apis/apiextensions/v1beta1/composition_types.go
+++ b/apis/apiextensions/v1beta1/composition_types.go
@@ -105,15 +105,15 @@ type ComposedTemplate struct {
 	ReadinessChecks []ReadinessCheck `json:"readinessChecks,omitempty"`
 }
 
-// TypeReadinessCheck is used for readiness check types.
-type TypeReadinessCheck string
+// ReadinessCheckType is used for readiness check types.
+type ReadinessCheckType string
 
 // The possible values for readiness check type.
 const (
-	ReadinessCheckNonEmpty     TypeReadinessCheck = "NonEmpty"
-	ReadinessCheckMatchString  TypeReadinessCheck = "MatchString"
-	ReadinessCheckMatchInteger TypeReadinessCheck = "MatchInteger"
-	ReadinessCheckNone         TypeReadinessCheck = "None"
+	ReadinessCheckTypeNonEmpty     ReadinessCheckType = "NonEmpty"
+	ReadinessCheckTypeMatchString  ReadinessCheckType = "MatchString"
+	ReadinessCheckTypeMatchInteger ReadinessCheckType = "MatchInteger"
+	ReadinessCheckTypeNone         ReadinessCheckType = "None"
 )
 
 // ReadinessCheck is used to indicate how to tell whether a resource is ready
@@ -121,7 +121,7 @@ const (
 type ReadinessCheck struct {
 	// Type indicates the type of probe you'd like to use.
 	// +kubebuilder:validation:Enum="MatchString";"MatchInteger";"NonEmpty";"None"
-	Type TypeReadinessCheck `json:"type"`
+	Type ReadinessCheckType `json:"type"`
 
 	// FieldPath shows the path of the field whose value will be used.
 	// +optional
@@ -143,6 +143,7 @@ type PatchType string
 const (
 	PatchTypeFromCompositeFieldPath PatchType = "FromCompositeFieldPath" // Default
 	PatchTypePatchSet               PatchType = "PatchSet"
+	PatchTypeToCompositeFieldPath   PatchType = "ToCompositeFieldPath"
 )
 
 // Patch objects are applied between composite and composed resources. Their
@@ -153,11 +154,11 @@ type Patch struct {
 	// Type sets the patching behaviour to be used. Each patch type may require
 	// its' own fields to be set on the Patch object.
 	// +optional
-	// +kubebuilder:validation:Enum=FromCompositeFieldPath;PatchSet
+	// +kubebuilder:validation:Enum=FromCompositeFieldPath;PatchSet;ToCompositeFieldPath
 	// +kubebuilder:default=FromCompositeFieldPath
 	Type PatchType `json:"type,omitempty"`
 
-	// FromFieldPath is the path of the field on the upstream resource whose value
+	// FromFieldPath is the path of the field on the composed resource whose value
 	// to be used as input. Required when type is FromCompositeFieldPath.
 	// +optional
 	FromFieldPath *string `json:"fromFieldPath,omitempty"`
@@ -194,6 +195,7 @@ const (
 type Transform struct {
 
 	// Type of the transform to be run.
+	// +kubebuilder:validation:Enum=map;math;string;convert
 	Type TransformType `json:"type"`
 
 	// Math is used to transform the input via mathematical operations such as
@@ -246,6 +248,16 @@ type ConvertTransform struct {
 	ToType string `json:"toType"`
 }
 
+// A ConnectionDetailType is a type of connection detail.
+type ConnectionDetailType string
+
+// ConnectionDetailType types.
+const (
+	ConnectionDetailTypeFromConnectionSecretKey ConnectionDetailType = "FromConnectionSecretKey" // Default
+	ConnectionDetailTypeFromFieldPath           ConnectionDetailType = "FromFieldPath"
+	ConnectionDetailTypeValue                   ConnectionDetailType = "Value"
+)
+
 // ConnectionDetail includes the information about the propagation of the connection
 // information from one secret to another.
 type ConnectionDetail struct {
@@ -255,10 +267,24 @@ type ConnectionDetail struct {
 	// +optional
 	Name *string `json:"name,omitempty"`
 
+	// Type sets the connection detail fetching behaviour to be used. Each
+	// connection detail type may require its' own fields to be set on the
+	// ConnectionDetail object.
+	// +optional
+	// +kubebuilder:validation:Enum=FromConnectionSecretKey;FromFieldPath;Value
+	// +kubebuilder:default=FromConnectionSecretKey
+	Type ConnectionDetailType `json:"type,omitempty"`
+
 	// FromConnectionSecretKey is the key that will be used to fetch the value
-	// from the given target resource.
+	// from the given target resource's secret.
 	// +optional
 	FromConnectionSecretKey *string `json:"fromConnectionSecretKey,omitempty"`
+
+	// FromFieldPath is the path of the field on the composed resource whose
+	// value to be used as input. Name must be specified if the type is
+	// FromFieldPath is specified.
+	// +optional
+	FromFieldPath *string `json:"fromFieldPath,omitempty"`
 
 	// Value that will be propagated to the connection secret of the composition
 	// instance. Typically you should use FromConnectionSecretKey instead, but

--- a/apis/apiextensions/v1beta1/zz_generated.deepcopy.go
+++ b/apis/apiextensions/v1beta1/zz_generated.deepcopy.go
@@ -366,6 +366,11 @@ func (in *ConnectionDetail) DeepCopyInto(out *ConnectionDetail) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.FromFieldPath != nil {
+		in, out := &in.FromFieldPath, &out.FromFieldPath
+		*out = new(string)
+		**out = **in
+	}
 	if in.Value != nil {
 		in, out := &in.Value, &out.Value
 		*out = new(string)

--- a/cluster/charts/crossplane/crds/apiextensions.crossplane.io_compositions.yaml
+++ b/cluster/charts/crossplane/crds/apiextensions.crossplane.io_compositions.yaml
@@ -65,13 +65,13 @@ spec:
                         description: Patch objects are applied between composite and composed resources. Their behaviour depends on the Type selected. The default Type, FromCompositeFieldPath, copies a value from the composite resource to the composed resource, applying any defined transformers.
                         properties:
                           fromFieldPath:
-                            description: FromFieldPath is the path of the field on the composed resource whose value to be used as input. Required when type is FromCompositeFieldPath.
+                            description: FromFieldPath is the path of the field on the resource whose value is to be used as input. Required when type is FromCompositeFieldPath or ToCompositeFieldPath.
                             type: string
                           patchSetName:
                             description: PatchSetName to include patches from. Required when type is PatchSet.
                             type: string
                           toFieldPath:
-                            description: ToFieldPath is the path of the field on the base resource whose value will be changed with the result of transforms. Leave empty if you'd like to propagate to the same path on the target resource.
+                            description: ToFieldPath is the path of the field on the resource whose value will be changed with the result of transforms. Leave empty if you'd like to propagate to the same path as fromFieldPath.
                             type: string
                           transforms:
                             description: Transforms are the list of functions that are used as a FIFO pipe for the input to be transformed.
@@ -186,13 +186,13 @@ spec:
                         description: Patch objects are applied between composite and composed resources. Their behaviour depends on the Type selected. The default Type, FromCompositeFieldPath, copies a value from the composite resource to the composed resource, applying any defined transformers.
                         properties:
                           fromFieldPath:
-                            description: FromFieldPath is the path of the field on the composed resource whose value to be used as input. Required when type is FromCompositeFieldPath.
+                            description: FromFieldPath is the path of the field on the resource whose value is to be used as input. Required when type is FromCompositeFieldPath or ToCompositeFieldPath.
                             type: string
                           patchSetName:
                             description: PatchSetName to include patches from. Required when type is PatchSet.
                             type: string
                           toFieldPath:
-                            description: ToFieldPath is the path of the field on the base resource whose value will be changed with the result of transforms. Leave empty if you'd like to propagate to the same path on the target resource.
+                            description: ToFieldPath is the path of the field on the resource whose value will be changed with the result of transforms. Leave empty if you'd like to propagate to the same path as fromFieldPath.
                             type: string
                           transforms:
                             description: Transforms are the list of functions that are used as a FIFO pipe for the input to be transformed.
@@ -379,13 +379,13 @@ spec:
                         description: Patch objects are applied between composite and composed resources. Their behaviour depends on the Type selected. The default Type, FromCompositeFieldPath, copies a value from the composite resource to the composed resource, applying any defined transformers.
                         properties:
                           fromFieldPath:
-                            description: FromFieldPath is the path of the field on the composed resource whose value to be used as input. Required when type is FromCompositeFieldPath.
+                            description: FromFieldPath is the path of the field on the resource whose value is to be used as input. Required when type is FromCompositeFieldPath or ToCompositeFieldPath.
                             type: string
                           patchSetName:
                             description: PatchSetName to include patches from. Required when type is PatchSet.
                             type: string
                           toFieldPath:
-                            description: ToFieldPath is the path of the field on the base resource whose value will be changed with the result of transforms. Leave empty if you'd like to propagate to the same path on the target resource.
+                            description: ToFieldPath is the path of the field on the resource whose value will be changed with the result of transforms. Leave empty if you'd like to propagate to the same path as fromFieldPath.
                             type: string
                           transforms:
                             description: Transforms are the list of functions that are used as a FIFO pipe for the input to be transformed.
@@ -500,13 +500,13 @@ spec:
                         description: Patch objects are applied between composite and composed resources. Their behaviour depends on the Type selected. The default Type, FromCompositeFieldPath, copies a value from the composite resource to the composed resource, applying any defined transformers.
                         properties:
                           fromFieldPath:
-                            description: FromFieldPath is the path of the field on the composed resource whose value to be used as input. Required when type is FromCompositeFieldPath.
+                            description: FromFieldPath is the path of the field on the resource whose value is to be used as input. Required when type is FromCompositeFieldPath or ToCompositeFieldPath.
                             type: string
                           patchSetName:
                             description: PatchSetName to include patches from. Required when type is PatchSet.
                             type: string
                           toFieldPath:
-                            description: ToFieldPath is the path of the field on the base resource whose value will be changed with the result of transforms. Leave empty if you'd like to propagate to the same path on the target resource.
+                            description: ToFieldPath is the path of the field on the resource whose value will be changed with the result of transforms. Leave empty if you'd like to propagate to the same path as fromFieldPath.
                             type: string
                           transforms:
                             description: Transforms are the list of functions that are used as a FIFO pipe for the input to be transformed.

--- a/cluster/charts/crossplane/crds/apiextensions.crossplane.io_compositions.yaml
+++ b/cluster/charts/crossplane/crds/apiextensions.crossplane.io_compositions.yaml
@@ -116,6 +116,11 @@ spec:
                                   type: object
                                 type:
                                   description: Type of the transform to be run.
+                                  enum:
+                                  - map
+                                  - math
+                                  - string
+                                  - convert
                                   type: string
                               required:
                               - type
@@ -152,7 +157,7 @@ spec:
                         description: ConnectionDetail includes the information about the propagation of the connection information from one secret to another.
                         properties:
                           fromConnectionSecretKey:
-                            description: FromConnectionSecretKey is the key that will be used to fetch the value from the given target resource's secret
+                            description: FromConnectionSecretKey is the key that will be used to fetch the value from the given target resource's secret.
                             type: string
                           fromFieldPath:
                             description: FromFieldPath is the path of the field on the composed resource whose value to be used as input. Name must be specified if the type is FromFieldPath is specified.
@@ -233,6 +238,11 @@ spec:
                                   type: object
                                 type:
                                   description: Type of the transform to be run.
+                                  enum:
+                                  - map
+                                  - math
+                                  - string
+                                  - convert
                                   type: string
                               required:
                               - type
@@ -370,7 +380,7 @@ spec:
                         description: Patch objects are applied between composite and composed resources. Their behaviour depends on the Type selected. The default Type, FromCompositeFieldPath, copies a value from the composite resource to the composed resource, applying any defined transformers.
                         properties:
                           fromFieldPath:
-                            description: FromFieldPath is the path of the field on the upstream resource whose value to be used as input. Required when type is FromCompositeFieldPath.
+                            description: FromFieldPath is the path of the field on the composed resource whose value to be used as input. Required when type is FromCompositeFieldPath.
                             type: string
                           patchSetName:
                             description: PatchSetName to include patches from. Required when type is PatchSet.
@@ -421,6 +431,11 @@ spec:
                                   type: object
                                 type:
                                   description: Type of the transform to be run.
+                                  enum:
+                                  - map
+                                  - math
+                                  - string
+                                  - convert
                                   type: string
                               required:
                               - type
@@ -432,6 +447,7 @@ spec:
                             enum:
                             - FromCompositeFieldPath
                             - PatchSet
+                            - ToCompositeFieldPath
                             type: string
                         type: object
                       type: array
@@ -456,10 +472,21 @@ spec:
                         description: ConnectionDetail includes the information about the propagation of the connection information from one secret to another.
                         properties:
                           fromConnectionSecretKey:
-                            description: FromConnectionSecretKey is the key that will be used to fetch the value from the given target resource.
+                            description: FromConnectionSecretKey is the key that will be used to fetch the value from the given target resource's secret.
+                            type: string
+                          fromFieldPath:
+                            description: FromFieldPath is the path of the field on the composed resource whose value to be used as input. Name must be specified if the type is FromFieldPath is specified.
                             type: string
                           name:
                             description: Name of the connection secret key that will be propagated to the connection secret of the composition instance. Leave empty if you'd like to use the same key name.
+                            type: string
+                          type:
+                            default: FromConnectionSecretKey
+                            description: Type sets the connection detail fetching behaviour to be used. Each connection detail type may require its' own fields to be set on the ConnectionDetail object.
+                            enum:
+                            - FromConnectionSecretKey
+                            - FromFieldPath
+                            - Value
                             type: string
                           value:
                             description: Value that will be propagated to the connection secret of the composition instance. Typically you should use FromConnectionSecretKey instead, but an explicit value may be set to inject a fixed, non-sensitive connection secret values, for example a well-known port. Supercedes FromConnectionSecretKey when set.
@@ -475,7 +502,7 @@ spec:
                         description: Patch objects are applied between composite and composed resources. Their behaviour depends on the Type selected. The default Type, FromCompositeFieldPath, copies a value from the composite resource to the composed resource, applying any defined transformers.
                         properties:
                           fromFieldPath:
-                            description: FromFieldPath is the path of the field on the upstream resource whose value to be used as input. Required when type is FromCompositeFieldPath.
+                            description: FromFieldPath is the path of the field on the composed resource whose value to be used as input. Required when type is FromCompositeFieldPath.
                             type: string
                           patchSetName:
                             description: PatchSetName to include patches from. Required when type is PatchSet.
@@ -526,6 +553,11 @@ spec:
                                   type: object
                                 type:
                                   description: Type of the transform to be run.
+                                  enum:
+                                  - map
+                                  - math
+                                  - string
+                                  - convert
                                   type: string
                               required:
                               - type
@@ -537,6 +569,7 @@ spec:
                             enum:
                             - FromCompositeFieldPath
                             - PatchSet
+                            - ToCompositeFieldPath
                             type: string
                         type: object
                       type: array

--- a/cluster/charts/crossplane/crds/apiextensions.crossplane.io_compositions.yaml
+++ b/cluster/charts/crossplane/crds/apiextensions.crossplane.io_compositions.yaml
@@ -166,8 +166,7 @@ spec:
                             description: Name of the connection secret key that will be propagated to the connection secret of the composition instance. Leave empty if you'd like to use the same key name.
                             type: string
                           type:
-                            default: FromConnectionSecretKey
-                            description: Type sets the connection detail fetching behaviour to be used. Each connection detail type may require its' own fields to be set on the ConnectionDetail object.
+                            description: Type sets the connection detail fetching behaviour to be used. Each connection detail type may require its own fields to be set on the ConnectionDetail object. If the type is omitted Crossplane will attempt to infer it based on which other fields were specified.
                             enum:
                             - FromConnectionSecretKey
                             - FromFieldPath
@@ -481,8 +480,7 @@ spec:
                             description: Name of the connection secret key that will be propagated to the connection secret of the composition instance. Leave empty if you'd like to use the same key name.
                             type: string
                           type:
-                            default: FromConnectionSecretKey
-                            description: Type sets the connection detail fetching behaviour to be used. Each connection detail type may require its' own fields to be set on the ConnectionDetail object.
+                            description: Type sets the connection detail fetching behaviour to be used. Each connection detail type may require its own fields to be set on the ConnectionDetail object. If the type is omitted Crossplane will attempt to infer it based on which other fields were specified.
                             enum:
                             - FromConnectionSecretKey
                             - FromFieldPath

--- a/cluster/charts/crossplane/crds/apiextensions.crossplane.io_compositions.yaml
+++ b/cluster/charts/crossplane/crds/apiextensions.crossplane.io_compositions.yaml
@@ -171,7 +171,7 @@ spec:
                             enum:
                             - FromConnectionSecretKey
                             - FromFieldPath
-                            - Value
+                            - FromValue
                             type: string
                           value:
                             description: Value that will be propagated to the connection secret of the composition instance. Typically you should use FromConnectionSecretKey instead, but an explicit value may be set to inject a fixed, non-sensitive connection secret values, for example a well-known port. Supercedes FromConnectionSecretKey when set.
@@ -486,7 +486,7 @@ spec:
                             enum:
                             - FromConnectionSecretKey
                             - FromFieldPath
-                            - Value
+                            - FromValue
                             type: string
                           value:
                             description: Value that will be propagated to the connection secret of the composition instance. Typically you should use FromConnectionSecretKey instead, but an explicit value may be set to inject a fixed, non-sensitive connection secret values, for example a well-known port. Supercedes FromConnectionSecretKey when set.

--- a/docs/getting-started/package-infrastructure.md
+++ b/docs/getting-started/package-infrastructure.md
@@ -401,7 +401,8 @@ spec:
         - fromConnectionSecretKey: username
         - fromConnectionSecretKey: password
         - fromConnectionSecretKey: endpoint
-        - name: port
+        - type: FromValue
+          name: port
           value: "5432"
 ```
 
@@ -473,7 +474,8 @@ spec:
         - fromConnectionSecretKey: username
         - fromConnectionSecretKey: password
         - fromConnectionSecretKey: endpoint
-        - name: port
+        - type: FromValue
+          name: port
           value: "5432"
     - name: firewallrule
       base:

--- a/docs/introduction/composition.md
+++ b/docs/introduction/composition.md
@@ -459,7 +459,8 @@ spec:
       # value, for example to expose fixed, non-sensitive connection details
       # like standard ports that are not published to the composed resource's
       # connection secret.
-    - name: port
+    - type: FromValue
+      name: port
       value: "3306"
     # Readiness checks allow you to define custom readiness checks. All checks
 	  # have to return true in order for resource to be considered ready. The

--- a/docs/snippets/package/azure/composition.yaml
+++ b/docs/snippets/package/azure/composition.yaml
@@ -53,7 +53,8 @@ spec:
         - fromConnectionSecretKey: username
         - fromConnectionSecretKey: password
         - fromConnectionSecretKey: endpoint
-        - name: port
+        - type: FromValue
+          name: port
           value: "5432"
     - name: firewallrule
       base:

--- a/docs/snippets/package/gcp/composition.yaml
+++ b/docs/snippets/package/gcp/composition.yaml
@@ -42,5 +42,6 @@ spec:
         - fromConnectionSecretKey: username
         - fromConnectionSecretKey: password
         - fromConnectionSecretKey: endpoint
-        - name: port
+        - type: FromValue
+          name: port
           value: "5432"

--- a/internal/controller/apiextensions/composite/composed.go
+++ b/internal/controller/apiextensions/composite/composed.go
@@ -421,7 +421,7 @@ func (cdf *APIConnectionDetailsFetcher) FetchConnectionDetails(ctx context.Conte
 
 	for _, d := range t.ConnectionDetails {
 		switch d.Type {
-		case v1.ConnectionDetailValue:
+		case v1.ConnectionDetailTypeValue:
 			// Name, Value must be set if value type
 			switch {
 			case d.Name == nil:
@@ -431,7 +431,7 @@ func (cdf *APIConnectionDetailsFetcher) FetchConnectionDetails(ctx context.Conte
 			default:
 				conn[*d.Name] = []byte(*d.Value)
 			}
-		case v1.ConnectionDetailFromConnectionSecretKey:
+		case v1.ConnectionDetailTypeFromConnectionSecretKey:
 			if d.FromConnectionSecretKey == nil {
 				return nil, errors.Errorf(errFmtConnDetailKey, d.Type)
 			}
@@ -447,7 +447,7 @@ func (cdf *APIConnectionDetailsFetcher) FetchConnectionDetails(ctx context.Conte
 			if key != "" {
 				conn[key] = data[*d.FromConnectionSecretKey]
 			}
-		case v1.ConnectionDetailFromFieldPath:
+		case v1.ConnectionDetailTypeFromFieldPath:
 			switch {
 			case d.Name == nil:
 				return nil, errors.Errorf(errFmtConnDetailKey, d.Type)
@@ -511,21 +511,21 @@ func IsReady(_ context.Context, cd resource.Composed, t v1.ComposedTemplate) (bo
 	for i, check := range t.ReadinessChecks {
 		var ready bool
 		switch check.Type {
-		case v1.ReadinessCheckNone:
+		case v1.ReadinessCheckTypeNone:
 			return true, nil
-		case v1.ReadinessCheckNonEmpty:
+		case v1.ReadinessCheckTypeNonEmpty:
 			_, err := paved.GetValue(check.FieldPath)
 			if resource.Ignore(fieldpath.IsNotFound, err) != nil {
 				return false, err
 			}
 			ready = !fieldpath.IsNotFound(err)
-		case v1.ReadinessCheckMatchString:
+		case v1.ReadinessCheckTypeMatchString:
 			val, err := paved.GetString(check.FieldPath)
 			if resource.Ignore(fieldpath.IsNotFound, err) != nil {
 				return false, err
 			}
 			ready = !fieldpath.IsNotFound(err) && val == check.MatchString
-		case v1.ReadinessCheckMatchInteger:
+		case v1.ReadinessCheckTypeMatchInteger:
 			val, err := paved.GetInteger(check.FieldPath)
 			if err != nil {
 				return false, err

--- a/internal/controller/apiextensions/composite/composed.go
+++ b/internal/controller/apiextensions/composite/composed.go
@@ -421,7 +421,7 @@ func (cdf *APIConnectionDetailsFetcher) FetchConnectionDetails(ctx context.Conte
 
 	for _, d := range t.ConnectionDetails {
 		switch d.Type {
-		case v1.ConnectionDetailTypeValue:
+		case v1.ConnectionDetailTypeFromValue:
 			// Name, Value must be set if value type
 			switch {
 			case d.Name == nil:

--- a/internal/controller/apiextensions/composite/composed_test.go
+++ b/internal/controller/apiextensions/composite/composed_test.go
@@ -568,11 +568,11 @@ func TestFetch(t *testing.T) {
 				t: v1.ComposedTemplate{ConnectionDetails: []v1.ConnectionDetail{
 					{
 						FromConnectionSecretKey: pointer.StringPtr("bar"),
-						Type:                    v1.ConnectionDetailFromConnectionSecretKey,
+						Type:                    v1.ConnectionDetailTypeFromConnectionSecretKey,
 					},
 					{
 						Name:  pointer.StringPtr("fixed"),
-						Type:  v1.ConnectionDetailValue,
+						Type:  v1.ConnectionDetailTypeValue,
 						Value: pointer.StringPtr("value"),
 					},
 				}},
@@ -614,21 +614,21 @@ func TestFetch(t *testing.T) {
 				t: v1.ComposedTemplate{ConnectionDetails: []v1.ConnectionDetail{
 					{
 						FromConnectionSecretKey: pointer.StringPtr("bar"),
-						Type:                    v1.ConnectionDetailFromConnectionSecretKey,
+						Type:                    v1.ConnectionDetailTypeFromConnectionSecretKey,
 					},
 					{
 						FromConnectionSecretKey: pointer.StringPtr("none"),
-						Type:                    v1.ConnectionDetailFromConnectionSecretKey,
+						Type:                    v1.ConnectionDetailTypeFromConnectionSecretKey,
 					},
 					{
 						Name:                    pointer.StringPtr("convfoo"),
 						FromConnectionSecretKey: pointer.StringPtr("foo"),
-						Type:                    v1.ConnectionDetailFromConnectionSecretKey,
+						Type:                    v1.ConnectionDetailTypeFromConnectionSecretKey,
 					},
 					{
 						Name:  pointer.StringPtr("fixed"),
 						Value: pointer.StringPtr("value"),
-						Type:  v1.ConnectionDetailValue,
+						Type:  v1.ConnectionDetailTypeValue,
 					},
 				}},
 			},
@@ -659,12 +659,12 @@ func TestFetch(t *testing.T) {
 				t: v1.ComposedTemplate{ConnectionDetails: []v1.ConnectionDetail{
 					{
 						Name: pointer.StringPtr("missingvalue"),
-						Type: v1.ConnectionDetailValue,
+						Type: v1.ConnectionDetailTypeValue,
 					},
 				}},
 			},
 			want: want{
-				err: errors.Errorf(errFmtConnDetailVal, v1.ConnectionDetailValue),
+				err: errors.Errorf(errFmtConnDetailVal, v1.ConnectionDetailTypeValue),
 			},
 		},
 		"ErrConnectionDetailNameNotSet": {
@@ -686,12 +686,12 @@ func TestFetch(t *testing.T) {
 				t: v1.ComposedTemplate{ConnectionDetails: []v1.ConnectionDetail{
 					{
 						Value: pointer.StringPtr("missingname"),
-						Type:  v1.ConnectionDetailValue,
+						Type:  v1.ConnectionDetailTypeValue,
 					},
 				}},
 			},
 			want: want{
-				err: errors.Errorf(errFmtConnDetailKey, v1.ConnectionDetailValue),
+				err: errors.Errorf(errFmtConnDetailKey, v1.ConnectionDetailTypeValue),
 			},
 		},
 		"ErrConnectionDetailFromConnectionSecretKeyNotSet": {
@@ -712,12 +712,12 @@ func TestFetch(t *testing.T) {
 				},
 				t: v1.ComposedTemplate{ConnectionDetails: []v1.ConnectionDetail{
 					{
-						Type: v1.ConnectionDetailFromConnectionSecretKey,
+						Type: v1.ConnectionDetailTypeFromConnectionSecretKey,
 					},
 				}},
 			},
 			want: want{
-				err: errors.Errorf(errFmtConnDetailKey, v1.ConnectionDetailFromConnectionSecretKey),
+				err: errors.Errorf(errFmtConnDetailKey, v1.ConnectionDetailTypeFromConnectionSecretKey),
 			},
 		},
 		"ErrConnectionDetailFromFieldPathNotSet": {
@@ -738,13 +738,13 @@ func TestFetch(t *testing.T) {
 				},
 				t: v1.ComposedTemplate{ConnectionDetails: []v1.ConnectionDetail{
 					{
-						Type: v1.ConnectionDetailFromFieldPath,
+						Type: v1.ConnectionDetailTypeFromFieldPath,
 						Name: pointer.StringPtr("missingname"),
 					},
 				}},
 			},
 			want: want{
-				err: errors.Errorf(errFmtConnDetailPath, v1.ConnectionDetailFromFieldPath),
+				err: errors.Errorf(errFmtConnDetailPath, v1.ConnectionDetailTypeFromFieldPath),
 			},
 		},
 		"ErrConnectionDetailFromFieldPathNameNotSet": {
@@ -765,13 +765,13 @@ func TestFetch(t *testing.T) {
 				},
 				t: v1.ComposedTemplate{ConnectionDetails: []v1.ConnectionDetail{
 					{
-						Type:          v1.ConnectionDetailFromFieldPath,
+						Type:          v1.ConnectionDetailTypeFromFieldPath,
 						FromFieldPath: pointer.StringPtr("fieldpath"),
 					},
 				}},
 			},
 			want: want{
-				err: errors.Errorf(errFmtConnDetailKey, v1.ConnectionDetailFromFieldPath),
+				err: errors.Errorf(errFmtConnDetailKey, v1.ConnectionDetailTypeFromFieldPath),
 			},
 		},
 		"SuccessFieldPath": {
@@ -797,7 +797,7 @@ func TestFetch(t *testing.T) {
 					{
 						Name:          pointer.StringPtr("name"),
 						FromFieldPath: pointer.StringPtr("objectMeta.name"),
-						Type:          v1.ConnectionDetailFromFieldPath,
+						Type:          v1.ConnectionDetailTypeFromFieldPath,
 					},
 				}},
 			},
@@ -830,7 +830,7 @@ func TestFetch(t *testing.T) {
 					{
 						Name:          pointer.StringPtr("generation"),
 						FromFieldPath: pointer.StringPtr("objectMeta.generation"),
-						Type:          v1.ConnectionDetailFromFieldPath,
+						Type:          v1.ConnectionDetailTypeFromFieldPath,
 					},
 				}},
 			},
@@ -882,7 +882,7 @@ func TestIsReady(t *testing.T) {
 			reason: "If the only readiness check is explicitly 'None' the resource is always ready.",
 			args: args{
 				cd: composed.New(),
-				t:  v1.ComposedTemplate{ReadinessChecks: []v1.ReadinessCheck{{Type: v1.ReadinessCheckNone}}},
+				t:  v1.ComposedTemplate{ReadinessChecks: []v1.ReadinessCheck{{Type: v1.ReadinessCheckTypeNone}}},
 			},
 			want: want{
 				ready: true,

--- a/internal/controller/apiextensions/composite/composed_test.go
+++ b/internal/controller/apiextensions/composite/composed_test.go
@@ -529,6 +529,9 @@ func TestGarbageCollectingAssociator(t *testing.T) {
 }
 
 func TestFetch(t *testing.T) {
+	fromKey := v1.ConnectionDetailTypeFromConnectionSecretKey
+	fromVal := v1.ConnectionDetailTypeFromValue
+	fromField := v1.ConnectionDetailTypeFromFieldPath
 
 	sref := &xpv1.SecretReference{Name: "foo", Namespace: "bar"}
 	s := &corev1.Secret{
@@ -568,11 +571,11 @@ func TestFetch(t *testing.T) {
 				t: v1.ComposedTemplate{ConnectionDetails: []v1.ConnectionDetail{
 					{
 						FromConnectionSecretKey: pointer.StringPtr("bar"),
-						Type:                    v1.ConnectionDetailTypeFromConnectionSecretKey,
+						Type:                    &fromKey,
 					},
 					{
 						Name:  pointer.StringPtr("fixed"),
-						Type:  v1.ConnectionDetailTypeFromValue,
+						Type:  &fromVal,
 						Value: pointer.StringPtr("value"),
 					},
 				}},
@@ -614,21 +617,21 @@ func TestFetch(t *testing.T) {
 				t: v1.ComposedTemplate{ConnectionDetails: []v1.ConnectionDetail{
 					{
 						FromConnectionSecretKey: pointer.StringPtr("bar"),
-						Type:                    v1.ConnectionDetailTypeFromConnectionSecretKey,
+						Type:                    &fromKey,
 					},
 					{
 						FromConnectionSecretKey: pointer.StringPtr("none"),
-						Type:                    v1.ConnectionDetailTypeFromConnectionSecretKey,
+						Type:                    &fromKey,
 					},
 					{
 						Name:                    pointer.StringPtr("convfoo"),
 						FromConnectionSecretKey: pointer.StringPtr("foo"),
-						Type:                    v1.ConnectionDetailTypeFromConnectionSecretKey,
+						Type:                    &fromKey,
 					},
 					{
 						Name:  pointer.StringPtr("fixed"),
 						Value: pointer.StringPtr("value"),
-						Type:  v1.ConnectionDetailTypeFromValue,
+						Type:  &fromVal,
 					},
 				}},
 			},
@@ -659,7 +662,7 @@ func TestFetch(t *testing.T) {
 				t: v1.ComposedTemplate{ConnectionDetails: []v1.ConnectionDetail{
 					{
 						Name: pointer.StringPtr("missingvalue"),
-						Type: v1.ConnectionDetailTypeFromValue,
+						Type: &fromVal,
 					},
 				}},
 			},
@@ -686,7 +689,7 @@ func TestFetch(t *testing.T) {
 				t: v1.ComposedTemplate{ConnectionDetails: []v1.ConnectionDetail{
 					{
 						Value: pointer.StringPtr("missingname"),
-						Type:  v1.ConnectionDetailTypeFromValue,
+						Type:  &fromVal,
 					},
 				}},
 			},
@@ -712,7 +715,7 @@ func TestFetch(t *testing.T) {
 				},
 				t: v1.ComposedTemplate{ConnectionDetails: []v1.ConnectionDetail{
 					{
-						Type: v1.ConnectionDetailTypeFromConnectionSecretKey,
+						Type: &fromKey,
 					},
 				}},
 			},
@@ -738,7 +741,7 @@ func TestFetch(t *testing.T) {
 				},
 				t: v1.ComposedTemplate{ConnectionDetails: []v1.ConnectionDetail{
 					{
-						Type: v1.ConnectionDetailTypeFromFieldPath,
+						Type: &fromField,
 						Name: pointer.StringPtr("missingname"),
 					},
 				}},
@@ -765,7 +768,7 @@ func TestFetch(t *testing.T) {
 				},
 				t: v1.ComposedTemplate{ConnectionDetails: []v1.ConnectionDetail{
 					{
-						Type:          v1.ConnectionDetailTypeFromFieldPath,
+						Type:          &fromField,
 						FromFieldPath: pointer.StringPtr("fieldpath"),
 					},
 				}},
@@ -797,7 +800,7 @@ func TestFetch(t *testing.T) {
 					{
 						Name:          pointer.StringPtr("name"),
 						FromFieldPath: pointer.StringPtr("objectMeta.name"),
-						Type:          v1.ConnectionDetailTypeFromFieldPath,
+						Type:          &fromField,
 					},
 				}},
 			},
@@ -830,7 +833,7 @@ func TestFetch(t *testing.T) {
 					{
 						Name:          pointer.StringPtr("generation"),
 						FromFieldPath: pointer.StringPtr("objectMeta.generation"),
-						Type:          v1.ConnectionDetailTypeFromFieldPath,
+						Type:          &fromField,
 					},
 				}},
 			},
@@ -850,6 +853,61 @@ func TestFetch(t *testing.T) {
 			}
 			if diff := cmp.Diff(tc.want.conn, conn); diff != "" {
 				t.Errorf("\n%s\nFetch(...): -want, +got:\n%s", tc.reason, diff)
+			}
+		})
+	}
+}
+
+func TestConnectionDetailType(t *testing.T) {
+	fromVal := v1.ConnectionDetailTypeFromValue
+	name := "coolsecret"
+	value := "coolvalue"
+	key := "coolkey"
+	field := "coolfield"
+
+	cases := map[string]struct {
+		d    v1.ConnectionDetail
+		want v1.ConnectionDetailType
+	}{
+		"FromValueExplicit": {
+			d:    v1.ConnectionDetail{Type: &fromVal},
+			want: v1.ConnectionDetailTypeFromValue,
+		},
+		"FromValueInferred": {
+			d: v1.ConnectionDetail{
+				Name:  &name,
+				Value: &value,
+
+				// Name and value trump key or field
+				FromConnectionSecretKey: &key,
+				FromFieldPath:           &field,
+			},
+			want: v1.ConnectionDetailTypeFromValue,
+		},
+		"FromConnectionSecretKeyInferred": {
+			d: v1.ConnectionDetail{
+				Name:                    &name,
+				FromConnectionSecretKey: &key,
+
+				// From key trumps from field
+				FromFieldPath: &field,
+			},
+			want: v1.ConnectionDetailTypeFromConnectionSecretKey,
+		},
+		"FromFieldPathInferred": {
+			d: v1.ConnectionDetail{
+				Name:          &name,
+				FromFieldPath: &field,
+			},
+			want: v1.ConnectionDetailTypeFromFieldPath,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got := connectionDetailType(tc.d)
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("connectionDetailType(...): -want, +got\n%s", diff)
 			}
 		})
 	}

--- a/internal/controller/apiextensions/composite/composed_test.go
+++ b/internal/controller/apiextensions/composite/composed_test.go
@@ -572,7 +572,7 @@ func TestFetch(t *testing.T) {
 					},
 					{
 						Name:  pointer.StringPtr("fixed"),
-						Type:  v1.ConnectionDetailTypeValue,
+						Type:  v1.ConnectionDetailTypeFromValue,
 						Value: pointer.StringPtr("value"),
 					},
 				}},
@@ -628,7 +628,7 @@ func TestFetch(t *testing.T) {
 					{
 						Name:  pointer.StringPtr("fixed"),
 						Value: pointer.StringPtr("value"),
-						Type:  v1.ConnectionDetailTypeValue,
+						Type:  v1.ConnectionDetailTypeFromValue,
 					},
 				}},
 			},
@@ -659,12 +659,12 @@ func TestFetch(t *testing.T) {
 				t: v1.ComposedTemplate{ConnectionDetails: []v1.ConnectionDetail{
 					{
 						Name: pointer.StringPtr("missingvalue"),
-						Type: v1.ConnectionDetailTypeValue,
+						Type: v1.ConnectionDetailTypeFromValue,
 					},
 				}},
 			},
 			want: want{
-				err: errors.Errorf(errFmtConnDetailVal, v1.ConnectionDetailTypeValue),
+				err: errors.Errorf(errFmtConnDetailVal, v1.ConnectionDetailTypeFromValue),
 			},
 		},
 		"ErrConnectionDetailNameNotSet": {
@@ -686,12 +686,12 @@ func TestFetch(t *testing.T) {
 				t: v1.ComposedTemplate{ConnectionDetails: []v1.ConnectionDetail{
 					{
 						Value: pointer.StringPtr("missingname"),
-						Type:  v1.ConnectionDetailTypeValue,
+						Type:  v1.ConnectionDetailTypeFromValue,
 					},
 				}},
 			},
 			want: want{
-				err: errors.Errorf(errFmtConnDetailKey, v1.ConnectionDetailTypeValue),
+				err: errors.Errorf(errFmtConnDetailKey, v1.ConnectionDetailTypeFromValue),
 			},
 		},
 		"ErrConnectionDetailFromConnectionSecretKeyNotSet": {


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
This PR:

* Copies a few backward compatible changes over from apiextensions/v1 to apiextensions/v1beta1
* Makes sure all Composition `FooType` types are named `FooType`, not `TypeFoo`.
* Renames the "Value" `ConnectionDetailType` to "ValueFrom".
* Marks 'value' connection details in our examples as such

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

I haven't - they're all pretty trivial.

[contribution process]: https://git.io/fj2m9
