### PR TITLE
Fix panic on optional FromFieldPath patches where field does not exist

### DIFF
--- a/apis/apiextensions/v1/composition_types_test.go
+++ b/apis/apiextensions/v1/composition_types_test.go
@@ -791,3 +791,102 @@ func TestPatchApply(t *testing.T) {
 		})
 	}
 }
+
+func TestFieldNotFoundNoop(t *testing.T) {
+	errBoom := errors.New("boom")
+	errNotFound := func() error {
+		p := &fieldpath.Paved{}
+		_, err := p.GetValue("boom")
+		return err
+	}
+	required := FromFieldPathPolicyRequired
+	optional := FromFieldPathPolicyOptional
+	type args struct {
+		err error
+		p   *PatchPolicy
+	}
+	type want struct {
+		noop bool
+		err  error
+	}
+
+	cases := map[string]struct {
+		reason string
+		args
+		want
+	}{
+		"NotAnError": {
+			reason: "Should perform patch if no error finding field.",
+			args:   args{},
+			want: want{
+				noop: false,
+			},
+		},
+		"NotFieldNotFoundError": {
+			reason: "Should return error if something other than field not found.",
+			args: args{
+				err: errBoom,
+			},
+			want: want{
+				noop: false,
+				err:  errBoom,
+			},
+		},
+		"DefaultOptionalNoPolicy": {
+			reason: "Should return no-op if field not found and no patch policy specified.",
+			args: args{
+				err: errNotFound(),
+			},
+			want: want{
+				noop: true,
+			},
+		},
+		"DefaultOptionalNoPathPolicy": {
+			reason: "Should return no-op if field not found and empty patch policy specified.",
+			args: args{
+				p:   &PatchPolicy{},
+				err: errNotFound(),
+			},
+			want: want{
+				noop: true,
+			},
+		},
+		"OptionalNotFound": {
+			reason: "Should return no-op if field not found and optional patch policy explicitly specified.",
+			args: args{
+				p: &PatchPolicy{
+					FromFieldPath: &optional,
+				},
+				err: errNotFound(),
+			},
+			want: want{
+				noop: true,
+			},
+		},
+		"RequiredNotFound": {
+			reason: "Should return error if field not found and required patch policy explicitly specified.",
+			args: args{
+				p: &PatchPolicy{
+					FromFieldPath: &required,
+				},
+				err: errNotFound(),
+			},
+			want: want{
+				noop: false,
+				err:  errNotFound(),
+			},
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got, err := FieldNotFoundNoop(tc.args.err, tc.args.p)
+
+			if diff := cmp.Diff(tc.want.noop, got); diff != "" {
+				t.Errorf("Resolve(b): -want, +got:\n%s", diff)
+			}
+			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
+				t.Errorf("Resolve(b): -want, +got:\n%s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Refactors the IgnoreNotFound function to determine if field not found
should cause an error, in the case where the patch policy is required,
or if field not found should cause a no-op patch, in the case where the
patch policy is optional.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

**Requires backport to `release-1.1` branch.**

Fixes #2141 

/cc @mcavoyk @benagricola 

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

Unit tests.

[contribution process]: https://git.io/fj2m9
