### PR TITLE
Use -r as shorthand revision history limit flag

### DIFF
--- a/cmd/crank/install.go
+++ b/cmd/crank/install.go
@@ -59,7 +59,7 @@ type installConfigCmd struct {
 	Package string `arg:"" help:"Image containing Configuration package."`
 
 	Name                 string   `arg:"" optional:"" help:"Name of Configuration."`
-	RevisionHistoryLimit int64    `short:"rl" help:"Revision history limit."`
+	RevisionHistoryLimit int64    `short:"r" help:"Revision history limit."`
 	ManualActivation     bool     `short:"m" help:"Enable manual revision activation policy."`
 	PackagePullSecrets   []string `help:"List of secrets used to pull package."`
 }
@@ -111,7 +111,7 @@ type installProviderCmd struct {
 	Package string `arg:"" help:"Image containing Provider package."`
 
 	Name                 string   `arg:"" optional:"" help:"Name of Provider."`
-	RevisionHistoryLimit int64    `short:"rl" help:"Revision history limit."`
+	RevisionHistoryLimit int64    `short:"r" help:"Revision history limit."`
 	ManualActivation     bool     `short:"m" help:"Enable manual revision activation policy."`
 	PackagePullSecrets   []string `help:"List of secrets used to pull package."`
 }


### PR DESCRIPTION


<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Updates the revision history limit flag for crank install to only use -r
instead of -rl. In practice, kong recognizes the -rl directive as just
-r so this is not an api or behavior change. Supplying -rl currently
will cause an error because the arg value is interpreted as l, which is
not an int64.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

`kubectl crossplane install`

[contribution process]: https://git.io/fj2m9
