### PR TITLE
Do not block composed resources on failed neighbor

### DIFF
--- a/internal/controller/apiextensions/composite/composed.go
+++ b/internal/controller/apiextensions/composite/composed.go
@@ -230,6 +230,10 @@ func (a *GarbageCollectingAssociator) AssociateTemplates(ctx context.Context, cr
 	}
 
 	for _, ref := range cr.GetResourceReferences() {
+		// If reference does not have a name then we haven't rendered it yet.
+		if ref.Name == "" {
+			continue
+		}
 		cd := composed.New(composed.FromReference(ref))
 		nn := types.NamespacedName{Namespace: ref.Namespace, Name: ref.Name}
 		err := a.client.Get(ctx, nn, cd)

--- a/internal/controller/apiextensions/composite/reconciler_test.go
+++ b/internal/controller/apiextensions/composite/reconciler_test.go
@@ -260,7 +260,12 @@ func TestReconcile(t *testing.T) {
 								}
 								return nil
 							}),
+							MockUpdate:       test.NewMockUpdateFn(nil),
+							MockStatusUpdate: test.NewMockStatusUpdateFn(nil),
 						},
+						Applicator: resource.ApplyFn(func(c context.Context, r client.Object, ao ...resource.ApplyOption) error {
+							return nil
+						}),
 					}),
 					WithCompositionSelector(CompositionSelectorFn(func(_ context.Context, cr resource.Composite) error {
 						cr.SetCompositionReference(&corev1.ObjectReference{})
@@ -271,6 +276,12 @@ func TestReconcile(t *testing.T) {
 					})),
 					WithRenderer(RendererFn(func(ctx context.Context, cp resource.Composite, cd resource.Composed, t v1.ComposedTemplate) error {
 						return errBoom
+					})),
+					WithConnectionDetailsFetcher(ConnectionDetailsFetcherFn(func(ctx context.Context, cd resource.Composed, t v1.ComposedTemplate) (managed.ConnectionDetails, error) {
+						return nil, nil
+					})),
+					WithReadinessChecker(ReadinessCheckerFn(func(ctx context.Context, cd resource.Composed, t v1.ComposedTemplate) (ready bool, err error) {
+						return false, nil
 					})),
 				},
 			},

--- a/internal/xcrd/crd_test.go
+++ b/internal/xcrd/crd_test.go
@@ -257,7 +257,7 @@ func TestForCompositeResource(t *testing.T) {
 													"name":       {Type: "string"},
 													"kind":       {Type: "string"},
 												},
-												Required: []string{"apiVersion", "kind", "name"},
+												Required: []string{"apiVersion", "kind"},
 											},
 										},
 									},

--- a/internal/xcrd/schemas.go
+++ b/internal/xcrd/schemas.go
@@ -106,7 +106,7 @@ func CompositeResourceSpecProps() map[string]extv1.JSONSchemaProps {
 						"name":       {Type: "string"},
 						"kind":       {Type: "string"},
 					},
-					Required: []string{"apiVersion", "kind", "name"},
+					Required: []string{"apiVersion", "kind"},
 				},
 			},
 		},


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Updates the composite resource reconciler to render all resources it is
able to even if it is not able to render all resources in the specified
composition. This is a change in behavior from refusing to render any
composed resources if not able to render all.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

Fixes #2175 

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

Using the manifests in #2175:
1. Create an `ObjectStorageBucket`
```
🤖 (crossplane) k get objectstoragebucket
NAME   READY   CONNECTION-SECRET   AGE
test   False                       119s
```
2. Observed that only the `Bucket` was created
```
🤖 (crossplane) k get bucket
NAME               READY   SYNCED   AGE
test-j4jhd-7kvk8   True    True     60m
```

3. See that both references are create but `IAMPolicy` does not have a `name`

```
- apiVersion: resources.company.systems/v1alpha1
  kind: CompositeObjectStorageBucket
  metadata:
    annotations:
      crossplane.io/external-name: ""
      kubectl.kubernetes.io/last-applied-configuration: |
        {"apiVersion":"resources.company.systems/v1alpha1","kind":"ObjectStorageBucket","metadata":{"annotations":{},"name":"test","namespace":"default"},"spec":{}}
    creationTimestamp: "2021-06-03T22:14:21Z"
    generateName: test-
    generation: 4
    labels:
      crossplane.io/claim-name: test
      crossplane.io/claim-namespace: default
      crossplane.io/composite: test-j4jhd
   ...
   name: test-j4jhd
  spec:
    claimRef:
      apiVersion: resources.company.systems/v1alpha1
      kind: ObjectStorageBucket
      name: test
      namespace: default
    compositionRef:
      name: object-storage-bucket-aws
    resourceRefs:
    - apiVersion: s3.aws.crossplane.io/v1beta1
      kind: Bucket
      name: test-j4jhd-7kvk8
    - apiVersion: identity.aws.crossplane.io/v1alpha1
      kind: IAMPolicy
  status:
    conditions:
    - lastTransitionTime: "2021-06-03T22:16:51Z"
      reason: Creating
      status: "False"
      type: Ready
    uid: arn:aws:s3:::test-j4jhd-7kvk8
```

4. Now that `uid` is populated in `status`, we can create the `IAMPolicy`

```
🤖 (crossplane-runtime) k get iampolicy
NAME               ARN                                           READY   SYNCED   AGE
test-j4jhd-5phzf   arn:aws:iam::609897127049:policy/test-j4jhd   True    True     6m23s
```

5. Name of `IAMRole` is now present in resource refs on the composite

```
- apiVersion: resources.company.systems/v1alpha1
  kind: CompositeObjectStorageBucket
  metadata:
    annotations:
      crossplane.io/external-name: ""
      kubectl.kubernetes.io/last-applied-configuration: |
        {"apiVersion":"resources.company.systems/v1alpha1","kind":"ObjectStorageBucket","metadata":{"annotations":{},"name":"test","namespace":"default"},"spec":{}}
    creationTimestamp: "2021-06-03T22:14:21Z"
    generateName: test-
    generation: 5
    labels:
      crossplane.io/claim-name: test
      crossplane.io/claim-namespace: default
      crossplane.io/composite: test-j4jhd
    ...
    name: test-j4jhd
    ...
  spec:
    claimRef:
      apiVersion: resources.company.systems/v1alpha1
      kind: ObjectStorageBucket
      name: test
      namespace: default
    compositionRef:
      name: object-storage-bucket-aws
    resourceRefs:
    - apiVersion: s3.aws.crossplane.io/v1beta1
      kind: Bucket
      name: test-j4jhd-7kvk8
    - apiVersion: identity.aws.crossplane.io/v1alpha1
      kind: IAMPolicy
      name: test-j4jhd-5phzf
  status:
    conditions:
    - lastTransitionTime: "2021-06-03T23:16:37Z"
      reason: Available
      status: "True"
      type: Ready
    uid: arn:aws:s3:::test-j4jhd-7kvk8
```

6. Deleting the claim cleans up the composite and all managed resources.

[contribution process]: https://git.io/fj2m9
