### PR TITLE
Move community day meetings to Thursday mornings

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ Kubernetes API.
 * Join our regular community meetings.
 * Provide feedback on our [roadmap](ROADMAP.md).
 
-The Crossplane community meeting takes place every other [Monday at 10:00am
+The Crossplane community meeting takes place every other [Thursday at 10:00am
 Pacific Time]. Anyone who wants to discuss the direction of the project, design
 and implementation reviews, or raise general questions with the broader
 community is encouraged to join.


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
I'd like to propose we move our community day meetings from Monday to Thursday mornings. I'd also like to offset the week by one - so for example we'd meet on Thursday 11th, Thursday 25th, etc rather than Monday 15th, Monday 29th, etc. This proposed time slot would be more convenient for those of us on the steering committee and maintainership team that work at Upbound.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [ ] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

[contribution process]: https://git.io/fj2m9
