### PR TITLE
Fix community meeting timezone link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,9 +123,9 @@ Kubernetes API.
 * Provide feedback on our [roadmap](ROADMAP.md).
 
 The Crossplane community meeting takes place every other [Thursday at 10:00am
-Pacific Time]. Anyone who wants to discuss the direction of the project, design
-and implementation reviews, or raise general questions with the broader
-community is encouraged to join.
+Pacific Time][community meeting time]. Anyone who wants to discuss the direction
+of the project, design and implementation reviews, or raise general questions
+with the broader community is encouraged to join.
 
 * Meeting link: <https://zoom.us/j/425148449?pwd=NEk4N0tHWGpEazhuam1yR28yWHY5QT09>
 * [Current agenda and past meeting notes]
@@ -161,6 +161,6 @@ Crossplane is under the Apache 2.0 license.
 [Email]: mailto:info@crossplane.io
 [issue against Crossplane]: https://github.com/crossplane/crossplane/issues
 [contributing guide]: CONTRIBUTING.md
-[Monday at 10:00am Pacific Time]: https://www.thetimezoneconverter.com/?t=10:00&tz=PT%20%28Pacific%20Time%29
+[community meeting time]: https://www.thetimezoneconverter.com/?t=10:00&tz=PT%20%28Pacific%20Time%29
 [Current agenda and past meeting notes]: https://docs.google.com/document/d/1q_sp2jLQsDEOX7Yug6TPOv7Fwrys6EwcF5Itxjkno7Y/edit?usp=sharing
 [Past meeting recordings]: https://www.youtube.com/playlist?list=PL510POnNVaaYYYDSICFSNWFqNbx1EMr-M


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
I broke the community meeting timezone conversion link in https://github.com/crossplane/crossplane/pull/2196.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [ ] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
I rendered the markdown and looked at it this time. :)

[contribution process]: https://git.io/fj2m9
