### PR TITLE
Update `reclaimPolicy` to `deletionPolicy` in docs

### DIFF
--- a/docs/concepts/managed-resources.md
+++ b/docs/concepts/managed-resources.md
@@ -42,7 +42,7 @@ spec:
       namespace: crossplane-system
   providerConfigRef:
     name: default
-  reclaimPolicy: Delete
+  deletionPolicy: Delete
 ```
 
 In Kubernetes, `spec` top field represents the desired state of the user.
@@ -118,7 +118,7 @@ of an `RDSInstance`.
 
 Some infrastructure tools such as Terraform delete and recreate the resource to
 accommodate those changes but Crossplane does not take that route. Unless the
-managed resource is deleted and its `reclaimPolicy` is `Delete`, its controller
+managed resource is deleted and its `deletionPolicy` is `Delete`, its controller
 never deletes the external resource in the provider.
 
 > Immutable fields are marked as `immutable` in Crossplane codebase but


### PR DESCRIPTION
### Description of your changes

Update `Managed Resources` documentation section
with renamed spec field according to
https://doc.crds.dev/github.com/crossplane/provider-aws/database.aws.crossplane.io/RDSInstance/v1beta1@v0.17.0#spec

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

n/a - documentation update