### PR TITLE
[release-1.1] Use correct key in ProviderConfig secret references

### DIFF
--- a/docs/snippets/configure/aws/providerconfig.yaml
+++ b/docs/snippets/configure/aws/providerconfig.yaml
@@ -9,4 +9,4 @@ spec:
     secretRef:
       namespace: crossplane-system
       name: aws-creds
-      key: key
+      key: creds

--- a/docs/snippets/configure/azure/providerconfig.yaml
+++ b/docs/snippets/configure/azure/providerconfig.yaml
@@ -9,4 +9,4 @@ spec:
     secretRef:
       namespace: crossplane-system
       name: azure-creds
-      key: key
+      key: creds


### PR DESCRIPTION


<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Updates the snippets to use the creds key, which follows the
modification of the secret key in the getting started docs workflow.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>
(cherry picked from commit 38b3b7ae6ae829d88e3ec5013e2be0166451a3cb)

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

Running through getting started guide.

[contribution process]: https://git.io/fj2m9
