### PR TITLE
Pass context to all package registry requests

### DIFF
--- a/internal/xpkg/fetch.go
+++ b/internal/xpkg/fetch.go
@@ -57,7 +57,7 @@ func (i *K8sFetcher) Fetch(ctx context.Context, ref name.Reference, secrets ...s
 	if err != nil {
 		return nil, err
 	}
-	return remote.Image(ref, remote.WithAuthFromKeychain(auth))
+	return remote.Image(ref, remote.WithAuthFromKeychain(auth), remote.WithContext(ctx))
 }
 
 // Head fetches a package descriptor.
@@ -69,7 +69,7 @@ func (i *K8sFetcher) Head(ctx context.Context, ref name.Reference, secrets ...st
 	if err != nil {
 		return nil, err
 	}
-	return remote.Head(ref, remote.WithAuthFromKeychain(auth))
+	return remote.Head(ref, remote.WithAuthFromKeychain(auth), remote.WithContext(ctx))
 }
 
 // Tags fetches a package's tags.
@@ -81,7 +81,7 @@ func (i *K8sFetcher) Tags(ctx context.Context, ref name.Reference, secrets ...st
 	if err != nil {
 		return nil, err
 	}
-	return remote.List(ref.Context(), remote.WithAuthFromKeychain(auth))
+	return remote.List(ref.Context(), remote.WithAuthFromKeychain(auth), remote.WithContext(ctx))
 }
 
 // NopFetcher always returns an empty image and never returns error.


### PR DESCRIPTION


<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Passes context to all package registry requests to ensure we do not hang
forever due to underlying client using DefaultTransport with disabled
(i.e. 0 value) timeout.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

Ran through package install flow.

[contribution process]: https://git.io/fj2m9
