### PR TITLE
[release-1.1] Use v1 Provider in ControllerConfig docs

### DIFF
--- a/docs/concepts/packages.md
+++ b/docs/concepts/packages.md
@@ -385,7 +385,7 @@ spec:
   podSecurityContext:
     fsGroup: 2000
 ---
-apiVersion: pkg.crossplane.io/v1alpha1
+apiVersion: pkg.crossplane.io/v1
 kind: Provider
 metadata:
   name: provider-aws


### PR DESCRIPTION


<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Uses the modern v1 Provider object instead of the now removed v1alpha1
version.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>
(cherry picked from commit 9c04f6fdaf9cf4b4252ecdb6341e65248a703a6b)

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

n/a

[contribution process]: https://git.io/fj2m9
