### PR TITLE
cli: make the message after install to do a sudo move more obvious

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -59,10 +59,14 @@ fi
 
 chmod +x kubectl-crossplane
 
-echo "kubectl plugin downloaded successfully! Run the following commands to finish installing it:"
-echo 
-echo sudo mv kubectl-crossplane $(dirname $(which kubectl))
-echo kubectl crossplane --help
+YELLOW_FOREGROUND=`tput setaf 3`
+RESET=`tput sgr0`
+
+echo "kubectl plugin downloaded successfully!"
+echo
+echo "${YELLOW_FOREGROUND}Run the following commands to finish installing it:"
+echo "sudo mv kubectl-crossplane $(dirname $(which kubectl))"
+echo "kubectl crossplane --help${RESET}"
 echo
 echo "Visit https://crossplane.io to get started. 🚀"
 echo "Have a nice day! 👋\n"


### PR DESCRIPTION
### Description of your changes

This PR adds a splash of color to the success output message in our `install.sh` script that installs the Crossplane CLI.  The command printed there to move the downloaded binary to where kubectl lives is really easy to miss when you quickly glance at the output.  This change would make the need to run this command more obvious.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

I have run the script directly with `./install.sh` locally on my Mac.

This [stackoverflow article](https://stackoverflow.com/questions/5947742/how-to-change-the-output-color-of-echo-in-linux) indicates that the `tput` approach is portable, but having a friendly reviewer of this PR that is using Linux test this change also would be appreciated :)

#### Before:

<img width="651" alt="Screen Shot 2021-03-20 at 6 41 53 PM" src="https://user-images.githubusercontent.com/4313439/111891001-15ea7800-89ac-11eb-88b5-3999e38506ff.png">

#### After:

<img width="369" alt="Screen Shot 2021-03-20 at 6 42 45 PM" src="https://user-images.githubusercontent.com/4313439/111891002-1daa1c80-89ac-11eb-94ae-eaf5c8bd06d7.png">

[contribution process]: https://git.io/fj2m9
