### PR TITLE
Revert "Merge pull request #2227 from jbw976/cli-install-colors"

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -59,14 +59,10 @@ fi
 
 chmod +x kubectl-crossplane
 
-YELLOW_FOREGROUND=`tput setaf 3`
-RESET=`tput sgr0`
-
-echo "kubectl plugin downloaded successfully!"
-echo
-echo "${YELLOW_FOREGROUND}Run the following commands to finish installing it:"
-echo "sudo mv kubectl-crossplane $(dirname $(which kubectl))"
-echo "kubectl crossplane --help${RESET}"
+echo "kubectl plugin downloaded successfully! Run the following commands to finish installing it:"
+echo 
+echo sudo mv kubectl-crossplane $(dirname $(which kubectl))
+echo kubectl crossplane --help
 echo
 echo "Visit https://crossplane.io to get started. 🚀"
 echo "Have a nice day! 👋\n"


### PR DESCRIPTION
This reverts commit 98237f718f699e5cdd028b934fe5e170259766d0, reversing changes made to b07187078e0fff03b7f620a7aa0c77a3c44fce17 as part of #2227.

This is being reverted because the github actions env is not compatible by default with the way that #2227 was calling `tput` (`$TERM` is not set in that environment).  Rather than floundering around trying to get a fix that works in all environments, we're simply reverting the change for now.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Manually ran `./install.sh` locally to ensure behavior is back to before #2227 :(

[contribution process]: https://git.io/fj2m9
