### PR TITLE
Fix "Getting Started with AWS (with VPC)" configuration

### DIFF
--- a/docs/getting-started/create-configuration.md
+++ b/docs/getting-started/create-configuration.md
@@ -247,7 +247,7 @@ spec:
             vpcIdSelector:
               matchControllerRef: true
             availabilityZone: us-east-1c
-    - name: subnet-c
+    - name: dbsubnetgroup
       base:
         apiVersion: database.aws.crossplane.io/v1beta1
         kind: DBSubnetGroup

--- a/docs/snippets/package/aws-with-vpc/composition.yaml
+++ b/docs/snippets/package/aws-with-vpc/composition.yaml
@@ -65,7 +65,7 @@ spec:
             vpcIdSelector:
               matchControllerRef: true
             availabilityZone: us-east-1c
-    - name: subnet-c
+    - name: dbsubnetgroup
       base:
         apiVersion: database.aws.crossplane.io/v1beta1
         kind: DBSubnetGroup

--- a/docs/snippets/package/aws-with-vpc/crossplane.yaml
+++ b/docs/snippets/package/aws-with-vpc/crossplane.yaml
@@ -10,5 +10,6 @@ spec:
   crossplane:
     version: ">=v1.0.0-0"
   dependsOn:
+    # TODO(negz): Update Composition for compatibility with v0.17.0.
     - provider: crossplane/provider-aws
-      version: ">=v0.14.0"
+      version: "v0.16.0"


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
The "AWS with VPC" guide appears to be broken as of Crossplane 1.1.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [ ] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
I haven't built and installed this configuration, but I have installed provider-aws v0.16, applied the XRD and Composition from this configuration, and validated that I can create a `CompositePostgreSQLInstance`.