### PR TITLE
adding extra env vars logic in helm chart to be injected in deployment yml

### DIFF
--- a/cluster/charts/crossplane/README.md
+++ b/cluster/charts/crossplane/README.md
@@ -105,7 +105,8 @@ and their default values.
 | `rbacManager.tolerations` | Enable tolerations for RBAC Managers pod | `{}` |
 | `alpha.oam.enabled` | Deploy the `crossplane/oam-kubernetes-runtime` Helm chart | `false` |
 | `metrics.enabled` | Expose Crossplane and RBAC Manager metrics endpoint | `false` |
-| `extraEnvironmentVars` | List of extra environment variables to set | `{}` |
+| `extraEnvVarsCrossplane` | List of extra environment variables to set in the crossplane deployment | `{}` |
+| `extraEnvVarsRBACManager` | List of extra environment variables to set in the crossplane rbac manager deployment | `{}` |
 
 ### Command Line
 

--- a/cluster/charts/crossplane/README.md
+++ b/cluster/charts/crossplane/README.md
@@ -105,6 +105,7 @@ and their default values.
 | `rbacManager.tolerations` | Enable tolerations for RBAC Managers pod | `{}` |
 | `alpha.oam.enabled` | Deploy the `crossplane/oam-kubernetes-runtime` Helm chart | `false` |
 | `metrics.enabled` | Expose Crossplane and RBAC Manager metrics endpoint | `false` |
+| `extraEnvironmentVars` | List of extra environment variables to set | `{}` |
 
 ### Command Line
 

--- a/cluster/charts/crossplane/templates/deployment.yaml
+++ b/cluster/charts/crossplane/templates/deployment.yaml
@@ -76,6 +76,10 @@ spec:
                 fieldPath: metadata.namespace
           - name: LEADER_ELECTION
             value: "{{ .Values.leaderElection }}"
+        {{- range $key, $value := .Values.extraEnvironmentVars }}
+          - name: {{ $key | replace "." "_" }}
+            value: {{ $value | quote }}
+        {{- end}}
         volumeMounts:
           - mountPath: /cache
             name: package-cache

--- a/cluster/charts/crossplane/templates/deployment.yaml
+++ b/cluster/charts/crossplane/templates/deployment.yaml
@@ -76,7 +76,7 @@ spec:
                 fieldPath: metadata.namespace
           - name: LEADER_ELECTION
             value: "{{ .Values.leaderElection }}"
-        {{- range $key, $value := .Values.extraEnvironmentVars }}
+        {{- range $key, $value := .Values.extraEnvVarsCrossplane }}
           - name: {{ $key | replace "." "_" }}
             value: {{ $value | quote }}
         {{- end}}

--- a/cluster/charts/crossplane/templates/rbac-manager-deployment.yaml
+++ b/cluster/charts/crossplane/templates/rbac-manager-deployment.yaml
@@ -69,6 +69,10 @@ spec:
         env:
           - name: LEADER_ELECTION
             value: "{{ .Values.rbacManager.leaderElection }}"
+        {{- range $key, $value := .Values.extraEnvVarsRBACManager }}
+          - name: {{ $key | replace "." "_" }}
+            value: {{ $value | quote }}
+        {{- end}}
       {{- if .Values.rbacManager.nodeSelector }}
       nodeSelector: {{ toYaml .Values.rbacManager.nodeSelector | nindent 8 }}
       {{- end }}

--- a/cluster/charts/crossplane/values.yaml.tmpl
+++ b/cluster/charts/crossplane/values.yaml.tmpl
@@ -72,3 +72,15 @@ alpha:
 
 metrics:
   enabled: false
+
+# List of extra environment variables to set in the deployment.
+# EXAMPLE
+# extraEnvironmentVars:
+#   sample.key=value1
+#   ANOTHER.KEY=value2
+# RESULT
+#   - name: sample_key
+#     value: "value1"
+#   - name: ANOTHER_KEY
+#     value: "value2"
+extraEnvironmentVars: {}

--- a/cluster/charts/crossplane/values.yaml.tmpl
+++ b/cluster/charts/crossplane/values.yaml.tmpl
@@ -73,7 +73,7 @@ alpha:
 metrics:
   enabled: false
 
-# List of extra environment variables to set in the deployment.
+# List of extra environment variables to set in the crossplane deployment.
 # EXAMPLE
 # extraEnvironmentVars:
 #   sample.key=value1
@@ -83,4 +83,16 @@ metrics:
 #     value: "value1"
 #   - name: ANOTHER_KEY
 #     value: "value2"
-extraEnvironmentVars: {}
+extraEnvVarsCrossplane: {}
+
+# List of extra environment variables to set in the crossplane rbac manager deployment.
+# EXAMPLE
+# extraEnvironmentVars:
+#   sample.key=value1
+#   ANOTHER.KEY=value2
+# RESULT
+#   - name: sample_key
+#     value: "value1"
+#   - name: ANOTHER_KEY
+#     value: "value2"
+extraEnvVarsRBACManager: {}

--- a/docs/reference/install.md
+++ b/docs/reference/install.md
@@ -112,7 +112,8 @@ and their default values.
 | `rbacManager.tolerations` | Enable tolerations for RBAC Managers pod | `{}` |
 | `alpha.oam.enabled` | Deploy the `crossplane/oam-kubernetes-runtime` Helm chart | `false` |
 | `metrics.enabled` | Expose Crossplane and RBAC Manager metrics endpoint | `false` |
-| `extraEnvironmentVars` | List of extra environment variables to set | `{}` |
+| `extraEnvVarsCrossplane` | List of extra environment variables to set in the crossplane deployment | `{}` |
+| `extraEnvVarsRBACManager` | List of extra environment variables to set in the crossplane rbac manager deployment | `{}` |
 
 ### Command Line
 

--- a/docs/reference/install.md
+++ b/docs/reference/install.md
@@ -112,6 +112,7 @@ and their default values.
 | `rbacManager.tolerations` | Enable tolerations for RBAC Managers pod | `{}` |
 | `alpha.oam.enabled` | Deploy the `crossplane/oam-kubernetes-runtime` Helm chart | `false` |
 | `metrics.enabled` | Expose Crossplane and RBAC Manager metrics endpoint | `false` |
+| `extraEnvironmentVars` | List of extra environment variables to set | `{}` |
 
 ### Command Line
 


### PR DESCRIPTION
…s to be set in deployment.yml

Signed-off-by: Kyle Zimmermann <kyle.s.zimmermann@gmail.com>

<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

This change exposes an extraEnvironmentVars field in the crossplane helm chart which can be used to
set/manage additional env vars that might be needed for a crossplane deployment.
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #2238

I have:

- [x] Read and followed Crossplane's [contribution process].
- [ ] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Locally executed a `helm template` command and validated that deployment.yml was created
properly with the additional env vars set.

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
