### PR TITLE
Set runAsUser and runAsGroup to nonroot uid and gid

### DIFF
--- a/cluster/charts/crossplane/README.md
+++ b/cluster/charts/crossplane/README.md
@@ -80,8 +80,8 @@ and their default values.
 | `resourcesCrossplane.limits.memory` | Memory resource limits for Crossplane | `512Mi` |
 | `resourcesCrossplane.requests.cpu` | CPU resource requests for Crossplane | `100m` |
 | `resourcesCrossplane.requests.memory` | Memory resource requests for Crossplane | `256Mi` |
-| `securityContextCrossplane.runAsUser` | Run as user for Crossplane | `2000` |
-| `securityContextCrossplane.runAsGroup` | Run as group for Crossplane | `2000` |
+| `securityContextCrossplane.runAsUser` | Run as user for Crossplane | `65532` |
+| `securityContextCrossplane.runAsGroup` | Run as group for Crossplane | `65532` |
 | `securityContextCrossplane.allowPrivilegeEscalation` | Allow privilege escalation for Crossplane | `false` |
 | `securityContextCrossplane.readOnlyRootFilesystem` | ReadOnly root filesystem for Crossplane | `true` |
 | `provider.packages` | The list of Provider packages to install together with Crossplane | `[]` |
@@ -94,6 +94,8 @@ and their default values.
 | `resourcesRBACManager.limits.memory` | Memory resource limits for RBAC Manager | `512Mi` |
 | `resourcesRBACManager.requests.cpu` | CPU resource requests for RBAC Manager | `100m` |
 | `resourcesRBACManager.requests.memory` | Memory resource requests for RBAC Manager | `256Mi` |
+| `securityContextRBACManager.runAsUser` | Run as user for RBAC Manager | `65532` |
+| `securityContextRBACManager.runAsGroup` | Run as group for RBAC Manager | `65532` |
 | `securityContextRBACManager.allowPrivilegeEscalation` | Allow privilege escalation for RBAC Manager | `false` |
 | `securityContextRBACManager.readOnlyRootFilesystem` | ReadOnly root filesystem for RBAC Manager | `true` |
 | `rbacManager.affinity` | Enable affinity for RBAC Managers pod | `{}` |

--- a/cluster/charts/crossplane/values.yaml.tmpl
+++ b/cluster/charts/crossplane/values.yaml.tmpl
@@ -44,8 +44,8 @@ resourcesCrossplane:
     memory: 256Mi
 
 securityContextCrossplane:
-  runAsUser: 2000
-  runAsGroup: 2000
+  runAsUser: 65532
+  runAsGroup: 65532
   allowPrivilegeEscalation: false
   readOnlyRootFilesystem: true
 
@@ -63,6 +63,8 @@ resourcesRBACManager:
     memory: 256Mi
 
 securityContextRBACManager:
+  runAsUser: 65532
+  runAsGroup: 65532
   allowPrivilegeEscalation: false
   readOnlyRootFilesystem: true
 

--- a/docs/reference/install.md
+++ b/docs/reference/install.md
@@ -87,8 +87,8 @@ and their default values.
 | `resourcesCrossplane.limits.memory` | Memory resource limits for Crossplane | `512Mi` |
 | `resourcesCrossplane.requests.cpu` | CPU resource requests for Crossplane | `100m` |
 | `resourcesCrossplane.requests.memory` | Memory resource requests for Crossplane | `256Mi` |
-| `securityContextCrossplane.runAsUser` | Run as user for Crossplane | `2000` |
-| `securityContextCrossplane.runAsGroup` | Run as group for Crossplane | `2000` |
+| `securityContextCrossplane.runAsUser` | Run as user for Crossplane | `65532` |
+| `securityContextCrossplane.runAsGroup` | Run as group for Crossplane | `65532` |
 | `securityContextCrossplane.allowPrivilegeEscalation` | Allow privilege escalation for Crossplane | `false` |
 | `securityContextCrossplane.readOnlyRootFilesystem` | ReadOnly root filesystem for Crossplane | `true` |
 | `provider.packages` | The list of Provider packages to install together with Crossplane | `[]` |
@@ -101,6 +101,8 @@ and their default values.
 | `resourcesRBACManager.limits.memory` | Memory resource limits for RBAC Manager | `512Mi` |
 | `resourcesRBACManager.requests.cpu` | CPU resource requests for RBAC Manager | `100m` |
 | `resourcesRBACManager.requests.memory` | Memory resource requests for RBAC Manager | `256Mi` |
+| `securityContextRBACManager.runAsUser` | Run as user for RBAC Manager | `65532` |
+| `securityContextRBACManager.runAsGroup` | Run as group for RBAC Manager | `65532` |
 | `securityContextRBACManager.allowPrivilegeEscalation` | Allow privilege escalation for RBAC Manager | `false` |
 | `securityContextRBACManager.readOnlyRootFilesystem` | ReadOnly root filesystem for RBAC Manager | `true` |
 | `rbacManager.affinity` | Enable affinity for RBAC Managers pod | `{}` |


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Updates runAsUser and runAsGroup ids to match those set in the
distroless nonroot base image.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

References
- https://github.com/tektoncd/pipeline/issues/3273
- https://github.com/GoogleContainerTools/distroless/blob/e52e560310a03432eab208f339e73bdfd701a6b6/base/base.bzl#L9
- https://github.com/kubernetes-sigs/kind/issues/1331

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

Successfully installed Crossplane.

[contribution process]: https://git.io/fj2m9
