### PR TITLE
Do not use nonroot distroless base image

### DIFF
--- a/cluster/images/crossplane/Dockerfile
+++ b/cluster/images/crossplane/Dockerfile
@@ -3,5 +3,5 @@ FROM BASEIMAGE
 ADD crossplane /usr/local/bin/
 ADD crds /crds
 EXPOSE 8080
-USER 1001
+USER 65532
 ENTRYPOINT ["crossplane"]

--- a/cluster/images/crossplane/Makefile
+++ b/cluster/images/crossplane/Makefile
@@ -7,7 +7,7 @@ include ../../../build/makelib/common.mk
 # ====================================================================================
 #  Options
 IMAGE = $(BUILD_REGISTRY)/crossplane-$(ARCH)
-OSBASEIMAGE = gcr.io/distroless/static:nonroot
+OSBASEIMAGE = gcr.io/distroless/static
 include ../../../build/makelib/image.mk
 
 # ====================================================================================

--- a/cluster/images/crossplane/Makefile
+++ b/cluster/images/crossplane/Makefile
@@ -7,7 +7,7 @@ include ../../../build/makelib/common.mk
 # ====================================================================================
 #  Options
 IMAGE = $(BUILD_REGISTRY)/crossplane-$(ARCH)
-OSBASEIMAGE = gcr.io/distroless/static
+OSBASEIMAGE = gcr.io/distroless/static@sha256:d2b0ec3141031720cf5eedef3493b8e129bc91935a43b50562fbe5429878d96b
 include ../../../build/makelib/image.mk
 
 # ====================================================================================


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

The overall issue we are addressing is described [here](https://bugzilla.redhat.com/show_bug.cgi?id=1934177).

Changes the crossplane base image to distroless static to workaround
issues with updated runc which executes chdir to cwd later in the init
sequence after setting up the container user.

See https://github.com/opencontainers/runc/commit/d869d05aba0fc2519060b3b20b679ac5a5068e78

The distroless nonroot image sets user as nonroot (uid=65532) and cwd to
/home/nonroot with 0700 permissions. If the container user is not 65532
the chdir to /home/nonroot fails with permission denied, effectively
making it impossible to run as any other user. We can mostly achieve our
desired outcome of running as nonroot user, but introducing more
flexibility for platforms, such as Openshift, which assign uid ranges
for namespaces, by switching to the regular distroless static base image
and assigning runAsUser: 65532 in our helm deployment. This will
eliminate the chdir permission denied errors when a different user is
selected because the default cwd is /, which has 0755 permissions.

See how both images (root and nonroot) are constructed [here](https://github.com/GoogleContainerTools/distroless/blob/9bff806aab486bad284339c7fa9dd87578905773/base/base.bzl#L19).

This PR also pins us to a specific digest of distroless static so that
contents will not change without explicit update to this repo.

For more information of how Openshift handles UIDs, take a look
at [this guide](https://www.openshift.com/blog/a-guide-to-openshift-and-uids).

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

I have tested deploying this in a variety of settings, including on an Openshift cluster. Running locally on kind I have demonstrated the differences before and after this switch.

*Update: Have now seen a user encounter this issue on EKS when upgrading to [`v20210329` AMI](https://github.com/awslabs/amazon-eks-ami/releases/tag/v20210329). They have verified that fix does address the issue.*

#### Scenario 1: (v1.1.0) `helm install crossplane --namespace crossplane-system crossplane-stable/crossplane`

<details>
  <summary>Expand for steps.</summary>


```
🤖 (crossplane) k get pods -n crossplane-system
NAME                                       READY   STATUS    RESTARTS   AGE
crossplane-5668d8974b-5s5px                1/1     Running   0          20s
crossplane-rbac-manager-6b97979649-kxgff   1/1     Running   0          20s
```

```
🤖 (crossplane) docker exec -it kind-control-plane /bin/bash
root@kind-control-plane:/# ps aux | grep crossplane
1001        6268  1.0  0.2 747896 41548 ?        SLsl 14:59   0:00 crossplane rbac --manage=All --provider-clusterrole=crossplane:allowed-provider-permissions
2000        6305  1.1  0.2 747896 40324 ?        SLsl 14:59   0:00 crossplane
```

Note the UIDs as this was before https://github.com/crossplane/crossplane/pull/2240

```
root@kind-control-plane:/# pwdx 6305
6305: /home/nonroot
root@kind-control-plane:/# pwdx 6268
6268: /home/nonroot
```

cwd is `/home/nonroot` as we are using `distroless/static:nonroot`

```
root@kind-control-plane:/# ls -la /proc/6305/cwd/
total 8
drwx------ 2 65532 65532 4096 Jan  1  1970 .
drwxr-xr-x 3 65532 65532 4096 Jan  1  1970 ..
```

`0700` permissions are set on `/home/nonroot` (i.e. cwd of pid)

</details>


#### Scenario 2: (master) `helm install crossplane --namespace crossplane-system crossplane-master/crossplane --devel --version 1.2.0-rc.0.106.gdb33bb23`

<details>
  <summary>Expand for steps.</summary>

```
🤖 (crossplane) k get pods -n crossplane-system
NAME                                       READY   STATUS    RESTARTS   AGE
crossplane-6b7f9cb5c4-g2w9n                1/1     Running   0          56s
crossplane-rbac-manager-6f5f7c54db-994pb   1/1     Running   0          56s
```

```
🤖 (crossplane) docker exec -it kind-control-plane /bin/bash
root@kind-control-plane:/# ps aux | grep crossplane
65532       7544  0.8  0.2 747680 40808 ?        SLsl 15:03   0:00 crossplane core start
65532       7609  0.9  0.2 747936 40796 ?        SLsl 15:03   0:00 crossplane rbac start --manage=All --provider-clusterrole=crossplane:allowed-provider-permissions
```


```
root@kind-control-plane:/# pwdx 7544
7544: /home/nonroot
root@kind-control-plane:/# pwdx 7609
7609: /home/nonroot
```

```
root@kind-control-plane:/# ls -la /proc/7544/cwd/
total 8
drwx------ 2 65532 65532 4096 Jan  1  1970 .
drwxr-xr-x 3 65532 65532 4096 Jan  1  1970 ..
```

`0700` permissions are set on `/home/nonroot` (i.e. cwd of pid)

</details>

#### Scenario 3: (image from this PR) `helm install crossplane --namespace crossplane-system crossplane-master/crossplane --devel --version 1.2.0-rc.0.106.gdb33bb23 --set image.repository=hasheddan/crossplane --set image.tag=pinned`

<details>
  <summary>Expand for steps.</summary>

```
🤖 (crossplane) k get pods -n crossplane-system
NAME                                       READY   STATUS    RESTARTS   AGE
crossplane-77546fc9d9-xfwd5                1/1     Running   0          31s
crossplane-rbac-manager-5c6c58c879-9qjd9   1/1     Running   0          31s
```

```
🤖 (crossplane) docker exec -it kind-control-plane /bin/bash
root@kind-control-plane:/# ps aux | grep crossplane
65532       2888  0.9  0.2 745984 43640 ?        Ssl  15:39   0:00 crossplane rbac start --manage=All --provider-clusterrole=crossplane:allowed-provider-permissions
65532       2928  0.8  0.2 745728 41488 ?        Ssl  15:39   0:00 crossplane core start
```

```
root@kind-control-plane:/# pwdx 2928
2928: /
root@kind-control-plane:/# pwdx 2888
2888: /
```

Note that cwd is now `/` but we are still uid 65532.

```
root@kind-control-plane:/# ls -la /proc/2928/cwd/
total 64
drwxr-xr-x   1 root  root  4096 Apr  2 15:39 .
drwxr-xr-x   1 root  root  4096 Apr  2 15:39 ..
drwxr-xr-x   2 root  root  4096 Jan  1  1970 bin
drwxr-xr-x   2 root  root  4096 Jan  1  1970 boot
drwxrwxrwx   2 root  root  4096 Apr  2 15:39 cache
drwxr-xr-x   2 root  root  4096 Apr  2 14:31 crds
drwxr-xr-x   5 root  root   360 Apr  2 15:39 dev
drwxr-xr-x   1 root  root  4096 Apr  2 15:39 etc
drwxr-xr-x   3 65532 65532 4096 Jan  1  1970 home
drwxr-xr-x   2 root  root  4096 Jan  1  1970 lib
dr-xr-xr-x 539 root  root     0 Apr  2 15:39 proc
drwx------   2 root  root  4096 Jan  1  1970 root
drwxr-xr-x   2 root  root  4096 Jan  1  1970 run
drwxr-xr-x   2 root  root  4096 Jan  1  1970 sbin
dr-xr-xr-x  13 root  root     0 Apr  2 15:39 sys
drwxrwxrwt   2 root  root  4096 Jan  1  1970 tmp
drwxr-xr-x   1 root  root  4096 Apr  2 14:31 usr
drwxr-xr-x   1 root  root  4096 Jan  1  1970 var
```

However, because permissions on `/` are `0755` (i.e. execute bit is set for all), if we run as a another user, we won't encounter any issues with when runc initializes container and switches to cwd after switching to container uid.

</details>

#### Scenario 4: (image from this PR + random `runAsUser`) `helm install crossplane --namespace crossplane-system crossplane-master/crossplane --devel --version 1.2.0-rc.0.106.gdb33bb23 --set image.repository=hasheddan/crossplane --set image.tag=pinned --set securityContextCrossplane.runAsUser=100000110`

<details>
  <summary>Expand for steps.</summary>

```
🤖 (crossplane) k get pods -n crossplane-system
NAME                                       READY   STATUS    RESTARTS   AGE
crossplane-5d6c5f9dd5-6lrvn                1/1     Running   0          70s
crossplane-rbac-manager-5c6c58c879-k8pzc   1/1     Running   0          70s
```

```
🤖 (crossplane) docker exec -it kind-control-plane /bin/bash
root@kind-control-plane:/# ps aux | grep crossplane
65532       1962  1.0  0.2 746496 42360 ?        Ssl  15:50   0:00 crossplane rbac start --manage=All --provider-clusterrole=crossplane:allowed-provider-permissions
1000001+    2025  1.0  0.2 745984 42460 ?        Ssl  15:50   0:00 crossplane core start
```

```
root@kind-control-plane:/# pwdx 2025
2025: /
```

Container starts successfully with random user and cwd `/`.

</details>

[contribution process]: https://git.io/fj2m9
