### PR TITLE
Remove assertion that timeseries metrics are not implemented

### DIFF
--- a/docs/contributing/observability_developer_guide.md
+++ b/docs/contributing/observability_developer_guide.md
@@ -11,8 +11,7 @@ indent: true
 
 Observability is crucial to Crossplane users; both those operating Crossplane
 and those using Crossplane to operate their infrastructure. Crossplane currently
-approaches observability via Kubernetes events and structured logs. Timeseries
-metrics are desired but [not yet implemented].
+approaches observability via Kubernetes events and structured logs.
 
 ## Goals
 
@@ -186,7 +185,6 @@ implementations.
 
 <!-- Named Links -->
 
-[not yet implemented]: https://github.com/crossplane/crossplane/issues/314
 [Events]: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.16/#event-v1-core
 [debugging an application cluster]: https://kubernetes.io/docs/tasks/debug-application-cluster/
 [Dave Cheney article]: https://dave.cheney.net/2015/11/05/lets-talk-about-logging


### PR DESCRIPTION


<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Crossplane does expose some timeseries metrics and the issue that was
referenced is now closed. It would be good to follow up with some
information on how to consume them.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

This was pointed out by @rbtcollins on Crossplane slack :+1: 

[contribution process]: https://git.io/fj2m9
