### PR TITLE
Add Config flag to provider install command

### DIFF
--- a/cmd/crank/install.go
+++ b/cmd/crank/install.go
@@ -30,6 +30,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 
+	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
 	v1 "github.com/crossplane/crossplane/apis/pkg/v1"
 	typedclient "github.com/crossplane/crossplane/internal/client/clientset/versioned/typed/pkg/v1"
 	"github.com/crossplane/crossplane/internal/version"
@@ -113,6 +114,7 @@ type installProviderCmd struct {
 	Name                 string   `arg:"" optional:"" help:"Name of Provider."`
 	RevisionHistoryLimit int64    `short:"r" help:"Revision history limit."`
 	ManualActivation     bool     `short:"m" help:"Enable manual revision activation policy."`
+	Config               string   `help:"Specify a ControllerConfig for this Provider."`
 	PackagePullSecrets   []string `help:"List of secrets used to pull package."`
 }
 
@@ -148,6 +150,11 @@ func (c *installProviderCmd) Run(k *kong.Context) error {
 				PackagePullSecrets:       packagePullSecrets,
 			},
 		},
+	}
+	if c.Config != "" {
+		cr.Spec.ControllerConfigReference = &xpv1.Reference{
+			Name: c.Config,
+		}
 	}
 	kube := typedclient.NewForConfigOrDie(ctrl.GetConfigOrDie())
 	res, err := kube.Providers().Create(context.Background(), cr, metav1.CreateOptions{})


### PR DESCRIPTION


<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Adds a --config flag to the provider install command such that a user
can specify a ControllerConfig on provider install.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

Fixes #2190 

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

Tested both with an without supplying the flag.

```
$ kubectl crossplane install provider --help
Usage: kubectl crossplane install provider <package> [<name>]

Install a Provider package.

Arguments:
  <package>    Image containing Provider package.
  [<name>]     Name of Provider.

Flags:
  -h, --help                                             Show context-sensitive help.
  -v, --version                                          Print version and quit.

  -r, --revision-history-limit=INT-64                    Revision history limit.
  -m, --manual-activation                                Enable manual revision activation policy.
      --config=STRING                                    Specify a ControllerConfig for this Provider.
      --package-pull-secrets=PACKAGE-PULL-SECRETS,...    List of secrets used to pull package.
```

```
$ kubectl crossplane install provider crossplane/provider-aws:v0.17.0 --config=some-controller-config
provider.pkg.crossplane.io/crossplane-provider-aws created
$ kubectl get provider.pkg.crossplane.io/crossplane-provider-aws -o yaml
apiVersion: pkg.crossplane.io/v1
kind: Provider
metadata:
  name: crossplane-stack-aws
  ...
spec:
  controllerConfigRef:
    name: some-controller-config
  ignoreCrossplaneConstraints: false
  package: crossplane/provider-aws:v0.17.0
  packagePullPolicy: IfNotPresent
  revisionActivationPolicy: Automatic
  revisionHistoryLimit: 0
  skipDependencyResolution: false
```

```
$ kubectl crossplane install provider crossplane/provider-aws:v0.17.0
provider.pkg.crossplane.io/crossplane-provider-aws created
$ kubectl get provider.pkg.crossplane.io/crossplane-provider-aws -o yaml
apiVersion: pkg.crossplane.io/v1
kind: Provider
metadata:
  name: crossplane-stack-aws
  ...
spec:
  ignoreCrossplaneConstraints: false
  package: crossplane/provider-aws:v0.17.0
  packagePullPolicy: IfNotPresent
  revisionActivationPolicy: Automatic
  revisionHistoryLimit: 0
  skipDependencyResolution: false
```

[contribution process]: https://git.io/fj2m9
