### PR TITLE
Docs: add missing quote to AWS provider example config

### DIFF
--- a/docs/concepts/providers.md
+++ b/docs/concepts/providers.md
@@ -54,7 +54,7 @@ kind: Provider
 metadata:
   name: provider-aws
 spec:
-  package: crossplane/provider-aws:master"
+  package: "crossplane/provider-aws:master"
 ```
 
 The field `spec.package` is where you refer to the container image of the


### PR DESCRIPTION
### Description of your changes

The current AWS provider example manifest results in the following error:

```
cannot unpack package: could not parse reference: crossplane/provider-aws:master"
```

This is due to a missing matching double-quote in the example.

This PR fixes this.

I have:

- [X] Read and followed Crossplane's [contribution process](https://git.io/fj2m9).
- [X] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

I tested the sample with the added fix and the Provider now becomes "Installed"
and "Healthy" successfully.
