### PR TITLE
rbac manager: make it optional to deploy the aggregated clusterroles

### DIFF
--- a/cluster/charts/crossplane/README.md
+++ b/cluster/charts/crossplane/README.md
@@ -105,6 +105,7 @@ and their default values.
 | `rbacManager.leaderElection` | Enable leader election for RBAC Managers pod | `true` |
 | `rbacManager.managementPolicy`| The extent to which the RBAC manager will manage permissions. `All` indicates to manage all Crossplane controller and user roles. `Basic` indicates to only manage Crossplane controller roles and the `crossplane-admin`, `crossplane-edit`, and `crossplane-view` user roles. | `All` |
 | `rbacManager.tolerations` | Enable tolerations for RBAC Managers pod | `{}` |
+| `rbacManager.skipAggregatedClusterRoles` | Opt out of deploying aggregated ClusterRoles | `false` |
 | `alpha.oam.enabled` | Deploy the `crossplane/oam-kubernetes-runtime` Helm chart | `false` |
 | `metrics.enabled` | Expose Crossplane and RBAC Manager metrics endpoint | `false` |
 | `extraEnvVarsCrossplane` | List of extra environment variables to set in the crossplane deployment | `{}` |

--- a/cluster/charts/crossplane/templates/rbac-manager-managed-clusterroles.yaml
+++ b/cluster/charts/crossplane/templates/rbac-manager-managed-clusterroles.yaml
@@ -68,6 +68,7 @@ aggregationRule:
   clusterRoleSelectors:
   - matchLabels:
       rbac.crossplane.io/aggregate-to-browse: "true"
+{{- if not .Values.rbacManager.skipAggregatedClusterRoles }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -273,5 +274,6 @@ rules:
 - apiGroups: [""]
   resources: [events]
   verbs: [get, list, watch]
-{{- end}}
-{{- end}}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/cluster/charts/crossplane/values.yaml.tmpl
+++ b/cluster/charts/crossplane/values.yaml.tmpl
@@ -25,6 +25,7 @@ imagePullSecrets:
 
 rbacManager:
   deploy: true
+  skipAggregatedClusterRoles: false
   replicas: 1
   managementPolicy: All
   leaderElection: true

--- a/docs/reference/install.md
+++ b/docs/reference/install.md
@@ -112,6 +112,7 @@ and their default values.
 | `rbacManager.leaderElection` | Enable leader election for RBAC Managers pod | `true` |
 | `rbacManager.managementPolicy`| The extent to which the RBAC manager will manage permissions. `All` indicates to manage all Crossplane controller and user roles. `Basic` indicates to only manage Crossplane controller roles and the `crossplane-admin`, `crossplane-edit`, and `crossplane-view` user roles. | `All` |
 | `rbacManager.tolerations` | Enable tolerations for RBAC Managers pod | `{}` |
+| `rbacManager.skipAggregatedClusterRoles` | Opt out of deploying aggregated ClusterRoles | `false` |
 | `alpha.oam.enabled` | Deploy the `crossplane/oam-kubernetes-runtime` Helm chart | `false` |
 | `metrics.enabled` | Expose Crossplane and RBAC Manager metrics endpoint | `false` |
 | `extraEnvVarsCrossplane` | List of extra environment variables to set in the crossplane deployment | `{}` |


### PR DESCRIPTION
### Description of your changes

I'd like to make my Crossplane security footprint as low as possible but these aggregated `ClusterRole`s are deployed no matter what even though I don't really use the `ClusterRole`s they aggregate to. We can make it optional to deploy them. I chose not to make it optional to deploy the actual `ClusterRoles` these ones aggregate to so that users can just replace the aggregated one with their own and keep using the actual ones.

The Helm value is `false` by default so there will be no change to users unless they explicitly specify that they want not to deploy them via the added Helm value.

Fixes #

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

```
$ kubectl create ns crossplane-system
namespace/crossplane-system created
$ helm install crossplane --namespace crossplane-system cluster/charts/crossplane --set rbacManager.skipAggregatedClusterRoles=true
```

Confirmed that the list of `ClusterRole`s does not include the ones I skipped here.


<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
