### PR TITLE
[release-1.2] Update Crossplane upgrade doc with v1.2 self-managed CRDs

### DIFF
--- a/docs/guides/upgrading-to-v1.x.md
+++ b/docs/guides/upgrading-to-v1.x.md
@@ -10,13 +10,28 @@ indent: true
 Crossplane versions post v1.0 do not introduce any breaking changes, but may
 make some backward compatible changes to the core Crossplane CRDs. Helm [does
 not currently touch CRDs](https://github.com/helm/helm/issues/6581) when a chart
-is upgraded, so you must apply them manually before upgrading. To upgrade from
-the currently installed version, run:
+is upgraded, so Crossplane has moved to [managing its own
+CRDs](https://github.com/crossplane/crossplane/pull/2160) as of v1.2.0. However,
+for versions prior to v1.2.0, you must manually apply the appropriate CRDs
+before upgrading.
+
+## Upgrading to v1.0.x or v1.1.x
+
+To upgrade from the currently installed version, run:
 
 ```console
 # Update to the latest CRDs.
-kubectl apply -k https://github.com/crossplane/crossplane//cluster?ref=release-1.0
+kubectl apply -k https://github.com/crossplane/crossplane//cluster?ref=<release-branch>
 
-# Update to the latest stable Helm chart
-helm --namespace crossplane-system upgrade crossplane crossplane-stable/crossplane
+# Update to the latest stable Helm chart for the desired version
+helm --namespace crossplane-system upgrade crossplane crossplane-stable/crossplane --version <version>
+```
+
+## Upgrading to v1.2.x and Subsequent Versions
+
+To upgrade from the currently installed version, run:
+
+```console
+# Update to the latest stable Helm chart for the desired version
+helm --namespace crossplane-system upgrade crossplane crossplane-stable/crossplane --version <version>
 ```


### PR DESCRIPTION


<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Now that Crossplane self-manages its CRDs, it is no longer necessary for
users to apply new CRDs before upgrading the helm chart.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>
(cherry picked from commit de6e7b64852c65e0ab0a241cec68311de75b005f)

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

n/a

[contribution process]: https://git.io/fj2m9
