### PR TITLE
Use a slimmer scheme, in part to fix an obscure scheme behaviour

### DIFF
--- a/cmd/crossplane/main.go
+++ b/cmd/crossplane/main.go
@@ -23,7 +23,9 @@ import (
 	"gopkg.in/alecthomas/kingpin.v2"
 	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	extv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
@@ -58,6 +60,11 @@ func main() {
 	// uses the controller manager's client (and thus scheme) to create packaged
 	// objects.
 	s := runtime.NewScheme()
+
+	// This is required when using scheme.AddToScheme in order to avoid issues
+	// like https://github.com/crossplane/crossplane/issues/2284.
+	metav1.AddToGroupVersion(s, schema.GroupVersion{Version: "v1"})
+
 	kingpin.FatalIfError(scheme.AddToScheme(s), "cannot add client-go scheme")
 	kingpin.FatalIfError(extv1.AddToScheme(s), "cannot add client-go extensions v1 scheme")
 	kingpin.FatalIfError(extv1beta1.AddToScheme(s), "cannot add client-go extensions v1beta1 scheme")

--- a/cmd/crossplane/main.go
+++ b/cmd/crossplane/main.go
@@ -21,12 +21,12 @@ import (
 	"path/filepath"
 
 	"gopkg.in/alecthomas/kingpin.v2"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	extv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
@@ -60,15 +60,12 @@ func main() {
 	// uses the controller manager's client (and thus scheme) to create packaged
 	// objects.
 	s := runtime.NewScheme()
-
-	// This is required when using scheme.AddToScheme in order to avoid issues
-	// like https://github.com/crossplane/crossplane/issues/2284.
-	metav1.AddToGroupVersion(s, schema.GroupVersion{Version: "v1"})
-
-	kingpin.FatalIfError(scheme.AddToScheme(s), "cannot add client-go scheme")
-	kingpin.FatalIfError(extv1.AddToScheme(s), "cannot add client-go extensions v1 scheme")
-	kingpin.FatalIfError(extv1beta1.AddToScheme(s), "cannot add client-go extensions v1beta1 scheme")
-	kingpin.FatalIfError(apis.AddToScheme(s), "cannot add crossplane scheme")
+	kingpin.FatalIfError(corev1.AddToScheme(s), "cannot add core v1 Kubernetes API types to scheme")
+	kingpin.FatalIfError(appsv1.AddToScheme(s), "cannot add apps v1 Kubernetes API types to scheme")
+	kingpin.FatalIfError(rbacv1.AddToScheme(s), "cannot add rbac v1 Kubernetes API types to scheme")
+	kingpin.FatalIfError(extv1.AddToScheme(s), "cannot add apiextensions v1 Kubernetes API types to scheme")
+	kingpin.FatalIfError(extv1beta1.AddToScheme(s), "cannot add apiextensions v1beta1 Kubernetes API types to scheme")
+	kingpin.FatalIfError(apis.AddToScheme(s), "cannot add Crossplane API types to scheme")
 
 	switch cmd {
 	case c.Name:


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes https://github.com/crossplane/crossplane/issues/2284

This PR includes two commits. The first appears to be the minimum change we can make to fix the above bug. I don't have a complete understanding of what exactly is happening in that bug, but it appears that if we don't emulate [this `metav1.AddToGroupVersion` call](https://github.com/kubernetes/client-go/blob/8c8fa70f/kubernetes/scheme/register.go#L138) that the client-go `scheme.Scheme` makes (including calling it _before_ calling `scheme.AddToScheme`) we see weird errors. Specifically when we try to call the controller-runtime client's `DeleteAllOf` method on an arbitrary type of `*unstructured.Unstructured` resource we see:

```console
no kind "DeleteOptions" is registered for version "admissionregistration.k8s.io/v1" in scheme "k8s.io/apiextensions-apiserver/pkg/apiserver/apiserver.go:52"
```

I suspect `admissionregistration.k8s.io/v1` is only relevant because it's the first thing in the scheme. I still have no idea why [the scheme that lives at `apiserver.go:52`](https://github.com/kubernetes/apiextensions-apiserver/blob/v0.20.1/pkg/apiserver/apiserver.go#L52) specifically is sad, because that appears to be a completely different scheme from any I'd expect us to actually be using.

The second commit fixes the issue in a slightly different way - by avoiding using `scheme.Scheme` at all. Instead we add only the types that we actually use in Crossplane, avoiding adding superfluous API groups like `admissionregistration`. This should help to avoid red herrings like this in future, but will require us to remember to add any Kubernetes types we start using to our scheme.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9

Primarily I've confirmed that I can successfully delete XRDs with these commits in place. However, I've also run the nascent https://github.com/crossplane/conformance test suite, which currently mostly ensures the package manager is behaving as expected (e.g. creating XRDs, provider deployments etc)