### PR TITLE
Change make run arguments

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -161,7 +161,7 @@ uninstall-crds:
 run: go.build
 	@$(INFO) Running Crossplane locally out-of-cluster . . .
 	@# To see other arguments that can be provided, run the command with --help instead
-	$(GO_OUT_DIR)/$(PROJECT_NAME) --debug
+	$(GO_OUT_DIR)/$(PROJECT_NAME) core start --debug
 
 .PHONY: manifests cobertura reviewable submodules fallthrough test-integration run install-crds uninstall-crds gen-kustomize-crds gen-install-doc
 


### PR DESCRIPTION
Signed-off-by: Steven Borrelli <steve@borrelli.org>

### Description of your changes

PR #2160 introduced new `core` command line options into crossplane, this PR updates the `make run` convenience target to use the new options. 

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Ran `make run` against a local kind cluster with Crossplane CRDs installed.