### PR TITLE
add plural to xrd shortNames

### DIFF
--- a/apis/apiextensions/v1/xrd_types.go
+++ b/apis/apiextensions/v1/xrd_types.go
@@ -162,7 +162,7 @@ type CompositeResourceDefinitionControllerStatus struct {
 // +kubebuilder:printcolumn:name="OFFERED",type="string",JSONPath=".status.conditions[?(@.type=='Offered')].status"
 // +kubebuilder:printcolumn:name="AGE",type="date",JSONPath=".metadata.creationTimestamp"
 // +kubebuilder:subresource:status
-// +kubebuilder:resource:scope=Cluster,categories=crossplane,shortName=xrd
+// +kubebuilder:resource:scope=Cluster,categories=crossplane,shortName=xrd;xrds
 type CompositeResourceDefinition struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/apis/apiextensions/v1beta1/xrd_types.go
+++ b/apis/apiextensions/v1beta1/xrd_types.go
@@ -161,7 +161,7 @@ type CompositeResourceDefinitionControllerStatus struct {
 // +kubebuilder:printcolumn:name="OFFERED",type="string",JSONPath=".status.conditions[?(@.type=='Offered')].status"
 // +kubebuilder:printcolumn:name="AGE",type="date",JSONPath=".metadata.creationTimestamp"
 // +kubebuilder:subresource:status
-// +kubebuilder:resource:scope=Cluster,categories=crossplane,shortName=xrd
+// +kubebuilder:resource:scope=Cluster,categories=crossplane,shortName=xrd;xrds
 type CompositeResourceDefinition struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/cluster/crds/apiextensions.crossplane.io_compositeresourcedefinitions.yaml
+++ b/cluster/crds/apiextensions.crossplane.io_compositeresourcedefinitions.yaml
@@ -15,6 +15,7 @@ spec:
     plural: compositeresourcedefinitions
     shortNames:
     - xrd
+    - xrds
     singular: compositeresourcedefinition
   scope: Cluster
   versions:


### PR DESCRIPTION
### Description of your changes

Adds an `xrds` shortName to a CompositeResourceDefinition CRD. 

Kubernetes supports singular and plural resource names (see [Resource Types](https://kubernetes.io/docs/reference/kubectl/overview/#resource-types) ), for example you can use `crd` or `crds` short names to list CustomResourceDefinitions.

In my daily use of Crossplane, I find myself erroneously typing in `kubectl get xrds` far too often. 

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Applied generated CRDs to a Crossplane 1.2.x cluster.

Before:
```
$ kubectl get xrds
error: the server doesn't have a resource type "xrds"
$ kubectl get xrd
NAME                                                ESTABLISHED   OFFERED   AGE
mysuperawesomecomposition.example.org   True          True      73m
```

After:

```
$ kubectl get xrds
NAME                                                ESTABLISHED   OFFERED   AGE
mysuperawesomecomposition.example.org   True          True      82m
$ kubectl get xrd
NAME                                                ESTABLISHED   OFFERED   AGE
mysuperawesomecomposition.example.org   True          True      83m
```

[contribution process]: https://git.io/fj2m9
