### PR TITLE
Getting started doc: fix API version for AWS resource RouteTable.

### DIFF
--- a/docs/getting-started/create-configuration.md
+++ b/docs/getting-started/create-configuration.md
@@ -574,7 +574,7 @@ spec:
     version: ">=v1.2.0-0"
   dependsOn:
     - provider: crossplane/provider-aws
-      version: "v0.18.1"
+      version: "v0.18.2"
 ```
 
 ```console
@@ -614,7 +614,7 @@ spec:
     version: ">=v1.2.0-0"
   dependsOn:
     - provider: crossplane/provider-aws
-      version: "v0.18.1"
+      version: "v0.18.2"
 ```
 
 ```console

--- a/docs/getting-started/create-configuration.md
+++ b/docs/getting-started/create-configuration.md
@@ -571,10 +571,10 @@ metadata:
     vpc: default
 spec:
   crossplane:
-    version: ">=v1.0.0-0"
+    version: ">=v1.2.0-0"
   dependsOn:
     - provider: crossplane/provider-aws
-      version: ">=v0.14.0"
+      version: "v0.18.1"
 ```
 
 ```console
@@ -611,10 +611,10 @@ metadata:
     vpc: new
 spec:
   crossplane:
-    version: ">=v1.0.0-0"
+    version: ">=v1.2.0-0"
   dependsOn:
     - provider: crossplane/provider-aws
-      version: "v0.16.0"
+      version: "v0.18.1"
 ```
 
 ```console

--- a/docs/getting-started/create-configuration.md
+++ b/docs/getting-started/create-configuration.md
@@ -268,7 +268,7 @@ spec:
               matchControllerRef: true
     - name: routetable
       base:
-        apiVersion: ec2.aws.crossplane.io/v1alpha4
+        apiVersion: ec2.aws.crossplane.io/v1beta1
         kind: RouteTable
         spec:
           forProvider:

--- a/docs/snippets/package/aws-with-vpc/composition.yaml
+++ b/docs/snippets/package/aws-with-vpc/composition.yaml
@@ -86,7 +86,7 @@ spec:
               matchControllerRef: true
     - name: routetable
       base:
-        apiVersion: ec2.aws.crossplane.io/v1alpha4
+        apiVersion: ec2.aws.crossplane.io/v1beta1
         kind: RouteTable
         spec:
           forProvider:

--- a/docs/snippets/package/aws-with-vpc/crossplane.yaml
+++ b/docs/snippets/package/aws-with-vpc/crossplane.yaml
@@ -8,8 +8,7 @@ metadata:
     vpc: new
 spec:
   crossplane:
-    version: ">=v1.0.0-0"
+    version: ">=v1.2.0-0"
   dependsOn:
-    # TODO(negz): Update Composition for compatibility with v0.17.0.
     - provider: crossplane/provider-aws
-      version: "v0.16.0"
+      version: "v0.18.1"

--- a/docs/snippets/package/aws-with-vpc/crossplane.yaml
+++ b/docs/snippets/package/aws-with-vpc/crossplane.yaml
@@ -11,4 +11,4 @@ spec:
     version: ">=v1.2.0-0"
   dependsOn:
     - provider: crossplane/provider-aws
-      version: "v0.18.1"
+      version: "v0.18.2"

--- a/docs/snippets/package/aws/crossplane.yaml
+++ b/docs/snippets/package/aws/crossplane.yaml
@@ -11,4 +11,4 @@ spec:
     version: ">=v1.2.0-0"
   dependsOn:
     - provider: crossplane/provider-aws
-      version: "v0.18.1"
+      version: "v0.18.2"

--- a/docs/snippets/package/aws/crossplane.yaml
+++ b/docs/snippets/package/aws/crossplane.yaml
@@ -8,7 +8,7 @@ metadata:
     vpc: default
 spec:
   crossplane:
-    version: ">=v1.0.0-0"
+    version: ">=v1.2.0-0"
   dependsOn:
     - provider: crossplane/provider-aws
-      version: ">=v0.14.0"
+      version: "v0.18.1"


### PR DESCRIPTION
In the getting started documentation, when using a new AWS VPC I noticed
the following error:

```console
cannot render composed resource from resource template at index 6:
cannot use dry-run create to name composed resource: no matches for kind
"RouteTable" in version "ec2.aws.crossplane.io/v1alpha4"
```

Crossplane v1.2.1

Updating the composition yaml to make use of the API version v1beta1 for
AWS RouteTable.

Signed-off-by: Smaine Kahlouch <smainklh@gmail.com>


I have:

- [x] Read and followed Crossplane's [contribution process].
- [ ] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

I was able to run through the getting started documentation
