### PR TITLE
Sync aws with vpc crossplane.yaml snippet with package

### DIFF
--- a/docs/getting-started/create-configuration.md
+++ b/docs/getting-started/create-configuration.md
@@ -614,7 +614,7 @@ spec:
     version: ">=v1.0.0-0"
   dependsOn:
     - provider: crossplane/provider-aws
-      version: ">=v0.14.0"
+      version: "v0.16.0"
 ```
 
 ```console


### PR DESCRIPTION


<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

We are currently pinning the aws-with-vpc getting started package to
provider-aws v0.16.0 due to some API version changes that we have not
yet accomodated for. However, this is not reflected in the instructions
for building your own configuration package, so users who follow those
instructions will likely get a package that fails unless they already
have provider-aws v0.16.0 installed.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

Follow-up to https://github.com/crossplane/crossplane/pull/2230, helps address problem seen in #2309 

**Needs backport to `release-1.2`**

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

n/a

[contribution process]: https://git.io/fj2m9
