### PR TITLE
Remove finalizer and do not requeue if lock is empty 

### DIFF
--- a/docs/reference/uninstall.md
+++ b/docs/reference/uninstall.md
@@ -82,7 +82,6 @@ Helm does not delete CRD objects. You can delete the ones Crossplane created
 with the following commands:
 
 ```console
-kubectl patch lock lock -p '{"metadata":{"finalizers": []}}' --type=merge
 kubectl get crd -o name | grep crossplane.io | xargs kubectl delete
 ```
 

--- a/internal/controller/pkg/resolver/reconciler_test.go
+++ b/internal/controller/pkg/resolver/reconciler_test.go
@@ -25,6 +25,7 @@ import (
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -80,11 +81,50 @@ func TestReconcile(t *testing.T) {
 				err: errors.Wrap(errBoom, errGetLock),
 			},
 		},
+		"ErrRemoveFinalizer": {
+			reason: "We should requeue after short wait if we fail to remove finalizer.",
+			args: args{
+				mgr: &fake.Manager{
+					Client: test.NewMockClient(),
+				},
+				req: reconcile.Request{NamespacedName: types.NamespacedName{Name: "test"}},
+				rec: []ReconcilerOption{
+					WithFinalizer(resource.FinalizerFns{RemoveFinalizerFn: func(_ context.Context, _ resource.Object) error {
+						return errBoom
+					}}),
+				},
+			},
+			want: want{
+				r: reconcile.Result{RequeueAfter: shortWait},
+			},
+		},
+		"SuccessfulEmptyList": {
+			reason: "We should not return error and not requeue if no packages in lock.",
+			args: args{
+				mgr: &fake.Manager{
+					Client: test.NewMockClient(),
+				},
+				req: reconcile.Request{NamespacedName: types.NamespacedName{Name: "test"}},
+			},
+		},
 		"ErrAddFinalizer": {
 			reason: "We should requeue after short wait if we fail to add finalizer.",
 			args: args{
 				mgr: &fake.Manager{
-					Client: test.NewMockClient(),
+					Client: &test.MockClient{
+						MockGet: test.NewMockGetFn(nil, func(o client.Object) error {
+							// Populate package list so we attempt reconciliation.
+							l := o.(*v1alpha1.Lock)
+							l.Packages = append(l.Packages, v1alpha1.LockPackage{
+								Name:    "cool-package",
+								Type:    v1alpha1.ProviderPackageType,
+								Source:  "cool-repo/cool-image",
+								Version: "v0.0.1",
+							})
+							return nil
+						}),
+						MockUpdate: test.NewMockUpdateFn(nil),
+					},
 				},
 				req: reconcile.Request{NamespacedName: types.NamespacedName{Name: "test"}},
 				rec: []ReconcilerOption{
@@ -101,7 +141,22 @@ func TestReconcile(t *testing.T) {
 			reason: "We should not requeue if we fail to initialize DAG.",
 			args: args{
 				mgr: &fake.Manager{
-					Client: test.NewMockClient(),
+					Client: &test.MockClient{
+						MockGet: test.NewMockGetFn(nil, func(o client.Object) error {
+							// Populate package list so we attempt
+							// reconciliation. This is overridden by the mock
+							// DAG.
+							l := o.(*v1alpha1.Lock)
+							l.Packages = append(l.Packages, v1alpha1.LockPackage{
+								Name:    "cool-package",
+								Type:    v1alpha1.ProviderPackageType,
+								Source:  "cool-repo/cool-image",
+								Version: "v0.0.1",
+							})
+							return nil
+						}),
+						MockUpdate: test.NewMockUpdateFn(nil),
+					},
 				},
 				req: reconcile.Request{NamespacedName: types.NamespacedName{Name: "test"}},
 				rec: []ReconcilerOption{
@@ -123,7 +178,22 @@ func TestReconcile(t *testing.T) {
 			reason: "We should not requeue if we fail to sort DAG.",
 			args: args{
 				mgr: &fake.Manager{
-					Client: test.NewMockClient(),
+					Client: &test.MockClient{
+						MockGet: test.NewMockGetFn(nil, func(o client.Object) error {
+							// Populate package list so we attempt
+							// reconciliation. This is overridden by the mock
+							// DAG.
+							l := o.(*v1alpha1.Lock)
+							l.Packages = append(l.Packages, v1alpha1.LockPackage{
+								Name:    "cool-package",
+								Type:    v1alpha1.ProviderPackageType,
+								Source:  "cool-repo/cool-image",
+								Version: "v0.0.1",
+							})
+							return nil
+						}),
+						MockUpdate: test.NewMockUpdateFn(nil),
+					},
 				},
 				req: reconcile.Request{NamespacedName: types.NamespacedName{Name: "test"}},
 				rec: []ReconcilerOption{
@@ -148,7 +218,22 @@ func TestReconcile(t *testing.T) {
 			reason: "We should not return error and not requeue if no missing dependencies.",
 			args: args{
 				mgr: &fake.Manager{
-					Client: test.NewMockClient(),
+					Client: &test.MockClient{
+						MockGet: test.NewMockGetFn(nil, func(o client.Object) error {
+							// Populate package list so we attempt
+							// reconciliation. This is overridden by the mock
+							// DAG.
+							l := o.(*v1alpha1.Lock)
+							l.Packages = append(l.Packages, v1alpha1.LockPackage{
+								Name:    "cool-package",
+								Type:    v1alpha1.ProviderPackageType,
+								Source:  "cool-repo/cool-image",
+								Version: "v0.0.1",
+							})
+							return nil
+						}),
+						MockUpdate: test.NewMockUpdateFn(nil),
+					},
 				},
 				req: reconcile.Request{NamespacedName: types.NamespacedName{Name: "test"}},
 				rec: []ReconcilerOption{
@@ -172,7 +257,22 @@ func TestReconcile(t *testing.T) {
 			reason: "We should not requeue if dependency is invalid.",
 			args: args{
 				mgr: &fake.Manager{
-					Client: test.NewMockClient(),
+					Client: &test.MockClient{
+						MockGet: test.NewMockGetFn(nil, func(o client.Object) error {
+							// Populate package list so we attempt
+							// reconciliation. This is overridden by the mock
+							// DAG.
+							l := o.(*v1alpha1.Lock)
+							l.Packages = append(l.Packages, v1alpha1.LockPackage{
+								Name:    "cool-package",
+								Type:    v1alpha1.ProviderPackageType,
+								Source:  "cool-repo/cool-image",
+								Version: "v0.0.1",
+							})
+							return nil
+						}),
+						MockUpdate: test.NewMockUpdateFn(nil),
+					},
 				},
 				req: reconcile.Request{NamespacedName: types.NamespacedName{Name: "test"}},
 				rec: []ReconcilerOption{
@@ -200,7 +300,22 @@ func TestReconcile(t *testing.T) {
 			reason: "We should requeue after short wait if fail to fetch tags to account for network issues.",
 			args: args{
 				mgr: &fake.Manager{
-					Client: test.NewMockClient(),
+					Client: &test.MockClient{
+						MockGet: test.NewMockGetFn(nil, func(o client.Object) error {
+							// Populate package list so we attempt
+							// reconciliation. This is overridden by the mock
+							// DAG.
+							l := o.(*v1alpha1.Lock)
+							l.Packages = append(l.Packages, v1alpha1.LockPackage{
+								Name:    "cool-package",
+								Type:    v1alpha1.ProviderPackageType,
+								Source:  "cool-repo/cool-image",
+								Version: "v0.0.1",
+							})
+							return nil
+						}),
+						MockUpdate: test.NewMockUpdateFn(nil),
+					},
 				},
 				req: reconcile.Request{NamespacedName: types.NamespacedName{Name: "test"}},
 				rec: []ReconcilerOption{
@@ -232,7 +347,22 @@ func TestReconcile(t *testing.T) {
 			reason: "We should not requeue if valid version does not exist for dependency.",
 			args: args{
 				mgr: &fake.Manager{
-					Client: test.NewMockClient(),
+					Client: &test.MockClient{
+						MockGet: test.NewMockGetFn(nil, func(o client.Object) error {
+							// Populate package list so we attempt
+							// reconciliation. This is overridden by the mock
+							// DAG.
+							l := o.(*v1alpha1.Lock)
+							l.Packages = append(l.Packages, v1alpha1.LockPackage{
+								Name:    "cool-package",
+								Type:    v1alpha1.ProviderPackageType,
+								Source:  "cool-repo/cool-image",
+								Version: "v0.0.1",
+							})
+							return nil
+						}),
+						MockUpdate: test.NewMockUpdateFn(nil),
+					},
 				},
 				req: reconcile.Request{NamespacedName: types.NamespacedName{Name: "test"}},
 				rec: []ReconcilerOption{
@@ -265,7 +395,19 @@ func TestReconcile(t *testing.T) {
 			args: args{
 				mgr: &fake.Manager{
 					Client: &test.MockClient{
-						MockGet:    test.NewMockGetFn(nil),
+						MockGet: test.NewMockGetFn(nil, func(o client.Object) error {
+							// Populate package list so we attempt
+							// reconciliation. This is overridden by the mock
+							// DAG.
+							l := o.(*v1alpha1.Lock)
+							l.Packages = append(l.Packages, v1alpha1.LockPackage{
+								Name:    "cool-package",
+								Type:    v1alpha1.ProviderPackageType,
+								Source:  "cool-repo/cool-image",
+								Version: "v0.0.1",
+							})
+							return nil
+						}),
 						MockCreate: test.NewMockCreateFn(errBoom),
 						MockUpdate: test.NewMockUpdateFn(nil),
 					},
@@ -302,7 +444,19 @@ func TestReconcile(t *testing.T) {
 			args: args{
 				mgr: &fake.Manager{
 					Client: &test.MockClient{
-						MockGet:    test.NewMockGetFn(nil),
+						MockGet: test.NewMockGetFn(nil, func(o client.Object) error {
+							// Populate package list so we attempt
+							// reconciliation. This is overridden by the mock
+							// DAG.
+							l := o.(*v1alpha1.Lock)
+							l.Packages = append(l.Packages, v1alpha1.LockPackage{
+								Name:    "cool-package",
+								Type:    v1alpha1.ProviderPackageType,
+								Source:  "cool-repo/cool-image",
+								Version: "v0.0.1",
+							})
+							return nil
+						}),
 						MockCreate: test.NewMockCreateFn(nil),
 						MockUpdate: test.NewMockUpdateFn(nil),
 					},


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Updates dependency resolver controller to remove finalizer on lock and
exit early without requeue if the lock package list is empty. This
allows for cleanup of the lock when uninstalling Crossplane after all
packages have already been uninstalled.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

Fixes #2320 

**If we consider this a bug fix, which I am inclined to do, per our [stated release policy](https://crossplane.io/docs/v1.2/reference/release-cycle.html#patch-releases) this should be a patch release for all active branches where applicable, which includes `v1.2`, `v1.1`, `v1.0` for this fix.**

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

1. Install Crossplane
2. Observe empty `Lock` with no finalizer
```yaml
🤖 (crossplane) k get lock -o yaml
apiVersion: v1
items:
- apiVersion: pkg.crossplane.io/v1alpha1
  kind: Lock
  metadata:
    creationTimestamp: "2021-05-21T19:37:11Z"
    generation: 1
    name: lock
    resourceVersion: "692"
    uid: aaa25d0b-0e68-44af-ac6e-ec67d7414420
kind: List
metadata:
  resourceVersion: ""
  selfLink: ""
```
3. Install `provider-gcp`
4. Observe `Lock` with one entry and finalizer
```yaml
🤖 (crossplane) kxp install get lock -o yaml
apiVersion: v1
items:
- apiVersion: pkg.crossplane.io/v1alpha1
  kind: Lock
  metadata:
    creationTimestamp: "2021-05-21T19:37:11Z"
    finalizers:
    - lock.pkg.crossplane.io
    generation: 2
    name: lock
    resourceVersion: "981"
    uid: aaa25d0b-0e68-44af-ac6e-ec67d7414420
  packages:
  - dependencies: []
    name: crossplane-provider-gcp-efb628debc28
    source: crossplane/provider-gcp
    type: Provider
    version: v0.16.0
kind: List
metadata:
  resourceVersion: ""
  selfLink: ""
```
5. Delete `provider-gcp`
6. Observe `Lock` with no entries and no finalizer
```yaml
🤖 (crossplane) k delete proget lock -o yaml
apiVersion: v1
items:
- apiVersion: pkg.crossplane.io/v1alpha1
  kind: Lock
  metadata:
    creationTimestamp: "2021-05-21T19:37:11Z"
    generation: 3
    name: lock
    resourceVersion: "1597"
    uid: aaa25d0b-0e68-44af-ac6e-ec67d7414420
kind: List
metadata:
  resourceVersion: ""
  selfLink: ""
```
7. Uninstall Crossplane
8. Delete all Crossplane CRDs 
```
kubectl get crd -o name | grep crossplane.io | xargs kubectl delete
```
9. Observe that they are cleaned up successfully
```
🤖 (crossplane) k get crds
No resources found
```

[contribution process]: https://git.io/fj2m9
