### PR TITLE
Add annotation commands to 1.2 upgrade section to prevent CRs from being removed

### DIFF
--- a/docs/guides/upgrading-to-v1.x.md
+++ b/docs/guides/upgrading-to-v1.x.md
@@ -29,7 +29,20 @@ helm --namespace crossplane-system upgrade crossplane crossplane-stable/crosspla
 
 ## Upgrading to v1.2.x and Subsequent Versions
 
-To upgrade from the currently installed version, run:
+Since `v1.2.0`, we do not include any custom resource instances in our Helm chart.
+This means the `Lock` object and `Provider`s and `Configuration`s you might have
+possibly installed via Helm values will get deleted when you upgrade to `v1.2.x`.
+The following commands will instruct Helm not to delete any instances of those
+types:
+
+```console
+for name in $(kubectl get locks.pkg.crossplane.io -o name); do kubectl annotate $name 'helm.sh/resource-policy=keep'; done
+for name in $(kubectl get providers.pkg.crossplane.io -o name); do kubectl annotate $name 'helm.sh/resource-policy=keep'; done
+for name in $(kubectl get configurations.pkg.crossplane.io -o name); do kubectl annotate $name 'helm.sh/resource-policy=keep'; done
+```
+
+After annotations are in place you can upgrade from the currently installed version
+by running:
 
 ```console
 # Update to the latest stable Helm chart for the desired version


### PR DESCRIPTION
### Description of your changes

Starting from v1.2.x, we don't include CRs in the Helm chart anymore but for users who are upgrading, that means the CRs they installed via Helm by using `provider.packages` and  `configuration.packages` values, their CRs can be deleted. This annotation tell Helm not to delete any of those CRs even if they are not included in the next version.

Fixes https://github.com/crossplane/crossplane/issues/2323

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

```console
$ helm install crossplane --namespace crossplane-system crossplane-stable/crossplane --version 1.1.1 -f /tmp/val.yaml
$ kubectl get providers
NAME                      INSTALLED   HEALTHY   PACKAGE                           AGE
crossplane-provider-aws   True        True      crossplane/provider-aws:v0.18.1   25s
crossplane-provider-gcp   True        True      crossplane/provider-gcp:v0.17.1   11s
```
```console
$ for name in $(kubectl get locks.pkg.crossplane.io -o name); do kubectl annotate $name 'helm.sh/resource-policy=keep'; done
lock.pkg.crossplane.io/lock annotated
$ for name in $(kubectl get providers.pkg.crossplane.io -o name); do kubectl annotate $name 'helm.sh/resource-policy=keep'; done
provider.pkg.crossplane.io/crossplane-provider-aws annotated
provider.pkg.crossplane.io/crossplane-provider-gcp annotated
$ for name in $(kubectl get configurations.pkg.crossplane.io -o name); do kubectl annotate $name 'helm.sh/resource-policy=keep'; done
```

They are not deleted!
```console
$ helm upgrade crossplane --namespace crossplane-system crossplane-stable/crossplane --version 1.2.1
$ kubectl get providers
NAME                      INSTALLED   HEALTHY   PACKAGE                           AGE
crossplane-provider-aws   True        True      crossplane/provider-aws:v0.18.1   3m25s
crossplane-provider-gcp   True        True      crossplane/provider-gcp:v0.17.1   3m11s
```
