### PR TITLE
add propogation of annotations from pkgMeta to package revision

### DIFF
--- a/internal/controller/pkg/revision/reconciler.go
+++ b/internal/controller/pkg/revision/reconciler.go
@@ -394,7 +394,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 
 	pr.SetAnnotations(pkgMeta.(metav1.ObjectMetaAccessor).GetObjectMeta().GetAnnotations())
 	if err := r.client.Update(ctx, pr); err != nil {
-		r.record.Event(pr, event.Warning(reasonSync, err))
+		r.record.Event(pr, event.Warning(reasonSync, errors.Wrap(err, errUpdateAnnotations)))
 		log.Debug(errUpdateAnnotations, "error", err)
 		pr.SetConditions(v1.Unhealthy())
 		return reconcile.Result{RequeueAfter: shortWait}, errors.Wrapf(r.client.Status().Update(ctx, pr), errUpdateStatus)

--- a/internal/controller/pkg/revision/reconciler_test.go
+++ b/internal/controller/pkg/revision/reconciler_test.go
@@ -131,7 +131,6 @@ func (m *MockDependencyManager) RemoveSelf(ctx context.Context, pr v1.PackageRev
 	return m.MockRemoveSelf()
 }
 
-// Make sure not to use tabs instead of spaces in the providerBytes
 var providerBytes = []byte(`apiVersion: meta.pkg.crossplane.io/v1
 kind: Provider
 metadata:

--- a/internal/controller/pkg/revision/reconciler_test.go
+++ b/internal/controller/pkg/revision/reconciler_test.go
@@ -131,10 +131,13 @@ func (m *MockDependencyManager) RemoveSelf(ctx context.Context, pr v1.PackageRev
 	return m.MockRemoveSelf()
 }
 
+// Make sure not to use tabs instead of spaces in the providerBytes
 var providerBytes = []byte(`apiVersion: meta.pkg.crossplane.io/v1
 kind: Provider
 metadata:
   name: test
+  annotations:
+    author: crossplane
 spec:
   controller:
     image: crossplane/provider-test-controller:v0.0.1
@@ -476,7 +479,18 @@ func TestReconcile(t *testing.T) {
 								want.SetGroupVersionKind(v1.ConfigurationRevisionGroupVersionKind)
 								want.SetDesiredState(v1.PackageRevisionActive)
 								want.SetConditions(v1.Unhealthy())
+								want.SetAnnotations(map[string]string{"author": "crossplane"})
 
+								if diff := cmp.Diff(want, o); diff != "" {
+									t.Errorf("-want, +got:\n%s", diff)
+								}
+								return nil
+							}),
+							MockUpdate: test.NewMockUpdateFn(nil, func(o client.Object) error {
+								want := &v1.ConfigurationRevision{}
+								want.SetGroupVersionKind(v1.ConfigurationRevisionGroupVersionKind)
+								want.SetDesiredState(v1.PackageRevisionActive)
+								want.SetAnnotations(map[string]string{"author": "crossplane"})
 								if diff := cmp.Diff(want, o); diff != "" {
 									t.Errorf("-want, +got:\n%s", diff)
 								}
@@ -564,8 +578,20 @@ func TestReconcile(t *testing.T) {
 								want.SetGroupVersionKind(v1.ProviderRevisionGroupVersionKind)
 								want.SetDesiredState(v1.PackageRevisionActive)
 								want.SetSkipDependencyResolution(pointer.BoolPtr(false))
+								want.SetAnnotations(map[string]string{"author": "crossplane"})
 								want.SetConditions(v1.UnknownHealth())
 
+								if diff := cmp.Diff(want, o); diff != "" {
+									t.Errorf("-want, +got:\n%s", diff)
+								}
+								return nil
+							}),
+							MockUpdate: test.NewMockUpdateFn(nil, func(o client.Object) error {
+								want := &v1.ProviderRevision{}
+								want.SetGroupVersionKind(v1.ProviderRevisionGroupVersionKind)
+								want.SetDesiredState(v1.PackageRevisionActive)
+								want.SetAnnotations(map[string]string{"author": "crossplane"})
+								want.SetSkipDependencyResolution(pointer.BoolPtr(false))
 								if diff := cmp.Diff(want, o); diff != "" {
 									t.Errorf("-want, +got:\n%s", diff)
 								}
@@ -605,8 +631,19 @@ func TestReconcile(t *testing.T) {
 								want := &v1.ProviderRevision{}
 								want.SetGroupVersionKind(v1.ProviderRevisionGroupVersionKind)
 								want.SetDesiredState(v1.PackageRevisionActive)
+								want.SetAnnotations(map[string]string{"author": "crossplane"})
 								want.SetConditions(v1.Unhealthy())
 
+								if diff := cmp.Diff(want, o); diff != "" {
+									t.Errorf("-want, +got:\n%s", diff)
+								}
+								return nil
+							}),
+							MockUpdate: test.NewMockUpdateFn(nil, func(o client.Object) error {
+								want := &v1.ProviderRevision{}
+								want.SetGroupVersionKind(v1.ProviderRevisionGroupVersionKind)
+								want.SetDesiredState(v1.PackageRevisionActive)
+								want.SetAnnotations(map[string]string{"author": "crossplane"})
 								if diff := cmp.Diff(want, o); diff != "" {
 									t.Errorf("-want, +got:\n%s", diff)
 								}
@@ -649,8 +686,19 @@ func TestReconcile(t *testing.T) {
 								want := &v1.ProviderRevision{}
 								want.SetGroupVersionKind(v1.ProviderRevisionGroupVersionKind)
 								want.SetDesiredState(v1.PackageRevisionActive)
+								want.SetAnnotations(map[string]string{"author": "crossplane"})
 								want.SetConditions(v1.Unhealthy())
 
+								if diff := cmp.Diff(want, o); diff != "" {
+									t.Errorf("-want, +got:\n%s", diff)
+								}
+								return nil
+							}),
+							MockUpdate: test.NewMockUpdateFn(nil, func(o client.Object) error {
+								want := &v1.ProviderRevision{}
+								want.SetGroupVersionKind(v1.ProviderRevisionGroupVersionKind)
+								want.SetDesiredState(v1.PackageRevisionActive)
+								want.SetAnnotations(map[string]string{"author": "crossplane"})
 								if diff := cmp.Diff(want, o); diff != "" {
 									t.Errorf("-want, +got:\n%s", diff)
 								}
@@ -695,6 +743,7 @@ func TestReconcile(t *testing.T) {
 								want := &v1.ConfigurationRevision{}
 								want.SetGroupVersionKind(v1.ConfigurationRevisionGroupVersionKind)
 								want.SetDesiredState(v1.PackageRevisionActive)
+								want.SetAnnotations(map[string]string{"author": "crossplane"})
 								want.SetConditions(v1.Healthy())
 
 								if diff := cmp.Diff(want, o); diff != "" {
@@ -702,6 +751,17 @@ func TestReconcile(t *testing.T) {
 								}
 								return nil
 							}),
+							MockUpdate: test.NewMockUpdateFn(nil, func(o client.Object) error {
+								want := &v1.ConfigurationRevision{}
+								want.SetGroupVersionKind(v1.ConfigurationRevisionGroupVersionKind)
+								want.SetDesiredState(v1.PackageRevisionActive)
+								want.SetAnnotations(map[string]string{"author": "crossplane"})
+								if diff := cmp.Diff(want, o); diff != "" {
+									t.Errorf("-want, +got:\n%s", diff)
+								}
+								return nil
+							}),
+
 							MockDelete: test.NewMockDeleteFn(nil),
 						},
 					}),
@@ -740,6 +800,7 @@ func TestReconcile(t *testing.T) {
 								want := &v1.ConfigurationRevision{}
 								want.SetGroupVersionKind(v1.ConfigurationRevisionGroupVersionKind)
 								want.SetDesiredState(v1.PackageRevisionActive)
+								want.SetAnnotations(map[string]string{"author": "crossplane"})
 								want.SetConditions(v1.Healthy())
 								want.SetIgnoreCrossplaneConstraints(&trueVal)
 
@@ -748,6 +809,19 @@ func TestReconcile(t *testing.T) {
 								}
 								return nil
 							}),
+							MockUpdate: test.NewMockUpdateFn(nil, func(o client.Object) error {
+								want := &v1.ConfigurationRevision{}
+								want.SetGroupVersionKind(v1.ConfigurationRevisionGroupVersionKind)
+								want.SetDesiredState(v1.PackageRevisionActive)
+								want.SetAnnotations(map[string]string{"author": "crossplane"})
+								want.SetIgnoreCrossplaneConstraints(&trueVal)
+
+								if diff := cmp.Diff(want, o); diff != "" {
+									t.Errorf("-want, +got:\n%s", diff)
+								}
+								return nil
+							}),
+
 							MockDelete: test.NewMockDeleteFn(nil),
 						},
 					}),
@@ -785,6 +859,7 @@ func TestReconcile(t *testing.T) {
 								want := &v1.ProviderRevision{}
 								want.SetGroupVersionKind(v1.ProviderRevisionGroupVersionKind)
 								want.SetDesiredState(v1.PackageRevisionActive)
+								want.SetAnnotations(map[string]string{"author": "crossplane"})
 								want.SetConditions(v1.Unhealthy())
 
 								if diff := cmp.Diff(want, o); diff != "" {
@@ -793,6 +868,16 @@ func TestReconcile(t *testing.T) {
 								return nil
 							}),
 							MockDelete: test.NewMockDeleteFn(nil),
+							MockUpdate: test.NewMockUpdateFn(nil, func(o client.Object) error {
+								want := &v1.ProviderRevision{}
+								want.SetGroupVersionKind(v1.ProviderRevisionGroupVersionKind)
+								want.SetDesiredState(v1.PackageRevisionActive)
+								want.SetAnnotations(map[string]string{"author": "crossplane"})
+								if diff := cmp.Diff(want, o); diff != "" {
+									t.Errorf("-want, +got:\n%s", diff)
+								}
+								return nil
+							}),
 						},
 					}),
 					WithFinalizer(resource.FinalizerFns{AddFinalizerFn: func(_ context.Context, _ resource.Object) error {
@@ -831,6 +916,7 @@ func TestReconcile(t *testing.T) {
 								want := &v1.ConfigurationRevision{}
 								want.SetGroupVersionKind(v1.ConfigurationRevisionGroupVersionKind)
 								want.SetDesiredState(v1.PackageRevisionInactive)
+								want.SetAnnotations(map[string]string{"author": "crossplane"})
 								want.SetConditions(v1.Healthy())
 
 								if diff := cmp.Diff(want, o); diff != "" {
@@ -838,6 +924,17 @@ func TestReconcile(t *testing.T) {
 								}
 								return nil
 							}),
+							MockUpdate: test.NewMockUpdateFn(nil, func(o client.Object) error {
+								want := &v1.ConfigurationRevision{}
+								want.SetGroupVersionKind(v1.ConfigurationRevisionGroupVersionKind)
+								want.SetDesiredState(v1.PackageRevisionInactive)
+								want.SetAnnotations(map[string]string{"author": "crossplane"})
+								if diff := cmp.Diff(want, o); diff != "" {
+									t.Errorf("-want, +got:\n%s", diff)
+								}
+								return nil
+							}),
+
 							MockDelete: test.NewMockDeleteFn(nil),
 						},
 					}),
@@ -875,6 +972,7 @@ func TestReconcile(t *testing.T) {
 								want := &v1.ConfigurationRevision{}
 								want.SetGroupVersionKind(v1.ConfigurationRevisionGroupVersionKind)
 								want.SetDesiredState(v1.PackageRevisionInactive)
+								want.SetAnnotations(map[string]string{"author": "crossplane"})
 								want.SetConditions(v1.Unhealthy())
 
 								if diff := cmp.Diff(want, o); diff != "" {
@@ -883,6 +981,16 @@ func TestReconcile(t *testing.T) {
 								return nil
 							}),
 							MockDelete: test.NewMockDeleteFn(nil),
+							MockUpdate: test.NewMockUpdateFn(nil, func(o client.Object) error {
+								want := &v1.ConfigurationRevision{}
+								want.SetGroupVersionKind(v1.ConfigurationRevisionGroupVersionKind)
+								want.SetDesiredState(v1.PackageRevisionInactive)
+								want.SetAnnotations(map[string]string{"author": "crossplane"})
+								if diff := cmp.Diff(want, o); diff != "" {
+									t.Errorf("-want, +got:\n%s", diff)
+								}
+								return nil
+							}),
 						},
 					}),
 					WithFinalizer(resource.FinalizerFns{AddFinalizerFn: func(_ context.Context, _ resource.Object) error {


### PR DESCRIPTION
### Description of your changes
This PR adds propagation of annotations from package meta to package revision and updates tests for the same.
Fixes #2307 

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested
I used provider-azure to test out this change: https://github.com/crossplane/provider-azure/blob/master/package/crossplane.yaml
The results are below on my local setup:
```
Name:         provider-azure-346c6b28d1ba
Namespace:
Labels:       pkg.crossplane.io/package=provider-azure
Annotations:  company: Crossplane
              description:
                The Microsoft Azure Crossplane provider adds support for managing Azure
                resources in Kubernetes.
              descriptionShort:
                The Azure Crossplane provider enables infrastructure management for the
                Microsoft Azure Cloud Platform.
              friendly-group-name.meta.crossplane.io/cache.azure.crossplane.io: Caches
              friendly-group-name.meta.crossplane.io/compute.azure.crossplane.io: Compute
              friendly-group-name.meta.crossplane.io/database.azure.crossplane.io: Databases
              friendly-group-name.meta.crossplane.io/network.azure.crossplane.io: Network
              friendly-group-name.meta.crossplane.io/storage.azure.crossplane.io: Storage
              friendly-kind-name.meta.crossplane.io/account.storage.azure.crossplane.io: Storage Account
              friendly-kind-name.meta.crossplane.io/akscluster.compute.azure.crossplane.io: AKS Cluster
              friendly-kind-name.meta.crossplane.io/container.storage.azure.crossplane.io: Storage Container
              friendly-kind-name.meta.crossplane.io/cosmosdbaccount.database.azure.crossplane.io: CosmosDB Account
              friendly-kind-name.meta.crossplane.io/mysqlserver.database.azure.crossplane.io: MySQL Server
              friendly-kind-name.meta.crossplane.io/mysqlserverfirewallrule.database.azure.crossplane.io: MySQL Firewall Rule
              friendly-kind-name.meta.crossplane.io/mysqlservervirtualnetworkrule.database.azure.crossplane.io: MySQL Virtual Network Rule
              friendly-kind-name.meta.crossplane.io/postgresqlserver.database.azure.crossplane.io: PostgreSQL Server
              friendly-kind-name.meta.crossplane.io/postgresqlserverfirewallrule.database.azure.crossplane.io: PostgreSQL Server Firewall Rule
              friendly-kind-name.meta.crossplane.io/postgresqlservervirtualnetworkrule.database.azure.crossplane.io:
                PostgreSQL Server Virtual Network Rule
...
```