### PR TITLE
Improve kubectl-crossplane cmd logging and add verbose flag

### DIFF
--- a/cmd/crank/build_test.go
+++ b/cmd/crank/build_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/spf13/afero"
 
+	"github.com/crossplane/crossplane-runtime/pkg/logging"
 	"github.com/crossplane/crossplane-runtime/pkg/parser"
 	"github.com/crossplane/crossplane-runtime/pkg/test"
 
@@ -72,7 +73,7 @@ func TestBuild(t *testing.T) {
 				PackageRoot: tc.args.root,
 				Ignore:      tc.args.ignore,
 			}
-			err := b.Run(tc.args.child)
+			err := b.Run(tc.args.child, logging.NewNopLogger())
 
 			if diff := cmp.Diff(tc.want, err, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\nRun(...): -want error, +got error:\n%s", tc.reason, diff)

--- a/cmd/crank/install.go
+++ b/cmd/crank/install.go
@@ -42,6 +42,8 @@ import (
 
 const (
 	errPkgIdentifier = "invalid package image identifier"
+	errKubeConfig    = "failed to get kube-config"
+	errKubeClient    = "failed to create kube client"
 )
 
 // installCmd installs a package.
@@ -98,7 +100,14 @@ func (c *installConfigCmd) Run(k *kong.Context) error {
 			},
 		},
 	}
-	kube := typedclient.NewForConfigOrDie(ctrl.GetConfigOrDie())
+	kubeConfig, err := ctrl.GetConfig()
+	if err != nil {
+		return errors.Wrap(err, errKubeConfig)
+	}
+	kube, err := typedclient.NewForConfig(kubeConfig)
+	if err != nil {
+		return errors.Wrap(err, errKubeClient)
+	}
 	res, err := kube.Configurations().Create(context.Background(), cr, metav1.CreateOptions{})
 	if err != nil {
 		return errors.Wrap(warnIfNotFound(err), "cannot create configuration")
@@ -156,7 +165,14 @@ func (c *installProviderCmd) Run(k *kong.Context) error {
 			Name: c.Config,
 		}
 	}
-	kube := typedclient.NewForConfigOrDie(ctrl.GetConfigOrDie())
+	kubeConfig, err := ctrl.GetConfig()
+	if err != nil {
+		return errors.Wrap(err, errKubeConfig)
+	}
+	kube, err := typedclient.NewForConfig(kubeConfig)
+	if err != nil {
+		return errors.Wrap(err, errKubeClient)
+	}
 	res, err := kube.Providers().Create(context.Background(), cr, metav1.CreateOptions{})
 	if err != nil {
 		return errors.Wrap(warnIfNotFound(err), "cannot create provider")

--- a/cmd/crank/update.go
+++ b/cmd/crank/update.go
@@ -13,6 +13,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 
+	"github.com/crossplane/crossplane-runtime/pkg/logging"
 	v1 "github.com/crossplane/crossplane/apis/pkg/v1"
 	typedclient "github.com/crossplane/crossplane/internal/client/clientset/versioned/typed/pkg/v1"
 
@@ -38,23 +39,33 @@ type updateConfigCmd struct {
 }
 
 // Run runs the Configuration update cmd.
-func (c *updateConfigCmd) Run(k *kong.Context) error { // nolint:gocyclo
+func (c *updateConfigCmd) Run(k *kong.Context, logger logging.Logger) error { // nolint:gocyclo
+	logger = logger.WithValues("Name", c.Name)
 	kubeConfig, err := ctrl.GetConfig()
 	if err != nil {
+		logger.Debug(errKubeConfig, "error", err)
 		return errors.Wrap(err, errKubeConfig)
 	}
+	logger.Debug("Found kubeconfig")
 	kube, err := typedclient.NewForConfig(kubeConfig)
 	if err != nil {
+		logger.Debug(errKubeClient, "error", err)
 		return errors.Wrap(err, errKubeClient)
 	}
+	logger.Debug("Created kubernetes client")
 	prevConf, err := kube.Configurations().Get(context.Background(), c.Name, metav1.GetOptions{})
 	if err != nil {
-		return errors.Wrap(warnIfNotFound(err), "cannot update configuration")
+		err = warnIfNotFound(err)
+		logger.Debug("Failed to update configuration", "error", err)
+		return errors.Wrap(err, "cannot update configuration")
 	}
+	logger.Debug("Found previous configuration object")
 	pkg := prevConf.Spec.Package
 	pkgReference, err := name.ParseReference(pkg, name.WithDefaultRegistry(""))
 	if err != nil {
-		return errors.Wrap(warnIfNotFound(err), "cannot update configuration")
+		err = warnIfNotFound(err)
+		logger.Debug("Failed to update configuration", "error", err)
+		return errors.Wrap(err, "cannot update configuration")
 	}
 	newPkg := ""
 	if strings.HasPrefix(c.Tag, "sha256") {
@@ -65,11 +76,15 @@ func (c *updateConfigCmd) Run(k *kong.Context) error { // nolint:gocyclo
 	prevConf.Spec.Package = newPkg
 	req, err := json.Marshal(prevConf)
 	if err != nil {
-		return errors.Wrap(warnIfNotFound(err), "cannot update configuration")
+		err = warnIfNotFound(err)
+		logger.Debug("Failed to update configuration", "error", err)
+		return errors.Wrap(err, "cannot update configuration")
 	}
 	res, err := kube.Configurations().Patch(context.Background(), c.Name, types.MergePatchType, req, metav1.PatchOptions{})
 	if err != nil {
-		return errors.Wrap(warnIfNotFound(err), "cannot update configuration")
+		err = warnIfNotFound(err)
+		logger.Debug("Failed to update configuration", "error", err)
+		return errors.Wrap(err, "cannot update configuration")
 	}
 	_, err = fmt.Fprintf(k.Stdout, "%s/%s updated\n", strings.ToLower(v1.ConfigurationGroupKind), res.GetName())
 	return err
@@ -82,23 +97,32 @@ type updateProviderCmd struct {
 }
 
 // Run runs the Provider update cmd.
-func (c *updateProviderCmd) Run(k *kong.Context) error { // nolint:gocyclo
+func (c *updateProviderCmd) Run(k *kong.Context, logger logging.Logger) error { // nolint:gocyclo
 	kubeConfig, err := ctrl.GetConfig()
 	if err != nil {
+		logger.Debug(errKubeConfig, "error", err)
 		return errors.Wrap(err, errKubeConfig)
 	}
+	logger.Debug("Found kubeconfig")
 	kube, err := typedclient.NewForConfig(kubeConfig)
 	if err != nil {
+		logger.Debug(errKubeClient, "error", err)
 		return errors.Wrap(err, errKubeClient)
 	}
+	logger.Debug("Created kubernetes client")
 	preProv, err := kube.Providers().Get(context.Background(), c.Name, metav1.GetOptions{})
 	if err != nil {
-		return errors.Wrap(warnIfNotFound(err), "cannot update provider")
+		err = warnIfNotFound(err)
+		logger.Debug("Failed to update provider", "error", err)
+		return errors.Wrap(err, "cannot update provider")
 	}
+	logger.Debug("Found previous provider object")
 	pkg := preProv.Spec.Package
 	pkgReference, err := name.ParseReference(pkg, name.WithDefaultRegistry(""))
 	if err != nil {
-		return errors.Wrap(warnIfNotFound(err), "cannot update provider")
+		err = warnIfNotFound(err)
+		logger.Debug("Failed to update provider", "error", err)
+		return errors.Wrap(err, "cannot update provider")
 	}
 	newPkg := ""
 	if strings.HasPrefix(c.Tag, "sha256") {
@@ -109,11 +133,15 @@ func (c *updateProviderCmd) Run(k *kong.Context) error { // nolint:gocyclo
 	preProv.Spec.Package = newPkg
 	req, err := json.Marshal(preProv)
 	if err != nil {
-		return errors.Wrap(warnIfNotFound(err), "cannot update provider")
+		err = warnIfNotFound(err)
+		logger.Debug("Failed to update provider", "error", err)
+		return errors.Wrap(err, "cannot update provider")
 	}
 	res, err := kube.Providers().Patch(context.Background(), c.Name, types.MergePatchType, req, metav1.PatchOptions{})
 	if err != nil {
-		return errors.Wrap(warnIfNotFound(err), "cannot update provider")
+		err = warnIfNotFound(err)
+		logger.Debug("Failed to update provider", "error", err)
+		return errors.Wrap(err, "cannot update provider")
 	}
 	_, err = fmt.Fprintf(k.Stdout, "%s/%s updated\n", strings.ToLower(v1.ProviderGroupKind), res.GetName())
 	return err

--- a/cmd/crank/update.go
+++ b/cmd/crank/update.go
@@ -39,7 +39,14 @@ type updateConfigCmd struct {
 
 // Run runs the Configuration update cmd.
 func (c *updateConfigCmd) Run(k *kong.Context) error { // nolint:gocyclo
-	kube := typedclient.NewForConfigOrDie(ctrl.GetConfigOrDie())
+	kubeConfig, err := ctrl.GetConfig()
+	if err != nil {
+		return errors.Wrap(err, errKubeConfig)
+	}
+	kube, err := typedclient.NewForConfig(kubeConfig)
+	if err != nil {
+		return errors.Wrap(err, errKubeClient)
+	}
 	prevConf, err := kube.Configurations().Get(context.Background(), c.Name, metav1.GetOptions{})
 	if err != nil {
 		return errors.Wrap(warnIfNotFound(err), "cannot update configuration")
@@ -76,7 +83,14 @@ type updateProviderCmd struct {
 
 // Run runs the Provider update cmd.
 func (c *updateProviderCmd) Run(k *kong.Context) error { // nolint:gocyclo
-	kube := typedclient.NewForConfigOrDie(ctrl.GetConfigOrDie())
+	kubeConfig, err := ctrl.GetConfig()
+	if err != nil {
+		return errors.Wrap(err, errKubeConfig)
+	}
+	kube, err := typedclient.NewForConfig(kubeConfig)
+	if err != nil {
+		return errors.Wrap(err, errKubeClient)
+	}
 	preProv, err := kube.Providers().Get(context.Background(), c.Name, metav1.GetOptions{})
 	if err != nil {
 		return errors.Wrap(warnIfNotFound(err), "cannot update provider")


### PR DESCRIPTION
### Description of your changes
This change fixes some of the silent failures in the `kubectl crossplane` cmd and adds a `--verbose` flag for verbose logging.

Fixes #2237 

Please let me know if any of the statements needs rewording or if you find some statements unnecessary for the CLI.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested
I have tested this PR locally primarily and update the supplied build test for this change.

[contribution process]: https://git.io/fj2m9
