### PR TITLE
feat(cli/crank): add wait flag in pkg install cmd in crossplane cli

### DIFF
--- a/cmd/crank/main.go
+++ b/cmd/crank/main.go
@@ -18,7 +18,6 @@ package main
 
 import (
 	"fmt"
-	"time"
 
 	"github.com/alecthomas/kong"
 	"github.com/spf13/afero"
@@ -71,13 +70,12 @@ func main() {
 		fs: afero.NewOsFs(),
 	}
 	logger := logging.NewNopLogger()
-	waitDuration := time.Duration(0)
 	ctx := kong.Parse(&cli,
 		kong.Name("kubectl crossplane"),
 		kong.Description("A command line tool for interacting with Crossplane."),
 		// Binding a variable to kong context makes it available to all commands
 		// at runtime.
-		kong.Bind(buildChild, pushChild, waitDuration),
+		kong.Bind(buildChild, pushChild),
 		kong.BindTo(logger, (*logging.Logger)(nil)),
 		kong.UsageOnError())
 	err := ctx.Run()

--- a/cmd/crank/main.go
+++ b/cmd/crank/main.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/alecthomas/kong"
 	"github.com/spf13/afero"
@@ -70,12 +71,13 @@ func main() {
 		fs: afero.NewOsFs(),
 	}
 	logger := logging.NewNopLogger()
+	waitDuration := time.Duration(0)
 	ctx := kong.Parse(&cli,
 		kong.Name("kubectl crossplane"),
 		kong.Description("A command line tool for interacting with Crossplane."),
 		// Binding a variable to kong context makes it available to all commands
 		// at runtime.
-		kong.Bind(buildChild, pushChild),
+		kong.Bind(buildChild, pushChild, waitDuration),
 		kong.BindTo(logger, (*logging.Logger)(nil)),
 		kong.UsageOnError())
 	err := ctx.Run()


### PR DESCRIPTION
### Description of your changes
This PR introduces a wait flag in the install cmd to wait for the installed package to be healthy.

Fixes #2182 

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested
Currently, none of the unit tests cover this CLI. This change has been mainly tested locally.