### PR TITLE
Deprecate v1beta1 pkg and apiextensions APIs

### DIFF
--- a/apis/apiextensions/v1beta1/composition_types.go
+++ b/apis/apiextensions/v1beta1/composition_types.go
@@ -332,6 +332,8 @@ type CompositionStatus struct {
 
 // Composition defines the group of resources to be created when a compatible
 // type is created with reference to the composition.
+// [DEPRECATED]: Please use the identical v1 API instead. The v1beta1 API is
+// scheduled to be removed in Crossplane v1.6.
 // +kubebuilder:printcolumn:name="AGE",type="date",JSONPath=".metadata.creationTimestamp"
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:scope=Cluster,categories=crossplane

--- a/apis/apiextensions/v1beta1/xrd_types.go
+++ b/apis/apiextensions/v1beta1/xrd_types.go
@@ -157,6 +157,8 @@ type CompositeResourceDefinitionControllerStatus struct {
 // An CompositeResourceDefinition defines a new kind of composite infrastructure
 // resource. The new resource is composed of other composite or managed
 // infrastructure resources.
+// [DEPRECATED]: Please use the identical v1 API instead. The v1beta1 API is
+// scheduled to be removed in Crossplane v1.6.
 // +kubebuilder:printcolumn:name="ESTABLISHED",type="string",JSONPath=".status.conditions[?(@.type=='Established')].status"
 // +kubebuilder:printcolumn:name="OFFERED",type="string",JSONPath=".status.conditions[?(@.type=='Offered')].status"
 // +kubebuilder:printcolumn:name="AGE",type="date",JSONPath=".metadata.creationTimestamp"

--- a/apis/pkg/v1beta1/configuration_types.go
+++ b/apis/pkg/v1beta1/configuration_types.go
@@ -27,6 +27,8 @@ import (
 // +genclient:nonNamespaced
 
 // Configuration is the CRD type for a request to add a configuration to Crossplane.
+// [DEPRECATED]: Please use the identical v1 API instead. The v1beta1 API is
+// scheduled to be removed in Crossplane v1.6.
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="INSTALLED",type="string",JSONPath=".status.conditions[?(@.type=='Installed')].status"
 // +kubebuilder:printcolumn:name="HEALTHY",type="string",JSONPath=".status.conditions[?(@.type=='Healthy')].status"
@@ -67,6 +69,8 @@ type ConfigurationList struct {
 // +genclient:nonNamespaced
 
 // A ConfigurationRevision that has been added to Crossplane.
+// [DEPRECATED]: Please use the identical v1 API instead. The v1beta1 API is
+// scheduled to be removed in Crossplane v1.6.
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="HEALTHY",type="string",JSONPath=".status.conditions[?(@.type=='Healthy')].status"
 // +kubebuilder:printcolumn:name="REVISION",type="string",JSONPath=".spec.revision"

--- a/apis/pkg/v1beta1/provider_types.go
+++ b/apis/pkg/v1beta1/provider_types.go
@@ -27,6 +27,8 @@ import (
 // +genclient:nonNamespaced
 
 // Provider is the CRD type for a request to add a provider to Crossplane.
+// [DEPRECATED]: Please use the identical v1 API instead. The v1beta1 API is
+// scheduled to be removed in Crossplane v1.6.
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="INSTALLED",type="string",JSONPath=".status.conditions[?(@.type=='Installed')].status"
 // +kubebuilder:printcolumn:name="HEALTHY",type="string",JSONPath=".status.conditions[?(@.type=='Healthy')].status"
@@ -72,6 +74,8 @@ type ProviderList struct {
 // +genclient:nonNamespaced
 
 // A ProviderRevision that has been added to Crossplane.
+// [DEPRECATED]: Please use the identical v1 API instead. The v1beta1 API is
+// scheduled to be removed in Crossplane v1.6.
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="HEALTHY",type="string",JSONPath=".status.conditions[?(@.type=='Healthy')].status"
 // +kubebuilder:printcolumn:name="REVISION",type="string",JSONPath=".spec.revision"

--- a/cluster/crds/apiextensions.crossplane.io_compositeresourcedefinitions.yaml
+++ b/cluster/crds/apiextensions.crossplane.io_compositeresourcedefinitions.yaml
@@ -379,9 +379,11 @@ spec:
     name: v1beta1
     schema:
       openAPIV3Schema:
-        description: An CompositeResourceDefinition defines a new kind of composite
+        description: 'An CompositeResourceDefinition defines a new kind of composite
           infrastructure resource. The new resource is composed of other composite
-          or managed infrastructure resources.
+          or managed infrastructure resources. [DEPRECATED]: Please use the identical
+          v1 API instead. The v1beta1 API is scheduled to be removed in Crossplane
+          v1.6.'
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation

--- a/cluster/crds/apiextensions.crossplane.io_compositions.yaml
+++ b/cluster/crds/apiextensions.crossplane.io_compositions.yaml
@@ -474,8 +474,10 @@ spec:
     name: v1beta1
     schema:
       openAPIV3Schema:
-        description: Composition defines the group of resources to be created when
-          a compatible type is created with reference to the composition.
+        description: 'Composition defines the group of resources to be created when
+          a compatible type is created with reference to the composition. [DEPRECATED]:
+          Please use the identical v1 API instead. The v1beta1 API is scheduled to
+          be removed in Crossplane v1.6.'
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation

--- a/cluster/crds/pkg.crossplane.io_configurationrevisions.yaml
+++ b/cluster/crds/pkg.crossplane.io_configurationrevisions.yaml
@@ -283,7 +283,9 @@ spec:
     name: v1beta1
     schema:
       openAPIV3Schema:
-        description: A ConfigurationRevision that has been added to Crossplane.
+        description: 'A ConfigurationRevision that has been added to Crossplane. [DEPRECATED]:
+          Please use the identical v1 API instead. The v1beta1 API is scheduled to
+          be removed in Crossplane v1.6.'
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation

--- a/cluster/crds/pkg.crossplane.io_configurations.yaml
+++ b/cluster/crds/pkg.crossplane.io_configurations.yaml
@@ -172,8 +172,9 @@ spec:
     name: v1beta1
     schema:
       openAPIV3Schema:
-        description: Configuration is the CRD type for a request to add a configuration
-          to Crossplane.
+        description: 'Configuration is the CRD type for a request to add a configuration
+          to Crossplane. [DEPRECATED]: Please use the identical v1 API instead. The
+          v1beta1 API is scheduled to be removed in Crossplane v1.6.'
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation

--- a/cluster/crds/pkg.crossplane.io_providerrevisions.yaml
+++ b/cluster/crds/pkg.crossplane.io_providerrevisions.yaml
@@ -283,7 +283,9 @@ spec:
     name: v1beta1
     schema:
       openAPIV3Schema:
-        description: A ProviderRevision that has been added to Crossplane.
+        description: 'A ProviderRevision that has been added to Crossplane. [DEPRECATED]:
+          Please use the identical v1 API instead. The v1beta1 API is scheduled to
+          be removed in Crossplane v1.6.'
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation

--- a/cluster/crds/pkg.crossplane.io_providers.yaml
+++ b/cluster/crds/pkg.crossplane.io_providers.yaml
@@ -181,7 +181,9 @@ spec:
     name: v1beta1
     schema:
       openAPIV3Schema:
-        description: Provider is the CRD type for a request to add a provider to Crossplane.
+        description: 'Provider is the CRD type for a request to add a provider to
+          Crossplane. [DEPRECATED]: Please use the identical v1 API instead. The v1beta1
+          API is scheduled to be removed in Crossplane v1.6.'
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Deprecates `v1beta1` `pkg` and `apiextensions` APIs in favor of their identical `v1` counterparts. They are scheduled for removal after 3 release (i.e. Crossplane `v1.6`). APIs included are:

- `Composition`
- `CompositeResourceDefinition`
- `Provider`
- `ProviderRevision`
- `Configuration`
- `ConfigurationRevision`

Fixes #2314

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

n/a

[contribution process]: https://git.io/fj2m9
