### PR TITLE
Remove kustomize dependency from Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,7 +95,7 @@ crds.clean:
 	@find $(CRD_DIR) -name '*.yaml.sed' -delete || $(FAIL)
 	@$(OK) cleaned generated CRDs
 
-generate: $(HELM) $(KUSTOMIZE) go.vendor go.generate crds.clean gen-kustomize-crds gen-install-doc
+generate: $(HELM) go.vendor go.generate crds.clean gen-kustomize-crds gen-install-doc
 	@$(OK) Finished generating
 
 gen-install-doc:


### PR DESCRIPTION


<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

We build a directory for Kustomize but we don't actually depend on the
tool. This updates to remove it.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

`make generate`

[contribution process]: https://git.io/fj2m9
