### PR TITLE
Prevent superfluous external-name annotation on XRs

### DIFF
--- a/internal/controller/apiextensions/claim/api.go
+++ b/internal/controller/apiextensions/claim/api.go
@@ -64,7 +64,11 @@ func (a *APIBinder) Bind(ctx context.Context, cm resource.CompositeClaim, cp res
 	}
 
 	// Propagate the actual external name back from the composite to the claim.
-	meta.SetExternalName(cm, meta.GetExternalName(cp))
+	if en, enExists := cp.GetAnnotations()[meta.AnnotationKeyExternalName]; enExists { // we may also add this as a utility to crossplane-runtime
+		meta.SetExternalName(cm, en)
+	} else {
+		meta.RemoveAnnotations(cm, meta.AnnotationKeyExternalName)
+	}
 
 	// We set the claim's resource reference first in order to reduce the chance
 	// of leaking newly created composite resources. We want as few calls that

--- a/internal/controller/apiextensions/claim/api.go
+++ b/internal/controller/apiextensions/claim/api.go
@@ -64,11 +64,10 @@ func (a *APIBinder) Bind(ctx context.Context, cm resource.CompositeClaim, cp res
 	}
 
 	// Propagate the actual external name back from the composite to the claim
-	// if the claim does not have one yet.
+	// if it's set.
 	// For dynamically provisioned composites, claim's external name is the
-	// authoritative source.
-	en := meta.GetExternalName(cp)
-	if meta.GetExternalName(cm) == "" && en != "" {
+	// source initially (if set) as expected.
+	if en := meta.GetExternalName(cp); en != "" {
 		meta.SetExternalName(cm, en)
 	}
 

--- a/internal/controller/apiextensions/claim/api.go
+++ b/internal/controller/apiextensions/claim/api.go
@@ -64,10 +64,9 @@ func (a *APIBinder) Bind(ctx context.Context, cm resource.CompositeClaim, cp res
 	}
 
 	// Propagate the actual external name back from the composite to the claim.
-	if en, enExists := cp.GetAnnotations()[meta.AnnotationKeyExternalName]; enExists { // we may also add this as a utility to crossplane-runtime
+	en := meta.GetExternalName(cp)
+	if meta.GetExternalName(cm) == "" && en != "" {
 		meta.SetExternalName(cm, en)
-	} else {
-		meta.RemoveAnnotations(cm, meta.AnnotationKeyExternalName)
 	}
 
 	// We set the claim's resource reference first in order to reduce the chance

--- a/internal/controller/apiextensions/claim/api.go
+++ b/internal/controller/apiextensions/claim/api.go
@@ -63,7 +63,10 @@ func (a *APIBinder) Bind(ctx context.Context, cm resource.CompositeClaim, cp res
 		return errors.New(errBindClaimConflict)
 	}
 
-	// Propagate the actual external name back from the composite to the claim.
+	// Propagate the actual external name back from the composite to the claim
+	// if the claim does not have one yet.
+	// For dynamically provisioned composites, claim's external name is the
+	// authoritative source.
 	en := meta.GetExternalName(cp)
 	if meta.GetExternalName(cm) == "" && en != "" {
 		meta.SetExternalName(cm, en)

--- a/internal/controller/apiextensions/claim/api_test.go
+++ b/internal/controller/apiextensions/claim/api_test.go
@@ -28,6 +28,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
+	"github.com/crossplane/crossplane-runtime/pkg/meta"
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
 	"github.com/crossplane/crossplane-runtime/pkg/resource/fake"
 	"github.com/crossplane/crossplane-runtime/pkg/test"
@@ -53,11 +54,59 @@ func TestBind(t *testing.T) {
 	}
 
 	cases := map[string]struct {
-		reason string
-		fields fields
-		args   args
-		want   error
+		reason    string
+		fields    fields
+		args      args
+		want      error
+		wantClaim resource.CompositeClaim
 	}{
+		"ReconcileXRCExtNameFromXR": {
+			reason: "If existing XR already has an external-name, XRC's external-name should be set from it",
+			fields: fields{
+				c: &test.MockClient{
+					MockUpdate: test.NewMockUpdateFn(nil),
+				},
+				t: fake.SchemeWith(&fake.Composite{}, &fake.CompositeClaim{}),
+			},
+			args: args{
+				cm: &fake.CompositeClaim{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							meta.AnnotationKeyExternalName: "name-from-claim",
+						},
+					},
+					CompositeResourceReferencer: fake.CompositeResourceReferencer{
+						Ref: &corev1.ObjectReference{
+							APIVersion: fake.GVK(&fake.Composite{}).GroupVersion().String(),
+							Kind:       fake.GVK(&fake.Composite{}).Kind,
+							Name:       "wat",
+						},
+					},
+				},
+				cp: &fake.Composite{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "wat",
+						Annotations: map[string]string{
+							meta.AnnotationKeyExternalName: "name-from-composite",
+						},
+					},
+				},
+			},
+			wantClaim: &fake.CompositeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						meta.AnnotationKeyExternalName: "name-from-composite",
+					},
+				},
+				CompositeResourceReferencer: fake.CompositeResourceReferencer{
+					Ref: &corev1.ObjectReference{
+						APIVersion: fake.GVK(&fake.Composite{}).GroupVersion().String(),
+						Kind:       fake.GVK(&fake.Composite{}).Kind,
+						Name:       "wat",
+					},
+				},
+			},
+		},
 		"CompositeRefConflict": {
 			reason: "An error should be returned if the claim is bound to another composite resource",
 			fields: fields{
@@ -175,6 +224,14 @@ func TestBind(t *testing.T) {
 			got := b.Bind(tc.args.ctx, tc.args.cm, tc.args.cp)
 			if diff := cmp.Diff(tc.want, got, test.EquateErrors()); diff != "" {
 				t.Errorf("b.Bind(...): %s\n-want, +got:\n%s\n", tc.reason, diff)
+			}
+			if got != nil {
+				return
+			}
+
+			// if no error, then assert the claim
+			if diff := cmp.Diff(tc.wantClaim, tc.args.cm); diff != "" {
+				t.Errorf("b.Bind(...): %s\n-wantClaim, +gotClaim:\n%s\n", tc.reason, diff)
 			}
 		})
 	}

--- a/internal/controller/apiextensions/claim/configurator.go
+++ b/internal/controller/apiextensions/claim/configurator.go
@@ -36,7 +36,7 @@ const (
 	errUnsupportedClaimSpec = "composite resource claim spec was not an object"
 	errUnsupportedDstObject = "destination object was not valid object"
 	errUnsupportedSrcObject = "source object was not valid object"
-	errExternalNameMismatch = "mismatch of external names between claim and managed resource"
+	errExternalNameMismatch = "mismatch of external names between claim and composite resource"
 
 	errMergeClaimSpec   = "unable to merge claim spec"
 	errMergeClaimStatus = "unable to merge claim status"

--- a/internal/controller/apiextensions/claim/configurator.go
+++ b/internal/controller/apiextensions/claim/configurator.go
@@ -36,7 +36,6 @@ const (
 	errUnsupportedClaimSpec = "composite resource claim spec was not an object"
 	errUnsupportedDstObject = "destination object was not valid object"
 	errUnsupportedSrcObject = "source object was not valid object"
-	errExternalNameMismatch = "mismatch of external names between claim and composite resource"
 
 	errMergeClaimSpec   = "unable to merge claim spec"
 	errMergeClaimStatus = "unable to merge claim status"
@@ -65,11 +64,6 @@ func ConfigureComposite(_ context.Context, cm resource.CompositeClaim, cp resour
 	// external name (even if that external name was empty) in order to ensure
 	// we don't try to rename anything after the fact.
 	if meta.WasCreated(cp) {
-		enCm := meta.GetExternalName(cm)
-		// if there is a mismatch between claim's external-name and composite's external-name
-		if enCm != "" && enCm != en {
-			return errors.New(errExternalNameMismatch)
-		}
 		// Fix(2353): do not introduce a superfluous extern-name
 		// (empty external-names are treated as invalid)
 		if en != "" {

--- a/internal/controller/apiextensions/claim/configurator.go
+++ b/internal/controller/apiextensions/claim/configurator.go
@@ -70,7 +70,8 @@ func ConfigureComposite(_ context.Context, cm resource.CompositeClaim, cp resour
 		if enCm != "" && enCm != en {
 			return errors.New(errExternalNameMismatch)
 		}
-		// fix(2353): do not introduce a superfluous extern-name (empty external-names are treated as invalid)
+		// Fix(2353): do not introduce a superfluous extern-name
+		// (empty external-names are treated as invalid)
 		if en != "" {
 			meta.SetExternalName(cp, en)
 		}

--- a/internal/controller/apiextensions/claim/configurator_test.go
+++ b/internal/controller/apiextensions/claim/configurator_test.go
@@ -33,7 +33,6 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/resource/unstructured/claim"
 	"github.com/crossplane/crossplane-runtime/pkg/resource/unstructured/composite"
 	"github.com/crossplane/crossplane-runtime/pkg/test"
-
 	"github.com/crossplane/crossplane/internal/xcrd"
 )
 
@@ -198,95 +197,10 @@ func TestCompositeConfigure(t *testing.T) {
 								"namespace": ns,
 								"name":      name,
 								"annotations": map[string]interface{}{
-									// If the claim is bound to an existing XR,
-									// an external-name exists on the claim, and
-									// XR already has an external name assigned,
-									// these names should match for successful
-									// reconciliation.
-									meta.AnnotationKeyExternalName: name,
-									"xrc":                          "annotation",
-								},
-							},
-							"spec": map[string]interface{}{
-								"coolness": 23,
-
-								// These should be filtered out.
-								"resourceRef":                "ref",
-								"writeConnectionSecretToRef": "ref",
-							},
-						},
-					},
-				},
-				cp: &composite.Unstructured{
-					Unstructured: unstructured.Unstructured{
-						Object: map[string]interface{}{
-							"metadata": map[string]interface{}{
-								"name": name,
-								"creationTimestamp": func() string {
-									b, _ := now.MarshalJSON()
-									return strings.Trim(string(b), "\"")
-								}(),
-								"labels": map[string]interface{}{
-									xcrd.LabelKeyClaimNamespace: ns,
-									xcrd.LabelKeyClaimName:      name,
-								},
-								"annotations": map[string]interface{}{
-									meta.AnnotationKeyExternalName: name,
-									"xr":                           "annotation",
-								},
-							},
-							"spec": map[string]interface{}{
-								// This should be overridden with the value of
-								// the equivalent claim field.
-								"coolness": 42,
-							},
-						},
-					},
-				},
-			},
-			want: want{
-				cp: &composite.Unstructured{
-					Unstructured: unstructured.Unstructured{
-						Object: map[string]interface{}{
-							"metadata": map[string]interface{}{
-								"name": name,
-								"creationTimestamp": func() string {
-									b, _ := now.MarshalJSON()
-									return strings.Trim(string(b), "\"")
-								}(),
-								"labels": map[string]interface{}{
-									xcrd.LabelKeyClaimNamespace: ns,
-									xcrd.LabelKeyClaimName:      name,
-								},
-								"annotations": map[string]interface{}{
-									meta.AnnotationKeyExternalName: name,
-									"xr":                           "annotation",
-									"xrc":                          "annotation",
-								},
-							},
-							"spec": map[string]interface{}{
-								"coolness": 23,
-							},
-						},
-					},
-				},
-			},
-		},
-		"NameMismatchExistingXR": {
-			reason: "If there is an external-name mismatch between a claim and a statically provisioned composite resource it's bound to, an error is expected",
-			args: args{
-				cm: &claim.Unstructured{
-					Unstructured: unstructured.Unstructured{
-						Object: map[string]interface{}{
-							"metadata": map[string]interface{}{
-								"namespace": ns,
-								"name":      name,
-								"annotations": map[string]interface{}{
-									// If the claim is bound to an existing XR,
-									// an external-name exists on the claim, and
-									// XR already has an external name assigned,
-									// but these names are not the same, then
-									// we now expect a reconciliation error.
+									// This should be reset to the equivalent
+									// composite resource value, since it has
+									// most likely already taken effect and
+									// cannot be updated retroactively.
 									meta.AnnotationKeyExternalName: "wat",
 									"xrc":                          "annotation",
 								},
@@ -329,7 +243,6 @@ func TestCompositeConfigure(t *testing.T) {
 				},
 			},
 			want: want{
-				err: errors.New(errExternalNameMismatch),
 				cp: &composite.Unstructured{
 					Unstructured: unstructured.Unstructured{
 						Object: map[string]interface{}{
@@ -344,13 +257,13 @@ func TestCompositeConfigure(t *testing.T) {
 									xcrd.LabelKeyClaimName:      name,
 								},
 								"annotations": map[string]interface{}{
-									meta.AnnotationKeyExternalName: "wat",
+									meta.AnnotationKeyExternalName: name,
 									"xr":                           "annotation",
 									"xrc":                          "annotation",
 								},
 							},
 							"spec": map[string]interface{}{
-								"coolness": 42, // expected not to be reconciled because of external-name mismatch
+								"coolness": 23,
 							},
 						},
 					},

--- a/internal/controller/apiextensions/claim/configurator_test.go
+++ b/internal/controller/apiextensions/claim/configurator_test.go
@@ -198,10 +198,11 @@ func TestCompositeConfigure(t *testing.T) {
 								"namespace": ns,
 								"name":      name,
 								"annotations": map[string]interface{}{
-									// This should be reset to the equivalent
-									// composite resource value, since it has
-									// most likely already taken effect and
-									// cannot be updated retroactively.
+									// If the claim is bound to an existing XR,
+									// an external-name exists on the claim, and
+									// XR already has an external name assigned,
+									// these names should match for successful
+									// reconciliation.
 									meta.AnnotationKeyExternalName: name,
 									"xrc":                          "annotation",
 								},
@@ -281,10 +282,11 @@ func TestCompositeConfigure(t *testing.T) {
 								"namespace": ns,
 								"name":      name,
 								"annotations": map[string]interface{}{
-									// This should be reset to the equivalent
-									// composite resource value, since it has
-									// most likely already taken effect and
-									// cannot be updated retroactively.
+									// If the claim is bound to an existing XR,
+									// an external-name exists on the claim, and
+									// XR already has an external name assigned,
+									// but these names are not the same, then
+									// we now expect a reconciliation error.
 									meta.AnnotationKeyExternalName: "wat",
 									"xrc":                          "annotation",
 								},


### PR DESCRIPTION
Signed-off-by: Alper Rifat Ulucinar <ulucinar@users.noreply.github.com>

<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #2350

I have:

- [X ] Read and followed Crossplane's [contribution process].
- [X] Run `make reviewable test` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested
Using getting-started guide's aws (with default VPC) configuration, I provisioned an XR via its claim. The superfluous external-name annotation is not observed. Please see the comment below for the semantics of this change.

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
