### PR TITLE
Move extra env vars documentation from template to README

### DIFF
--- a/cluster/charts/crossplane/README.md
+++ b/cluster/charts/crossplane/README.md
@@ -107,8 +107,8 @@ and their default values.
 | `rbacManager.tolerations` | Enable tolerations for RBAC Managers pod | `{}` |
 | `rbacManager.skipAggregatedClusterRoles` | Opt out of deploying aggregated ClusterRoles | `false` |
 | `metrics.enabled` | Expose Crossplane and RBAC Manager metrics endpoint | `false` |
-| `extraEnvVarsCrossplane` | List of extra environment variables to set in the crossplane deployment | `{}` |
-| `extraEnvVarsRBACManager` | List of extra environment variables to set in the crossplane rbac manager deployment | `{}` |
+| `extraEnvVarsCrossplane` | List of extra environment variables to set in the crossplane deployment. Any `.` in variable names will be replaced with `_` (example: `SAMPLE.KEY=value1` becomes `SAMPLE_KEY=value1`). | `{}` |
+| `extraEnvVarsRBACManager` | List of extra environment variables to set in the crossplane rbac manager deployment. Any `.` in variable names will be replaced with `_` (example: `SAMPLE.KEY=value1` becomes `SAMPLE_KEY=value1`). | `{}` |
 
 ### Command Line
 

--- a/cluster/charts/crossplane/values.yaml.tmpl
+++ b/cluster/charts/crossplane/values.yaml.tmpl
@@ -72,26 +72,6 @@ securityContextRBACManager:
 metrics:
   enabled: false
 
-# List of extra environment variables to set in the crossplane deployment.
-# EXAMPLE
-# extraEnvironmentVars:
-#   sample.key=value1
-#   ANOTHER.KEY=value2
-# RESULT
-#   - name: sample_key
-#     value: "value1"
-#   - name: ANOTHER_KEY
-#     value: "value2"
 extraEnvVarsCrossplane: {}
 
-# List of extra environment variables to set in the crossplane rbac manager deployment.
-# EXAMPLE
-# extraEnvironmentVars:
-#   sample.key=value1
-#   ANOTHER.KEY=value2
-# RESULT
-#   - name: sample_key
-#     value: "value1"
-#   - name: ANOTHER_KEY
-#     value: "value2"
 extraEnvVarsRBACManager: {}

--- a/docs/reference/install.md
+++ b/docs/reference/install.md
@@ -114,8 +114,8 @@ and their default values.
 | `rbacManager.tolerations` | Enable tolerations for RBAC Managers pod | `{}` |
 | `rbacManager.skipAggregatedClusterRoles` | Opt out of deploying aggregated ClusterRoles | `false` |
 | `metrics.enabled` | Expose Crossplane and RBAC Manager metrics endpoint | `false` |
-| `extraEnvVarsCrossplane` | List of extra environment variables to set in the crossplane deployment | `{}` |
-| `extraEnvVarsRBACManager` | List of extra environment variables to set in the crossplane rbac manager deployment | `{}` |
+| `extraEnvVarsCrossplane` | List of extra environment variables to set in the crossplane deployment. Any `.` in variable names will be replaced with `_` (example: `SAMPLE.KEY=value1` becomes `SAMPLE_KEY=value1`). | `{}` |
+| `extraEnvVarsRBACManager` | List of extra environment variables to set in the crossplane rbac manager deployment. Any `.` in variable names will be replaced with `_` (example: `SAMPLE.KEY=value1` becomes `SAMPLE_KEY=value1`). | `{}` |
 
 ### Command Line
 


### PR DESCRIPTION


<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Removes the examples in the helm values template file and updates the
documentation to specify how extra environment variables can be
provided. This makes it such that the examples will be shown on the
documentation website and makes it such that we don't have some fields
documented in the template file but not others.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

n/a -- documentation changes only.

[contribution process]: https://git.io/fj2m9
