### PR TITLE
Add coordination APIs to scheme

### DIFF
--- a/cmd/crossplane/main.go
+++ b/cmd/crossplane/main.go
@@ -22,6 +22,7 @@ import (
 
 	"gopkg.in/alecthomas/kingpin.v2"
 	appsv1 "k8s.io/api/apps/v1"
+	coordinationv1 "k8s.io/api/coordination/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -63,6 +64,7 @@ func main() {
 	kingpin.FatalIfError(corev1.AddToScheme(s), "cannot add core v1 Kubernetes API types to scheme")
 	kingpin.FatalIfError(appsv1.AddToScheme(s), "cannot add apps v1 Kubernetes API types to scheme")
 	kingpin.FatalIfError(rbacv1.AddToScheme(s), "cannot add rbac v1 Kubernetes API types to scheme")
+	kingpin.FatalIfError(coordinationv1.AddToScheme(s), "cannot add coordination v1 Kubernetes API types to scheme")
 	kingpin.FatalIfError(extv1.AddToScheme(s), "cannot add apiextensions v1 Kubernetes API types to scheme")
 	kingpin.FatalIfError(extv1beta1.AddToScheme(s), "cannot add apiextensions v1beta1 Kubernetes API types to scheme")
 	kingpin.FatalIfError(apis.AddToScheme(s), "cannot add Crossplane API types to scheme")


### PR DESCRIPTION
### Description of your changes

Add coordination API scheme as well to the scheme so that Lease object can be used by controller-runtime. Otherwise, we see the following logged and making the initialization of `start` containers take longer:
```
I0609 17:41:35.878400       1 leaderelection.go:243] attempting to acquire leader lease crossplane-system/crossplane-leader-election-rbac...
E0609 17:41:35.922482       1 event.go:329] Could not construct reference to: '&v1.Lease{TypeMeta:v1.TypeMeta{Kind:"", APIVersion:""}, ObjectMeta:v1.ObjectMeta{Name:"crossplane-leader-election-rbac", GenerateName:"", Namespace:"crossplane-system", SelfLink:"/apis/coordination.k8s.io/v1/namespaces/crossplane-system/leases/crossplane-leader-election-rbac", UID:"bf867ddf-d131-4244-88f5-474dc719a107", ResourceVersion:"722", Generation:0, CreationTimestamp:v1.Time{Time:time.Time{wall:0x0, ext:63758857295, loc:(*time.Location)(0x283dc20)}}, DeletionTimestamp:(*v1.Time)(nil), DeletionGracePeriodSeconds:(*int64)(nil), Labels:map[string]string(nil), Annotations:map[string]string(nil), OwnerReferences:[]v1.OwnerReference(nil), Finalizers:[]string(nil), ClusterName:"", ManagedFields:[]v1.ManagedFieldsEntry{v1.ManagedFieldsEntry{Manager:"crossplane", Operation:"Update", APIVersion:"coordination.k8s.io/v1", Time:(*v1.Time)(0xc00074bfa0), FieldsType:"FieldsV1", FieldsV1:(*v1.FieldsV1)(0xc00074bfc0)}}}, Spec:v1.LeaseSpec{HolderIdentity:(*string)(nil), LeaseDurationSeconds:(*int32)(nil), AcquireTime:(*v1.MicroTime)(nil), RenewTime:(*v1.MicroTime)(nil), LeaseTransitions:(*int32)(nil)}}' due to: 'no kind is registered for the type v1.Lease in scheme "pkg/runtime/scheme.go:100"'. Will not report event: 'Normal' 'LeaderElection' 'crossplane-rbac-manager-5cbdc6568f-tgkbn_fefca87e-7fce-4ae6-8fd0-92a28a53bb31 became leader'
I0609 17:41:35.922611       1 leaderelection.go:253] successfully acquired lease crossplane-system/crossplane-leader-election-rbac
```


I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

Manually.

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
