### PR TITLE
Clean up CLI flag descriptions and shorten install wait interval

### DIFF
--- a/cmd/crank/install.go
+++ b/cmd/crank/install.go
@@ -63,7 +63,7 @@ const (
 )
 
 const (
-	waitInterval = 10 * time.Second
+	waitInterval = 3 * time.Second
 )
 
 // installCmd installs a package.

--- a/cmd/crank/install.go
+++ b/cmd/crank/install.go
@@ -82,7 +82,7 @@ type installConfigCmd struct {
 	Package string `arg:"" help:"Image containing Configuration package."`
 
 	Name                 string        `arg:"" optional:"" help:"Name of Configuration."`
-	Wait                 time.Duration `short:"w" help:"Wait for installation of package"`
+	Wait                 time.Duration `short:"w" help:"Wait for installation of package."`
 	RevisionHistoryLimit int64         `short:"r" help:"Revision history limit."`
 	ManualActivation     bool          `short:"m" help:"Enable manual revision activation policy."`
 	PackagePullSecrets   []string      `help:"List of secrets used to pull package."`

--- a/cmd/crank/main.go
+++ b/cmd/crank/main.go
@@ -54,7 +54,7 @@ func (v verboseFlag) BeforeApply(ctx *kong.Context) error { // nolint:unparam
 
 var cli struct {
 	Version versionFlag `short:"v" name:"version" help:"Print version and quit."`
-	Verbose verboseFlag `name:"verbose" help:"Print verbose logging statements"`
+	Verbose verboseFlag `name:"verbose" help:"Print verbose logging statements."`
 
 	Build   buildCmd   `cmd:"" help:"Build Crossplane packages."`
 	Install installCmd `cmd:"" help:"Install Crossplane packages."`


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Follow-up to #2345 

Adds periods to CLI flag descriptions that do not currently have them.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

Updates install polling to use a shorter interval so that feedback is
provided more rapidly. In the future, a list watch on the conditions of
the resource could make this functionality even more responsive.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

@psinghal20 if interested, you could look into enhancing this awesome functionality you added even further by using a [listwatch](https://github.com/kubernetes/client-go/blob/1bccfc8c60977e2ce3235394daff128996818f7b/tools/cache/listwatch.go#L54) :)

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

Tested manually:

```
🤖 (crossplane) kubectl crossplane install configuration -h
Usage: kubectl crossplane install configuration <package> [<name>]

Install a Configuration package.

Arguments:
  <package>    Image containing Configuration package.
  [<name>]     Name of Configuration.

Flags:
  -h, --help                                             Show context-sensitive help.
  -v, --version                                          Print version and quit.
      --verbose                                          Print verbose logging statements.

  -w, --wait=DURATION                                    Wait for installation of package.
  -r, --revision-history-limit=INT-64                    Revision history limit.
  -m, --manual-activation                                Enable manual revision activation policy.
      --package-pull-secrets=PACKAGE-PULL-SECRETS,...    List of secrets used to pull package.
```

```
🤖 (crossplane) kubectl crossplane install configuration registry.upbound.io/xp/getting-started-with-aws:v1.2.2 -w 5m --verbose
2021-06-14T09:09:16.610-0400	DEBUG	Found kubeconfig	{"configurationName": "xp-getting-started-with-aws"}
2021-06-14T09:09:16.611-0400	DEBUG	Created Kubernetes client	{"configurationName": "xp-getting-started-with-aws"}
2021-06-14T09:09:16.621-0400	DEBUG	Waiting for the Configuration to be ready	{"configurationName": "xp-getting-started-with-aws"}
2021-06-14T09:09:16.623-0400	DEBUG	Configuration is not ready	{"configurationName": "xp-getting-started-with-aws"}
2021-06-14T09:09:19.626-0400	DEBUG	Waiting for the Configuration to be ready	{"configurationName": "xp-getting-started-with-aws"}
2021-06-14T09:09:19.633-0400	DEBUG	Configuration is not ready	{"configurationName": "xp-getting-started-with-aws"}
2021-06-14T09:09:22.624-0400	DEBUG	Waiting for the Configuration to be ready	{"configurationName": "xp-getting-started-with-aws"}
2021-06-14T09:09:22.630-0400	DEBUG	Configuration is not ready	{"configurationName": "xp-getting-started-with-aws"}
2021-06-14T09:09:25.623-0400	DEBUG	Waiting for the Configuration to be ready	{"configurationName": "xp-getting-started-with-aws"}
2021-06-14T09:09:25.629-0400	DEBUG	Configuration is not ready	{"configurationName": "xp-getting-started-with-aws"}
2021-06-14T09:09:28.624-0400	DEBUG	Waiting for the Configuration to be ready	{"configurationName": "xp-getting-started-with-aws"}
2021-06-14T09:09:28.632-0400	DEBUG	Configuration is not ready	{"configurationName": "xp-getting-started-with-aws"}
2021-06-14T09:09:31.624-0400	DEBUG	Waiting for the Configuration to be ready	{"configurationName": "xp-getting-started-with-aws"}
2021-06-14T09:09:31.631-0400	DEBUG	Configuration is not ready	{"configurationName": "xp-getting-started-with-aws"}
2021-06-14T09:09:34.624-0400	DEBUG	Waiting for the Configuration to be ready	{"configurationName": "xp-getting-started-with-aws"}
2021-06-14T09:09:34.631-0400	DEBUG	Configuration is not ready	{"configurationName": "xp-getting-started-with-aws"}
2021-06-14T09:09:37.623-0400	DEBUG	Waiting for the Configuration to be ready	{"configurationName": "xp-getting-started-with-aws"}
2021-06-14T09:09:37.625-0400	DEBUG	Configuration is not ready	{"configurationName": "xp-getting-started-with-aws"}
2021-06-14T09:09:40.624-0400	DEBUG	Waiting for the Configuration to be ready	{"configurationName": "xp-getting-started-with-aws"}
2021-06-14T09:09:40.626-0400	DEBUG	Configuration is not ready	{"configurationName": "xp-getting-started-with-aws"}
2021-06-14T09:09:43.623-0400	DEBUG	Waiting for the Configuration to be ready	{"configurationName": "xp-getting-started-with-aws"}
2021-06-14T09:09:43.625-0400	DEBUG	Configuration is not ready	{"configurationName": "xp-getting-started-with-aws"}
2021-06-14T09:09:46.623-0400	DEBUG	Waiting for the Configuration to be ready	{"configurationName": "xp-getting-started-with-aws"}
2021-06-14T09:09:46.625-0400	DEBUG	Configuration is not ready	{"configurationName": "xp-getting-started-with-aws"}
2021-06-14T09:09:49.624-0400	DEBUG	Waiting for the Configuration to be ready	{"configurationName": "xp-getting-started-with-aws"}
2021-06-14T09:09:49.626-0400	DEBUG	Configuration is not ready	{"configurationName": "xp-getting-started-with-aws"}
2021-06-14T09:09:52.624-0400	DEBUG	Waiting for the Configuration to be ready	{"configurationName": "xp-getting-started-with-aws"}
2021-06-14T09:09:52.628-0400	DEBUG	Configuration is not ready	{"configurationName": "xp-getting-started-with-aws"}
2021-06-14T09:09:55.624-0400	DEBUG	Waiting for the Configuration to be ready	{"configurationName": "xp-getting-started-with-aws"}
2021-06-14T09:09:55.626-0400	DEBUG	Configuration is ready	{"configurationName": "xp-getting-started-with-aws"}
configuration.pkg.crossplane.io/xp-getting-started-with-aws created
```

[contribution process]: https://git.io/fj2m9
