### PR TITLE
Give providers proper lease access in coordination.k8s.io

### DIFF
--- a/internal/controller/rbac/provider/roles/roles.go
+++ b/internal/controller/rbac/provider/roles/roles.go
@@ -19,6 +19,7 @@ package roles
 import (
 	"sort"
 
+	coordinationv1 "k8s.io/api/coordination/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -64,7 +65,7 @@ var (
 // * Events for debugging.
 var rulesSystemExtra = []rbacv1.PolicyRule{
 	{
-		APIGroups: []string{"", "coordination/v1"},
+		APIGroups: []string{"", coordinationv1.GroupName},
 		Resources: []string{pluralSecrets, pluralConfigmaps, pluralEvents, pluralLeases},
 		Verbs:     verbsEdit,
 	},


### PR DESCRIPTION


<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Providers were previously being given access to leases in the
coordination/v1 API group, which should be coordination.k8s.io. This
updates to use the proper API group.

Note that this only causes issues in the case that providers are run
with leader election enabled.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

Fixes #2372 

**NOTE: this fix will be backported to all active release branches and a round of patch releases should be made.**

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

1. Installed Crossplane
2. Installed `provider-aws` with `ControllerConfig` as specified in #2372 
3. Verified that leader election was successful by one `Pod` acquiring the `Lease`

[contribution process]: https://git.io/fj2m9
