### PR TITLE
Bump Postgres in the docs/examples from version v9.6 to v12

### DIFF
--- a/docs/getting-started/create-configuration.md
+++ b/docs/getting-started/create-configuration.md
@@ -147,7 +147,7 @@ spec:
             dbInstanceClass: db.t2.small
             masterUsername: masteruser
             engine: postgres
-            engineVersion: "9.6"
+            engineVersion: "12"
             skipFinalSnapshotBeforeDeletion: true
             publiclyAccessible: true
           writeConnectionSecretToRef:

--- a/docs/getting-started/provision-infrastructure.md
+++ b/docs/getting-started/provision-infrastructure.md
@@ -211,7 +211,7 @@ metadata:
 spec:
   containers:
   - name: see-db
-    image: postgres:9.6
+    image: postgres:12
     command: ['psql']
     args: ['-c', 'SELECT current_database();']
     env:

--- a/docs/guides/direct-managed.md
+++ b/docs/guides/direct-managed.md
@@ -48,7 +48,7 @@ spec:
     masterUsername: masteruser
     allocatedStorage: 20
     engine: postgres
-    engineVersion: "9.6"
+    engineVersion: "12"
     skipFinalSnapshotBeforeDeletion: true
   writeConnectionSecretToRef:
     namespace: crossplane-system

--- a/docs/snippets/compose/pod.yaml
+++ b/docs/snippets/compose/pod.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   containers:
   - name: see-db
-    image: postgres:9.6
+    image: postgres:12
     command: ['psql']
     args: ['-c', 'SELECT current_database();']
     env:

--- a/docs/snippets/package/aws-with-vpc/composition.yaml
+++ b/docs/snippets/package/aws-with-vpc/composition.yaml
@@ -139,7 +139,7 @@ spec:
             dbInstanceClass: db.t2.small
             masterUsername: masteruser
             engine: postgres
-            engineVersion: "9.6"
+            engineVersion: "12"
             skipFinalSnapshotBeforeDeletion: true
             publiclyAccessible: true
           writeConnectionSecretToRef:

--- a/docs/snippets/package/aws/composition.yaml
+++ b/docs/snippets/package/aws/composition.yaml
@@ -23,7 +23,7 @@ spec:
             dbInstanceClass: db.t2.small
             masterUsername: masteruser
             engine: postgres
-            engineVersion: "9.6"
+            engineVersion: "12"
             skipFinalSnapshotBeforeDeletion: true
             publiclyAccessible: true
           writeConnectionSecretToRef:

--- a/docs/snippets/provision/aws.yaml
+++ b/docs/snippets/provision/aws.yaml
@@ -9,7 +9,7 @@ spec:
     masterUsername: masteruser
     allocatedStorage: 20
     engine: postgres
-    engineVersion: "9.6"
+    engineVersion: "12"
     skipFinalSnapshotBeforeDeletion: true
   writeConnectionSecretToRef:
     namespace: crossplane-system


### PR DESCRIPTION
### Description of your changes

I've bumped the version from v9.6 to v12 in the snippet and the docs markdown.

Fixes #2391

I have:

- [ ] Read and followed Crossplane's [contribution process].
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

I ran the getting started docs with the updated version: 

```
k describe pod see-db
Name:         see-db
Namespace:    default
Priority:     0
Node:         kind-control-plane/172.18.0.2
Start Time:   Fri, 18 Jun 2021 14:40:15 +0200
Labels:       <none>
Annotations:  <none>
Status:       Running
IP:           10.244.0.8
IPs:
  IP:  10.244.0.8
Containers:
  see-db:
    Container ID:  containerd://0b929c6572c4882d34d30ac865ce81ee2968320b2e627179ca8e54c02a3671a8
    Image:         postgres:12
    Image ID:      docker.io/library/postgres@sha256:097e6fc733e01597390d5190a6b99744e75da91c1bce628b2dedea3acd68958b
    Port:          <none>
    Host Port:     <none>
    Command:
      psql
    Args:
      -c
      SELECT current_database();
    State:          Terminated
      Reason:       Completed
      Exit Code:    0
      Started:      Fri, 18 Jun 2021 14:40:48 +0200
      Finished:     Fri, 18 Jun 2021 14:40:49 +0200
    Last State:     Terminated
      Reason:       Completed
      Exit Code:    0
      Started:      Fri, 18 Jun 2021 14:40:36 +0200
      Finished:     Fri, 18 Jun 2021 14:40:37 +0200
    Ready:          False
    Restart Count:  2
    Environment:
      PGDATABASE:  postgres
      PGHOST:      <set to the key 'endpoint' in secret 'db-conn'>  Optional: false
      PGUSER:      <set to the key 'username' in secret 'db-conn'>  Optional: false
      PGPASSWORD:  <set to the key 'password' in secret 'db-conn'>  Optional: false
      PGPORT:      <set to the key 'port' in secret 'db-conn'>      Optional: false
    Mounts:
      /var/run/secrets/kubernetes.io/serviceaccount from default-token-cw7v4 (ro)
Conditions:
  Type              Status
  Initialized       True
  Ready             False
  ContainersReady   False
  PodScheduled      True
Volumes:
  default-token-cw7v4:
    Type:        Secret (a volume populated by a Secret)
    SecretName:  default-token-cw7v4
    Optional:    false
QoS Class:       BestEffort
Node-Selectors:  <none>
Tolerations:     node.kubernetes.io/not-ready:NoExecute op=Exists for 300s
                 node.kubernetes.io/unreachable:NoExecute op=Exists for 300s
Events:
  Type     Reason     Age               From               Message
  ----     ------     ----              ----               -------
  Normal   Scheduled  35s               default-scheduler  Successfully assigned default/see-db to kind-control-plane
  Normal   Pulling    34s               kubelet            Pulling image "postgres:12"
  Normal   Pulled     21s               kubelet            Successfully pulled image "postgres:12"
  Normal   Created    2s (x3 over 21s)  kubelet            Created container see-db
  Normal   Started    2s (x3 over 21s)  kubelet            Started container see-db
  Normal   Pulled     2s (x2 over 14s)  kubelet            Container image "postgres:12" already present on machine
  Warning  BackOff    0s (x2 over 13s)  kubelet            Back-off restarting failed container
```

```
k logs see-db
 current_database
------------------
 postgres
(1 row)
```

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
