### PR TITLE
replace kingpin with kong cli framework

### DIFF
--- a/cmd/crossplane/core/core.go
+++ b/cmd/crossplane/core/core.go
@@ -37,7 +37,9 @@ type Command struct {
 	Init  initCommand  `cmd:"" help:"Make cluster ready for Crossplane controllers."`
 }
 
-// Run runs the core command
+// Run is the no-op method required for kong call tree
+// Kong requires each node in the calling path to have associated
+// Run method.
 func (c *Command) Run() error {
 	return nil
 }
@@ -52,7 +54,6 @@ type startCommand struct {
 
 // Run core Crossplane controllers.
 func (c *startCommand) Run(s *runtime.Scheme, log logging.Logger) error {
-	log.WithValues("CmdName", "core start")
 	cfg, err := ctrl.GetConfig()
 	if err != nil {
 		return errors.Wrap(err, "Cannot get config")

--- a/cmd/crossplane/core/core.go
+++ b/cmd/crossplane/core/core.go
@@ -40,7 +40,7 @@ type Command struct {
 }
 
 // KongVars represent the kong variables associated with the CLI parser
-// required for the RBAC enum interpolation.
+// required for the Registry default variable interpolation.
 var KongVars = kong.Vars{
 	"default_registry": name.DefaultRegistry,
 }
@@ -55,7 +55,7 @@ func (c *Command) Run() error {
 type startCommand struct {
 	Namespace      string        `short:"n" help:"Namespace used to unpack and run packages." default:"crossplane-system" env:"POD_NAMESPACE"`
 	CacheDir       string        `short:"c" help:"Directory used for caching package images." default:"/cache" env:"CACHE_DIR"`
-	LeaderElection bool          `short:"l" help:"Use leader election for the conroller manager." default:"false" env:"LEADER_ELECTION"`
+	LeaderElection bool          `short:"l" help:"Use leader election for the controller manager." default:"false" env:"LEADER_ELECTION"`
 	Registry       string        `short:"r" help:"Default registry used to fetch packages when not specified in tag." default:"${default_registry}" env:"REGISTRY"`
 	Sync           time.Duration `short:"s" help:"Controller manager sync period duration such as 300ms, 1.5h or 2h45m" default:"1h"`
 }

--- a/cmd/crossplane/core/core.go
+++ b/cmd/crossplane/core/core.go
@@ -19,6 +19,8 @@ package core
 import (
 	"time"
 
+	"github.com/alecthomas/kong"
+	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/pkg/errors"
 	"github.com/spf13/afero"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -37,6 +39,12 @@ type Command struct {
 	Init  initCommand  `cmd:"" help:"Make cluster ready for Crossplane controllers."`
 }
 
+// KongVars represent the kong variables associated with the CLI parser
+// required for the RBAC enum interpolation.
+var KongVars = kong.Vars{
+	"default_registry": name.DefaultRegistry,
+}
+
 // Run is the no-op method required for kong call tree
 // Kong requires each node in the calling path to have associated
 // Run method.
@@ -48,7 +56,7 @@ type startCommand struct {
 	Namespace      string        `short:"n" help:"Namespace used to unpack and run packages." default:"crossplane-system" env:"POD_NAMESPACE"`
 	CacheDir       string        `short:"c" help:"Directory used for caching package images." default:"/cache" env:"CACHE_DIR"`
 	LeaderElection bool          `short:"l" help:"Use leader election for the conroller manager." default:"false" env:"LEADER_ELECTION"`
-	Registry       string        `short:"r" help:"Default registry used to fetch packages when not specified in tag." env:"REGISTRY"`
+	Registry       string        `short:"r" help:"Default registry used to fetch packages when not specified in tag." default:"${default_registry}" env:"REGISTRY"`
 	Sync           time.Duration `short:"s" help:"Controller manager sync period duration such as 300ms, 1.5h or 2h45m" default:"1h"`
 }
 

--- a/cmd/crossplane/core/init.go
+++ b/cmd/crossplane/core/init.go
@@ -37,7 +37,6 @@ type initCommand struct {
 
 // Run starts the initialization process.
 func (c *initCommand) Run(s *runtime.Scheme, log logging.Logger) error {
-	log.WithValues("CmdName", "core init")
 	cfg, err := ctrl.GetConfig()
 	if err != nil {
 		return errors.Wrap(err, "Cannot get config")

--- a/cmd/crossplane/core/init.go
+++ b/cmd/crossplane/core/init.go
@@ -29,15 +29,15 @@ import (
 	"github.com/crossplane/crossplane/internal/initializer"
 )
 
-// InitCommand configuration for the initialization of core Crossplane controllers.
-type InitCommand struct {
-	Name           string
+// initCommand configuration for the initialization of core Crossplane controllers.
+type initCommand struct {
 	Providers      []string
 	Configurations []string
 }
 
 // Run starts the initialization process.
-func (c *InitCommand) Run(s *runtime.Scheme, log logging.Logger) error {
+func (c *initCommand) Run(s *runtime.Scheme, log logging.Logger) error {
+	log.WithValues("CmdName", "core init")
 	cfg, err := ctrl.GetConfig()
 	if err != nil {
 		return errors.Wrap(err, "Cannot get config")

--- a/cmd/crossplane/main.go
+++ b/cmd/crossplane/main.go
@@ -62,8 +62,6 @@ func (d debugFlag) BeforeApply(ctx *kong.Context) error { // nolint:unparam
 }
 
 func main() {
-	// NOTE(negz): We must setup our logger after calling kingpin.MustParse in
-	// order to ensure the debug flag has been parsed and set.
 	zl := zap.New().WithName("crossplane")
 
 	// Note that the controller managers scheme must be a superset of the

--- a/cmd/crossplane/main.go
+++ b/cmd/crossplane/main.go
@@ -77,6 +77,7 @@ func main() {
 		kong.BindTo(logging.NewLogrLogger(zl), (*logging.Logger)(nil)),
 		kong.UsageOnError(),
 		rbac.KongVars,
+		core.KongVars,
 	)
 	ctx.FatalIfErrorf(corev1.AddToScheme(s), "cannot add core v1 Kubernetes API types to scheme")
 	ctx.FatalIfErrorf(appsv1.AddToScheme(s), "cannot add apps v1 Kubernetes API types to scheme")

--- a/cmd/crossplane/main.go
+++ b/cmd/crossplane/main.go
@@ -17,10 +17,9 @@ limitations under the License.
 package main
 
 import (
-	"os"
-	"path/filepath"
+	"strings"
 
-	"gopkg.in/alecthomas/kingpin.v2"
+	"github.com/alecthomas/kong"
 	appsv1 "k8s.io/api/apps/v1"
 	coordinationv1 "k8s.io/api/coordination/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -37,48 +36,57 @@ import (
 	"github.com/crossplane/crossplane/cmd/crossplane/rbac"
 )
 
-func main() {
-	var (
-		app   = kingpin.New(filepath.Base(os.Args[0]), "An open source multicloud control plane.").DefaultEnvars()
-		debug = app.Flag("debug", "Run with debug logging.").Short('d').Bool()
-	)
-	c, ci := core.FromKingpin(app.Command("core", "Start core Crossplane controllers.").Default())
-	r, ri := rbac.FromKingpin(app.Command("rbac", "Start Crossplane RBAC Manager controllers."))
-	cmd := kingpin.MustParse(app.Parse(os.Args[1:]))
+type debugFlag bool
 
-	// NOTE(negz): We must setup our logger after calling kingpin.MustParse in
-	// order to ensure the debug flag has been parsed and set.
-	zl := zap.New(zap.UseDevMode(*debug))
-	if *debug {
-		// The controller-runtime runs with a no-op logger by default. It is
-		// *very* verbose even at info level, so we only provide it a real
-		// logger when we're running in debug mode.
-		ctrl.SetLogger(zl)
-	}
+var cli struct {
+	Debug debugFlag `short:"d" help:"Print verbose logging statements."`
+
+	Core core.Command `cmd:"" help:"Start core Crossplane controllers." default:"1"`
+	Rbac rbac.Command `cmd:"" help:"Start Crossplane RBAC Manager controllers."`
+}
+
+func (d debugFlag) BeforeApply(ctx *kong.Context) error { // nolint:unparam
+	zl := zap.New(zap.UseDevMode(true))
+	ctx.BindTo(logging.NewLogrLogger(zl), (*logging.Logger)(nil))
+	ctrl.SetLogger(zl)
+	return nil
+}
+
+func main() {
+	// // NOTE(negz): We must setup our logger after calling kingpin.MustParse in
+	// // order to ensure the debug flag has been parsed and set.
+	zl := zap.New(zap.UseDevMode(false))
+	ctrl.SetLogger(zl)
+
 	// Note that the controller managers scheme must be a superset of the
 	// package manager's object scheme; it must contain all object types that
 	// may appear in a Crossplane package. This is because the package manager
 	// uses the controller manager's client (and thus scheme) to create packaged
 	// objects.
 	s := runtime.NewScheme()
-	kingpin.FatalIfError(corev1.AddToScheme(s), "cannot add core v1 Kubernetes API types to scheme")
-	kingpin.FatalIfError(appsv1.AddToScheme(s), "cannot add apps v1 Kubernetes API types to scheme")
-	kingpin.FatalIfError(rbacv1.AddToScheme(s), "cannot add rbac v1 Kubernetes API types to scheme")
-	kingpin.FatalIfError(coordinationv1.AddToScheme(s), "cannot add coordination v1 Kubernetes API types to scheme")
-	kingpin.FatalIfError(extv1.AddToScheme(s), "cannot add apiextensions v1 Kubernetes API types to scheme")
-	kingpin.FatalIfError(extv1beta1.AddToScheme(s), "cannot add apiextensions v1beta1 Kubernetes API types to scheme")
-	kingpin.FatalIfError(apis.AddToScheme(s), "cannot add Crossplane API types to scheme")
 
-	switch cmd {
-	case c.Name:
-		kingpin.FatalIfError(c.Run(s, logging.NewLogrLogger(zl.WithName("core"))), "cannot run crossplane")
-	case ci.Name:
-		kingpin.FatalIfError(ci.Run(s, logging.NewLogrLogger(zl.WithName("core init"))), "cannot initialize crossplane")
-	case r.Name:
-		kingpin.FatalIfError(r.Run(s, logging.NewLogrLogger(zl.WithName("rbac"))), "cannot run RBAC manager")
-	case ri.Name:
-		kingpin.FatalIfError(ri.Run(s, logging.NewLogrLogger(zl.WithName("rbac init"))), "cannot initialize RBAC manager")
-	default:
-		kingpin.FatalUsage("unknown command %s", cmd)
-	}
+	ctx := kong.Parse(&cli,
+		kong.Name("crossplane"),
+		kong.Description("An open source multicloud control plane."),
+		kong.BindTo(logging.NewLogrLogger(zl), (*logging.Logger)(nil)),
+		kong.UsageOnError(),
+		kong.Vars{
+			"rbac_manage_default_var": rbac.ManagementPolicyAll,
+			"rbac_manage_enum_var": strings.Join(
+				[]string{
+					rbac.ManagementPolicyAll,
+					rbac.ManagementPolicyBasic,
+				},
+				", "),
+		},
+	)
+	ctx.FatalIfErrorf(corev1.AddToScheme(s), "cannot add core v1 Kubernetes API types to scheme")
+	ctx.FatalIfErrorf(appsv1.AddToScheme(s), "cannot add apps v1 Kubernetes API types to scheme")
+	ctx.FatalIfErrorf(rbacv1.AddToScheme(s), "cannot add rbac v1 Kubernetes API types to scheme")
+	ctx.FatalIfErrorf(coordinationv1.AddToScheme(s), "cannot add coordination v1 Kubernetes API types to scheme")
+	ctx.FatalIfErrorf(extv1.AddToScheme(s), "cannot add apiextensions v1 Kubernetes API types to scheme")
+	ctx.FatalIfErrorf(extv1beta1.AddToScheme(s), "cannot add apiextensions v1beta1 Kubernetes API types to scheme")
+	ctx.FatalIfErrorf(apis.AddToScheme(s), "cannot add Crossplane API types to scheme")
+	err := ctx.Run(s)
+	ctx.FatalIfErrorf(err)
 }

--- a/cmd/crossplane/rbac/init.go
+++ b/cmd/crossplane/rbac/init.go
@@ -38,7 +38,6 @@ type initCommand struct{}
 
 // Run starts the initialization process.
 func (c *initCommand) Run(s *runtime.Scheme, log logging.Logger) error {
-	log.WithValues("CmdName", "rbac init")
 	cfg, err := ctrl.GetConfig()
 	if err != nil {
 		return errors.Wrap(err, "Cannot get config")

--- a/cmd/crossplane/rbac/init.go
+++ b/cmd/crossplane/rbac/init.go
@@ -33,13 +33,12 @@ import (
 	"github.com/crossplane/crossplane/internal/initializer"
 )
 
-// InitCommand configuration for the initialization of RBAC controllers.
-type InitCommand struct {
-	Name string
-}
+// initCommand configuration for the initialization of RBAC controllers.
+type initCommand struct{}
 
 // Run starts the initialization process.
-func (c *InitCommand) Run(s *runtime.Scheme, log logging.Logger) error {
+func (c *initCommand) Run(s *runtime.Scheme, log logging.Logger) error {
+	log.WithValues("CmdName", "rbac init")
 	cfg, err := ctrl.GetConfig()
 	if err != nil {
 		return errors.Wrap(err, "Cannot get config")

--- a/cmd/crossplane/rbac/rbac.go
+++ b/cmd/crossplane/rbac/rbac.go
@@ -20,7 +20,6 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
-	"gopkg.in/alecthomas/kingpin.v2"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 
@@ -35,28 +34,27 @@ const (
 	ManagementPolicyBasic = string(rbac.ManagementPolicyBasic)
 )
 
-// Command configuration for the RBAC manager.
+// Command runs the crossplane RBAC controllers
 type Command struct {
-	Name                string
-	Sync                time.Duration
-	LeaderElection      bool
-	ManagementPolicy    string
-	ProviderClusterRole string
+	Start startCommand `cmd:"" help:"Start Crossplane RBAC controllers."`
+	Init  initCommand  `cmd:"" help:"Initialize RBAC Manager."`
 }
 
-// FromKingpin produces the RBAC manager command from a Kingpin command.
-func FromKingpin(cmd *kingpin.CmdClause) (*Command, *InitCommand) {
-	startCmd := cmd.Command("start", "Start Crossplane RBAC controllers.")
-	c := &Command{Name: startCmd.FullCommand()}
-	cmd.Flag("sync", "Controller manager sync period duration such as 300ms, 1.5h or 2h45m").Short('s').Default("1h").DurationVar(&c.Sync)
-	cmd.Flag("manage", "RBAC management policy.").Short('m').Default(ManagementPolicyAll).EnumVar(&c.ManagementPolicy, ManagementPolicyAll, ManagementPolicyBasic)
-	cmd.Flag("provider-clusterrole", "A ClusterRole enumerating the permissions provider packages may request.").StringVar(&c.ProviderClusterRole)
-	cmd.Flag("leader-election", "Use leader election for the conroller manager.").Short('l').Default("false").OverrideDefaultFromEnvar("LEADER_ELECTION").BoolVar(&c.LeaderElection)
-	return c, &InitCommand{Name: cmd.Command("init", "Initialize RBAC Manager.").FullCommand()}
+// Run runs the Rbac command
+func (c *Command) Run() error {
+	return nil
+}
+
+type startCommand struct {
+	ProviderClusterRole string        `name:"provider-clusterrole" help:"A ClusterRole enumerating the permissions provider packages may request."`
+	LeaderElection      bool          `name:"leader-election" short:"l" help:"Use leader election for the conroller manager." env:"LEADER_ELECTION"`
+	Sync                time.Duration `short:"s" help:"Controller manager sync period duration such as 300ms, 1.5h or 2h45m" default:"1h"`
+	ManagementPolicy    string        `name:"manage" short:"m" help:"RBAC management policy." default:"${rbac_manage_default_var}" enum:"${rbac_manage_enum_var}"`
 }
 
 // Run the RBAC manager.
-func (c *Command) Run(s *runtime.Scheme, log logging.Logger) error {
+func (c *startCommand) Run(s *runtime.Scheme, log logging.Logger) error {
+	log.WithValues("CmdName", "rbac start")
 	cfg, err := ctrl.GetConfig()
 	if err != nil {
 		return errors.Wrap(err, "cannot get config")

--- a/cmd/crossplane/rbac/rbac.go
+++ b/cmd/crossplane/rbac/rbac.go
@@ -17,8 +17,10 @@ limitations under the License.
 package rbac
 
 import (
+	"strings"
 	"time"
 
+	"github.com/alecthomas/kong"
 	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -34,13 +36,27 @@ const (
 	ManagementPolicyBasic = string(rbac.ManagementPolicyBasic)
 )
 
+// KongVars represent the kong variables associated with the CLI parser
+// required for the RBAC enum interpolation.
+var KongVars = kong.Vars{
+	"rbac_manage_default_var": ManagementPolicyAll,
+	"rbac_manage_enum_var": strings.Join(
+		[]string{
+			ManagementPolicyAll,
+			ManagementPolicyBasic,
+		},
+		", "),
+}
+
 // Command runs the crossplane RBAC controllers
 type Command struct {
 	Start startCommand `cmd:"" help:"Start Crossplane RBAC controllers."`
 	Init  initCommand  `cmd:"" help:"Initialize RBAC Manager."`
 }
 
-// Run runs the Rbac command
+// Run is the no-op method required for kong call tree.
+// Kong requires each node in the calling path to have associated
+// Run method.
 func (c *Command) Run() error {
 	return nil
 }
@@ -54,7 +70,6 @@ type startCommand struct {
 
 // Run the RBAC manager.
 func (c *startCommand) Run(s *runtime.Scheme, log logging.Logger) error {
-	log.WithValues("CmdName", "rbac start")
 	cfg, err := ctrl.GetConfig()
 	if err != nil {
 		return errors.Wrap(err, "cannot get config")

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,6 @@ require (
 	github.com/Azure/go-autorest/autorest/validation v0.2.0 // indirect
 	github.com/Masterminds/semver v1.5.0
 	github.com/alecthomas/kong v0.2.11
-	github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d // indirect
 	github.com/aws/aws-sdk-go v1.31.6 // indirect
 	github.com/crossplane/crossplane-runtime v0.14.0
 	github.com/docker/cli v0.0.0-20200915230204-cd8016b6bcc5 // indirect
@@ -17,7 +16,6 @@ require (
 	github.com/imdario/mergo v0.3.11
 	github.com/pkg/errors v0.9.1
 	github.com/spf13/afero v1.4.1
-	gopkg.in/alecthomas/kingpin.v2 v2.2.6
 	k8s.io/api v0.20.1
 	k8s.io/apiextensions-apiserver v0.20.1
 	k8s.io/apimachinery v0.20.1

--- a/go.sum
+++ b/go.sum
@@ -81,12 +81,9 @@ github.com/agnivade/levenshtein v1.0.1/go.mod h1:CURSv5d9Uaml+FovSIICkLbAUZ9S4Rq
 github.com/alecthomas/kong v0.2.11 h1:RKeJXXWfg9N47RYfMm0+igkxBCTF4bzbneAxaqid0c4=
 github.com/alecthomas/kong v0.2.11/go.mod h1:kQOmtJgV+Lb4aj+I2LEn40cbtawdWJ9Y8QLq+lElKxE=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
-github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751 h1:JYp7IbQjafoB+tBA3gMyHYHrpOtNuDiK/uB5uXxq5wM=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
-github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d h1:UQZhZ2O0vMHr2cI+DC1Mbh0TJxzA3RcLoMsFw+aXw7E=
-github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo29Kk6CurOXKm700vrz8f0KW0JNfpkRJY/8=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
@@ -915,7 +912,6 @@ google.golang.org/protobuf v1.23.1-0.20200526195155-81db48ad09cc/go.mod h1:EGpAD
 google.golang.org/protobuf v1.24.0/go.mod h1:r/3tXBNzIEhYS9I1OUVjXDlt8tc493IdKGjtUeSXeh4=
 google.golang.org/protobuf v1.25.0 h1:Ejskq+SyPohKW+1uil0JJMtmHCgJPJ/qWTxr8qp+R4c=
 google.golang.org/protobuf v1.25.0/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlbajtzgsN7c=
-gopkg.in/alecthomas/kingpin.v2 v2.2.6 h1:jMFz6MfLP0/4fUyZle81rXUoxOBFi19VUFKVDOQfozc=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=


### PR DESCRIPTION
### Description of your changes

This PR replaces the kingpin CLI framework with its successor Kong. 

Logically there is no change in the CLI structure. One thing to note though, I have replaced the `zl.WithName(<NAME>)` to `log.WithValues("CmdName", "<NAME>")`. This allowed binding the single common logger to Kong and use that for each command. 

Fixes #1953 

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested
Tested manually. 