### PR TITLE
Delete one pager host aware stack manager

### DIFF
--- a/design/deprecated/one-pager-host-aware-stack-manager.md
+++ b/design/deprecated/one-pager-host-aware-stack-manager.md
@@ -2,7 +2,7 @@
 
 * Owner: Hasan Turken (@turkenh)
 * Reviewers: Crossplane Maintainers
-* Status: Draft
+* Status: Deprecated
 
 ## Terminology
 


### PR DESCRIPTION
### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
This PR deletes the one-pager doc for host aware stack manager which is a feature that was removed from Crossplane a long time ago. 

I have:

- [x] Read and followed Crossplane's [contribution process].
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9

N/A
