### PR TITLE
Allow setting default package registry

### DIFF
--- a/internal/controller/pkg/manager/reconciler.go
+++ b/internal/controller/pkg/manager/reconciler.go
@@ -138,7 +138,7 @@ type Reconciler struct {
 }
 
 // SetupProvider adds a controller that reconciles Providers.
-func SetupProvider(mgr ctrl.Manager, l logging.Logger, namespace string, registry string) error {
+func SetupProvider(mgr ctrl.Manager, l logging.Logger, namespace, registry string) error {
 	name := "packages/" + strings.ToLower(v1.ProviderGroupKind)
 	np := func() v1.Package { return &v1.Provider{} }
 	nr := func() v1.PackageRevision { return &v1.ProviderRevision{} }
@@ -166,7 +166,7 @@ func SetupProvider(mgr ctrl.Manager, l logging.Logger, namespace string, registr
 }
 
 // SetupConfiguration adds a controller that reconciles Configurations.
-func SetupConfiguration(mgr ctrl.Manager, l logging.Logger, namespace string, registry string) error {
+func SetupConfiguration(mgr ctrl.Manager, l logging.Logger, namespace, registry string) error {
 	name := "packages/" + strings.ToLower(v1.ConfigurationGroupKind)
 	np := func() v1.Package { return &v1.Configuration{} }
 	nr := func() v1.PackageRevision { return &v1.ConfigurationRevision{} }

--- a/internal/controller/pkg/manager/reconciler.go
+++ b/internal/controller/pkg/manager/reconciler.go
@@ -138,7 +138,7 @@ type Reconciler struct {
 }
 
 // SetupProvider adds a controller that reconciles Providers.
-func SetupProvider(mgr ctrl.Manager, l logging.Logger, namespace string) error {
+func SetupProvider(mgr ctrl.Manager, l logging.Logger, namespace string, registry string) error {
 	name := "packages/" + strings.ToLower(v1.ProviderGroupKind)
 	np := func() v1.Package { return &v1.Provider{} }
 	nr := func() v1.PackageRevision { return &v1.ProviderRevision{} }
@@ -153,7 +153,7 @@ func SetupProvider(mgr ctrl.Manager, l logging.Logger, namespace string) error {
 		WithNewPackageFn(np),
 		WithNewPackageRevisionFn(nr),
 		WithNewPackageRevisionListFn(nrl),
-		WithRevisioner(NewPackageRevisioner(xpkg.NewK8sFetcher(clientset, namespace))),
+		WithRevisioner(NewPackageRevisioner(xpkg.NewK8sFetcher(clientset, namespace), WithDefaultRegistry(registry))),
 		WithLogger(l.WithValues("controller", name)),
 		WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name))),
 	)
@@ -166,7 +166,7 @@ func SetupProvider(mgr ctrl.Manager, l logging.Logger, namespace string) error {
 }
 
 // SetupConfiguration adds a controller that reconciles Configurations.
-func SetupConfiguration(mgr ctrl.Manager, l logging.Logger, namespace string) error {
+func SetupConfiguration(mgr ctrl.Manager, l logging.Logger, namespace string, registry string) error {
 	name := "packages/" + strings.ToLower(v1.ConfigurationGroupKind)
 	np := func() v1.Package { return &v1.Configuration{} }
 	nr := func() v1.PackageRevision { return &v1.ConfigurationRevision{} }
@@ -181,7 +181,7 @@ func SetupConfiguration(mgr ctrl.Manager, l logging.Logger, namespace string) er
 		WithNewPackageFn(np),
 		WithNewPackageRevisionFn(nr),
 		WithNewPackageRevisionListFn(nrl),
-		WithRevisioner(NewPackageRevisioner(xpkg.NewK8sFetcher(clientset, namespace))),
+		WithRevisioner(NewPackageRevisioner(xpkg.NewK8sFetcher(clientset, namespace), WithDefaultRegistry(registry))),
 		WithLogger(l.WithValues("controller", name)),
 		WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name))),
 	)

--- a/internal/controller/pkg/pkg.go
+++ b/internal/controller/pkg/pkg.go
@@ -27,21 +27,23 @@ import (
 )
 
 // Setup package controllers.
-func Setup(mgr ctrl.Manager, l logging.Logger, c xpkg.Cache, namespace string) error {
-	for _, setup := range []func(ctrl.Manager, logging.Logger, string) error{
+func Setup(mgr ctrl.Manager, l logging.Logger, c xpkg.Cache, namespace string, registry string) error {
+	for _, setup := range []func(ctrl.Manager, logging.Logger, string, string) error{
 		manager.SetupConfiguration,
 		manager.SetupProvider,
-		resolver.Setup,
 	} {
-		if err := setup(mgr, l, namespace); err != nil {
+		if err := setup(mgr, l, namespace, registry); err != nil {
 			return err
 		}
 	}
-	for _, setup := range []func(ctrl.Manager, logging.Logger, xpkg.Cache, string) error{
+	if err := resolver.Setup(mgr, l, namespace); err != nil {
+		return err
+	}
+	for _, setup := range []func(ctrl.Manager, logging.Logger, xpkg.Cache, string, string) error{
 		revision.SetupConfigurationRevision,
 		revision.SetupProviderRevision,
 	} {
-		if err := setup(mgr, l, c, namespace); err != nil {
+		if err := setup(mgr, l, c, namespace, registry); err != nil {
 			return err
 		}
 	}

--- a/internal/controller/pkg/pkg.go
+++ b/internal/controller/pkg/pkg.go
@@ -27,7 +27,7 @@ import (
 )
 
 // Setup package controllers.
-func Setup(mgr ctrl.Manager, l logging.Logger, c xpkg.Cache, namespace string, registry string) error {
+func Setup(mgr ctrl.Manager, l logging.Logger, c xpkg.Cache, namespace, registry string) error {
 	for _, setup := range []func(ctrl.Manager, logging.Logger, string, string) error{
 		manager.SetupConfiguration,
 		manager.SetupProvider,

--- a/internal/controller/pkg/revision/reconciler.go
+++ b/internal/controller/pkg/revision/reconciler.go
@@ -197,7 +197,7 @@ type Reconciler struct {
 }
 
 // SetupProviderRevision adds a controller that reconciles ProviderRevisions.
-func SetupProviderRevision(mgr ctrl.Manager, l logging.Logger, cache xpkg.Cache, namespace string, registry string) error {
+func SetupProviderRevision(mgr ctrl.Manager, l logging.Logger, cache xpkg.Cache, namespace, registry string) error {
 	name := "packages/" + strings.ToLower(v1.ProviderRevisionGroupKind)
 	nr := func() v1.PackageRevision { return &v1.ProviderRevision{} }
 
@@ -237,7 +237,7 @@ func SetupProviderRevision(mgr ctrl.Manager, l logging.Logger, cache xpkg.Cache,
 }
 
 // SetupConfigurationRevision adds a controller that reconciles ConfigurationRevisions.
-func SetupConfigurationRevision(mgr ctrl.Manager, l logging.Logger, cache xpkg.Cache, namespace string, registry string) error {
+func SetupConfigurationRevision(mgr ctrl.Manager, l logging.Logger, cache xpkg.Cache, namespace, registry string) error {
 	name := "packages/" + strings.ToLower(v1.ConfigurationRevisionGroupKind)
 	nr := func() v1.PackageRevision { return &v1.ConfigurationRevision{} }
 

--- a/internal/controller/pkg/revision/reconciler.go
+++ b/internal/controller/pkg/revision/reconciler.go
@@ -197,7 +197,7 @@ type Reconciler struct {
 }
 
 // SetupProviderRevision adds a controller that reconciles ProviderRevisions.
-func SetupProviderRevision(mgr ctrl.Manager, l logging.Logger, cache xpkg.Cache, namespace string) error {
+func SetupProviderRevision(mgr ctrl.Manager, l logging.Logger, cache xpkg.Cache, namespace string, registry string) error {
 	name := "packages/" + strings.ToLower(v1.ProviderRevisionGroupKind)
 	nr := func() v1.PackageRevision { return &v1.ProviderRevision{} }
 
@@ -224,7 +224,7 @@ func SetupProviderRevision(mgr ctrl.Manager, l logging.Logger, cache xpkg.Cache,
 		}, namespace)),
 		WithNewPackageRevisionFn(nr),
 		WithParser(parser.New(metaScheme, objScheme)),
-		WithParserBackend(NewImageBackend(cache, xpkg.NewK8sFetcher(clientset, namespace))),
+		WithParserBackend(NewImageBackend(cache, xpkg.NewK8sFetcher(clientset, namespace), WithDefaultRegistry(registry))),
 		WithLinter(xpkg.NewProviderLinter()),
 		WithLogger(l.WithValues("controller", name)),
 		WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name))),
@@ -237,7 +237,7 @@ func SetupProviderRevision(mgr ctrl.Manager, l logging.Logger, cache xpkg.Cache,
 }
 
 // SetupConfigurationRevision adds a controller that reconciles ConfigurationRevisions.
-func SetupConfigurationRevision(mgr ctrl.Manager, l logging.Logger, cache xpkg.Cache, namespace string) error {
+func SetupConfigurationRevision(mgr ctrl.Manager, l logging.Logger, cache xpkg.Cache, namespace string, registry string) error {
 	name := "packages/" + strings.ToLower(v1.ConfigurationRevisionGroupKind)
 	nr := func() v1.PackageRevision { return &v1.ConfigurationRevision{} }
 
@@ -261,7 +261,7 @@ func SetupConfigurationRevision(mgr ctrl.Manager, l logging.Logger, cache xpkg.C
 		WithHooks(NewConfigurationHooks()),
 		WithNewPackageRevisionFn(nr),
 		WithParser(parser.New(metaScheme, objScheme)),
-		WithParserBackend(NewImageBackend(cache, xpkg.NewK8sFetcher(clientset, namespace))),
+		WithParserBackend(NewImageBackend(cache, xpkg.NewK8sFetcher(clientset, namespace), WithDefaultRegistry(registry))),
 		WithLinter(xpkg.NewConfigurationLinter()),
 		WithLogger(l.WithValues("controller", name)),
 		WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name))),

--- a/internal/xpkg/name.go
+++ b/internal/xpkg/name.go
@@ -21,6 +21,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/spf13/afero"
 	"sigs.k8s.io/yaml"
 )
@@ -41,6 +42,12 @@ const (
 
 	// XpkgMatchPattern is the match pattern for identifying compiled Crossplane packages.
 	XpkgMatchPattern string = "*" + XpkgExtension
+)
+
+const (
+	// identifierDelimeters is the set of valid OCI image identifier delimeter
+	// characters.
+	identifierDelimeters string = ":@"
 )
 
 func truncate(str string, num int) string {
@@ -94,6 +101,17 @@ func ParseNameFromMeta(fs afero.Fs, path string) (string, error) {
 		return "", err
 	}
 	return pkgName, nil
+}
+
+// ParsePackageSourceFromReference parses a package source from an OCI image
+// reference. A source is defined as an OCI image reference with the identifier
+// (tag or digest) stripped and no other changes to the original reference
+// source. This is necessary because go-containerregistry will convert docker.io
+// to index.docker.io for backwards compatibility before pulling an image. We do
+// not want to do that in cases where we are not pulling an image because it
+// breaks comparison with dependencies defined in a Configuration manifest.
+func ParsePackageSourceFromReference(ref name.Reference) string {
+	return strings.TrimRight(strings.TrimSuffix(ref.String(), ref.Identifier()), identifierDelimeters)
 }
 
 type metaPkg struct {


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Adds the ability to set default package registry for pulling packages when the tag does not specify. Importantly, registry defaulting is not performed when adding packages to the lock, so dependencies declared by `Configuration` packages are preserved and able to be matched. There is currently an issue when the default registry is set and users specify a `docker.io/*` package source because it is overwritten to `index.docker.io` per https://github.com/google/go-containerregistry/issues/68. This causes the dependent package to fail to resolve whether its dependencies exist. PR will remain in draft until addressed.

Fixes #1965 

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

1. Installed CRDs
```
kubectl apply -f cluster/crds/
```
2. Created `crossplane-system` namespace:
```
kubectl create ns crossplane-system
```
3. Ran core Crossplane with the following flags:
```
go run ./cmd/crossplane core start -d --namespace crossplane-system -r "registry.upbound.io" -c "./cache"
```
4. Modified the `getting-started-with-aws` package `crossplane.yaml`:
```yaml
apiVersion: meta.pkg.crossplane.io/v1alpha1
kind: Configuration
metadata:
  name: getting-started-with-aws
  annotations:
    guide: quickstart
    provider: aws
    vpc: default
spec:
  crossplane:
    version: ">=v1.0.0-0"
  dependsOn:
    - provider: docker.io/crossplane/provider-aws
      version: ">=v0.14.0"
```
> Notice that `docker.io` is explicitly specified for the `provider-aws` dependency. We would attempt to pull from `registry.upbound.io` if not specified.
5. Build and push new package to https://cloud.upbound.io/registry/hasheddan/dan-aws/v0.1.0:
```
up xpkg build
up xpkg push hasheddan/dan-aws:v0.1.0
```
6. Install `Configuration`:
```
kxp install configuration hasheddan/dan-aws:v0.1.0
```
> Notice that no registry is specified.
7. Observed successful installation of `Configuration` package and `provider-aws` dependency:
```
🤖 (xp) k get pkg
NAME                                                 INSTALLED   HEALTHY   PACKAGE                                     AGE
provider.pkg.crossplane.io/crossplane-provider-aws   True        True      docker.io/crossplane/provider-aws:v0.19.0   47s

NAME                                                INSTALLED   HEALTHY   PACKAGE                    AGE
configuration.pkg.crossplane.io/hasheddan-dan-aws   True        True      hasheddan/dan-aws:v0.1.0   50s
```
8. Observed expected content in `Lock`:
```yaml
🤖 (xp) k get lock lock -o yaml
apiVersion: pkg.crossplane.io/v1alpha1
kind: Lock
metadata:
  creationTimestamp: "2021-06-29T16:02:55Z"
  finalizers:
  - lock.pkg.crossplane.io
  generation: 3
  name: lock
  resourceVersion: "700"
  uid: 92a1135f-48c9-4ea0-910a-15b1e896736f
packages:
- dependencies:
  - constraints: '>=v0.14.0'
    package: docker.io/crossplane/provider-aws
    type: Provider
  name: hasheddan-dan-aws-0fbb9b6bac8e
  source: hasheddan/dan-aws
  type: Configuration
  version: v0.1.0
- dependencies: []
  name: crossplane-provider-aws-dd1e35810a48
  source: docker.io/crossplane/provider-aws
  type: Provider
  version: v0.19.0
```

[contribution process]: https://git.io/fj2m9
