### PR TITLE
Update events link

### DIFF
--- a/docs/contributing/observability_developer_guide.md
+++ b/docs/contributing/observability_developer_guide.md
@@ -185,7 +185,7 @@ implementations.
 
 <!-- Named Links -->
 
-[Events]: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.16/#event-v1-core
+[Events]: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#event-v1-core
 [debugging an application cluster]: https://kubernetes.io/docs/tasks/debug-application-cluster/
 [Dave Cheney article]: https://dave.cheney.net/2015/11/05/lets-talk-about-logging
 [`event`]: https://godoc.org/github.com/crossplane/crossplane-runtime/pkg/event


### PR DESCRIPTION

### Description of your changes

The link to the events documentation is out-dated. Updating to the current link.

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

Verified new link was successful
