### PR TITLE
Preserve rendered annotations & labels on composed resources

### DIFF
--- a/internal/controller/apiextensions/composite/composed.go
+++ b/internal/controller/apiextensions/composite/composed.go
@@ -336,6 +336,13 @@ func (r *APIDryRunRenderer) Render(ctx context.Context, cp resource.Composite, c
 		return errors.New(errNamePrefix)
 	}
 
+	// Unmarshalling the template will overwrite any existing fields, so we must
+	// restore the existing name, if any. We also set generate name in case we
+	// haven't yet named this composed resource.
+	cd.SetGenerateName(cp.GetLabels()[xcrd.LabelKeyNamePrefixForComposed] + "-")
+	cd.SetName(name)
+	cd.SetNamespace(namespace)
+
 	onlyPatches := []v1.PatchType{v1.PatchTypeFromCompositeFieldPath, v1.PatchTypeCombineFromComposite}
 	for i, p := range t.Patches {
 		if err := p.Apply(cp, cd, onlyPatches...); err != nil {
@@ -353,13 +360,6 @@ func (r *APIDryRunRenderer) Render(ctx context.Context, cp resource.Composite, c
 	if t.Name != nil {
 		SetCompositionResourceName(cd, *t.Name)
 	}
-
-	// Unmarshalling the template will overwrite any existing fields, so we must
-	// restore the existing name, if any. We also set generate name in case we
-	// haven't yet named this composed resource.
-	cd.SetGenerateName(cp.GetLabels()[xcrd.LabelKeyNamePrefixForComposed] + "-")
-	cd.SetName(name)
-	cd.SetNamespace(namespace)
 
 	// We do this last to ensure that a Composition cannot influence owner (and
 	// especially controller) references.

--- a/internal/controller/apiextensions/composite/composed.go
+++ b/internal/controller/apiextensions/composite/composed.go
@@ -350,7 +350,7 @@ func (r *APIDryRunRenderer) Render(ctx context.Context, cp resource.Composite, c
 		}
 	}
 
-	// Fix(2416): composed labels and annotations should be rendered after patches are applied
+	// Composed labels and annotations should be rendered after patches are applied
 	meta.AddLabels(cd, map[string]string{
 		xcrd.LabelKeyNamePrefixForComposed: cp.GetLabels()[xcrd.LabelKeyNamePrefixForComposed],
 		xcrd.LabelKeyClaimName:             cp.GetLabels()[xcrd.LabelKeyClaimName],


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":
-->
As detailed in #2416, we would like to keep any rendered annotations or labels on composed resources when patches on `metada.annotations` or `metadata.labels` are applied. Notably, if there is a patch (from composition to composed) is defined on `metadata.annotations` in the composition:
```
...
  patchSets:
  - name: metadata
    patches:
    - fromFieldPath: metadata.annotations
      type: FromCompositeFieldPath
```

and the composite has non-zero `metadata.annotations`, we lose the rendered `crossplane.io/composition-resource-name: rdsinstance` annotation on the composed.

Fixes #2416 

I have:

- [X] Read and followed Crossplane's [contribution process].
- [X] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
With a composition specifying a patch on `metadata.annotations` (exemplified above) selected, a dynamically provisioned XR with the following annotations:
```
...
metadata:
  annotations:
    a: b
  labels:
    crossplane.io/claim-name: my-db
    crossplane.io/claim-namespace: default
    crossplane.io/composite: my-db-p7vk9
...
```  
now renders the following composed resource:
```
...
metadata:
  annotations:
    a: b
    crossplane.io/composition-resource-name: rdsinstance
  labels:
    crossplane.io/claim-name: my-db
    crossplane.io/claim-namespace: default
    crossplane.io/composite: my-db-p7vk9
...
```

Without the proposed changes, it renders a composed like the following:
```
...
metadata:
  annotations:
    a: b
  labels:
    crossplane.io/claim-name: my-db
    crossplane.io/claim-namespace: default
    crossplane.io/composite: my-db-p7vk9
...
```

[contribution process]: https://git.io/fj2m9
