### PR TITLE
Use go-containerregistry default registry if none provided

### DIFF
--- a/cmd/crossplane/core/core.go
+++ b/cmd/crossplane/core/core.go
@@ -19,6 +19,7 @@ package core
 import (
 	"time"
 
+	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/pkg/errors"
 	"github.com/spf13/afero"
 	"gopkg.in/alecthomas/kingpin.v2"
@@ -47,7 +48,7 @@ func FromKingpin(cmd *kingpin.CmdClause) (*Command, *InitCommand) {
 	startCmd := cmd.Command("start", "Start Crossplane controllers.")
 	c := &Command{Name: startCmd.FullCommand()}
 	cmd.Flag("namespace", "Namespace used to unpack and run packages.").Short('n').Default("crossplane-system").OverrideDefaultFromEnvar("POD_NAMESPACE").StringVar(&c.Namespace)
-	cmd.Flag("registry", "Default registry used to fetch packages when not specified in tag.").Short('r').Envar("REGISTRY").StringVar(&c.Registry)
+	cmd.Flag("registry", "Default registry used to fetch packages when not specified in tag.").Short('r').Default(name.DefaultRegistry).Envar("REGISTRY").StringVar(&c.Registry)
 	cmd.Flag("cache-dir", "Directory used for caching package images.").Short('c').Default("/cache").OverrideDefaultFromEnvar("CACHE_DIR").StringVar(&c.CacheDir)
 	cmd.Flag("sync", "Controller manager sync period duration such as 300ms, 1.5h or 2h45m").Short('s').Default("1h").DurationVar(&c.Sync)
 	cmd.Flag("leader-election", "Use leader election for the conroller manager.").Short('l').Default("false").OverrideDefaultFromEnvar("LEADER_ELECTION").BoolVar(&c.LeaderElection)


### PR DESCRIPTION


<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Makes the default registry match the upstream go-containerregistry
default if none is supplied. This same behavior could be accomplished by
not passing the WithDefaultRegistry option to places where we parse
image references, but it is a bit cleaner to always pass the option and
just populate it with the upstream default if not overridden with a flag
or environment variable. It also makes it more discoverable at the core
crossplane command level.

This change makes the default behavior match that from before the
default registry was configurable.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

Follow-up to #2404 

(This does not require backport as #2404 is not present on any release branch.)

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

This bug was identified in our periodic e2e tests! https://github.com/crossplane/test/runs/3008764426?check_suite_focus=true

These same tests have been executed against the build from this PR successfully. The issue was due to the fact that the registry was being set to empty if none provided, so installing without an explicit registry (as [we do with `provider-nop`](https://github.com/crossplane/crossplane/blob/231ba7de48970da2657e9a971e5e1b1d607c87b5/test/e2e/apiextensions/composition_test.go#L82) in our e2e tests) resulted in an inability to pull the image.

<details>
  <summary>Expand for e2e test output</summary>
 

```
🤖 (crossplane) go test -p 1 -timeout 10m -v --tags=e2e ./test/e2e/...
=== RUN   TestCompositeResourceGetsReady
=== RUN   TestCompositeResourceGetsReady/TestCompositeResourceGetsReady
=== CONT  TestCompositeResourceGetsReady
    composition_test.go:92: Created provider "provider-nop"
    composition_test.go:155: Created XRD "clusternopresources.nop.example.org"
    composition_test.go:168: Waiting for the XRD's Established and Offered status conditions to become 'True'.
    composition_test.go:175: XRD "clusternopresources.nop.example.org" is not yet Established
    composition_test.go:184: XRD "clusternopresources.nop.example.org" is Established and Offered
    composition_test.go:285: Created composition "clusternopresources.sample.nop.example.org"
    composition_test.go:318: Created nop-example "nop-example"
    composition_test.go:330: nop-example "nop-example" is not yet Ready
    composition_test.go:330: nop-example "nop-example" is not yet Ready
    composition_test.go:330: nop-example "nop-example" is not yet Ready
    composition_test.go:330: nop-example "nop-example" is not yet Ready
    composition_test.go:340: Cleaning up nop-example "nop-example".
    composition_test.go:348: Deleted nop-example "nop-example"
    composition_test.go:288: Cleaning up composition "clusternopresources.sample.nop.example.org".
    composition_test.go:295: Deleted composition "clusternopresources.sample.nop.example.org"
    composition_test.go:158: Cleaning up XRD "clusternopresources.nop.example.org".
    composition_test.go:165: Deleted XRD "clusternopresources.nop.example.org"
    composition_test.go:95: Cleaning up provider "provider-nop".
    composition_test.go:102: Deleted provider "provider-nop"
--- PASS: TestCompositeResourceGetsReady (50.70s)
    --- PASS: TestCompositeResourceGetsReady/TestCompositeResourceGetsReady (50.65s)
=== RUN   TestNopResourcesGetReady
=== RUN   TestNopResourcesGetReady/TestNopResourcesGetReady
=== CONT  TestNopResourcesGetReady
    composition_test.go:410: Created provider "provider-nop"
    composition_test.go:466: Create XRD "clusternopresources.nop.example.org": object is being deleted: compositeresourcedefinitions.apiextensions.crossplane.io "clusternopresources.nop.example.org" already exists
    composition_test.go:473: Created XRD "clusternopresources.nop.example.org"
    composition_test.go:486: Waiting for the XRD's Established and Offered status conditions to become 'True'.
    composition_test.go:493: XRD "clusternopresources.nop.example.org" is not yet Established
    composition_test.go:502: XRD "clusternopresources.nop.example.org" is Established and Offered
    composition_test.go:603: Created composition "clusternopresources.sample.nop.example.org"
    composition_test.go:638: Created nop-example "nop-example"
    composition_test.go:677: Cleaning up nop-example "nop-example".
    composition_test.go:685: Deleted nop-example "nop-example"
    composition_test.go:606: Cleaning up composition "clusternopresources.sample.nop.example.org".
    composition_test.go:613: Deleted composition "clusternopresources.sample.nop.example.org"
    composition_test.go:476: Cleaning up XRD "clusternopresources.nop.example.org".
    composition_test.go:483: Deleted XRD "clusternopresources.nop.example.org"
    composition_test.go:413: Cleaning up provider "provider-nop".
    composition_test.go:420: Deleted provider "provider-nop"
--- PASS: TestNopResourcesGetReady (42.86s)
    --- PASS: TestNopResourcesGetReady/TestNopResourcesGetReady (42.80s)
PASS
ok  	github.com/crossplane/crossplane/test/e2e/apiextensions	93.584s
=== RUN   TestDependencies
=== RUN   TestDependencies/ResolveDependencies
=== RUN   TestDependencies/DoNotResolveDependencies
--- PASS: TestDependencies (50.07s)
    --- PASS: TestDependencies/ResolveDependencies (20.03s)
    --- PASS: TestDependencies/DoNotResolveDependencies (30.04s)
PASS
ok  	github.com/crossplane/crossplane/test/e2e/pkg	50.092s
```

</details>


[contribution process]: https://git.io/fj2m9
