### PR TITLE
Fail don't panic on failure to list NopResources

### DIFF
--- a/test/e2e/apiextensions/composition_test.go
+++ b/test/e2e/apiextensions/composition_test.go
@@ -640,7 +640,10 @@ func TestNopResourcesGetReady(t *testing.T) {
 				if err := wait.PollImmediate(2*time.Second, 90*time.Second, func() (done bool, err error) {
 
 					// Get 2 nopresources created by the provider
-					list, _ := dc.Resource(obj).List(context.TODO(), metav1.ListOptions{})
+					list, err := dc.Resource(obj).List(context.TODO(), metav1.ListOptions{})
+					if err != nil {
+						t.Fatalf("List NopResources: %v", err)
+					}
 
 					if len(list.Items) == 0 {
 						return false, nil


### PR DESCRIPTION


<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fails on error to list NopResource with descriptive error rather than
panic on deferencing a nil pointer.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

Ran e2e tests (with this change but not #2425) and identified error rather than the panic we see in https://github.com/crossplane/test/runs/3008764426?check_suite_focus=true#step:8:132

[contribution process]: https://git.io/fj2m9
