### PR TITLE
[Backport release-1.2] Preserve rendered annotations & labels on composed resources

### DIFF
--- a/internal/controller/apiextensions/composite/composed.go
+++ b/internal/controller/apiextensions/composite/composed.go
@@ -346,7 +346,7 @@ func (r *APIDryRunRenderer) Render(ctx context.Context, cp resource.Composite, c
 		}
 	}
 
-	// Fix(2416): composed labels and annotations should be rendered after patches are applied
+	// Composed labels and annotations should be rendered after patches are applied
 	meta.AddLabels(cd, map[string]string{
 		xcrd.LabelKeyNamePrefixForComposed: cp.GetLabels()[xcrd.LabelKeyNamePrefixForComposed],
 		xcrd.LabelKeyClaimName:             cp.GetLabels()[xcrd.LabelKeyClaimName],

--- a/internal/controller/apiextensions/composite/composed.go
+++ b/internal/controller/apiextensions/composite/composed.go
@@ -332,6 +332,13 @@ func (r *APIDryRunRenderer) Render(ctx context.Context, cp resource.Composite, c
 		return errors.New(errNamePrefix)
 	}
 
+	// Unmarshalling the template will overwrite any existing fields, so we must
+	// restore the existing name, if any. We also set generate name in case we
+	// haven't yet named this composed resource.
+	cd.SetGenerateName(cp.GetLabels()[xcrd.LabelKeyNamePrefixForComposed] + "-")
+	cd.SetName(name)
+	cd.SetNamespace(namespace)
+
 	onlyPatches := []v1.PatchType{v1.PatchTypeFromCompositeFieldPath}
 	for i, p := range t.Patches {
 		if err := p.Apply(cp, cd, onlyPatches...); err != nil {
@@ -349,13 +356,6 @@ func (r *APIDryRunRenderer) Render(ctx context.Context, cp resource.Composite, c
 	if t.Name != nil {
 		SetCompositionResourceName(cd, *t.Name)
 	}
-
-	// Unmarshalling the template will overwrite any existing fields, so we must
-	// restore the existing name, if any. We also set generate name in case we
-	// haven't yet named this composed resource.
-	cd.SetGenerateName(cp.GetLabels()[xcrd.LabelKeyNamePrefixForComposed] + "-")
-	cd.SetName(name)
-	cd.SetNamespace(namespace)
 
 	// We do this last to ensure that a Composition cannot influence owner (and
 	// especially controller) references.

--- a/internal/controller/apiextensions/composite/composed.go
+++ b/internal/controller/apiextensions/composite/composed.go
@@ -35,6 +35,7 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/reconciler/managed"
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
 	"github.com/crossplane/crossplane-runtime/pkg/resource/unstructured/composed"
+
 	v1 "github.com/crossplane/crossplane/apis/apiextensions/v1"
 	"github.com/crossplane/crossplane/internal/xcrd"
 )
@@ -331,6 +332,14 @@ func (r *APIDryRunRenderer) Render(ctx context.Context, cp resource.Composite, c
 		return errors.New(errNamePrefix)
 	}
 
+	onlyPatches := []v1.PatchType{v1.PatchTypeFromCompositeFieldPath}
+	for i, p := range t.Patches {
+		if err := p.Apply(cp, cd, onlyPatches...); err != nil {
+			return errors.Wrapf(err, errFmtPatch, i)
+		}
+	}
+
+	// Fix(2416): composed labels and annotations should be rendered after patches are applied
 	meta.AddLabels(cd, map[string]string{
 		xcrd.LabelKeyNamePrefixForComposed: cp.GetLabels()[xcrd.LabelKeyNamePrefixForComposed],
 		xcrd.LabelKeyClaimName:             cp.GetLabels()[xcrd.LabelKeyClaimName],
@@ -347,13 +356,6 @@ func (r *APIDryRunRenderer) Render(ctx context.Context, cp resource.Composite, c
 	cd.SetGenerateName(cp.GetLabels()[xcrd.LabelKeyNamePrefixForComposed] + "-")
 	cd.SetName(name)
 	cd.SetNamespace(namespace)
-
-	onlyPatches := []v1.PatchType{v1.PatchTypeFromCompositeFieldPath}
-	for i, p := range t.Patches {
-		if err := p.Apply(cp, cd, onlyPatches...); err != nil {
-			return errors.Wrapf(err, errFmtPatch, i)
-		}
-	}
 
 	// We do this last to ensure that a Composition cannot influence owner (and
 	// especially controller) references.


### PR DESCRIPTION
Description
Backport of #2423 to release-1.2.