### PR TITLE
Add IBM Power Linux Platform (ppc64le) support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 PROJECT_NAME := crossplane
 PROJECT_REPO := github.com/crossplane/$(PROJECT_NAME)
 
-PLATFORMS ?= linux_amd64 linux_arm64 linux_arm darwin_amd64 windows_amd64
+PLATFORMS ?= linux_amd64 linux_arm64 linux_arm linux_ppc64le darwin_amd64 windows_amd64
 # -include will silently skip missing files, which allows us
 # to load those files with a target in the Makefile. If only
 # "include" was used, the make command would fail and refuse

--- a/cluster/images/crossplane/Makefile
+++ b/cluster/images/crossplane/Makefile
@@ -1,7 +1,7 @@
 # ====================================================================================
 # Setup Project
 
-PLATFORMS := linux_amd64 linux_arm64 linux_arm
+PLATFORMS := linux_amd64 linux_arm64 linux_arm linux_ppc64le
 include ../../../build/makelib/common.mk
 
 # ====================================================================================


### PR DESCRIPTION
### Description of your changes

Fixes https://github.com/crossplane/crossplane/issues/2424

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

I used the following steps to validate the changes on a RH8.3 ppc64le VM with docker 19.03.8:

```
docker run --rm --privileged tonistiigi/binfmt:latest --install all
wget https://github.com/docker/buildx/releases/download/v0.4.2/buildx-v0.4.2.linux-ppc64le
mv buildx-v0.4.2.linux-ppc64le docker-buildx
chmod a+x docker-buildx
mkdir ~/.docker/cli-plugins; mv docker-buildx ~/.docker/cli-plugins/
docker buildx create --name builder-44d7402c-521e-43d5-aa50-064d1fe5a99a --driver docker-container --buildkitd-flags '--allow-insecure-entitlement security.insecure --allow-insecure-entitlement network.host' --use
docker buildx inspect --bootstrap --builder builder-44d7402c-521e-43d5-aa50-064d1fe5a99a
docker buildx install

yum install -y make git wget gcc perl-Digest-SHA

# Download and install go
wget https://golang.org/dl/go1.14.13.linux-ppc64le.tar.gz
tar -xzf go1.14.13.linux-ppc64le.tar.gz
rm -rf go1.14.13.linux-ppc64le.tar.gz
export GOPATH=`pwd`/gopath
export PATH=`pwd`/go/bin:$GOPATH/bin:$PATH

mkdir -p $GOPATH/src/github.com/crossplane
cd $GOPATH/src/github.com/crossplane
git clone https://github.com/crossplane/crossplane.git
cd crossplane/

### APPLY THE PATCH

make submodules
make vendor vendor.check
make BUILD_ARGS="--load" -j2 build.all
make test
make e2e
```

And then confirmed that the crossplane pods come up in minikube cluster as:

```
docker tag build-a5425108/crossplane-ppc64le:latest crossplane/crossplane:v1.4.0-rc.0.42.gaa7c2807.dirty
helm install crossplane --namespace crossplane-system `pwd`/cluster/charts/crossplane/ --set image.pullPolicy=Never,imagePullSecrets=''
```