### PR TITLE
Addresses some minor install/setup docs issues

### DIFF
--- a/docs/cloud-providers/aws/aws-provider.md
+++ b/docs/cloud-providers/aws/aws-provider.md
@@ -30,6 +30,7 @@ provider` instance in Crossplane:
 ```bash
 curl -O https://raw.githubusercontent.com/crossplane/crossplane/master/docs/snippets/configure/aws/providerconfig.yaml
 curl -O https://raw.githubusercontent.com/crossplane/crossplane/master/docs/snippets/configure/aws/setup.sh
+chmod +x setup.sh
 ./setup.sh [--profile aws_profile]
 ```
 

--- a/docs/getting-started/install-configure.md
+++ b/docs/getting-started/install-configure.md
@@ -239,7 +239,7 @@ kubectl crossplane install configuration registry.upbound.io/xp/getting-started-
 
 Wait until all packages become healthy:
 ```
-kubectl get pkg --watch
+watch kubectl get pkg
 ```
 
 ### Get AWS Account Keyfile
@@ -293,7 +293,7 @@ kubectl crossplane install configuration registry.upbound.io/xp/getting-started-
 
 Wait until all packages become healthy:
 ```
-kubectl get pkg --watch
+watch kubectl get pkg
 ```
 
 ### Get AWS Account Keyfile
@@ -347,7 +347,7 @@ kubectl crossplane install configuration registry.upbound.io/xp/getting-started-
 
 Wait until all packages become healthy:
 ```
-kubectl get pkg --watch
+watch kubectl get pkg
 ```
 
 ### Get GCP Account Keyfile
@@ -417,7 +417,7 @@ kubectl crossplane install configuration registry.upbound.io/xp/getting-started-
 
 Wait until all packages become healthy:
 ```
-kubectl get pkg --watch
+watch kubectl get pkg
 ```
 
 ### Get Azure Principal Keyfile


### PR DESCRIPTION
### Description of your changes

In the current crossplane docs there are two issues addressed in this PR:
1. In [Setup AWS Provider](https://crossplane.io/docs/v1.3/cloud-providers/aws/aws-provider.html#step-2-setup-aws-providerconfig), there is an assumption that once curl downloads `./setup.sh`, it is immediately executable. This PR adds a step to run `chmod` to ensure it's executable.
2. In [Install Configuration Package](https://crossplane.io/docs/v1.3/getting-started/install-configure.html#install-configuration-package), the command `kubectl get pkg --watch` returns the following error:
```
error: you may only specify a single resource type
```
This PR updates the command to be `watch kubectl get pkg`.

I have:

- [X] Read and followed Crossplane's [contribution process].
- [X] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

Outlined suggested steps were tested as part of going through the setup process(es).

[contribution process]: https://git.io/fj2m9
