### PR TITLE
Adds support for building/running using darwin_arm64

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
 
 env:
   # Common versions
-  GO_VERSION: '1.14'
+  GO_VERSION: '1.16'
   GOLANGCI_VERSION: 'v1.31'
   DOCKER_BUILDX_VERSION: 'v0.4.2'
 

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 PROJECT_NAME := crossplane
 PROJECT_REPO := github.com/crossplane/$(PROJECT_NAME)
 
-PLATFORMS ?= linux_amd64 linux_arm64 linux_arm linux_ppc64le darwin_amd64 windows_amd64
+PLATFORMS ?= linux_amd64 linux_arm64 linux_arm linux_ppc64le darwin_amd64 darwin_arm64 windows_amd64
 # -include will silently skip missing files, which allows us
 # to load those files with a target in the Makefile. If only
 # "include" was used, the make command would fail and refuse

--- a/cluster/images/crossplane/Makefile
+++ b/cluster/images/crossplane/Makefile
@@ -13,7 +13,7 @@ include ../../../build/makelib/image.mk
 # ====================================================================================
 # Targets
 
-ifeq ($(PLATFORM),$(filter $(PLATFORM),darwin_amd64 windows_amd64)) 
+ifeq ($(PLATFORM),$(filter $(PLATFORM),darwin_amd64 darwin_arm64 windows_amd64)) 
 $(info Skipping image build for $(PLATFORM))
 img.build:
 else

--- a/cluster/local/kind.sh
+++ b/cluster/local/kind.sh
@@ -13,7 +13,7 @@ eval $(make --no-print-directory -C ${scriptdir}/../.. build.vars)
 # ensure the tools we need are installed
 make ${KIND} ${KUBECTL} ${HELM3}
 
-BUILD_IMAGE="${BUILD_REGISTRY}/${PROJECT_NAME}-amd64"
+BUILD_IMAGE="${BUILD_REGISTRY}/${PROJECT_NAME}-${TARGETARCH}"
 DEFAULT_NAMESPACE="crossplane-system"
 
 function copy_image_to_cluster() {
@@ -42,7 +42,7 @@ function check_context() {
 }
 
 # configure kind
-KUBE_IMAGE=${KUBE_IMAGE:-"kindest/node:v1.16.15@sha256:a89c771f7de234e6547d43695c7ab047809ffc71a0c3b65aa54eda051c45ed20"}
+KUBE_IMAGE=${KUBE_IMAGE:-"kindest/node:v1.16.15"}
 KIND_NAME=${KIND_NAME:-"kind"}
 case "${1:-}" in
   up)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/crossplane/crossplane
 
-go 1.13
+go 1.16
 
 require (
 	github.com/Azure/go-autorest/autorest/validation v0.2.0 // indirect

--- a/install.sh
+++ b/install.sh
@@ -31,7 +31,17 @@ case $OS in
     fi
     ;;
   Darwin)
-    OS_ARCH=darwin_amd64
+    case $ARCH in
+      amd64)
+        OS_ARCH=darwin_amd64
+        ;;
+      arm64)
+        OS_ARCH=darwin_arm64
+        ;;
+      *)
+        unsupported_arch $OS $ARCH
+        ;;
+    esac
     ;;
   Linux)
     case $ARCH in


### PR DESCRIPTION
### Description of your changes

These changes allow individuals using Apple Silicon to build/run crossplane locally.
Changes outlined:
1. bring in update to build submodule that updates kind to latest version
2. update hardcoded references to `arm64` for the crossplane image tag
3. updates the helper functions to work with arm64 in addition to amd64

I have:

- [X] Read and followed Crossplane's [contribution process].
- [X] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested
1. `make`
2. `make test`
3. `make e2e SAFEHOSTARCH=arm64` -  for now, you'll need to override `SAFEHOSTARCH` in this manner when running on darwin_arm64
4. `make reviewable`
5. `./cluster/local/kind.sh up`
6. `./cluster/local/kind.sh helm-install`

[contribution process]: https://git.io/fj2m9
