### PR TITLE
Output darwin_amd64 for both x86_64 and amd64 in install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -32,7 +32,7 @@ case $OS in
     ;;
   Darwin)
     case $ARCH in
-      amd64)
+      x86_64|amd64)
         OS_ARCH=darwin_amd64
         ;;
       arm64)


### PR DESCRIPTION
### Description of your changes
A recent change https://github.com/crossplane/crossplane/pull/2453 accidentally removed support for darwin_x86_64. This change follows the linux conditional approach and uses darwin_amd64 if either x86_64 or amd64 is seen.

I have:

- [X] Read and followed Crossplane's [contribution process].
- [X] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested
Ran changes for darwin_arm64 locally. Unfortunately I don't have a way to test darwin_amd64 nor darwin_x86_64.

[contribution process]: https://git.io/fj2m9
