### PR TITLE
Direct Darwin arm64 download to Darwin amd64 (as Darwin arm64 downloa…

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -45,11 +45,8 @@ case $OS in
     ;;
   Linux)
     case $ARCH in
-      x86_64|amd64)
+      x86_64|amd64|arm64)
         OS_ARCH=linux_amd64
-        ;;
-      arm64)
-        OS_ARCH=linux_arm64
         ;;
       *)
         unsupported_arch $OS $ARCH


### PR DESCRIPTION
…d doesn't exist)

### Description of your changes

I'm running on an MacBook Air (M1, 2020).  The arch on that comes back as "arm64."  Strictly speaking that's true.  However, there's no build for arm64.  There is a build for amd64 that runs just fine in the Mac's emulation.  So, the install script should probably grab that.

Interestingly this exposed a second issue with the script.  It's spitting out this url: https://releases.crossplane.io/stable/current/bin/darwin_arm64/crank.  It probably ought to be generating an unsupported architecture message.  So, it looks like the logic in install.sh isn't detecting that right.

This PR aims to fix both those things without introducing any fun new bugs.

The cause of the issue seems to be that there's a case statement for arm64 but no binary to match it.  So, this PR drops the case statement and downloads Darwin amd64 on the Darwin arm64 system.  I assume the arm64 case is a branch for a not yet existing build that made it into the repo too fast.

I have:
- [x] Read and followed Crossplane's [contribution process].
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested
I tested this on the command line on my machine.  It's not great but I'm not sure a better way to test it.

[contribution process]: https://git.io/fj2m9
