### PR TITLE
output darwin_amd64 for arm64 (m1)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -32,11 +32,8 @@ case $OS in
     ;;
   Darwin)
     case $ARCH in
-      x86_64|amd64)
+      x86_64|amd64|arm64)
         OS_ARCH=darwin_amd64
-        ;;
-      arm64)
-        OS_ARCH=darwin_arm64
         ;;
       *)
         unsupported_arch $OS $ARCH


### PR DESCRIPTION
Signed-off-by: Ben Lackey <ben.lackey@outlook.com>

### Description of your changes

I'm running on an MacBook Air (M1, 2020).  The arch on that comes back as "arm64."  Strictly speaking that's true.  However, there's no build for arm64.  There is a build for amd64 that runs just fine in the Mac's emulation.  So, the install script should probably grab that.

Interestingly this exposed a second issue with the script.  It's spitting out this url: https://releases.crossplane.io/stable/current/bin/darwin_arm64/crank.  It probably ought to be generated a unsupported architecture message.  So, it looks like the logic in install.sh isn't detecting that right.

This PR aims to fix both those things without introducing any fun new bugs.

The cause of the issue seems to be that there's a case statement for arm64 but no binary to match it.  So, this PR drops the case statement and downloads Darwin amd64 on the Darwin arm64 system.  I assume the arm64 case is a branch for a not yet existing build that made it into the repo too fast.

I also did a "chmod +x install.sh" as the script is unrunnable in its current state.  Though, it's conceivable there's some reason that wasn't done before.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

I tried to change nothing but the issue I saw and then ran the install script on my local machine.  I can't think of any way this can break things but I don't know how this install.sh is used (other than in the documentation I've been following).