### PR TITLE
Persist claim resourceRefs before creating XRs

### DIFF
--- a/internal/controller/apiextensions/claim/api.go
+++ b/internal/controller/apiextensions/claim/api.go
@@ -60,16 +60,6 @@ func (a *APIBinder) Bind(ctx context.Context, cm resource.CompositeClaim, cp res
 		return errors.New(errBindClaimConflict)
 	}
 
-	// Propagate the actual external name back from the composite to the
-	// claim if it's set. The name we're propagating here will may be a name
-	// the XR must enforce (i.e. overriding any requested by the claim) but
-	// will often actually just be propagating back a name that was already
-	// propagated forward from the claim to the XR during the
-	// preceding configure phase.
-	if en := meta.GetExternalName(cp); en != "" {
-		meta.SetExternalName(cm, en)
-	}
-
 	cm.SetResourceReference(proposed)
 	return errors.Wrap(a.client.Update(ctx, cm), errUpdateClaim)
 }

--- a/internal/controller/apiextensions/claim/api_test.go
+++ b/internal/controller/apiextensions/claim/api_test.go
@@ -29,7 +29,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
-	"github.com/crossplane/crossplane-runtime/pkg/meta"
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
 	"github.com/crossplane/crossplane-runtime/pkg/resource/fake"
 	"github.com/crossplane/crossplane-runtime/pkg/test"
@@ -60,48 +59,6 @@ func TestBind(t *testing.T) {
 		want      error
 		wantClaim resource.CompositeClaim
 	}{
-		"ReconcileXRCExtNameFromXR": {
-			reason: "If existing XR already has an external-name, XRC's external-name should be set from it",
-			fields: fields{
-				c: &test.MockClient{
-					MockUpdate: test.NewMockUpdateFn(nil),
-				},
-			},
-			args: args{
-				cm: &fake.CompositeClaim{
-					ObjectMeta: metav1.ObjectMeta{
-						Annotations: map[string]string{
-							meta.AnnotationKeyExternalName: "name-from-claim",
-						},
-					},
-					CompositeResourceReferencer: fake.CompositeResourceReferencer{
-						Ref: &corev1.ObjectReference{
-							Name: "wat",
-						},
-					},
-				},
-				cp: &fake.Composite{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "wat",
-						Annotations: map[string]string{
-							meta.AnnotationKeyExternalName: "name-from-composite",
-						},
-					},
-				},
-			},
-			wantClaim: &fake.CompositeClaim{
-				ObjectMeta: metav1.ObjectMeta{
-					Annotations: map[string]string{
-						meta.AnnotationKeyExternalName: "name-from-composite",
-					},
-				},
-				CompositeResourceReferencer: fake.CompositeResourceReferencer{
-					Ref: &corev1.ObjectReference{
-						Name: "wat",
-					},
-				},
-			},
-		},
 		"CompositeRefConflict": {
 			reason: "An error should be returned if the claim is bound to another composite resource",
 			args: args{

--- a/internal/controller/apiextensions/claim/api_test.go
+++ b/internal/controller/apiextensions/claim/api_test.go
@@ -137,58 +137,6 @@ func TestBind(t *testing.T) {
 			},
 			want: errors.Wrap(errBoom, errUpdateClaim),
 		},
-		"ClaimRefConflict": {
-			reason: "An error should be returned if the composite resource is bound to another claim",
-			fields: fields{
-				c: &test.MockClient{
-					MockUpdate: test.NewMockUpdateFn(nil),
-				},
-			},
-			args: args{
-				cm: &fake.CompositeClaim{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "wat",
-					},
-					CompositeResourceReferencer: fake.CompositeResourceReferencer{
-						Ref: &corev1.ObjectReference{},
-					},
-				},
-				cp: &fake.Composite{
-					ClaimReferencer: fake.ClaimReferencer{
-						Ref: &corev1.ObjectReference{
-							Name: "who",
-						},
-					},
-				},
-			},
-			want: errors.New(errBindCompositeConflict),
-		},
-		"UpdateCompositeError": {
-			reason: "Errors updating the composite resource should be returned",
-			fields: fields{
-				c: &test.MockClient{
-					MockUpdate: test.NewMockUpdateFn(nil, func(obj client.Object) error {
-						if _, ok := obj.(*fake.Composite); ok {
-							return errBoom
-						}
-						return nil
-					}),
-				},
-			},
-			args: args{
-				cm: &fake.CompositeClaim{
-					CompositeResourceReferencer: fake.CompositeResourceReferencer{
-						Ref: &corev1.ObjectReference{},
-					},
-				},
-				cp: &fake.Composite{
-					ClaimReferencer: fake.ClaimReferencer{
-						Ref: &corev1.ObjectReference{},
-					},
-				},
-			},
-			want: errors.Wrap(errBoom, errUpdateComposite),
-		},
 	}
 
 	for name, tc := range cases {

--- a/internal/controller/apiextensions/claim/configurator.go
+++ b/internal/controller/apiextensions/claim/configurator.go
@@ -95,6 +95,7 @@ func ConfigureComposite(_ context.Context, cm resource.CompositeClaim, cp resour
 	}
 	claimSpecFilter := xcrd.GetPropFields(baseClaimSpec)
 	ucp.Object["spec"] = filter(spec, claimSpecFilter...)
+
 	return nil
 }
 

--- a/internal/controller/apiextensions/claim/configurator.go
+++ b/internal/controller/apiextensions/claim/configurator.go
@@ -60,15 +60,11 @@ func ConfigureComposite(_ context.Context, cm resource.CompositeClaim, cp resour
 		xcrd.LabelKeyClaimNamespace: cm.GetNamespace(),
 	})
 
-	// If our composite resource already exists we want to restore its original
-	// external name (even if that external name was empty) in order to ensure
-	// we don't try to rename anything after the fact.
-	if meta.WasCreated(cp) {
-		// Fix(2353): do not introduce a superfluous extern-name
-		// (empty external-names are treated as invalid)
-		if en != "" {
-			meta.SetExternalName(cp, en)
-		}
+	// If our composite resource already exists we want to restore its
+	// original external name (if set) in order to ensure we don't try to
+	// rename anything after the fact.
+	if meta.WasCreated(cp) && en != "" {
+		meta.SetExternalName(cp, en)
 	}
 
 	ucm, ok := cm.(*claim.Unstructured)

--- a/internal/controller/apiextensions/claim/configurator_test.go
+++ b/internal/controller/apiextensions/claim/configurator_test.go
@@ -39,6 +39,8 @@ import (
 func TestCompositeConfigure(t *testing.T) {
 	ns := "spacename"
 	name := "cool"
+	apiVersion := "v"
+	kind := "k"
 	now := metav1.Now()
 	errBoom := errors.New("boom")
 
@@ -114,6 +116,53 @@ func TestCompositeConfigure(t *testing.T) {
 				err: errors.New(errUnsupportedClaimSpec),
 			},
 		},
+		"AlreadyClaimedError": {
+			reason: "We should return an error if we appear to be configuring a composite resource claimed by a different... claim.",
+			args: args{
+				cm: &claim.Unstructured{
+					Unstructured: unstructured.Unstructured{
+						Object: map[string]interface{}{
+							"metadata": map[string]interface{}{
+								"namespace": ns,
+								"name":      name,
+							},
+							"spec": map[string]interface{}{},
+						},
+					},
+				},
+				cp: &composite.Unstructured{
+					Unstructured: unstructured.Unstructured{
+						Object: map[string]interface{}{
+							"spec": map[string]interface{}{
+								"claimRef": map[string]interface{}{
+									"apiVersion": apiVersion,
+									"kind":       kind,
+									"namespace":  ns,
+									"name":       "some-other-claim",
+								},
+							},
+						},
+					},
+				},
+			},
+			want: want{
+				cp: &composite.Unstructured{
+					Unstructured: unstructured.Unstructured{
+						Object: map[string]interface{}{
+							"spec": map[string]interface{}{
+								"claimRef": map[string]interface{}{
+									"apiVersion": apiVersion,
+									"kind":       kind,
+									"namespace":  ns,
+									"name":       "some-other-claim",
+								},
+							},
+						},
+					},
+				},
+				err: errors.New(errBindCompositeConflict),
+			},
+		},
 		"DryRunError": {
 			reason: "We should return any error we encounter while dry-run creating a dynamically provisioned composite",
 			c: &test.MockClient{
@@ -123,6 +172,8 @@ func TestCompositeConfigure(t *testing.T) {
 				cm: &claim.Unstructured{
 					Unstructured: unstructured.Unstructured{
 						Object: map[string]interface{}{
+							"apiVersion": apiVersion,
+							"kind":       kind,
 							"metadata": map[string]interface{}{
 								"namespace": ns,
 								"name":      name,
@@ -158,6 +209,12 @@ func TestCompositeConfigure(t *testing.T) {
 								"coolness":            23,
 								"compositionRef":      "ref",
 								"compositionSelector": "ref",
+								"claimRef": map[string]interface{}{
+									"apiVersion": apiVersion,
+									"kind":       kind,
+									"namespace":  ns,
+									"name":       name,
+								},
 							},
 						},
 					},
@@ -174,6 +231,8 @@ func TestCompositeConfigure(t *testing.T) {
 				cm: &claim.Unstructured{
 					Unstructured: unstructured.Unstructured{
 						Object: map[string]interface{}{
+							"apiVersion": apiVersion,
+							"kind":       kind,
 							"metadata": map[string]interface{}{
 								"namespace": ns,
 								"name":      name,
@@ -209,6 +268,12 @@ func TestCompositeConfigure(t *testing.T) {
 								"coolness":            23,
 								"compositionRef":      "ref",
 								"compositionSelector": "ref",
+								"claimRef": map[string]interface{}{
+									"apiVersion": apiVersion,
+									"kind":       kind,
+									"namespace":  ns,
+									"name":       name,
+								},
 							},
 						},
 					},
@@ -221,6 +286,8 @@ func TestCompositeConfigure(t *testing.T) {
 				cm: &claim.Unstructured{
 					Unstructured: unstructured.Unstructured{
 						Object: map[string]interface{}{
+							"apiVersion": apiVersion,
+							"kind":       kind,
 							"metadata": map[string]interface{}{
 								"namespace": ns,
 								"name":      name,
@@ -292,6 +359,12 @@ func TestCompositeConfigure(t *testing.T) {
 							},
 							"spec": map[string]interface{}{
 								"coolness": 23,
+								"claimRef": map[string]interface{}{
+									"apiVersion": apiVersion,
+									"kind":       kind,
+									"namespace":  ns,
+									"name":       name,
+								},
 							},
 						},
 					},

--- a/internal/controller/apiextensions/claim/configurator_test.go
+++ b/internal/controller/apiextensions/claim/configurator_test.go
@@ -583,6 +583,9 @@ func TestClaimConfigure(t *testing.T) {
 							"metadata": map[string]interface{}{
 								"namespace": ns,
 								"name":      name,
+								"annotations": map[string]interface{}{
+									meta.AnnotationKeyExternalName: "nope",
+								},
 							},
 							"spec": map[string]interface{}{
 								"someField":                  "someValue",
@@ -599,6 +602,9 @@ func TestClaimConfigure(t *testing.T) {
 							"metadata": map[string]interface{}{
 								"namespace": ns,
 								"name":      name + "-12345",
+								"annotations": map[string]interface{}{
+									meta.AnnotationKeyExternalName: name,
+								},
 							},
 							"spec": map[string]interface{}{
 								"coolness": 23,
@@ -619,6 +625,9 @@ func TestClaimConfigure(t *testing.T) {
 							"metadata": map[string]interface{}{
 								"namespace": ns,
 								"name":      name,
+								"annotations": map[string]interface{}{
+									meta.AnnotationKeyExternalName: name,
+								},
 							},
 							"spec": map[string]interface{}{
 								"someField":                  "someValue",

--- a/internal/controller/apiextensions/claim/reconciler.go
+++ b/internal/controller/apiextensions/claim/reconciler.go
@@ -24,7 +24,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -143,10 +142,10 @@ type crComposite struct {
 	ConnectionPropagator
 }
 
-func defaultCRComposite(c client.Client, t runtime.ObjectTyper) crComposite {
+func defaultCRComposite(c client.Client) crComposite {
 	return crComposite{
 		Configurator:         ConfiguratorFn(ConfigureComposite),
-		ConnectionPropagator: NewAPIConnectionPropagator(c, t),
+		ConnectionPropagator: NewAPIConnectionPropagator(c),
 	}
 }
 
@@ -156,10 +155,10 @@ type crClaim struct {
 	Configurator
 }
 
-func defaultCRClaim(c client.Client, t runtime.ObjectTyper) crClaim {
+func defaultCRClaim(c client.Client) crClaim {
 	return crClaim{
 		Finalizer:    resource.NewAPIFinalizer(c, finalizer),
-		Binder:       NewAPIBinder(c, t),
+		Binder:       NewAPIBinder(c),
 		Configurator: NewAPIClaimConfigurator(c),
 	}
 }
@@ -247,8 +246,8 @@ func NewReconciler(m manager.Manager, of resource.CompositeClaimKind, with resou
 		newComposite: func() resource.Composite {
 			return composite.New(composite.WithGroupVersionKind(schema.GroupVersionKind(with)))
 		},
-		composite: defaultCRComposite(c, m.GetScheme()),
-		claim:     defaultCRClaim(c, m.GetScheme()),
+		composite: defaultCRComposite(c),
+		claim:     defaultCRClaim(c),
 		log:       logging.NewNopLogger(),
 		record:    event.NewNopRecorder(),
 	}

--- a/internal/controller/apiextensions/claim/reconciler.go
+++ b/internal/controller/apiextensions/claim/reconciler.go
@@ -386,7 +386,6 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 	log.Debug("Successfully applied composite resource")
 	record.Event(cm, event.Normal(reasonCompositeConfigure, "Successfully applied composite resource"))
 
-	// TODO(negz): Can we back-propagate the external-name in this guy?
 	if err := r.claim.Configure(ctx, cm, cp); err != nil {
 		log.Debug("Cannot configure composite resource claim", "error", err, "requeue-after", time.Now().Add(aShortWait))
 		record.Event(cm, event.Warning(reasonClaimConfigure, err))

--- a/internal/controller/apiextensions/claim/reconciler.go
+++ b/internal/controller/apiextensions/claim/reconciler.go
@@ -144,7 +144,7 @@ type crComposite struct {
 
 func defaultCRComposite(c client.Client) crComposite {
 	return crComposite{
-		Configurator:         ConfiguratorFn(ConfigureComposite),
+		Configurator:         NewAPIDryRunCompositeConfigurator(c),
 		ConnectionPropagator: NewAPIConnectionPropagator(c),
 	}
 }

--- a/internal/controller/apiextensions/claim/reconciler_test.go
+++ b/internal/controller/apiextensions/claim/reconciler_test.go
@@ -40,6 +40,7 @@ import (
 
 func TestReconcile(t *testing.T) {
 	errBoom := errors.New("boom")
+	name := "coolclaim"
 
 	type args struct {
 		mgr  manager.Manager
@@ -129,6 +130,35 @@ func TestReconcile(t *testing.T) {
 				r: reconcile.Result{Requeue: false},
 			},
 		},
+		"DeleteUnboundCompositeError": {
+			reason: "We should return without requeuing if we try to delete a composite resource that does not reference us",
+			args: args{
+				mgr: &fake.Manager{},
+				opts: []ReconcilerOption{
+					WithClientApplicator(resource.ClientApplicator{
+						Client: &test.MockClient{
+							MockGet: test.NewMockGetFn(nil, func(obj client.Object) error {
+								switch o := obj.(type) {
+								case *claim.Unstructured:
+									now := metav1.Now()
+									o.SetName(name)
+									o.SetDeletionTimestamp(&now)
+									o.SetResourceReference(&corev1.ObjectReference{})
+								case *composite.Unstructured:
+									o.SetCreationTimestamp(metav1.Now())
+									o.SetClaimReference(&corev1.ObjectReference{Name: "some-other-claim"})
+								}
+								return nil
+							}),
+							MockDelete: test.NewMockDeleteFn(errBoom),
+						},
+					}),
+				},
+			},
+			want: want{
+				r: reconcile.Result{Requeue: false},
+			},
+		},
 		"DeleteCompositeError": {
 			reason: "We should requeue after a short wait if we encounter an error while deleting the referenced composite resource",
 			args: args{
@@ -140,10 +170,12 @@ func TestReconcile(t *testing.T) {
 								switch o := obj.(type) {
 								case *claim.Unstructured:
 									now := metav1.Now()
+									o.SetName(name)
 									o.SetDeletionTimestamp(&now)
 									o.SetResourceReference(&corev1.ObjectReference{})
 								case *composite.Unstructured:
 									o.SetCreationTimestamp(metav1.Now())
+									o.SetClaimReference(&corev1.ObjectReference{Name: name})
 								}
 								return nil
 							}),


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes https://github.com/crossplane/crossplane/issues/2078
Fixes https://github.com/crossplane/crossplane/issues/2464
Fixes https://github.com/crossplane/crossplane/issues/2473

This PR updates the claim reconciler to persist a claim's `spec.resourceRef` before dynamically provisioning an XR. It uses a similar approach to the XR reconciler in that it now uses a dry-run create to generate an XR name (and validate the XR) without actually creating it. 'Binding' a claim to an XR is now broken up into three stages.

1. We set the XR's claimRef during Configure.
2. We set (and persist) the XRC's resourceRef during Bind
3. We persist the XR's claimRef during Apply.

This approach has a handful of benefits:

1. It prevents 'leaking' XRs. Previously if anything went wrong between when we first created an XR and when we persisted its resourceRef we'd return from the Reconcile and requeue a new one. The new reconcile would have no way of knowing that we'd already created an XR for this claim so it would create a new one.
2. It ensures dynamically provisioned XRs never exist without a claimRef - it's set when the XR is created. This can help avoid issues like #2464. Note that XRs should still be designed to support static binding - i.e. they should not assume that the claimRef will always be set at XR creation time.
3. It eliminates one superfluous API server write, because we only update the XR once, rather than applying it then updating it to bind it.

Note that this commit changes the behaviour of the (AFAIK _exceedingly_ obscure) edge case in which someone attempts to claim an XR tha does not exist - i.e. by explicitly setting their claim's resourceRef. Previously we'd assume they did in fact want to claim an XR that hadn't yet been created, and wait around for it to exist. Now we assume that the resourceRef was populated by a previous iteration of the reconciler and proceed to dynamically provision an XR of that name. One interesting side effect here is that this means claim authors can now influence the (Kubernetes) name of the XR they would like to provision, though we'll still bail out if they try to 'claim over' an XR that is claimed by some other entity.

This PR also contains a small additional fix for https://github.com/crossplane/crossplane/issues/2473, which I (re)discovered while addressing the original issue. The original refactoring done in this PR is a partial fix for this issue because we now detect 'misbound' claims earlier and refuse to make any mutations on composite resources we don't own, so I only needed to fix the delete flow to ensure a claim could not delete an XR it was not bound to.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9

I've tested this by walking through the GCP getting started guide and confirming that dynamic provisioning works as expected. I've also followed similar steps to those outlined in https://github.com/crossplane/crossplane/issues/2473 to ensure I can't reproduce that issue with this PR.