### PR TITLE
Update pkg e2e tests to use v1 types and build e2e tests in CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -145,6 +145,20 @@ install-crds: $(KUBECTL) reviewable
 uninstall-crds:
 	$(KUBECTL) delete -f $(CRD_DIR)
 
+# Compile e2e tests.
+# TODO(hasheddan): integrate this functionality into build submodule. The build
+# submodule currently distinguishes tests and integration tests, but it only
+# builds tests and does not support passing build tags only to the test build.
+# Note that we are not publishing the builds that come from this step.
+e2e-tests-compile:
+	@$(INFO) Checking that e2e tests compile
+	@$(GO) test -c -o $(WORK_DIR)/e2e/$(PLATFORM)/apiextensions.test ./test/e2e/apiextensions --tags=e2e
+	@$(GO) test -c -o $(WORK_DIR)/e2e/$(PLATFORM)/pkg.test ./test/e2e/pkg --tags=e2e
+	@$(OK) Verified e2e tests compile
+
+# Compile e2e tests for each platform.
+build.code.platform: e2e-tests-compile
+
 # This is for running out-of-cluster locally, and is for convenience. Running
 # this make target will print out the command which was used. For more control,
 # try running the binary directly with different arguments.
@@ -153,7 +167,7 @@ run: go.build
 	@# To see other arguments that can be provided, run the command with --help instead
 	$(GO_OUT_DIR)/$(PROJECT_NAME) core start --debug
 
-.PHONY: manifests cobertura submodules fallthrough test-integration run install-crds uninstall-crds gen-kustomize-crds gen-install-doc
+.PHONY: manifests cobertura submodules fallthrough test-integration run install-crds uninstall-crds gen-kustomize-crds gen-install-doc e2e-tests-compile
 
 # ====================================================================================
 # Special Targets

--- a/test/e2e/pkg/dependency_test.go
+++ b/test/e2e/pkg/dependency_test.go
@@ -31,8 +31,8 @@ import (
 	"k8s.io/utils/pointer"
 	ctrl "sigs.k8s.io/controller-runtime"
 
-	"github.com/crossplane/crossplane/apis/pkg/v1beta1"
-	typedclient "github.com/crossplane/crossplane/internal/client/clientset/versioned/typed/pkg/v1beta1"
+	v1 "github.com/crossplane/crossplane/apis/pkg/v1"
+	typedclient "github.com/crossplane/crossplane/internal/client/clientset/versioned/typed/pkg/v1"
 )
 
 const (
@@ -50,12 +50,12 @@ func TestDependencies(t *testing.T) {
 			body: func() error {
 				ctx := context.Background()
 				c := typedclient.NewForConfigOrDie(ctrl.GetConfigOrDie())
-				cr := &v1beta1.Configuration{
+				cr := &v1.Configuration{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: configName,
 					},
-					Spec: v1beta1.ConfigurationSpec{
-						PackageSpec: v1beta1.PackageSpec{
+					Spec: v1.ConfigurationSpec{
+						PackageSpec: v1.PackageSpec{
 							Package: configPackage,
 						},
 					},
@@ -73,10 +73,10 @@ func TestDependencies(t *testing.T) {
 						return false, nil
 					}
 					for _, p := range l.Items {
-						if p.GetCondition(v1beta1.TypeInstalled).Status != corev1.ConditionTrue {
+						if p.GetCondition(v1.TypeInstalled).Status != corev1.ConditionTrue {
 							return false, nil
 						}
-						if p.GetCondition(v1beta1.TypeHealthy).Status != corev1.ConditionTrue {
+						if p.GetCondition(v1.TypeHealthy).Status != corev1.ConditionTrue {
 							return false, nil
 						}
 					}
@@ -110,12 +110,12 @@ func TestDependencies(t *testing.T) {
 			body: func() error {
 				ctx := context.Background()
 				c := typedclient.NewForConfigOrDie(ctrl.GetConfigOrDie())
-				cr := &v1beta1.Configuration{
+				cr := &v1.Configuration{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: configName,
 					},
-					Spec: v1beta1.ConfigurationSpec{
-						PackageSpec: v1beta1.PackageSpec{
+					Spec: v1.ConfigurationSpec{
+						PackageSpec: v1.PackageSpec{
 							Package:                  configPackage,
 							SkipDependencyResolution: pointer.BoolPtr(true),
 						},
@@ -129,10 +129,10 @@ func TestDependencies(t *testing.T) {
 					if err != nil {
 						return false, err
 					}
-					if config.GetCondition(v1beta1.TypeInstalled).Status != corev1.ConditionTrue {
+					if config.GetCondition(v1.TypeInstalled).Status != corev1.ConditionTrue {
 						return false, nil
 					}
-					if config.GetCondition(v1beta1.TypeHealthy).Status != corev1.ConditionTrue {
+					if config.GetCondition(v1.TypeHealthy).Status != corev1.ConditionTrue {
 						return false, nil
 					}
 					l, err := c.Providers().List(ctx, metav1.ListOptions{})


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Updates pkg e2e tests to use v1 types now that the interfaces for
v1beta1 types have been removed.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

`make build` and running updated e2e tests along with changes in https://github.com/crossplane/test/pull/22

[contribution process]: https://git.io/fj2m9
