### PR TITLE
Do not requeue on successful revision reconcile

### DIFF
--- a/internal/controller/pkg/revision/reconciler.go
+++ b/internal/controller/pkg/revision/reconciler.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -233,6 +234,7 @@ func SetupProviderRevision(mgr ctrl.Manager, l logging.Logger, cache xpkg.Cache,
 	return ctrl.NewControllerManagedBy(mgr).
 		Named(name).
 		For(&v1.ProviderRevision{}).
+		Owns(&appsv1.Deployment{}).
 		Complete(r)
 }
 
@@ -453,5 +455,5 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 
 	r.record.Event(pr, event.Normal(reasonSync, "Successfully configured package revision"))
 	pr.SetConditions(v1.Healthy())
-	return reconcile.Result{RequeueAfter: longWait}, errors.Wrap(r.client.Status().Update(ctx, pr), errUpdateStatus)
+	return reconcile.Result{Requeue: false}, errors.Wrap(r.client.Status().Update(ctx, pr), errUpdateStatus)
 }

--- a/internal/controller/pkg/revision/reconciler.go
+++ b/internal/controller/pkg/revision/reconciler.go
@@ -29,6 +29,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	"github.com/crossplane/crossplane-runtime/pkg/event"
 	"github.com/crossplane/crossplane-runtime/pkg/logging"
@@ -235,6 +236,9 @@ func SetupProviderRevision(mgr ctrl.Manager, l logging.Logger, cache xpkg.Cache,
 		Named(name).
 		For(&v1.ProviderRevision{}).
 		Owns(&appsv1.Deployment{}).
+		Watches(&source.Kind{Type: &v1alpha1.ControllerConfig{}}, &EnqueueRequestForReferencingProviderRevisions{
+			client: mgr.GetClient(),
+		}).
 		Complete(r)
 }
 

--- a/internal/controller/pkg/revision/reconciler_test.go
+++ b/internal/controller/pkg/revision/reconciler_test.go
@@ -776,7 +776,7 @@ func TestReconcile(t *testing.T) {
 				},
 			},
 			want: want{
-				r: reconcile.Result{RequeueAfter: longWait},
+				r: reconcile.Result{Requeue: false},
 			},
 		},
 		"SuccessfulActiveRevisionIgnoreConstraints": {
@@ -836,7 +836,7 @@ func TestReconcile(t *testing.T) {
 				},
 			},
 			want: want{
-				r: reconcile.Result{RequeueAfter: longWait},
+				r: reconcile.Result{Requeue: false},
 			},
 		},
 		"ErrEstablishActiveRevision": {
@@ -949,7 +949,7 @@ func TestReconcile(t *testing.T) {
 				},
 			},
 			want: want{
-				r: reconcile.Result{RequeueAfter: longWait},
+				r: reconcile.Result{Requeue: false},
 			},
 		},
 		"ErrEstablishInactiveRevision": {

--- a/internal/controller/pkg/revision/watch.go
+++ b/internal/controller/pkg/revision/watch.go
@@ -1,0 +1,87 @@
+/*
+Copyright 2021 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package revision
+
+import (
+	"context"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/workqueue"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	v1 "github.com/crossplane/crossplane/apis/pkg/v1"
+	"github.com/crossplane/crossplane/apis/pkg/v1alpha1"
+)
+
+type adder interface {
+	Add(item interface{})
+}
+
+// EnqueueRequestForReferencingProviderRevisions enqueues a request for all
+// provider revisions tha reference a ControllerConfig when the given
+// ControllerConfig changes.
+type EnqueueRequestForReferencingProviderRevisions struct {
+	client client.Client
+}
+
+// Create enqueues a request for all provider revisions that reference a given
+// ControllerConfig.
+func (e *EnqueueRequestForReferencingProviderRevisions) Create(evt event.CreateEvent, q workqueue.RateLimitingInterface) {
+	e.add(evt.Object, q)
+}
+
+// Update enqueues a request for all provider revisions that reference a given
+// ControllerConfig.
+func (e *EnqueueRequestForReferencingProviderRevisions) Update(evt event.UpdateEvent, q workqueue.RateLimitingInterface) {
+	e.add(evt.ObjectOld, q)
+	e.add(evt.ObjectNew, q)
+}
+
+// Delete enqueues a request for all provider revisions that reference a given
+// ControllerConfig.
+func (e *EnqueueRequestForReferencingProviderRevisions) Delete(evt event.DeleteEvent, q workqueue.RateLimitingInterface) {
+	e.add(evt.Object, q)
+}
+
+// Generic enqueues a request for all provider revisions that reference a given
+// ControllerConfig.
+func (e *EnqueueRequestForReferencingProviderRevisions) Generic(evt event.GenericEvent, q workqueue.RateLimitingInterface) {
+	e.add(evt.Object, q)
+}
+
+func (e *EnqueueRequestForReferencingProviderRevisions) add(obj runtime.Object, queue adder) {
+	cc, ok := obj.(*v1alpha1.ControllerConfig)
+	if !ok {
+		return
+	}
+
+	l := &v1.ProviderRevisionList{}
+	if err := e.client.List(context.TODO(), l); err != nil {
+		// TODO(hasheddan): Handle this error?
+		return
+	}
+
+	for _, pr := range l.Items {
+		ref := pr.GetControllerConfigRef()
+		if ref != nil && ref.Name == cc.GetName() {
+			queue.Add(reconcile.Request{NamespacedName: types.NamespacedName{Name: pr.GetName()}})
+		}
+	}
+}

--- a/internal/controller/pkg/revision/watch.go
+++ b/internal/controller/pkg/revision/watch.go
@@ -35,7 +35,7 @@ type adder interface {
 }
 
 // EnqueueRequestForReferencingProviderRevisions enqueues a request for all
-// provider revisions tha reference a ControllerConfig when the given
+// provider revisions that reference a ControllerConfig when the given
 // ControllerConfig changes.
 type EnqueueRequestForReferencingProviderRevisions struct {
 	client client.Client

--- a/internal/controller/pkg/revision/watch_test.go
+++ b/internal/controller/pkg/revision/watch_test.go
@@ -1,0 +1,103 @@
+/*
+Copyright 2021 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package revision
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/pkg/errors"
+
+	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
+	"github.com/crossplane/crossplane-runtime/pkg/test"
+
+	v1 "github.com/crossplane/crossplane/apis/pkg/v1"
+	"github.com/crossplane/crossplane/apis/pkg/v1alpha1"
+)
+
+var (
+	_ handler.EventHandler = &EnqueueRequestForReferencingProviderRevisions{}
+)
+
+type addFn func(item interface{})
+
+func (fn addFn) Add(item interface{}) {
+	fn(item)
+}
+
+func TestAdd(t *testing.T) {
+	errBoom := errors.New("boom")
+	name := "coolname"
+	prName := "coolpr"
+
+	cases := map[string]struct {
+		obj              runtime.Object
+		client           client.Client
+		controllerConfig *v1alpha1.ControllerConfig
+		queue            adder
+	}{
+		"ObjectIsNotAControllConfig": {
+			queue: addFn(func(_ interface{}) { t.Errorf("queue.Add() called unexpectedly") }),
+		},
+		"ListError": {
+			obj: &v1alpha1.ControllerConfig{ObjectMeta: metav1.ObjectMeta{Name: name}},
+			client: &test.MockClient{
+				MockList: test.NewMockListFn(errBoom),
+			},
+			controllerConfig: &v1alpha1.ControllerConfig{},
+			queue:            addFn(func(_ interface{}) { t.Errorf("queue.Add() called unexpectedly") }),
+		},
+		"SuccessfulEnqueue": {
+			obj: &v1alpha1.ControllerConfig{ObjectMeta: metav1.ObjectMeta{Name: name}},
+			client: &test.MockClient{
+				MockList: test.NewMockListFn(nil, func(obj client.ObjectList) error {
+					l := obj.(*v1.ProviderRevisionList)
+					l.Items = []v1.ProviderRevision{
+						{
+							ObjectMeta: metav1.ObjectMeta{Name: prName},
+							Spec: v1.PackageRevisionSpec{
+								ControllerConfigReference: &xpv1.Reference{},
+							},
+						},
+						{
+							ObjectMeta: metav1.ObjectMeta{Name: "noRef"},
+						},
+					}
+					return nil
+				}),
+			},
+			queue: addFn(func(got interface{}) {
+				want := reconcile.Request{NamespacedName: types.NamespacedName{Name: prName}}
+				if diff := cmp.Diff(want, got); diff != "" {
+					t.Errorf("-want, +got:\n%s\n", diff)
+				}
+			}),
+		},
+	}
+
+	for _, tc := range cases {
+		e := &EnqueueRequestForReferencingProviderRevisions{client: tc.client}
+		e.add(tc.obj, tc.queue)
+	}
+}


### PR DESCRIPTION

<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
This is a fairly substantial change in the package revision controller
behavior, but should drastically reduce the number of calls we make to
the API Server. We previously reconciled package revisions every minute
after a successful reconcile, but we now opt for only requeing if a
reconcile is not successful. This means that installed resources could
drift from what is specified in the package, but the odds of this
causing negative impact on an environment are somewhat mininal.

We also update to watch owned Deployments for a ProviderRevision as we
need to be notified immediately if a provider Deployment is unhealthy.
This does have the consequence that we will update all installed
resources on a regular cadence in the case that a provider Deployment
remains unhealthy. That being said, an unhealthy provider Deployment
should call for urgent intervention, either by the controller or the
cluster administrator.

~A potential negative side-effect of not regularly reconciling
ProviderRevisions is that an updated ControllerConfig will not flow
through to the provider Deployment within a minute, which was the
previous guarantee. That being said, any update to the Provider itself
will trigger a reconcile, which would cause ControllerConfig changes to
also be picked up.~

Update: we are now enqueing reconciles for ProviderRevisions when
an event on a ControllerConfig it references is observed.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

Fixes #2449 

_Note: I could go either way on this being backported. Typically I would not want to backport a behavior change, but this feels like it could be considered a "bug fix" given that the excessive API calls are causing issues for folks. Because I don't foresee if having negative impact on any existing users, I have opted to backport._

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

Tested this by installing `provider-aws` and the `getting-started-with-gcp` Configuration. Once resources were established and `Deployment` was healthy, I observed no further reconciles taking place. I also observed that when a `Deployment` became unhealthy, we reconcile on our short wait cadence (i.e. `30s`) until it becomes healthy again, at which point we cease requeing.

[contribution process]: https://git.io/fj2m9
