### PR TITLE
[(Manual) Backport release-1.1] Do not requeue on successful revision reconcile 

### DIFF
--- a/internal/controller/pkg/revision/reconciler.go
+++ b/internal/controller/pkg/revision/reconciler.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/client-go/kubernetes"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -230,6 +231,7 @@ func SetupProviderRevision(mgr ctrl.Manager, l logging.Logger, cache xpkg.Cache,
 	return ctrl.NewControllerManagedBy(mgr).
 		Named(name).
 		For(&v1.ProviderRevision{}).
+		Owns(&appsv1.Deployment{}).
 		Complete(r)
 }
 
@@ -441,5 +443,5 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 
 	r.record.Event(pr, event.Normal(reasonSync, "Successfully configured package revision"))
 	pr.SetConditions(v1.Healthy())
-	return reconcile.Result{RequeueAfter: longWait}, errors.Wrap(r.client.Status().Update(ctx, pr), errUpdateStatus)
+	return reconcile.Result{Requeue: false}, errors.Wrap(r.client.Status().Update(ctx, pr), errUpdateStatus)
 }

--- a/internal/controller/pkg/revision/reconciler.go
+++ b/internal/controller/pkg/revision/reconciler.go
@@ -28,6 +28,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	"github.com/crossplane/crossplane-runtime/pkg/event"
 	"github.com/crossplane/crossplane-runtime/pkg/logging"
@@ -232,6 +233,9 @@ func SetupProviderRevision(mgr ctrl.Manager, l logging.Logger, cache xpkg.Cache,
 		Named(name).
 		For(&v1.ProviderRevision{}).
 		Owns(&appsv1.Deployment{}).
+		Watches(&source.Kind{Type: &v1alpha1.ControllerConfig{}}, &EnqueueRequestForReferencingProviderRevisions{
+			client: mgr.GetClient(),
+		}).
 		Complete(r)
 }
 

--- a/internal/controller/pkg/revision/reconciler_test.go
+++ b/internal/controller/pkg/revision/reconciler_test.go
@@ -717,7 +717,7 @@ func TestReconcile(t *testing.T) {
 				},
 			},
 			want: want{
-				r: reconcile.Result{RequeueAfter: longWait},
+				r: reconcile.Result{Requeue: false},
 			},
 		},
 		"SuccessfulActiveRevisionIgnoreConstraints": {
@@ -763,7 +763,7 @@ func TestReconcile(t *testing.T) {
 				},
 			},
 			want: want{
-				r: reconcile.Result{RequeueAfter: longWait},
+				r: reconcile.Result{Requeue: false},
 			},
 		},
 		"ErrEstablishActiveRevision": {
@@ -853,7 +853,7 @@ func TestReconcile(t *testing.T) {
 				},
 			},
 			want: want{
-				r: reconcile.Result{RequeueAfter: longWait},
+				r: reconcile.Result{Requeue: false},
 			},
 		},
 		"ErrEstablishInactiveRevision": {

--- a/internal/controller/pkg/revision/watch.go
+++ b/internal/controller/pkg/revision/watch.go
@@ -1,0 +1,87 @@
+/*
+Copyright 2021 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package revision
+
+import (
+	"context"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/workqueue"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	v1 "github.com/crossplane/crossplane/apis/pkg/v1"
+	"github.com/crossplane/crossplane/apis/pkg/v1alpha1"
+)
+
+type adder interface {
+	Add(item interface{})
+}
+
+// EnqueueRequestForReferencingProviderRevisions enqueues a request for all
+// provider revisions tha reference a ControllerConfig when the given
+// ControllerConfig changes.
+type EnqueueRequestForReferencingProviderRevisions struct {
+	client client.Client
+}
+
+// Create enqueues a request for all provider revisions that reference a given
+// ControllerConfig.
+func (e *EnqueueRequestForReferencingProviderRevisions) Create(evt event.CreateEvent, q workqueue.RateLimitingInterface) {
+	e.add(evt.Object, q)
+}
+
+// Update enqueues a request for all provider revisions that reference a given
+// ControllerConfig.
+func (e *EnqueueRequestForReferencingProviderRevisions) Update(evt event.UpdateEvent, q workqueue.RateLimitingInterface) {
+	e.add(evt.ObjectOld, q)
+	e.add(evt.ObjectNew, q)
+}
+
+// Delete enqueues a request for all provider revisions that reference a given
+// ControllerConfig.
+func (e *EnqueueRequestForReferencingProviderRevisions) Delete(evt event.DeleteEvent, q workqueue.RateLimitingInterface) {
+	e.add(evt.Object, q)
+}
+
+// Generic enqueues a request for all provider revisions that reference a given
+// ControllerConfig.
+func (e *EnqueueRequestForReferencingProviderRevisions) Generic(evt event.GenericEvent, q workqueue.RateLimitingInterface) {
+	e.add(evt.Object, q)
+}
+
+func (e *EnqueueRequestForReferencingProviderRevisions) add(obj runtime.Object, queue adder) {
+	cc, ok := obj.(*v1alpha1.ControllerConfig)
+	if !ok {
+		return
+	}
+
+	l := &v1.ProviderRevisionList{}
+	if err := e.client.List(context.TODO(), l); err != nil {
+		// TODO(hasheddan): Handle this error?
+		return
+	}
+
+	for _, pr := range l.Items {
+		ref := pr.GetControllerConfigRef()
+		if ref != nil && ref.Name == cc.GetName() {
+			queue.Add(reconcile.Request{NamespacedName: types.NamespacedName{Name: pr.GetName()}})
+		}
+	}
+}

--- a/internal/controller/pkg/revision/watch.go
+++ b/internal/controller/pkg/revision/watch.go
@@ -35,7 +35,7 @@ type adder interface {
 }
 
 // EnqueueRequestForReferencingProviderRevisions enqueues a request for all
-// provider revisions tha reference a ControllerConfig when the given
+// provider revisions that reference a ControllerConfig when the given
 // ControllerConfig changes.
 type EnqueueRequestForReferencingProviderRevisions struct {
 	client client.Client

--- a/internal/controller/pkg/revision/watch_test.go
+++ b/internal/controller/pkg/revision/watch_test.go
@@ -1,0 +1,103 @@
+/*
+Copyright 2021 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package revision
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/pkg/errors"
+
+	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
+	"github.com/crossplane/crossplane-runtime/pkg/test"
+
+	v1 "github.com/crossplane/crossplane/apis/pkg/v1"
+	"github.com/crossplane/crossplane/apis/pkg/v1alpha1"
+)
+
+var (
+	_ handler.EventHandler = &EnqueueRequestForReferencingProviderRevisions{}
+)
+
+type addFn func(item interface{})
+
+func (fn addFn) Add(item interface{}) {
+	fn(item)
+}
+
+func TestAdd(t *testing.T) {
+	errBoom := errors.New("boom")
+	name := "coolname"
+	prName := "coolpr"
+
+	cases := map[string]struct {
+		obj              runtime.Object
+		client           client.Client
+		controllerConfig *v1alpha1.ControllerConfig
+		queue            adder
+	}{
+		"ObjectIsNotAControllConfig": {
+			queue: addFn(func(_ interface{}) { t.Errorf("queue.Add() called unexpectedly") }),
+		},
+		"ListError": {
+			obj: &v1alpha1.ControllerConfig{ObjectMeta: metav1.ObjectMeta{Name: name}},
+			client: &test.MockClient{
+				MockList: test.NewMockListFn(errBoom),
+			},
+			controllerConfig: &v1alpha1.ControllerConfig{},
+			queue:            addFn(func(_ interface{}) { t.Errorf("queue.Add() called unexpectedly") }),
+		},
+		"SuccessfulEnqueue": {
+			obj: &v1alpha1.ControllerConfig{ObjectMeta: metav1.ObjectMeta{Name: name}},
+			client: &test.MockClient{
+				MockList: test.NewMockListFn(nil, func(obj client.ObjectList) error {
+					l := obj.(*v1.ProviderRevisionList)
+					l.Items = []v1.ProviderRevision{
+						{
+							ObjectMeta: metav1.ObjectMeta{Name: prName},
+							Spec: v1.PackageRevisionSpec{
+								ControllerConfigReference: &xpv1.Reference{},
+							},
+						},
+						{
+							ObjectMeta: metav1.ObjectMeta{Name: "noRef"},
+						},
+					}
+					return nil
+				}),
+			},
+			queue: addFn(func(got interface{}) {
+				want := reconcile.Request{NamespacedName: types.NamespacedName{Name: prName}}
+				if diff := cmp.Diff(want, got); diff != "" {
+					t.Errorf("-want, +got:\n%s\n", diff)
+				}
+			}),
+		},
+	}
+
+	for _, tc := range cases {
+		e := &EnqueueRequestForReferencingProviderRevisions{client: tc.client}
+		e.add(tc.obj, tc.queue)
+	}
+}


### PR DESCRIPTION
# Description
Backport of #2503 to `release-1.1`.

_This backport was performed manually due to a minor merge conflict._