### PR TITLE
Add pkgrev category to revision types

### DIFF
--- a/apis/pkg/v1/configuration_types.go
+++ b/apis/pkg/v1/configuration_types.go
@@ -77,7 +77,7 @@ type ConfigurationList struct {
 // +kubebuilder:printcolumn:name="DEP-FOUND",type="string",JSONPath=".status.foundDependencies"
 // +kubebuilder:printcolumn:name="DEP-INSTALLED",type="string",JSONPath=".status.installedDependencies"
 // +kubebuilder:printcolumn:name="AGE",type="date",JSONPath=".metadata.creationTimestamp"
-// +kubebuilder:resource:scope=Cluster,categories={crossplane}
+// +kubebuilder:resource:scope=Cluster,categories={crossplane,pkgrev}
 type ConfigurationRevision struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/apis/pkg/v1/provider_types.go
+++ b/apis/pkg/v1/provider_types.go
@@ -82,7 +82,7 @@ type ProviderList struct {
 // +kubebuilder:printcolumn:name="DEP-FOUND",type="string",JSONPath=".status.foundDependencies"
 // +kubebuilder:printcolumn:name="DEP-INSTALLED",type="string",JSONPath=".status.installedDependencies"
 // +kubebuilder:printcolumn:name="AGE",type="date",JSONPath=".metadata.creationTimestamp"
-// +kubebuilder:resource:scope=Cluster,categories={crossplane}
+// +kubebuilder:resource:scope=Cluster,categories={crossplane,pkgrev}
 type ProviderRevision struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/apis/pkg/v1beta1/configuration_types.go
+++ b/apis/pkg/v1beta1/configuration_types.go
@@ -79,7 +79,7 @@ type ConfigurationList struct {
 // +kubebuilder:printcolumn:name="DEP-FOUND",type="string",JSONPath=".status.foundDependencies"
 // +kubebuilder:printcolumn:name="DEP-INSTALLED",type="string",JSONPath=".status.installedDependencies"
 // +kubebuilder:printcolumn:name="AGE",type="date",JSONPath=".metadata.creationTimestamp"
-// +kubebuilder:resource:scope=Cluster,categories={crossplane}
+// +kubebuilder:resource:scope=Cluster,categories={crossplane,pkgrev}
 type ConfigurationRevision struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/apis/pkg/v1beta1/provider_types.go
+++ b/apis/pkg/v1beta1/provider_types.go
@@ -84,7 +84,7 @@ type ProviderList struct {
 // +kubebuilder:printcolumn:name="DEP-FOUND",type="string",JSONPath=".status.foundDependencies"
 // +kubebuilder:printcolumn:name="DEP-INSTALLED",type="string",JSONPath=".status.installedDependencies"
 // +kubebuilder:printcolumn:name="AGE",type="date",JSONPath=".metadata.creationTimestamp"
-// +kubebuilder:resource:scope=Cluster,categories={crossplane}
+// +kubebuilder:resource:scope=Cluster,categories={crossplane,pkgrev}
 type ProviderRevision struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/cluster/crds/pkg.crossplane.io_configurationrevisions.yaml
+++ b/cluster/crds/pkg.crossplane.io_configurationrevisions.yaml
@@ -10,6 +10,7 @@ spec:
   names:
     categories:
     - crossplane
+    - pkgrev
     kind: ConfigurationRevision
     listKind: ConfigurationRevisionList
     plural: configurationrevisions

--- a/cluster/crds/pkg.crossplane.io_providerrevisions.yaml
+++ b/cluster/crds/pkg.crossplane.io_providerrevisions.yaml
@@ -10,6 +10,7 @@ spec:
   names:
     categories:
     - crossplane
+    - pkgrev
     kind: ProviderRevision
     listKind: ProviderRevisionList
     plural: providerrevisions


### PR DESCRIPTION


<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Adds a pkgrev category to provider revisions and configuration revisions
so that they can be listed more easily in a cluster.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

> Note: I am of the opinion that this change can be included in v1.4 despite being in code freeze given that it is mostly non-functional and is simply adding some metadata to our CRDs.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

Installed Crossplane and `registry.upbound.io/xp/getting-started-with-aws:v1.3.1` and confirmed that `k get pkgrev` shows revision for both `getting-started-with-aws` and `provider-aws`.

```
🤖 (enterprise-server) k get pkgrev
NAME                                                                               HEALTHY   REVISION   IMAGE                                                    STATE    DEP-FOUND   DEP-INSTALLED   AGE
configurationrevision.pkg.crossplane.io/xp-getting-started-with-aws-937fe46aec0d   True      1          registry.upbound.io/xp/getting-started-with-aws:v1.3.1   Active   1           1               37s

NAME                                                                      HEALTHY   REVISION   IMAGE                             STATE    DEP-FOUND   DEP-INSTALLED   AGE
providerrevision.pkg.crossplane.io/crossplane-provider-aws-dd1e35810a48   True      1          crossplane/provider-aws:v0.19.0   Active                               34s
```

[contribution process]: https://git.io/fj2m9
