### PR TITLE
Design doc for generated providers that are based on Terraform

### DIFF
--- a/design/design-doc-terraform-code-generation.md
+++ b/design/design-doc-terraform-code-generation.md
@@ -1,0 +1,225 @@
+# Code Generation Against Terraform
+* Owner: Muvaffak Onus (@muvaf)
+* Reviewers: Crossplane Maintainers
+* Status: Draft
+
+## Background
+
+Managed resources are granular, high fidelity Crossplane representations of a
+resource in an external system - i.e. resources that are managed by Crossplane.
+A provider extends Crossplane by installing controllers for new kinds of managed
+resources. Providers typically group conceptually related managed resources;
+for example the AWS provider installs support for AWS managed resources like
+RDSInstance and S3Bucket.
+
+Crossplane community has been developing providers in Go to add support for the
+services they need. However, the development process can be cumbersome for some
+and sometimes just the sheer number of managed resources needed can be way too
+many for one to develop one by one. In order to address this issue, we have come
+up with several solutions like [crossplane-tools][crossplane-tools] for simple
+generic code generation and integrating to code generator pipeline of AWS Controllers
+for Kubernetes project to generate fully-fledged resources, albeit still need
+manual additions to make sure corner cases are handled.
+
+The main challenge with the code generation efforts is that the corresponding APIs
+are usually not as consistent, hence need resource specific logic to be implemented
+manually. However, we are not alone in this space. Terraform community has been
+building declarative API for many infrastructure services handling those corner
+cases. As Crossplane community, we'd like to build on top of the shoulders of the
+giants and leverage that support that's been developed for years.
+
+## Goals
+
+We would like to develop a code generation pipeline that can be used for generating
+a Crossplane provider for any Terraform provider. We'd like the code generator
+pipeline to be able to:
+
+* Offload resource-specific logic to Terraform CLI and/or Terraform Provider as
+  much as possible so that we can get hands-off generation,
+* Generate managed resources taht satisfy Crossplane Resource Model requirements,
+* Target any Terraform provider available.
+
+While it'd be nice to generate a whole provider from scratch, that's not our main
+goal. For example, it should be fine to manually write `ProviderConfig` CRD and
+its logic. The key point is to automate things that have to be implemented for
+every resource differently.
+
+## Options
+
+There are different ways that we can choose to leverage Terraform providers:
+* Import provider code
+* Talk directly with provider server via gRPC
+* Talk with Terraform CLI using HCL/JSON interface
+
+In order to make a decision, let's inspect what makes up a managed resource support
+and see how they cover those requirements.
+
+The Go code that needs to be written to add support for a managed resource can be
+classified as following:
+* CRD Structs
+  * Separate Spec and Status structs
+* Translation Functions
+  * Spec -> API Input
+  * Target SDK Struct -> Spec Late Initialization
+  * API Output -> Status
+  * Spec <-> API Output Comparison for up-to-date check
+* Controller Code
+  * Readiness Check
+  * Calls to API
+  * Connection Details
+
+| Functionality | Import Provider | Talk to Provider | HCL |
+| --- | --- | --- | ---|
+| Separate Spec and Status structs | Iterate over schema.Provider | Iterate over schema.Provider | Iterate over schema.Provider |
+| Spec -> API Input | Generated `cty` Translation | Generated `cty` Translation | JSON Marshalling (multi-key) |
+| Target SDK Struct -> Spec Late Initialization | Generated `cty` Translation | Generated `cty` Translation | JSON Marshalling (multi-key) and reflection |
+| API Output -> Status | Generated `cty` Translation | Generated `cty` Translation | JSON Marshalling (multi-key) |
+| Spec <-> API Output Comparison for up-to-date check | Generated `cty` Translation (leaking) | Generated `cty` Translation (leaking) | `terraform plan` diff |
+| Readiness Check | `create/update` completion | `create/update` completion | `terraform apply` completion |
+| Calls to API | call `create/update/delete/read` funcs | call `create/update/delete/read` funcs | `terraform apply/destroy` |
+| Connection Details | iterate over `create` result | iterate over `create` result | `sensitive_attributes` in tfstate |
+
+> "leaking" in this context means that there are resource-specific details we can't
+> generate.
+
+> jsoniter library allows usage of tag keys other than "json", which would allow
+> us define multiple keys for the same field to cover snake case Terraform struct
+> fields and camel case CRD struct fields.
+
+### Import Provider
+
+The main advantage of this approach is that we're closer to the actual API calls
+that are made to the external API, which would possibly make things run faster
+since we eliminate HCL middleware.
+
+On the other hand, we'd have to do some of the operations Terraform CLI does, like
+diff operations. Additionally, the mechanics of providers naturally include core
+Terraform code structs that we'd need to develop logic to work on and that'd increase
+our bug surface since they are not intended to be called by something other than
+Terraform CLI code.
+
+### Talk to Provider
+
+When Terraform starts executing an action, it spawns the provider gRPC server and
+talks with it. Similarly, Crossplane provider process could bring up a server
+and different reconciliation routines could talk with it via gRPC.
+
+This option is not too different than importing provider since we'd still work
+with `cty` wire format and implement things that Terraform CLI provides. In fact,
+the earlier effort for building code generation built on top of Terraform used
+this approach.
+
+### Interact with Terraform CLI
+
+We can produce a blob of JSON and give that to Terraform CLI for processing whenever
+we need to execute an operation. [As mentioned][json-hcl-compatibility] in
+Terraform docs, JSON can be a full replacement for HCL and thanks to [`jsoniter`][jsoniter]
+library, we'll be able to have multiple tag keys to use in marshall/unmarshall
+operations depending on the context.
+
+
+This option has the advantage that we'd be interacting
+with Terraform just like any user, hence all features, stability guarantees and
+community support would be available to us. Additionally, doing conversion from
+and to JSON wouldn't require generated code as HCL library provides powerful tools
+to do that.
+
+A disadvantage of this approach is speed because the information format flow would
+be `Go Struct -> JSON -> cty -> provider call`, whereas other options don't include
+HCL in their flow. Additionally, we'd need to work with the filesystem to manage
+HCL files and `.tfstate` file that contains the state. The footprint of multiple
+instances of Terraform CLI working at the same time could also bring in resource
+problems, however, we can fork the CLI to allow calling the CLI functions directly
+in our code to avoid that.
+
+## Proposal
+
+From the three options listed, interacting with Terraform CLI via HCL will get us
+faster to the finish line and will open up less bug surface. The main driver of
+this decision is the simplicity of the workflow, i.e. there will be very few
+places where we'd have to interact with Terraform Go structs, which are not designed
+for such interaction.
+
+### Schema Generation
+
+Every Terraform provider exposes a [`*schema.Schema`][schema-schema] object per
+resource type that has all information related to a field, such as whether it's
+immutable, computed, required etc. In our pipeline, we will iterate through
+each [`*schema.Schema`][schema-schema] and generate spec and status structs and
+fields. We will use standard Go `types` library to encode the information and
+then print it using standard Go templating tooling. These structs will need to
+be convertible to and from JSON, which will be handled by multiple field tags.
+An example output will be like following:
+
+```go
+// VPCParameters define the desired state of an AWS Virtual Private Cloud.
+type VPCParameters struct {
+	// Region is the region you'd like your VPC to be created in.
+	Region *string `json:"region" tf:"region"`
+
+	// CIDRBlock is the IPv4 network range for the VPC, in CIDR notation. For
+	// example, 10.0.0.0/16.
+	// +kubebuilder:validation:Required
+	// +immutable
+	CIDRBlock string `json:"cidrBlock" tf:"cidr_block"`
+
+	// A boolean flag to enable/disable DNS support in the VPC
+	// +optional
+	EnableDNSSupport *bool `json:"enableDnsSupport,omitempty" tf:"enable_dns_support"`
+
+	// Indicates whether the instances launched in the VPC get DNS hostnames.
+	// +optional
+	EnableDNSHostNames *bool `json:"enableDnsHostNames,omitempty" tf:"enable_dns_host_names"`
+
+	// The allowed tenancy of instances launched into the VPC.
+	// +optional
+	InstanceTenancy *string `json:"instanceTenancy,omitempty" tf:"instance_tenancy"`
+}
+```
+
+As you might have noticed, the field tags Terraform uses are snake case whereas
+the JSON tags we use should be camel case and Go field name should be upper camel.
+A small utility for doing back and forth with these strings will be introduced.
+The source of truth will always be the one from Terraform Provider schema.
+
+### Translation Functions
+
+We will introduce additional tag key called `tf` in order to store the field name
+used in Terraform schema so that conversions don't require strong-typed functions
+to be generated. Namely, the following mechanisms will be used for each:
+
+* Spec -> API Input
+  * `jsoniter.Marshal` (using `tf` key)
+* Target SDK Struct -> Spec Late Initialization
+  * `jsoniter.Marshal` (using `tf` key) on empty `Parameters` object
+  * Recursive iteration of fields of two `Parameters` object using `reflect` library to late-initialize. 
+* API Output -> Status
+  * `jsoniter.Unmarshal` (using `tf` key) using output of `terraform show --json`
+* Spec <-> API Output Comparison for up-to-date check
+  * Running `terraform plan --json` to see if an update is needed
+  
+
+### Controller Code
+
+We will have a single implementation of [`ExternalClient`][external-client] that
+will be used across all providers built on top of Terraform. However, since
+connection details differ between provider APIs, there will be single implementation
+of [`ExternalConnecter`][external-connecter] struct for every provider implemented
+manually, which will instantiate the generic [`ExternalClient`][external-client]
+struct per CRD.
+
+The Terraform controller will have two main parts:
+* Scheduler
+  * It will manage all the low-level interaction with Terraform CLI.
+* Reconciler
+  * It will be the struct that implements [`ExternalClient`][external-client]
+
+#### Scheduler
+
+
+
+[jsoniter]: https://github.com/scoutapp/jsoniter-go
+[json-multipletagkey]: https://github.com/scoutapp/jsoniter-go/blob/ca39e5a/config.go#L22
+[schema-schema]: https://github.com/hashicorp/terraform-plugin-sdk/blob/9321fe1/helper/schema/schema.go#L37
+[external-client]: https://github.com/crossplane/crossplane-runtime/blob/5193d24/pkg/reconciler/managed/reconciler.go#L187
+[external-connecter]: https://github.com/crossplane/crossplane-runtime/blob/5193d24/pkg/reconciler/managed/reconciler.go#L166

--- a/design/design-doc-terraform-code-generation.md
+++ b/design/design-doc-terraform-code-generation.md
@@ -85,6 +85,13 @@ roughly classified as following:
 | Calls to API | call `create/update/delete/read` funcs | call `create/update/delete/read` funcs | `terraform apply/destroy` |
 | Connection Details | iterate over `create` result | iterate over `create` result | `sensitive_attributes` in tfstate |
 
+> Note that even if we import provider code, we need to work with `cty` format
+> because the input provider functions expect is of type [`schema.ResourceData`][resource-data],
+> which can be generated only if you have [`terraform.InstanceState`][instance-state]
+> because all of its fields are internal. While state can be constructed, due to
+> its structure of [how it stores][instance-state-map] key/values, using `cty`
+> empowered with the schema of the resource would be the best choice.
+
 > "leaking" in this context means that there are resource-specific details we can't
 > generate.
 
@@ -514,3 +521,6 @@ hand-crafted code and no other tool has as much coverage as Terraform.
 [crossplane-tools]: https://github.com/crossplane/crossplane-tools/
 [ack-guide]: https://github.com/crossplane/provider-aws/blob/master/CODE_GENERATION.md
 [secret-key-selector]: https://github.com/crossplane/crossplane-runtime/blob/36fc69eff96ecb5856f156fec077ed3f3c3b30b1/apis/common/v1/resource.go#L72
+[instance-state]: https://github.com/hashicorp/terraform-plugin-sdk/blob/0e34772/helper/schema/resource.go#L859
+[resource-data]: https://github.com/hashicorp/terraform-plugin-sdk/blob/0e34772dad547d6b69148f57d95b324af9929542/helper/schema/resource_data.go#L22
+[instance-state-map]: https://github.com/hashicorp/terraform-plugin-sdk/blob/0e34772dad547d6b69148f57d95b324af9929542/terraform/state.go#L1330

--- a/design/design-doc-terrajet.md
+++ b/design/design-doc-terrajet.md
@@ -507,6 +507,20 @@ exceptional cases that need to be handled and customizations that should be
 implemented per resource. Terraform community has done that for years with
 hand-crafted code and no other tool has as much coverage as Terraform.
 
+## Prior Art
+
+There are many projects in infrastructure space that builds on top of Terraform.
+Each of the projects have their own limitations, additional features and different
+license restrictions.
+
+* [Crossplane: Terraform Provider Runtime](https://github.com/crossplane/crossplane/blob/e2d7278/design/design-doc-terraform-provider-runtime.md)
+* [Crossplane: provider-terraform](https://github.com/crossplane-contrib/provider-terraform)
+* [Hashicorp Terraform Cloud Operator](https://github.com/hashicorp/terraform-k8s)
+* [Rancher Terraform Controller](https://github.com/rancher/terraform-controller)
+* [OAM Terraform Controller](https://github.com/oam-dev/terraform-controller)
+* [Kubeform](https://github.com/kubeform/kubeform)
+* [Terraform Operator](https://github.com/isaaguilar/terraform-operator)
+
 [jsoniter]: https://github.com/scoutapp/jsoniter-go
 [json-multipletagkey]: https://github.com/scoutapp/jsoniter-go/blob/ca39e5a/config.go#L22
 [schema-schema]: https://github.com/hashicorp/terraform-plugin-sdk/blob/9321fe1/helper/schema/schema.go#L37

--- a/design/design-doc-terrajet.md
+++ b/design/design-doc-terrajet.md
@@ -114,7 +114,9 @@ CLI.
 Additionally, the mechanics of providers naturally include core Terraform code
 structs that we'd need to develop logic to work on and that'd increase
 our bug surface since they are not intended to be called by something other than
-Terraform CLI code.
+Terraform CLI code. This fact has some consequences around how the authors of the
+providers organize their code as well. For example, Azure provider stores everything
+under `internal` package which would force us to fork the provider.
 
 ### Talk to Provider Server
 
@@ -178,6 +180,12 @@ For example, [`ResourceDiff`][resource-diff] struct here has many fields and
 functions that are not exposed. So the implementation we'd be doing if we went
 with other two options will be very similar to how Terraform CLI implemented these
 functions already.
+
+Additionally, we see that some providers hide everything under `internal` package.
+This makes it essential to fork the code for the importing option. In other options,
+we still need to import the provider to get the schema to be used for generating
+the CRD types, but that happens during development time, so we can have some
+workarounds making the generator access the schema.
 
 #### Optionality for the Future
 

--- a/design/design-doc-terrajet.md
+++ b/design/design-doc-terrajet.md
@@ -1,7 +1,7 @@
 # Terrajet: Code Generation for Terraform-based Providers
 * Owner: Muvaffak Onus (@muvaf)
 * Reviewers: Crossplane Maintainers
-* Status: Draft
+* Status: Approved
 
 ## Background
 

--- a/design/design-doc-terrajet.md
+++ b/design/design-doc-terrajet.md
@@ -413,6 +413,22 @@ and the sensitive attributes will be stored in the connection detail secret of t
 resource. For sensitive inputs, we'll have a mechanism to add a [`SecretKeySelector`][secret-key-selector]
 for that field and use it to get the input from a `Secret` user pointed to.
 
+#### API Representation
+
+Crossplane tries to match the corresponding provider API as closely as possible
+with a clear separation, i.e. dedicated `spec.forProvider`. While Terraform also
+does that for most resources, there are occasionally fields in the Terraform schema
+of the resource that configures the behavior of Terraform execution rather than
+only the request made to the provider API. For example, `force_destroy` is a field
+in S3 Bucket Terraform schema but there is no corresponding API call - Terraform
+just deletes all objects in the bucket before calling deletion.
+
+For such cases, we'll expose configuration points for provider authors to provide
+per-resource exception information. They will be able to remove/add specific fields,
+manipulate their JSON tags or code comments. Since authors will call the pipeline
+in a Go context, they will be able to reuse same exception information for many
+resources if it's generic enough.
+
 #### References
 
 > It is still to be decided whether we'll keep current cross-resource references.

--- a/design/design-doc-terrajet.md
+++ b/design/design-doc-terrajet.md
@@ -1,4 +1,4 @@
-# Code Generation Against Terraform
+# Terrajet: Code Generation for Terraform-based Providers
 * Owner: Muvaffak Onus (@muvaf)
 * Reviewers: Crossplane Maintainers
 * Status: Draft
@@ -486,9 +486,7 @@ in Terraform CLI had to be implemented and in some cases, like `cty` conversion,
 it used code generation instead of generic marshaling like Terraform CLI.
 Additionally, due to the fact that that effort wasn't finished, it didn't cover
 all Terraform logic, hence there are places where we need to keep implementing
-functionality of CLI. ~~Also, some functionality is half-baked, for example,
-generated schema generation doesn't support nested structs, hence many resources
-cannot be supported.~~ (need more investigation)
+functionality of CLI.
 
 Overall, the cost of writing the pipeline from scratch targeting the CLI is lower
 than to understand the existing code, spot the broken parts, adopt it and make


### PR DESCRIPTION
### Description of your changes

This design doc has been in draft state for a while but the implementation has already started. Code generation tools and common utilities are in [terrajet](https://github.com/crossplane-contrib/terrajet) repository. [`provider-tf-aws`](https://github.com/crossplane-contrib/provider-tf-aws) is the first terraform-based provider that is compatible with (most) Crossplane Resource Model requirements.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

N/A

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
