### PR TITLE
Do not couple lifecycle of CRDs/XRDs to revisions

### DIFF
--- a/internal/controller/pkg/revision/establisher.go
+++ b/internal/controller/pkg/revision/establisher.go
@@ -18,10 +18,10 @@ package revision
 
 import (
 	"context"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/pkg/errors"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -150,7 +150,7 @@ func (e *APIEstablisher) create(ctx context.Context, obj resource.Object, parent
 	// get deleted when the new revision doesn't include it in order not to lose
 	// user data, such as custom resources of an old CRD.
 	falseVal := false
-	refs := make([]v1.OwnerReference, len(parent.GetOwnerReferences())+1)
+	refs := make([]metav1.OwnerReference, len(parent.GetOwnerReferences())+1)
 	for i, ownerRef := range parent.GetOwnerReferences() {
 		nonControllerRef := ownerRef.DeepCopy()
 		nonControllerRef.Controller = &falseVal
@@ -167,7 +167,7 @@ func (e *APIEstablisher) update(ctx context.Context, current, desired resource.O
 	// get deleted when the new revision doesn't include it in order not to lose
 	// user data, such as custom resources of an old CRD.
 	falseVal := false
-	pkgRefs := make([]v1.OwnerReference, len(parent.GetOwnerReferences()))
+	pkgRefs := make([]metav1.OwnerReference, len(parent.GetOwnerReferences()))
 	for i, ownerRef := range parent.GetOwnerReferences() {
 		nonControllerRef := ownerRef.DeepCopy()
 		nonControllerRef.Controller = &falseVal
@@ -175,7 +175,7 @@ func (e *APIEstablisher) update(ctx context.Context, current, desired resource.O
 	}
 	if !control {
 		refs := append(pkgRefs, meta.AsOwner(meta.TypedReferenceTo(parent, parent.GetObjectKind().GroupVersionKind())))
-		for _,  ref := range refs {
+		for _, ref := range refs {
 			meta.AddOwnerReference(current, ref)
 		}
 		return e.client.Update(ctx, current, opts...)

--- a/internal/controller/pkg/revision/establisher_test.go
+++ b/internal/controller/pkg/revision/establisher_test.go
@@ -72,7 +72,16 @@ func TestAPIEstablisherEstablish(t *testing.T) {
 						},
 					},
 				},
-				parent:  &v1.ProviderRevision{},
+				parent: &v1.ProviderRevision{
+					ObjectMeta: metav1.ObjectMeta{
+						OwnerReferences: []metav1.OwnerReference{
+							{
+								Name: "provider-name",
+								UID:  "some-unique-uid-2312",
+							},
+						},
+					},
+				},
 				control: true,
 			},
 			want: want{
@@ -95,7 +104,16 @@ func TestAPIEstablisherEstablish(t *testing.T) {
 						},
 					},
 				},
-				parent:  &v1.ProviderRevision{},
+				parent: &v1.ProviderRevision{
+					ObjectMeta: metav1.ObjectMeta{
+						OwnerReferences: []metav1.OwnerReference{
+							{
+								Name: "provider-name",
+								UID:  "some-unique-uid-2312",
+							},
+						},
+					},
+				},
 				control: true,
 			},
 			want: want{


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

Per the discussion in https://github.com/crossplane/crossplane/issues/2219 , now all CRDs have two owner references: one controlling `ProviderRevision` and another one non-controlling `Provider` (or `Configuration` flavor). This allows users to keep CRDs/XRDs in the cluster even if `ProviderRevision`s are deleted. They will be gone only if you decide to delete `Provider`.

Fixes https://github.com/crossplane/crossplane/issues/2219

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

Manually. I've installed AWS Provider and validated that deleting `ProviderRevision` doesn't affect the existing CRDs; it only removes that `ProviderRevision` from the owner references list. Then new revision is created immediately and gets added in the place of the deleted one.

The previous behavior was that when you delete `ProviderRevision`, all CRDs would be gone, new revision would be created and CRDs would be installed again. Now they are only _updated_.

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
