### PR TITLE
Fix helm chart init flags

### DIFF
--- a/cmd/crossplane/core/init.go
+++ b/cmd/crossplane/core/init.go
@@ -31,8 +31,8 @@ import (
 
 // initCommand configuration for the initialization of core Crossplane controllers.
 type initCommand struct {
-	Providers      []string
-	Configurations []string
+	Providers      []string `name:"provider" help:"Pre-install a Provider by giving its image URI. This argument can be repeated."`
+	Configurations []string `name:"configuration" help:"Pre-install a Configuration by giving its image URI. This argument can be repeated."`
 }
 
 // Run starts the initialization process.


### PR DESCRIPTION
Fixes #2549

I have:

- [X] Read and followed Crossplane's [contribution process].
- [X] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested
On an empty cluster:
```
make
helm install crossplane ./_output/charts/crossplane-1.5.0-rc.0.9.g99643d04.dirty.tgz  --set provider.packages[0]=crossplane/provider-helm:master,provider.packages[1]=crossplane/provider-kubernetes:main --set image.tag=master
```
-> check that crossplane was installed and providers are healthy.


Does the auto backport label work with the helm charts? Getting the existing chart updated would definitely come in handy
