### PR TITLE
Update doc: fix import example

### DIFF
--- a/docs/concepts/managed-resources.md
+++ b/docs/concepts/managed-resources.md
@@ -238,6 +238,7 @@ metadata:
   annotations:
     crossplane.io/external-name: existing-network
 spec:
+  forProvider: {}
   providerConfigRef:
     name: default
 ```


### PR DESCRIPTION
### Description of your changes

The example for _importing existing resources_ is not working as it is, since `spec.forProvider` is a required field for all (most?) managed resources.

Fixes https://github.com/crossplane/provider-gcp/issues/362

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

Try importing an existing resource with the updated example. 

[contribution process]: https://git.io/fj2m9
