### PR TITLE
Reeanble K8s credential providers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,8 +32,8 @@ GO_TEST_PARALLEL := $(shell echo $$(( $(NPROCS) / 2 )))
 GO_STATIC_PACKAGES = $(GO_PROJECT)/cmd/crossplane $(GO_PROJECT)/cmd/crank
 GO_LDFLAGS += -X $(GO_PROJECT)/internal/version.version=$(VERSION)
 GO_SUBDIRS += cmd internal apis
-# disables credential providers for pulling package images
-GO_TAGS += disable_gcp disable_aws disable_azure
+# uncomment to disable credential providers for pulling package images
+# GO_TAGS += disable_gcp disable_aws disable_azure
 GO111MODULE = on
 -include build/makelib/golang.mk
 


### PR DESCRIPTION
### Description of your changes

Fixes #2561

This PR reactivates K8s keychain credential providers that have been disabled in #2108 because of some issues that have now been fixed.

This PR bumps `go-containerregistry` and its dependencies to the latest version.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

Manually on an EKS cluster
