### PR TITLE
Fixed 'crossplane: error: unknown flag --provider, did you mean --providers?' error

### DIFF
--- a/cluster/charts/crossplane/templates/deployment.yaml
+++ b/cluster/charts/crossplane/templates/deployment.yaml
@@ -37,7 +37,7 @@ spec:
           - core
           - init
           {{- range $arg := .Values.provider.packages }}
-          - --provider
+          - --providers
           - "{{ $arg }}"
           {{- end }}
           {{- range $arg := .Values.configuration.packages }}


### PR DESCRIPTION
### Description of your changes

When you try to install a provider package with `--set provider.packages={crossplane/provider-aws:master}` you get an error `crossplane: error: unknown flag --provider, did you mean --providers?`

Fixes #

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested
Installed AWS provider using the updated chart 

[contribution process]: https://git.io/fj2m9
