### PR TITLE
Re-enable installing darwin arm64 CLI binaries

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -32,8 +32,11 @@ case $OS in
     ;;
   Darwin)
     case $ARCH in
-      x86_64|amd64|arm64)
+      x86_64|amd64)
         OS_ARCH=darwin_amd64
+        ;;
+      arm64)
+        OS_ARCH=darwin_arm64
         ;;
       *)
         unsupported_arch $OS $ARCH


### PR DESCRIPTION


<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Support for building and publishing darwin arm64 builds was added prior
to the v1.4.0 release, but downloading it was removed from the install
script since a stable darwin arm64 build did not yet exist. Now that
v1.4.0 has been released, we add back the darwin arm64 stanza.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

Follow up to #2466 

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

I have verified that this target exists (https://releases.crossplane.io/stable/v1.4.0/bin/darwin_arm64/), but I have do not have a machine to test it on. Will defer to @tnthornton for confirmation 👍🏻 

[contribution process]: https://git.io/fj2m9
