### PR TITLE
fix provider init arg on helm chart

### DIFF
--- a/cluster/charts/crossplane/templates/deployment.yaml
+++ b/cluster/charts/crossplane/templates/deployment.yaml
@@ -37,7 +37,7 @@ spec:
           - core
           - init
           {{- range $arg := .Values.provider.packages }}
-          - --provider
+          - --providers
           - "{{ $arg }}"
           {{- end }}
           {{- range $arg := .Values.configuration.packages }}

--- a/cluster/charts/crossplane/templates/deployment.yaml
+++ b/cluster/charts/crossplane/templates/deployment.yaml
@@ -36,9 +36,9 @@ spec:
           args:
           - core
           - init
-          {{- range $arg := .Values.provider.packages }}
+          {{- if $arg := .Values.provider.packages }}
           - --providers
-          - "{{ $arg }}"
+          - "{{ join "," $arg }}"
           {{- end }}
           {{- range $arg := .Values.configuration.packages }}
           - --configuration


### PR DESCRIPTION
Signed-off-by: dullest <49hack@gmail.com>

<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes provider init
- argument name from `provider` to `providers` in helm chart.  
- value generation logic when it has multiple providers (https://crossplane.slack.com/archives/CEF5N8X08/p1630425812009900)

I have installed chart `v1.4.0` with following `value.yaml` to include specific `provider.packages`.  

```
provider:
  packages:
    - crossplane/provider-aws:v0.19.1
```
It failed by following initContainer's error.

```
❯ k -n crossplane-system logs crossplane-5c95d6d5c6-8xxrr crossplane-init
Usage: crossplane core init

Make cluster ready for Crossplane controllers.

Flags:
  -h, --help                       Show context-sensitive help.
  -d, --debug                      Print verbose logging statements.

      --providers=PROVIDERS,...
      --configurations=CONFIGURATIONS,...


crossplane: error: unknown flag --provider, did you mean "--providers"?
```

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

```
❯ cat values-local.yaml
provider:
  packages:
    - crossplane/provider-aws:v0.19.1
    - crossplane-contrib/provider-helm:v0.8.0
    - crossplane-contrib/provider-gcp:v0.17.1

❯ helm install crossplane ./ --values values-local.yaml

❯ k logs crossplane-5bc656bbb9-z2hsd
I0910 07:23:48.267168       1 request.go:668] Waited for 1.0003632s due to client-side throttling, not priority and fairness, request: GET:https://10.96.0.1:443/apis/identity.aws.crossplane.io/v1alpha1?timeout=32s
I0910 07:23:51.870141       1 leaderelection.go:243] attempting to acquire leader lease default/crossplane-leader-election-core...
I0910 07:24:07.558131       1 leaderelection.go:253] successfully acquired lease default/crossplane-leader-election-core
I0910 07:24:21.532905       1 trace.go:205] Trace[1922361495]: "Reflector ListAndWatch" name:sigs.k8s.io/controller-runtime/pkg/cache/internal/informers_map.go:245 (10-Sep-2021 07:24:07.833) (total time: 13698ms):
Trace[1922361495]: ---"Objects listed" 13607ms (07:24:21.441)
Trace[1922361495]: [13.6989392s] [13.6989392s] END

❯ k get pod
NAME                                      READY   STATUS      RESTARTS   AGE
crossplane-5bc656bbb9-z2hsd               1/1     Running     0          47s
crossplane-rbac-manager-b775544f5-gcwqn   1/1     Running     0          47s

❯ k get providers
NAME                                      INSTALLED   HEALTHY   PACKAGE                                   AGE
crossplane-contrib-provider-gcp-v0-17-1   False                 crossplane-contrib/provider-gcp:v0.17.1   79s
crossplane-contrib-provider-helm-v0-8-0   False                 crossplane-contrib/provider-helm:v0.8.0   79s
crossplane-provider-aws-v0-19-1           True        Unknown   crossplane/provider-aws:v0.19.1           80s
```


[contribution process]: https://git.io/fj2m9
