### PR TITLE
Bump context deadline for ProviderRevision controller to 3 mins

### DIFF
--- a/internal/controller/pkg/revision/reconciler.go
+++ b/internal/controller/pkg/revision/reconciler.go
@@ -47,7 +47,7 @@ import (
 )
 
 const (
-	reconcileTimeout = 1 * time.Minute
+	reconcileTimeout = 3 * time.Minute
 
 	shortWait = 30 * time.Second
 	longWait  = 1 * time.Minute


### PR DESCRIPTION
### Description of your changes

This PRs bumps the context deadline for `providerrevision` controller from **1 min** to **3 mins**. The current deadline is not sufficient when the provider package contains a high number of CRDs. Even it does not make sense to bump the deadline indefinitely to support an infinite number of CRDs, we expect that supporting around 1000 CRDs should be a good expectation, given [provider-tf-aws](https://github.com/crossplane-contrib/provider-tf-aws) contains around 750.

I have experimented installing `turkenh/provider-tf-aws:daf1e9f7-2` with this change couple of times and noticed that it is installed in around 2 mins. I believe 3 mins should be a good value leaving some room for different environments and around 250 more CRDs (to reach our rough target of 1000).

Fixes #2564

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

Install the provider package in the issue description:

```
kubectl crossplane install provider turkenh/provider-tf-aws:daf1e9f7-2
```

[contribution process]: https://git.io/fj2m9
