### PR TITLE
Update example to get claim-name from labels

### DIFF
--- a/docs/concepts/composition.md
+++ b/docs/concepts/composition.md
@@ -510,7 +510,7 @@ spec:
           # the value of a source field in the same manner as the
           # FromCompositeFieldPath patch type.
           - fromFieldPath: spec.parameters.location
-          - fromFieldPath: metadata.annotations[crossplane.io/claim-name]
+          - fromFieldPath: metadata.labels[crossplane.io/claim-name]
         strategy: string
         string:
           # Patch output e.g: us-west-my-sql-server where location = "us-west"


### PR DESCRIPTION
It seems like crossplane.io/claim-name used to be set as an annotation, but to my knowledge this is now set as a label.

<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #

I have:

- [x] Read and followed Crossplane's [contribution process].
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
