### PR TITLE
Support exponential backoff and configurable reconcile rates

### DIFF
--- a/cmd/crossplane/core/core.go
+++ b/cmd/crossplane/core/core.go
@@ -87,7 +87,7 @@ func (c *startCommand) Run(s *runtime.Scheme, log logging.Logger) error {
 
 	o := controller.Options{
 		Logger:                  log,
-		MaxConcurrentReconciles: 1,
+		MaxConcurrentReconciles: 10,
 		PollInterval:            1 * time.Minute,
 		GlobalRateLimiter:       ratelimiter.NewGlobal(ratelimiter.DefaultGlobalRPS),
 	}

--- a/cmd/crossplane/rbac/rbac.go
+++ b/cmd/crossplane/rbac/rbac.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/alecthomas/kong"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/leaderelection/resourcelock"
 	ctrl "sigs.k8s.io/controller-runtime"
 
 	"github.com/crossplane/crossplane-runtime/pkg/controller"
@@ -84,10 +85,11 @@ func (c *startCommand) Run(s *runtime.Scheme, log logging.Logger) error {
 	}
 
 	mgr, err := ctrl.NewManager(ratelimiter.LimitRESTConfig(cfg, c.MaxReconcileRate), ctrl.Options{
-		Scheme:           s,
-		LeaderElection:   c.LeaderElection,
-		LeaderElectionID: "crossplane-leader-election-rbac",
-		SyncPeriod:       &c.SyncInterval,
+		Scheme:                     s,
+		LeaderElection:             c.LeaderElection,
+		LeaderElectionID:           "crossplane-leader-election-rbac",
+		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
+		SyncPeriod:                 &c.SyncInterval,
 	})
 	if err != nil {
 		return errors.Wrap(err, "cannot create manager")

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/Masterminds/semver v1.5.0
 	github.com/alecthomas/kong v0.2.17
 	github.com/aws/aws-sdk-go v1.31.6 // indirect
-	github.com/crossplane/crossplane-runtime v0.15.1-0.20210913015452-6a7a44ac50aa
+	github.com/crossplane/crossplane-runtime v0.15.1-0.20211029211307-c72bcdd922eb
 	github.com/docker/cli v0.0.0-20200915230204-cd8016b6bcc5 // indirect
 	github.com/docker/docker v17.12.0-ce-rc1.0.20200926000217-2617742802f6+incompatible // indirect
 	github.com/google/go-cmp v0.5.6

--- a/go.sum
+++ b/go.sum
@@ -150,8 +150,8 @@ github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsr
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/creack/pty v1.1.11/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
-github.com/crossplane/crossplane-runtime v0.15.1-0.20210913015452-6a7a44ac50aa h1:lrc8DHGKUKuYcE4xiWooB0LGl83tNOzOO4GFJTnr+J0=
-github.com/crossplane/crossplane-runtime v0.15.1-0.20210913015452-6a7a44ac50aa/go.mod h1:gKix9Gq5kRzVe/4XOpwlFgG7OurzrYayviJxWZakhw0=
+github.com/crossplane/crossplane-runtime v0.15.1-0.20211029211307-c72bcdd922eb h1:l5M88pddkMA4c4UY4isVvfTt9ThzMMasguP9NDerQoM=
+github.com/crossplane/crossplane-runtime v0.15.1-0.20211029211307-c72bcdd922eb/go.mod h1:gKix9Gq5kRzVe/4XOpwlFgG7OurzrYayviJxWZakhw0=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/internal/controller/apiextensions/apiextensions.go
+++ b/internal/controller/apiextensions/apiextensions.go
@@ -19,29 +19,28 @@ package apiextensions
 import (
 	ctrl "sigs.k8s.io/controller-runtime"
 
-	"github.com/crossplane/crossplane-runtime/pkg/logging"
-
+	"github.com/crossplane/crossplane-runtime/pkg/controller"
 	"github.com/crossplane/crossplane/internal/controller/apiextensions/composition"
 	"github.com/crossplane/crossplane/internal/controller/apiextensions/definition"
 	"github.com/crossplane/crossplane/internal/controller/apiextensions/offered"
-	"github.com/crossplane/crossplane/internal/feature"
+	"github.com/crossplane/crossplane/internal/features"
 )
 
 // Setup API extensions controllers.
-func Setup(mgr ctrl.Manager, l logging.Logger, f *feature.Flags) error {
+func Setup(mgr ctrl.Manager, o controller.Options) error {
 
 	// The Composition controller only deals in the management of
 	// CompositionRevisions, so we don't need it at all unless the
 	// CompositionRevision feature flag is enabled.
-	if f.Enabled(feature.FlagEnableAlphaCompositionRevisions) {
-		if err := composition.Setup(mgr, l); err != nil {
+	if o.Features.Enabled(features.EnableAlphaCompositionRevisions) {
+		if err := composition.Setup(mgr, o); err != nil {
 			return err
 		}
 	}
 
-	if err := definition.Setup(mgr, l, f); err != nil {
+	if err := definition.Setup(mgr, o); err != nil {
 		return err
 	}
 
-	return offered.Setup(mgr, l)
+	return offered.Setup(mgr, o)
 }

--- a/internal/controller/apiextensions/claim/reconciler_test.go
+++ b/internal/controller/apiextensions/claim/reconciler_test.go
@@ -71,11 +71,11 @@ func TestReconcile(t *testing.T) {
 				},
 			},
 			want: want{
-				r: reconcile.Result{},
+				r: reconcile.Result{Requeue: false},
 			},
 		},
 		"GetCompositeError": {
-			reason: "We should requeue after a short wait if we encounter an error while getting the referenced composite resource",
+			reason: "We should return any error we encounter while getting the referenced composite resource",
 			args: args{
 				mgr: &fake.Manager{},
 				opts: []ReconcilerOption{
@@ -96,7 +96,7 @@ func TestReconcile(t *testing.T) {
 				},
 			},
 			want: want{
-				r: reconcile.Result{RequeueAfter: aShortWait},
+				err: errors.Wrap(errBoom, errGetComposite),
 			},
 		},
 		"CompositeAlreadyDeleted": {
@@ -160,7 +160,7 @@ func TestReconcile(t *testing.T) {
 			},
 		},
 		"DeleteCompositeError": {
-			reason: "We should requeue after a short wait if we encounter an error while deleting the referenced composite resource",
+			reason: "We should return any error we encounter while deleting the referenced composite resource",
 			args: args{
 				mgr: &fake.Manager{},
 				opts: []ReconcilerOption{
@@ -185,11 +185,11 @@ func TestReconcile(t *testing.T) {
 				},
 			},
 			want: want{
-				r: reconcile.Result{RequeueAfter: aShortWait},
+				err: errors.Wrap(errBoom, errDeleteComposite),
 			},
 		},
 		"RemoveFinalizerError": {
-			reason: "We should requeue after a short wait if we encounter an error while removing the claim's finalizer",
+			reason: "We should return any error we encounter while removing the claim's finalizer",
 			args: args{
 				mgr: &fake.Manager{},
 				opts: []ReconcilerOption{
@@ -212,7 +212,7 @@ func TestReconcile(t *testing.T) {
 				},
 			},
 			want: want{
-				r: reconcile.Result{RequeueAfter: aShortWait},
+				err: errors.Wrap(errBoom, errRemoveFinalizer),
 			},
 		},
 		"SuccessfulDelete": {
@@ -243,7 +243,7 @@ func TestReconcile(t *testing.T) {
 			},
 		},
 		"AddFinalizerError": {
-			reason: "We should requeue after a short wait if we encounter an error while adding the claim's finalizer",
+			reason: "We should return any error we encounter while adding the claim's finalizer",
 			args: args{
 				mgr: &fake.Manager{},
 				opts: []ReconcilerOption{
@@ -263,11 +263,11 @@ func TestReconcile(t *testing.T) {
 				},
 			},
 			want: want{
-				r: reconcile.Result{RequeueAfter: aShortWait},
+				err: errors.Wrap(errBoom, errAddFinalizer),
 			},
 		},
 		"ConfigureError": {
-			reason: "We should requeue after a short wait if we encounter an error configuring the composite resource",
+			reason: "We should return any error we encounter configuring the composite resource",
 			args: args{
 				mgr: &fake.Manager{},
 				opts: []ReconcilerOption{
@@ -288,11 +288,11 @@ func TestReconcile(t *testing.T) {
 				},
 			},
 			want: want{
-				r: reconcile.Result{RequeueAfter: aShortWait},
+				err: errors.Wrap(errBoom, errConfigureComposite),
 			},
 		},
 		"BindError": {
-			reason: "We should requeue after a short wait if we encounter an error binding the composite resource",
+			reason: "We should return any error we encounter binding the composite resource",
 			args: args{
 				mgr: &fake.Manager{},
 				opts: []ReconcilerOption{
@@ -315,11 +315,11 @@ func TestReconcile(t *testing.T) {
 				},
 			},
 			want: want{
-				r: reconcile.Result{RequeueAfter: aShortWait},
+				err: errors.Wrap(errBoom, errBindComposite),
 			},
 		},
 		"ApplyError": {
-			reason: "We should requeue after a short wait if we encounter an error applying the composite resource",
+			reason: "We should return any error we encounter applying the composite resource",
 			args: args{
 				mgr: &fake.Manager{},
 				opts: []ReconcilerOption{
@@ -344,11 +344,11 @@ func TestReconcile(t *testing.T) {
 				},
 			},
 			want: want{
-				r: reconcile.Result{RequeueAfter: aShortWait},
+				err: errors.Wrap(errBoom, errApplyComposite),
 			},
 		},
 		"ClaimConfigureError": {
-			reason: "We should requeue after a short wait if we encounter an error configuring the claim resource",
+			reason: "We should return any error we encounter configuring the claim resource",
 			args: args{
 				mgr: &fake.Manager{},
 				opts: []ReconcilerOption{
@@ -375,7 +375,7 @@ func TestReconcile(t *testing.T) {
 				},
 			},
 			want: want{
-				r: reconcile.Result{RequeueAfter: aShortWait},
+				err: errors.Wrap(errBoom, errConfigureClaim),
 			},
 		},
 		"CompositeNotReady": {
@@ -406,11 +406,11 @@ func TestReconcile(t *testing.T) {
 				},
 			},
 			want: want{
-				r: reconcile.Result{},
+				r: reconcile.Result{Requeue: false},
 			},
 		},
 		"PropagateConnectionError": {
-			reason: "We should requeue after a short wait if an error is encountered while propagating the bound composite's connection details",
+			reason: "We should return any error we encounter while propagating the bound composite's connection details",
 			args: args{
 				mgr: &fake.Manager{},
 				opts: []ReconcilerOption{
@@ -443,7 +443,7 @@ func TestReconcile(t *testing.T) {
 				},
 			},
 			want: want{
-				r: reconcile.Result{RequeueAfter: aShortWait},
+				err: errors.Wrap(errBoom, errPropagateCDs),
 			},
 		},
 		"SuccessfulPropagate": {

--- a/internal/controller/apiextensions/composition/reconciler.go
+++ b/internal/controller/apiextensions/composition/reconciler.go
@@ -67,6 +67,7 @@ func Setup(mgr ctrl.Manager, o controller.Options) error {
 		Named(name).
 		For(&v1.Composition{}).
 		Owns(&v1alpha1.CompositionRevision{}).
+		WithOptions(o.ForControllerRuntime()).
 		Complete(NewReconciler(mgr,
 			WithLogger(o.Logger.WithValues("controller", name)),
 			WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name)))))

--- a/internal/controller/apiextensions/composition/reconciler.go
+++ b/internal/controller/apiextensions/composition/reconciler.go
@@ -28,6 +28,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
+	"github.com/crossplane/crossplane-runtime/pkg/controller"
 	"github.com/crossplane/crossplane-runtime/pkg/errors"
 	"github.com/crossplane/crossplane-runtime/pkg/event"
 	"github.com/crossplane/crossplane-runtime/pkg/logging"
@@ -59,7 +60,7 @@ const (
 
 // Setup adds a controller that reconciles Compositions by creating new
 // CompositionRevisions for each revision of the Composition's spec.
-func Setup(mgr ctrl.Manager, log logging.Logger) error {
+func Setup(mgr ctrl.Manager, o controller.Options) error {
 	name := "revisions/" + strings.ToLower(v1.CompositionGroupKind)
 
 	return ctrl.NewControllerManagedBy(mgr).
@@ -67,7 +68,7 @@ func Setup(mgr ctrl.Manager, log logging.Logger) error {
 		For(&v1.Composition{}).
 		Owns(&v1alpha1.CompositionRevision{}).
 		Complete(NewReconciler(mgr,
-			WithLogger(log.WithValues("controller", name)),
+			WithLogger(o.Logger.WithValues("controller", name)),
 			WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name)))))
 }
 

--- a/internal/controller/apiextensions/definition/reconciler_test.go
+++ b/internal/controller/apiextensions/definition/reconciler_test.go
@@ -92,7 +92,7 @@ func TestReconcile(t *testing.T) {
 				},
 			},
 			want: want{
-				r: reconcile.Result{},
+				r: reconcile.Result{Requeue: false},
 			},
 		},
 		"GetCompositeResourceDefinitionError": {
@@ -112,7 +112,7 @@ func TestReconcile(t *testing.T) {
 			},
 		},
 		"RenderCustomResourceDefinitionError": {
-			reason: "We should requeue after a short wait if we encounter an error rendering a CRD.",
+			reason: "We should return any error we encounter rendering a CRD.",
 			args: args{
 				mgr: &fake.Manager{},
 				opts: []ReconcilerOption{
@@ -127,11 +127,11 @@ func TestReconcile(t *testing.T) {
 				},
 			},
 			want: want{
-				r: reconcile.Result{RequeueAfter: shortWait},
+				err: errors.Wrap(errBoom, errRenderCRD),
 			},
 		},
 		"SetTerminatingConditionError": {
-			reason: "We should requeue after a short wait if we encounter an error while setting the terminating status condition.",
+			reason: "We should return any error we encounter while setting the terminating status condition.",
 			args: args{
 				mgr: &fake.Manager{},
 				opts: []ReconcilerOption{
@@ -151,11 +151,11 @@ func TestReconcile(t *testing.T) {
 				},
 			},
 			want: want{
-				r: reconcile.Result{RequeueAfter: shortWait},
+				err: errors.Wrap(errBoom, errUpdateStatus),
 			},
 		},
 		"GetCustomResourceDefinitionError": {
-			reason: "We should requeue after a short wait if we encounter an error getting a CRD.",
+			reason: "We should return any error we encounter getting a CRD.",
 			args: args{
 				mgr: &fake.Manager{},
 				opts: []ReconcilerOption{
@@ -181,11 +181,11 @@ func TestReconcile(t *testing.T) {
 				},
 			},
 			want: want{
-				r: reconcile.Result{RequeueAfter: shortWait},
+				err: errors.Wrap(errBoom, errGetCRD),
 			},
 		},
 		"RemoveFinalizerError": {
-			reason: "We should requeue after a short wait if we encounter an error while removing a finalizer.",
+			reason: "We should return any error we encounter while removing a finalizer.",
 			args: args{
 				mgr: &fake.Manager{},
 				opts: []ReconcilerOption{
@@ -211,7 +211,7 @@ func TestReconcile(t *testing.T) {
 				},
 			},
 			want: want{
-				r: reconcile.Result{RequeueAfter: shortWait},
+				err: errors.Wrap(errBoom, errRemoveFinalizer),
 			},
 		},
 		"SuccessfulDelete": {
@@ -245,7 +245,7 @@ func TestReconcile(t *testing.T) {
 			},
 		},
 		"DeleteAllCustomResourcesError": {
-			reason: "We should requeue after a short wait if we encounter an error while deleting all defined resources.",
+			reason: "We should return any error we encounter while deleting all defined resources.",
 			args: args{
 				mgr: &fake.Manager{},
 				opts: []ReconcilerOption{
@@ -276,11 +276,11 @@ func TestReconcile(t *testing.T) {
 				},
 			},
 			want: want{
-				r: reconcile.Result{RequeueAfter: shortWait},
+				err: errors.Wrap(errBoom, errDeleteCRs),
 			},
 		},
 		"ListCustomResourcesError": {
-			reason: "We should requeue after a short wait if we encounter an error while listing all defined resources.",
+			reason: "We should return any error we encounter while listing all defined resources.",
 			args: args{
 				mgr: &fake.Manager{},
 				opts: []ReconcilerOption{
@@ -312,7 +312,7 @@ func TestReconcile(t *testing.T) {
 				},
 			},
 			want: want{
-				r: reconcile.Result{RequeueAfter: shortWait},
+				err: errors.Wrap(errBoom, errListCRs),
 			},
 		},
 		"WaitForDeleteAllOf": {
@@ -354,11 +354,11 @@ func TestReconcile(t *testing.T) {
 				},
 			},
 			want: want{
-				r: reconcile.Result{RequeueAfter: tinyWait},
+				r: reconcile.Result{Requeue: true},
 			},
 		},
 		"DeleteCustomResourceDefinitionError": {
-			reason: "We should requeue after a short wait if we encounter an error while deleting the CRD we created.",
+			reason: "We should return any error we encounter while deleting the CRD we created.",
 			args: args{
 				mgr: &fake.Manager{},
 				opts: []ReconcilerOption{
@@ -391,11 +391,11 @@ func TestReconcile(t *testing.T) {
 				},
 			},
 			want: want{
-				r: reconcile.Result{RequeueAfter: shortWait},
+				err: errors.Wrap(errBoom, errDeleteCRD),
 			},
 		},
 		"SuccessfulCleanup": {
-			reason: "We should requeue after a tiny wait to remove our finalizer once we've cleaned up our defined resources and CRD.",
+			reason: "We should requeue to remove our finalizer once we've cleaned up our defined resources and CRD.",
 			args: args{
 				mgr: &fake.Manager{},
 				opts: []ReconcilerOption{
@@ -439,11 +439,11 @@ func TestReconcile(t *testing.T) {
 				},
 			},
 			want: want{
-				r: reconcile.Result{RequeueAfter: tinyWait},
+				r: reconcile.Result{Requeue: true},
 			},
 		},
 		"AddFinalizerError": {
-			reason: "We should requeue after a short wait if we encounter an error while adding a finalizer.",
+			reason: "We should return any error we encounter while adding a finalizer.",
 			args: args{
 				mgr: &fake.Manager{},
 				opts: []ReconcilerOption{
@@ -461,11 +461,11 @@ func TestReconcile(t *testing.T) {
 				},
 			},
 			want: want{
-				r: reconcile.Result{RequeueAfter: shortWait},
+				err: errors.Wrap(errBoom, errAddFinalizer),
 			},
 		},
 		"ApplyCustomResourceDefinitionError": {
-			reason: "We should requeue after a short wait if we encounter an error while applying our CRD.",
+			reason: "We should return any error we encounter while applying our CRD.",
 			args: args{
 				mgr: &fake.Manager{},
 				opts: []ReconcilerOption{
@@ -486,11 +486,11 @@ func TestReconcile(t *testing.T) {
 				},
 			},
 			want: want{
-				r: reconcile.Result{RequeueAfter: shortWait},
+				err: errors.Wrap(errBoom, errApplyCRD),
 			},
 		},
 		"CustomResourceDefinitionIsNotEstablished": {
-			reason: "We should requeue after a tiny wait if we're waiting for a newly created CRD to become established.",
+			reason: "We should requeue if we're waiting for a newly created CRD to become established.",
 			args: args{
 				mgr: &fake.Manager{},
 				opts: []ReconcilerOption{
@@ -511,11 +511,11 @@ func TestReconcile(t *testing.T) {
 				},
 			},
 			want: want{
-				r: reconcile.Result{RequeueAfter: tinyWait},
+				r: reconcile.Result{Requeue: true},
 			},
 		},
 		"StartControllerError": {
-			reason: "We should requeue after a short wait if we encounter an error while starting our controller.",
+			reason: "We should return any error we encounter while starting our controller.",
 			args: args{
 				mgr: &fake.Manager{},
 				opts: []ReconcilerOption{
@@ -546,11 +546,12 @@ func TestReconcile(t *testing.T) {
 				},
 			},
 			want: want{
-				r: reconcile.Result{RequeueAfter: shortWait},
+				r:   reconcile.Result{},
+				err: errors.Wrap(errBoom, errStartController),
 			},
 		},
 		"SuccessfulStart": {
-			reason: "We should not requeue after a short wait if we successfully ensured our CRD exists and controller is started.",
+			reason: "We should return without requeueing if we successfully ensured our CRD exists and controller is started.",
 			args: args{
 				mgr: &fake.Manager{},
 				opts: []ReconcilerOption{
@@ -594,7 +595,7 @@ func TestReconcile(t *testing.T) {
 			},
 		},
 		"SuccessfulUpdateControllerVersion": {
-			reason: "We should not requeue after a short wait if we successfully ensured our CRD exists, the old controller stopped, and the new one started.",
+			reason: "We should return without requeueing if we successfully ensured our CRD exists, the old controller stopped, and the new one started.",
 			args: args{
 				mgr: &fake.Manager{},
 				opts: []ReconcilerOption{

--- a/internal/controller/apiextensions/offered/reconciler.go
+++ b/internal/controller/apiextensions/offered/reconciler.go
@@ -111,7 +111,8 @@ func Setup(mgr ctrl.Manager, o controller.Options) error {
 
 	r := NewReconciler(mgr,
 		WithLogger(o.Logger.WithValues("controller", name)),
-		WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name))))
+		WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name))),
+		WithOptions(o))
 
 	return ctrl.NewControllerManagedBy(mgr).
 		Named(name).

--- a/internal/controller/apiextensions/offered/reconciler.go
+++ b/internal/controller/apiextensions/offered/reconciler.go
@@ -110,7 +110,7 @@ func (fn CRDRenderFn) Render(d *v1.CompositeResourceDefinition) (*extv1.CustomRe
 // Setup adds a controller that reconciles CompositeResourceDefinitions by
 // defining a composite resource claim and starting a controller to reconcile
 // it.
-func Setup(mgr ctrl.Manager, log logging.Logger) error {
+func Setup(mgr ctrl.Manager, o controller.Options) error {
 	name := "offered/" + strings.ToLower(v1.CompositeResourceDefinitionGroupKind)
 
 	return ctrl.NewControllerManagedBy(mgr).
@@ -120,7 +120,7 @@ func Setup(mgr ctrl.Manager, log logging.Logger) error {
 		WithEventFilter(resource.NewPredicates(OffersClaim())).
 		WithOptions(kcontroller.Options{MaxConcurrentReconciles: maxConcurrency}).
 		Complete(NewReconciler(mgr,
-			WithLogger(log.WithValues("controller", name)),
+			WithLogger(o.Logger.WithValues("controller", name)),
 			WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name)))))
 }
 

--- a/internal/controller/apiextensions/offered/reconciler_test.go
+++ b/internal/controller/apiextensions/offered/reconciler_test.go
@@ -92,7 +92,7 @@ func TestReconcile(t *testing.T) {
 				},
 			},
 			want: want{
-				r: reconcile.Result{},
+				r: reconcile.Result{Requeue: false},
 			},
 		},
 		"GetCompositeResourceDefinitionError": {
@@ -112,7 +112,7 @@ func TestReconcile(t *testing.T) {
 			},
 		},
 		"RenderCompositeResourceDefinitionError": {
-			reason: "We should requeue after a short wait if we encounter an error while rendering a CRD.",
+			reason: "We should return any error we encounter while rendering a CRD.",
 			args: args{
 				mgr: &fake.Manager{},
 				opts: []ReconcilerOption{
@@ -127,11 +127,11 @@ func TestReconcile(t *testing.T) {
 				},
 			},
 			want: want{
-				r: reconcile.Result{RequeueAfter: shortWait},
+				err: errors.Wrap(errBoom, errRenderCRD),
 			},
 		},
 		"SetTerminatingConditionError": {
-			reason: "We should requeue after a short wait if we encounter an error while setting the terminating status condition.",
+			reason: "We should return any error we encounter while setting the terminating status condition.",
 			args: args{
 				mgr: &fake.Manager{},
 				opts: []ReconcilerOption{
@@ -151,11 +151,11 @@ func TestReconcile(t *testing.T) {
 				},
 			},
 			want: want{
-				r: reconcile.Result{RequeueAfter: shortWait},
+				err: errors.Wrap(errBoom, errUpdateStatus),
 			},
 		},
 		"GetCustomResourceDefinitionError": {
-			reason: "We should requeue after a short wait if we encounter an error while getting a CRD.",
+			reason: "We should return any error we encounter while getting a CRD.",
 			args: args{
 				mgr: &fake.Manager{},
 				opts: []ReconcilerOption{
@@ -181,11 +181,11 @@ func TestReconcile(t *testing.T) {
 				},
 			},
 			want: want{
-				r: reconcile.Result{RequeueAfter: shortWait},
+				err: errors.Wrap(errBoom, errGetCRD),
 			},
 		},
 		"RemoveFinalizerError": {
-			reason: "We should requeue after a short wait if we encounter an error while removing a finalizer.",
+			reason: "We should return any error we encounter while removing a finalizer.",
 			args: args{
 				mgr: &fake.Manager{},
 				opts: []ReconcilerOption{
@@ -211,7 +211,7 @@ func TestReconcile(t *testing.T) {
 				},
 			},
 			want: want{
-				r: reconcile.Result{RequeueAfter: shortWait},
+				err: errors.Wrap(errBoom, errRemoveFinalizer),
 			},
 		},
 		"SuccessfulDelete": {
@@ -245,7 +245,7 @@ func TestReconcile(t *testing.T) {
 			},
 		},
 		"ListCustomResourcesError": {
-			reason: "We should requeue after a short wait if we encounter an error while listing all defined resources.",
+			reason: "We should return any error we encounter while listing all defined resources.",
 			args: args{
 				mgr: &fake.Manager{},
 				opts: []ReconcilerOption{
@@ -276,11 +276,11 @@ func TestReconcile(t *testing.T) {
 				},
 			},
 			want: want{
-				r: reconcile.Result{RequeueAfter: shortWait},
+				err: errors.Wrap(errBoom, errListCRs),
 			},
 		},
 		"DeleteCustomResourcesError": {
-			reason: "We should requeue after a short wait if we encounter an error while deleting defined resources.",
+			reason: "We should return any error we encounter while deleting defined resources.",
 			args: args{
 				mgr: &fake.Manager{},
 				opts: []ReconcilerOption{
@@ -318,11 +318,11 @@ func TestReconcile(t *testing.T) {
 				},
 			},
 			want: want{
-				r: reconcile.Result{RequeueAfter: shortWait},
+				err: errors.Wrap(errBoom, errDeleteCR),
 			},
 		},
 		"SuccessfulDeleteCustomResources": {
-			reason: "We should requeue after a tiny wait to ensure our defined resources are gone before we remove our CRD.",
+			reason: "We should requeue to ensure our defined resources are gone before we remove our CRD.",
 			args: args{
 				mgr: &fake.Manager{},
 				opts: []ReconcilerOption{
@@ -360,11 +360,11 @@ func TestReconcile(t *testing.T) {
 				},
 			},
 			want: want{
-				r: reconcile.Result{RequeueAfter: tinyWait},
+				r: reconcile.Result{Requeue: true},
 			},
 		},
 		"DeleteCustomResourceDefinitionError": {
-			reason: "We should requeue after a short wait if we encounter an error while deleting the CRD we created.",
+			reason: "We should return any error we encounter while deleting the CRD we created.",
 			args: args{
 				mgr: &fake.Manager{},
 				opts: []ReconcilerOption{
@@ -398,11 +398,11 @@ func TestReconcile(t *testing.T) {
 				},
 			},
 			want: want{
-				r: reconcile.Result{RequeueAfter: shortWait},
+				err: errors.Wrap(errBoom, errDeleteCRD),
 			},
 		},
 		"SuccessfulCleanup": {
-			reason: "We should requeue after a tiny wait to remove our finalizer once we've cleaned up our defined resources and CRD.",
+			reason: "We should requeue to remove our finalizer once we've cleaned up our defined resources and CRD.",
 			args: args{
 				mgr: &fake.Manager{},
 				opts: []ReconcilerOption{
@@ -445,11 +445,11 @@ func TestReconcile(t *testing.T) {
 				},
 			},
 			want: want{
-				r: reconcile.Result{RequeueAfter: tinyWait},
+				r: reconcile.Result{Requeue: true},
 			},
 		},
 		"AddFinalizerError": {
-			reason: "We should requeue after a short wait if we encounter an error while adding a finalizer.",
+			reason: "We should return any error we encounter while adding a finalizer.",
 			args: args{
 				mgr: &fake.Manager{},
 				opts: []ReconcilerOption{
@@ -467,11 +467,11 @@ func TestReconcile(t *testing.T) {
 				},
 			},
 			want: want{
-				r: reconcile.Result{RequeueAfter: shortWait},
+				err: errors.Wrap(errBoom, errAddFinalizer),
 			},
 		},
 		"ApplyCRDError": {
-			reason: "We should requeue after a short wait if we encounter an error while applying our CRD.",
+			reason: "We should return any error we encounter while applying our CRD.",
 			args: args{
 				mgr: &fake.Manager{},
 				opts: []ReconcilerOption{
@@ -492,11 +492,11 @@ func TestReconcile(t *testing.T) {
 				},
 			},
 			want: want{
-				r: reconcile.Result{RequeueAfter: shortWait},
+				err: errors.Wrap(errBoom, errApplyCRD),
 			},
 		},
 		"CustomResourceDefinitionIsNotEstablished": {
-			reason: "We should requeue after a tiny wait if we're waiting for a newly created CRD to become established.",
+			reason: "We should requeue if we're waiting for a newly created CRD to become established.",
 			args: args{
 				mgr: &fake.Manager{},
 				opts: []ReconcilerOption{
@@ -517,11 +517,11 @@ func TestReconcile(t *testing.T) {
 				},
 			},
 			want: want{
-				r: reconcile.Result{RequeueAfter: tinyWait},
+				r: reconcile.Result{Requeue: true},
 			},
 		},
 		"StartControllerError": {
-			reason: "We should requeue after a short wait if we encounter an error while starting our controller.",
+			reason: "We should return any error we encounter while starting our controller.",
 			args: args{
 				mgr: &fake.Manager{},
 				opts: []ReconcilerOption{
@@ -552,11 +552,11 @@ func TestReconcile(t *testing.T) {
 				},
 			},
 			want: want{
-				r: reconcile.Result{RequeueAfter: shortWait},
+				err: errors.Wrap(errBoom, errStartController),
 			},
 		},
 		"SuccessfulStart": {
-			reason: "We should not requeue after a short wait if we successfully ensured our CRD exists and controller is started.",
+			reason: "We should not requeue if we successfully ensured our CRD exists and controller is started.",
 			args: args{
 				mgr: &fake.Manager{},
 				opts: []ReconcilerOption{
@@ -600,7 +600,7 @@ func TestReconcile(t *testing.T) {
 			},
 		},
 		"SuccessfulUpdateControllerVersion": {
-			reason: "We should not requeue after a short wait if we successfully ensured our CRD exists, the old controller stopped, and the new one started.",
+			reason: "We should not requeue if we successfully ensured our CRD exists, the old controller stopped, and the new one started.",
 			args: args{
 				mgr: &fake.Manager{},
 				opts: []ReconcilerOption{

--- a/internal/controller/pkg/controller/options.go
+++ b/internal/controller/pkg/controller/options.go
@@ -1,0 +1,42 @@
+/*
+Copyright 2021 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package controller contains options specific to pkg controllers.
+package controller
+
+import (
+	"github.com/crossplane/crossplane/internal/xpkg"
+
+	"github.com/crossplane/crossplane-runtime/pkg/controller"
+)
+
+// Options specific to pkg controllers.
+type Options struct {
+	controller.Options
+
+	// Cache for package OCI images.
+	Cache xpkg.Cache
+
+	// Namespace used to unpack and run packages.
+	Namespace string
+
+	// DefaultRegistry used to pull packages.
+	DefaultRegistry string
+
+	// FetcherOptions can be used to add optional parameters to
+	// NewK8sFetcher.
+	FetcherOptions []xpkg.FetcherOpt
+}

--- a/internal/controller/pkg/manager/reconciler.go
+++ b/internal/controller/pkg/manager/reconciler.go
@@ -33,6 +33,7 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/event"
 	"github.com/crossplane/crossplane-runtime/pkg/logging"
 	"github.com/crossplane/crossplane-runtime/pkg/meta"
+	"github.com/crossplane/crossplane-runtime/pkg/ratelimiter"
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
 
 	v1 "github.com/crossplane/crossplane/apis/pkg/v1"
@@ -165,7 +166,7 @@ func SetupProvider(mgr ctrl.Manager, o controller.Options) error {
 		For(&v1.Provider{}).
 		Owns(&v1.ProviderRevision{}).
 		WithOptions(o.ForControllerRuntime()).
-		Complete(r)
+		Complete(ratelimiter.NewReconciler(name, r, o.GlobalRateLimiter))
 }
 
 // SetupConfiguration adds a controller that reconciles Configurations.
@@ -198,7 +199,7 @@ func SetupConfiguration(mgr ctrl.Manager, o controller.Options) error {
 		For(&v1.Configuration{}).
 		Owns(&v1.ConfigurationRevision{}).
 		WithOptions(o.ForControllerRuntime()).
-		Complete(r)
+		Complete(ratelimiter.NewReconciler(name, r, o.GlobalRateLimiter))
 }
 
 // NewReconciler creates a new package reconciler.

--- a/internal/controller/pkg/manager/reconciler_test.go
+++ b/internal/controller/pkg/manager/reconciler_test.go
@@ -85,7 +85,7 @@ func TestReconcile(t *testing.T) {
 				},
 			},
 			want: want{
-				r: reconcile.Result{},
+				r: reconcile.Result{Requeue: false},
 			},
 		},
 		"ErrGetPackage": {
@@ -101,12 +101,11 @@ func TestReconcile(t *testing.T) {
 				},
 			},
 			want: want{
-				r:   reconcile.Result{},
 				err: errors.Wrap(errBoom, errGetPackage),
 			},
 		},
 		"ErrListRevisions": {
-			reason: "We should requeue after short wait if listing revisions for a package fails.",
+			reason: "We should return an error if listing revisions for a package fails.",
 			args: args{
 				req: reconcile.Request{NamespacedName: types.NamespacedName{Name: "test"}},
 				rec: &Reconciler{
@@ -123,7 +122,7 @@ func TestReconcile(t *testing.T) {
 				},
 			},
 			want: want{
-				r: reconcile.Result{RequeueAfter: shortWait},
+				err: errors.Wrap(errBoom, errListRevisions),
 			},
 		},
 		"SuccessfulNoExistingRevisionsAutoActivate": {
@@ -170,7 +169,7 @@ func TestReconcile(t *testing.T) {
 				},
 			},
 			want: want{
-				r: reconcile.Result{},
+				r: reconcile.Result{Requeue: false},
 			},
 		},
 		"SuccessfulNoExistingRevisionsAutoActivatePullAlways": {
@@ -219,7 +218,7 @@ func TestReconcile(t *testing.T) {
 				},
 			},
 			want: want{
-				r: reconcile.Result{RequeueAfter: pullWait},
+				r: reconcile.Result{Requeue: true},
 			},
 		},
 		"SuccessfulNoExistingRevisionsManualActivate": {
@@ -266,7 +265,7 @@ func TestReconcile(t *testing.T) {
 				},
 			},
 			want: want{
-				r: reconcile.Result{},
+				r: reconcile.Result{Requeue: false},
 			},
 		},
 		"SuccessfulActiveRevisionExists": {
@@ -324,7 +323,7 @@ func TestReconcile(t *testing.T) {
 				},
 			},
 			want: want{
-				r: reconcile.Result{},
+				r: reconcile.Result{Requeue: false},
 			},
 		},
 		"SuccessfulRevisionExistsNeedsActive": {
@@ -402,11 +401,11 @@ func TestReconcile(t *testing.T) {
 				},
 			},
 			want: want{
-				r: reconcile.Result{},
+				r: reconcile.Result{Requeue: false},
 			},
 		},
 		"ErrUpdatePackageRevision": {
-			reason: "Failing to update a package revision should cause requeue after short wait.",
+			reason: "Failing to update a package revision should cause us to return an error.",
 			args: args{
 				req: reconcile.Request{NamespacedName: types.NamespacedName{Name: "test"}},
 				rec: &Reconciler{
@@ -461,7 +460,7 @@ func TestReconcile(t *testing.T) {
 				},
 			},
 			want: want{
-				r: reconcile.Result{RequeueAfter: shortWait},
+				err: errors.Wrap(errBoom, errApplyPackageRevision),
 			},
 		},
 		"SuccessfulTransitionUnhealthy": {
@@ -521,7 +520,7 @@ func TestReconcile(t *testing.T) {
 				},
 			},
 			want: want{
-				r: reconcile.Result{},
+				r: reconcile.Result{Requeue: false},
 			},
 		},
 		"SuccessfulRevisionExistsNeedGC": {
@@ -618,11 +617,11 @@ func TestReconcile(t *testing.T) {
 				},
 			},
 			want: want{
-				r: reconcile.Result{},
+				r: reconcile.Result{Requeue: false},
 			},
 		},
 		"ErrGC": {
-			reason: "Failure to garbage collect old package revision should cause requeue after short wait.",
+			reason: "Failure to garbage collect old package revision should cause return an error.",
 			args: args{
 				req: reconcile.Request{NamespacedName: types.NamespacedName{Name: "test"}},
 				rec: &Reconciler{
@@ -697,7 +696,7 @@ func TestReconcile(t *testing.T) {
 				},
 			},
 			want: want{
-				r: reconcile.Result{RequeueAfter: shortWait},
+				err: errors.Wrap(errBoom, errGCPackageRevision),
 			},
 		},
 	}

--- a/internal/controller/pkg/pkg.go
+++ b/internal/controller/pkg/pkg.go
@@ -19,40 +19,22 @@ package pkg
 import (
 	ctrl "sigs.k8s.io/controller-runtime"
 
-	"github.com/crossplane/crossplane-runtime/pkg/logging"
+	"github.com/crossplane/crossplane/internal/controller/pkg/controller"
 	"github.com/crossplane/crossplane/internal/controller/pkg/manager"
 	"github.com/crossplane/crossplane/internal/controller/pkg/resolver"
 	"github.com/crossplane/crossplane/internal/controller/pkg/revision"
-	"github.com/crossplane/crossplane/internal/xpkg"
 )
 
 // Setup package controllers.
-func Setup(mgr ctrl.Manager, l logging.Logger, c xpkg.Cache, namespace, registry, caBundlePath string) error {
-	fetcherOpts := []xpkg.FetcherOpt{}
-	if caBundlePath != "" {
-		rootCAs, err := xpkg.ParseCertificatesFromPath(caBundlePath)
-		if err != nil {
-			return err
-		}
-		fetcherOpts = append(fetcherOpts, xpkg.WithCustomCA(rootCAs))
-	}
-
-	for _, setup := range []func(ctrl.Manager, logging.Logger, string, string, ...xpkg.FetcherOpt) error{
+func Setup(mgr ctrl.Manager, o controller.Options) error {
+	for _, setup := range []func(ctrl.Manager, controller.Options) error{
 		manager.SetupConfiguration,
 		manager.SetupProvider,
-	} {
-		if err := setup(mgr, l, namespace, registry, fetcherOpts...); err != nil {
-			return err
-		}
-	}
-	if err := resolver.Setup(mgr, l, namespace, fetcherOpts...); err != nil {
-		return err
-	}
-	for _, setup := range []func(ctrl.Manager, logging.Logger, xpkg.Cache, string, string, ...xpkg.FetcherOpt) error{
+		resolver.Setup,
 		revision.SetupConfigurationRevision,
 		revision.SetupProviderRevision,
 	} {
-		if err := setup(mgr, l, c, namespace, registry, fetcherOpts...); err != nil {
+		if err := setup(mgr, o); err != nil {
 			return err
 		}
 	}

--- a/internal/controller/pkg/resolver/reconciler.go
+++ b/internal/controller/pkg/resolver/reconciler.go
@@ -38,6 +38,7 @@ import (
 
 	v1 "github.com/crossplane/crossplane/apis/pkg/v1"
 	"github.com/crossplane/crossplane/apis/pkg/v1beta1"
+	"github.com/crossplane/crossplane/internal/controller/pkg/controller"
 	"github.com/crossplane/crossplane/internal/dag"
 	"github.com/crossplane/crossplane/internal/xpkg"
 )
@@ -117,22 +118,22 @@ type Reconciler struct {
 }
 
 // Setup adds a controller that reconciles the Lock.
-func Setup(mgr ctrl.Manager, l logging.Logger, namespace string, fetcherOpts ...xpkg.FetcherOpt) error {
+func Setup(mgr ctrl.Manager, o controller.Options) error {
 	name := "packages/" + strings.ToLower(v1beta1.LockGroupKind)
 
-	clientset, err := kubernetes.NewForConfig(mgr.GetConfig())
+	cs, err := kubernetes.NewForConfig(mgr.GetConfig())
 	if err != nil {
 		return errors.Wrap(err, "failed to initialize clientset")
 	}
-	fetcher, err := xpkg.NewK8sFetcher(clientset, namespace, fetcherOpts...)
+	f, err := xpkg.NewK8sFetcher(cs, o.Namespace, o.FetcherOptions...)
 	if err != nil {
 		return errors.Wrap(err, "cannot build fetcher")
 	}
 
 	r := NewReconciler(mgr,
-		WithLogger(l.WithValues("controller", name)),
+		WithLogger(o.Logger.WithValues("controller", name)),
 		WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name))),
-		WithFetcher(fetcher),
+		WithFetcher(f),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/pkg/resolver/reconciler.go
+++ b/internal/controller/pkg/resolver/reconciler.go
@@ -33,6 +33,7 @@ import (
 
 	"github.com/crossplane/crossplane-runtime/pkg/errors"
 	"github.com/crossplane/crossplane-runtime/pkg/logging"
+	"github.com/crossplane/crossplane-runtime/pkg/ratelimiter"
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
 
 	v1 "github.com/crossplane/crossplane/apis/pkg/v1"
@@ -130,7 +131,7 @@ func Setup(mgr ctrl.Manager, o controller.Options) error {
 		Owns(&v1.ConfigurationRevision{}).
 		Owns(&v1.ProviderRevision{}).
 		WithOptions(o.ForControllerRuntime()).
-		Complete(r)
+		Complete(ratelimiter.NewReconciler(name, r, o.GlobalRateLimiter))
 }
 
 // NewReconciler creates a new package revision reconciler.

--- a/internal/controller/pkg/resolver/reconciler_test.go
+++ b/internal/controller/pkg/resolver/reconciler_test.go
@@ -65,7 +65,7 @@ func TestReconcile(t *testing.T) {
 				req: reconcile.Request{NamespacedName: types.NamespacedName{Name: "test"}},
 			},
 			want: want{
-				r: reconcile.Result{},
+				r: reconcile.Result{Requeue: false},
 			},
 		},
 		"ErrGetLock": {
@@ -77,12 +77,11 @@ func TestReconcile(t *testing.T) {
 				req: reconcile.Request{NamespacedName: types.NamespacedName{Name: "test"}},
 			},
 			want: want{
-				r:   reconcile.Result{},
 				err: errors.Wrap(errBoom, errGetLock),
 			},
 		},
 		"ErrRemoveFinalizer": {
-			reason: "We should requeue after short wait if we fail to remove finalizer.",
+			reason: "We should return an error if we fail to remove finalizer.",
 			args: args{
 				mgr: &fake.Manager{
 					Client: test.NewMockClient(),
@@ -95,7 +94,7 @@ func TestReconcile(t *testing.T) {
 				},
 			},
 			want: want{
-				r: reconcile.Result{RequeueAfter: shortWait},
+				err: errors.Wrap(errBoom, errRemoveFinalizer),
 			},
 		},
 		"SuccessfulEmptyList": {
@@ -108,7 +107,7 @@ func TestReconcile(t *testing.T) {
 			},
 		},
 		"ErrAddFinalizer": {
-			reason: "We should requeue after short wait if we fail to add finalizer.",
+			reason: "We should return an error if we fail to add finalizer.",
 			args: args{
 				mgr: &fake.Manager{
 					Client: &test.MockClient{
@@ -134,7 +133,7 @@ func TestReconcile(t *testing.T) {
 				},
 			},
 			want: want{
-				r: reconcile.Result{RequeueAfter: shortWait},
+				err: errors.Wrap(errBoom, errAddFinalizer),
 			},
 		},
 		"ErrInitDag": {
@@ -170,12 +169,11 @@ func TestReconcile(t *testing.T) {
 				},
 			},
 			want: want{
-				r:   reconcile.Result{Requeue: false},
 				err: errors.Wrap(errBoom, errBuildDAG),
 			},
 		},
 		"ErrSortDag": {
-			reason: "We should not requeue if we fail to sort DAG.",
+			reason: "We should return an error if we fail to sort the DAG.",
 			args: args{
 				mgr: &fake.Manager{
 					Client: &test.MockClient{
@@ -210,7 +208,6 @@ func TestReconcile(t *testing.T) {
 				},
 			},
 			want: want{
-				r:   reconcile.Result{Requeue: false},
 				err: errors.Wrap(errBoom, errSortDAG),
 			},
 		},
@@ -297,7 +294,7 @@ func TestReconcile(t *testing.T) {
 			},
 		},
 		"ErrorFetchTags": {
-			reason: "We should requeue after short wait if fail to fetch tags to account for network issues.",
+			reason: "We should return an error if fail to fetch tags to account for network issues.",
 			args: args{
 				mgr: &fake.Manager{
 					Client: &test.MockClient{
@@ -340,7 +337,7 @@ func TestReconcile(t *testing.T) {
 				},
 			},
 			want: want{
-				r: reconcile.Result{RequeueAfter: shortWait},
+				err: errors.Wrap(errBoom, errFetchTags),
 			},
 		},
 		"ErrorNoValidVersion": {
@@ -391,7 +388,7 @@ func TestReconcile(t *testing.T) {
 			},
 		},
 		"ErrorCreateMissingDependency": {
-			reason: "We should requeue after short wait if unable to create missing dependency.",
+			reason: "We should return an error if unable to create missing dependency.",
 			args: args{
 				mgr: &fake.Manager{
 					Client: &test.MockClient{
@@ -436,7 +433,7 @@ func TestReconcile(t *testing.T) {
 				},
 			},
 			want: want{
-				r: reconcile.Result{RequeueAfter: shortWait},
+				err: errors.Wrap(errBoom, errCreateDependency),
 			},
 		},
 		"SuccessfulCreateMissingDependency": {

--- a/internal/controller/pkg/revision/reconciler.go
+++ b/internal/controller/pkg/revision/reconciler.go
@@ -35,6 +35,7 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/logging"
 	"github.com/crossplane/crossplane-runtime/pkg/meta"
 	"github.com/crossplane/crossplane-runtime/pkg/parser"
+	"github.com/crossplane/crossplane-runtime/pkg/ratelimiter"
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
 
 	pkgmetav1 "github.com/crossplane/crossplane/apis/pkg/meta/v1"
@@ -248,7 +249,7 @@ func SetupProviderRevision(mgr ctrl.Manager, o controller.Options) error {
 			client: mgr.GetClient(),
 		}).
 		WithOptions(o.ForControllerRuntime()).
-		Complete(r)
+		Complete(ratelimiter.NewReconciler(name, r, o.GlobalRateLimiter))
 }
 
 // SetupConfigurationRevision adds a controller that reconciles ConfigurationRevisions.
@@ -290,7 +291,7 @@ func SetupConfigurationRevision(mgr ctrl.Manager, o controller.Options) error {
 		Named(name).
 		For(&v1.ConfigurationRevision{}).
 		WithOptions(o.ForControllerRuntime()).
-		Complete(r)
+		Complete(ratelimiter.NewReconciler(name, r, o.GlobalRateLimiter))
 }
 
 // NewReconciler creates a new package revision reconciler.

--- a/internal/controller/rbac/controller/options.go
+++ b/internal/controller/rbac/controller/options.go
@@ -1,0 +1,51 @@
+/*
+Copyright 2021 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package controller contains options specific to rbac controllers.
+package controller
+
+import (
+	"github.com/crossplane/crossplane-runtime/pkg/controller"
+)
+
+// The ManagementPolicy specifies which roles the RBAC manager should manage.
+type ManagementPolicy string
+
+const (
+	// ManagementPolicyAll indicates that all RBAC manager functionality should
+	// be enabled.
+	ManagementPolicyAll ManagementPolicy = "All"
+
+	// ManagementPolicyBasic indicates that basic RBAC manager functionality
+	// should be enabled. The RBAC manager will create ClusterRoles for each
+	// XRD. The ClusterRoles it creates will aggregate to the core Crossplane
+	// ClusterRoles (e.g. crossplane, crossplane-admin, etc).
+	ManagementPolicyBasic ManagementPolicy = "Basic"
+)
+
+// Options specific to rbac controllers.
+type Options struct {
+	controller.Options
+
+	// ManagementPolicy specifies which roles the RBAC manager should
+	// manage.
+	ManagementPolicy ManagementPolicy
+
+	// AllowClusterRole is used to determine what additional RBAC
+	// permissions may be granted to Providers that request them. The
+	// provider may request any permission that appears in the named role.
+	AllowClusterRole string
+}

--- a/internal/controller/rbac/definition/reconciler.go
+++ b/internal/controller/rbac/definition/reconciler.go
@@ -25,7 +25,6 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
-	kcontroller "sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -35,13 +34,14 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/meta"
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
 	v1 "github.com/crossplane/crossplane/apis/apiextensions/v1"
+
+	"github.com/crossplane/crossplane/internal/controller/rbac/controller"
 )
 
 const (
 	shortWait = 30 * time.Second
 
-	timeout        = 2 * time.Minute
-	maxConcurrency = 5
+	timeout = 2 * time.Minute
 
 	errGetXRD    = "cannot get CompositeResourceDefinition"
 	errApplyRole = "cannot apply ClusterRoles"
@@ -69,16 +69,16 @@ func (fn ClusterRoleRenderFn) RenderClusterRoles(d *v1.CompositeResourceDefiniti
 // Setup adds a controller that reconciles a CompositeResourceDefinition by
 // creating a series of opinionated ClusterRoles that may be bound to allow
 // access to the resources it defines.
-func Setup(mgr ctrl.Manager, log logging.Logger) error {
+func Setup(mgr ctrl.Manager, o controller.Options) error {
 	name := "rbac/" + strings.ToLower(v1.CompositeResourceDefinitionGroupKind)
 
 	return ctrl.NewControllerManagedBy(mgr).
 		Named(name).
 		For(&v1.CompositeResourceDefinition{}).
 		Owns(&rbacv1.ClusterRole{}).
-		WithOptions(kcontroller.Options{MaxConcurrentReconciles: maxConcurrency}).
+		WithOptions(o.ForControllerRuntime()).
 		Complete(NewReconciler(mgr,
-			WithLogger(log.WithValues("controller", name)),
+			WithLogger(o.Logger.WithValues("controller", name)),
 			WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name)))))
 }
 

--- a/internal/controller/rbac/definition/reconciler.go
+++ b/internal/controller/rbac/definition/reconciler.go
@@ -32,6 +32,7 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/event"
 	"github.com/crossplane/crossplane-runtime/pkg/logging"
 	"github.com/crossplane/crossplane-runtime/pkg/meta"
+	"github.com/crossplane/crossplane-runtime/pkg/ratelimiter"
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
 	v1 "github.com/crossplane/crossplane/apis/apiextensions/v1"
 
@@ -70,14 +71,16 @@ func (fn ClusterRoleRenderFn) RenderClusterRoles(d *v1.CompositeResourceDefiniti
 func Setup(mgr ctrl.Manager, o controller.Options) error {
 	name := "rbac/" + strings.ToLower(v1.CompositeResourceDefinitionGroupKind)
 
+	r := NewReconciler(mgr,
+		WithLogger(o.Logger.WithValues("controller", name)),
+		WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name))))
+
 	return ctrl.NewControllerManagedBy(mgr).
 		Named(name).
 		For(&v1.CompositeResourceDefinition{}).
 		Owns(&rbacv1.ClusterRole{}).
 		WithOptions(o.ForControllerRuntime()).
-		Complete(NewReconciler(mgr,
-			WithLogger(o.Logger.WithValues("controller", name)),
-			WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name)))))
+		Complete(ratelimiter.NewReconciler(name, r, o.GlobalRateLimiter))
 }
 
 // ReconcilerOption is used to configure the Reconciler.

--- a/internal/controller/rbac/definition/reconciler.go
+++ b/internal/controller/rbac/definition/reconciler.go
@@ -39,8 +39,6 @@ import (
 )
 
 const (
-	shortWait = 30 * time.Second
-
 	timeout = 2 * time.Minute
 
 	errGetXRD    = "cannot get CompositeResourceDefinition"
@@ -186,8 +184,9 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 		}
 		if err != nil {
 			log.Debug(errApplyRole, "error", err)
-			r.record.Event(d, event.Warning(reasonApplyRoles, errors.Wrap(err, errApplyRole)))
-			return reconcile.Result{RequeueAfter: shortWait}, nil
+			err = errors.Wrap(err, errApplyRole)
+			r.record.Event(d, event.Warning(reasonApplyRoles, err))
+			return reconcile.Result{}, err
 		}
 		log.Debug("Applied RBAC ClusterRole")
 	}

--- a/internal/controller/rbac/definition/reconciler_test.go
+++ b/internal/controller/rbac/definition/reconciler_test.go
@@ -108,7 +108,7 @@ func TestReconcile(t *testing.T) {
 			},
 		},
 		"ApplyClusterRoleError": {
-			reason: "We should requeue when an error is encountered applying a ClusterRole.",
+			reason: "We should return errors encountered while applying a ClusterRole.",
 			args: args{
 				mgr: &fake.Manager{},
 				opts: []ReconcilerOption{
@@ -126,7 +126,7 @@ func TestReconcile(t *testing.T) {
 				},
 			},
 			want: want{
-				r: reconcile.Result{RequeueAfter: shortWait},
+				err: errors.Wrap(errBoom, errApplyRole),
 			},
 		},
 		"SuccessfulNoOp": {

--- a/internal/controller/rbac/namespace/reconciler.go
+++ b/internal/controller/rbac/namespace/reconciler.go
@@ -39,8 +39,6 @@ import (
 )
 
 const (
-	shortWait = 30 * time.Second
-
 	timeout = 2 * time.Minute
 
 	errGetNamespace = "cannot get CompositeResourceDefinition"
@@ -186,8 +184,9 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 	l := &rbacv1.ClusterRoleList{}
 	if err := r.client.List(ctx, l); err != nil {
 		log.Debug(errListRoles, "error", err)
-		r.record.Event(ns, event.Warning(reasonApplyRoles, errors.Wrap(err, errListRoles)))
-		return reconcile.Result{RequeueAfter: shortWait}, nil
+		err = errors.Wrap(err, errListRoles)
+		r.record.Event(ns, event.Warning(reasonApplyRoles, err))
+		return reconcile.Result{}, err
 	}
 
 	for _, rl := range r.rbac.RenderRoles(ns, l.Items) {
@@ -201,8 +200,9 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 		}
 		if err != nil {
 			log.Debug(errApplyRole, "error", err)
-			r.record.Event(ns, event.Warning(reasonApplyRoles, errors.Wrap(err, errApplyRole)))
-			return reconcile.Result{RequeueAfter: shortWait}, nil
+			err = errors.Wrap(err, errApplyRole)
+			r.record.Event(ns, event.Warning(reasonApplyRoles, err))
+			return reconcile.Result{}, err
 		}
 
 		log.Debug("Applied RBAC Role")

--- a/internal/controller/rbac/namespace/reconciler.go
+++ b/internal/controller/rbac/namespace/reconciler.go
@@ -25,7 +25,6 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
-	kcontroller "sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
@@ -35,13 +34,14 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/logging"
 	"github.com/crossplane/crossplane-runtime/pkg/meta"
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
+
+	"github.com/crossplane/crossplane/internal/controller/rbac/controller"
 )
 
 const (
 	shortWait = 30 * time.Second
 
-	timeout        = 2 * time.Minute
-	maxConcurrency = 5
+	timeout = 2 * time.Minute
 
 	errGetNamespace = "cannot get CompositeResourceDefinition"
 	errApplyRole    = "cannot apply Roles"
@@ -70,7 +70,7 @@ func (fn RoleRenderFn) RenderRoles(d *corev1.Namespace, crs []rbacv1.ClusterRole
 // Setup adds a controller that reconciles a Namespace by creating a series of
 // opinionated Roles that may be bound to allow access to resources within that
 // namespace.
-func Setup(mgr ctrl.Manager, log logging.Logger) error {
+func Setup(mgr ctrl.Manager, o controller.Options) error {
 	name := "rbac/namespace"
 
 	return ctrl.NewControllerManagedBy(mgr).
@@ -78,9 +78,9 @@ func Setup(mgr ctrl.Manager, log logging.Logger) error {
 		For(&corev1.Namespace{}).
 		Owns(&rbacv1.Role{}).
 		Watches(&source.Kind{Type: &rbacv1.ClusterRole{}}, &EnqueueRequestForNamespaces{client: mgr.GetClient()}).
-		WithOptions(kcontroller.Options{MaxConcurrentReconciles: maxConcurrency}).
+		WithOptions(o.ForControllerRuntime()).
 		Complete(NewReconciler(mgr,
-			WithLogger(log.WithValues("controller", name)),
+			WithLogger(o.Logger.WithValues("controller", name)),
 			WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name)))))
 }
 

--- a/internal/controller/rbac/namespace/reconciler_test.go
+++ b/internal/controller/rbac/namespace/reconciler_test.go
@@ -108,7 +108,7 @@ func TestReconcile(t *testing.T) {
 			},
 		},
 		"ListClusterRolesError": {
-			reason: "We should requeue when an error is encountered listing ClusterRoles.",
+			reason: "We should return an error encountered listing ClusterRoles.",
 			args: args{
 				mgr: &fake.Manager{},
 				opts: []ReconcilerOption{
@@ -121,11 +121,11 @@ func TestReconcile(t *testing.T) {
 				},
 			},
 			want: want{
-				r: reconcile.Result{RequeueAfter: shortWait},
+				err: errors.Wrap(errBoom, errListRoles),
 			},
 		},
 		"ApplyRoleError": {
-			reason: "We should requeue when an error is encountered applying a Role.",
+			reason: "We should return an error encountered applying a Role.",
 			args: args{
 				mgr: &fake.Manager{},
 				opts: []ReconcilerOption{
@@ -144,7 +144,7 @@ func TestReconcile(t *testing.T) {
 				},
 			},
 			want: want{
-				r: reconcile.Result{RequeueAfter: shortWait},
+				err: errors.Wrap(errBoom, errApplyRole),
 			},
 		},
 		"SuccessfulNoOp": {

--- a/internal/controller/rbac/provider/binding/reconciler_test.go
+++ b/internal/controller/rbac/provider/binding/reconciler_test.go
@@ -107,7 +107,7 @@ func TestReconcile(t *testing.T) {
 			},
 		},
 		"ListServiceAccountsError": {
-			reason: "We should requeue when an error is encountered listing ServiceAccounts.",
+			reason: "We should return an error encountered listing ServiceAccounts.",
 			args: args{
 				mgr: &fake.Manager{},
 				opts: []ReconcilerOption{
@@ -124,11 +124,11 @@ func TestReconcile(t *testing.T) {
 				},
 			},
 			want: want{
-				r: reconcile.Result{RequeueAfter: shortWait},
+				err: errors.Wrap(errBoom, errListSAs),
 			},
 		},
 		"ApplyClusterRoleBindingError": {
-			reason: "We should requeue when an error is encountered applying a ClusterRoleBinding.",
+			reason: "We should return an error encountered applying a ClusterRoleBinding.",
 			args: args{
 				mgr: &fake.Manager{},
 				opts: []ReconcilerOption{
@@ -149,7 +149,7 @@ func TestReconcile(t *testing.T) {
 				},
 			},
 			want: want{
-				r: reconcile.Result{RequeueAfter: shortWait},
+				err: errors.Wrap(errBoom, errApplyBinding),
 			},
 		},
 		"SuccessfulApply": {

--- a/internal/controller/rbac/provider/roles/reconciler_test.go
+++ b/internal/controller/rbac/provider/roles/reconciler_test.go
@@ -109,7 +109,7 @@ func TestReconcile(t *testing.T) {
 			},
 		},
 		"ListCRDsError": {
-			reason: "We should requeue when an error is encountered listing CRDs.",
+			reason: "We should return an error encountered listing CRDs.",
 			args: args{
 				mgr: &fake.Manager{},
 				opts: []ReconcilerOption{
@@ -122,11 +122,11 @@ func TestReconcile(t *testing.T) {
 				},
 			},
 			want: want{
-				r: reconcile.Result{RequeueAfter: shortWait},
+				err: errors.Wrap(errBoom, errListCRDs),
 			},
 		},
 		"ValidatePermissionRequestsError": {
-			reason: "We should requeue when an error is encountered validating permission requests.",
+			reason: "We should return an error encountered validating permission requests.",
 			args: args{
 				mgr: &fake.Manager{},
 				opts: []ReconcilerOption{
@@ -142,7 +142,7 @@ func TestReconcile(t *testing.T) {
 				},
 			},
 			want: want{
-				r: reconcile.Result{RequeueAfter: shortWait},
+				err: errors.Wrap(errBoom, errValidatePermissions),
 			},
 		},
 		"PermissionRequestRejected": {
@@ -166,7 +166,7 @@ func TestReconcile(t *testing.T) {
 			},
 		},
 		"ApplyClusterRoleError": {
-			reason: "We should requeue when an error is encountered applying a ClusterRole.",
+			reason: "We should return an error encountered applying a ClusterRole.",
 			args: args{
 				mgr: &fake.Manager{},
 				opts: []ReconcilerOption{
@@ -185,7 +185,7 @@ func TestReconcile(t *testing.T) {
 				},
 			},
 			want: want{
-				r: reconcile.Result{RequeueAfter: shortWait},
+				err: errors.Wrap(errBoom, errApplyRole),
 			},
 		},
 		"SuccessfulNoOp": {

--- a/internal/features/features.go
+++ b/internal/features/features.go
@@ -1,0 +1,27 @@
+/*
+Copyright 2019 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package features
+
+import "github.com/crossplane/crossplane-runtime/pkg/feature"
+
+// Feature flags.
+const (
+	// EnableAlphaCompositionRevisions enables alpha support for
+	// CompositionRevisions. See the below design for more details.
+	// https://github.com/crossplane/crossplane/blob/ecd9d5/design/one-pager-composition-revisions.md
+	EnableAlphaCompositionRevisions feature.Flag = "EnableAlphaCompositionRevisions"
+)


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Partially addresses https://github.com/crossplane/crossplane/issues/2595 and https://github.com/crossplane/crossplane/issues/2477.

I've tested this (per https://github.com/crossplane/crossplane/issues/2568) and observed that - with no changes to the providers this is sitting in front of - it reduces the time for a spike of 100 new claims (each producing an XR and 5 MRs) from ~18 minutes to ~8 minutes. The crossplane-runtime changes depend on https://github.com/crossplane/crossplane-runtime/pull/294.

Combined with a similar change to provider-gcp (https://github.com/crossplane/provider-gcp/pull/380) the time for a spike of 100 new claims drops to ~3.5 minutes. A single claim takes < 30 seconds to become ready.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9

I've tested that it works using https://github.com/negz/crossplane-scale. I've tested this with up to 1,000 claims, each with four composed provider-gcp resources. I think there are more improvements that can be made, but that doesn't need to block moving forward here.