### PR TITLE
Fix Crossplane CLI latest installation command

### DIFF
--- a/docs/getting-started/install-configure.md
+++ b/docs/getting-started/install-configure.md
@@ -174,7 +174,7 @@ curl -sL https://raw.githubusercontent.com/crossplane/crossplane/master/install.
 <div class="tab-pane fade" id="install-tab-cli-latest" markdown="1">
 
 ```console
-curl -sL https://raw.githubusercontent.com/crossplane/crossplane/master/install.sh | CHANNEL=master sh
+CHANNEL=master | curl -sL https://raw.githubusercontent.com/crossplane/crossplane/master/install.sh | sh
 ```
 
 You may also specify `VERSION` for download if you would like to select a
@@ -182,7 +182,7 @@ specific version from the given release channel. If a version is not specified
 the latest version from the release channel will be used.
 
 ```console
-curl -sL https://raw.githubusercontent.com/crossplane/crossplane/master/install.sh | CHANNEL=master VERSION=v1.0.0-rc.0.130.g94f34fd3 sh
+CHANNEL=master VERSION=v1.0.0-rc.0.130.g94f34fd3 | curl -sL https://raw.githubusercontent.com/crossplane/crossplane/master/install.sh | sh
 ```
 
 </div>


### PR DESCRIPTION
This fixes the following error:
```
curl -sL https://raw.githubusercontent.com/crossplane/crossplane/master/install.sh | CHANNEL=master
(23) Failed writing body
```

<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
