### PR TITLE
docs: Fix incorrect created providerConfigRef name used in RDSInstance

### DIFF
--- a/docs/concepts/providers.md
+++ b/docs/concepts/providers.md
@@ -114,7 +114,7 @@ metadata:
   name: prod-sql
 spec:
   providerConfigRef:
-    name: prod-acc
+    name: aws-provider
   ...
 ```
 


### PR DESCRIPTION
Signed-off-by: Yuan Tang <terrytangyuan@gmail.com>

<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
