### PR TITLE
Expose provider Prometheus metrics by default

### DIFF
--- a/internal/controller/pkg/revision/deployment.go
+++ b/internal/controller/pkg/revision/deployment.go
@@ -64,7 +64,10 @@ func buildProviderDeployment(provider *pkgmetav1.Provider, revision v1.PackageRe
 		Spec: appsv1.DeploymentSpec{
 			Replicas: &replicas,
 			Selector: &metav1.LabelSelector{
-				MatchLabels: map[string]string{"pkg.crossplane.io/revision": revision.GetName()},
+				MatchLabels: map[string]string{
+					"pkg.crossplane.io/revision": revision.GetName(),
+					"pkg.crossplane.io/provider": provider.GetName(),
+				},
 			},
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{

--- a/internal/controller/pkg/revision/deployment_test.go
+++ b/internal/controller/pkg/revision/deployment_test.go
@@ -57,13 +57,19 @@ func deployment(provider *pkgmetav1.Provider, revision string, modifiers ...depl
 		Spec: appsv1.DeploymentSpec{
 			Replicas: &replicas,
 			Selector: &metav1.LabelSelector{
-				MatchLabels: map[string]string{"pkg.crossplane.io/revision": revision},
+				MatchLabels: map[string]string{
+					"pkg.crossplane.io/revision": revision,
+					"pkg.crossplane.io/provider": provider.GetName(),
+				},
 			},
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      provider.GetName(),
 					Namespace: namespace,
-					Labels:    map[string]string{"pkg.crossplane.io/revision": revision},
+					Labels: map[string]string{
+						"pkg.crossplane.io/revision": revision,
+						"pkg.crossplane.io/provider": provider.GetName(),
+					},
 				},
 				Spec: corev1.PodSpec{
 					ServiceAccountName: revision,
@@ -165,6 +171,7 @@ func TestBuildProviderDeployment(t *testing.T) {
 			},
 			want: deployment(provider, revisionWithCC.GetName(), withPodTemplateLabels(map[string]string{
 				"pkg.crossplane.io/revision": revisionWithCC.GetName(),
+				"pkg.crossplane.io/provider": provider.GetName(),
 				"k":                          "v",
 			})),
 		},


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
This makes it easier to use pod/service based Prometheus service discovery without needing to provide a ControllerConfig. In particular it's not possible to use a prometheus-operator PodMonitor or ServiceMonitor to discover targets without a named port to target. I feel this is a common enough use case that it makes sense to be on by default or all providers rather than requiring a ControllerConfig.

This can be used with the following `PodMonitor`:

```yaml
apiVersion: monitoring.coreos.com/v1
kind: PodMonitor
metadata:
  namespace: crossplane-system
  name: crossplane-providers
spec:
  namespaceSelector:
    matchNames:
      - crossplane-system
  selector:
    matchExpressions:
      - key: pkg.crossplane.io/provider
        operator: Exists
  podMetricsEndpoints:
    - port: metrics
```

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9

Installed provider-gcp and confirmed the deployment has the new port and label.