### PR TITLE
[release-1.4 #2625] Strip version from package name when installed with initializer

### DIFF
--- a/internal/initializer/installer.go
+++ b/internal/initializer/installer.go
@@ -18,9 +18,9 @@ package initializer
 
 import (
 	"context"
-	"strings"
 
 	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/pkg/errors"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 

--- a/internal/initializer/installer_test.go
+++ b/internal/initializer/installer_test.go
@@ -18,6 +18,7 @@ package initializer
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -28,7 +29,6 @@ import (
 
 	"github.com/crossplane/crossplane-runtime/pkg/test"
 	v1 "github.com/crossplane/crossplane/apis/pkg/v1"
-	"github.com/crossplane/crossplane/apis/pkg/v1beta1"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -47,12 +47,10 @@ var errBoom = errors.New("boom")
 func TestInstaller(t *testing.T) {
 	p1Existing := "existing-provider"
 	p1 := "crossplane/provider-aws:v1.16.0"
-	p1Version := "v1.16.0"
 	p1Repo := "crossplane/provider-aws"
 	p1Name := "crossplane-provider-aws"
 	c1Existing := "existing-configuration"
 	c1 := "crossplane/getting-started-aws:v0.0.1"
-	c1Version := "v0.0.1"
 	c1Repo := "crossplane/getting-started-aws"
 	c1Name := "crossplane-getting-started-aws"
 	type args struct {
@@ -72,28 +70,45 @@ func TestInstaller(t *testing.T) {
 				p: []string{p1},
 				c: []string{c1},
 				kube: &test.MockClient{
-					MockGet: func(_ context.Context, key client.ObjectKey, obj client.Object) error {
-						switch o := obj.(type) {
-						case *v1beta1.Lock:
-							*o = v1beta1.Lock{
-								ObjectMeta: metav1.ObjectMeta{
-									Name: "lock",
-								},
-								Packages: []v1beta1.LockPackage{
+					MockList: func(_ context.Context, list client.ObjectList, _ ...client.ListOption) error {
+						switch l := list.(type) {
+						case *v1.ProviderList:
+							*l = v1.ProviderList{
+								Items: []v1.Provider{
 									{
-										Name:    p1Name,
-										Type:    v1beta1.ProviderPackageType,
-										Source:  p1Repo,
-										Version: p1Version,
-									},
-									{
-										Name:    c1Name,
-										Type:    v1beta1.ConfigurationPackageType,
-										Source:  c1Repo,
-										Version: c1Version,
+										ObjectMeta: metav1.ObjectMeta{
+											Name: p1Name,
+										},
+										Spec: v1.ProviderSpec{
+											PackageSpec: v1.PackageSpec{
+												Package: p1,
+											},
+										},
 									},
 								},
 							}
+						case *v1.ConfigurationList:
+							*l = v1.ConfigurationList{
+								Items: []v1.Configuration{
+									{
+										ObjectMeta: metav1.ObjectMeta{
+											Name: c1Name,
+										},
+										Spec: v1.ConfigurationSpec{
+											PackageSpec: v1.PackageSpec{
+												Package: c1,
+											},
+										},
+									},
+								},
+							}
+						default:
+							t.Errorf("unexpected type")
+						}
+						return nil
+					},
+					MockGet: func(_ context.Context, key client.ObjectKey, obj client.Object) error {
+						switch obj.(type) {
 						case *v1.Provider:
 							if key.Name != p1Name {
 								t.Errorf(errGetProviderFmt, key.Name)
@@ -130,28 +145,45 @@ func TestInstaller(t *testing.T) {
 				p: []string{p1},
 				c: []string{c1},
 				kube: &test.MockClient{
-					MockGet: func(_ context.Context, key client.ObjectKey, obj client.Object) error {
-						switch o := obj.(type) {
-						case *v1beta1.Lock:
-							*o = v1beta1.Lock{
-								ObjectMeta: metav1.ObjectMeta{
-									Name: "lock",
-								},
-								Packages: []v1beta1.LockPackage{
+					MockList: func(_ context.Context, list client.ObjectList, _ ...client.ListOption) error {
+						switch l := list.(type) {
+						case *v1.ProviderList:
+							*l = v1.ProviderList{
+								Items: []v1.Provider{
 									{
-										Name:    p1Existing,
-										Type:    v1beta1.ProviderPackageType,
-										Source:  p1Repo,
-										Version: "v0.0.0",
-									},
-									{
-										Name:    c1Existing,
-										Type:    v1beta1.ConfigurationPackageType,
-										Source:  c1Repo,
-										Version: "v0.0.0",
+										ObjectMeta: metav1.ObjectMeta{
+											Name: p1Existing,
+										},
+										Spec: v1.ProviderSpec{
+											PackageSpec: v1.PackageSpec{
+												Package: fmt.Sprintf("%s:%s", p1Repo, "v100.100.100"),
+											},
+										},
 									},
 								},
 							}
+						case *v1.ConfigurationList:
+							*l = v1.ConfigurationList{
+								Items: []v1.Configuration{
+									{
+										ObjectMeta: metav1.ObjectMeta{
+											Name: c1Existing,
+										},
+										Spec: v1.ConfigurationSpec{
+											PackageSpec: v1.PackageSpec{
+												Package: fmt.Sprintf("%s:%s", c1Repo, "v100.100.100"),
+											},
+										},
+									},
+								},
+							}
+						default:
+							t.Errorf("unexpected type")
+						}
+						return nil
+					},
+					MockGet: func(_ context.Context, key client.ObjectKey, obj client.Object) error {
+						switch obj.(type) {
 						case *v1.Provider:
 							if key.Name != p1Existing {
 								t.Errorf(errGetProviderFmt, key.Name)
@@ -194,10 +226,11 @@ func TestInstaller(t *testing.T) {
 				p: []string{p1},
 				c: []string{c1},
 				kube: &test.MockClient{
+					MockList: func(_ context.Context, list client.ObjectList, _ ...client.ListOption) error {
+						return nil
+					},
 					MockGet: func(_ context.Context, key client.ObjectKey, obj client.Object) error {
 						switch obj.(type) {
-						case *v1beta1.Lock:
-							return nil
 						case *v1.Provider:
 							if key.Name != p1Name {
 								t.Errorf(errGetProviderFmt, key.Name)
@@ -222,28 +255,42 @@ func TestInstaller(t *testing.T) {
 				p: []string{p1},
 				c: []string{c1},
 				kube: &test.MockClient{
-					MockGet: func(_ context.Context, key client.ObjectKey, obj client.Object) error {
-						switch o := obj.(type) {
-						case *v1beta1.Lock:
-							*o = v1beta1.Lock{
-								ObjectMeta: metav1.ObjectMeta{
-									Name: "lock",
-								},
-								Packages: []v1beta1.LockPackage{
+					MockList: func(_ context.Context, list client.ObjectList, _ ...client.ListOption) error {
+						switch l := list.(type) {
+						case *v1.ProviderList:
+							*l = v1.ProviderList{
+								Items: []v1.Provider{
 									{
-										Name:    p1Existing,
-										Type:    v1beta1.ProviderPackageType,
-										Source:  "some/source",
-										Version: "v0.0.0",
+										ObjectMeta: metav1.ObjectMeta{
+											Name: "other-package",
+										},
+										Spec: v1.ProviderSpec{
+											PackageSpec: v1.PackageSpec{
+												Package: fmt.Sprintf("%s:%s", "other-repo", "v100.100.100"),
+											},
+										},
 									},
 									{
-										Name:    c1Existing,
-										Type:    v1beta1.ConfigurationPackageType,
-										Source:  "some/othersource",
-										Version: "v0.0.0",
+										ObjectMeta: metav1.ObjectMeta{
+											Name: "another-package",
+										},
+										Spec: v1.ProviderSpec{
+											PackageSpec: v1.PackageSpec{
+												Package: "preloaded-source",
+											},
+										},
 									},
 								},
 							}
+						case *v1.ConfigurationList:
+							return nil
+						default:
+							t.Errorf("unexpected type")
+						}
+						return nil
+					},
+					MockGet: func(_ context.Context, key client.ObjectKey, obj client.Object) error {
+						switch obj.(type) {
 						case *v1.Provider:
 							if key.Name != p1Name {
 								t.Errorf(errGetProviderFmt, key.Name)
@@ -269,14 +316,15 @@ func TestInstaller(t *testing.T) {
 			args: args{
 				c: []string{c1},
 				kube: &test.MockClient{
+					MockList: func(_ context.Context, list client.ObjectList, _ ...client.ListOption) error {
+						return nil
+					},
 					MockGet: func(_ context.Context, key client.ObjectKey, obj client.Object) error {
 						switch obj.(type) {
-						case *v1beta1.Lock:
-							return nil
 						case *v1.Provider:
 							t.Errorf("no providers specified")
 						case *v1.Configuration:
-							if key.Name != cleanUpName(c1) {
+							if key.Name != c1Name {
 								t.Errorf("unexpected name in configuration apply")
 							}
 						default:
@@ -295,10 +343,10 @@ func TestInstaller(t *testing.T) {
 				p: []string{p1},
 				c: []string{c1},
 				kube: &test.MockClient{
+					MockList: func(_ context.Context, list client.ObjectList, _ ...client.ListOption) error {
+						return nil
+					},
 					MockGet: func(_ context.Context, key client.ObjectKey, obj client.Object) error {
-						if _, ok := obj.(*v1beta1.Lock); ok {
-							return nil
-						}
 						return errBoom
 					},
 				},


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->


Backport of #2625 to `release-1.4`, which required some minor conflict resolution.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->



1. Install stable
`helm install crossplane --namespace crossplane-system crossplane-stable/crossplane -f values.yaml`

`values.yaml`
```
image:
  tag: v1.4.1
provider:
  packages:
  - crossplane/provider-aws:v0.19.0
```

`k get pkg`

```
NAME                                                         INSTALLED   HEALTHY   PACKAGE                           AGE
provider.pkg.crossplane.io/crossplane-provider-aws-v0-19-0   True        True      crossplane/provider-aws:v0.19.0   28s
```

2. Upgrade to this build with same provider-aws version (see no change to provider)

`helm upgrade crossplane --namespace crossplane-system _output/charts/crossplane-1.4.1-42.g98970d68.tgz -f values.yaml`

`values.yaml`
```
provider:
  packages:
  - crossplane/provider-aws:v0.19.0
```

`k get pkg`

```
NAME                                                         INSTALLED   HEALTHY   PACKAGE                           AGE
provider.pkg.crossplane.io/crossplane-provider-aws-v0-19-0   True        True      crossplane/provider-aws:v0.19.0   2m6s
```

3. Upgrade to this version with new provider-aws version (provider-aws version updated)

`helm upgrade crossplane --namespace crossplane-system _output/charts/crossplane-1.4.1-42.g98970d68.tgz -f values2.yaml`

`values2.yaml`
```
provider:
  packages:
  - crossplane/provider-aws:v0.19.1
```

`k get pkg`

```
NAME                                                         INSTALLED   HEALTHY   PACKAGE                           AGE
provider.pkg.crossplane.io/crossplane-provider-aws-v0-19-0   True        True      crossplane/provider-aws:v0.19.1   4m12s
```

`k get pkgrev`

```
NAME                                                                              HEALTHY   REVISION   IMAGE                             STATE      DEP-FOUND   DEP-INSTALLED   AGE
providerrevision.pkg.crossplane.io/crossplane-provider-aws-v0-19-0-ad3092152cc6   True      2          crossplane/provider-aws:v0.19.1   Active                                 103s
providerrevision.pkg.crossplane.io/crossplane-provider-aws-v0-19-0-dd1e35810a48   True      1          crossplane/provider-aws:v0.19.0   Inactive                               4m18s
```

-- NEW CLUSTER --

1. Fresh install with this build of crossplane and provider-aws (see new naming scheme)

`helm install crossplane --namespace crossplane-system _output/charts/crossplane-1.4.1-42.g98970d68.tgz -f values.yaml`

`values.yaml`
```
provider:
  packages:
  - crossplane/provider-aws:v0.19.0
```

`k get pkg`
```
NAME                                                 INSTALLED   HEALTHY   PACKAGE                           AGE
provider.pkg.crossplane.io/crossplane-provider-aws   True        True      crossplane/provider-aws:v0.19.0   42s
```

[contribution process]: https://git.io/fj2m9
