### PR TITLE
composite: publish all keys if the filter on xrd is empty

### DIFF
--- a/apis/apiextensions/v1/xrd_types.go
+++ b/apis/apiextensions/v1/xrd_types.go
@@ -50,6 +50,7 @@ type CompositeResourceDefinitionSpec struct {
 
 	// ConnectionSecretKeys is the list of keys that will be exposed to the end
 	// user of the defined kind.
+	// If the list is empty, all keys will be published.
 	// +optional
 	ConnectionSecretKeys []string `json:"connectionSecretKeys,omitempty"`
 

--- a/cluster/crds/apiextensions.crossplane.io_compositeresourcedefinitions.yaml
+++ b/cluster/crds/apiextensions.crossplane.io_compositeresourcedefinitions.yaml
@@ -102,7 +102,8 @@ spec:
                 type: object
               connectionSecretKeys:
                 description: ConnectionSecretKeys is the list of keys that will be
-                  exposed to the end user of the defined kind.
+                  exposed to the end user of the defined kind. If the list is empty,
+                  all keys will be published.
                 items:
                   type: string
                 type: array

--- a/docs/reference/composition.md
+++ b/docs/reference/composition.md
@@ -162,7 +162,12 @@ spec:
   claimNames:
     kind: PostgreSQLInstance
     plural: postgresqlinstances
-  # Each type of XR must declare any keys they write to their connection secret.
+  # Each type of XR can declare any keys they write to their connection secret
+  # which will act as a filter during aggregation of the connection secret from
+  # composed resources. It's recommended to provide the set of keys here so that
+  # consumers of claims and XRs can see what to expect in the connection secret.
+  # If no key is given, then all keys in the aggregated connection secret will
+  # be written to the connection secret of the XR.
   connectionSecretKeys:
   - hostname
   # Each type of XR may specify a default Composition to be used when none is
@@ -558,8 +563,17 @@ true converts to integer 1 and float 1.0, while false converts to 0 and 0.0.
 
 ### Connection Details
 
+Connection details secret of XR is an aggregated sum of the connection details
+of the composed resources. It's recommended that the author of XRD specify
+exactly which keys will be allowed in the XR connection secret by listing them
+in `spec.connectionSecretKeys` so that consumers of claims and XRs can see what
+they can expect in the connection details secret.
+
+If `spec.connectionSecretKeys` is empty, then all keys of the aggregated connection
+details secret will be propagated.
+
 You can derive the following types of connection details from a composed
-resource:
+resource to be aggregated:
 
 `FromConnectionSecretKey`. Derives an XR connection detail from a connection
 secret key of a composed resource.

--- a/internal/controller/apiextensions/composite/api.go
+++ b/internal/controller/apiextensions/composite/api.go
@@ -82,13 +82,14 @@ func (a *APIFilteredSecretPublisher) PublishConnection(ctx context.Context, o re
 	}
 
 	s := resource.ConnectionSecretFor(o, o.GetObjectKind().GroupVersionKind())
-	m := map[string]bool{}
-	// TODO(muvaf): Should empty filter allow all keys?
+	m := map[string]struct{}{}
 	for _, key := range a.filter {
-		m[key] = true
+		m[key] = struct{}{}
 	}
 	for key, val := range c {
-		if _, ok := m[key]; ok {
+		// If the filter does not have any keys, we allow all given keys to be
+		// published.
+		if _, ok := m[key]; len(m) == 0 || ok {
 			s.Data[key] = val
 		}
 	}

--- a/internal/controller/apiextensions/composite/api.go
+++ b/internal/controller/apiextensions/composite/api.go
@@ -82,14 +82,14 @@ func (a *APIFilteredSecretPublisher) PublishConnection(ctx context.Context, o re
 	}
 
 	s := resource.ConnectionSecretFor(o, o.GetObjectKind().GroupVersionKind())
-	m := map[string]struct{}{}
+	m := map[string]bool{}
 	for _, key := range a.filter {
-		m[key] = struct{}{}
+		m[key] = true
 	}
 	for key, val := range c {
 		// If the filter does not have any keys, we allow all given keys to be
 		// published.
-		if _, ok := m[key]; len(m) == 0 || ok {
+		if len(m) == 0 || m[key] {
 			s.Data[key] = val
 		}
 	}

--- a/internal/controller/apiextensions/composite/api_test.go
+++ b/internal/controller/apiextensions/composite/api_test.go
@@ -100,7 +100,7 @@ func TestPublishConnection(t *testing.T) {
 			},
 		},
 		"SuccessfulPublish": {
-			reason: "if the secret changed we should publish it.",
+			reason: "If the secret changed we should publish it.",
 			args: args{
 				applicator: resource.ApplyFn(func(_ context.Context, o client.Object, _ ...resource.ApplyOption) error {
 					want := resource.ConnectionSecretFor(owner, owner.GetObjectKind().GroupVersionKind())
@@ -113,6 +113,25 @@ func TestPublishConnection(t *testing.T) {
 				o:      owner,
 				c:      managed.ConnectionDetails{"cool": {42}, "onlyme": {41}},
 				filter: []string{"onlyme"},
+			},
+			want: want{
+				published: true,
+			},
+		},
+		"SuccessfulPublishAllWithEmptyList": {
+			reason: "We should publish all keys if the filter is empty.",
+			args: args{
+				applicator: resource.ApplyFn(func(_ context.Context, o client.Object, _ ...resource.ApplyOption) error {
+					want := resource.ConnectionSecretFor(owner, owner.GetObjectKind().GroupVersionKind())
+					want.Data = managed.ConnectionDetails{"cool": {42}, "onlyme": {41}}
+					if diff := cmp.Diff(want, o); diff != "" {
+						t.Errorf("-want, +got:\n%s", diff)
+					}
+					return nil
+				}),
+				o:      owner,
+				c:      managed.ConnectionDetails{"cool": {42}, "onlyme": {41}},
+				filter: []string{},
 			},
 			want: want{
 				published: true,


### PR DESCRIPTION
### Description of your changes

It should be a non-breaking change. The only difference will be that people who left the filter list empty may now see a `Secret` with some data but I'd not really consider this as breaking.

Fixes https://github.com/crossplane/crossplane/issues/2593

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

Unit test.

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
