### PR TITLE
late initializing some xrc fields from the xr

### DIFF
--- a/internal/xcrd/schemas.go
+++ b/internal/xcrd/schemas.go
@@ -29,6 +29,10 @@ const (
 // when translating an XRC into an XR.
 var PropagateClaimSpecProps = []string{"compositionRef", "compositionSelector", "compositionRevisionRef", "compositionUpdatePolicy"}
 
+// PropagateCompositeSpecProps is the list of XR spec properties to propagate
+// when translating an XR into an XRC.
+var PropagateCompositeSpecProps = []string{"compositionRef", "compositionSelector"}
+
 // TODO(negz): Add descriptions to schema fields.
 
 // BaseProps is a partial OpenAPIV3Schema for the spec fields that Crossplane

--- a/internal/xcrd/schemas.go
+++ b/internal/xcrd/schemas.go
@@ -25,13 +25,9 @@ const (
 	LabelKeyClaimNamespace        = "crossplane.io/claim-namespace"
 )
 
-// PropagateClaimSpecProps is the list of XRC spec properties to propagate
-// when translating an XRC into an XR.
-var PropagateClaimSpecProps = []string{"compositionRef", "compositionSelector", "compositionRevisionRef", "compositionUpdatePolicy"}
-
-// PropagateCompositeSpecProps is the list of XR spec properties to propagate
-// when translating an XR into an XRC.
-var PropagateCompositeSpecProps = []string{"compositionRef", "compositionSelector"}
+// PropagateSpecProps is the list of XRC spec properties to propagate
+// when translating an XRC into an XR and vice-versa.
+var PropagateSpecProps = []string{"compositionRef", "compositionSelector", "compositionRevisionRef", "compositionUpdatePolicy"}
 
 // TODO(negz): Add descriptions to schema fields.
 


### PR DESCRIPTION
Signed-off-by: RinkiyaKeDad <arshsharma461@gmail.com>

<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

Followed @negz's suggestion and used the [existing pattern](https://github.com/crossplane/crossplane/blob/06fadd7433bbc9d6b9ba00125f36864e6a2a80c7/internal/controller/apiextensions/claim/configurator.go#L116-L121) of late initializing the claim's spec from the composite's spec.

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #2263 

I have:

- [ ] Read and followed Crossplane's [contribution process].
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
