### PR TITLE
Update 'an' to 'a' in `CompositeResourceDefinition` docstrings

### DIFF
--- a/apis/apiextensions/v1/xrd_types.go
+++ b/apis/apiextensions/v1/xrd_types.go
@@ -155,7 +155,7 @@ type CompositeResourceDefinitionControllerStatus struct {
 // +genclient
 // +genclient:nonNamespaced
 
-// An CompositeResourceDefinition defines a new kind of composite infrastructure
+// A CompositeResourceDefinition defines a new kind of composite infrastructure
 // resource. The new resource is composed of other composite or managed
 // infrastructure resources.
 // +kubebuilder:printcolumn:name="ESTABLISHED",type="string",JSONPath=".status.conditions[?(@.type=='Established')].status"

--- a/apis/apiextensions/v1beta1/xrd_types.go
+++ b/apis/apiextensions/v1beta1/xrd_types.go
@@ -154,7 +154,7 @@ type CompositeResourceDefinitionControllerStatus struct {
 // +genclient
 // +genclient:nonNamespaced
 
-// An CompositeResourceDefinition defines a new kind of composite infrastructure
+// A CompositeResourceDefinition defines a new kind of composite infrastructure
 // resource. The new resource is composed of other composite or managed
 // infrastructure resources.
 // [DEPRECATED]: Please use the identical v1 API instead. The v1beta1 API is

--- a/cluster/crds/apiextensions.crossplane.io_compositeresourcedefinitions.yaml
+++ b/cluster/crds/apiextensions.crossplane.io_compositeresourcedefinitions.yaml
@@ -32,7 +32,7 @@ spec:
     name: v1
     schema:
       openAPIV3Schema:
-        description: An CompositeResourceDefinition defines a new kind of composite
+        description: A CompositeResourceDefinition defines a new kind of composite
           infrastructure resource. The new resource is composed of other composite
           or managed infrastructure resources.
         properties:
@@ -379,7 +379,7 @@ spec:
     name: v1beta1
     schema:
       openAPIV3Schema:
-        description: 'An CompositeResourceDefinition defines a new kind of composite
+        description: 'A CompositeResourceDefinition defines a new kind of composite
           infrastructure resource. The new resource is composed of other composite
           or managed infrastructure resources. [DEPRECATED]: Please use the identical
           v1 API instead. The v1beta1 API is scheduled to be removed in Crossplane

--- a/internal/controller/apiextensions/definition/reconciler.go
+++ b/internal/controller/apiextensions/definition/reconciler.go
@@ -89,13 +89,13 @@ type ControllerEngine interface {
 	Err(name string) error
 }
 
-// A CRDRenderer renders an CompositeResourceDefinition's corresponding
+// A CRDRenderer renders a CompositeResourceDefinition's corresponding
 // CustomResourceDefinition.
 type CRDRenderer interface {
 	Render(d *v1.CompositeResourceDefinition) (*extv1.CustomResourceDefinition, error)
 }
 
-// A CRDRenderFn renders an CompositeResourceDefinition's corresponding
+// A CRDRenderFn renders a CompositeResourceDefinition's corresponding
 // CustomResourceDefinition.
 type CRDRenderFn func(d *v1.CompositeResourceDefinition) (*extv1.CustomResourceDefinition, error)
 

--- a/internal/controller/apiextensions/definition/reconciler_test.go
+++ b/internal/controller/apiextensions/definition/reconciler_test.go
@@ -96,7 +96,7 @@ func TestReconcile(t *testing.T) {
 			},
 		},
 		"GetCompositeResourceDefinitionError": {
-			reason: "We should return any other error encountered while getting an CompositeResourceDefinition.",
+			reason: "We should return any other error encountered while getting a CompositeResourceDefinition.",
 			args: args{
 				mgr: &fake.Manager{},
 				opts: []ReconcilerOption{

--- a/internal/controller/apiextensions/offered/reconciler.go
+++ b/internal/controller/apiextensions/offered/reconciler.go
@@ -91,13 +91,13 @@ type ControllerEngine interface {
 	Err(name string) error
 }
 
-// A CRDRenderer renders an CompositeResourceDefinition's corresponding
+// A CRDRenderer renders a CompositeResourceDefinition's corresponding
 // CustomResourceDefinition.
 type CRDRenderer interface {
 	Render(d *v1.CompositeResourceDefinition) (*extv1.CustomResourceDefinition, error)
 }
 
-// A CRDRenderFn renders an CompositeResourceDefinition's corresponding
+// A CRDRenderFn renders a CompositeResourceDefinition's corresponding
 // CustomResourceDefinition.
 type CRDRenderFn func(d *v1.CompositeResourceDefinition) (*extv1.CustomResourceDefinition, error)
 

--- a/internal/controller/apiextensions/offered/reconciler_test.go
+++ b/internal/controller/apiextensions/offered/reconciler_test.go
@@ -96,7 +96,7 @@ func TestReconcile(t *testing.T) {
 			},
 		},
 		"GetCompositeResourceDefinitionError": {
-			reason: "We should return any other error encountered while getting an CompositeResourceDefinition.",
+			reason: "We should return any other error encountered while getting a CompositeResourceDefinition.",
 			args: args{
 				mgr: &fake.Manager{},
 				opts: []ReconcilerOption{

--- a/internal/controller/rbac/definition/reconciler_test.go
+++ b/internal/controller/rbac/definition/reconciler_test.go
@@ -72,7 +72,7 @@ func TestReconcile(t *testing.T) {
 			},
 		},
 		"GetCompositeResourceDefinitionError": {
-			reason: "We should return any other error encountered while getting an CompositeResourceDefinition.",
+			reason: "We should return any other error encountered while getting a CompositeResourceDefinition.",
 			args: args{
 				mgr: &fake.Manager{},
 				opts: []ReconcilerOption{


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Just happened to notice this on https://doc.crds.dev/github.com/crossplane/crossplane today and saw it was a remnant of the find & replace from `InfrastructureDefinition` (RIP) :)

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

n/a

[contribution process]: https://git.io/fj2m9
