### PR TITLE
[helm] Add podSecurityContext to values to allow setting securityContext on Pod level

### DIFF
--- a/cluster/charts/crossplane/templates/deployment.yaml
+++ b/cluster/charts/crossplane/templates/deployment.yaml
@@ -27,6 +27,8 @@ spec:
         app: {{ template "name" . }}
         release: {{ .Release.Name }}
     spec:
+      securityContext:
+        {{- toYaml .Values.podSecurityContextCrossplane | nindent 8 }}
       {{- if .Values.priorityClassName }}
       priorityClassName: {{ .Values.priorityClassName  | quote }}
       {{- end }}

--- a/cluster/charts/crossplane/templates/rbac-manager-deployment.yaml
+++ b/cluster/charts/crossplane/templates/rbac-manager-deployment.yaml
@@ -28,6 +28,8 @@ spec:
         app: {{ template "name" . }}-rbac-manager
         release: {{ .Release.Name }}
     spec:
+      securityContext:
+        {{- toYaml .Values.podSecurityContextRBACManager | nindent 8 }}
       {{- if .Values.priorityClassName }}
       priorityClassName: {{ .Values.priorityClassName | quote }}
       {{- end }}

--- a/cluster/charts/crossplane/values.yaml.tmpl
+++ b/cluster/charts/crossplane/values.yaml.tmpl
@@ -77,3 +77,7 @@ metrics:
 extraEnvVarsCrossplane: {}
 
 extraEnvVarsRBACManager: {}
+
+podSecurityContextCrossplane: {}
+
+podSecurityContextRBACManager: {}


### PR DESCRIPTION
Signed-off-by: Mohamed Chiheb <mc.benjemaa@gmail.com>

<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->


### Description of your changes

Adding PVC (dynamic pv) for the cache on GKE  cluster, causes this issue:

```
cannot initialize parser backend: failed to store package in cache: open /cache/crossplane-provider-helm-d29c7a1e7fbb.xpkg: permission denied
```
That's because the volume is mounted without proper permissions.

To make the pod able to set ownership for the mounted volume! we need to set, `fsGroup` on the [PodSecurityContext ](https://pkg.go.dev/k8s.io/api@v0.22.3/core/v1#PodSecurityContext)

e.g.
```
spec:
  securityContext:
     fsGroup: 2000
```

Current crossplane values doesn't have option to set securityContext on the pod level.

In this PR I added an option to allow setting POD level `securityContext`.
While I believe that by design this is fine,  as long as container level `securityContext` will override pod level ones.



<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #2694

I have:

- [X] Read and followed Crossplane's [contribution process].
- [X] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


/cc @negz @hasheddan 

I think this is worth to have a patch release.
Can you create a patch release to adapt this? 

[contribution process]: https://git.io/fj2m9
