### PR TITLE
Fix Slack link in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -502,7 +502,7 @@ kubectl -n crossplane-system scale deploy crossplane --replicas=0
 make run
 ```
 
-[Slack]: https://crossplane.slack.com/channels/dev
+[Slack]: https://slack.crossplane.io/
 [code of conduct]: https://github.com/cncf/foundation/blob/master/code-of-conduct.md
 [build submodule]: https://github.com/upbound/build/
 [`kind`]: https://kind.sigs.k8s.io/


### PR DESCRIPTION
For a user who has not registered with the Crossplane Slack yet, the
previous link pointing directly to the Slack channel would insist the
user register with an @upbound.io email address.

Instead, link to the invite sending helper page, like everywhere else.

<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

I have:

- [x] Read and followed Crossplane's [contribution process].
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

I... read the diff? It's a documentation change.