### PR TITLE
Use dedicated Upbound Registry robots for Configurations and Crossplane

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ env:
   # a step 'if env.AWS_USR' != ""', so we copy these to succinctly test whether
   # credentials have been provided before trying to run steps that need them.
   DOCKER_USR: ${{ secrets.DOCKER_USR }}
-  UPBOUND_ROBOT_USR: ${{ secrets.UPBOUND_ROBOT_USR }}
+  UPBOUND_CROSSPLANE_ROBOT_USR: ${{ secrets.UPBOUND_CROSSPLANE_ROBOT_USR }}
   AWS_USR: ${{ secrets.AWS_USR }}
 
 jobs:
@@ -307,15 +307,15 @@ jobs:
       
       - name: Login to Upbound Registry
         uses: docker/login-action@v1
-        if: env.UPBOUND_ROBOT_USR != ''
+        if: env.UPBOUND_CROSSPLANE_ROBOT_USR != ''
         with:
           registry: registry.upbound.io
-          username: ${{ secrets.UPBOUND_ROBOT_USR }}
-          password: ${{ secrets.UPBOUND_ROBOT_PSW }}
+          username: ${{ secrets.UPBOUND_CROSSPLANE_ROBOT_USR }}
+          password: ${{ secrets.UPBOUND_CROSSPLANE_ROBOT_PSW }}
 
       - name: Publish Artifacts to S3, DockerHub, and Upbound Registry
         run: make -j2 publish BRANCH_NAME=${GITHUB_REF##*/}
-        if: env.AWS_USR != '' && env.DOCKER_USR != '' && env.UPBOUND_ROBOT_USR != ''
+        if: env.AWS_USR != '' && env.DOCKER_USR != '' && env.UPBOUND_CROSSPLANE_ROBOT_USR != ''
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_USR }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_PSW }}
@@ -324,7 +324,7 @@ jobs:
           DOCS_GIT_PSW: ${{ secrets.UPBOUND_BOT_GITHUB_PSW }}
 
       - name: Promote Artifacts in S3, DockerHub, and Upbound Registry
-        if: github.ref == 'refs/heads/master' && env.AWS_USR != '' && env.DOCKER_USR != '' && env.UPBOUND_ROBOT_USR != ''
+        if: github.ref == 'refs/heads/master' && env.AWS_USR != '' && env.DOCKER_USR != '' && env.UPBOUND_CROSSPLANE_ROBOT_USR != ''
         run: make -j2 promote
         env:
           BRANCH_NAME: master

--- a/.github/workflows/configurations.yml
+++ b/.github/workflows/configurations.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch: {}
 
 env:
-  DOCKER_USR: ${{ secrets.UPBOUND_ROBOT_USR }}
+  DOCKER_USR: ${{ secrets.UPBOUND_XP_ROBOT_USR }}
 
 jobs:
   getting-started-with-aws:
@@ -29,8 +29,8 @@ jobs:
         if: env.DOCKER_USR != ''
         with:
           registry: registry.upbound.io
-          username: ${{ secrets.UPBOUND_ROBOT_USR }}
-          password: ${{ secrets.UPBOUND_ROBOT_PSW }}
+          username: ${{ secrets.UPBOUND_XP_ROBOT_USR }}
+          password: ${{ secrets.UPBOUND_XP_ROBOT_PSW }}
       - name: Build
         uses: crossplane-contrib/xpkg-action@v0.2.0
         with:
@@ -62,8 +62,8 @@ jobs:
         if: env.DOCKER_USR != ''
         with:
           registry: registry.upbound.io
-          username: ${{ secrets.UPBOUND_ROBOT_USR }}
-          password: ${{ secrets.UPBOUND_ROBOT_PSW }}
+          username: ${{ secrets.UPBOUND_XP_ROBOT_USR }}
+          password: ${{ secrets.UPBOUND_XP_ROBOT_PSW }}
       - name: Build
         uses: crossplane-contrib/xpkg-action@v0.2.0
         with:
@@ -95,8 +95,8 @@ jobs:
         if: env.DOCKER_USR != ''
         with:
           registry: registry.upbound.io
-          username: ${{ secrets.UPBOUND_ROBOT_USR }}
-          password: ${{ secrets.UPBOUND_ROBOT_PSW }}
+          username: ${{ secrets.UPBOUND_XP_ROBOT_USR }}
+          password: ${{ secrets.UPBOUND_XP_ROBOT_PSW }}
       - name: Build
         uses: crossplane-contrib/xpkg-action@v0.2.0
         with:
@@ -128,8 +128,8 @@ jobs:
         if: env.DOCKER_USR != ''
         with:
           registry: registry.upbound.io
-          username: ${{ secrets.UPBOUND_ROBOT_USR }}
-          password: ${{ secrets.UPBOUND_ROBOT_PSW }}
+          username: ${{ secrets.UPBOUND_XP_ROBOT_USR }}
+          password: ${{ secrets.UPBOUND_XP_ROBOT_PSW }}
       - name: Build
         uses: crossplane-contrib/xpkg-action@v0.2.0
         with:

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -16,7 +16,7 @@ env:
   # a step 'if env.AWS_USR' != ""', so we copy these to succinctly test whether
   # credentials have been provided before trying to run steps that need them.
   DOCKER_USR: ${{ secrets.DOCKER_USR }}
-  UPBOUND_ROBOT_USR: ${{ secrets.UPBOUND_ROBOT_USR }}
+  UPBOUND_CROSSPLANE_ROBOT_USR: ${{ secrets.UPBOUND_CROSSPLANE_ROBOT_USR }}
   AWS_USR: ${{ secrets.AWS_USR }}
 
 jobs:
@@ -41,14 +41,14 @@ jobs:
         
       - name: Login to Upbound Registry
         uses: docker/login-action@v1
-        if: env.UPBOUND_ROBOT_USR != ''
+        if: env.UPBOUND_CROSSPLANE_ROBOT_USR != ''
         with:
           registry: registry.upbound.io
-          username: ${{ secrets.UPBOUND_ROBOT_USR }}
-          password: ${{ secrets.UPBOUND_ROBOT_PSW }}
+          username: ${{ secrets.UPBOUND_CROSSPLANE_ROBOT_USR }}
+          password: ${{ secrets.UPBOUND_CROSSPLANE_ROBOT_PSW }}
 
       - name: Promote Artifacts in S3, DockerHub, and Upbound Registry
-        if: env.AWS_USR != '' && env.DOCKER_USR != '' && env.UPBOUND_ROBOT_USR != ''
+        if: env.AWS_USR != '' && env.DOCKER_USR != '' && env.UPBOUND_CROSSPLANE_ROBOT_USR != ''
         run: make -j2 promote BRANCH_NAME=${GITHUB_REF##*/}
         env:
           VERSION: ${{ github.event.inputs.version }}


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Updates the configurations workflow to use UPBOUND_XP_ROBOT, which has
credentials to push repositories in the XP org on Upbound Registry.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

Moves to using UPBOUND_CROSSPLANE_ROBOT for pushing the crossplane image
to Upbound Registry. This robot account has permissions to push to
repositories in the Crossplane org.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

I have tested registry operations with both of these sets of credentials, but we won't know for sure until CI runs.

[contribution process]: https://git.io/fj2m9
