### PR TITLE
readme: add release calendar link

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ documentation].
 |   v1.5  |     [v1.5.1]    | Oct 26, 2021 | April 2022    |
 |   v1.6  |     Upcoming    | Dec 21, 2021 | June 2022    |
 
+You can subscribe to [release calendar] to track all release dates.
+
 [v1.3.3]: https://github.com/crossplane/crossplane/releases/tag/v1.3.3
 [v1.4.3]: https://github.com/crossplane/crossplane/releases/tag/v1.4.3
 [v1.5.1]: https://github.com/crossplane/crossplane/releases/tag/v1.5.1
@@ -75,3 +77,4 @@ Crossplane is under the Apache 2.0 license.
 [Past meeting recordings]: https://www.youtube.com/playlist?list=PL510POnNVaaYYYDSICFSNWFqNbx1EMr-M
 [roadmap]: https://github.com/orgs/crossplane/projects/12
 [cncf]: https://www.cncf.io/
+[release calendar]: https://calendar.google.com/calendar/u/0/embed?src=c_uttnrqr6t7r167uf57nja58mdc@group.calendar.google.com


### PR DESCRIPTION
### Description of your changes

This should make it easier for people to track releases. Current admins of the calendar are owners of this repo.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

Clicking the link.

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
