### PR TITLE
Fix matchLabels blocking upgrade

### DIFF
--- a/cluster/charts/crossplane/templates/_helpers.tpl
+++ b/cluster/charts/crossplane/templates/_helpers.tpl
@@ -21,19 +21,12 @@ helm.sh/chart: {{ include "crossplane.chart" . }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 app.kubernetes.io/component: cloud-infrastructure-controller
 app.kubernetes.io/part-of: {{ template "crossplane.name" . }}
-{{- include "crossplane.selectorLabels" . }}
+app.kubernetes.io/name: {{ include "crossplane.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 {{- if .Values.customLabels }}
 {{ toYaml .Values.customLabels }}
 {{- end }}
-{{- end }}
-
-{{/*
-Selector labels
-*/}}
-{{- define "crossplane.selectorLabels" }}
-app.kubernetes.io/name: {{ include "crossplane.name" . }}
-app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}

--- a/cluster/charts/crossplane/templates/deployment.yaml
+++ b/cluster/charts/crossplane/templates/deployment.yaml
@@ -4,13 +4,14 @@ metadata:
   name: {{ template "crossplane.name" . }}
   labels:
     app: {{ template "crossplane.name" . }}
+    release: {{ .Release.Name }}
     {{- include "crossplane.labels" . | indent 4 }}
 spec:
   replicas: {{ .Values.replicas }}
   selector:
     matchLabels:
       app: {{ template "crossplane.name" . }}
-      {{- include "crossplane.selectorLabels" . | indent 6 }}
+      release: {{ .Release.Name }}
   strategy:
     type: {{ .Values.deploymentStrategy }}
   template:
@@ -23,6 +24,7 @@ spec:
       {{- end }}
       labels:
         app: {{ template "crossplane.name" . }}
+        release: {{ .Release.Name }}
         {{- include "crossplane.labels" . | indent 8 }}
     spec:
       securityContext:

--- a/cluster/charts/crossplane/templates/rbac-manager-deployment.yaml
+++ b/cluster/charts/crossplane/templates/rbac-manager-deployment.yaml
@@ -5,13 +5,14 @@ metadata:
   name: {{ template "crossplane.name" . }}-rbac-manager
   labels:
     app: {{ template "crossplane.name" . }}-rbac-manager
+    release: {{ .Release.Name }}
     {{- include "crossplane.labels" . | indent 4 }}
 spec:
   replicas: {{ .Values.rbacManager.replicas }}
   selector:
     matchLabels:
       app: {{ template "crossplane.name" . }}-rbac-manager
-      {{- include "crossplane.selectorLabels" . | indent 6 }}
+      release: {{ .Release.Name }}
   strategy:
     type: {{ .Values.deploymentStrategy }}
   template:
@@ -24,6 +25,7 @@ spec:
       {{- end }}
       labels:
         app: {{ template "crossplane.name" . }}-rbac-manager
+        release: {{ .Release.Name }}
         {{- include "crossplane.labels" . | indent 8 }}
     spec:
       securityContext:


### PR DESCRIPTION


<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

The matchLabels stanza for the Crossplane and RBAC manager deployments
was recently changed, causing upgrades to fail as this field is
immutable. This reverts back to the previous matchLables stanza and
makes them static such that they are not modified by user input.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

Fixes #2745 

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

Installed `v1.5.1`
```
kubectl create namespace crossplane-system

helm repo add crossplane-stable https://charts.crossplane.io/stable
helm repo update

helm install crossplane --namespace crossplane-system crossplane-stable/crossplane
```

Built chart and image from this commit:
```
make build
```

Loaded docker image:
```
🤖 (crossplane) docker tag build-c0d442a4/crossplane-amd64 crossplane/crossplane:v1.6.0-rc.0.95.g203d6c35.dirty
🤖 (crossplane) kind load docker-image crossplane/crossplane:v1.6.0-rc.0.95.g203d6c35.dirty
Image: "crossplane/crossplane:v1.6.0-rc.0.95.g203d6c35.dirty" with ID "sha256:8b444e6997667adc1dbac569b9c6d10f47c16896af9d7b858e4a4c24e8428228" not yet present on node "kind-control-plane", loading...
```

Upgraded Helm chart:
```
🤖 (crossplane) helm upgrade crossplane  _output/charts/crossplane-1.6.0-rc.0.95.g203d6c35.dirty.tgz -n crossplane-system
Release "crossplane" has been upgraded. Happy Helming!
NAME: crossplane
LAST DEPLOYED: Wed Dec  8 12:43:06 2021
NAMESPACE: crossplane-system
STATUS: deployed
REVISION: 2
TEST SUITE: None
NOTES:
Release: crossplane

Chart Name: crossplane
Chart Description: Crossplane is an open source Kubernetes add-on that enables platform teams to assemble infrastructure from multiple vendors, and expose higher level self-service APIs for application teams to consume.
Chart Version: 1.6.0-rc.0.95.g203d6c35.dirty
Chart Application Version: 1.6.0-rc.0.95.g203d6c35.dirty

Kube Version: v1.21.1
```

Verified install successful
```
🤖 (crossplane) k get pods -A
NAMESPACE            NAME                                         READY   STATUS    RESTARTS   AGE
crossplane-system    crossplane-5dddfbf955-lmkj5                  1/1     Running   0          86s
crossplane-system    crossplane-rbac-manager-6d74bb9f59-dvzpk     1/1     Running   0          86s
kube-system          coredns-558bd4d5db-m78cn                     1/1     Running   0          15m
kube-system          coredns-558bd4d5db-tjzvp                     1/1     Running   0          15m
kube-system          etcd-kind-control-plane                      1/1     Running   0          15m
kube-system          kindnet-4rsnf                                1/1     Running   0          15m
kube-system          kube-apiserver-kind-control-plane            1/1     Running   0          15m
kube-system          kube-controller-manager-kind-control-plane   1/1     Running   0          15m
kube-system          kube-proxy-d9r8x                             1/1     Running   0          15m
kube-system          kube-scheduler-kind-control-plane            1/1     Running   0          15m
local-path-storage   local-path-provisioner-547f784dff-x2qrs      1/1     Running   0          15m
```

```
🤖 (crossplane) k describe -n crossplane-system pod crossplane-5dddfbf955-lmkj5
Name:         crossplane-5dddfbf955-lmkj5
Namespace:    crossplane-system
Priority:     0
Node:         kind-control-plane/172.18.0.2
Start Time:   Wed, 08 Dec 2021 12:43:06 -0500
Labels:       app=crossplane
              app.kubernetes.io/component=cloud-infrastructure-controller
              app.kubernetes.io/instance=crossplane
              app.kubernetes.io/managed-by=Helm
              app.kubernetes.io/name=crossplane
              app.kubernetes.io/part-of=crossplane
              app.kubernetes.io/version=1.6.0-rc.0.95.g203d6c35.dirty
              helm.sh/chart=crossplane-1.6.0-rc.0.95.g203d6c35.dirty
              pod-template-hash=5dddfbf955
              release=crossplane
```

[contribution process]: https://git.io/fj2m9
