### PR TITLE
Make crossplane ServiceAccount creation optional

### DIFF
--- a/cluster/charts/crossplane/README.md
+++ b/cluster/charts/crossplane/README.md
@@ -87,6 +87,7 @@ and their default values.
 | `securityContextCrossplane.runAsGroup` | Run as group for Crossplane | `65532` |
 | `securityContextCrossplane.allowPrivilegeEscalation` | Allow privilege escalation for Crossplane | `false` |
 | `securityContextCrossplane.readOnlyRootFilesystem` | ReadOnly root filesystem for Crossplane | `true` |
+| `serviceAccount.crossplane.create` | Setting to `false` means the crossplane ServiceAccount is managed outside this chart | `true` |
 | `provider.packages` | The list of Provider packages to install together with Crossplane | `[]` |
 | `configuration.packages` | The list of Configuration packages to install together with Crossplane | `[]` |
 | `packageCache.medium` | Storage medium for package cache. `Memory` means volume will be backed by tmpfs, which can be useful for development. | `""` |

--- a/cluster/charts/crossplane/templates/serviceaccount.yaml
+++ b/cluster/charts/crossplane/templates/serviceaccount.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.serviceAccount.crossplane.create }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -11,3 +12,4 @@ imagePullSecrets:
 - name: {{ $secret }}
 {{- end }}
 {{ end }}
+{{- end }}

--- a/cluster/charts/crossplane/values.yaml.tmpl
+++ b/cluster/charts/crossplane/values.yaml.tmpl
@@ -55,6 +55,10 @@ securityContextCrossplane:
   allowPrivilegeEscalation: false
   readOnlyRootFilesystem: true
 
+serviceAccount:
+  crossplane:
+    create: true
+
 packageCache:
   medium: ""
   sizeLimit: 5Mi


### PR DESCRIPTION
For anyone who wants to manage the crossplane ServiceAccount externally
this defines a flag to allow disabling the creation of this specific
ServiceAccount in the Helm chart.

<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #2755 ":

-->
Fixes #2755 

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

I tried to run `make reviewable`:
~~~
make reviewable
make: *** No rule to make target `reviewable'.  Stop.
~~~

### How has this code been tested

I have used the existing values.yaml.tmpl file to create a valid values.yaml file. I then used my own override of the new setting.

Below shows the steps I used other than having to provide a valid value to replace `%%VERSION%%` from the template.

~~~
$ cp values.yaml.tmpl values.yaml
$ helm template . > /tmp/default.yaml
$ helm template . -f myvalues.yaml > /tmp/serviceaccountdisabled.yaml
$ diff /tmp/default.yaml /tmp/serviceaccountdisabled.yaml 
17,33d16
< # Source: crossplane/templates/serviceaccount.yaml
< apiVersion: v1
< kind: ServiceAccount
< metadata:
<   name: crossplane
<   labels:
<     app: crossplane    
<     helm.sh/chart: crossplane-0.0.1
<     app.kubernetes.io/managed-by: Helm
<     app.kubernetes.io/component: cloud-infrastructure-controller
<     app.kubernetes.io/part-of: crossplane
<     app.kubernetes.io/name: crossplane
<     app.kubernetes.io/instance: RELEASE-NAME
<     app.kubernetes.io/version: "0.0.1"
< imagePullSecrets:
< - name: dockerhub
< ---
~~~

This shows that the flag works as intended.

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
