### PR TITLE
Include imagePullSecrets to rbac-manager serviceaccount

### DIFF
--- a/cluster/charts/crossplane/templates/rbac-manager-serviceaccount.yaml
+++ b/cluster/charts/crossplane/templates/rbac-manager-serviceaccount.yaml
@@ -6,4 +6,10 @@ metadata:
   labels:
     app: {{ template "crossplane.name" . }}
     {{- include "crossplane.labels" . | indent 4 }}
+{{- if .Values.imagePullSecrets }}
+imagePullSecrets:
+{{- range $index, $secret := .Values.imagePullSecrets }}
+- name: {{ $secret }}
+{{- end }}
+{{- end }}
 {{- end}}


### PR DESCRIPTION
Signed-off-by: Mohamed Chiheb <mc.benjemaa@gmail.com>

<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

Since we have some internal clusters without public access, and We have replicated our images to another registry,

Yet, We used `imagePullSecrets` in the crossplane serviceaccount, so that the kubelet is able to pull the images from the registry.. 

But, `rbac-manager` uses his standalone serviceaccount `rbac-manager` which in fact doesn't include the option to add `imagePullSecrets`

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #2781

I have:

- [X] Read and followed Crossplane's [contribution process].
- [X] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

/cc @hasheddan  

Yet! worth for patch release.

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
