### PR TITLE
Apply merge options from patch policy

### DIFF
--- a/apis/apiextensions/v1/composition_patches.go
+++ b/apis/apiextensions/v1/composition_patches.go
@@ -166,13 +166,13 @@ func (c *Patch) applyTransforms(input interface{}) (interface{}, error) {
 // patchFieldValueToObject, given a path, value and "to" object, will
 // apply the value to the "to" object at the given path, returning
 // any errors as they occur.
-func patchFieldValueToObject(fieldPath string, value interface{}, to runtime.Object, mergeOpts *xpv1.MergeOptions) error {
+func patchFieldValueToObject(fieldPath string, value interface{}, to runtime.Object, mo *xpv1.MergeOptions) error {
 	paved, err := fieldpath.PaveObject(to)
 	if err != nil {
 		return err
 	}
 
-	if err := paved.MergeValue(fieldPath, value, mergeOpts); err != nil {
+	if err := paved.MergeValue(fieldPath, value, mo); err != nil {
 		return err
 	}
 
@@ -205,12 +205,9 @@ func (c *Patch) applyFromFieldPathPatch(from, to runtime.Object) error {
 		return err
 	}
 
-	var mergeOpts *xpv1.MergeOptions
-
-	if c.Policy == nil {
-		mergeOpts = nil
-	} else {
-		mergeOpts = c.Policy.MergeOptions
+	var mo *xpv1.MergeOptions
+	if c.Policy != nil {
+		mo = c.Policy.MergeOptions
 	}
 
 	// Apply transform pipeline
@@ -219,7 +216,7 @@ func (c *Patch) applyFromFieldPathPatch(from, to runtime.Object) error {
 		return err
 	}
 
-	return patchFieldValueToObject(*c.ToFieldPath, out, to, mergeOpts)
+	return patchFieldValueToObject(*c.ToFieldPath, out, to, mo)
 }
 
 // applyCombineFromVariablesPatch patches the "to" resource, taking a list of


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

Prior to this commit, merge options were not applied to the
paved.MergeValue method and were effectively thrown away. This commit
passes in any options from Policy.MergeOptions, passing in nil if none
were supplied so that fields can be correctly preserved and merged.

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #2690

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

Unit test added for preserving map values and arraySlice merges tested with locally running Crossplane and applying XRs to create MRs with appended fields.
<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
