### PR TITLE
Only set package revision in context of ImageBackend Init() to avoid concurrent access issues

### DIFF
--- a/internal/controller/pkg/revision/imageback.go
+++ b/internal/controller/pkg/revision/imageback.go
@@ -44,7 +44,6 @@ const (
 
 // ImageBackend is a backend for parser.
 type ImageBackend struct {
-	pr       v1.PackageRevision
 	registry string
 	cache    xpkg.Cache
 	fetcher  xpkg.Fetcher
@@ -74,35 +73,36 @@ func NewImageBackend(cache xpkg.Cache, fetcher xpkg.Fetcher, opts ...ImageBacken
 
 // Init initializes an ImageBackend.
 func (i *ImageBackend) Init(ctx context.Context, bo ...parser.BackendOption) (io.ReadCloser, error) {
+	n := &nestedBackend{}
 	for _, o := range bo {
-		o(i)
+		o(n)
 	}
 	var img regv1.Image
 	var err error
 
-	pullPolicy := i.pr.GetPackagePullPolicy()
+	pullPolicy := n.pr.GetPackagePullPolicy()
 	if pullPolicy != nil && *pullPolicy == corev1.PullNever {
 		// If package is pre-cached we assume there are never multiple tags in
 		// the same image.
-		img, err = i.cache.Get("", i.pr.GetSource())
+		img, err = i.cache.Get("", n.pr.GetSource())
 		if err != nil {
 			return nil, errors.Wrap(err, errPullPolicyNever)
 		}
 	} else {
 		// Ensure source is a valid image reference.
-		ref, err := name.ParseReference(i.pr.GetSource(), name.WithDefaultRegistry(i.registry))
+		ref, err := name.ParseReference(n.pr.GetSource(), name.WithDefaultRegistry(i.registry))
 		if err != nil {
 			return nil, errors.Wrap(err, errBadReference)
 		}
 		// Attempt to fetch image from cache.
-		img, err = i.cache.Get(i.pr.GetSource(), i.pr.GetName())
+		img, err = i.cache.Get(n.pr.GetSource(), n.pr.GetName())
 		if err != nil {
-			img, err = i.fetcher.Fetch(ctx, ref, v1.RefNames(i.pr.GetPackagePullSecrets())...)
+			img, err = i.fetcher.Fetch(ctx, ref, v1.RefNames(n.pr.GetPackagePullSecrets())...)
 			if err != nil {
 				return nil, errors.Wrap(err, errFetchPackage)
 			}
 			// Cache image.
-			if err := i.cache.Store(i.pr.GetSource(), i.pr.GetName(), img); err != nil {
+			if err := i.cache.Store(n.pr.GetSource(), n.pr.GetName(), img); err != nil {
 				return nil, errors.Wrap(err, errCachePackage)
 			}
 		}
@@ -118,10 +118,23 @@ func (i *ImageBackend) Init(ctx context.Context, bo ...parser.BackendOption) (io
 	return f, nil
 }
 
+// nestedBackend is a nop parser backend that conforms to the parser backend
+// interface to allow holding intermediate data passed via parser backend
+// options.
+type nestedBackend struct {
+	pr v1.PackageRevision
+}
+
+// Init is a nop because nestedBackend does not actually meant to act as a
+// parser backend.
+func (n *nestedBackend) Init(ctx context.Context, bo ...parser.BackendOption) (io.ReadCloser, error) {
+	return nil, nil
+}
+
 // PackageRevision sets the package revision for ImageBackend.
 func PackageRevision(pr v1.PackageRevision) parser.BackendOption {
 	return func(p parser.Backend) {
-		i, ok := p.(*ImageBackend)
+		i, ok := p.(*nestedBackend)
 		if !ok {
 			return
 		}


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Modifies the ImageBackend by removing the member package revision and
instead using a local nestedBackend to hold the package revision locally
to the Init method. This fixes a bug where simultaneous reconciles of
providers or configurations could overwrite the package revision
mid-init, causing a given revision to install and control the wrong
types.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

@haarchri discovered this was happening in a scenario that I replicated using a `Configuration` package with only the following:

```
apiVersion: meta.pkg.crossplane.io/v1alpha1
kind: Configuration
metadata:
  name: testing
spec:
  crossplane:
    version: ">=v1.0.0-0"
  dependsOn:
    - provider: crossplane/provider-aws
      version: ">=v0.13.0"
    - provider: crossplane/provider-helm
      version: ">=v0.7.0"
    - provider: crossplane/provider-kubernetes
      version: ">=v0.1.0-0"
    - provider: crossplane/provider-zpa
      version: ">=v0.1.0"
```

On installation, `provider-helm` was unhealthy and I could see the following event when describing:

```
  Warning  SyncPackage  18m (x4 over 18m)  packages/providerrevision.pkg.crossplane.io  cannot establish control of object: objects.kubernetes.crossplane.io is already controlled by ProviderRevision crossplane-provider-kubernetes-c2f4051377f9 (UID d4b266ef-f1c2-4555-a193-99b0c5cfa1e8)
```

We do not expect that `provider-helm` should be attempting to take control of `objects.kubernetes.crossplane.io`, and I had not seen this behavior before. I went back and tried the same experiment with `v1.5.1` and did not see the issue occurring. None of the PRs between `v1.5.1` and current `master` indicated a significant change to our logic, so I slowly narrowed the commit range and found that the issue did not appear before https://github.com/crossplane/crossplane/pull/2602, but did appear after. This PR was modifying how we enqueue reconciles and backoff, which means that we moved away from some of our `30s` wait periods [we were using as `shortWait`](https://github.com/crossplane/crossplane/pull/2602/files#diff-200ac717ae6864710b10e96aae5be36493f5dfcc57216add6ff46baaffa3f0bfL52) and started explicitly returning errors and requeing according to backoff schedule. It also set our [`MaxConcurrentReconciles` to default to `10`](https://github.com/crossplane/crossplane/pull/2602/files#diff-20d88315192c28a14e8d19b9042c1dfbfad06ce54916ab4b387dda1aae5e2894R104) and it appears that we previously were [not setting this option](https://github.com/crossplane/crossplane/pull/2602/files#diff-200ac717ae6864710b10e96aae5be36493f5dfcc57216add6ff46baaffa3f0bfR251). Both of these changes, especially the latter would make it much more likely that this issue would occur.

Note that though this bug likely only appears on `master` and `release-1.6`, I am opting to backport to all active branches because anything we use in a reconcile loop should be able to be consumer in a thread-safe manner.

Thanks again to @haarchri for reporting this bug!

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

I tested the same scenario (and a variety of others) with a `crossplane` build including this fix and verified that installation was successful and each revision owned its appropriate types:

```
🤖 (crossplane) k get pkgrev
NAME                                                                          HEALTHY   REVISION   IMAGE                           STATE    DEP-FOUND   DEP-INSTALLED   AGE
configurationrevision.pkg.crossplane.io/hasheddan-dep-res-test-5f15b2d7c78f   True      1          hasheddan/dep-res-test:v0.0.1   Active   4           4               71s

NAME                                                                             HEALTHY   REVISION   IMAGE                                                         STATE    DEP-FOUND   DEP-INSTALLED   AGE
providerrevision.pkg.crossplane.io/crossplane-provider-aws-2189bc61e0bd          True      1          crossplane/provider-aws:v0.22.0                               Active                               61s
providerrevision.pkg.crossplane.io/crossplane-provider-helm-f6c5ce0da0dd         True      1          crossplane/provider-helm:v0.9.0                               Active                               59s
providerrevision.pkg.crossplane.io/crossplane-provider-kubernetes-c2f4051377f9   True      1          crossplane/provider-kubernetes:v0.2.0-rc.0.10.gc79df6f-main   Active                               58s
providerrevision.pkg.crossplane.io/crossplane-provider-zpa-bb9432e119a0          True      1          crossplane/provider-zpa:v0.1.0                                Active                               56s
🤖 (crossplane) k get pkg
NAME                                                     INSTALLED   HEALTHY   PACKAGE                         AGE
configuration.pkg.crossplane.io/hasheddan-dep-res-test   True        True      hasheddan/dep-res-test:v0.0.1   106s

NAME                                                        INSTALLED   HEALTHY   PACKAGE                                                       AGE
provider.pkg.crossplane.io/crossplane-provider-aws          True        True      crossplane/provider-aws:v0.22.0                               64s
provider.pkg.crossplane.io/crossplane-provider-helm         True        True      crossplane/provider-helm:v0.9.0                               62s
provider.pkg.crossplane.io/crossplane-provider-kubernetes   True        True      crossplane/provider-kubernetes:v0.2.0-rc.0.10.gc79df6f-main   61s
provider.pkg.crossplane.io/crossplane-provider-zpa          True        True      crossplane/provider-zpa:v0.1.0                                60s
```

[contribution process]: https://git.io/fj2m9
