### PR TITLE
Patch multiple array fields when passed a wildcarded path

### DIFF
--- a/apis/apiextensions/v1/composition_patches.go
+++ b/apis/apiextensions/v1/composition_patches.go
@@ -19,6 +19,7 @@ package v1
 import (
 	"fmt"
 	"reflect"
+	"strings"
 
 	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -37,6 +38,7 @@ const (
 	errFmtCombineStrategyNotSupported = "combine strategy %s is not supported"
 	errFmtCombineConfigMissing        = "given combine strategy %s requires configuration"
 	errFmtCombineStrategyFailed       = "%s strategy could not combine"
+	errExpandingArrayFieldPaths       = "Cannot expand ToFieldPath %s"
 )
 
 // A PatchType is a type of patch.
@@ -163,6 +165,33 @@ func (c *Patch) applyTransforms(input interface{}) (interface{}, error) {
 	return input, nil
 }
 
+// patchFieldValueToMultiple, given a path with wildcards in an array index,
+// expands the arrays paths in the "to" object and patches the value into each
+// of the resulting fields, returning any errors as they occur.
+func patchFieldValueToMultiple(fieldPath string, value interface{}, to runtime.Object) error {
+	paved, err := fieldpath.PaveObject(to)
+	if err != nil {
+		return err
+	}
+
+	arrayFieldPaths, err := paved.ExpandWildcards(fieldPath)
+	if err != nil {
+		return err
+	}
+
+	if len(arrayFieldPaths) == 0 {
+		return errors.Errorf(errExpandingArrayFieldPaths, fieldPath)
+	}
+
+	for _, field := range arrayFieldPaths {
+		if err := paved.MergeValue(field, value, nil); err != nil {
+			return err
+		}
+	}
+
+	return runtime.DefaultUnstructuredConverter.FromUnstructured(paved.UnstructuredContent(), to)
+}
+
 // patchFieldValueToObject, given a path, value and "to" object, will
 // apply the value to the "to" object at the given path, returning
 // any errors as they occur.
@@ -214,6 +243,11 @@ func (c *Patch) applyFromFieldPathPatch(from, to runtime.Object) error {
 	out, err := c.applyTransforms(in)
 	if err != nil {
 		return err
+	}
+
+	// Patch all expanded fields if the ToFieldPath contains wildcards
+	if strings.Contains(*c.ToFieldPath, "[*]") {
+		return patchFieldValueToMultiple(*c.ToFieldPath, out, to)
 	}
 
 	return patchFieldValueToObject(*c.ToFieldPath, out, to, mo)

--- a/apis/apiextensions/v1/composition_patches.go
+++ b/apis/apiextensions/v1/composition_patches.go
@@ -168,7 +168,7 @@ func (c *Patch) applyTransforms(input interface{}) (interface{}, error) {
 // patchFieldValueToMultiple, given a path with wildcards in an array index,
 // expands the arrays paths in the "to" object and patches the value into each
 // of the resulting fields, returning any errors as they occur.
-func patchFieldValueToMultiple(fieldPath string, value interface{}, to runtime.Object) error {
+func patchFieldValueToMultiple(fieldPath string, value interface{}, to runtime.Object, mo *xpv1.MergeOptions) error {
 	paved, err := fieldpath.PaveObject(to)
 	if err != nil {
 		return err
@@ -184,7 +184,7 @@ func patchFieldValueToMultiple(fieldPath string, value interface{}, to runtime.O
 	}
 
 	for _, field := range arrayFieldPaths {
-		if err := paved.MergeValue(field, value, nil); err != nil {
+		if err := paved.MergeValue(field, value, mo); err != nil {
 			return err
 		}
 	}
@@ -247,7 +247,7 @@ func (c *Patch) applyFromFieldPathPatch(from, to runtime.Object) error {
 
 	// Patch all expanded fields if the ToFieldPath contains wildcards
 	if strings.Contains(*c.ToFieldPath, "[*]") {
-		return patchFieldValueToMultiple(*c.ToFieldPath, out, to)
+		return patchFieldValueToMultiple(*c.ToFieldPath, out, to, mo)
 	}
 
 	return patchFieldValueToObject(*c.ToFieldPath, out, to, mo)

--- a/apis/apiextensions/v1/composition_patches.go
+++ b/apis/apiextensions/v1/composition_patches.go
@@ -38,7 +38,7 @@ const (
 	errFmtCombineStrategyNotSupported = "combine strategy %s is not supported"
 	errFmtCombineConfigMissing        = "given combine strategy %s requires configuration"
 	errFmtCombineStrategyFailed       = "%s strategy could not combine"
-	errExpandingArrayFieldPaths       = "Cannot expand ToFieldPath %s"
+	errFmtExpandingArrayFieldPaths    = "cannot expand ToFieldPath %s"
 )
 
 // A PatchType is a type of patch.
@@ -180,7 +180,7 @@ func patchFieldValueToMultiple(fieldPath string, value interface{}, to runtime.O
 	}
 
 	if len(arrayFieldPaths) == 0 {
-		return errors.Errorf(errExpandingArrayFieldPaths, fieldPath)
+		return errors.Errorf(errFmtExpandingArrayFieldPaths, fieldPath)
 	}
 
 	for _, field := range arrayFieldPaths {

--- a/apis/apiextensions/v1/composition_patches_test.go
+++ b/apis/apiextensions/v1/composition_patches_test.go
@@ -195,7 +195,7 @@ func TestPatchApply(t *testing.T) {
 				},
 			},
 			want: want{
-				err: errors.Errorf(errExpandingArrayFieldPaths, "objectMeta.ownerReferences[*].badField"),
+				err: errors.Errorf(errFmtExpandingArrayFieldPaths, "objectMeta.ownerReferences[*].badField"),
 			},
 		},
 		"MissingOptionalFieldPath": {

--- a/apis/apiextensions/v1/composition_patches_test.go
+++ b/apis/apiextensions/v1/composition_patches_test.go
@@ -123,6 +123,81 @@ func TestPatchApply(t *testing.T) {
 				err: nil,
 			},
 		},
+		"ValidCompositeFieldPathPatchWithWildcards": {
+			reason: "When passed a wildcarded path, adds a field to each element of an array",
+			args: args{
+				patch: Patch{
+					Type:          PatchTypeFromCompositeFieldPath,
+					FromFieldPath: pointer.StringPtr("objectMeta.name"),
+					ToFieldPath:   pointer.StringPtr("objectMeta.ownerReferences[*].name"),
+				},
+				cp: &fake.Composite{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test",
+					},
+					ConnectionDetailsLastPublishedTimer: lpt,
+				},
+				cd: &fake.Composed{
+					ObjectMeta: metav1.ObjectMeta{
+						OwnerReferences: []metav1.OwnerReference{
+							{
+								Name:       "",
+								APIVersion: "v1",
+							},
+							{
+								Name:       "",
+								APIVersion: "v1alpha1",
+							},
+						},
+					},
+				},
+			},
+			want: want{
+				cd: &fake.Composed{
+					ObjectMeta: metav1.ObjectMeta{
+						OwnerReferences: []metav1.OwnerReference{
+							{
+								Name:       "test",
+								APIVersion: "v1",
+							},
+							{
+								Name:       "test",
+								APIVersion: "v1alpha1",
+							},
+						},
+					},
+				},
+			},
+		},
+		"InvalidCompositeFieldPathPatchWithWildcards": {
+			reason: "When passed a wildcarded path, throws an error if ToFieldPath cannot be expanded",
+			args: args{
+				patch: Patch{
+					Type:          PatchTypeFromCompositeFieldPath,
+					FromFieldPath: pointer.StringPtr("objectMeta.name"),
+					ToFieldPath:   pointer.StringPtr("objectMeta.ownerReferences[*].badField"),
+				},
+				cp: &fake.Composite{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test",
+					},
+					ConnectionDetailsLastPublishedTimer: lpt,
+				},
+				cd: &fake.Composed{
+					ObjectMeta: metav1.ObjectMeta{
+						OwnerReferences: []metav1.OwnerReference{
+							{
+								Name:       "test",
+								APIVersion: "v1",
+							},
+						},
+					},
+				},
+			},
+			want: want{
+				err: errors.Errorf(errExpandingArrayFieldPaths, "objectMeta.ownerReferences[*].badField"),
+			},
+		},
 		"MissingOptionalFieldPath": {
 			reason: "A FromFieldPath patch should be a no-op when an optional fromFieldPath doesn't exist",
 			args: args{
@@ -373,6 +448,53 @@ func TestPatchApply(t *testing.T) {
 						}},
 				},
 				err: nil,
+			},
+		},
+		"ValidToCompositeFieldPathPatchWithWildcards": {
+			reason: "When passed a wildcarded path, adds a field to each element of an array",
+			args: args{
+				patch: Patch{
+					Type:          PatchTypeToCompositeFieldPath,
+					FromFieldPath: pointer.StringPtr("objectMeta.name"),
+					ToFieldPath:   pointer.StringPtr("objectMeta.ownerReferences[*].name"),
+				},
+				cp: &fake.Composite{
+					ObjectMeta: metav1.ObjectMeta{
+						OwnerReferences: []metav1.OwnerReference{
+							{
+								Name:       "",
+								APIVersion: "v1",
+							},
+							{
+								Name:       "",
+								APIVersion: "v1alpha1",
+							},
+						},
+					},
+					ConnectionDetailsLastPublishedTimer: lpt,
+				},
+				cd: &fake.Composed{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test",
+					},
+				},
+			},
+			want: want{
+				cp: &fake.Composite{
+					ObjectMeta: metav1.ObjectMeta{
+						OwnerReferences: []metav1.OwnerReference{
+							{
+								Name:       "test",
+								APIVersion: "v1",
+							},
+							{
+								Name:       "test",
+								APIVersion: "v1alpha1",
+							},
+						},
+					},
+					ConnectionDetailsLastPublishedTimer: lpt,
+				},
 			},
 		},
 		"MissingCombineFromCompositeConfig": {

--- a/docs/reference/composition.md
+++ b/docs/reference/composition.md
@@ -405,6 +405,34 @@ field.
   toFieldPath: status.zone
 ```
 
+Both `FromCompositeFieldPath` and `ToCompositeFieldPath` can take a wildcarded
+field path containing arrays and patch each array element on a specified
+field.
+
+```yaml
+# Patch from the XR's spec.parameters.allowedIPs to the CIDRBlock elements
+# inside the array spec.forProvider.firewallRules on the composed resource.
+resources:
+- name: exampleFirewall
+  base:
+    apiVersion: firewall.example.crossplane.io/v1beta1
+    kind: Firewall
+    spec:
+      forProvider:
+        firewallRules:
+        - Action: "Allow"
+          Destination: "example1"
+          CIDRBlock: ""
+        - Action: "Allow"
+          Destination: "example2"
+          CIDRBlock: ""
+- type: FromCompositeFieldPath
+  fromFieldPath: spec.parameters.allowedIP
+  toFieldPath: spec.forProvider.firewallRules[*].CIDRBlock
+```
+
+Note that the field to be patched requires some initial value to be set.
+
 `CombineFromComposite`. Combines multiple fields from the XR to produce one
 composed resource field.
 

--- a/docs/reference/composition.md
+++ b/docs/reference/composition.md
@@ -405,9 +405,9 @@ field.
   toFieldPath: status.zone
 ```
 
-Both `FromCompositeFieldPath` and `ToCompositeFieldPath` can take a wildcarded
-field path containing arrays and patch each array element on a specified
-field.
+`FromCompositeFieldPath` and `ToCompositeFieldPath` patches can also take a wildcarded
+field path in the `toFieldPath` parameter and patch each array element in the `toFieldPath`
+with the singular value provided in the `fromFieldPath`.
 
 ```yaml
 # Patch from the XR's spec.parameters.allowedIPs to the CIDRBlock elements


### PR DESCRIPTION
This change allows patches of the FromCompositeFieldPath and
ToCompositeFieldPath types to patch from one field in the "from"
resource to multiple object fields nested inside an array in the "to" resource.
This allows an indefinite number of arrays to be patched without
needing to specify a patch per each individual element.

<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #2784

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

Unit tests written to check the new functionality and I ran Crossplane locally to deploy real resources using the multiple wildcard patching.

[contribution process]: https://git.io/fj2m9
