### PR TITLE
Match more windows uname output in install script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -21,8 +21,8 @@ unsupported_arch() {
 }
 
 case $OS in
-  CYGWIN* | MINGW64*)
-    if [ $ARCH = "amd64" ]
+  CYGWIN* | MINGW64* | Windows*)
+    if [ $ARCH = "x86_64" ]
     then
       OS_ARCH=windows_amd64
       BIN=crank.exe


### PR DESCRIPTION


<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Updates install script to match OS values that start with "Windows".
Also switches to match arch x86_64 instead of amd64 as that appears to
be the uname -m output for valid distributions.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

I am basing this off of user feedback and https://en.wikipedia.org/wiki/Uname#Examples

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

I have run this locally setting the environment variables manually. I don't have a Windows system to test this against, but did see output of `uname -s` and `uname -m` from a Windows user.

[contribution process]: https://git.io/fj2m9
