### PR TITLE
Make release template (arguably) less onerous

### DIFF
--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -16,13 +16,10 @@ For example:
 Please assign the release manager to the issue.
 -->
 
-### Steps
-<!--
-Please complete the following steps in order. Links should be populated at the
-bottom of this section.
--->
-
-This issue can be closed when we have:
+This issue can be closed when we have completed the following steps (in order).
+Please ensure all artifacts (PRs, workflow runs, Tweets, etc) are linked from
+this issue for posterity. Refer to this [prior release issue][release-1.6] for
+examples of each step.
 
 <!--
 Please uncomment the following block only if cutting a minor release. Most of
@@ -34,88 +31,27 @@ code freeze time, but it should not be merged until the release is complete.
 -->
 
 <!--
-- [ ] Created the [release branch][release-branch].
-- [ ] Created and merged an empty commit to the `master` branch ([PR][empty-commit-pr]).
-- [ ] Run the [Tag workflow][rc-tag-workflow] on the `master` branch with the next release candidate tag ([Tag][rc-tag]).
-- [ ] Updated the current release version in the [Crossplane docs website repo] ([link][website-pr]).
-- [ ] Updated the release branch reaching EOL with docs removal directive ([link][eol-pr]).
+- [ ] Created the release branch.
+- [ ] Created and merged an empty commit to the `master` branch.
+- [ ] Run the [Tag workflow][tag-workflow] on the `master` branch with the next release candidate tag.
+- [ ] Updated the current release version in the [Crossplane docs website repo].
+- [ ] Updated the release branch reaching EOL with docs removal directive.
 -->
-- [ ] Updated all version information in the documentation on the relevant release branch ([link][docs-update-pr]).
-- [ ] Run the [Tag workflow][tag-workflow] on the relevant release branch with the proper release version ([link][tag]).
-- [ ] Run the [CI workflow][ci-workflow] on the release branch and verified that the tagged build version exists on the [releases.crossplane.io] `build` channel. ([link][release-build]).
+- [ ] Updated all version information in the documentation on the relevant release branch.
+- [ ] Run the [Tag workflow][tag-workflow] on the relevant release branch with the proper release version.
+- [ ] Run the [CI workflow][ci-workflow] on the release branch and verified that the tagged build version exists on the [releases.crossplane.io] `build` channel..
 - [ ] Run the [Configurations workflow][configurations-workflow] on the release branch and verified  that version exists on [registry.upbound.io] for all getting started packages.
-    - [ ] `xp/getting-started-with-aws` ([link][xp/getting-started-with-aws])
-    - [ ] `xp/getting-started-with-with-with-vpc` ([link][xp/getting-started-with-aws-with-vpc])
-    - [ ] `xp/getting-started-with-azure` ([link][xp/getting-started-with-azure])
-    - [ ] `xp/getting-started-with-gcp` ([link][xp/getting-started-with-gcp])
-- [ ] Run the [Promote workflow][promote-workflow] with channel `stable` on the release branch and verified that the tagged build version exists on the [releases.crossplane.io] `stable` channel ([link][stable-build]).
-- [ ] Published a [new release] for the tagged version, with the same name as the version and descriptive release notes ([link][release]).
-- [ ] Updated the [releases table] in the `README.md` on `master` ([link][release-table-pr]).
+    - [ ] `xp/getting-started-with-aws`
+    - [ ] `xp/getting-started-with-with-with-vpc`
+    - [ ] `xp/getting-started-with-azure`
+    - [ ] `xp/getting-started-with-gcp`
+- [ ] Run the [Promote workflow][promote-workflow] with channel `stable` on the release branch and verified that the tagged build version exists on the [releases.crossplane.io] `stable` channel.
+- [ ] Published a [new release] for the tagged version, with the same name as the version and descriptive release notes.
+- [ ] Updated the [releases table] in the `README.md` on `master`.
 - [ ] Ensured that users have been notified of the release on all communication channels:
-    - [ ] Slack ([link][slack])
-    - [ ] Twitter ([link][twitter])
+    - [ ] Slack
+    - [ ] Twitter
 
-
-<!-- Links Populated by Release Manager -->
-
-<!--
-Only relevant for minor releases. This should look something like the below
-example from the v1.3.0 release.
-
-[release-branch]: https://github.com/crossplane/crossplane/tree/release-1.3
-[empty-commit-pr]: https://github.com/crossplane/crossplane/pull/2395
-[rc-tag-workflow]: https://github.com/crossplane/crossplane/runs/2880453549?check_suite_focus=true
-[rc-tag]: https://github.com/crossplane/crossplane/releases/tag/v1.4.0-rc.0
-[website-pr]: https://github.com/crossplane/crossplane.github.io/pull/112
-[eol-pr]: https://github.com/crossplane/crossplane/pull/2679
--->
-[release-branch]: #
-[empty-commit-pr]: #
-[rc-tag-workflow]: #
-[rc-tag]: #
-[website-pr]: #
-[eol-pr]: #
-
-<!--
-Relevant for all releases. This should look something like the below example
-from the v1.3.0 release.
-
-[docs-update-pr]: https://github.com/crossplane/crossplane/pull/2412
-[tag-workflow]: https://github.com/crossplane/crossplane/runs/2945452331?check_suite_focus=true
-[tag]: https://github.com/crossplane/crossplane/releases/tag/v1.3.0
-[ci-workflow]: https://github.com/crossplane/crossplane/actions/runs/983799776
-[release-build]: https://releases.crossplane.io/build/release-1.3/
-[configurations-workflow]: https://github.com/crossplane/crossplane/runs/2945538373
-[xp/getting-started-with-aws]: https://cloud.upbound.io/registry/xp/getting-started-with-aws/v1.3.0
-[xp/getting-started-with-aws-with-vpc]: https://cloud.upbound.io/registry/xp/getting-started-with-aws-with-vpc/v1.3.0
-[xp/getting-started-with-azure]: https://cloud.upbound.io/registry/xp/getting-started-with-azure/v1.3.0
-[xp/getting-started-with-gcp]: https://cloud.upbound.io/registry/xp/getting-started-with-gcp/v1.3.0
-[promote-workflow]: https://github.com/crossplane/crossplane/actions/runs/983871530
-[stable-build]: https://releases.crossplane.io/stable/v1.3.0/
-[release]: https://github.com/crossplane/crossplane/releases/tag/v1.3.0
-[slack]: https://crossplane.slack.com/archives/CEFQCGW1H/p1625001259051300
-[twitter]: https://twitter.com/crossplane_io/status/1409986997687627778?s=20
--->
-[docs-update-pr]: #
-[tag-workflow]: #
-[tag]: #
-[ci-workflow]: #
-[release-build]: #
-[configurations-workflow]: #
-[xp/getting-started-with-aws]: #
-[xp/getting-started-with-aws-with-vpc]: #
-[xp/getting-started-with-azure]: #
-[xp/getting-started-with-gcp]: #
-[promote-workflow]: #
-[stable-build]: #
-[release]: #
-[slack]: #
-[twitter]: #
-[release-table-pr]: #
-
-### Notes
-
-<!-- This section is reserved for any relevant notes or links for this release. -->
 
 <!-- Named Links -->
 [releases.crossplane.io]: https://releases.crossplane.io
@@ -123,3 +59,8 @@ from the v1.3.0 release.
 [new release]: https://github.com/crossplane/crossplane/releases/new
 [releases table]: https://github.com/crossplane/crossplane#releases
 [Crossplane docs website repo]: https://github.com/crossplane/crossplane.github.io
+[tag-workflow]: https://github.com/crossplane/crossplane/actions/workflows/tag.yml
+[ci-workflow]: https://github.com/crossplane/crossplane/actions/workflows/ci.yml
+[configurations-workflow]: https://github.com/crossplane/crossplane/actions/workflows/configurations.yml
+[promote-workflow]: https://github.com/crossplane/crossplane/actions/workflows/promote.yml
+[release-1.6]: https://github.com/crossplane/crossplane/issues/2764


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
When running a release I prefer to be able to simply check off boxes via the GitHub UI (i.e. rendered, not in markdown). I find that having to keep the issue open in markdown mode while I insert links to each step to be quite onerous. In practice GitHub automatically cross references most things (e.g. PRs and commits) as long as they're opened with a reference back to the release issue. Anything else (e.g. CI runs, Tweets etc) would (in my opinion) be quicker to drop in as a comment on the release issue.

Specifically this PR:

* Removes the notes section. In my experience we rarely use it, and we can always add one in if needed.
* Removes the list of example artifacts in favor of referencing an older release issue.
* Removes all the links that the author is expected to fill in.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
N/A