### PR TITLE
Adding distro information to the getting started guide

### DIFF
--- a/docs/getting-started/install-configure.md
+++ b/docs/getting-started/install-configure.md
@@ -12,9 +12,9 @@ them today. The first way option to use the upstream distribution of Crossplane
 which is maintained and released by the community. 
 
 Your second option is to use a vendor supported Crossplane distribution. These 
-distributions are fully compatible with upstream Crossplane, but may include 
-additional features or tooling around it that makes it easier to use in 
-production environments. 
+distributions are [certified by the CNCF] to be conformant with upstream 
+Crossplane, but may include additional features or tooling around it that makes 
+it easier to use in production environments. 
 
 <ul class="nav nav-tabs"> 
 <li class="active"><a href="#using-upstream-crossplane" data-toggle="tab">Upstream Crossplane</a></li>
@@ -539,3 +539,4 @@ you can [provision infrastructure].
 [Providers]: ../concepts/providers.md
 [Universal Crossplane]: https://cloud.upbound.io/docs/uxp
 [Get started with Universal Crossplane]: https://cloud.upbound.io/docs/getting-started/
+[certified by the CNCF]: https://github.com/cncf/crossplane-conformance

--- a/docs/getting-started/install-configure.md
+++ b/docs/getting-started/install-configure.md
@@ -17,8 +17,8 @@ may include additional features or tooling around it that makes it easier to use
 in production environments.
 
 <ul class="nav nav-tabs"> 
-<li class="active"><a href="#using-upstream-crossplane" data-toggle="tab">Crossplane</a></li>
-<li><a href="#using-a-downstream-distro" data-toggle="tab">Downstream Distribution</a></li>
+<li class="active"><a href="#using-upstream-crossplane" data-toggle="tab">Crossplane (upstream)</a></li>
+<li><a href="#using-a-downstream-distro" data-toggle="tab">Downstream Distributions</a></li>
 </ul>
 <br>
 <!-- Begin Distro Tabs -->

--- a/docs/getting-started/install-configure.md
+++ b/docs/getting-started/install-configure.md
@@ -5,44 +5,27 @@ weight: 2
 indent: true
 ---
 
-# Choosing Hosted or Self-Hosted Crossplane
+# Choosing Your Crossplane Distribution
 
 Users looking to use Crossplane for the first time have two options available to
-them today. The first way is to use a hosted Crossplane service like [Upbound
-Cloud][Upbound Cloud]. Alternatively, users looking for some more
-flexibility can install Crossplane into their own Kubernetes cluster.
+them today. The first way option to use the upstream distribution of Crossplane 
+which is maintained and released by the community. 
 
-Crossplane will be installed using the regularly published Helm chart. The Helm
-chart contains all the custom resources and controllers needed to deploy and
-configure Crossplane.
+Your second option is to use a vendor supported Crossplane distribution. These 
+distributions are fully compatible with upstream Crossplane, but may include 
+additional features or tooling around it that makes it easier to use in 
+production environments. 
 
-Users choosing the self-hosted option can reference our [Install] and
-[Configure] docs for installing alternate versions and more detailed
-instructions.
-
-<ul class="nav nav-tabs">
-<li class="active"><a href="#using-hosted-crossplane" data-toggle="tab">Hosted Crossplane</a></li>
-<li><a href="#using-self-hosted-crossplane" data-toggle="tab">Self-Hosted Crossplane</a></li>
+<ul class="nav nav-tabs"> 
+<li class="active"><a href="#using-upstream-crossplane" data-toggle="tab">Upstream Crossplane</a></li>
+<li><a href="#using-a-downstream-distro" data-toggle="tab">Downstream Distribution</a></li>
 </ul>
 <br>
-<div class="tab-content">
-<div class="tab-pane fade in active" id="using-hosted-crossplane" markdown="1">
-
-## Start with a Hosted Crossplane
-
-Upbound, the founders of Crossplane, offers a free service for community members
-which makes getting started with Crossplane easy. [Create an account] to get
-started. Once logged in, create a new hosted control plane and connect to it via
-the [up] CLI. See the [Upbound documentation] for more information.
-
-<i>Want see another hosted Crossplane service listed? Please [reach out on
-Slack][Slack] and our community will highlight it here!</i>
-
-</div>
-
-<div class="tab-pane fade" id="using-self-hosted-crossplane" markdown="1">
-
-## Start with a Self-Hosted Crossplane
+<!-- Begin Distro Tabs -->
+<div class="tab-content"> 
+<!-- Begin Upstream Tab -->
+<div class="tab-pane fade in active" id="using-upstream-crossplane" markdown="1">
+## Start with Upstream Crossplane
 
 Installing Crossplane into an existing Kubernetes cluster will require a bit
 more setup, but can provide more flexibility for users who need it.
@@ -55,7 +38,9 @@ more setup, but can provide more flexibility for users who need it.
 <li><a href="#setup-windows" data-toggle="tab">Windows</a></li>
 </ul>
 <br>
+<!-- Begin Get Cluster Tabs -->
 <div class="tab-content">
+<!-- Begin MacOS Tab -->
 <div class="tab-pane fade in active" id="setup-mac-brew" markdown="1">
 For macOS via Homebrew use the following:
 
@@ -68,7 +53,9 @@ brew install helm
 kind create cluster --image kindest/node:v1.23.0 --wait 5m
 ```
 </div>
+<!-- End MacOS Tab -->
 
+<!-- Begin Linux Tab -->
 <div class="tab-pane fade" id="setup-mac-linux" markdown="1">
 For macOS / Linux use the following:
 
@@ -80,6 +67,9 @@ For macOS / Linux use the following:
 * [Helm], minimum version `v3.0.0+`.
 
 </div>
+<!-- End Linux Tab -->
+
+<!-- Begin Windows Tab -->
 <div class="tab-pane fade" id="setup-windows" markdown="1">
 For Windows use the following:
 
@@ -91,7 +81,9 @@ For Windows use the following:
 * [Helm], minimum version `v3.0.0+`.
 
 </div>
+<!-- End Windows Tab -->
 </div>
+<!-- End Get Cluster Tabs -->
 
 ### Install Crossplane
 
@@ -100,7 +92,10 @@ For Windows use the following:
 <li><a href="#install-tab-helm3-latest" data-toggle="tab">Helm 3 (latest)</a></li>
 </ul>
 <br>
+<!-- Begin Helm Tabs -->
 <div class="tab-content">
+
+<!-- Begin Stable Tab -->
 <div class="tab-pane fade in active" id="install-tab-helm3" markdown="1">
 Use Helm 3 to install the latest official `stable` release of Crossplane, suitable for community use and testing:
 
@@ -114,6 +109,9 @@ helm install crossplane --namespace crossplane-system crossplane-stable/crosspla
 ```
 
 </div>
+<!-- End Stable Tab -->
+
+<!-- Begin Latest Tab -->
 <div class="tab-pane fade" id="install-tab-helm3-latest" markdown="1">
 Use Helm 3 to install the latest pre-release version of Crossplane:
 
@@ -136,7 +134,10 @@ helm install crossplane --namespace crossplane-system crossplane-master/crosspla
 ```
 
 </div>
+<!-- End Latest Tab -->
+
 </div>
+<!-- End Helm Tabs -->
 
 ### Check Crossplane Status
 
@@ -145,9 +146,6 @@ helm list -n crossplane-system
 
 kubectl get all -n crossplane-system
 ```
-
-</div>
-</div>
 
 ## Install Crossplane CLI
 
@@ -159,7 +157,11 @@ install [Crossplane packages]:
 <li><a href="#install-tab-cli-latest" data-toggle="tab">Latest</a></li>
 </ul>
 <br>
+
+<!-- Begin CLI Tabs -->
 <div class="tab-content">
+
+<!-- Begin CLI Stable Tab -->
 <div class="tab-pane fade in active" id="install-tab-cli" markdown="1">
 
 ```console
@@ -167,6 +169,9 @@ curl -sL https://raw.githubusercontent.com/crossplane/crossplane/master/install.
 ```
 
 </div>
+<!-- End CLI Stable Tab -->
+
+<!-- Begin CLI Latest Tab -->
 <div class="tab-pane fade" id="install-tab-cli-latest" markdown="1">
 
 ```console
@@ -182,7 +187,10 @@ curl -sL https://raw.githubusercontent.com/crossplane/crossplane/master/install.
 ```
 
 </div>
+<!-- End CLI Latest Tab -->
+
 </div>
+<!-- End CLI tabs -->
 
 ## Select a Getting Started Configuration
 
@@ -220,7 +228,11 @@ provider that can satisfy a `PostgreSQLInstance`. Let's get started!
 <li><a href="#azure-tab-1" data-toggle="tab">Azure</a></li>
 </ul>
 <br>
+
+<!-- Begin Cloud Provider Tabs -->
 <div class="tab-content">
+
+<!-- Begin AWS Default VPC Tab -->
 <div class="tab-pane fade in active" id="aws-tab-1" markdown="1">
 
 ### Install Configuration Package
@@ -275,6 +287,9 @@ kubectl apply -f https://raw.githubusercontent.com/crossplane/crossplane/master/
 ```
 
 </div>
+<!-- End AWS Default VPC Tab -->
+
+<!-- Begin AWS New VPC Tab -->
 <div class="tab-pane fade" id="aws-new-tab-1" markdown="1">
 
 ### Install Configuration Package
@@ -329,6 +344,9 @@ kubectl apply -f https://raw.githubusercontent.com/crossplane/crossplane/master/
 ```
 
 </div>
+<!-- End AWS New VPC Tab -->
+
+<!-- Begin GCP Tab -->
 <div class="tab-pane fade" id="gcp-tab-1" markdown="1">
 
 ### Install Configuration Package
@@ -399,6 +417,9 @@ spec:
 ```
 
 </div>
+<!-- End GCP Tab -->
+
+<!-- Begin Azure Tab -->
 <div class="tab-pane fade" id="azure-tab-1" markdown="1">
 
 ### Install Configuration Package
@@ -447,12 +468,41 @@ spec:
       name: azure-creds
       key: creds
 ```
+
 ```console
 kubectl apply -f https://raw.githubusercontent.com/crossplane/crossplane/master/docs/snippets/configure/azure/providerconfig.yaml
 ```
 
 </div>
+<!-- End Azure Tab -->
+
 </div>
+<!-- End Cloud Provider Tabs -->
+
+</div>
+<!-- End Upstream Tab -->
+
+<!-- Begin Downstream Tab -->
+<div class="tab-pane fade" id="using-a-downstream-distro" markdown="1">
+
+## Start with a Downstream Distribution
+
+Upbound, the founders of Crossplane, maintains a free and open source downstream
+distribution of Crossplane which makes getting started with Crossplane easy. 
+Universal Crossplane, or UXP for short, connects to Upbound's hosted management 
+console and Registry to make it easier to develop, debug, and manage Provider
+and Configuration packages.
+
+[Get started with Universal Crossplane] on the Upbound Documentation site.
+
+<i>Want see another hosted Crossplane service listed? Please [reach out on
+Slack][Slack] and our community will highlight it here!</i>
+
+</div>
+<!-- End Downstream Tab -->
+
+</div>
+<!-- End Distro Tabs -->
 
 ## Next Steps
 
@@ -484,8 +534,8 @@ you can [provision infrastructure].
 [Kind]: https://kind.sigs.k8s.io/docs/user/quick-start/
 [Crossplane packages]: ../concepts/packages.md
 [Slack]: http://slack.crossplane.io/
-[Upbound Cloud]: https://upbound.io
-[Create an account]: https://cloud.upbound.io/register
 [up]: https://github.com/upbound/up
 [Upbound documentation]: https://cloud.upbound.io/docs
 [Providers]: ../concepts/providers.md
+[Universal Crossplane]: https://cloud.upbound.io/docs/uxp
+[Get started with Universal Crossplane]: https://cloud.upbound.io/docs/getting-started/

--- a/docs/getting-started/install-configure.md
+++ b/docs/getting-started/install-configure.md
@@ -8,16 +8,16 @@ indent: true
 # Choosing Your Crossplane Distribution
 
 Users looking to use Crossplane for the first time have two options available to
-them today. The first way is to use the upstream distribution of Crossplane 
-which is maintained and released by the community. 
+them today. The first way is to use the version of Crossplane which is 
+maintained and released by the community and found on the [Crossplane GitHub].
 
-Your second option is to use a vendor supported Crossplane distribution. These 
-distributions are [certified by the CNCF] to be conformant with upstream 
-Crossplane, but may include additional features or tooling around it that makes 
-it easier to use in production environments. 
+The second option is to use a vendor supported Crossplane distribution. These 
+distributions are [certified by the CNCF] to be conformant with Crossplane, but 
+may include additional features or tooling around it that makes it easier to use 
+in production environments.
 
 <ul class="nav nav-tabs"> 
-<li class="active"><a href="#using-upstream-crossplane" data-toggle="tab">Upstream Crossplane</a></li>
+<li class="active"><a href="#using-upstream-crossplane" data-toggle="tab">Crossplane</a></li>
 <li><a href="#using-a-downstream-distro" data-toggle="tab">Downstream Distribution</a></li>
 </ul>
 <br>
@@ -541,3 +541,4 @@ you can [provision infrastructure].
 [Universal Crossplane]: https://cloud.upbound.io/docs/uxp
 [Get started with Universal Crossplane]: https://cloud.upbound.io/docs/getting-started/
 [certified by the CNCF]: https://github.com/cncf/crossplane-conformance
+[Crossplane GitHub]: https://github.com/crossplane/crossplane

--- a/docs/getting-started/install-configure.md
+++ b/docs/getting-started/install-configure.md
@@ -25,6 +25,7 @@ it easier to use in production environments.
 <div class="tab-content"> 
 <!-- Begin Upstream Tab -->
 <div class="tab-pane fade in active" id="using-upstream-crossplane" markdown="1">
+
 ## Start with Upstream Crossplane
 
 Installing Crossplane into an existing Kubernetes cluster will require a bit

--- a/docs/getting-started/install-configure.md
+++ b/docs/getting-started/install-configure.md
@@ -8,7 +8,7 @@ indent: true
 # Choosing Your Crossplane Distribution
 
 Users looking to use Crossplane for the first time have two options available to
-them today. The first way option to use the upstream distribution of Crossplane 
+them today. The first way is to use the upstream distribution of Crossplane 
 which is maintained and released by the community. 
 
 Your second option is to use a vendor supported Crossplane distribution. These 


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes
In the current Crossplane documentation, Upbound's hosted control plane feature is presented like it's the same thing as a hosted upstream Crossplane deployment. While this is somewhat true, in reality, it serves very different use cases. 

Users reading the getting started guide see hosed control planes, create an Upbound account, and attempt to go through the Crossplane quickstart using a hosted control plane in Upbound. Because of the underlying differences, they quickly run into trouble, and Upbounders find themselves having to explain why a hosted control plane isn't exactly upstream Crossplane managed by Upbound. For example, a common issue is hosted Crossplane uses the `upbound-system` namespaces vs. the `crossplane-system` one mentioned in the Crossplane docs.

The changes in this PR attempt to do the following:

- Clarify that community members have a choice in distribution when using Crossplane
- Route users who would like to use the Upbound Crossplane distribution to the Upbound docs site in order to avoid confusion
- Make the nested tab structure more clear by commenting begin/end sections in the code

Fixes #

I have:

- [x ] Read and followed Crossplane's [contribution process].
- [x ] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

[contribution process]: https://git.io/fj2m9
