### PR TITLE
Initialize feature flags in core

### DIFF
--- a/cmd/crossplane/core/core.go
+++ b/cmd/crossplane/core/core.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/crossplane/crossplane-runtime/pkg/controller"
 	"github.com/crossplane/crossplane-runtime/pkg/errors"
+	"github.com/crossplane/crossplane-runtime/pkg/feature"
 	"github.com/crossplane/crossplane-runtime/pkg/logging"
 	"github.com/crossplane/crossplane-runtime/pkg/ratelimiter"
 
@@ -104,6 +105,7 @@ func (c *startCommand) Run(s *runtime.Scheme, log logging.Logger) error {
 		MaxConcurrentReconciles: c.MaxReconcileRate,
 		PollInterval:            c.PollInterval,
 		GlobalRateLimiter:       ratelimiter.NewGlobal(c.MaxReconcileRate),
+		Features:                &feature.Flags{},
 	}
 
 	if c.EnableCompositionRevisions {


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes https://github.com/crossplane/crossplane/issues/2825

The `*feature.Flags` in `controller.Options` can be `nil` when no feature flags are enabled, but it needs to be set to `&feature.Flags{}` in order to enable any. This means Crossplane currently panics when we try to enable Composition Revisions (our only feature flag at the moment).

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9

I've verified that `go run cmd/crossplane/main.go core start --enable-composition-revisions` does not panic, and does log that Crossplane is being started with Composition Revision support, with these changes.