### PR TITLE
Use bold formatting for xpkg spec motivation section

### DIFF
--- a/docs/reference/xpkg.md
+++ b/docs/reference/xpkg.md
@@ -90,7 +90,7 @@ If no layer descriptors have an annotation in the form `io.crossplane.xpkg:
 base`, the resultant filesystem from [applying changesets] from all layers will
 be used. It is preferred to use layer descriptor annotations.
 
-#### Motivation
+**Motivation**
 
 Crossplane prefers the usage of annotated layer descriptors because it allows
 for fetching and processing individual layers, rather than all layers in the


### PR DESCRIPTION


<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

The four hash header is rendered as a higher-level section than the
surround three hash headers on the Crossplane website. This modifies to
just use bold formatting to ensure the Motivation section appears nested
within the Manifests section.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

See https://crossplane.io/docs/master/reference/xpkg.html#motivation for section being corrected. I have opened https://github.com/crossplane/crossplane.github.io/issues/132 to fix the underlying problem, but I think just using a **bold** header here makes sense as the section is inherent to the manifests section.

[contribution process]: https://git.io/fj2m9
