### PR TITLE
Do not build unpublished architectures

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 PROJECT_NAME := crossplane
 PROJECT_REPO := github.com/crossplane/$(PROJECT_NAME)
 
-PLATFORMS ?= linux_amd64 linux_arm64 linux_arm linux_ppc64le darwin_amd64 darwin_arm64 windows_amd64
+PLATFORMS ?= linux_amd64 linux_arm64 linux_arm linux_ppc64le
 # -include will silently skip missing files, which allows us
 # to load those files with a target in the Makefile. If only
 # "include" was used, the make command would fail and refuse


### PR DESCRIPTION
Signed-off-by: Aaron Eaton <aaron@upbound.io>

### Description of your changes

CI is building all supported architectures, though only publishing linux docker images. This PR removes unpublished architectures from CI.

I have:

- [X] Read and followed Crossplane's [contribution process].
- [X] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

Running `make build` locally confirmed that the local architecture always builds.
Running `make build.all` locally confirmed that only published architectures are built for CI.

[contribution process]: https://git.io/fj2m9
