### PR TITLE
documentation: Set provider-aws version to v0.23.0

### DIFF
--- a/docs/concepts/providers.md
+++ b/docs/concepts/providers.md
@@ -52,7 +52,7 @@ kind: Provider
 metadata:
   name: provider-aws
 spec:
-  package: "crossplane/provider-aws:v1.6.2"
+  package: "crossplane/provider-aws:v0.23.0"
 ```
 
 The field `spec.package` is where you refer to the container image of the
@@ -63,9 +63,9 @@ There are a few other ways to to trigger the installation of provider packages:
 
 * As part of Crossplane Helm chart by adding the following statement to your
   `helm install` command: `--set
-  provider.packages={crossplane/provider-aws:v1.6.2}`.
+  provider.packages={crossplane/provider-aws:v0.23.0}`.
 * Using the Crossplane CLI: `kubectl crossplane install provider
-  crossplane/provider-aws:v1.6.2`
+  crossplane/provider-aws:v0.23.0`
 
 You can uninstall a provider by deleting the `Provider` resource
 you've created.


### PR DESCRIPTION
Signed-off-by: LStuker <lucien.stuker@gmail.com>

<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Documentation fix: Set provider-aws version to v0.23.0 instead to v.1.6.2

While starting with crossplane I notice that the documentation is setting a wrong version for the aws-provider.
It defines 1.6.2 where the latest version is v0.23.0.

This will results in an error, as version 1.6.2 does not exist yet for provider-aws.
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #

I have:

- [x ] Read and followed Crossplane's [contribution process].
- [x ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
