### PR TITLE
Use serviceAccountName for Service Account creation

### DIFF
--- a/internal/controller/pkg/revision/deployment.go
+++ b/internal/controller/pkg/revision/deployment.go
@@ -116,6 +116,9 @@ func buildProviderDeployment(provider *pkgmetav1.Provider, revision v1.PackageRe
 		s.Annotations = cc.Annotations
 		d.Labels = cc.Labels
 		d.Annotations = cc.Annotations
+		if cc.Spec.ServiceAccountName != nil {
+			s.Name = *cc.Spec.ServiceAccountName
+		}
 		if cc.Spec.Metadata != nil {
 			d.Spec.Template.Annotations = cc.Spec.Metadata.Annotations
 		}


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Updates the name of a Service Account, which is to be created by a controller, to be specified by the `.spec.serviceAccountName` field of `ControllerConfig` if specified.

It's currently named the same name of a `ProviderRevision` even if the `.spec.serviceAccountName` is specified whereas the `.spec.template.spec.serviceAccountName` in a Deployment is specified by it.

The current approach wouldn't make a lot of sense because:

- ClusterRolebindings to be created by a controller target only Service Accounts that are managed by the controller so necessary Roles aren't granted to a Service Account defined in a `ControllerConfig` by default.
- Inconstant names aren't helpful in some cases. A notable example is Workload Identity in GCP, where a Kubernetes Service Account needs to specified in IAM binding. With the current implementation, whenever a new `ProvierRevision` is created, which means a Service Account is "renamed", IAM binding for Workload Identity also needs to be updated. Though Workload Identity isn't supported in `provider-gcp` yet, this would meet one of the requirements to support it.

On the other hand, there wouldn't be a lot of practical use cases where it's necessary to specify a custom Service Account to a Deployment and keep letting a controller create Service Accounts with different names.

Signed-off-by: micnncim <micnncim@gmail.com>

Fixes #2295

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

https://github.com/crossplane/crossplane/blob/master/CONTRIBUTING.md#establishing-a-development-environment doens't work in M1 Mac machines so I haven't tested it locally.

[contribution process]: https://git.io/fj2m9
