### PR TITLE
Add missing word to composition revision guide

### DIFF
--- a/docs/guides/composition-revisions.md
+++ b/docs/guides/composition-revisions.md
@@ -71,7 +71,8 @@ When you enable Composition Revisions three things happen:
 Each time you edit a `Composition` Crossplane will automatically create a
 `CompositionRevision` that represents that 'revision' of the `Composition` -
 that unique state. Each revision is allocated an increasing revision number.
-This `CompositionRevision` consumers an idea about which revision is 'newest'.
+This gives `CompositionRevision` consumers an idea about which revision is
+'newest'.
 
 Crossplane distinguishes between the 'newest' and the 'current' revision of a
 `Composition`. That is, if you revert a `Composition` to a previous state that


### PR DESCRIPTION
### Description of your changes

This is a very small docs only change that adds a missing word to the composition revision guide.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

The markdown for this page has been previewed/verified in my fork: https://github.com/jbw976/crossplane/blob/docs-fix/docs/guides/composition-revisions.md

[contribution process]: https://git.io/fj2m9