### PR TITLE
Support package base layer descriptor in package images

### DIFF
--- a/cmd/crank/build.go
+++ b/cmd/crank/build.go
@@ -93,7 +93,7 @@ func (c *buildCmd) Run(child *buildChild, logger logging.Logger) error {
 		pkgName = xpkg.FriendlyID(pkgName, hash.Hex)
 	}
 
-	f, err := child.fs.Create(xpkg.BuildPath(root, pkgName))
+	f, err := child.fs.Create(xpkg.BuildPath(root, pkgName, xpkg.XpkgExtension))
 	if err != nil {
 		logger.Debug(errCreatePackage, "error", err)
 		return errors.Wrap(err, errCreatePackage)

--- a/cmd/crossplane/core/core.go
+++ b/cmd/crossplane/core/core.go
@@ -119,7 +119,7 @@ func (c *startCommand) Run(s *runtime.Scheme, log logging.Logger) error {
 
 	po := pkgcontroller.Options{
 		Options:         o,
-		Cache:           xpkg.NewImageCache(c.CacheDir, afero.NewOsFs()),
+		Cache:           xpkg.NewPackageCache(c.CacheDir, afero.NewOsFs()),
 		Namespace:       c.Namespace,
 		DefaultRegistry: c.Registry,
 	}

--- a/cmd/crossplane/core/core.go
+++ b/cmd/crossplane/core/core.go
@@ -119,7 +119,7 @@ func (c *startCommand) Run(s *runtime.Scheme, log logging.Logger) error {
 
 	po := pkgcontroller.Options{
 		Options:         o,
-		Cache:           xpkg.NewPackageCache(c.CacheDir, afero.NewOsFs()),
+		Cache:           xpkg.NewFsPackageCache(c.CacheDir, afero.NewOsFs()),
 		Namespace:       c.Namespace,
 		DefaultRegistry: c.Registry,
 	}

--- a/internal/controller/pkg/controller/options.go
+++ b/internal/controller/pkg/controller/options.go
@@ -28,7 +28,7 @@ type Options struct {
 	controller.Options
 
 	// Cache for package OCI images.
-	Cache xpkg.Cache
+	Cache xpkg.PackageCache
 
 	// Namespace used to unpack and run packages.
 	Namespace string

--- a/internal/controller/pkg/revision/imageback.go
+++ b/internal/controller/pkg/revision/imageback.go
@@ -22,10 +22,8 @@ import (
 	"io"
 
 	"github.com/google/go-containerregistry/pkg/name"
-	regv1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/mutate"
 	"github.com/spf13/afero/tarfs"
-	corev1 "k8s.io/api/core/v1"
 
 	"github.com/crossplane/crossplane-runtime/pkg/errors"
 	"github.com/crossplane/crossplane-runtime/pkg/parser"
@@ -35,17 +33,23 @@ import (
 )
 
 const (
-	errPullPolicyNever   = "failed to get pre-cached package with pull policy Never"
-	errBadReference      = "package tag is not a valid reference"
-	errFetchPackage      = "failed to fetch package from remote"
-	errCachePackage      = "failed to store package in cache"
-	errOpenPackageStream = "failed to open package stream file"
+	errBadReference            = "package tag is not a valid reference"
+	errFetchPackage            = "failed to fetch package from remote"
+	errGetManifest             = "failed to get package image manifest from remote"
+	errFetchLayer              = "failed to fetch annotated base layer from remote"
+	errGetUncompressed         = "failed to get uncompressed contents from layer"
+	errMultipleAnnotatedLayers = "package is invalid due to multiple annotated base layers"
+	errOpenPackageStream       = "failed to open package stream file"
+)
+
+const (
+	layerAnnotation     = "io.crossplane.xpkg"
+	baseAnnotationValue = "base"
 )
 
 // ImageBackend is a backend for parser.
 type ImageBackend struct {
 	registry string
-	cache    xpkg.Cache
 	fetcher  xpkg.Fetcher
 }
 
@@ -60,9 +64,8 @@ func WithDefaultRegistry(registry string) ImageBackendOption {
 }
 
 // NewImageBackend creates a new image backend.
-func NewImageBackend(cache xpkg.Cache, fetcher xpkg.Fetcher, opts ...ImageBackendOption) *ImageBackend {
+func NewImageBackend(fetcher xpkg.Fetcher, opts ...ImageBackendOption) *ImageBackend {
 	i := &ImageBackend{
-		cache:   cache,
 		fetcher: fetcher,
 	}
 	for _, opt := range opts {
@@ -72,7 +75,8 @@ func NewImageBackend(cache xpkg.Cache, fetcher xpkg.Fetcher, opts ...ImageBacken
 }
 
 // Init initializes an ImageBackend.
-func (i *ImageBackend) Init(ctx context.Context, bo ...parser.BackendOption) (io.ReadCloser, error) {
+// NOTE(hasheddan): this method is slightly over our cyclomatic complexity goal
+func (i *ImageBackend) Init(ctx context.Context, bo ...parser.BackendOption) (io.ReadCloser, error) { //nolint:gocyclo
 	// NOTE(hasheddan): we use nestedBackend here because simultaneous
 	// reconciles of providers or configurations can lead to the package
 	// revision being overwritten mid-execution in the shared image backend when
@@ -85,45 +89,48 @@ func (i *ImageBackend) Init(ctx context.Context, bo ...parser.BackendOption) (io
 	for _, o := range bo {
 		o(n)
 	}
-	var img regv1.Image
-	var err error
-
-	pullPolicy := n.pr.GetPackagePullPolicy()
-	if pullPolicy != nil && *pullPolicy == corev1.PullNever {
-		// If package is pre-cached we assume there are never multiple tags in
-		// the same image.
-		img, err = i.cache.Get("", n.pr.GetSource())
-		if err != nil {
-			return nil, errors.Wrap(err, errPullPolicyNever)
-		}
-	} else {
-		// Ensure source is a valid image reference.
-		ref, err := name.ParseReference(n.pr.GetSource(), name.WithDefaultRegistry(i.registry))
-		if err != nil {
-			return nil, errors.Wrap(err, errBadReference)
-		}
-		// Attempt to fetch image from cache.
-		img, err = i.cache.Get(n.pr.GetSource(), n.pr.GetName())
-		if err != nil {
-			img, err = i.fetcher.Fetch(ctx, ref, v1.RefNames(n.pr.GetPackagePullSecrets())...)
-			if err != nil {
-				return nil, errors.Wrap(err, errFetchPackage)
-			}
-			// Cache image.
-			if err := i.cache.Store(n.pr.GetSource(), n.pr.GetName(), img); err != nil {
-				return nil, errors.Wrap(err, errCachePackage)
-			}
-		}
-	}
-
-	// Extract package contents from image.
-	r := mutate.Extract(img)
-	fs := tarfs.New(tar.NewReader(r))
-	f, err := fs.Open(xpkg.StreamFile)
+	ref, err := name.ParseReference(n.pr.GetSource(), name.WithDefaultRegistry(i.registry))
 	if err != nil {
-		return nil, errors.Wrap(err, errOpenPackageStream)
+		return nil, errors.Wrap(err, errBadReference)
 	}
-	return f, nil
+	// Fetch image from registry.
+	img, err := i.fetcher.Fetch(ctx, ref, v1.RefNames(n.pr.GetPackagePullSecrets())...)
+	if err != nil {
+		return nil, errors.Wrap(err, errFetchPackage)
+	}
+	// Get image manifest.
+	manifest, err := img.Manifest()
+	if err != nil {
+		return nil, errors.Wrap(err, errGetManifest)
+	}
+	// Determine if the image is using annotated layers.
+	var tarc io.ReadCloser
+	foundAnnotated := false
+	for _, l := range manifest.Layers {
+		if a, ok := l.Annotations[layerAnnotation]; !ok || a != baseAnnotationValue {
+			continue
+		}
+		if foundAnnotated {
+			return nil, errors.New(errMultipleAnnotatedLayers)
+		}
+		foundAnnotated = true
+		layer, err := img.LayerByDigest(l.Digest)
+		if err != nil {
+			return nil, errors.Wrap(err, errFetchLayer)
+		}
+		tarc, err = layer.Uncompressed()
+		if err != nil {
+			return nil, errors.Wrap(err, errGetUncompressed)
+		}
+	}
+	// If we still don't have content then we need to flatten image and
+	// extract its package file in filesystem root.
+	if !foundAnnotated {
+		tarc = mutate.Extract(img)
+	}
+	fs := tarfs.New(tar.NewReader(tarc))
+	f, err := fs.Open(xpkg.StreamFile)
+	return f, errors.Wrap(err, errOpenPackageStream)
 }
 
 // nestedBackend is a nop parser backend that conforms to the parser backend

--- a/internal/controller/pkg/revision/imageback_test.go
+++ b/internal/controller/pkg/revision/imageback_test.go
@@ -21,9 +21,7 @@ import (
 	"bytes"
 	"context"
 	"io"
-	"os"
 	"strings"
-	"syscall"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -119,7 +117,7 @@ func TestImageBackend(t *testing.T) {
 					},
 				})},
 			},
-			want: errors.Wrap(&os.PathError{Op: "open", Path: xpkg.StreamFile, Err: syscall.ENOENT}, errOpenPackageStream),
+			want: errors.Wrap(io.EOF, errOpenPackageStream),
 		},
 		"ErrEmptyImage": {
 			reason: "Should return error if image is empty.",
@@ -133,7 +131,7 @@ func TestImageBackend(t *testing.T) {
 					},
 				})},
 			},
-			want: errors.Wrap(&os.PathError{Op: "open", Path: "package.yaml", Err: syscall.ENOENT}, errOpenPackageStream),
+			want: errors.Wrap(io.EOF, errOpenPackageStream),
 		},
 		"ErrFetchPackage": {
 			reason: "Should return error if package is not in cache and we fail to fetch it.",

--- a/internal/controller/pkg/revision/imageback_test.go
+++ b/internal/controller/pkg/revision/imageback_test.go
@@ -32,7 +32,6 @@ import (
 	"github.com/google/go-containerregistry/pkg/v1/random"
 	"github.com/google/go-containerregistry/pkg/v1/tarball"
 	"github.com/google/go-containerregistry/pkg/v1/types"
-	corev1 "k8s.io/api/core/v1"
 
 	"github.com/crossplane/crossplane-runtime/pkg/errors"
 	"github.com/crossplane/crossplane-runtime/pkg/parser"
@@ -44,9 +43,20 @@ import (
 
 func TestImageBackend(t *testing.T) {
 	errBoom := errors.New("boom")
-	pullPolicy := corev1.PullNever
 	randLayer, _ := random.Layer(int64(1000), types.DockerLayer)
-	randImg, _ := mutate.AppendLayers(empty.Image, randLayer)
+	randImg, _ := mutate.Append(empty.Image, mutate.Addendum{
+		Layer: randLayer,
+		Annotations: map[string]string{
+			layerAnnotation: baseAnnotationValue,
+		},
+	})
+
+	randImgDup, _ := mutate.Append(randImg, mutate.Addendum{
+		Layer: randLayer,
+		Annotations: map[string]string{
+			layerAnnotation: baseAnnotationValue,
+		},
+	})
 
 	streamCont := "somestreamofyaml"
 	tarBuf := new(bytes.Buffer)
@@ -63,7 +73,6 @@ func TestImageBackend(t *testing.T) {
 	packImg, _ := mutate.AppendLayers(empty.Image, packLayer)
 
 	type args struct {
-		c    xpkg.Cache
 		f    xpkg.Fetcher
 		opts []parser.BackendOption
 	}
@@ -84,10 +93,23 @@ func TestImageBackend(t *testing.T) {
 			},
 			want: errors.Wrap(errors.New("could not parse reference: :test"), errBadReference),
 		},
+		"ErrMultipleAnnotatedLayers": {
+			reason: "Should return error if image has multiple layers annotated as base.",
+			args: args{
+				f: &fake.MockFetcher{
+					MockFetch: fake.NewMockFetchFn(randImgDup, nil),
+				},
+				opts: []parser.BackendOption{PackageRevision(&v1.ProviderRevision{
+					Spec: v1.PackageRevisionSpec{
+						Package: "test/test:latest",
+					},
+				})},
+			},
+			want: errors.New(errMultipleAnnotatedLayers),
+		},
 		"ErrFetchedBadPackage": {
 			reason: "Should return error if image with contents does not have package.yaml.",
 			args: args{
-				c: xpkg.NewNopCache(),
 				f: &fake.MockFetcher{
 					MockFetch: fake.NewMockFetchFn(randImg, nil),
 				},
@@ -102,7 +124,6 @@ func TestImageBackend(t *testing.T) {
 		"ErrEmptyImage": {
 			reason: "Should return error if image is empty.",
 			args: args{
-				c: xpkg.NewNopCache(),
 				f: &fake.MockFetcher{
 					MockFetch: fake.NewMockFetchFn(empty.Image, nil),
 				},
@@ -117,7 +138,6 @@ func TestImageBackend(t *testing.T) {
 		"ErrFetchPackage": {
 			reason: "Should return error if package is not in cache and we fail to fetch it.",
 			args: args{
-				c: xpkg.NewNopCache(),
 				f: &fake.MockFetcher{
 					MockFetch: fake.NewMockFetchFn(nil, errBoom),
 				},
@@ -129,76 +149,15 @@ func TestImageBackend(t *testing.T) {
 			},
 			want: errors.Wrap(errBoom, errFetchPackage),
 		},
-		"ErrStorePackage": {
-			reason: "Should return error if package is not in cache, we fetch successfully, but we fail to store it in cache.",
-			args: args{
-				c: &fake.MockCache{
-					MockGet:   fake.NewMockCacheGetFn(nil, errBoom),
-					MockStore: fake.NewMockCacheStoreFn(errBoom),
-				},
-				f: &fake.MockFetcher{
-					MockFetch: fake.NewMockFetchFn(packImg, nil),
-				},
-				opts: []parser.BackendOption{PackageRevision(&v1.ProviderRevision{
-					Spec: v1.PackageRevisionSpec{
-						Package: "test/test:latest",
-					},
-				})},
-			},
-			want: errors.Wrap(errBoom, errCachePackage),
-		},
 		"SuccessFetchPackage": {
 			reason: "Should not return error is package is not in cache but is fetched successfully.",
 			args: args{
-				c: xpkg.NewNopCache(),
 				f: &fake.MockFetcher{
 					MockFetch: fake.NewMockFetchFn(packImg, nil),
 				},
 				opts: []parser.BackendOption{PackageRevision(&v1.ProviderRevision{
 					Spec: v1.PackageRevisionSpec{
 						Package: "test/test:latest",
-					},
-				})},
-			},
-		},
-		"SuccessCachedPackage": {
-			reason: "Should not return error is package is in cache and is gotten successfully.",
-			args: args{
-				c: &fake.MockCache{
-					MockGet: fake.NewMockCacheGetFn(packImg, nil),
-				},
-				opts: []parser.BackendOption{PackageRevision(&v1.ProviderRevision{
-					Spec: v1.PackageRevisionSpec{
-						Package: "test/test:latest",
-					},
-				})},
-			},
-		},
-		"ErrorCachedPackageNoPull": {
-			reason: "Should return error if package is pre-cached and is not gotten successfully.",
-			args: args{
-				c: &fake.MockCache{
-					MockGet: fake.NewMockCacheGetFn(nil, errBoom),
-				},
-				opts: []parser.BackendOption{PackageRevision(&v1.ProviderRevision{
-					Spec: v1.PackageRevisionSpec{
-						Package:           "test/test:latest",
-						PackagePullPolicy: &pullPolicy,
-					},
-				})},
-			},
-			want: errors.Wrap(errBoom, errPullPolicyNever),
-		},
-		"SuccessCachedPackageNoPull": {
-			reason: "Should not return error if package is pre-cached and is gotten successfully.",
-			args: args{
-				c: &fake.MockCache{
-					MockGet: fake.NewMockCacheGetFn(packImg, nil),
-				},
-				opts: []parser.BackendOption{PackageRevision(&v1.ProviderRevision{
-					Spec: v1.PackageRevisionSpec{
-						Package:           "test/test:latest",
-						PackagePullPolicy: &pullPolicy,
 					},
 				})},
 			},
@@ -207,9 +166,11 @@ func TestImageBackend(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			b := NewImageBackend(tc.args.c, tc.args.f)
-			_, err := b.Init(context.TODO(), tc.args.opts...)
-
+			b := NewImageBackend(tc.args.f)
+			rc, err := b.Init(context.TODO(), tc.args.opts...)
+			if err == nil && rc != nil {
+				_, err = io.ReadAll(rc)
+			}
 			if diff := cmp.Diff(tc.want, err, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\nb.Init(...): -want error, +got error:\n%s", tc.reason, diff)
 			}

--- a/internal/controller/pkg/revision/reconciler.go
+++ b/internal/controller/pkg/revision/reconciler.go
@@ -449,7 +449,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 
 		// Package is not in cache, so we write it to the cache while parsing.
 		pipeR, pipeW := io.Pipe()
-		rc = xpkg.NewTeeReadCloser(imgrc, pipeW)
+		rc = xpkg.TeeReadCloser(imgrc, pipeW)
 		go func() {
 			defer pipeR.Close() //nolint:errcheck
 			if err := r.cache.Store(pr.GetName(), pipeR); err != nil {

--- a/internal/controller/pkg/revision/reconciler.go
+++ b/internal/controller/pkg/revision/reconciler.go
@@ -105,7 +105,7 @@ func WithClientApplicator(ca resource.ClientApplicator) ReconcilerOption {
 }
 
 // WithCache specifies how the Reconcile should cache package contents.
-func WithCache(c xpkg.Cache) ReconcilerOption {
+func WithCache(c xpkg.PackageCache) ReconcilerOption {
 	return func(r *Reconciler) {
 		r.cache = c
 	}
@@ -193,7 +193,7 @@ func WithVersioner(v version.Operations) ReconcilerOption {
 // Reconciler reconciles packages.
 type Reconciler struct {
 	client    client.Client
-	cache     xpkg.Cache
+	cache     xpkg.PackageCache
 	revision  resource.Finalizer
 	lock      DependencyManager
 	hook      Hooks
@@ -401,10 +401,10 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 	}
 
 	var rc io.ReadCloser
-	var err error
 	cacheWrite := make(chan error)
 
 	if r.cache.Has(id) {
+		var err error
 		rc, err = r.cache.Get(id)
 		if err != nil {
 			// If package contents are in the cache, but we cannot access them,

--- a/internal/xpkg/cache.go
+++ b/internal/xpkg/cache.go
@@ -73,7 +73,7 @@ func (c *PackageCache) Get(id string) (io.ReadCloser, error) {
 	if err != nil {
 		return nil, err
 	}
-	return newGzipFileReader(f)
+	return GzipFileReader(f)
 }
 
 // Store saves the package contents to the cache.

--- a/internal/xpkg/cache.go
+++ b/internal/xpkg/cache.go
@@ -73,7 +73,7 @@ func (c *PackageCache) Get(id string) (io.ReadCloser, error) {
 	if err != nil {
 		return nil, err
 	}
-	return GzipFileReader(f)
+	return GzipReadCloser(f)
 }
 
 // Store saves the package contents to the cache.

--- a/internal/xpkg/cache.go
+++ b/internal/xpkg/cache.go
@@ -17,93 +17,101 @@ limitations under the License.
 package xpkg
 
 import (
+	"compress/gzip"
 	"io"
 	"os"
 	"sync"
 
-	"github.com/google/go-containerregistry/pkg/name"
-	v1 "github.com/google/go-containerregistry/pkg/v1"
-	"github.com/google/go-containerregistry/pkg/v1/tarball"
 	"github.com/spf13/afero"
 
 	"github.com/crossplane/crossplane-runtime/pkg/errors"
 )
 
 const (
-	errGetNopCache = "cannot get an image from a NopCache"
+	errGetNopCache = "cannot get content from a NopCache"
 )
 
-// A Cache caches OCI images.
+const cacheContentExt = ".gz"
+
+// A Cache caches package content.
 type Cache interface {
-	Get(tag string, id string) (v1.Image, error)
-	Store(tag string, id string, img v1.Image) error
+	Has(id string) bool
+	Get(id string) (io.ReadCloser, error)
+	Store(id string, content io.ReadCloser) error
 	Delete(id string) error
 }
 
-// ImageCache stores and retrieves OCI images in a filesystem-backed cache in a
-// thread-safe manner.
-type ImageCache struct {
+// PackageCache stores and retrieves package content in a filesystem-backed
+// cache in a thread-safe manner.
+type PackageCache struct {
 	dir string
 	fs  afero.Fs
 	mu  sync.RWMutex
 }
 
-// NewImageCache creates a new ImageCache.
-func NewImageCache(dir string, fs afero.Fs) *ImageCache {
-	return &ImageCache{
+// NewPackageCache creates a new PackageCache.
+func NewPackageCache(dir string, fs afero.Fs) *PackageCache {
+	return &PackageCache{
 		dir: dir,
 		fs:  fs,
 	}
 }
 
-// Get retrieves an image from the ImageCache.
-func (c *ImageCache) Get(tag, id string) (v1.Image, error) {
-	c.mu.RLock()
-	defer c.mu.RUnlock()
-	var t *name.Tag
-	if tag != "" {
-		nt, err := name.NewTag(tag)
-		if err != nil {
-			return nil, err
-		}
-		t = &nt
+// Has indicates whether an item with the given id is in the cache.
+func (c *PackageCache) Has(id string) bool {
+	if fi, err := c.fs.Stat(BuildPath(c.dir, id, cacheContentExt)); err == nil && !fi.IsDir() {
+		return true
 	}
-	return tarball.Image(fsOpener(BuildPath(c.dir, id), c.fs), t)
+	return false
 }
 
-// Store saves an image to the ImageCache.
-func (c *ImageCache) Store(tag, id string, img v1.Image) error {
+// Get retrieves package contents from the cache.
+func (c *PackageCache) Get(id string) (io.ReadCloser, error) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	f, err := c.fs.Open(BuildPath(c.dir, id, cacheContentExt))
+	if err != nil {
+		return nil, err
+	}
+	return newGzipFileReader(f)
+}
+
+// Store saves the package contents to the cache.
+func (c *PackageCache) Store(id string, content io.ReadCloser) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	ref, err := name.ParseReference(tag)
+	cf, err := c.fs.Create(BuildPath(c.dir, id, cacheContentExt))
 	if err != nil {
 		return err
 	}
-	cf, err := c.fs.Create(BuildPath(c.dir, id))
+	// NOTE(hasheddan): we don't check error on deferred file close as Close()
+	// is explicitly called in the happy path.
+	defer cf.Close() //nolint:errcheck
+	w, err := gzip.NewWriterLevel(cf, gzip.BestSpeed)
 	if err != nil {
 		return err
 	}
-	if err := tarball.Write(ref, img, cf); err != nil {
+	_, err = io.Copy(w, content)
+	if err != nil {
+		return err
+	}
+	// NOTE(hasheddan): gzip writer must be closed to ensure all data is flushed
+	// to file.
+	if err := w.Close(); err != nil {
 		return err
 	}
 	return cf.Close()
 }
 
-// Delete removes an image from the ImageCache.
-func (c *ImageCache) Delete(id string) error {
+// Delete removes package contents from the cache.
+func (c *PackageCache) Delete(id string) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	err := c.fs.Remove(BuildPath(c.dir, id))
+	err := c.fs.Remove(BuildPath(c.dir, id, cacheContentExt))
 	if os.IsNotExist(err) {
 		return nil
 	}
 	return err
-}
-
-func fsOpener(path string, fs afero.Fs) tarball.Opener {
-	return func() (io.ReadCloser, error) {
-		return fs.Open(path)
-	}
 }
 
 // NopCache is a cache implementation that does not store anything and always
@@ -115,17 +123,22 @@ func NewNopCache() *NopCache {
 	return &NopCache{}
 }
 
-// Get retrieves an image from the NopCache.
-func (c *NopCache) Get(tag, id string) (v1.Image, error) {
+// Has indicates whether content is in the NopCache.
+func (c *NopCache) Has(string) bool {
+	return false
+}
+
+// Get retrieves content from the NopCache.
+func (c *NopCache) Get(string) (io.ReadCloser, error) {
 	return nil, errors.New(errGetNopCache)
 }
 
-// Store saves an image to the NopCache.
-func (c *NopCache) Store(tag, id string, img v1.Image) error {
+// Store saves content to the NopCache.
+func (c *NopCache) Store(string, io.ReadCloser) error {
 	return nil
 }
 
-// Delete removes an image from the NopCache.
-func (c *NopCache) Delete(id string) error {
+// Delete removes content from the NopCache.
+func (c *NopCache) Delete(string) error {
 	return nil
 }

--- a/internal/xpkg/cache_test.go
+++ b/internal/xpkg/cache_test.go
@@ -30,7 +30,7 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/test"
 )
 
-var _ Cache = &PackageCache{}
+var _ PackageCache = &FsPackageCache{}
 
 func TestHas(t *testing.T) {
 	fs := afero.NewMemMapFs()
@@ -39,7 +39,7 @@ func TestHas(t *testing.T) {
 	defer cf.Close()
 
 	type args struct {
-		cache Cache
+		cache PackageCache
 		id    string
 	}
 	cases := map[string]struct {
@@ -50,7 +50,7 @@ func TestHas(t *testing.T) {
 		"Success": {
 			reason: "Should not return an error if package exists at path.",
 			args: args{
-				cache: NewPackageCache("/cache", fs),
+				cache: NewFsPackageCache("/cache", fs),
 				id:    "exists",
 			},
 			want: true,
@@ -58,7 +58,7 @@ func TestHas(t *testing.T) {
 		"ErrNotExist": {
 			reason: "Should return error if package does not exist at path.",
 			args: args{
-				cache: NewPackageCache("/cache", fs),
+				cache: NewFsPackageCache("/cache", fs),
 				id:    "not-exist",
 			},
 			want: false,
@@ -66,7 +66,7 @@ func TestHas(t *testing.T) {
 		"ErrIsDir": {
 			reason: "Should return error if path is a directory.",
 			args: args{
-				cache: NewPackageCache("/cache", fs),
+				cache: NewFsPackageCache("/cache", fs),
 				id:    "some-dir.gz",
 			},
 			want: false,
@@ -94,7 +94,7 @@ func TestGet(t *testing.T) {
 	defer cf.Close()
 
 	type args struct {
-		cache Cache
+		cache PackageCache
 		id    string
 	}
 	cases := map[string]struct {
@@ -105,14 +105,14 @@ func TestGet(t *testing.T) {
 		"Success": {
 			reason: "Should not return an error if package exists at path.",
 			args: args{
-				cache: NewPackageCache("/cache", fs),
+				cache: NewFsPackageCache("/cache", fs),
 				id:    "exists",
 			},
 		},
 		"ErrNotGzip": {
 			reason: "Should return error if package does not exist at path.",
 			args: args{
-				cache: NewPackageCache("/cache", fs),
+				cache: NewFsPackageCache("/cache", fs),
 				id:    "not-gzip",
 			},
 			want: gzip.ErrHeader,
@@ -120,7 +120,7 @@ func TestGet(t *testing.T) {
 		"ErrNotExist": {
 			reason: "Should return error if package does not exist at path.",
 			args: args{
-				cache: NewPackageCache("/cache", fs),
+				cache: NewFsPackageCache("/cache", fs),
 				id:    "not-exist",
 			},
 			want: &os.PathError{Op: "open", Path: "/cache/not-exist.gz", Err: afero.ErrFileNotFound},
@@ -142,7 +142,7 @@ func TestStore(t *testing.T) {
 	fs := afero.NewMemMapFs()
 
 	type args struct {
-		cache Cache
+		cache PackageCache
 		id    string
 	}
 	cases := map[string]struct {
@@ -153,14 +153,14 @@ func TestStore(t *testing.T) {
 		"Success": {
 			reason: "Should not return an error if package is created at path.",
 			args: args{
-				cache: NewPackageCache("/cache", fs),
+				cache: NewFsPackageCache("/cache", fs),
 				id:    "exists-1234567",
 			},
 		},
 		"ErrFailedCreate": {
 			reason: "Should return an error if file creation fails.",
 			args: args{
-				cache: NewPackageCache("/cache", afero.NewReadOnlyFs(fs)),
+				cache: NewFsPackageCache("/cache", afero.NewReadOnlyFs(fs)),
 				id:    "exists-1234567",
 			},
 			want: syscall.EPERM,
@@ -183,7 +183,7 @@ func TestDelete(t *testing.T) {
 	_, _ = fs.Create("/cache/exists.xpkg")
 
 	type args struct {
-		cache Cache
+		cache PackageCache
 		id    string
 	}
 	cases := map[string]struct {
@@ -194,21 +194,21 @@ func TestDelete(t *testing.T) {
 		"Success": {
 			reason: "Should not return an error if package is deleted at path.",
 			args: args{
-				cache: NewPackageCache("/cache", fs),
+				cache: NewFsPackageCache("/cache", fs),
 				id:    "exists",
 			},
 		},
 		"SuccessNotExist": {
 			reason: "Should not return an error if package does not exist.",
 			args: args{
-				cache: NewPackageCache("/cache", fs),
+				cache: NewFsPackageCache("/cache", fs),
 				id:    "not-exist",
 			},
 		},
 		"ErrFailedDelete": {
 			reason: "Should return an error if file deletion fails.",
 			args: args{
-				cache: NewPackageCache("/cache", afero.NewReadOnlyFs(fs)),
+				cache: NewFsPackageCache("/cache", afero.NewReadOnlyFs(fs)),
 				id:    "exists-1234567",
 			},
 			want: syscall.EPERM,

--- a/internal/xpkg/fake/mocks.go
+++ b/internal/xpkg/fake/mocks.go
@@ -18,6 +18,7 @@ package fake
 
 import (
 	"context"
+	"io"
 
 	"github.com/google/go-containerregistry/pkg/name"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
@@ -29,19 +30,25 @@ var _ xpkg.Cache = &MockCache{}
 
 // MockCache is a mock Cache.
 type MockCache struct {
-	MockGet    func() (v1.Image, error)
-	MockStore  func() error
+	MockHas    func() bool
+	MockGet    func() (io.ReadCloser, error)
+	MockStore  func(s string, rc io.ReadCloser) error
 	MockDelete func() error
 }
 
+// NewMockCacheHasFn creates a new MockGet function for MockCache.
+func NewMockCacheHasFn(has bool) func() bool {
+	return func() bool { return has }
+}
+
 // NewMockCacheGetFn creates a new MockGet function for MockCache.
-func NewMockCacheGetFn(img v1.Image, err error) func() (v1.Image, error) {
-	return func() (v1.Image, error) { return img, err }
+func NewMockCacheGetFn(rc io.ReadCloser, err error) func() (io.ReadCloser, error) {
+	return func() (io.ReadCloser, error) { return rc, err }
 }
 
 // NewMockCacheStoreFn creates a new MockStore function for MockCache.
-func NewMockCacheStoreFn(err error) func() error {
-	return func() error { return err }
+func NewMockCacheStoreFn(err error) func(s string, rc io.ReadCloser) error {
+	return func(s string, rc io.ReadCloser) error { return err }
 }
 
 // NewMockCacheDeleteFn creates a new MockDelete function for MockCache.
@@ -49,18 +56,23 @@ func NewMockCacheDeleteFn(err error) func() error {
 	return func() error { return err }
 }
 
+// Has calls the underlying MockHas.
+func (c *MockCache) Has(string) bool {
+	return c.MockHas()
+}
+
 // Get calls the underlying MockGet.
-func (c *MockCache) Get(source, id string) (v1.Image, error) {
+func (c *MockCache) Get(string) (io.ReadCloser, error) {
 	return c.MockGet()
 }
 
 // Store calls the underlying MockStore.
-func (c *MockCache) Store(source, id string, img v1.Image) error {
-	return c.MockStore()
+func (c *MockCache) Store(s string, rc io.ReadCloser) error {
+	return c.MockStore(s, rc)
 }
 
 // Delete calls the underlying MockDelete.
-func (c *MockCache) Delete(id string) error {
+func (c *MockCache) Delete(string) error {
 	return c.MockDelete()
 }
 

--- a/internal/xpkg/fake/mocks.go
+++ b/internal/xpkg/fake/mocks.go
@@ -26,7 +26,7 @@ import (
 	"github.com/crossplane/crossplane/internal/xpkg"
 )
 
-var _ xpkg.Cache = &MockCache{}
+var _ xpkg.PackageCache = &MockCache{}
 
 // MockCache is a mock Cache.
 type MockCache struct {

--- a/internal/xpkg/name.go
+++ b/internal/xpkg/name.go
@@ -82,12 +82,11 @@ func ToDNSLabel(s string) string { // nolint:gocyclo
 	return strings.Trim(cut.String(), "-")
 }
 
-// BuildPath builds a path for a compiled Crossplane package. If file name has
-// extension it will be replaced.
-func BuildPath(path, name string) string {
+// BuildPath builds a path with the provided extension.
+func BuildPath(path, name, ext string) string {
 	full := filepath.Join(path, name)
-	ext := filepath.Ext(full)
-	return full[0:len(full)-len(ext)] + XpkgExtension
+	existExt := filepath.Ext(full)
+	return full[0:len(full)-len(existExt)] + ext
 }
 
 // ParseNameFromMeta extracts the package name from its meta file.

--- a/internal/xpkg/name_test.go
+++ b/internal/xpkg/name_test.go
@@ -184,6 +184,7 @@ func TestBuildPath(t *testing.T) {
 	type args struct {
 		path string
 		name string
+		ext  string
 	}
 
 	cases := map[string]struct {
@@ -196,6 +197,7 @@ func TestBuildPath(t *testing.T) {
 			args: args{
 				path: "path/to/somewhere",
 				name: "test",
+				ext:  XpkgExtension,
 			},
 			want: "path/to/somewhere/test.xpkg",
 		},
@@ -204,6 +206,7 @@ func TestBuildPath(t *testing.T) {
 			args: args{
 				path: "path/to/somewhere",
 				name: "test.tar",
+				ext:  XpkgExtension,
 			},
 			want: "path/to/somewhere/test.xpkg",
 		},
@@ -212,6 +215,7 @@ func TestBuildPath(t *testing.T) {
 			args: args{
 				path: "path/to/somewhere.tar",
 				name: "",
+				ext:  XpkgExtension,
 			},
 			want: "path/to/somewhere.xpkg",
 		},
@@ -219,7 +223,7 @@ func TestBuildPath(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			full := BuildPath(tc.args.path, tc.args.name)
+			full := BuildPath(tc.args.path, tc.args.name, tc.args.ext)
 
 			if diff := cmp.Diff(tc.want, full); diff != "" {
 				t.Errorf("\n%s\nBuildPath(...): -want, +got:\n%s", tc.reason, diff)

--- a/internal/xpkg/reader.go
+++ b/internal/xpkg/reader.go
@@ -1,0 +1,84 @@
+/*
+Copyright 2022 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package xpkg
+
+import (
+	"compress/gzip"
+	"io"
+
+	"github.com/spf13/afero"
+)
+
+var _ io.ReadCloser = &gzipFileReader{}
+
+// GzipFileReader reads compressed contents from a file.
+type gzipFileReader struct {
+	f    afero.File
+	gzip *gzip.Reader
+}
+
+// newGzipFileReader builds a gzipFileReader with the provided file.
+func newGzipFileReader(f afero.File) (*gzipFileReader, error) {
+	r, err := gzip.NewReader(f)
+	if err != nil {
+		return nil, err
+	}
+	return &gzipFileReader{
+		f:    f,
+		gzip: r,
+	}, nil
+}
+
+// Read calls the underlying gzip reader's Read method.
+func (g *gzipFileReader) Read(p []byte) (n int, err error) {
+	return g.gzip.Read(p)
+}
+
+// Close first closes the gzip reader, then closes the underlying file.
+func (g *gzipFileReader) Close() error {
+	if err := g.gzip.Close(); err != nil {
+		return err
+	}
+	return g.f.Close()
+}
+
+// TeeReadCloser is a TeeReader that also closes the underlying writer.
+type TeeReadCloser struct {
+	w io.WriteCloser
+	t io.Reader
+}
+
+var _ io.ReadCloser = &TeeReadCloser{}
+
+// NewTeeReadCloser constructs a TeeReadCloser from the passed reader and
+// writer.
+func NewTeeReadCloser(r io.ReadCloser, w io.WriteCloser) *TeeReadCloser {
+	return &TeeReadCloser{
+		w: w,
+		t: io.TeeReader(r, w),
+	}
+}
+
+// Read calls the underlying TeeReader Read method.
+func (t *TeeReadCloser) Read(b []byte) (int, error) {
+	return t.t.Read(b)
+}
+
+// Close closes the writer for the TeeReader.
+func (t *TeeReadCloser) Close() error {
+	return t.w.Close()
+}


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Updates the package manager (primarily the package revision controller) to honor `io.crossplane.xpkg: base` layers in Crossplane packages, as described in [the `xpkg` specification](https://github.com/crossplane/crossplane/blob/master/docs/reference/xpkg.md#manifests). A few notes on the implementation:
- The `ImageBackend` used for the package parser, which IMO was pretty bloated (and still is to some extent, but further improvements require restructuring parser interface in `crossplane-runtime`), is refactored to _only_ deal with fetching package images and extracting the YAML stream. It does not handle caching.
- If one layer descriptor is annotated with `io.crossplane.xpkg: base`, the `ImageBackend` will _only_ download it for extracting the YAML stream. If no layer descriptor is annotated, the _whole_ image is downloaded and flattened to extract the YAML stream, but only the stream contents are cached.
- The revision reconciler is refactored to handle all caching directly, rather than deferring some of it to the `ImageBackend`, which created a leaky separation of concern.
- In the event that package contents are not in the cache, we read the YAML stream contents while also passing them along to the cache to be written to a gzipped file concurrently.
- In the event that package contents are in the cache, we stream them through the gzip reader to the parser.

> Note: potential future optimizations can be made around the use of `afero.TarFs`, which reads file contents into a map. The simplest improvement would be to just return the `tar.Reader` in annotated packages since we require that the `package.yaml` is the only file in that layer. I am running some benchmarks to illustrate the change in performance before implementing.

Fixes #2888 

> Note: as detailed in the issue, additional machinery will be added to `crank` / `crossplane-runtime` to support writing annotated package layer descriptors.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

Tested with both existing packages (`registry.upbound.io/upbound/platform-ref-azure:v0.1.0`) and one with annotated layer descriptors ([hasheddan/cool-layers:v0.0.3](https://explore.ggcr.dev/?image=hasheddan%2Fcool-layers%3Av0.0.3)). Cache used a local directory mount:

```
🤖 (crossplane) k get pkgrev
NAME                                                                              HEALTHY   REVISION   IMAGE                                                   STATE    DEP-FOUND   DEP-INSTALLED   AGE
configurationrevision.pkg.crossplane.io/upbound-platform-ref-azure-2941a425862c   True      1          registry.upbound.io/upbound/platform-ref-azure:v0.1.0   Active   2           2               18s

NAME                                                                        HEALTHY   REVISION   IMAGE                                                   STATE    DEP-FOUND   DEP-INSTALLED   AGE
providerrevision.pkg.crossplane.io/crossplane-provider-azure-4ce0c0d45ac9   True      1          registry.upbound.io/crossplane/provider-azure:v0.18.1   Active                               14s
providerrevision.pkg.crossplane.io/crossplane-provider-helm-295bcd0e6dc3    True      1          registry.upbound.io/crossplane/provider-helm:v0.9.0     Active                               8s
providerrevision.pkg.crossplane.io/hasheddan-cool-layers-0a2ec46c4ef1       True      1          hasheddan/cool-layers:v0.0.3                            Active                               3m14s

🤖 (crossplane) ls -la .work/inttest-package-cache/ --block-size=K
total 420K
drwxrwxrwx 2 dan   dan     4K Mar  1 14:37 .
drwxrwxr-x 6 dan   dan     4K Mar  1 14:31 ..
-rw-r--r-- 1 65532 65532  33K Mar  1 14:37 crossplane-provider-azure-4ce0c0d45ac9.gz
-rw-r--r-- 1 65532 65532  13K Mar  1 14:37 crossplane-provider-helm-295bcd0e6dc3.gz
-rw-r--r-- 1 65532 65532 347K Mar  1 14:35 hasheddan-cool-layers-0a2ec46c4ef1.gz
-rw-r--r-- 1 65532 65532   9K Mar  1 14:37 upbound-platform-ref-azure-2941a425862c.gz
```

Also verified that unzipped contents of items in the package cache matched expected YAML stream.

[contribution process]: https://git.io/fj2m9
