### PR TITLE
feat(claim): Add SYCNED condition to XRs and XRCs

### DIFF
--- a/internal/xcrd/crd_test.go
+++ b/internal/xcrd/crd_test.go
@@ -170,6 +170,11 @@ func TestForCompositeResource(t *testing.T) {
 				},
 				AdditionalPrinterColumns: []extv1.CustomResourceColumnDefinition{
 					{
+						Name:     "SYNCED",
+						Type:     "string",
+						JSONPath: ".status.conditions[?(@.type=='Synced')].status",
+					},
+					{
 						Name:     "READY",
 						Type:     "string",
 						JSONPath: ".status.conditions[?(@.type=='Ready')].status",
@@ -582,6 +587,11 @@ func TestForCompositeResourceClaim(t *testing.T) {
 						Status: &extv1.CustomResourceSubresourceStatus{},
 					},
 					AdditionalPrinterColumns: []extv1.CustomResourceColumnDefinition{
+						{
+							Name:     "SYNCED",
+							Type:     "string",
+							JSONPath: ".status.conditions[?(@.type=='Synced')].status",
+						},
 						{
 							Name:     "READY",
 							Type:     "string",

--- a/internal/xcrd/schemas.go
+++ b/internal/xcrd/schemas.go
@@ -309,6 +309,11 @@ func CompositeResourceStatusProps() map[string]extv1.JSONSchemaProps {
 func CompositeResourcePrinterColumns() []extv1.CustomResourceColumnDefinition {
 	return []extv1.CustomResourceColumnDefinition{
 		{
+			Name:     "SYNCED",
+			Type:     "string",
+			JSONPath: ".status.conditions[?(@.type=='Synced')].status",
+		},
+		{
 			Name:     "READY",
 			Type:     "string",
 			JSONPath: ".status.conditions[?(@.type=='Ready')].status",
@@ -330,6 +335,11 @@ func CompositeResourcePrinterColumns() []extv1.CustomResourceColumnDefinition {
 // columns that should exist in all generated composite resource claim CRDs.
 func CompositeResourceClaimPrinterColumns() []extv1.CustomResourceColumnDefinition {
 	return []extv1.CustomResourceColumnDefinition{
+		{
+			Name:     "SYNCED",
+			Type:     "string",
+			JSONPath: ".status.conditions[?(@.type=='Synced')].status",
+		},
 		{
 			Name:     "READY",
 			Type:     "string",


### PR DESCRIPTION
### Description of your changes

Fixes #2850

* Add `Synced` condition that can be used to track reconcile errors
(similar to managed resources in providers)
* Add an additional printer column to XR CRDs that references the
`Synced` condition

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

Manually and unit tests

[contribution process]: https://git.io/fj2m9
