### PR TITLE
Move releases to the new Crossplane Community Calendar

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ documentation].
 |   v1.6  | Jan 4, 2022  |     [v1.6.4]    |   July 2022   |
 |   v1.7  | Mar 22, 2022 |     Upcoming    |   Sept 2022   |
 
-You can subscribe to [release calendar] to track all release dates.
+You can subscribe to the [community calendar] to track all release dates.
 
 [v1.4.4]: https://github.com/crossplane/crossplane/releases/tag/v1.4.4
 [v1.5.2]: https://github.com/crossplane/crossplane/releases/tag/v1.5.3
@@ -54,6 +54,7 @@ with the broader community is encouraged to join.
 * Meeting link: <https://zoom.us/j/425148449?pwd=NEk4N0tHWGpEazhuam1yR28yWHY5QT09>
 * [Current agenda and past meeting notes]
 * [Past meeting recordings]
+* [Community Calendar][community calendar]
 
 ## License
 
@@ -77,4 +78,4 @@ Crossplane is under the Apache 2.0 license.
 [Past meeting recordings]: https://www.youtube.com/playlist?list=PL510POnNVaaYYYDSICFSNWFqNbx1EMr-M
 [roadmap]: https://github.com/orgs/crossplane/projects/12
 [cncf]: https://www.cncf.io/
-[release calendar]: https://calendar.google.com/calendar/u/0/embed?src=c_uttnrqr6t7r167uf57nja58mdc@group.calendar.google.com
+[community calendar]: https://calendar.google.com/calendar/embed?src=c_2cdn0hs9e2m05rrv1233cjoj1k%40group.calendar.google.com


### PR DESCRIPTION

<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
We'd like to consolidate all our various events/meetings into one shared calendar for the Crossplane community. Step one is removing the releases calendar to the new Crossplane Community Calendar.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9

N/A