### PR TITLE
[release-1.6] Allow packages with webhook configs to be installed in v1.6 without webhook support

### DIFF
--- a/internal/controller/pkg/revision/establisher.go
+++ b/internal/controller/pkg/revision/establisher.go
@@ -19,6 +19,7 @@ package revision
 import (
 	"context"
 
+	admv1 "k8s.io/api/admissionregistration/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -74,6 +75,15 @@ func (e *APIEstablisher) Establish(ctx context.Context, objs []runtime.Object, p
 	allObjs := []currentDesired{}
 	resourceRefs := []xpv1.TypedReference{}
 	for _, res := range objs {
+		// NOTE(muvaf): These types can be included in providers that can work
+		// with future releases of Crossplane, however, support for them is not
+		// implemented in this version of Crossplane. So, we will just skip
+		// installing them.
+		switch res.(type) {
+		case *admv1.MutatingWebhookConfiguration, *admv1.ValidatingWebhookConfiguration:
+			continue
+		}
+
 		// Assert desired object to resource.Object so that we can access its
 		// metadata.
 		d, ok := res.(resource.Object)

--- a/internal/xpkg/scheme.go
+++ b/internal/xpkg/scheme.go
@@ -17,6 +17,7 @@ limitations under the License.
 package xpkg
 
 import (
+	admv1 "k8s.io/api/admissionregistration/v1"
 	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	extv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -51,6 +52,9 @@ func BuildObjectScheme() (*runtime.Scheme, error) {
 		return nil, err
 	}
 	if err := extv1.AddToScheme(objScheme); err != nil {
+		return nil, err
+	}
+	if err := admv1.AddToScheme(objScheme); err != nil {
 		return nil, err
 	}
 	return objScheme, nil


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

Webhook configs are new types that providers have to include in the package alongside `CustomResourceDefinition`s. Today, you can use those packages with v1.7 and after with `--set webhooks.enabled=false` and you'd see no change. However, if you don't want to use webhooks and are on a version older than v1.7, you cannot install those packages even though they can run without webhook support. See discussion in https://github.com/crossplane/crossplane/issues/2947

This PR relaxes the linter restriction and ignores webhook config types in v1.6. Users will still need to upgrade to a new version but they will have the choice to update to a patch version instead of minor.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

Manually. Usual installation of Crossplane and installation of `muvaf/provider-aws:v0.25.0-rc.0.22.gac09cd47.dirty` package which contains webhook configs.

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
