### PR TITLE
Bump Postgresql version in the documentation samples

### DIFF
--- a/cluster/composition/postgresqlinstance.yaml
+++ b/cluster/composition/postgresqlinstance.yaml
@@ -33,9 +33,9 @@ spec:
             properties:
               engineVersion:
                 description: 'EngineVersion specifies the desired PostgreSQL engine
-                              version. Allowed Versions: 9.6 and 11.'
+                              version. Allowed Versions: 10 and 11.'
                 enum:
-                  - "9.6"
+                  - "10"
                   - "11"
                 type: string
               storageGB:

--- a/design/design-doc-provider-strategy.md
+++ b/design/design-doc-provider-strategy.md
@@ -343,7 +343,7 @@ spec:
     location: West US 2
     minimalTlsVersion: TLS12
     sslEnforcement: Disabled
-    version: "9.6"
+    version: "11"
     sku:
       tier: GeneralPurpose
       capacity: 2
@@ -363,7 +363,7 @@ spec:
     location: "East US"
     administratorLogin: "psqladminun"
     skuName: "GP_Gen5_4" # different than native where 3 fields are used.
-    version: "9.6"
+    version: "11"
     storageMb: 640000 # different than native where this is given under storageProfile
     publicNetworkAccessEnabled: true # schema same, but not supported in our native provider yet.
     sslEnforcementEnabled: true # in native, enum Disabled/Enabled instead of boolean
@@ -383,7 +383,7 @@ spec:
     location: West US 2
     minimalTlsVersion: TLS12
     sslEnforcement: Disabled
-    version: "9.6"
+    version: "11"
     sku:
       tier: GeneralPurpose
       capacity: 2

--- a/design/one-pager-composition-revisions.md
+++ b/design/one-pager-composition-revisions.md
@@ -102,7 +102,7 @@ spec:
         kind: CloudSQLInstance
         spec:
           forProvider:
-            databaseVersion: POSTGRES_9_6
+            databaseVersion: POSTGRES_12
             region: us-central1
             settings:
               tier: db-custom-1-3840
@@ -147,7 +147,7 @@ spec:
         kind: CloudSQLInstance
         spec:
           forProvider:
-            databaseVersion: POSTGRES_9_6
+            databaseVersion: POSTGRES_12
             region: us-central1
             settings:
               tier: db-custom-1-3840

--- a/design/one-pager-k8s-native-providers.md
+++ b/design/one-pager-k8s-native-providers.md
@@ -335,7 +335,7 @@ spec:
     name: postgresql-standard
   writeConnectionSecretToRef:
     name: postgresqlconn
-  engineVersion: "9.6"
+  engineVersion: "12"
 ```
 
 On creation of the `PostgreSQLInstance` claim, the claim controller would

--- a/docs/concepts/composition.md
+++ b/docs/concepts/composition.md
@@ -150,7 +150,7 @@ spec:
       kind: CloudSQLInstance
       spec:
         forProvider:
-          databaseVersion: POSTGRES_9_6
+          databaseVersion: POSTGRES_12
           region: us-central1
           settings:
             tier: db-custom-1-3840

--- a/docs/concepts/managed-resources.md
+++ b/docs/concepts/managed-resources.md
@@ -99,7 +99,7 @@ metadata:
   name: cloudsqlpostgresql
 spec:
   forProvider:
-    databaseVersion: POSTGRES_9_6
+    databaseVersion: POSTGRES_12
     region: us-central1
     settings:
       tier: db-custom-1-3840

--- a/docs/getting-started/create-configuration.md
+++ b/docs/getting-started/create-configuration.md
@@ -321,7 +321,7 @@ spec:
             dbInstanceClass: db.t2.small
             masterUsername: masteruser
             engine: postgres
-            engineVersion: "9.6"
+            engineVersion: "12"
             skipFinalSnapshotBeforeDeletion: true
             publiclyAccessible: true
           writeConnectionSecretToRef:
@@ -369,7 +369,7 @@ spec:
         kind: CloudSQLInstance
         spec:
           forProvider:
-            databaseVersion: POSTGRES_9_6
+            databaseVersion: POSTGRES_12
             region: us-central1
             settings:
               tier: db-custom-1-3840

--- a/docs/guides/vault-injection.md
+++ b/docs/guides/vault-injection.md
@@ -292,7 +292,7 @@ metadata:
   name: postgres-vault-demo
 spec:
   forProvider:
-    databaseVersion: POSTGRES_9_6
+    databaseVersion: POSTGRES_12
     region: us-central1
     settings:
       tier: db-custom-1-3840

--- a/docs/reference/composition.md
+++ b/docs/reference/composition.md
@@ -308,7 +308,7 @@ spec:
       kind: CloudSQLInstance
       spec:
         forProvider:
-          databaseVersion: POSTGRES_9_6
+          databaseVersion: POSTGRES_12
           region: us-central1
           settings:
             dataDiskType: PD_SSD

--- a/docs/snippets/package/azure/composition.yaml
+++ b/docs/snippets/package/azure/composition.yaml
@@ -29,7 +29,7 @@ spec:
               matchControllerRef: true
             location: West US 2
             sslEnforcement: Disabled
-            version: "9.6"
+            version: "11"
             sku:
               tier: GeneralPurpose
               capacity: 2

--- a/docs/snippets/package/gcp/composition.yaml
+++ b/docs/snippets/package/gcp/composition.yaml
@@ -18,7 +18,7 @@ spec:
         kind: CloudSQLInstance
         spec:
           forProvider:
-            databaseVersion: POSTGRES_9_6
+            databaseVersion: POSTGRES_12
             region: us-central1
             settings:
               tier: db-custom-1-3840

--- a/docs/snippets/provision/azure.yaml
+++ b/docs/snippets/provision/azure.yaml
@@ -16,7 +16,7 @@ spec:
       name: sqlserverpostgresql-rg
     location: West US 2
     sslEnforcement: Disabled
-    version: "9.6"
+    version: "11"
     sku:
       tier: GeneralPurpose
       capacity: 2

--- a/docs/snippets/provision/gcp.yaml
+++ b/docs/snippets/provision/gcp.yaml
@@ -4,7 +4,7 @@ metadata:
   name: cloudsqlpostgresql
 spec:
   forProvider:
-    databaseVersion: POSTGRES_9_6
+    databaseVersion: POSTGRES_12
     region: us-central1
     settings:
       tier: db-custom-1-3840


### PR DESCRIPTION


<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

Affected Azure examples are using the retired 9.6 version.

Bump them to the supported version.

See https://docs.microsoft.com/en-us/azure/postgresql/concepts-supported-versions

Signed-off-by: Yury Tsarev <yury@upbound.io>



I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

Instantiating `postgresqlserver.database.azure.crossplane.io` with version 11

[contribution process]: https://git.io/fj2m9
