### PR TITLE
Remove the empty 'rules' field from ClusterRole

### DIFF
--- a/cluster/charts/crossplane/templates/clusterrole.yaml
+++ b/cluster/charts/crossplane/templates/clusterrole.yaml
@@ -9,7 +9,6 @@ aggregationRule:
   clusterRoleSelectors:
   - matchLabels:
       rbac.crossplane.io/aggregate-to-crossplane: "true"
-rules: []
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

This PR removes the empty rules field from ClusterRole in crossplane chart.

This ClusterRole uses aggregationRules feature and the rules are overwritten by kube-controller-manager. In such a case, if the manifest is applied with Server-Side Apply (SSA), trying to apply the manifest with SSA again will cause a conflict. There are several other ClusterRoles that do not have a rules field and therefore do not have this problem.

I use Flux (https://fluxcd.io/) for GitOps tool and faced this problem because Flux uses SSA to apply manifests. I now work around this issue by removing the rules field in advance.

```
$ kind version
kind v0.12.0 go1.17.8 linux/amd64
$ kind create cluster --image=kindest/node:v1.23.4
$  kubectl version
Client Version: version.Info{Major:"1", Minor:"23", GitVersion:"v1.23.4", GitCommit:"e6c093d87ea4cbb530a7b2ae91e54c0842d8308a", GitTreeState:"clean", BuildDate:"2022-02-16T12:38:05Z", GoVersion:"go1.17.7", Compiler:"gc", Platform:"linux/amd64"}
Server Version: version.Info{Major:"1", Minor:"23", GitVersion:"v1.23.4", GitCommit:"e6c093d87ea4cbb530a7b2ae91e54c0842d8308a", GitTreeState:"clean", BuildDate:"2022-03-06T21:32:53Z", GoVersion:"go1.17.7", Compiler:"gc", Platform:"linux/amd64"}
$ kubectl create namespace crossplane-system
$ helm repo add crossplane-master https://charts.crossplane.io/master/
$ helm repo update
$ helm template crossplane crossplane-master/crossplane --version 1.7.0-rc.0.190.ga86feb1b | kubectl apply -f- --server-side
serviceaccount/rbac-manager serverside-applied
serviceaccount/crossplane serverside-applied
clusterrole.rbac.authorization.k8s.io/crossplane serverside-applied
clusterrole.rbac.authorization.k8s.io/crossplane:system:aggregate-to-crossplane serverside-applied
clusterrole.rbac.authorization.k8s.io/crossplane:allowed-provider-permissions serverside-applied
clusterrole.rbac.authorization.k8s.io/crossplane-rbac-manager serverside-applied
clusterrole.rbac.authorization.k8s.io/crossplane-admin serverside-applied
clusterrole.rbac.authorization.k8s.io/crossplane-edit serverside-applied
clusterrole.rbac.authorization.k8s.io/crossplane-view serverside-applied
clusterrole.rbac.authorization.k8s.io/crossplane-browse serverside-applied
clusterrole.rbac.authorization.k8s.io/crossplane:aggregate-to-admin serverside-applied
clusterrole.rbac.authorization.k8s.io/crossplane:aggregate-to-edit serverside-applied
clusterrole.rbac.authorization.k8s.io/crossplane:aggregate-to-view serverside-applied
clusterrole.rbac.authorization.k8s.io/crossplane:aggregate-to-browse serverside-applied
clusterrole.rbac.authorization.k8s.io/crossplane:aggregate-to-ns-admin serverside-applied
clusterrole.rbac.authorization.k8s.io/crossplane:aggregate-to-ns-edit serverside-applied
clusterrole.rbac.authorization.k8s.io/crossplane:aggregate-to-ns-view serverside-applied
clusterrolebinding.rbac.authorization.k8s.io/crossplane serverside-applied
clusterrolebinding.rbac.authorization.k8s.io/crossplane-rbac-manager serverside-applied
clusterrolebinding.rbac.authorization.k8s.io/crossplane-admin serverside-applied
deployment.apps/crossplane serverside-applied
deployment.apps/crossplane-rbac-manager serverside-applied
$ helm template crossplane crossplane-master/crossplane --version 1.7.0-rc.0.190.ga86feb1b | kubectl apply -f- --server-side
serviceaccount/rbac-manager serverside-applied
serviceaccount/crossplane serverside-applied
clusterrole.rbac.authorization.k8s.io/crossplane:system:aggregate-to-crossplane serverside-applied
clusterrole.rbac.authorization.k8s.io/crossplane:allowed-provider-permissions serverside-applied
clusterrole.rbac.authorization.k8s.io/crossplane-rbac-manager serverside-applied
clusterrole.rbac.authorization.k8s.io/crossplane-admin serverside-applied
clusterrole.rbac.authorization.k8s.io/crossplane-edit serverside-applied
clusterrole.rbac.authorization.k8s.io/crossplane-view serverside-applied
clusterrole.rbac.authorization.k8s.io/crossplane-browse serverside-applied
clusterrole.rbac.authorization.k8s.io/crossplane:aggregate-to-admin serverside-applied
clusterrole.rbac.authorization.k8s.io/crossplane:aggregate-to-edit serverside-applied
clusterrole.rbac.authorization.k8s.io/crossplane:aggregate-to-view serverside-applied
clusterrole.rbac.authorization.k8s.io/crossplane:aggregate-to-browse serverside-applied
clusterrole.rbac.authorization.k8s.io/crossplane:aggregate-to-ns-admin serverside-applied
clusterrole.rbac.authorization.k8s.io/crossplane:aggregate-to-ns-edit serverside-applied
clusterrole.rbac.authorization.k8s.io/crossplane:aggregate-to-ns-view serverside-applied
clusterrolebinding.rbac.authorization.k8s.io/crossplane serverside-applied
clusterrolebinding.rbac.authorization.k8s.io/crossplane-rbac-manager serverside-applied
clusterrolebinding.rbac.authorization.k8s.io/crossplane-admin serverside-applied
deployment.apps/crossplane serverside-applied
deployment.apps/crossplane-rbac-manager serverside-applied
error: Apply failed with 1 conflict: conflict with "clusterrole-aggregation-controller": .rules
Please review the fields above--they currently have other managers. Here
are the ways you can resolve this warning:
* If you intend to manage all of these fields, please re-run the apply
  command with the `--force-conflicts` flag.
* If you do not intend to manage all of the fields, please edit your
  manifest to remove references to the fields that should keep their
  current managers.
* You may co-own fields by updating your manifest to match the existing
  value; in this case, you'll become the manager if the other manager(s)
  stop managing the field (remove it from their configuration).
See https://kubernetes.io/docs/reference/using-api/server-side-apply/#conflicts
```

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

```
$ git show -q
commit de9d6f0697d4813d4f5e21571391e162e9b09522 (HEAD -> chart-remove-rules-clusterrole, superbrothers/chart-remove-rules-clusterrole)
Author: Kazuki Suda <kazuki.suda@gmail.com>
Date:   Sun Mar 20 09:57:29 2022 +0900

    Remove the empty 'rules' field from ClusterRole

    Signed-off-by: Kazuki Suda <kazuki.suda@gmail.com>
$ helm template crossplane ./cluster/charts/crossplane/ | kubectl apply -f- --server-side
serviceaccount/rbac-manager serverside-applied
serviceaccount/crossplane serverside-applied
clusterrole.rbac.authorization.k8s.io/crossplane serverside-applied
clusterrole.rbac.authorization.k8s.io/crossplane:system:aggregate-to-crossplane serverside-applied
clusterrole.rbac.authorization.k8s.io/crossplane:allowed-provider-permissions serverside-applied
clusterrole.rbac.authorization.k8s.io/crossplane-rbac-manager serverside-applied
clusterrole.rbac.authorization.k8s.io/crossplane-admin serverside-applied
clusterrole.rbac.authorization.k8s.io/crossplane-edit serverside-applied
clusterrole.rbac.authorization.k8s.io/crossplane-view serverside-applied
clusterrole.rbac.authorization.k8s.io/crossplane-browse serverside-applied
clusterrole.rbac.authorization.k8s.io/crossplane:aggregate-to-admin serverside-applied
clusterrole.rbac.authorization.k8s.io/crossplane:aggregate-to-edit serverside-applied
clusterrole.rbac.authorization.k8s.io/crossplane:aggregate-to-view serverside-applied
clusterrole.rbac.authorization.k8s.io/crossplane:aggregate-to-browse serverside-applied
clusterrole.rbac.authorization.k8s.io/crossplane:aggregate-to-ns-admin serverside-applied
clusterrole.rbac.authorization.k8s.io/crossplane:aggregate-to-ns-edit serverside-applied
clusterrole.rbac.authorization.k8s.io/crossplane:aggregate-to-ns-view serverside-applied
clusterrolebinding.rbac.authorization.k8s.io/crossplane serverside-applied
clusterrolebinding.rbac.authorization.k8s.io/crossplane-rbac-manager serverside-applied
clusterrolebinding.rbac.authorization.k8s.io/crossplane-admin serverside-applied
deployment.apps/crossplane serverside-applied
deployment.apps/crossplane-rbac-manager serverside-applied
$ helm template crossplane ./cluster/charts/crossplane/ | kubectl apply -f- --server-side
serviceaccount/rbac-manager serverside-applied
serviceaccount/crossplane serverside-applied
clusterrole.rbac.authorization.k8s.io/crossplane serverside-applied
clusterrole.rbac.authorization.k8s.io/crossplane:system:aggregate-to-crossplane serverside-applied
clusterrole.rbac.authorization.k8s.io/crossplane:allowed-provider-permissions serverside-applied
clusterrole.rbac.authorization.k8s.io/crossplane-rbac-manager serverside-applied
clusterrole.rbac.authorization.k8s.io/crossplane-admin serverside-applied
clusterrole.rbac.authorization.k8s.io/crossplane-edit serverside-applied
clusterrole.rbac.authorization.k8s.io/crossplane-view serverside-applied
clusterrole.rbac.authorization.k8s.io/crossplane-browse serverside-applied
clusterrole.rbac.authorization.k8s.io/crossplane:aggregate-to-admin serverside-applied
clusterrole.rbac.authorization.k8s.io/crossplane:aggregate-to-edit serverside-applied
clusterrole.rbac.authorization.k8s.io/crossplane:aggregate-to-view serverside-applied
clusterrole.rbac.authorization.k8s.io/crossplane:aggregate-to-browse serverside-applied
clusterrole.rbac.authorization.k8s.io/crossplane:aggregate-to-ns-admin serverside-applied
clusterrole.rbac.authorization.k8s.io/crossplane:aggregate-to-ns-edit serverside-applied
clusterrole.rbac.authorization.k8s.io/crossplane:aggregate-to-ns-view serverside-applied
clusterrolebinding.rbac.authorization.k8s.io/crossplane serverside-applied
clusterrolebinding.rbac.authorization.k8s.io/crossplane-rbac-manager serverside-applied
clusterrolebinding.rbac.authorization.k8s.io/crossplane-admin serverside-applied
deployment.apps/crossplane serverside-applied
deployment.apps/crossplane-rbac-manager serverside-applied
```

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
