### PR TITLE
Add customAnnotations parameter to the Helm chart

### DIFF
--- a/cluster/charts/crossplane/README.md
+++ b/cluster/charts/crossplane/README.md
@@ -78,7 +78,8 @@ and their default values.
 | `leaderElection` | Enable leader election for Crossplane Managers pod | `true` |
 | `nodeSelector` | Enable nodeSelector for Crossplane pod | `{}` |
 | `customLabels` | Custom labels to add into metadata | `{}` |
-| `serviceAccount.customAnnotations` | Custom annotations to add to the sercviceaccount of Crossplane | `{}` |
+| `customAnnotations` | Custom annotations to add to the Crossplane deployment and pod | `{}` |
+| `serviceAccount.customAnnotations` | Custom annotations to add to the serviceaccount of Crossplane | `{}` |
 | `priorityClassName` | Priority class name for Crossplane and RBAC Manager (if enabled) pods | `""` |
 | `resourcesCrossplane.limits.cpu` | CPU resource limits for Crossplane | `100m` |
 | `resourcesCrossplane.limits.memory` | Memory resource limits for Crossplane | `512Mi` |

--- a/cluster/charts/crossplane/templates/deployment.yaml
+++ b/cluster/charts/crossplane/templates/deployment.yaml
@@ -6,6 +6,9 @@ metadata:
     app: {{ template "crossplane.name" . }}
     release: {{ .Release.Name }}
     {{- include "crossplane.labels" . | indent 4 }}
+  {{- with .Values.customAnnotations }}
+  annotations: {{ toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   replicas: {{ .Values.replicas }}
   selector:
@@ -16,11 +19,16 @@ spec:
     type: {{ .Values.deploymentStrategy }}
   template:
     metadata:
-      {{- if .Values.metrics.enabled }}
+      {{- if or .Values.metrics.enabled .Values.customAnnotations }}
       annotations:
+      {{- end }}
+      {{- if .Values.metrics.enabled }}
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"
+      {{- end }}
+      {{- with .Values.customAnnotations }}
+        {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:
         app: {{ template "crossplane.name" . }}

--- a/cluster/charts/crossplane/values.yaml.tmpl
+++ b/cluster/charts/crossplane/values.yaml.tmpl
@@ -14,7 +14,10 @@ affinity: {}
 # -- Custom labels to add into metadata
 customLabels: {}
 
-# -- Custom Annotations to add to crossplane serviceaccount
+# -- Custom annotations to add to the Crossplane deployment and pod
+customAnnotations: {}
+
+# -- Custom annotations to add to the serviceaccount of Crossplane
 serviceAccount:
   customAnnotations: {}
 

--- a/docs/reference/install.md
+++ b/docs/reference/install.md
@@ -85,7 +85,8 @@ and their default values.
 | `leaderElection` | Enable leader election for Crossplane Managers pod | `true` |
 | `nodeSelector` | Enable nodeSelector for Crossplane pod | `{}` |
 | `customLabels` | Custom labels to add into metadata | `{}` |
-| `serviceAccount.customAnnotations` | Custom annotations to add to the sercviceaccount of Crossplane | `{}` |
+| `customAnnotations` | Custom annotations to add to the Crossplane deployment and pod | `{}` |
+| `serviceAccount.customAnnotations` | Custom annotations to add to the serviceaccount of Crossplane | `{}` |
 | `priorityClassName` | Priority class name for Crossplane and RBAC Manager (if enabled) pods | `""` |
 | `resourcesCrossplane.limits.cpu` | CPU resource limits for Crossplane | `100m` |
 | `resourcesCrossplane.limits.memory` | Memory resource limits for Crossplane | `512Mi` |


### PR DESCRIPTION
### Description of your changes

This PR adds `customAnnotations` helm parameter to set custom annotations to the Crossplane pod. This is required to configure Crossplane for Vault sidecar injection as part of https://github.com/crossplane/crossplane/pull/2986

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

Helm install with the following parameters and verify annotations landed properly.

```shell
helm install ... --set-string customAnnotations."vault\.hashicorp\.com/agent-inject"=true \
  --set-string customAnnotations."vault\.hashicorp\.com/agent-inject-token"=true \
  --set-string customAnnotations."vault\.hashicorp\.com/role"=crossplane
```

[contribution process]: https://git.io/fj2m9
