### PR TITLE
Update xpkg spec with webhook configurations in providers

### DIFF
--- a/docs/reference/xpkg.md
+++ b/docs/reference/xpkg.md
@@ -167,6 +167,10 @@ requirements:
   in the YAML stream.
 - Zero (0) or more `CustomResourceDefinition.apiextensions.k8s.io` objects MAY
   be defined in the YAML stream.
+- Zero (0) or more `AdmissionWebhookConfiguration.admissionregistration.k8s.io`
+  objects MAY be defined in the YAML stream.
+- Zero (0) or more `MutatingWebhookConfiguration.admissionregistration.k8s.io`
+  objects MAY be defined in the YAML stream.
 - Zero (0) other object types may be defined in the YAML stream.
 
 ### Object Annotations


### PR DESCRIPTION


<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Updates the xpkg spec to include AdmissionWebhookConfiguration and
MutatingWebhookConfiguration as valid types in a Provider package.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

Fixes #2975 

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

n/a -- documentation only

[contribution process]: https://git.io/fj2m9
