### PR TITLE
Shorten Guide Entry Title

### DIFF
--- a/docs/guides/self-signed-ca-certs.md
+++ b/docs/guides/self-signed-ca-certs.md
@@ -1,5 +1,5 @@
 ---  
-title: Fetch Packages from Registry with Self-Signed CA Certificate  
+title: Self-Signed CA Certs 
 toc: true  
 weight: 270  
 indent: true  


### PR DESCRIPTION
### Description of your changes
The title of the self-signed cert was too long for the formatting of the docs web page. Made it shorter for better page layout.

I have:

- [x ] Read and followed Crossplane's [contribution process].
- [x ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested


[contribution process]: https://git.io/fj2m9
