### PR TITLE
chore(helm): add arg '--max-reconcile-rate' to crossplane deployment

### DIFF
--- a/cluster/charts/crossplane/README.md
+++ b/cluster/charts/crossplane/README.md
@@ -77,6 +77,7 @@ and their default values.
 | `deploymentStrategy` | The deployment strategy for the Crossplane and RBAC Manager (if enabled) pods | `RollingUpdate` |
 | `leaderElection` | Enable leader election for Crossplane Managers pod | `true` |
 | `nodeSelector` | Enable nodeSelector for Crossplane pod | `{}` |
+| `maxReconcileRate` | How frequently Crossplane may reconcile its resources (seconds) | `""` |
 | `customLabels` | Custom labels to add into metadata | `{}` |
 | `customAnnotations` | Custom annotations to add to the Crossplane deployment and pod | `{}` |
 | `serviceAccount.customAnnotations` | Custom annotations to add to the serviceaccount of Crossplane | `{}` |

--- a/cluster/charts/crossplane/templates/deployment.yaml
+++ b/cluster/charts/crossplane/templates/deployment.yaml
@@ -46,6 +46,9 @@ spec:
           args:
           - core
           - init
+          {{- if .Values.maxReconcileRate }}
+          - --max-reconcile-rate={{ .Values.maxReconcileRate }}
+          {{- end }}
           {{- range $arg := .Values.provider.packages }}
           - --provider
           - "{{ $arg }}"

--- a/cluster/charts/crossplane/values.yaml.tmpl
+++ b/cluster/charts/crossplane/values.yaml.tmpl
@@ -24,6 +24,9 @@ serviceAccount:
 leaderElection: true
 args: {}
 
+# How frequently Crossplane may reconcile its resources (seconds). Default: 10
+maxReconcileRate: ""
+
 provider:
   packages: []
 

--- a/docs/reference/install.md
+++ b/docs/reference/install.md
@@ -84,6 +84,7 @@ and their default values.
 | `deploymentStrategy` | The deployment strategy for the Crossplane and RBAC Manager (if enabled) pods | `RollingUpdate` |
 | `leaderElection` | Enable leader election for Crossplane Managers pod | `true` |
 | `nodeSelector` | Enable nodeSelector for Crossplane pod | `{}` |
+| `maxReconcileRate` | How frequently Crossplane may reconcile its resources (seconds) | `""` |
 | `customLabels` | Custom labels to add into metadata | `{}` |
 | `customAnnotations` | Custom annotations to add to the Crossplane deployment and pod | `{}` |
 | `serviceAccount.customAnnotations` | Custom annotations to add to the serviceaccount of Crossplane | `{}` |


### PR DESCRIPTION
### Description of your changes

Add the ability to set the argument `--max-reconcile-rate` using the Helm chart.

I have:

- [x] Read and followed Crossplane's [contribution process].

### How has this code been tested
I deployed the helm chart with and without the values `maxReconcileRate` set
