### PR TITLE
Claim's namespace is used as the ProviderConfig name in single-cluster multi-tenancy Scenarios

### DIFF
--- a/docs/guides/multi-tenant.md
+++ b/docs/guides/multi-tenant.md
@@ -223,7 +223,7 @@ spec:
       key: key
 ```
 
-2. Define a `Composition` that patches the name of the Claim reference in the XR
+2. Define a `Composition` that patches the namespace of the Claim reference in the XR
    to the `providerConfigRef` of the `RDSInstance`.
 
 ```yaml


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
In single-cluster multi-tenancy scenarios based on isolation using (namespaced) claims, claim's namespace is patched to the composed resource's `spec.providerConfigRef.name`. The provided example composition manifest is correct but the explanation text states that the source field of the patch is the claim's name. This PR is a fix for this typo.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
N.A.

[contribution process]: https://git.io/fj2m9
