### PR TITLE
docs.managed resources: add more details to versioning policy

### DIFF
--- a/docs/concepts/managed-resources.md
+++ b/docs/concepts/managed-resources.md
@@ -9,10 +9,10 @@ indent: true
 
 ## Overview
 
-A Managed Resource (MR) is Crossplane's representation of a resource in an external
-system - most commonly a cloud provider. Managed Resources are opinionated,
-Crossplane Resource Model ([XRM][term-xrm]) compliant Kubernetes Custom
-Resources that are installed by a Crossplane [provider].
+A Managed Resource (MR) is Crossplane's representation of a resource in an
+external system - most commonly a cloud provider. Managed Resources are
+opinionated, Crossplane Resource Model ([XRM][term-xrm]) compliant Kubernetes
+Custom Resources that are installed by a Crossplane [provider].
 
 For example, `RDSInstance` in the AWS Provider corresponds to an actual RDS
 Instance in AWS. There is a one-to-one relationship and the changes on managed
@@ -74,7 +74,8 @@ kubectl get rdsinstance rdspostgresql
 ```
 
 When provisioning is complete, you should see `READY: True` in the output. You
-can take a look at its connection secret that is referenced under `spec.writeConnectionSecretToRef`:
+can take a look at its connection secret that is referenced under
+`spec.writeConnectionSecretToRef`:
 
 ```console
 kubectl describe secret aws-rdspostgresql-conn -n crossplane-system
@@ -122,7 +123,8 @@ kubectl get cloudsqlinstance cloudsqlpostgresql
 ```
 
 When provisioning is complete, you should see `READY: True` in the output. You
-can take a look at its connection secret that is referenced under `spec.writeConnectionSecretToRef`:
+can take a look at its connection secret that is referenced under
+`spec.writeConnectionSecretToRef`:
 
 ```console
 kubectl describe secret cloudsqlpostgresql-conn -n crossplane-system
@@ -189,7 +191,8 @@ kubectl get postgresqlserver sqlserverpostgresql
 ```
 
 When provisioning is complete, you should see `READY: True` in the output. You
-can take a look at its connection secret that is referenced under `spec.writeConnectionSecretToRef`:
+can take a look at its connection secret that is referenced under
+`spec.writeConnectionSecretToRef`:
 
 ```console
 kubectl describe secret sqlserverpostgresql-conn -n crossplane-system
@@ -241,6 +244,23 @@ conventions][api-versioning] for the CRDs that it deploys. In short, for
 instructions for manual migration will be provided when a new version of that
 CRD schema is released.
 
+In practice, we suggest the following guidelines to provider developers:
+* Every new kind has to be introduced as `v1alpha1` with no exception.
+* Breaking changes require a version change, i.e. `v1alpha1` needs to become
+  `v1alpha2`.
+  * Alpha resources don't require automatic conversions or manual instructions
+    but it's recommended that manual instructions are provided.
+  * Beta resources require at least manual instructions but it's recommended
+    that conversion webhooks are used so that users can upgrade without any
+    hands-on operation.
+  * Stable resources require conversion webhooks.
+* As long as the developer feels comfortable with the guarantees above, they can
+  bump the version to beta or stable given that the CRD shape adheres to the
+  Crossplane Resource Model (XRM) specifications for managed resources
+  [here][managed-api-patterns].
+* It's suggested that the bump from Alpha to Beta or from Beta to Stable happen
+  after a bake period which includes at least one release.
+
 ### Grouping
 
 In general, managed resources are high fidelity resources meaning they will
@@ -278,14 +298,14 @@ all managed resources actually have connection details to write - many will
 write an empty `Secret`.
 
 > Which managed resources have connection details and what connection details
-> they have is currently undocumented. This is tracked in
-> [this issue][issue-1143].
+> they have is currently undocumented. This is tracked in [this
+> issue][issue-1143].
 
 #### Immutable Properties
 
 There are configuration parameters in external resources that cloud providers do
-not allow to be changed. For example, in AWS, you cannot change the region
-of an `RDSInstance`.
+not allow to be changed. For example, in AWS, you cannot change the region of an
+`RDSInstance`.
 
 Some infrastructure tools such as Terraform delete and recreate the resource to
 accommodate those changes but Crossplane does not take that route. Unless the
@@ -439,9 +459,12 @@ including Velero.
 
 [term-xrm]: terminology.md#crossplane-resource-model
 [composition]: composition.md
-[api-versioning]: https://kubernetes.io/docs/reference/using-api/api-overview/#api-versioning
+[api-versioning]:
+    https://kubernetes.io/docs/reference/using-api/api-overview/#api-versioning
 [velero]: https://velero.io/
 [api-reference]: ../api-docs/overview.md
 [provider]: providers.md
 [issue-727]: https://github.com/crossplane/crossplane/issues/727
 [issue-1143]: https://github.com/crossplane/crossplane/issues/1143
+[managed-api-patterns]:
+    https://github.com/crossplane/crossplane/blob/master/design/one-pager-managed-resource-api-design.md


### PR DESCRIPTION
Signed-off-by: Muvaffak Onus <me@muvaf.com>

<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

Provider developers ask when a resource needs to be bumped from alpha to beta. While the Kubernetes API Versioning doc is what we follow, more details seem to be helpful.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

N/A

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
