### PR TITLE
Update release issue template with recent links and clarify process for removing old docs

### DIFF
--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -18,13 +18,13 @@ Please assign the release manager to the issue.
 
 This issue can be closed when we have completed the following steps (in order).
 Please ensure all artifacts (PRs, workflow runs, Tweets, etc) are linked from
-this issue for posterity. Refer to this [prior release issue][release-1.6] for
+this issue for posterity. Refer to this [prior release issue][release-1.7] for
 examples of each step.
 
 <!--
 Please uncomment the following block only if cutting a minor release. Most of
 these should be completed at the beginning of Code Freeze:
-https://crossplane.io/docs/v1.2/reference/release-cycle.html#code-freeze
+https://crossplane.io/docs/v1.7/reference/release-cycle.html#code-freeze
 
 The exception is the Crossplane docs website repo update. You can open a PR at
 code freeze time, but it should not be merged until the release is complete.
@@ -35,23 +35,23 @@ code freeze time, but it should not be merged until the release is complete.
 - [ ] Created and merged an empty commit to the `master` branch.
 - [ ] Run the [Tag workflow][tag-workflow] on the `master` branch with the next release candidate tag.
 - [ ] Updated the current release version in the [Crossplane docs website repo].
-- [ ] Updated the release branch reaching EOL with docs removal directive.
+- [ ] Updated the release branch reaching EOL with [docs removal directive].
+- [ ] Request @jbw976 to remove the EOL docs version from Google Search
 -->
 - [ ] Updated all version information in the documentation on the relevant release branch.
 - [ ] Run the [Tag workflow][tag-workflow] on the relevant release branch with the proper release version.
 - [ ] Run the [CI workflow][ci-workflow] on the release branch and verified that the tagged build version exists on the [releases.crossplane.io] `build` channel..
 - [ ] Run the [Configurations workflow][configurations-workflow] on the release branch and verified  that version exists on [registry.upbound.io] for all getting started packages.
-    - [ ] `xp/getting-started-with-aws`
-    - [ ] `xp/getting-started-with-with-with-vpc`
-    - [ ] `xp/getting-started-with-azure`
-    - [ ] `xp/getting-started-with-gcp`
+  - [ ] `xp/getting-started-with-aws`
+  - [ ] `xp/getting-started-with-with-with-vpc`
+  - [ ] `xp/getting-started-with-azure`
+  - [ ] `xp/getting-started-with-gcp`
 - [ ] Run the [Promote workflow][promote-workflow] with channel `stable` on the release branch and verified that the tagged build version exists on the [releases.crossplane.io] `stable` channel.
 - [ ] Published a [new release] for the tagged version, with the same name as the version and descriptive release notes.
 - [ ] Updated the [releases table] in the `README.md` on `master`.
 - [ ] Ensured that users have been notified of the release on all communication channels:
-    - [ ] Slack
-    - [ ] Twitter
-
+  - [ ] Slack
+  - [ ] Twitter
 
 <!-- Named Links -->
 [releases.crossplane.io]: https://releases.crossplane.io
@@ -59,8 +59,9 @@ code freeze time, but it should not be merged until the release is complete.
 [new release]: https://github.com/crossplane/crossplane/releases/new
 [releases table]: https://github.com/crossplane/crossplane#releases
 [Crossplane docs website repo]: https://github.com/crossplane/crossplane.github.io
+[docs removal directive]: https://github.com/crossplane/crossplane/pull/3003
 [tag-workflow]: https://github.com/crossplane/crossplane/actions/workflows/tag.yml
 [ci-workflow]: https://github.com/crossplane/crossplane/actions/workflows/ci.yml
 [configurations-workflow]: https://github.com/crossplane/crossplane/actions/workflows/configurations.yml
 [promote-workflow]: https://github.com/crossplane/crossplane/actions/workflows/promote.yml
-[release-1.6]: https://github.com/crossplane/crossplane/issues/2764
+[release-1.7]: https://github.com/crossplane/crossplane/issues/2977


### PR DESCRIPTION
### Description of your changes

This PR attempts to bring some clarity around what happens to old docs during an official release:

* Give an example of what "docs removal directive" means
* Add a step for removing the old docs from Google Search
* Update links to more recent equivalents

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

This code has been previewed in VS Code preview mode, where all the links were tested.

[contribution process]: https://git.io/fj2m9
