### PR TITLE
Drop pushing latest tags for example configurations

### DIFF
--- a/.github/workflows/configurations.yml
+++ b/.github/workflows/configurations.yml
@@ -41,10 +41,6 @@ jobs:
         uses: crossplane-contrib/xpkg-action@v0.2.0
         with:
           command: push configuration -f docs/snippets/package/aws/getting-started-with-aws.xpkg registry.upbound.io/xp/getting-started-with-aws:${{ steps.tagger.outputs.VERSION_TAG }}
-      - name: Push Latest
-        uses: crossplane-contrib/xpkg-action@v0.2.0
-        with:
-          command: push configuration -f docs/snippets/package/aws/getting-started-with-aws.xpkg registry.upbound.io/xp/getting-started-with-aws
   
   getting-started-with-aws-with-vpc:
     runs-on: ubuntu-18.04
@@ -74,10 +70,6 @@ jobs:
         uses: crossplane-contrib/xpkg-action@v0.2.0
         with:
           command: push configuration -f docs/snippets/package/aws-with-vpc/getting-started-with-aws-with-vpc.xpkg registry.upbound.io/xp/getting-started-with-aws-with-vpc:${{ steps.tagger.outputs.VERSION_TAG }}
-      - name: Push Latest
-        uses: crossplane-contrib/xpkg-action@v0.2.0
-        with:
-          command: push configuration -f docs/snippets/package/aws-with-vpc/getting-started-with-aws-with-vpc.xpkg registry.upbound.io/xp/getting-started-with-aws-with-vpc
   
   getting-started-with-gcp:
     runs-on: ubuntu-18.04
@@ -107,10 +99,6 @@ jobs:
         uses: crossplane-contrib/xpkg-action@v0.2.0
         with:
           command: push configuration -f docs/snippets/package/gcp/getting-started-with-gcp.xpkg registry.upbound.io/xp/getting-started-with-gcp:${{ steps.tagger.outputs.VERSION_TAG }}
-      - name: Push Latest
-        uses: crossplane-contrib/xpkg-action@v0.2.0
-        with:
-          command: push configuration -f docs/snippets/package/gcp/getting-started-with-gcp.xpkg registry.upbound.io/xp/getting-started-with-gcp
   
   getting-started-with-azure:
     runs-on: ubuntu-18.04
@@ -140,7 +128,3 @@ jobs:
         uses: crossplane-contrib/xpkg-action@v0.2.0
         with:
           command: push configuration -f docs/snippets/package/azure/getting-started-with-azure.xpkg registry.upbound.io/xp/getting-started-with-azure:${{ steps.tagger.outputs.VERSION_TAG }}
-      - name: Push Latest
-        uses: crossplane-contrib/xpkg-action@v0.2.0
-        with:
-          command: push configuration -f docs/snippets/package/azure/getting-started-with-azure.xpkg registry.upbound.io/xp/getting-started-with-azure


### PR DESCRIPTION


<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Updates the example configurations workflow to drop the latest tag push
as Crossplane does not use explicit latest tags and Upbound's registry
requires the use of semantic version tags.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

See https://github.com/crossplane/crossplane/actions/runs/2244728642, where all pushes were successful except for those using `latest`.

[contribution process]: https://git.io/fj2m9
