### PR TITLE
Fix panic from missing argument to log.Debug

### DIFF
--- a/internal/controller/apiextensions/claim/reconciler.go
+++ b/internal/controller/apiextensions/claim/reconciler.go
@@ -408,7 +408,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 	}
 
 	if err := r.claim.AddFinalizer(ctx, cm); err != nil {
-		log.Debug(errAddFinalizer, "error")
+		log.Debug(errAddFinalizer, "error", err)
 		err = errors.Wrap(err, errAddFinalizer)
 		record.Event(cm, event.Warning(reasonBind, err))
 		return reconcile.Result{}, err

--- a/internal/controller/apiextensions/composite/reconciler.go
+++ b/internal/controller/apiextensions/composite/reconciler.go
@@ -414,7 +414,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 		}
 
 		if err := r.composite.RemoveFinalizer(ctx, cr); err != nil {
-			log.Debug(errRemoveFinalizer, "error")
+			log.Debug(errRemoveFinalizer, "error", err)
 			err = errors.Wrap(err, errRemoveFinalizer)
 			r.record.Event(cr, event.Warning(reasonDelete, err))
 			return reconcile.Result{}, err
@@ -425,7 +425,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 	}
 
 	if err := r.composite.AddFinalizer(ctx, cr); err != nil {
-		log.Debug(errAddFinalizer, "error")
+		log.Debug(errAddFinalizer, "error", err)
 		err = errors.Wrap(err, errAddFinalizer)
 		r.record.Event(cr, event.Warning(reasonInit, err))
 		return reconcile.Result{}, err


### PR DESCRIPTION
Signed-off-by: Bob Haddleton <bob.haddleton@nokia.com>

### Description of your changes

Add the error argument to log.Debug statements that are expecting it.

Fixes #3071

I have:

- [X] Read and followed Crossplane's [contribution process].
- [X] Run `make reviewable` to ensure this PR is ready for review.
- [X] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

Tested locally in the environment where the crash was happening.

