### PR TITLE
Don't link to latest patch releases in README.md

### DIFF
--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -21,22 +21,12 @@ Please ensure all artifacts (PRs, workflow runs, Tweets, etc) are linked from
 this issue for posterity. Refer to this [prior release issue][release-1.7] for
 examples of each step.
 
+<!-- Uncomment the following block only if cutting a minor release. -->
 <!--
-Please uncomment the following block only if cutting a minor release. Most of
-these should be completed at the beginning of Code Freeze:
-https://crossplane.io/docs/v1.7/reference/release-cycle.html#code-freeze
-
-The exception is the Crossplane docs website repo update. You can open a PR at
-code freeze time, but it should not be merged until the release is complete.
--->
-
-<!--
-- [ ] Created the release branch.
-- [ ] Created and merged an empty commit to the `master` branch.
-- [ ] Run the [Tag workflow][tag-workflow] on the `master` branch with the next release candidate tag.
-- [ ] Updated the current release version in the [Crossplane docs website repo].
-- [ ] Updated the release branch reaching EOL with [docs removal directive].
-- [ ] Request @jbw976 to remove the EOL docs version from Google Search
+- [ ] Prepare the release branch at the beginning of [Code Freeze]:
+  - [ ] Created the release branch.
+  - [ ] Created and merged an empty commit to the `master` branch.
+  - [ ] Run the [Tag workflow][tag-workflow] on the `master` branch with the next release candidate tag.
 -->
 - [ ] Updated all version information in the documentation on the relevant release branch.
 - [ ] Run the [Tag workflow][tag-workflow] on the relevant release branch with the proper release version.
@@ -48,10 +38,16 @@ code freeze time, but it should not be merged until the release is complete.
   - [ ] `xp/getting-started-with-gcp`
 - [ ] Run the [Promote workflow][promote-workflow] with channel `stable` on the release branch and verified that the tagged build version exists on the [releases.crossplane.io] `stable` channel.
 - [ ] Published a [new release] for the tagged version, with the same name as the version and descriptive release notes.
-- [ ] Updated the [releases table] in the `README.md` on `master`.
 - [ ] Ensured that users have been notified of the release on all communication channels:
   - [ ] Slack
   - [ ] Twitter
+<!-- Uncomment the following block only if cutting a minor release. -->
+<!--
+- [ ] Updated the [releases table] in the `README.md` on `master`.
+- [ ] Updated the current release version in the [Crossplane docs website repo].
+- [ ] Updated the release branch reaching EOL with [docs removal directive].
+- [ ] Request @jbw976 to remove the EOL docs version from Google Search
+-->
 
 <!-- Named Links -->
 [releases.crossplane.io]: https://releases.crossplane.io
@@ -65,3 +61,4 @@ code freeze time, but it should not be merged until the release is complete.
 [configurations-workflow]: https://github.com/crossplane/crossplane/actions/workflows/configurations.yml
 [promote-workflow]: https://github.com/crossplane/crossplane/actions/workflows/promote.yml
 [release-1.7]: https://github.com/crossplane/crossplane/issues/2977
+[Code Freeze]: https://crossplane.io/docs/master/reference/release-cycle.html#code-freeze

--- a/README.md
+++ b/README.md
@@ -17,18 +17,14 @@ Currently maintained releases, as well as the next upcoming release are listed
 below. For more information take a look at the Crossplane [release cycle
 documentation].
 
-| Release | Release Date |  Current Patch  |      EOL      |
-|:-------:|:------------:|:---------------:|:-------------:|
-|   v1.5  | Oct 26, 2021 |     [v1.5.3]    |    May 2022   |
-|   v1.6  | Jan 4, 2022  |     [v1.6.5]    |   July 2022   |
-|   v1.7  | Mar 22, 2022 |     [v1.7.0]    |   Sept 2022   |
-|   v1.8  | May 17, 2022 |     Upcoming    |    Dec 2022   |
+| Release | Release Date |      EOL      |
+|:-------:|:------------:|:-------------:|
+|   v1.6  | Jan 4, 2022  |   July 2022   |
+|   v1.7  | Mar 22, 2022 |   Sept 2022   |
+|   v1.8  | May 17, 2022 |    Dec 2022   |
 
-You can subscribe to the [community calendar] to track all release dates.
-
-[v1.5.3]: https://github.com/crossplane/crossplane/releases/tag/v1.5.3
-[v1.6.5]: https://github.com/crossplane/crossplane/releases/tag/v1.6.5
-[v1.7.0]: https://github.com/crossplane/crossplane/releases/tag/v1.7.0
+You can subscribe to the [community calendar] to track all release dates, and
+find the most recent releases on the [releases] page.
 
 ## Get Involved
 
@@ -75,3 +71,4 @@ Crossplane is under the Apache 2.0 license.
 [roadmap]: https://github.com/orgs/crossplane/projects/12
 [cncf]: https://www.cncf.io/
 [community calendar]: https://calendar.google.com/calendar/embed?src=c_2cdn0hs9e2m05rrv1233cjoj1k%40group.calendar.google.com
+[releases]: https://github.com/crossplane/crossplane/releases


### PR DESCRIPTION


<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
This PR removes the releases table's links to patch releases.

I'm sure it's of non-zero use, but I'm (very) skeptical that it's worth the extra step in the release process.

GitHub releases may not have the ideal UX for a project that releases patches on multiple release branches but it's quite a common pattern nonetheless and I don't see too many other projects going out of their way to clarify which one is latest. Speaking personally (as a user of other projects) I'd find this to be a minor convenience at best.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
