### PR TITLE
Pin docs snippet links and configurations to v1.8.0

### DIFF
--- a/docs/cloud-providers/aws/aws-provider.md
+++ b/docs/cloud-providers/aws/aws-provider.md
@@ -28,8 +28,8 @@ Run `setup.sh` to read `aws` credentials and region, and create an `aws
 provider` instance in Crossplane:
 
 ```bash
-curl -O https://raw.githubusercontent.com/crossplane/crossplane/master/docs/snippets/configure/aws/providerconfig.yaml
-curl -O https://raw.githubusercontent.com/crossplane/crossplane/master/docs/snippets/configure/aws/setup.sh
+curl -O https://raw.githubusercontent.com/crossplane/crossplane/release-1.8/docs/snippets/configure/aws/providerconfig.yaml
+curl -O https://raw.githubusercontent.com/crossplane/crossplane/release-1.8/docs/snippets/configure/aws/setup.sh
 chmod +x setup.sh
 ./setup.sh [--profile aws_profile]
 ```

--- a/docs/cloud-providers/gcp/gcp-provider.md
+++ b/docs/cloud-providers/gcp/gcp-provider.md
@@ -33,7 +33,7 @@ account will have access to the services and roles sufficient to run the
 Crossplane GCP examples.
 
 ```bash
-curl -O https://raw.githubusercontent.com/crossplane/crossplane/master/docs/snippets/configure/gcp/credentials.sh
+curl -O https://raw.githubusercontent.com/crossplane/crossplane/release-1.8/docs/snippets/configure/gcp/credentials.sh
 ./credentials.sh
 # ... EXAMPLE OUTPUT ONLY
 # export ORGANIZATION_ID=987654321

--- a/docs/concepts/managed-resources.md
+++ b/docs/concepts/managed-resources.md
@@ -63,7 +63,7 @@ spec:
 ```
 
 ```console
-kubectl apply -f https://raw.githubusercontent.com/crossplane/crossplane/master/docs/snippets/provision/aws.yaml
+kubectl apply -f https://raw.githubusercontent.com/crossplane/crossplane/release-1.8/docs/snippets/provision/aws.yaml
 ```
 
 Creating the above instance will cause Crossplane to provision an RDS instance
@@ -112,7 +112,7 @@ spec:
 ```
 
 ```console
-kubectl apply -f https://raw.githubusercontent.com/crossplane/crossplane/master/docs/snippets/provision/gcp.yaml
+kubectl apply -f https://raw.githubusercontent.com/crossplane/crossplane/release-1.8/docs/snippets/provision/gcp.yaml
 ```
 
 Creating the above instance will cause Crossplane to provision a CloudSQL
@@ -179,7 +179,7 @@ spec:
 ```
 
 ```console
-kubectl apply -f https://raw.githubusercontent.com/crossplane/crossplane/master/docs/snippets/provision/azure.yaml
+kubectl apply -f https://raw.githubusercontent.com/crossplane/crossplane/release-1.8/docs/snippets/provision/azure.yaml
 ```
 
 Creating the above instance will cause Crossplane to provision a PostgreSQL

--- a/docs/concepts/packages.md
+++ b/docs/concepts/packages.md
@@ -109,8 +109,8 @@ all types that its package installs, as well as `Secrets`, `ConfigMaps`, and
 > Note that the Crossplane RBAC manager can be configured to reject permissions
 > for certain API groups. If a package requests permissions that Crossplane is
 > configured to reject, the package will fail to be installed.
-> Authorized permissions should be aggregated to the rbac manager clusterrole 
-> (the cluster role defined by the provider-clusterrole flag in the rbac manager) 
+> Authorized permissions should be aggregated to the rbac manager clusterrole
+> (the cluster role defined by the provider-clusterrole flag in the rbac manager)
 > by using the label `rbac.crossplane.io/aggregate-to-allowed-provider-permissions: "true"`
 
 The `spec.crossplane.version` field specifies the version constraints for core
@@ -478,7 +478,6 @@ ensure that the controller image that it references is able to be pulled by the
 cluster nodes. This can be accomplished either by pushing it to a registry, or
 by [pre-pulling images] onto nodes in the cluster.
 
-
 <!-- Named Links -->
 
 [OCI images]: https://github.com/opencontainers/image-spec
@@ -486,7 +485,7 @@ by [pre-pulling images] onto nodes in the cluster.
 [provider-docs]: https://doc.crds.dev/github.com/crossplane/crossplane/meta.pkg.crossplane.io/Provider/v1
 [configuration-docs]: https://doc.crds.dev/github.com/crossplane/crossplane/meta.pkg.crossplane.io/Configuration/v1
 [lock-api]: https://doc.crds.dev/github.com/crossplane/crossplane/pkg.crossplane.io/Lock/v1beta1
-[getting-started-with-gcp]: https://github.com/crossplane/crossplane/tree/master/docs/snippets/package/gcp
+[getting-started-with-gcp]: https://github.com/crossplane/crossplane/tree/release-1.8/docs/snippets/package/gcp
 [specification]: https://github.com/Masterminds/semver#basic-comparisons
 [composition]: composition.md
 [IAM Roles for Service Accounts]: https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html

--- a/docs/getting-started/create-configuration.md
+++ b/docs/getting-started/create-configuration.md
@@ -92,7 +92,7 @@ spec:
 ```
 
 ```console
-curl -OL https://raw.githubusercontent.com/crossplane/crossplane/master/docs/snippets/package/definition.yaml
+curl -OL https://raw.githubusercontent.com/crossplane/crossplane/release-1.8/docs/snippets/package/definition.yaml
 ```
 
 > You might notice that the XRD we created specifies both "names" and "claim
@@ -169,7 +169,7 @@ spec:
 ```
 
 ```console
-curl -OL https://raw.githubusercontent.com/crossplane/crossplane/master/docs/snippets/package/aws/composition.yaml
+curl -OL https://raw.githubusercontent.com/crossplane/crossplane/release-1.8/docs/snippets/package/aws/composition.yaml
 ```
 
 </div>
@@ -343,7 +343,7 @@ spec:
 ```
 
 ```console
-curl -OL https://raw.githubusercontent.com/crossplane/crossplane/master/docs/snippets/package/aws-with-vpc/composition.yaml
+curl -OL https://raw.githubusercontent.com/crossplane/crossplane/release-1.8/docs/snippets/package/aws-with-vpc/composition.yaml
 ```
 
 </div>
@@ -399,7 +399,7 @@ spec:
 ```
 
 ```console
-curl -OL https://raw.githubusercontent.com/crossplane/crossplane/master/docs/snippets/package/gcp/composition.yaml
+curl -OL https://raw.githubusercontent.com/crossplane/crossplane/release-1.8/docs/snippets/package/gcp/composition.yaml
 ```
 
 </div>
@@ -485,7 +485,7 @@ spec:
 ```
 
 ```console
-curl -OL https://raw.githubusercontent.com/crossplane/crossplane/master/docs/snippets/package/azure/composition.yaml
+curl -OL https://raw.githubusercontent.com/crossplane/crossplane/release-1.8/docs/snippets/package/azure/composition.yaml
 ```
 
 </div>
@@ -535,7 +535,7 @@ spec:
 ```
 
 ```console
-curl -OL https://raw.githubusercontent.com/crossplane/crossplane/master/docs/snippets/package/alibaba/composition.yaml
+curl -OL https://raw.githubusercontent.com/crossplane/crossplane/release-1.8/docs/snippets/package/alibaba/composition.yaml
 ```
 
 </div>
@@ -578,7 +578,7 @@ spec:
 ```
 
 ```console
-curl -OL https://raw.githubusercontent.com/crossplane/crossplane/master/docs/snippets/package/aws/crossplane.yaml
+curl -OL https://raw.githubusercontent.com/crossplane/crossplane/release-1.8/docs/snippets/package/aws/crossplane.yaml
 
 kubectl crossplane build configuration
 ```
@@ -591,7 +591,7 @@ you may specify a specific package by using the `-f` flag.
 ```console
 # Set this to the Docker Hub username or OCI registry you wish to use.
 REG=my-package-repo
-kubectl crossplane push configuration ${REG}/getting-started-with-aws:master
+kubectl crossplane push configuration ${REG}/getting-started-with-aws:v1.8.0
 ```
 
 > Note that the Crossplane CLI will not follow symbolic links for files in the
@@ -618,7 +618,7 @@ spec:
 ```
 
 ```console
-curl -OL https://raw.githubusercontent.com/crossplane/crossplane/master/docs/snippets/package/aws-with-vpc/crossplane.yaml
+curl -OL https://raw.githubusercontent.com/crossplane/crossplane/release-1.8/docs/snippets/package/aws-with-vpc/crossplane.yaml
 
 kubectl crossplane build configuration
 ```
@@ -631,7 +631,7 @@ you may specify a specific package by using the `-f` flag.
 ```console
 # Set this to the Docker Hub username or OCI registry you wish to use.
 REG=my-package-repo
-kubectl crossplane push configuration ${REG}/getting-started-with-aws-with-vpc:master
+kubectl crossplane push configuration ${REG}/getting-started-with-aws-with-vpc:v1.8.0
 ```
 
 > Note that the Crossplane CLI will not follow symbolic links for files in the
@@ -657,7 +657,7 @@ spec:
 ```
 
 ```console
-curl -OL https://raw.githubusercontent.com/crossplane/crossplane/master/docs/snippets/package/gcp/crossplane.yaml
+curl -OL https://raw.githubusercontent.com/crossplane/crossplane/release-1.8/docs/snippets/package/gcp/crossplane.yaml
 
 kubectl crossplane build configuration
 ```
@@ -670,7 +670,7 @@ you may specify a specific package by using the `-f` flag.
 ```console
 # Set this to the Docker Hub username or OCI registry you wish to use.
 REG=my-package-repo
-kubectl crossplane push configuration ${REG}/getting-started-with-gcp:master
+kubectl crossplane push configuration ${REG}/getting-started-with-gcp:v1.8.0
 ```
 
 > Note that the Crossplane CLI will not follow symbolic links for files in the
@@ -696,7 +696,7 @@ spec:
 ```
 
 ```console
-curl -OL https://raw.githubusercontent.com/crossplane/crossplane/master/docs/snippets/package/azure/crossplane.yaml
+curl -OL https://raw.githubusercontent.com/crossplane/crossplane/release-1.8/docs/snippets/package/azure/crossplane.yaml
 
 kubectl crossplane build configuration
 ```
@@ -709,7 +709,7 @@ you may specify a specific package by using the `-f` flag.
 ```console
 # Set this to the Docker Hub username or OCI registry you wish to use.
 REG=my-package-repo
-kubectl crossplane push configuration ${REG}/getting-started-with-azure:master
+kubectl crossplane push configuration ${REG}/getting-started-with-azure:v1.8.0
 ```
 
 > Note that the Crossplane CLI will not follow symbolic links for files in the

--- a/docs/getting-started/install-configure.md
+++ b/docs/getting-started/install-configure.md
@@ -8,21 +8,21 @@ indent: true
 # Choosing Your Crossplane Distribution
 
 Users looking to use Crossplane for the first time have two options available to
-them today. The first way is to use the version of Crossplane which is 
+them today. The first way is to use the version of Crossplane which is
 maintained and released by the community and found on the [Crossplane GitHub].
 
-The second option is to use a vendor supported Crossplane distribution. These 
-distributions are [certified by the CNCF] to be conformant with Crossplane, but 
-may include additional features or tooling around it that makes it easier to use 
+The second option is to use a vendor supported Crossplane distribution. These
+distributions are [certified by the CNCF] to be conformant with Crossplane, but
+may include additional features or tooling around it that makes it easier to use
 in production environments.
 
-<ul class="nav nav-tabs"> 
+<ul class="nav nav-tabs">
 <li class="active"><a href="#using-upstream-crossplane" data-toggle="tab">Crossplane (upstream)</a></li>
 <li><a href="#using-a-downstream-distro" data-toggle="tab">Downstream Distributions</a></li>
 </ul>
 <br>
 <!-- Begin Distro Tabs -->
-<div class="tab-content"> 
+<div class="tab-content">
 <!-- Begin Upstream Tab -->
 <div class="tab-pane fade in active" id="using-upstream-crossplane" markdown="1">
 
@@ -243,7 +243,7 @@ provider that can satisfy a `PostgreSQLInstance`. Let's get started!
 > section.
 
 ```console
-kubectl crossplane install configuration registry.upbound.io/xp/getting-started-with-aws:latest
+kubectl crossplane install configuration registry.upbound.io/xp/getting-started-with-aws:v1.8.0
 ```
 
 Wait until all packages become healthy:
@@ -284,7 +284,7 @@ spec:
       key: creds
 ```
 ```console
-kubectl apply -f https://raw.githubusercontent.com/crossplane/crossplane/master/docs/snippets/configure/aws/providerconfig.yaml
+kubectl apply -f https://raw.githubusercontent.com/crossplane/crossplane/release-1.8/docs/snippets/configure/aws/providerconfig.yaml
 ```
 
 </div>
@@ -300,7 +300,7 @@ kubectl apply -f https://raw.githubusercontent.com/crossplane/crossplane/master/
 > section.
 
 ```console
-kubectl crossplane install configuration registry.upbound.io/xp/getting-started-with-aws-with-vpc:latest
+kubectl crossplane install configuration registry.upbound.io/xp/getting-started-with-aws-with-vpc:v1.8.0
 ```
 
 Wait until all packages become healthy:
@@ -341,7 +341,7 @@ spec:
       key: creds
 ```
 ```console
-kubectl apply -f https://raw.githubusercontent.com/crossplane/crossplane/master/docs/snippets/configure/aws/providerconfig.yaml
+kubectl apply -f https://raw.githubusercontent.com/crossplane/crossplane/release-1.8/docs/snippets/configure/aws/providerconfig.yaml
 ```
 
 </div>
@@ -357,7 +357,7 @@ kubectl apply -f https://raw.githubusercontent.com/crossplane/crossplane/master/
 > section.
 
 ```console
-kubectl crossplane install configuration registry.upbound.io/xp/getting-started-with-gcp:latest
+kubectl crossplane install configuration registry.upbound.io/xp/getting-started-with-gcp:v1.8.0
 ```
 
 Wait until all packages become healthy:
@@ -430,7 +430,7 @@ spec:
 > section.
 
 ```console
-kubectl crossplane install configuration registry.upbound.io/xp/getting-started-with-azure:latest
+kubectl crossplane install configuration registry.upbound.io/xp/getting-started-with-azure:v1.8.0
 ```
 
 Wait until all packages become healthy:
@@ -471,7 +471,7 @@ spec:
 ```
 
 ```console
-kubectl apply -f https://raw.githubusercontent.com/crossplane/crossplane/master/docs/snippets/configure/azure/providerconfig.yaml
+kubectl apply -f https://raw.githubusercontent.com/crossplane/crossplane/release-1.8/docs/snippets/configure/azure/providerconfig.yaml
 ```
 
 </div>
@@ -494,8 +494,8 @@ you can [provision infrastructure].
 ## Start with a Downstream Distribution
 
 Upbound, the founders of Crossplane, maintains a free and open source downstream
-distribution of Crossplane which makes getting started with Crossplane easy. 
-Universal Crossplane, or UXP for short, connects to Upbound's hosted management 
+distribution of Crossplane which makes getting started with Crossplane easy.
+Universal Crossplane, or UXP for short, connects to Upbound's hosted management
 console and Registry to make it easier to develop, debug, and manage Provider
 and Configuration packages.
 

--- a/docs/getting-started/provision-infrastructure.md
+++ b/docs/getting-started/provision-infrastructure.md
@@ -66,7 +66,7 @@ spec:
 ```
 
 ```console
-kubectl apply -f https://raw.githubusercontent.com/crossplane/crossplane/master/docs/snippets/compose/claim-aws.yaml
+kubectl apply -f https://raw.githubusercontent.com/crossplane/crossplane/release-1.8/docs/snippets/compose/claim-aws.yaml
 ```
 
 </div>
@@ -95,7 +95,7 @@ spec:
 ```
 
 ```console
-kubectl apply -f https://raw.githubusercontent.com/crossplane/crossplane/master/docs/snippets/compose/claim-aws.yaml
+kubectl apply -f https://raw.githubusercontent.com/crossplane/crossplane/release-1.8/docs/snippets/compose/claim-aws.yaml
 ```
 
 </div>
@@ -118,7 +118,7 @@ spec:
 ```
 
 ```console
-kubectl apply -f https://raw.githubusercontent.com/crossplane/crossplane/master/docs/snippets/compose/claim-gcp.yaml
+kubectl apply -f https://raw.githubusercontent.com/crossplane/crossplane/release-1.8/docs/snippets/compose/claim-gcp.yaml
 ```
 
 </div>
@@ -141,7 +141,7 @@ spec:
 ```
 
 ```console
-kubectl apply -f https://raw.githubusercontent.com/crossplane/crossplane/master/docs/snippets/compose/claim-azure.yaml
+kubectl apply -f https://raw.githubusercontent.com/crossplane/crossplane/release-1.8/docs/snippets/compose/claim-azure.yaml
 ```
 
 </div>
@@ -240,7 +240,7 @@ spec:
 ```
 
 ```console
-kubectl apply -f https://raw.githubusercontent.com/crossplane/crossplane/master/docs/snippets/compose/pod.yaml
+kubectl apply -f https://raw.githubusercontent.com/crossplane/crossplane/release-1.8/docs/snippets/compose/pod.yaml
 ```
 
 This `Pod` simply connects to a PostgreSQL database and prints its name, so you


### PR DESCRIPTION
### Description of your changes

Pin snippet links and configurations to v1.8.0 for the release as per #3088.  Previous example from v1.7 in #3004 was used as a model for these changes.

A few trailing whitespace changes were automatically included by my editor/tooling.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

The changes have been spot checked in VS code preview mode

[contribution process]: https://git.io/fj2m9
