### PR TITLE
Deactivate docs for release-1.5 branch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,8 @@
 PROJECT_NAME := crossplane
 PROJECT_REPO := github.com/crossplane/$(PROJECT_NAME)
 
+DOCS_VERSION_ACTIVE = false
+
 PLATFORMS ?= linux_amd64 linux_arm64 linux_arm linux_ppc64le darwin_amd64 darwin_arm64 windows_amd64
 # -include will silently skip missing files, which allows us
 # to load those files with a target in the Makefile. If only


### PR DESCRIPTION
### Description of your changes

This PR deactivates (removes) the docs for the v1.5 branch, as part of the v1.8 release.  Tracking issue #3088.

Previous example in #3003 

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

This change has not explicitly been tested.

[contribution process]: https://git.io/fj2m9
