### PR TITLE
Remove propagation of annotations to CRDS from CompositeResourceDefinitions

### DIFF
--- a/internal/xcrd/crd.go
+++ b/internal/xcrd/crd.go
@@ -62,7 +62,6 @@ func ForCompositeResource(xrd *v1.CompositeResourceDefinition) (*extv1.CustomRes
 
 	crd.SetName(xrd.GetName())
 	crd.SetLabels(xrd.GetLabels())
-	crd.SetAnnotations(xrd.GetAnnotations())
 	crd.SetOwnerReferences([]metav1.OwnerReference{meta.AsController(
 		meta.TypedReferenceTo(xrd, v1.CompositeResourceDefinitionGroupVersionKind),
 	)})
@@ -135,7 +134,6 @@ func ForCompositeResourceClaim(xrd *v1.CompositeResourceDefinition) (*extv1.Cust
 
 	crd.SetName(xrd.Spec.ClaimNames.Plural + "." + xrd.Spec.Group)
 	crd.SetLabels(xrd.GetLabels())
-	crd.SetAnnotations(xrd.GetAnnotations())
 	crd.SetOwnerReferences([]metav1.OwnerReference{meta.AsController(
 		meta.TypedReferenceTo(xrd, v1.CompositeResourceDefinitionGroupVersionKind),
 	)})

--- a/internal/xcrd/crd_test.go
+++ b/internal/xcrd/crd_test.go
@@ -145,9 +145,8 @@ func TestForCompositeResource(t *testing.T) {
 
 	want := &extv1.CustomResourceDefinition{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        name,
-			Labels:      labels,
-			Annotations: annotations,
+			Name:   name,
+			Labels: labels,
 			OwnerReferences: []metav1.OwnerReference{
 				meta.AsController(meta.TypedReferenceTo(d, v1.CompositeResourceDefinitionGroupVersionKind)),
 			},
@@ -558,9 +557,8 @@ func TestForCompositeResourceClaim(t *testing.T) {
 
 	want := &extv1.CustomResourceDefinition{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        claimPlural + "." + group,
-			Labels:      labels,
-			Annotations: annotations,
+			Name:   claimPlural + "." + group,
+			Labels: labels,
 			OwnerReferences: []metav1.OwnerReference{
 				meta.AsController(meta.TypedReferenceTo(d, v1.CompositeResourceDefinitionGroupVersionKind)),
 			},


### PR DESCRIPTION
### Description of your changes

Stops annotations being propagated from CompositeResourceDefinition to the two CRD's.
Fixes #3123

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

Deployed Crossplane to local KinD cluster. Applied the CompositeResourceDefinition below, checked that the CRD's haven't copied the annotations from the CompositeResourceDefinition. Did the same on master, where the annotations are being propagated as expected.

```yaml
apiVersion: apiextensions.crossplane.io/v1
kind: CompositeResourceDefinition
metadata:
  name: xtests.shopify.com
  labels:
    app: copied
  annotations:
    copied-as-well: "this is also copied over"
spec:
  group: shopify.com
  names:
    kind: XTest
    plural: xtests
  claimNames:
    kind: TestInstance
    plural: testinstances
  versions:
  - name: v1
    served: true
    referenceable: true
    schema:
      openAPIV3Schema:
        type: object
        properties:
          spec:
```

```sh
kubectl get crd xtests.shopify.com -oyaml 
kubectl get crd testinstances.shopify.com -oyaml
```