### PR TITLE
docs: fix broken named links on concepts/managed-resources.

### DIFF
--- a/docs/concepts/managed-resources.md
+++ b/docs/concepts/managed-resources.md
@@ -459,12 +459,10 @@ including Velero.
 
 [term-xrm]: terminology.md#crossplane-resource-model
 [composition]: composition.md
-[api-versioning]:
-    https://kubernetes.io/docs/reference/using-api/api-overview/#api-versioning
+[api-versioning]: https://kubernetes.io/docs/reference/using-api/api-overview/#api-versioning
 [velero]: https://velero.io/
 [api-reference]: ../api-docs/overview.md
 [provider]: providers.md
 [issue-727]: https://github.com/crossplane/crossplane/issues/727
 [issue-1143]: https://github.com/crossplane/crossplane/issues/1143
-[managed-api-patterns]:
-    https://github.com/crossplane/crossplane/blob/master/design/one-pager-managed-resource-api-design.md
+[managed-api-patterns]: https://github.com/crossplane/crossplane/blob/master/design/one-pager-managed-resource-api-design.md


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes
The newline breaks the named link. 

Fixes #3133 

I have:

- [X] Read and followed Crossplane's [contribution process].
- [X] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

Fixed it on my fork of [crossplane.github.io](https://renescheepers.github.io/crossplane.github.io/docs/master/concepts/managed-resources.html) in this [branch](https://github.com/crossplane/crossplane.github.io/compare/master...renescheepers:renescheepers/fix_docs_links). Didn't find any other pages that its broken on.

[contribution process]: https://git.io/fj2m9
