### PR TITLE
docs: added --scopes flag to the Get Azure Principal Keyfile command

### DIFF
--- a/docs/getting-started/install-configure.md
+++ b/docs/getting-started/install-configure.md
@@ -442,7 +442,9 @@ watch kubectl get pkg
 
 ```console
 # create service principal with Owner role
-az ad sp create-for-rbac --sdk-auth --role Owner > "creds.json"
+az ad sp create-for-rbac --name [servicePrincipalName] \
+                         --role Owner \
+                         --scopes /subscriptions/[subcriptionId]/resourceGroups/[resourceGroupName] > "creds.json"
 ```
 
 ### Create a Provider Secret


### PR DESCRIPTION
### Description of your changes
 Updated the Install and configure guide to add `--scopes` flag to the Get Azure Principal Keyfile command. 

Signed-off-by: parul5sahoo <parulsahoo5jan@gmail.com>

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

