### PR TITLE
feat(transform): Allow mapping to any JSON value

### DIFF
--- a/apis/apiextensions/v1/composition_patches_test.go
+++ b/apis/apiextensions/v1/composition_patches_test.go
@@ -17,11 +17,13 @@ limitations under the License.
 package v1
 
 import (
+	"encoding/json"
 	"testing"
 	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/pkg/errors"
+	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/pointer"
 
@@ -923,6 +925,18 @@ func TestOptionalFieldPathNotFound(t *testing.T) {
 }
 
 func TestComposedTemplates(t *testing.T) {
+	asJSON := func(val interface{}) extv1.JSON {
+		raw, err := json.Marshal(val)
+		if err != nil {
+			t.Fatal(err)
+		}
+		res := extv1.JSON{}
+		if err := json.Unmarshal(raw, &res); err != nil {
+			t.Fatal(err)
+		}
+		return res
+	}
+
 	type args struct {
 		cs CompositionSpec
 	}
@@ -1025,9 +1039,9 @@ func TestComposedTemplates(t *testing.T) {
 									Transforms: []Transform{{
 										Type: TransformTypeMap,
 										Map: &MapTransform{
-											Pairs: map[string]string{
-												"k-1": "v-1",
-												"k-2": "v-2",
+											Pairs: map[string]extv1.JSON{
+												"k-1": asJSON("v-1"),
+												"k-2": asJSON("v-2"),
 											},
 										},
 									}},
@@ -1078,9 +1092,9 @@ func TestComposedTemplates(t *testing.T) {
 								Transforms: []Transform{{
 									Type: TransformTypeMap,
 									Map: &MapTransform{
-										Pairs: map[string]string{
-											"k-1": "v-1",
-											"k-2": "v-2",
+										Pairs: map[string]extv1.JSON{
+											"k-1": asJSON("v-1"),
+											"k-2": asJSON("v-2"),
 										},
 									},
 								}},

--- a/apis/apiextensions/v1/zz_generated.deepcopy.go
+++ b/apis/apiextensions/v1/zz_generated.deepcopy.go
@@ -467,9 +467,9 @@ func (in *MapTransform) DeepCopyInto(out *MapTransform) {
 	*out = *in
 	if in.Pairs != nil {
 		in, out := &in.Pairs, &out.Pairs
-		*out = make(map[string]string, len(*in))
+		*out = make(map[string]apiextensionsv1.JSON, len(*in))
 		for key, val := range *in {
-			(*out)[key] = val
+			(*out)[key] = *val.DeepCopy()
 		}
 	}
 }

--- a/apis/apiextensions/v1alpha1/revision_types.go
+++ b/apis/apiextensions/v1alpha1/revision_types.go
@@ -21,6 +21,7 @@ import (
 	"reflect"
 
 	"github.com/pkg/errors"
+	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -381,7 +382,7 @@ type MapTransform struct {
 	// Pairs is the map that will be used for transform.
 	// +optional
 	// +immutable
-	Pairs map[string]string `json:",inline"`
+	Pairs map[string]extv1.JSON `json:",inline"`
 }
 
 // NOTE(negz): The Kubernetes JSON decoder doesn't seem to like inlining a map

--- a/apis/apiextensions/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/apiextensions/v1alpha1/zz_generated.deepcopy.go
@@ -22,6 +22,7 @@ limitations under the License.
 package v1alpha1
 
 import (
+	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -280,9 +281,9 @@ func (in *MapTransform) DeepCopyInto(out *MapTransform) {
 	*out = *in
 	if in.Pairs != nil {
 		in, out := &in.Pairs, &out.Pairs
-		*out = make(map[string]string, len(*in))
+		*out = make(map[string]v1.JSON, len(*in))
 		for key, val := range *in {
-			(*out)[key] = val
+			(*out)[key] = *val.DeepCopy()
 		}
 	}
 }

--- a/cluster/crds/apiextensions.crossplane.io_compositionrevisions.yaml
+++ b/cluster/crds/apiextensions.crossplane.io_compositionrevisions.yaml
@@ -187,7 +187,7 @@ spec:
                                   type: object
                                 map:
                                   additionalProperties:
-                                    type: string
+                                    x-kubernetes-preserve-unknown-fields: true
                                   description: Map uses the input as a key in the
                                     given map and returns the value.
                                   type: object
@@ -481,7 +481,7 @@ spec:
                                   type: object
                                 map:
                                   additionalProperties:
-                                    type: string
+                                    x-kubernetes-preserve-unknown-fields: true
                                   description: Map uses the input as a key in the
                                     given map and returns the value.
                                   type: object

--- a/cluster/crds/apiextensions.crossplane.io_compositions.yaml
+++ b/cluster/crds/apiextensions.crossplane.io_compositions.yaml
@@ -192,7 +192,7 @@ spec:
                                   type: object
                                 map:
                                   additionalProperties:
-                                    type: string
+                                    x-kubernetes-preserve-unknown-fields: true
                                   description: Map uses the input as a key in the
                                     given map and returns the value.
                                   type: object
@@ -499,7 +499,7 @@ spec:
                                   type: object
                                 map:
                                   additionalProperties:
-                                    type: string
+                                    x-kubernetes-preserve-unknown-fields: true
                                   description: Map uses the input as a key in the
                                     given map and returns the value.
                                   type: object

--- a/internal/controller/apiextensions/composite/revision_test.go
+++ b/internal/controller/apiextensions/composite/revision_test.go
@@ -17,9 +17,11 @@ limitations under the License.
 package composite
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/utils/pointer"
 
@@ -28,6 +30,18 @@ import (
 )
 
 func TestAsComposition(t *testing.T) {
+	asJSON := func(val interface{}) extv1.JSON {
+		raw, err := json.Marshal(val)
+		if err != nil {
+			t.Fatal(err)
+		}
+		res := extv1.JSON{}
+		if err := json.Unmarshal(raw, &res); err != nil {
+			t.Fatal(err)
+		}
+		return res
+	}
+
 	sf := "f"
 	rev := &v1alpha1.CompositionRevision{
 		Spec: v1alpha1.CompositionRevisionSpec{
@@ -57,7 +71,7 @@ func TestAsComposition(t *testing.T) {
 							Multiply: pointer.Int64(42),
 						},
 						Map: &v1alpha1.MapTransform{
-							Pairs: map[string]string{"k": "v"},
+							Pairs: map[string]extv1.JSON{"k": asJSON("v")},
 						},
 						String: &v1alpha1.StringTransform{
 							Type:   v1alpha1.StringTransformTypeFormat,
@@ -102,7 +116,7 @@ func TestAsComposition(t *testing.T) {
 						{
 							Type: v1alpha1.TransformTypeMap,
 							Map: &v1alpha1.MapTransform{
-								Pairs: map[string]string{"k": "v"},
+								Pairs: map[string]extv1.JSON{"k": asJSON("v")},
 							},
 						},
 						{
@@ -201,7 +215,7 @@ func TestAsComposition(t *testing.T) {
 							Multiply: pointer.Int64(42),
 						},
 						Map: &v1.MapTransform{
-							Pairs: map[string]string{"k": "v"},
+							Pairs: map[string]extv1.JSON{"k": asJSON("v")},
 						},
 						String: &v1.StringTransform{
 							Type:   v1.StringTransformTypeFormat,
@@ -246,7 +260,7 @@ func TestAsComposition(t *testing.T) {
 						{
 							Type: v1.TransformTypeMap,
 							Map: &v1.MapTransform{
-								Pairs: map[string]string{"k": "v"},
+								Pairs: map[string]extv1.JSON{"k": asJSON("v")},
 							},
 						},
 						{

--- a/internal/controller/apiextensions/composition/revision_test.go
+++ b/internal/controller/apiextensions/composition/revision_test.go
@@ -17,9 +17,11 @@ limitations under the License.
 package composition
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/utils/pointer"
@@ -31,6 +33,18 @@ import (
 )
 
 func TestNewCompositionRevision(t *testing.T) {
+	asJSON := func(val interface{}) extv1.JSON {
+		raw, err := json.Marshal(val)
+		if err != nil {
+			t.Fatal(err)
+		}
+		res := extv1.JSON{}
+		if err := json.Unmarshal(raw, &res); err != nil {
+			t.Fatal(err)
+		}
+		return res
+	}
+
 	comp := &v1.Composition{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "coolcomp",
@@ -62,7 +76,7 @@ func TestNewCompositionRevision(t *testing.T) {
 							Multiply: pointer.Int64(42),
 						},
 						Map: &v1.MapTransform{
-							Pairs: map[string]string{"k": "v"},
+							Pairs: map[string]extv1.JSON{"k": asJSON("v")},
 						},
 						String: &v1.StringTransform{
 							Format: pointer.String("fmt"),
@@ -106,7 +120,7 @@ func TestNewCompositionRevision(t *testing.T) {
 						{
 							Type: v1.TransformTypeMap,
 							Map: &v1.MapTransform{
-								Pairs: map[string]string{"k": "v"},
+								Pairs: map[string]extv1.JSON{"k": asJSON("v")},
 							},
 						},
 						{
@@ -225,7 +239,7 @@ func TestNewCompositionRevision(t *testing.T) {
 							Multiply: pointer.Int64(42),
 						},
 						Map: &v1alpha1.MapTransform{
-							Pairs: map[string]string{"k": "v"},
+							Pairs: map[string]extv1.JSON{"k": asJSON("v")},
 						},
 						String: &v1alpha1.StringTransform{
 							Format: pointer.String("fmt"),
@@ -269,7 +283,7 @@ func TestNewCompositionRevision(t *testing.T) {
 						{
 							Type: v1alpha1.TransformTypeMap,
 							Map: &v1alpha1.MapTransform{
-								Pairs: map[string]string{"k": "v"},
+								Pairs: map[string]extv1.JSON{"k": asJSON("v")},
 							},
 						},
 						{


### PR DESCRIPTION
### Description of your changes

This modifies the implementation for map transforms to allow mapping to any kind of JSON value (string, number, bool, slice, object).

The API changes are fully backward compatible since a single string does also count as valid JSON.

Fixes #3150 

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

Unit tests

[contribution process]: https://git.io/fj2m9
