### PR TITLE
remove default value to fix duplicate secrets

### DIFF
--- a/cluster/crds/apiextensions.crossplane.io_compositionrevisions.yaml
+++ b/cluster/crds/apiextensions.crossplane.io_compositionrevisions.yaml
@@ -284,8 +284,6 @@ spec:
                   type: object
                 type: array
               publishConnectionDetailsWithStoreConfigRef:
-                default:
-                  name: default
                 description: PublishConnectionDetailsWithStoreConfig specifies the
                   secret store config with which the connection secrets of composite
                   resource dynamically provisioned using this composition will be

--- a/cluster/crds/apiextensions.crossplane.io_compositions.yaml
+++ b/cluster/crds/apiextensions.crossplane.io_compositions.yaml
@@ -289,8 +289,6 @@ spec:
                   type: object
                 type: array
               publishConnectionDetailsWithStoreConfigRef:
-                default:
-                  name: default
                 description: PublishConnectionDetailsWithStoreConfig specifies the
                   secret store config with which the connection secrets of composite
                   resource dynamically provisioned using this composition will be


### PR DESCRIPTION
### Description of your changes

Fixes #3172 

All info in issue description, in this PR removed default CRD field.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

By changing generated CRD inside EKS cluster and reprovision resources(examples in issue).

[contribution process]: https://git.io/fj2m9
