### PR TITLE
Add secret delete permission to Core Crossplane

### DIFF
--- a/cluster/charts/crossplane/templates/clusterrole.yaml
+++ b/cluster/charts/crossplane/templates/clusterrole.yaml
@@ -46,6 +46,7 @@ rules:
   - create
   - update
   - patch
+  - delete
 - apiGroups:
   - ""
   resources:


### PR DESCRIPTION
### Description of your changes

With ESS, we can no longer rely on K8s garbage collection to clean
up Composite secrets hence need explicit delete permissions.

Fixes #3195

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

See #3195

[contribution process]: https://git.io/fj2m9
