### PR TITLE
[release-1.7] Remove Upbound Registry login from CI and Promotion workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,6 @@ env:
   # a step 'if env.AWS_USR' != ""', so we copy these to succinctly test whether
   # credentials have been provided before trying to run steps that need them.
   DOCKER_USR: ${{ secrets.DOCKER_USR }}
-  UPBOUND_CROSSPLANE_ROBOT_USR: ${{ secrets.UPBOUND_CROSSPLANE_ROBOT_USR }}
   AWS_USR: ${{ secrets.AWS_USR }}
 
 jobs:
@@ -304,18 +303,10 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_USR }}
           password: ${{ secrets.DOCKER_PSW }}
-      
-      - name: Login to Upbound Registry
-        uses: docker/login-action@v1
-        if: env.UPBOUND_CROSSPLANE_ROBOT_USR != ''
-        with:
-          registry: registry.upbound.io
-          username: ${{ secrets.UPBOUND_CROSSPLANE_ROBOT_USR }}
-          password: ${{ secrets.UPBOUND_CROSSPLANE_ROBOT_PSW }}
 
-      - name: Publish Artifacts to S3, DockerHub, and Upbound Registry
+      - name: Publish Artifacts to S3, DockerHub
         run: make -j2 publish BRANCH_NAME=${GITHUB_REF##*/}
-        if: env.AWS_USR != '' && env.DOCKER_USR != '' && env.UPBOUND_CROSSPLANE_ROBOT_USR != ''
+        if: env.AWS_USR != '' && env.DOCKER_USR != ''
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_USR }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_PSW }}
@@ -324,8 +315,8 @@ jobs:
           DOCS_GIT_USR: ${{ secrets.UPBOUND_BOT_GITHUB_USR }}
           DOCS_GIT_PSW: ${{ secrets.UPBOUND_BOT_GITHUB_PSW }}
 
-      - name: Promote Artifacts in S3, DockerHub, and Upbound Registry
-        if: github.ref == 'refs/heads/master' && env.AWS_USR != '' && env.DOCKER_USR != '' && env.UPBOUND_CROSSPLANE_ROBOT_USR != ''
+      - name: Promote Artifacts in S3, DockerHub
+        if: github.ref == 'refs/heads/master' && env.AWS_USR != '' && env.DOCKER_USR != ''
         run: make -j2 promote
         env:
           BRANCH_NAME: master

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -16,7 +16,6 @@ env:
   # a step 'if env.AWS_USR' != ""', so we copy these to succinctly test whether
   # credentials have been provided before trying to run steps that need them.
   DOCKER_USR: ${{ secrets.DOCKER_USR }}
-  UPBOUND_CROSSPLANE_ROBOT_USR: ${{ secrets.UPBOUND_CROSSPLANE_ROBOT_USR }}
   AWS_USR: ${{ secrets.AWS_USR }}
 
 jobs:
@@ -38,17 +37,9 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_USR }}
           password: ${{ secrets.DOCKER_PSW }}
-        
-      - name: Login to Upbound Registry
-        uses: docker/login-action@v1
-        if: env.UPBOUND_CROSSPLANE_ROBOT_USR != ''
-        with:
-          registry: registry.upbound.io
-          username: ${{ secrets.UPBOUND_CROSSPLANE_ROBOT_USR }}
-          password: ${{ secrets.UPBOUND_CROSSPLANE_ROBOT_PSW }}
 
       - name: Promote Artifacts in S3, DockerHub, and Upbound Registry
-        if: env.AWS_USR != '' && env.DOCKER_USR != '' && env.UPBOUND_CROSSPLANE_ROBOT_USR != ''
+        if: env.AWS_USR != '' && env.DOCKER_USR != ''
         run: make -j2 promote BRANCH_NAME=${GITHUB_REF##*/}
         env:
           VERSION: ${{ github.event.inputs.version }}


### PR DESCRIPTION


<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Drops the Upbound Registry login from the CI and Promotion workflows as
actual publishing of the Crossplane image to the Upbound Registry has
been removed, making this step extraneous.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>
(cherry picked from commit 319d7c0f7c240a4655b2c3901cd37783c819d1a6)

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

Manual backport of https://github.com/crossplane/crossplane/pull/3215

[contribution process]: https://git.io/fj2m9
