### PR TITLE
Allow the stale action ~50% of our hourly operation budget every other hour

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,8 +1,8 @@
 name: Stale Issues and PRs
 on:
   schedule:
-  # Run once every hour.
-  - cron: '0 */1 * * *'
+  # Run once every other hour.
+  - cron: '0 */2 * * *'
   workflow_dispatch: {}
 
 permissions:

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,7 +1,7 @@
 name: Stale Issues and PRs
 on:
   schedule:
-  # Run once an hour.
+  # Run once every hour.
   - cron: '0 */1 * * *'
   workflow_dispatch: {}
 
@@ -15,6 +15,18 @@ jobs:
     steps:
     - uses: actions/stale@v5
       with:
+        # TODO(negz): Lower this once we have fewer stale issues.
+        #
+        # This will use half of our hourly rate-limit budget per
+        # https://docs.github.com/en/rest/overview/resources-in-the-rest-api#requests-from-github-actions.
+        #
+        # We currently have ~150 stale issues because we just enabled the action
+        # and many old issues were marked stale at once. The action uses ~2
+        # operations per stale issue per run to determine whether it's still
+        # stale. It also uses 2-3 operations to mark an issue stale or not.
+        # Once we've burned through our initial backlog of stale issues it will
+        # most likely be safe to lower this to ~100 or even fewer operations.
+        operations-per-run: 500
         days-before-stale: 90
         days-before-close: 7
         stale-issue-label: stale


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
This will use half of our hourly rate-limit budget per https://docs.github.com/en/rest/overview/resources-in-the-rest-api#requests-from-github-actions.

We currently have ~150 stale issues because we just enabled the action and many old issues were marked stale at once. The action uses ~2 operations per stale issue per run to determine whether it's still stale. It also uses 2-3 operations to mark an issue stale or not. Once we've burned through our initial backlog of stale issues it will most likely be safe to lower this to ~100 or even fewer operations.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9

I believe we need to merge this to test.