### PR TITLE
Fix typo in registry self-signed certs guide

### DIFF
--- a/docs/guides/self-signed-ca-certs.md
+++ b/docs/guides/self-signed-ca-certs.md
@@ -17,7 +17,7 @@ Crossplane needs to be installed via the Helm chart with the
 `registryCaBundleConfig.name` and `registryCaBundleConfig.key` parameters 
 defined. See [Install Crossplane].
 
-## Conifgure
+## Configure
 
 1. Create a CA Bundle (A file containing your Root and Intermediate 
 certificates in a specific order). This can be done with any text editor or 


### PR DESCRIPTION

<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes a typo of Configure in the registry self-signed certs guide.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>


I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

n/a -- docs

[contribution process]: https://git.io/fj2m9
