### PR TITLE
Use rooted paths in CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -33,25 +33,25 @@ ROADMAP.md                          @crossplane/steering-committee
 LICENSE                             @crossplane/steering-committee
 
 # Design documents
-design/                             @crossplane/crossplane-maintainers @negz
+/design/                             @crossplane/crossplane-maintainers @negz
 
 # Package manager
-apis/pkg/                           @crossplane/crossplane-reviewers @hasheddan
-internal/xpkg/                      @crossplane/crossplane-reviewers @hasheddan
-internal/dag/                       @crossplane/crossplane-reviewers @hasheddan
-internal/controller/pkg/            @crossplane/crossplane-reviewers @hasheddan
+/apis/pkg/                           @crossplane/crossplane-reviewers @hasheddan
+/internal/xpkg/                      @crossplane/crossplane-reviewers @hasheddan
+/internal/dag/                       @crossplane/crossplane-reviewers @hasheddan
+/internal/controller/pkg/            @crossplane/crossplane-reviewers @hasheddan
 
 # Composition
-apis/apiextensions/                 @crossplane/crossplane-reviewers @muvaf
-internal/xcrd/                      @crossplane/crossplane-reviewers @muvaf
-internal/controller/apiextensions/  @crossplane/crossplane-reviewers @muvaf
+/apis/apiextensions/                 @crossplane/crossplane-reviewers @muvaf
+/internal/xcrd/                      @crossplane/crossplane-reviewers @muvaf
+/internal/controller/apiextensions/  @crossplane/crossplane-reviewers @muvaf
 
 # RBAC
-cmd/crossplane/rbac/                @crossplane/crossplane-reviewers @negz
-internal/controller/rbac/           @crossplane/crossplane-reviewers @negz
+/cmd/crossplane/rbac/                @crossplane/crossplane-reviewers @negz
+/internal/controller/rbac/           @crossplane/crossplane-reviewers @negz
 
 # Misc
-apis/secrets/                       @crossplane/crossplane-reviewers @turkenh
-cmd/crank/                          @crossplane/crossplane-reviewers @hasheddan
-internal/initializer/               @crossplane/crossplane-reviewers @muvaf
-internal/features/                  @crossplane/crossplane-reviewers @negz
+/apis/secrets/                       @crossplane/crossplane-reviewers @turkenh
+/cmd/crank/                          @crossplane/crossplane-reviewers @hasheddan
+/internal/initializer/               @crossplane/crossplane-reviewers @muvaf
+/internal/features/                  @crossplane/crossplane-reviewers @negz

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -5,9 +5,9 @@
 #
 # The goal of this file is for most PRs to automatically and fairly have one
 # maintainer and two reviewers set as PR reviewers. All maintainers have
-# permission to approve and merge PRs, but reviewers do not. Most PRs should by
-# members of the reviewers group before being passed to a maintainer for final
-# review.
+# permission to approve and merge PRs, but reviewers do not. Most PRs should be
+# reviewed by members of the reviewers group before being passed to a maintainer
+# for final review.
 #
 # This in part depends on how the groups in this file are configured.
 #


### PR DESCRIPTION


<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Uses rooted paths in CODEOWNERS such that the paths are exact.
Not specifying the root means that an arbitrarily nested directory that
matched part of its path to one of the paths in the CODEOWNERS file
would receive the same review requests. This makes the exact paths explicit.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

This is based on my interpretation of https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners.

Fixes wording in CODEOWNERS regarding how the review process should
typically work.
    
Signed-off-by: hasheddan <georgedanielmangum@gmail.com>


I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

n/a -- I don't think this is going to have functional changes initially, but it protects us from accidentally specifying CODEOWNERs implicitly in the future.

[contribution process]: https://git.io/fj2m9
