### PR TITLE
:bug: add new composition for new AWS VPC

### DIFF
--- a/docs/getting-started/provision-infrastructure.md
+++ b/docs/getting-started/provision-infrastructure.md
@@ -95,7 +95,7 @@ spec:
 ```
 
 ```console
-kubectl apply -f https://raw.githubusercontent.com/crossplane/crossplane/master/docs/snippets/compose/claim-aws.yaml
+kubectl apply -f https://raw.githubusercontent.com/crossplane/crossplane/master/docs/snippets/compose/claim-aws-new.yaml
 ```
 
 </div>

--- a/docs/snippets/compose/claim-aws-new.yaml
+++ b/docs/snippets/compose/claim-aws-new.yaml
@@ -1,0 +1,14 @@
+apiVersion: database.example.org/v1alpha1
+kind: PostgreSQLInstance
+metadata:
+  name: my-db
+  namespace: default
+spec:
+  parameters:
+    storageGB: 20
+  compositionSelector:
+    matchLabels:
+      provider: aws
+      vpc: new
+  writeConnectionSecretToRef:
+    name: db-conn


### PR DESCRIPTION
### Description of your changes

We can't use `claim-aws.yaml` to create RDS with new VPC because we need `vpc: new`.

I add new file and fix doc.
I was able to change the procedure to edit the file.
However, I wanted to just apply the file like the other example, so I created a new file.


I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

I applied my kind cluster on my PC and work it.