### PR TITLE
Ensure the stale workflow uses fewer operations

### DIFF
--- a/.github/workflows/commands.yml
+++ b/.github/workflows/commands.yml
@@ -90,3 +90,37 @@ jobs:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         github_workspace: ${{ github.workspace }}
         version: v0.0.4
+
+  fresh:
+    runs-on: ubuntu-20.04
+    if: startsWith(github.event.comment.body, '/fresh')
+
+    steps:
+    - name: Extract Command
+      id: command
+      uses: xt0rted/slash-command-action@v1
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        command: fresh
+        reaction: "true"
+        reaction-type: "eyes"
+        allow-edits: "false"
+        permission-level: write
+    - name: Handle Command
+      uses: actions/github-script@v4
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        script: |
+          // Delete the stale label.
+          try {
+            await github.issues.deleteLabel({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              name: ['stale']
+            })
+            console.log("Deleted 'stale' label.")
+          }
+          catch(e) {
+            console.log("Failed to delete label 'stale' - does it exist?")
+          }

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,8 +1,10 @@
 name: Stale Issues and PRs
 on:
   schedule:
-  # Run once every other hour.
-  - cron: '0 */2 * * *'
+  # Process new stale issues once a day. Folks can /fresh for a fast un-stale
+  # per the commands workflow. Run at 1:15 mostly as a somewhat unique time to
+  # help correlate any issues with this workflow.
+  - cron: '15 1 * * *'
   workflow_dispatch: {}
 
 permissions:
@@ -15,18 +17,16 @@ jobs:
     steps:
     - uses: actions/stale@v5
       with:
-        # TODO(negz): Lower this once we have fewer stale issues.
+        # This action uses ~2 operations per stale issue per run to determine
+        # whether it's still stale. It also uses 2-3 operations to mark an issue
+        # stale or not. During steady state (no issues to mark stale, check, or
+        # close) we seem to use less than 10 operations with ~150 issues and PRs
+        # open.
         #
-        # This will use half of our hourly rate-limit budget per
-        # https://docs.github.com/en/rest/overview/resources-in-the-rest-api#requests-from-github-actions.
-        #
-        # We currently have ~150 stale issues because we just enabled the action
-        # and many old issues were marked stale at once. The action uses ~2
-        # operations per stale issue per run to determine whether it's still
-        # stale. It also uses 2-3 operations to mark an issue stale or not.
-        # Once we've burned through our initial backlog of stale issues it will
-        # most likely be safe to lower this to ~100 or even fewer operations.
-        operations-per-run: 500
+        # Our hourly rate-limit budget for all workflows that use GITHUB_TOKEN
+        # is 1,000 requests per the below docs.
+        # https://docs.github.com/en/rest/overview/resources-in-the-rest-api#requests-from-github-actions
+        operations-per-run: 100
         days-before-stale: 90
         days-before-close: 7
         stale-issue-label: stale
@@ -35,16 +35,14 @@ jobs:
           Crossplane does not currently have enough maintainers to address every
           issue and pull request. This issue has been automatically marked as
           `stale` because it has had no activity in the last 90 days. It will be
-          closed in 7 days if no further activity occurs. Leaving a comment will
-          remove the `stale` label and prevent the issue from being closed. Note
-          that it may take this bot several hours to react to comments.
+          closed in 7 days if no further activity occurs. Leaving a comment
+          **starting with** `/fresh` will mark this issue as not stale.
         stale-pr-label: stale
         exempt-pr-labels: exempt-from-stale
         stale-pr-message:
           Crossplane does not currently have enough maintainers to address every
           issue and pull request. This pull request has been automatically
           marked as `stale` because it has had no activity in the last 90 days.
-          It will be closed in 7 days if no further activity occurs. Leaving a
-          comment will remove the `stale` label and prevent the issue from being
-          closed. Note that it may take this bot several hours to react to
-          comments.
+          It will be closed in 7 days if no further activity occurs.
+          closed in 7 days if no further activity occurs. Adding a comment
+          **starting with** `/fresh` will mark this PR as not stale.


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
We only get 1,000 operations per hour for every workflow that uses GITHUB_TOKEN. We're now seeing the stale workflow use relatively few operations with few to no stale issues open.

In addition to lowering the workflow's operation limit this change has the workflow run once a day. It adds a new `/fresh` comment command that can be used to instantly mark an issue or PR as not stale, rather than waiting up to a day for the stale workflow to run.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9

This needs to be merged to test it.