### PR TITLE
Ensure AWS credential key in setup script matches provider config

### DIFF
--- a/docs/cloud-providers/aws/aws-provider.md
+++ b/docs/cloud-providers/aws/aws-provider.md
@@ -92,7 +92,7 @@ metadata:
   namespace: crossplane-system
 type: Opaque
 data:
-  credentials: ${BASE64ENCODED_AWS_ACCOUNT_CREDS}
+  creds: ${BASE64ENCODED_AWS_ACCOUNT_CREDS}
 ---
 apiVersion: aws.crossplane.io/v1beta1
 kind: ProviderConfig
@@ -104,7 +104,7 @@ spec:
     secretRef:
       namespace: crossplane-system
       name: aws-account-creds
-      key: credentials
+      key: creds
 EOF
 
 # apply it to the cluster:

--- a/docs/cloud-providers/gcp/gcp-provider.md
+++ b/docs/cloud-providers/gcp/gcp-provider.md
@@ -228,7 +228,7 @@ metadata:
   namespace: ${PROVIDER_SECRET_NAMESPACE}
 type: Opaque
 data:
-  credentials: ${BASE64ENCODED_GCP_PROVIDER_CREDS}
+  creds: ${BASE64ENCODED_GCP_PROVIDER_CREDS}
 ---
 apiVersion: gcp.crossplane.io/v1beta1
 kind: ProviderConfig
@@ -242,7 +242,7 @@ spec:
     secretRef:
       namespace: ${PROVIDER_SECRET_NAMESPACE}
       name: gcp-account-creds
-      key: credentials
+      key: creds
 EOF
 
 # apply it to the cluster:

--- a/docs/concepts/providers.md
+++ b/docs/concepts/providers.md
@@ -90,7 +90,7 @@ spec:
     secretRef:
       namespace: crossplane-system
       name: aws-creds
-      key: key
+      key: creds
 ```
 
 You can see that there is a reference to a key in a specific `Secret`. The value

--- a/docs/guides/multi-tenant.md
+++ b/docs/guides/multi-tenant.md
@@ -67,7 +67,7 @@ spec:
     secretRef:
       namespace: crossplane-system
       name: aws-creds
-      key: key
+      key: creds
 ```
 
 If a user desired for these credentials to be used to provision an
@@ -220,7 +220,7 @@ spec:
     secretRef:
       namespace: crossplane-system
       name: team-1-creds
-      key: key
+      key: creds
 ```
 
 2. Define a `Composition` that patches the namespace of the Claim reference in the XR

--- a/docs/snippets/configure/aws/setup.sh
+++ b/docs/snippets/configure/aws/setup.sh
@@ -45,7 +45,7 @@ fi
 
 echo "apiVersion: v1
 data:
-  key: $AWS_CREDS_BASE64
+  creds: $AWS_CREDS_BASE64
 kind: Secret
 metadata:
   name: aws-creds


### PR DESCRIPTION
The key used in the aws-creds `Secret` has to match the corresponding
settings in `spec:credentials:secretRef:key`, which is `creds` rather
than `key`.

Without this change, users see errors such as the following when
trying to reconcile resources:

```
Warning CannotObserveExternalResource 6s (x4 over 11s)
managed/queue.sqs.aws.crossplane.io cannot get Queue URL: operation
error SQS: GetQueueUrl, failed to sign request: failed to retrieve
credentials: failed to refresh cached credentials, static credentials
are empty
```
Signed-off-by: Wolodja Wentland <w@wentland.dev>

<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #

I have:

- [X] Read and followed Crossplane's [contribution process].
- [X] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

Ran through the [provider-aws configuration instructions](provider-aws) again, created a simple managed resource, and verified that it synchronised successfully.

[contribution process]: https://git.io/fj2m9
[provider-aws]: https://crossplane.io/docs/v1.9/cloud-providers/aws/aws-provider.html