### PR TITLE
Remove `/points` command, fix `/fresh`

### DIFF
--- a/.github/workflows/commands.yml
+++ b/.github/workflows/commands.yml
@@ -3,65 +3,6 @@ name: Comment Commands
 on: issue_comment
 
 jobs:
-  points:
-    runs-on: ubuntu-20.04
-    if: startsWith(github.event.comment.body, '/points')
-
-    steps:
-    - name: Extract Command
-      id: command
-      uses: xt0rted/slash-command-action@v1
-      with:
-        repo-token: ${{ secrets.GITHUB_TOKEN }}
-        command: points
-        reaction: "true"
-        reaction-type: "eyes"
-        allow-edits: "false"
-        permission-level: write
-    - name: Handle Command
-      uses: actions/github-script@v4
-      env:
-        POINTS: ${{ steps.command.outputs.command-arguments }}
-      with:
-        github-token: ${{ secrets.GITHUB_TOKEN }}
-        script: |
-          const points = process.env.POINTS
-
-          if (isNaN(parseInt(points))) {
-            console.log("Malformed command - expected '/points <int>'")
-            github.reactions.createForIssueComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              comment_id: context.payload.comment.id,
-              content: "confused"
-            })
-            return
-          }
-          const label = "points/" + points
-
-          // Delete our needs-points-label label.
-          try {
-            await github.issues.deleteLabel({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              name: ['needs-points-label']
-            })
-            console.log("Deleted 'needs-points-label' label.")
-          }
-          catch(e) {
-            console.log("Label 'needs-points-label' probably didn't exist.")
-          }
-
-          // Add our points label.
-          github.issues.addLabels({
-            issue_number: context.issue.number,
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            labels: [label]
-          })
-          console.log("Added '" + label + "' label.")
-
   # NOTE(negz): See also backport.yml, which is the variant that triggers on PR
   # merge rather than on comment.
   backport:

--- a/.github/workflows/commands.yml
+++ b/.github/workflows/commands.yml
@@ -48,20 +48,7 @@ jobs:
         allow-edits: "false"
         permission-level: read
     - name: Handle Command
-      uses: actions/github-script@v4
+      uses: actions-ecosystem/action-remove-labels@v1
       with:
-        github-token: ${{ secrets.GITHUB_TOKEN }}
-        script: |
-          // Delete the stale label.
-          try {
-            await github.issues.deleteLabel({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              name: ['stale']
-            })
-            console.log("Deleted 'stale' label.")
-          }
-          catch(e) {
-            console.log("Failed to delete label 'stale' - does it exist?")
-          }
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        labels: stale

--- a/.github/workflows/commands.yml
+++ b/.github/workflows/commands.yml
@@ -46,7 +46,7 @@ jobs:
         reaction: "true"
         reaction-type: "eyes"
         allow-edits: "false"
-        permission-level: write
+        permission-level: read
     - name: Handle Command
       uses: actions/github-script@v4
       with:


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
We never really used `/points`, and `/fresh` was broken in that:

* It was only allowing folks with write access to use it.
* It was deleting the `stale` label entirely (i.e. from existence and thus from all issues/PRs).

I have:

- [x] Read and followed Crossplane's [contribution process].
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9

Unfortunately I don't know how to test actions without merging them.