### PR TITLE
Use package revision name to identify self when adding or removing from Lock

### DIFF
--- a/internal/controller/pkg/resolver/reconciler_test.go
+++ b/internal/controller/pkg/resolver/reconciler_test.go
@@ -165,7 +165,7 @@ func TestReconcile(t *testing.T) {
 				rec: []ReconcilerOption{
 					WithNewDagFn(func() dag.DAG {
 						return &fakedag.MockDag{
-							MockInit: func(nodes []dag.Node, fns ...dag.NodeFn) ([]dag.Node, error) {
+							MockInit: func(nodes []dag.Node) ([]dag.Node, error) {
 								return nil, errBoom
 							},
 						}
@@ -201,7 +201,7 @@ func TestReconcile(t *testing.T) {
 				rec: []ReconcilerOption{
 					WithNewDagFn(func() dag.DAG {
 						return &fakedag.MockDag{
-							MockInit: func(nodes []dag.Node, fns ...dag.NodeFn) ([]dag.Node, error) {
+							MockInit: func(nodes []dag.Node) ([]dag.Node, error) {
 								return nil, nil
 							},
 							MockSort: func() ([]string, error) {
@@ -240,7 +240,7 @@ func TestReconcile(t *testing.T) {
 				rec: []ReconcilerOption{
 					WithNewDagFn(func() dag.DAG {
 						return &fakedag.MockDag{
-							MockInit: func(nodes []dag.Node, fns ...dag.NodeFn) ([]dag.Node, error) {
+							MockInit: func(nodes []dag.Node) ([]dag.Node, error) {
 								return nil, nil
 							},
 							MockSort: func() ([]string, error) {
@@ -279,7 +279,7 @@ func TestReconcile(t *testing.T) {
 				rec: []ReconcilerOption{
 					WithNewDagFn(func() dag.DAG {
 						return &fakedag.MockDag{
-							MockInit: func(nodes []dag.Node, fns ...dag.NodeFn) ([]dag.Node, error) {
+							MockInit: func(nodes []dag.Node) ([]dag.Node, error) {
 								return []dag.Node{
 									&v1beta1.Dependency{
 										Package: "not.a.valid.package",
@@ -322,7 +322,7 @@ func TestReconcile(t *testing.T) {
 				rec: []ReconcilerOption{
 					WithNewDagFn(func() dag.DAG {
 						return &fakedag.MockDag{
-							MockInit: func(nodes []dag.Node, fns ...dag.NodeFn) ([]dag.Node, error) {
+							MockInit: func(nodes []dag.Node) ([]dag.Node, error) {
 								return []dag.Node{
 									&v1beta1.Dependency{
 										Package:     "hasheddan/config-nop-b",
@@ -369,7 +369,7 @@ func TestReconcile(t *testing.T) {
 				rec: []ReconcilerOption{
 					WithNewDagFn(func() dag.DAG {
 						return &fakedag.MockDag{
-							MockInit: func(nodes []dag.Node, fns ...dag.NodeFn) ([]dag.Node, error) {
+							MockInit: func(nodes []dag.Node) ([]dag.Node, error) {
 								return []dag.Node{
 									&v1beta1.Dependency{
 										Package:     "hasheddan/config-nop-b",
@@ -417,7 +417,7 @@ func TestReconcile(t *testing.T) {
 				rec: []ReconcilerOption{
 					WithNewDagFn(func() dag.DAG {
 						return &fakedag.MockDag{
-							MockInit: func(nodes []dag.Node, fns ...dag.NodeFn) ([]dag.Node, error) {
+							MockInit: func(nodes []dag.Node) ([]dag.Node, error) {
 								return []dag.Node{
 									&v1beta1.Dependency{
 										Package:     "hasheddan/config-nop-c",
@@ -466,7 +466,7 @@ func TestReconcile(t *testing.T) {
 				rec: []ReconcilerOption{
 					WithNewDagFn(func() dag.DAG {
 						return &fakedag.MockDag{
-							MockInit: func(nodes []dag.Node, fns ...dag.NodeFn) ([]dag.Node, error) {
+							MockInit: func(nodes []dag.Node) ([]dag.Node, error) {
 								return []dag.Node{
 									&v1beta1.Dependency{
 										Package:     "hasheddan/config-nop-c",

--- a/internal/controller/pkg/revision/dependency_test.go
+++ b/internal/controller/pkg/revision/dependency_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/utils/pointer"
@@ -60,50 +61,6 @@ func TestResolve(t *testing.T) {
 		args   args
 		want   want
 	}{
-		"ErrNotMeta": {
-			reason: "Should return error if not a valid package meta type.",
-			args: args{
-				dep:  &PackageDependencyManager{},
-				meta: &v1.Configuration{},
-			},
-			want: want{
-				err: errors.New(errNotMeta),
-			},
-		},
-		"ErrGetLock": {
-			reason: "Should return error if we cannot get lock.",
-			args: args{
-				dep: &PackageDependencyManager{
-					client: &test.MockClient{
-						MockGet: test.NewMockGetFn(errBoom),
-					},
-				},
-				meta: &pkgmetav1.Configuration{},
-			},
-			want: want{
-				err: errors.Wrap(errBoom, errGetOrCreateLock),
-			},
-		},
-		"ErrCreateLock": {
-			reason: "Should return error if we cannot get or create lock.",
-			args: args{
-				dep: &PackageDependencyManager{
-					client: &test.MockClient{
-						MockGet:    test.NewMockGetFn(kerrors.NewNotFound(schema.GroupResource{}, "")),
-						MockCreate: test.NewMockCreateFn(errBoom),
-					},
-				},
-				meta: &pkgmetav1.Configuration{},
-				pr: &v1.ConfigurationRevision{
-					Spec: v1.PackageRevisionSpec{
-						DesiredState: v1.PackageRevisionActive,
-					},
-				},
-			},
-			want: want{
-				err: errors.Wrap(errBoom, errGetOrCreateLock),
-			},
-		},
 		"SuccessfulInactiveNoLock": {
 			reason: "Should not return error if we are inactive and lock does not exist.",
 			args: args{
@@ -121,26 +78,18 @@ func TestResolve(t *testing.T) {
 				},
 			},
 		},
-		"ErrBuildDag": {
-			reason: "Should return error if we cannot build DAG.",
+		"ErrorInactiveGetLock": {
+			reason: "Should return error if we are inactive and we fail to get the lock.",
 			args: args{
 				dep: &PackageDependencyManager{
 					client: &test.MockClient{
-						MockGet:    test.NewMockGetFn(kerrors.NewNotFound(schema.GroupResource{}, "")),
-						MockCreate: test.NewMockCreateFn(nil),
-					},
-					newDag: func() dag.DAG {
-						return &dagfake.MockDag{
-							MockInit: func(_ []dag.Node) ([]dag.Node, error) {
-								return nil, errBoom
-							},
-						}
+						MockGet: test.NewMockGetFn(errBoom),
 					},
 				},
 				meta: &pkgmetav1.Configuration{},
 				pr: &v1.ConfigurationRevision{
 					Spec: v1.PackageRevisionSpec{
-						Package: "hasheddan/config-nop-a:v0.0.1",
+						DesiredState: v1.PackageRevisionInactive,
 					},
 				},
 			},
@@ -153,19 +102,17 @@ func TestResolve(t *testing.T) {
 			args: args{
 				dep: &PackageDependencyManager{
 					client: &test.MockClient{
-						MockGet:    test.NewMockGetFn(kerrors.NewNotFound(schema.GroupResource{}, "")),
+						MockGet: test.NewMockGetFn(nil, func(obj client.Object) error {
+							return nil
+						}),
 						MockCreate: test.NewMockCreateFn(nil),
-					},
-					newDag: func() dag.DAG {
-						return &dagfake.MockDag{
-							MockInit: func(_ []dag.Node) ([]dag.Node, error) {
-								return nil, nil
-							},
-						}
 					},
 				},
 				meta: &pkgmetav1.Configuration{},
 				pr: &v1.ConfigurationRevision{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "config-nop-a-abc123",
+					},
 					Spec: v1.PackageRevisionSpec{
 						Package:      "hasheddan/config-nop-a:v0.0.1",
 						DesiredState: v1.PackageRevisionInactive,
@@ -177,7 +124,7 @@ func TestResolve(t *testing.T) {
 			},
 		},
 		"SuccessfulInactiveExists": {
-			reason: "Should not return error if we are inactive and not in lock.",
+			reason: "Should not return error if we are inactive and successfully remove from lock.",
 			args: args{
 				dep: &PackageDependencyManager{
 					client: &test.MockClient{
@@ -191,13 +138,6 @@ func TestResolve(t *testing.T) {
 							return nil
 						}),
 						MockUpdate: test.NewMockUpdateFn(nil),
-					},
-					newDag: func() dag.DAG {
-						return &dagfake.MockDag{
-							MockInit: func(nodes []dag.Node) ([]dag.Node, error) {
-								return nil, nil
-							},
-						}
 					},
 				},
 				meta: &pkgmetav1.Configuration{},
@@ -228,10 +168,85 @@ func TestResolve(t *testing.T) {
 						}),
 						MockUpdate: test.NewMockUpdateFn(errBoom),
 					},
+				},
+				meta: &pkgmetav1.Configuration{},
+				pr: &v1.ConfigurationRevision{
+					Spec: v1.PackageRevisionSpec{
+						Package:      "hasheddan/config-nop-a:v0.0.1",
+						DesiredState: v1.PackageRevisionInactive,
+					},
+				},
+			},
+			want: want{
+				err: errBoom,
+			},
+		},
+		"ErrNotMeta": {
+			reason: "Should return error if not a valid package meta type.",
+			args: args{
+				dep:  &PackageDependencyManager{},
+				meta: &v1.Configuration{},
+				pr: &v1.ConfigurationRevision{
+					Spec: v1.PackageRevisionSpec{
+						DesiredState: v1.PackageRevisionActive,
+					},
+				},
+			},
+			want: want{
+				err: errors.New(errNotMeta),
+			},
+		},
+		"ErrGetLock": {
+			reason: "Should return error if we cannot get lock.",
+			args: args{
+				dep: &PackageDependencyManager{
+					client: &test.MockClient{
+						MockGet: test.NewMockGetFn(errBoom),
+					},
+				},
+				meta: &pkgmetav1.Configuration{},
+				pr: &v1.ConfigurationRevision{
+					Spec: v1.PackageRevisionSpec{
+						DesiredState: v1.PackageRevisionActive,
+					},
+				},
+			},
+			want: want{
+				err: errors.Wrap(errBoom, errGetOrCreateLock),
+			},
+		},
+		"ErrCreateLock": {
+			reason: "Should return error if we cannot get or create lock.",
+			args: args{
+				dep: &PackageDependencyManager{
+					client: &test.MockClient{
+						MockGet:    test.NewMockGetFn(kerrors.NewNotFound(schema.GroupResource{}, "")),
+						MockCreate: test.NewMockCreateFn(errBoom),
+					},
+				},
+				meta: &pkgmetav1.Configuration{},
+				pr: &v1.ConfigurationRevision{
+					Spec: v1.PackageRevisionSpec{
+						DesiredState: v1.PackageRevisionActive,
+					},
+				},
+			},
+			want: want{
+				err: errors.Wrap(errBoom, errGetOrCreateLock),
+			},
+		},
+		"ErrBuildDag": {
+			reason: "Should return error if we cannot build DAG.",
+			args: args{
+				dep: &PackageDependencyManager{
+					client: &test.MockClient{
+						MockGet:    test.NewMockGetFn(kerrors.NewNotFound(schema.GroupResource{}, "")),
+						MockCreate: test.NewMockCreateFn(nil),
+					},
 					newDag: func() dag.DAG {
 						return &dagfake.MockDag{
-							MockInit: func(nodes []dag.Node) ([]dag.Node, error) {
-								return nil, nil
+							MockInit: func(_ []dag.Node) ([]dag.Node, error) {
+								return nil, errBoom
 							},
 						}
 					},
@@ -239,8 +254,7 @@ func TestResolve(t *testing.T) {
 				meta: &pkgmetav1.Configuration{},
 				pr: &v1.ConfigurationRevision{
 					Spec: v1.PackageRevisionSpec{
-						Package:      "hasheddan/config-nop-a:v0.0.1",
-						DesiredState: v1.PackageRevisionInactive,
+						Package: "hasheddan/config-nop-a:v0.0.1",
 					},
 				},
 			},
@@ -257,6 +271,7 @@ func TestResolve(t *testing.T) {
 							l := obj.(*v1beta1.Lock)
 							l.Packages = []v1beta1.LockPackage{
 								{
+									Name:   "config-nop-a-abc123",
 									Source: "hasheddan/config-nop-a",
 								},
 							}
@@ -276,6 +291,9 @@ func TestResolve(t *testing.T) {
 				},
 				meta: &pkgmetav1.Configuration{},
 				pr: &v1.ConfigurationRevision{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "config-nop-a-abc123",
+					},
 					Spec: v1.PackageRevisionSpec{
 						Package:      "hasheddan/config-nop-a:v0.0.1",
 						DesiredState: v1.PackageRevisionActive,
@@ -290,22 +308,6 @@ func TestResolve(t *testing.T) {
 				dep: &PackageDependencyManager{
 					client: &test.MockClient{
 						MockGet: test.NewMockGetFn(nil, func(obj client.Object) error {
-							l := obj.(*v1beta1.Lock)
-							l.Packages = []v1beta1.LockPackage{
-								{
-									Source: "hasheddan/config-nop-a",
-									Dependencies: []v1beta1.Dependency{
-										{
-											Package: "not-here-1",
-											Type:    v1beta1.ProviderPackageType,
-										},
-										{
-											Package: "not-here-2",
-											Type:    v1beta1.ConfigurationPackageType,
-										},
-									},
-								},
-							}
 							return nil
 						}),
 						MockUpdate: test.NewMockUpdateFn(nil),
@@ -315,11 +317,11 @@ func TestResolve(t *testing.T) {
 							MockInit: func(nodes []dag.Node) ([]dag.Node, error) {
 								return nil, nil
 							},
-							MockAddNode: func(_ dag.Node) error {
-								return nil
-							},
 							MockNodeExists: func(_ string) bool {
 								return false
+							},
+							MockAddNode: func(_ dag.Node) error {
+								return nil
 							},
 							MockAddOrUpdateNodes: func(_ ...dag.Node) {},
 						}
@@ -340,6 +342,9 @@ func TestResolve(t *testing.T) {
 					},
 				},
 				pr: &v1.ConfigurationRevision{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "config-nop-a-abc123",
+					},
 					Spec: v1.PackageRevisionSpec{
 						Package:      "hasheddan/config-nop-a:v0.0.1",
 						DesiredState: v1.PackageRevisionActive,
@@ -360,6 +365,7 @@ func TestResolve(t *testing.T) {
 							l := obj.(*v1beta1.Lock)
 							l.Packages = []v1beta1.LockPackage{
 								{
+									Name:   "config-nop-a-abc123",
 									Source: "hasheddan/config-nop-a",
 									Dependencies: []v1beta1.Dependency{
 										{
@@ -423,6 +429,9 @@ func TestResolve(t *testing.T) {
 					},
 				},
 				pr: &v1.ConfigurationRevision{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "config-nop-a-abc123",
+					},
 					Spec: v1.PackageRevisionSpec{
 						Package:      "hasheddan/config-nop-a:v0.0.1",
 						DesiredState: v1.PackageRevisionActive,
@@ -444,6 +453,7 @@ func TestResolve(t *testing.T) {
 							l := obj.(*v1beta1.Lock)
 							l.Packages = []v1beta1.LockPackage{
 								{
+									Name:   "config-nop-a-abc123",
 									Source: "hasheddan/config-nop-a",
 									Dependencies: []v1beta1.Dependency{
 										{
@@ -517,6 +527,9 @@ func TestResolve(t *testing.T) {
 					},
 				},
 				pr: &v1.ConfigurationRevision{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "config-nop-a-abc123",
+					},
 					Spec: v1.PackageRevisionSpec{
 						Package:      "hasheddan/config-nop-a:v0.0.1",
 						DesiredState: v1.PackageRevisionActive,
@@ -539,6 +552,7 @@ func TestResolve(t *testing.T) {
 							l := obj.(*v1beta1.Lock)
 							l.Packages = []v1beta1.LockPackage{
 								{
+									Name:   "config-nop-a-abc123",
 									Source: "hasheddan/config-nop-a",
 									Dependencies: []v1beta1.Dependency{
 										{
@@ -569,6 +583,9 @@ func TestResolve(t *testing.T) {
 						return &dagfake.MockDag{
 							MockInit: func(nodes []dag.Node) ([]dag.Node, error) {
 								return nil, nil
+							},
+							MockNodeExists: func(identifier string) bool {
+								return true
 							},
 							MockTraceNode: func(_ string) (map[string]dag.Node, error) {
 								return map[string]dag.Node{
@@ -612,6 +629,9 @@ func TestResolve(t *testing.T) {
 					},
 				},
 				pr: &v1.ConfigurationRevision{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "config-nop-a-abc123",
+					},
 					Spec: v1.PackageRevisionSpec{
 						Package:      "hasheddan/config-nop-a:v0.0.1",
 						DesiredState: v1.PackageRevisionActive,

--- a/internal/controller/pkg/revision/dependency_test.go
+++ b/internal/controller/pkg/revision/dependency_test.go
@@ -131,7 +131,7 @@ func TestResolve(t *testing.T) {
 					},
 					newDag: func() dag.DAG {
 						return &dagfake.MockDag{
-							MockInit: func(_ []dag.Node, _ ...dag.NodeFn) ([]dag.Node, error) {
+							MockInit: func(_ []dag.Node) ([]dag.Node, error) {
 								return nil, errBoom
 							},
 						}
@@ -158,7 +158,7 @@ func TestResolve(t *testing.T) {
 					},
 					newDag: func() dag.DAG {
 						return &dagfake.MockDag{
-							MockInit: func(_ []dag.Node, _ ...dag.NodeFn) ([]dag.Node, error) {
+							MockInit: func(_ []dag.Node) ([]dag.Node, error) {
 								return nil, nil
 							},
 						}
@@ -194,12 +194,7 @@ func TestResolve(t *testing.T) {
 					},
 					newDag: func() dag.DAG {
 						return &dagfake.MockDag{
-							MockInit: func(nodes []dag.Node, fns ...dag.NodeFn) ([]dag.Node, error) {
-								for i, n := range nodes {
-									for _, f := range fns {
-										f(i, n)
-									}
-								}
+							MockInit: func(nodes []dag.Node) ([]dag.Node, error) {
 								return nil, nil
 							},
 						}
@@ -235,12 +230,7 @@ func TestResolve(t *testing.T) {
 					},
 					newDag: func() dag.DAG {
 						return &dagfake.MockDag{
-							MockInit: func(nodes []dag.Node, fns ...dag.NodeFn) ([]dag.Node, error) {
-								for i, n := range nodes {
-									for _, f := range fns {
-										f(i, n)
-									}
-								}
+							MockInit: func(nodes []dag.Node) ([]dag.Node, error) {
 								return nil, nil
 							},
 						}
@@ -275,12 +265,7 @@ func TestResolve(t *testing.T) {
 					},
 					newDag: func() dag.DAG {
 						return &dagfake.MockDag{
-							MockInit: func(nodes []dag.Node, fns ...dag.NodeFn) ([]dag.Node, error) {
-								for i, n := range nodes {
-									for _, f := range fns {
-										f(i, n)
-									}
-								}
+							MockInit: func(nodes []dag.Node) ([]dag.Node, error) {
 								return nil, nil
 							},
 							MockTraceNode: func(_ string) (map[string]dag.Node, error) {
@@ -327,7 +312,7 @@ func TestResolve(t *testing.T) {
 					},
 					newDag: func() dag.DAG {
 						return &dagfake.MockDag{
-							MockInit: func(nodes []dag.Node, fns ...dag.NodeFn) ([]dag.Node, error) {
+							MockInit: func(nodes []dag.Node) ([]dag.Node, error) {
 								return nil, nil
 							},
 							MockAddNode: func(_ dag.Node) error {
@@ -403,12 +388,7 @@ func TestResolve(t *testing.T) {
 					},
 					newDag: func() dag.DAG {
 						return &dagfake.MockDag{
-							MockInit: func(nodes []dag.Node, fns ...dag.NodeFn) ([]dag.Node, error) {
-								for i, n := range nodes {
-									for _, f := range fns {
-										f(i, n)
-									}
-								}
+							MockInit: func(nodes []dag.Node) ([]dag.Node, error) {
 								return []dag.Node{
 									&v1beta1.Dependency{
 										Package: "not-here-2",
@@ -492,12 +472,7 @@ func TestResolve(t *testing.T) {
 					},
 					newDag: func() dag.DAG {
 						return &dagfake.MockDag{
-							MockInit: func(nodes []dag.Node, fns ...dag.NodeFn) ([]dag.Node, error) {
-								for i, n := range nodes {
-									for _, f := range fns {
-										f(i, n)
-									}
-								}
+							MockInit: func(nodes []dag.Node) ([]dag.Node, error) {
 								return nil, nil
 							},
 							MockTraceNode: func(_ string) (map[string]dag.Node, error) {
@@ -592,12 +567,7 @@ func TestResolve(t *testing.T) {
 					},
 					newDag: func() dag.DAG {
 						return &dagfake.MockDag{
-							MockInit: func(nodes []dag.Node, fns ...dag.NodeFn) ([]dag.Node, error) {
-								for i, n := range nodes {
-									for _, f := range fns {
-										f(i, n)
-									}
-								}
+							MockInit: func(nodes []dag.Node) ([]dag.Node, error) {
 								return nil, nil
 							},
 							MockTraceNode: func(_ string) (map[string]dag.Node, error) {

--- a/internal/dag/dag.go
+++ b/internal/dag/dag.go
@@ -33,7 +33,7 @@ type Node interface {
 
 // DAG is a Directed Acyclic Graph.
 type DAG interface {
-	Init(nodes []Node, fns ...NodeFn) ([]Node, error)
+	Init(nodes []Node) ([]Node, error)
 	AddNode(Node) error
 	AddNodes(...Node) error
 	AddOrUpdateNodes(...Node)
@@ -52,20 +52,6 @@ type MapDag struct {
 	nodes map[string]Node
 }
 
-// NodeFn performs executes a function on each node.
-type NodeFn func(int, Node)
-
-// FindIndex searches for the index of a specific node. The passed index
-// parameter will be updated to the index of the node if found, or left
-// unchanged if not.
-func FindIndex(identifier string, index *int) NodeFn {
-	return func(i int, n Node) {
-		if n.Identifier() == identifier {
-			*index = i
-		}
-	}
-}
-
 // NewDAGFn is a function that returns a DAG.
 type NewDAGFn func() DAG
 
@@ -76,15 +62,12 @@ func NewMapDag() DAG {
 
 // Init initializes a MapDag and implies missing destination nodes. Any implied
 // nodes are returned. Any existing nodes are cleared.
-func (d *MapDag) Init(nodes []Node, fns ...NodeFn) ([]Node, error) {
+func (d *MapDag) Init(nodes []Node) ([]Node, error) {
 	d.nodes = map[string]Node{}
 	// Add all nodes before adding edges so we know what nodes were implied.
-	for i, node := range nodes {
+	for _, node := range nodes {
 		if err := d.AddNode(node); err != nil {
 			return nil, err
-		}
-		for _, f := range fns {
-			f(i, node)
 		}
 	}
 	var implied []Node // nolint:prealloc

--- a/internal/dag/dag_test.go
+++ b/internal/dag/dag_test.go
@@ -66,7 +66,6 @@ func toNodes(n []simpleNode) []Node {
 
 var _ DAG = &MapDag{}
 var _ NewDAGFn = NewMapDag
-var t int = 1
 
 func sortedFnNop([]simpleNode, []string) error {
 	return nil

--- a/internal/dag/dag_test.go
+++ b/internal/dag/dag_test.go
@@ -67,7 +67,6 @@ func toNodes(n []simpleNode) []Node {
 var _ DAG = &MapDag{}
 var _ NewDAGFn = NewMapDag
 var t int = 1
-var _ NodeFn = FindIndex("", &t)
 
 func sortedFnNop([]simpleNode, []string) error {
 	return nil

--- a/internal/dag/fake/mocks.go
+++ b/internal/dag/fake/mocks.go
@@ -24,7 +24,7 @@ var _ dag.DAG = &MockDag{}
 
 // MockDag is a mock DAG.
 type MockDag struct {
-	MockInit             func(nodes []dag.Node, fns ...dag.NodeFn) ([]dag.Node, error)
+	MockInit             func(nodes []dag.Node) ([]dag.Node, error)
 	MockAddNode          func(dag.Node) error
 	MockAddNodes         func(...dag.Node) error
 	MockAddOrUpdateNodes func(...dag.Node)
@@ -38,8 +38,8 @@ type MockDag struct {
 }
 
 // Init calls the underlying MockInit.
-func (d *MockDag) Init(nodes []dag.Node, fns ...dag.NodeFn) ([]dag.Node, error) {
-	return d.MockInit(nodes, fns...)
+func (d *MockDag) Init(nodes []dag.Node) ([]dag.Node, error) {
+	return d.MockInit(nodes)
 }
 
 // AddNode calls the underlying MockAddNode.


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Passing NodeFns proved to not be a very ergonomic API to work with and
most places where FindIndex was used could be replaced by either working
with the Nodes directly or calling NodeExists. The index of a Node
should not be the responsibility of the DAG, which provides an interface
into a graph.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

Updates the package revision dependency manager to use the package
revision name to identify self in the Lock. This prevents the case of
one package revision attempting to remove itself from the Lock while
another is adding with the same source. Source is still used as an
identifier in the DAG as it dictates whether we determine a dependency
is present or not.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

Fixes #3295 

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

Unit test coverage expanded, e2e tests below.

Installed `provider-aws`, then updated it to a new version:
```
🤖 (crossplane) k get pkgrev
NAME                                                                      HEALTHY   REVISION   IMAGE                             STATE      DEP-FOUND   DEP-INSTALLED   AGE
providerrevision.pkg.crossplane.io/crossplane-provider-aws-55f4b7e3267e   True      1          crossplane/provider-aws:v0.30.0   Inactive                               5m10s
providerrevision.pkg.crossplane.io/crossplane-provider-aws-edfa6e79bd65   True      2          crossplane/provider-aws:v0.31.0   Active                                 3m16s
```

Verified that before the lock showed the old version, it temporarily showed both (updated functionality), and then it only showed the new one.

Deleted package, then install `upbound/platform-ref-multi-k8s`:
```
🤖 (crossplane) k get pkg
NAME                                                  INSTALLED   HEALTHY   PACKAGE                                                                 AGE
provider.pkg.crossplane.io/crossplane-provider-aws    True        True      registry.upbound.io/crossplane/provider-aws:v0.32.0-rc.0.28.gafa73905   3m8s
provider.pkg.crossplane.io/crossplane-provider-gcp    True        True      registry.upbound.io/crossplane/provider-gcp:v0.22.0-rc.44.gd24f532      2m33s
provider.pkg.crossplane.io/crossplane-provider-helm   True        True      registry.upbound.io/crossplane/provider-helm:v0.10.0                    2m16s

NAME                                                             INSTALLED   HEALTHY   PACKAGE                                                 AGE
configuration.pkg.crossplane.io/upbound-platform-ref-multi-k8s   True        True      xpkg.upbound.io/upbound/platform-ref-multi-k8s:v0.0.9   3m11s
```

Verified lock had all items:
```
🤖 (crossplane) k get lock -o yaml
apiVersion: v1
items:
- apiVersion: pkg.crossplane.io/v1beta1
  kind: Lock
  metadata:
    creationTimestamp: "2022-09-12T23:11:17Z"
    finalizers:
    - lock.pkg.crossplane.io
    generation: 8
    name: lock
    resourceVersion: "5676"
    uid: 161dcc3d-b2b9-48e4-8d34-aa96a525e2a2
  packages:
  - dependencies:
    - constraints: '>=v0.22.0-0'
      package: registry.upbound.io/crossplane/provider-aws
      type: Provider
    - constraints: '>=v0.18.0-0'
      package: registry.upbound.io/crossplane/provider-gcp
      type: Provider
    - constraints: '>=v0.9.0-0'
      package: registry.upbound.io/crossplane/provider-helm
      type: Provider
    name: upbound-platform-ref-multi-k8s-0988bd9df728
    source: xpkg.upbound.io/upbound/platform-ref-multi-k8s
    type: Configuration
    version: v0.0.9
  - dependencies: []
    name: crossplane-provider-aws-e3b67495e0a0
    source: registry.upbound.io/crossplane/provider-aws
    type: Provider
    version: v0.32.0-rc.0.28.gafa73905
  - dependencies: []
    name: crossplane-provider-gcp-d91daa28a4d7
    source: registry.upbound.io/crossplane/provider-gcp
    type: Provider
    version: v0.22.0-rc.44.gd24f532
kind: List
metadata:
  resourceVersion: ""
  selfLink: ""
```

Pinned `provider-aws` to `v0.24.1`, then verified both revisions were in the Lock:
```
🤖 (crossplane) k get lock -o yaml
apiVersion: v1
items:
- apiVersion: pkg.crossplane.io/v1beta1
  kind: Lock
  metadata:
    creationTimestamp: "2022-09-12T23:11:17Z"
    finalizers:
    - lock.pkg.crossplane.io
    generation: 10
    name: lock
    resourceVersion: "10898"
    uid: 161dcc3d-b2b9-48e4-8d34-aa96a525e2a2
  packages:
  - dependencies:
    - constraints: '>=v0.22.0-0'
      package: registry.upbound.io/crossplane/provider-aws
      type: Provider
    - constraints: '>=v0.18.0-0'
      package: registry.upbound.io/crossplane/provider-gcp
      type: Provider
    - constraints: '>=v0.9.0-0'
      package: registry.upbound.io/crossplane/provider-helm
      type: Provider
    name: upbound-platform-ref-multi-k8s-0988bd9df728
    source: xpkg.upbound.io/upbound/platform-ref-multi-k8s
    type: Configuration
    version: v0.0.9
  - dependencies: []
    name: crossplane-provider-aws-e3b67495e0a0
    source: registry.upbound.io/crossplane/provider-aws
    type: Provider
    version: v0.32.0-rc.0.28.gafa73905
  - dependencies: []
    name: crossplane-provider-gcp-d91daa28a4d7
    source: registry.upbound.io/crossplane/provider-gcp
    type: Provider
    version: v0.22.0-rc.44.gd24f532
  - dependencies: []
    name: crossplane-provider-helm-b9e90b3c7ff8
    source: registry.upbound.io/crossplane/provider-helm
    type: Provider
    version: v0.10.0
  - dependencies: []
    name: crossplane-provider-aws-33860d71579a
    source: registry.upbound.io/crossplane/provider-aws
    type: Provider
    version: v0.24.1
kind: List
metadata:
  resourceVersion: ""
  selfLink: ""
```

Verified old revision eventually removed self:
```
🤖 (crossplane) k get lock -o yaml
apiVersion: v1
items:
- apiVersion: pkg.crossplane.io/v1beta1
  kind: Lock
  metadata:
    creationTimestamp: "2022-09-12T23:11:17Z"
    finalizers:
    - lock.pkg.crossplane.io
    generation: 11
    name: lock
    resourceVersion: "11102"
    uid: 161dcc3d-b2b9-48e4-8d34-aa96a525e2a2
  packages:
  - dependencies:
    - constraints: '>=v0.22.0-0'
      package: registry.upbound.io/crossplane/provider-aws
      type: Provider
    - constraints: '>=v0.18.0-0'
      package: registry.upbound.io/crossplane/provider-gcp
      type: Provider
    - constraints: '>=v0.9.0-0'
      package: registry.upbound.io/crossplane/provider-helm
      type: Provider
    name: upbound-platform-ref-multi-k8s-0988bd9df728
    source: xpkg.upbound.io/upbound/platform-ref-multi-k8s
    type: Configuration
    version: v0.0.9
  - dependencies: []
    name: crossplane-provider-gcp-d91daa28a4d7
    source: registry.upbound.io/crossplane/provider-gcp
    type: Provider
    version: v0.22.0-rc.44.gd24f532
  - dependencies: []
    name: crossplane-provider-helm-b9e90b3c7ff8
    source: registry.upbound.io/crossplane/provider-helm
    type: Provider
    version: v0.10.0
  - dependencies: []
    name: crossplane-provider-aws-33860d71579a
    source: registry.upbound.io/crossplane/provider-aws
    type: Provider
    version: v0.24.1
kind: List
metadata:
  resourceVersion: ""
  selfLink: ""
```

Verified new revision became healthy:
```
🤖 (crossplane) k get pkgrev
NAME                                                                                  HEALTHY   REVISION   IMAGE                                                   STATE    DEP-FOUND   DEP-INSTALLED   AGE
configurationrevision.pkg.crossplane.io/upbound-platform-ref-multi-k8s-0988bd9df728   True      1          xpkg.upbound.io/upbound/platform-ref-multi-k8s:v0.0.9   Active   3           3               18m

NAME                                                                       HEALTHY   REVISION   IMAGE                                                                   STATE      DEP-FOUND   DEP-INSTALLED   AGE
providerrevision.pkg.crossplane.io/crossplane-provider-aws-33860d71579a    True      2          registry.upbound.io/crossplane/provider-aws:v0.24.1                     Active                                 3m48s
providerrevision.pkg.crossplane.io/crossplane-provider-aws-e3b67495e0a0    True      1          registry.upbound.io/crossplane/provider-aws:v0.32.0-rc.0.28.gafa73905   Inactive                               18m
providerrevision.pkg.crossplane.io/crossplane-provider-gcp-d91daa28a4d7    True      1          registry.upbound.io/crossplane/provider-gcp:v0.22.0-rc.44.gd24f532      Active                                 18m
providerrevision.pkg.crossplane.io/crossplane-provider-helm-b9e90b3c7ff8   True      1          registry.upbound.io/crossplane/provider-helm:v0.10.0                    Active                                 17m
```

[contribution process]: https://git.io/fj2m9
