### PR TITLE
Update install-configure.md to update Azure Principal Keyfile generate commands

### DIFF
--- a/docs/getting-started/install-configure.md
+++ b/docs/getting-started/install-configure.md
@@ -442,7 +442,7 @@ watch kubectl get pkg
 
 ```console
 # create service principal with Owner role
-az ad sp create-for-rbac --role Contributor --scopes /subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx > "creds.json"
+az ad sp create-for-rbac --role Contributor --scopes --sdk-auth /subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx > "creds.json"
 ```
 
 ### Create a Provider Secret


### PR DESCRIPTION
The command to create the Azure Principal Keyfile has been updated.  Without including --sdk-auth,  the resulting creds.json file does not include ClientId and the required URL's.

Additional Details can be found [here](https://github.com/crossplane-contrib/provider-azure/issues/351). 

<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes crossplane/crossplane#500":

-->
Fixes #

I have:

- [x] Read and followed Crossplane's [contribution process].
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested
I have used the updated command to create and verify the creds.json file and then used it to deploy resources in Azure sing Crossplane.
<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
