### PR TITLE
Fetch package pull secrets from Crossplane SA and propagate to Provider Deployments

### DIFF
--- a/cluster/charts/crossplane/templates/deployment.yaml
+++ b/cluster/charts/crossplane/templates/deployment.yaml
@@ -65,6 +65,10 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
+          - name: POD_SERVICE_ACCOUNT
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.serviceAccountName
           {{- if .Values.webhooks.enabled }}
           - name: "WEBHOOK_TLS_SECRET_NAME"
             value: webhook-tls-secret

--- a/cmd/crossplane/core/core.go
+++ b/cmd/crossplane/core/core.go
@@ -61,6 +61,7 @@ func (c *Command) Run() error {
 
 type startCommand struct {
 	Namespace            string `short:"n" help:"Namespace used to unpack and run packages." default:"crossplane-system" env:"POD_NAMESPACE"`
+	ServiceAccount       string `help:"Name of the Crossplane Service Account." default:"crossplane" env:"POD_SERVICE_ACCOUNT"`
 	CacheDir             string `short:"c" help:"Directory used for caching package images." default:"/cache" env:"CACHE_DIR"`
 	LeaderElection       bool   `short:"l" help:"Use leader election for the controller manager." default:"false" env:"LEADER_ELECTION"`
 	Registry             string `short:"r" help:"Default registry used to fetch packages when not specified in tag." default:"${default_registry}" env:"REGISTRY"`
@@ -130,6 +131,7 @@ func (c *startCommand) Run(s *runtime.Scheme, log logging.Logger) error { //noli
 		Options:              o,
 		Cache:                xpkg.NewFsPackageCache(c.CacheDir, afero.NewOsFs()),
 		Namespace:            c.Namespace,
+		ServiceAccount:       c.ServiceAccount,
 		DefaultRegistry:      c.Registry,
 		Features:             feats,
 		WebhookTLSSecretName: c.WebhookTLSSecretName,

--- a/internal/controller/pkg/controller/options.go
+++ b/internal/controller/pkg/controller/options.go
@@ -34,6 +34,9 @@ type Options struct {
 	// Namespace used to unpack and run packages.
 	Namespace string
 
+	// ServiceAccount is the core Crossplane ServiceAccount name.
+	ServiceAccount string
+
 	// DefaultRegistry used to pull packages.
 	DefaultRegistry string
 

--- a/internal/controller/pkg/manager/reconciler.go
+++ b/internal/controller/pkg/manager/reconciler.go
@@ -156,7 +156,7 @@ func SetupProvider(mgr ctrl.Manager, o controller.Options) error {
 	if err != nil {
 		return errors.Wrap(err, errCreateK8sClient)
 	}
-	f, err := xpkg.NewK8sFetcher(cs, o.Namespace, o.FetcherOptions...)
+	f, err := xpkg.NewK8sFetcher(cs, append(o.FetcherOptions, xpkg.WithNamespace(o.Namespace), xpkg.WithServiceAccount(o.ServiceAccount))...)
 	if err != nil {
 		return errors.Wrap(err, errBuildFetcher)
 	}
@@ -191,7 +191,7 @@ func SetupConfiguration(mgr ctrl.Manager, o controller.Options) error {
 	if err != nil {
 		return errors.Wrap(err, "failed to initialize clientset")
 	}
-	fetcher, err := xpkg.NewK8sFetcher(clientset, o.Namespace, o.FetcherOptions...)
+	fetcher, err := xpkg.NewK8sFetcher(clientset, append(o.FetcherOptions, xpkg.WithNamespace(o.Namespace), xpkg.WithServiceAccount(o.ServiceAccount))...)
 	if err != nil {
 		return errors.Wrap(err, "cannot build fetcher")
 	}

--- a/internal/controller/pkg/resolver/reconciler.go
+++ b/internal/controller/pkg/resolver/reconciler.go
@@ -115,7 +115,7 @@ func Setup(mgr ctrl.Manager, o controller.Options) error {
 	if err != nil {
 		return errors.Wrap(err, "failed to initialize clientset")
 	}
-	f, err := xpkg.NewK8sFetcher(cs, o.Namespace, o.FetcherOptions...)
+	f, err := xpkg.NewK8sFetcher(cs, append(o.FetcherOptions, xpkg.WithNamespace(o.Namespace), xpkg.WithServiceAccount(o.ServiceAccount))...)
 	if err != nil {
 		return errors.Wrap(err, "cannot build fetcher")
 	}

--- a/internal/controller/pkg/revision/deployment.go
+++ b/internal/controller/pkg/revision/deployment.go
@@ -51,13 +51,14 @@ const (
 	webhookPort             = 9443
 )
 
-func buildProviderDeployment(provider *pkgmetav1.Provider, revision v1.PackageRevision, cc *v1alpha1.ControllerConfig, namespace string) (*corev1.ServiceAccount, *appsv1.Deployment, *corev1.Service) { // nolint:gocyclo
+func buildProviderDeployment(provider *pkgmetav1.Provider, revision v1.PackageRevision, cc *v1alpha1.ControllerConfig, namespace string, pullSecrets []corev1.LocalObjectReference) (*corev1.ServiceAccount, *appsv1.Deployment, *corev1.Service) { // nolint:gocyclo
 	s := &corev1.ServiceAccount{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            revision.GetName(),
 			Namespace:       namespace,
 			OwnerReferences: []metav1.OwnerReference{meta.AsController(meta.TypedReferenceTo(revision, v1.ProviderRevisionGroupVersionKind))},
 		},
+		ImagePullSecrets: pullSecrets,
 	}
 	pullPolicy := corev1.PullIfNotPresent
 	if revision.GetPackagePullPolicy() != nil {

--- a/internal/controller/pkg/revision/deployment_test.go
+++ b/internal/controller/pkg/revision/deployment_test.go
@@ -334,7 +334,7 @@ func TestBuildProviderDeployment(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			sa, d, svc := buildProviderDeployment(tc.fields.provider, tc.fields.revision, tc.fields.cc, namespace)
+			sa, d, svc := buildProviderDeployment(tc.fields.provider, tc.fields.revision, tc.fields.cc, namespace, nil)
 
 			if diff := cmp.Diff(tc.want.sa, sa, cmpopts.IgnoreTypes([]metav1.OwnerReference{})); diff != "" {
 				t.Errorf("-want, +got:\n%s\n", diff)

--- a/internal/controller/pkg/revision/reconciler.go
+++ b/internal/controller/pkg/revision/reconciler.go
@@ -226,7 +226,7 @@ func SetupProviderRevision(mgr ctrl.Manager, o controller.Options) error {
 	if err != nil {
 		return errors.New("cannot build object scheme for package parser")
 	}
-	fetcher, err := xpkg.NewK8sFetcher(clientset, o.Namespace, o.FetcherOptions...)
+	fetcher, err := xpkg.NewK8sFetcher(clientset, append(o.FetcherOptions, xpkg.WithNamespace(o.Namespace), xpkg.WithServiceAccount(o.ServiceAccount))...)
 	if err != nil {
 		return errors.Wrap(err, "cannot build fetcher for package parser")
 	}
@@ -237,7 +237,7 @@ func SetupProviderRevision(mgr ctrl.Manager, o controller.Options) error {
 		WithHooks(NewProviderHooks(resource.ClientApplicator{
 			Client:     mgr.GetClient(),
 			Applicator: resource.NewAPIPatchingApplicator(mgr.GetClient()),
-		}, o.Namespace)),
+		}, o.Namespace, o.ServiceAccount)),
 		WithEstablisher(NewAPIEstablisher(mgr.GetClient(), o.Namespace)),
 		WithNewPackageRevisionFn(nr),
 		WithParser(parser.New(metaScheme, objScheme)),
@@ -276,7 +276,7 @@ func SetupConfigurationRevision(mgr ctrl.Manager, o controller.Options) error {
 	if err != nil {
 		return errors.New("cannot build object scheme for package parser")
 	}
-	f, err := xpkg.NewK8sFetcher(cs, o.Namespace, o.FetcherOptions...)
+	f, err := xpkg.NewK8sFetcher(cs, append(o.FetcherOptions, xpkg.WithNamespace(o.Namespace), xpkg.WithServiceAccount(o.ServiceAccount))...)
 	if err != nil {
 		return errors.Wrap(err, "cannot build fetcher for package parser")
 	}

--- a/internal/xpkg/fetch.go
+++ b/internal/xpkg/fetch.go
@@ -54,9 +54,10 @@ type Fetcher interface {
 
 // K8sFetcher uses kubernetes credentials to fetch package images.
 type K8sFetcher struct {
-	client    kubernetes.Interface
-	namespace string
-	transport http.RoundTripper
+	client         kubernetes.Interface
+	namespace      string
+	serviceAccount string
+	transport      http.RoundTripper
 }
 
 // FetcherOpt can be used to add optional parameters to NewK8sFetcher
@@ -98,11 +99,28 @@ func WithCustomCA(rootCAs *x509.CertPool) FetcherOpt {
 	}
 }
 
+// WithNamespace is a FetcherOpt that sets the Namespace for fetching package
+// pull secrets.
+func WithNamespace(ns string) FetcherOpt {
+	return func(k *K8sFetcher) error {
+		k.namespace = ns
+		return nil
+	}
+}
+
+// WithServiceAccount is a FetcherOpt that sets the ServiceAccount name for
+// fetching package pull secrets.
+func WithServiceAccount(sa string) FetcherOpt {
+	return func(k *K8sFetcher) error {
+		k.serviceAccount = sa
+		return nil
+	}
+}
+
 // NewK8sFetcher creates a new K8sFetcher.
-func NewK8sFetcher(client kubernetes.Interface, namespace string, opts ...FetcherOpt) (*K8sFetcher, error) {
+func NewK8sFetcher(client kubernetes.Interface, opts ...FetcherOpt) (*K8sFetcher, error) {
 	k := &K8sFetcher{
 		client:    client,
-		namespace: namespace,
 		transport: remote.DefaultTransport.Clone(),
 	}
 
@@ -118,8 +136,9 @@ func NewK8sFetcher(client kubernetes.Interface, namespace string, opts ...Fetche
 // Fetch fetches a package image.
 func (i *K8sFetcher) Fetch(ctx context.Context, ref name.Reference, secrets ...string) (v1.Image, error) {
 	auth, err := k8schain.New(ctx, i.client, k8schain.Options{
-		Namespace:        i.namespace,
-		ImagePullSecrets: secrets,
+		Namespace:          i.namespace,
+		ServiceAccountName: i.serviceAccount,
+		ImagePullSecrets:   secrets,
 	})
 	if err != nil {
 		return nil, err
@@ -130,8 +149,9 @@ func (i *K8sFetcher) Fetch(ctx context.Context, ref name.Reference, secrets ...s
 // Head fetches a package descriptor.
 func (i *K8sFetcher) Head(ctx context.Context, ref name.Reference, secrets ...string) (*v1.Descriptor, error) {
 	auth, err := k8schain.New(ctx, i.client, k8schain.Options{
-		Namespace:        i.namespace,
-		ImagePullSecrets: secrets,
+		Namespace:          i.namespace,
+		ServiceAccountName: i.serviceAccount,
+		ImagePullSecrets:   secrets,
 	})
 	if err != nil {
 		return nil, err
@@ -150,8 +170,9 @@ func (i *K8sFetcher) Head(ctx context.Context, ref name.Reference, secrets ...st
 // Tags fetches a package's tags.
 func (i *K8sFetcher) Tags(ctx context.Context, ref name.Reference, secrets ...string) ([]string, error) {
 	auth, err := k8schain.New(ctx, i.client, k8schain.Options{
-		Namespace:        i.namespace,
-		ImagePullSecrets: secrets,
+		Namespace:          i.namespace,
+		ServiceAccountName: i.serviceAccount,
+		ImagePullSecrets:   secrets,
 	})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

This changeset updates to consume package pull secrets from the Crossplane `ServiceAccount`, rather than the previous behavior of falling back to the `default` `ServiceAccount`. It also propagates secrets from the `ServiceAccount` to the `ServiceAccount` of any Provider `Deployment`. This enables installing chains of private dependencies by attaching all required package pull secrets to the Crossplane `ServiceAccount`.

Lastly, any package pull secrets on a `ProviderRevision` are propagated to their `Deployment` as well, but they are not propagated to dependencies. We may opt to do this in the future, but there is some subtleties around shared dependents that make it more complex to do so. Because propagating the package pull secrets from the `ServiceAccount` makes it possible to install chains of private dependencies, we defer propagating revision secrets to dependencies until a future date.

Fixes https://github.com/crossplane/crossplane/issues/3294

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

`make build` && `make e2e.run skipcleanup=true`

Then created pull secret:
```
up ctp pull-secret create package-pull-secret -n crossplane-system -f creds.json
```

Patched Crossplane SA:
```
kubectl patch serviceaccount crossplane -n crossplane-system -p '{"imagePullSecrets": [{"name": "package-pull-secret"}]}'
```

Installed provider without pull secrets:
```
kxp install provider xpkg.upbound.io/upbound/provider-aws:v0.13.0
```

Verified installed and healthy:
```
🤖 (crossplane) k describe provider.pkg.crossplane.io/upbound-provider-aws
Name:         upbound-provider-aws
Namespace:    
Labels:       <none>
Annotations:  <none>
API Version:  pkg.crossplane.io/v1
Kind:         Provider
Spec:
  Ignore Crossplane Constraints:  false
  Package:                        xpkg.upbound.io/upbound/provider-aws:v0.13.0
  Package Pull Policy:            IfNotPresent
  Revision Activation Policy:     Automatic
  Revision History Limit:         0
  Skip Dependency Resolution:     false
Status:
  Conditions:
    Last Transition Time:  2022-09-21T13:53:22Z
    Reason:                HealthyPackageRevision
    Status:                True
    Type:                  Healthy
    Last Transition Time:  2022-09-21T13:52:17Z
    Reason:                ActivePackageRevision
    Status:                True
    Type:                  Installed
  Current Identifier:      xpkg.upbound.io/upbound/provider-aws:v0.13.0
  Current Revision:        upbound-provider-aws-fc98ece40acb
Events:
  Type     Reason                  Age                From                                 Message
  ----     ------                  ----               ----                                 -------
  Warning  InstallPackageRevision  48s (x3 over 89s)  packages/provider.pkg.crossplane.io  current package revision health is unknown
  Normal   InstallPackageRevision  24s (x2 over 24s)  packages/provider.pkg.crossplane.io  Successfully installed package revision
```

[contribution process]: https://git.io/fj2m9
