### PR TITLE
Docs hugo migration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ OSBASEIMAGE = gcr.io/distroless/static:nonroot
 # Setup Docs
 
 SOURCE_DOCS_DIR = docs
-DEST_DOCS_DIR = content/
+DEST_DOCS_DIR = content/docs/
 DOCS_GIT_REPO = https://$(DOCS_GIT_USR):$(DOCS_GIT_PSW)@github.com/crossplane/crossplane.github.io.git
 -include build/makelib/docs.mk
 

--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ OSBASEIMAGE = gcr.io/distroless/static:nonroot
 # Setup Docs
 
 SOURCE_DOCS_DIR = docs
-DEST_DOCS_DIR = docs
+DEST_DOCS_DIR = content/
 DOCS_GIT_REPO = https://$(DOCS_GIT_USR):$(DOCS_GIT_PSW)@github.com/crossplane/crossplane.github.io.git
 -include build/makelib/docs.mk
 
@@ -112,8 +112,8 @@ gen-kustomize-crds:
 	@$(INFO) Adding all CRDs to Kustomize file for local development
 	@rm cluster/kustomization.yaml
 	@echo "# This kustomization can be used to remotely install all Crossplane CRDs" >> cluster/kustomization.yaml
-	@echo "# by running kubectl apply -k https://github.com/crossplane/crossplane//cluster?ref=master" >> cluster/kustomization.yaml 
-	@echo "resources:" >> cluster/kustomization.yaml 
+	@echo "# by running kubectl apply -k https://github.com/crossplane/crossplane//cluster?ref=master" >> cluster/kustomization.yaml
+	@echo "resources:" >> cluster/kustomization.yaml
 	@find $(CRD_DIR) -type f -name '*.yaml' | sort | \
 		while read filename ;\
 		do echo "- $${filename#*/}" >> cluster/kustomization.yaml \

--- a/cluster/charts/crossplane/README.md
+++ b/cluster/charts/crossplane/README.md
@@ -1,4 +1,4 @@
-# Install Crossplane
+
 
 Crossplane can be easily installed into any existing Kubernetes cluster using
 the regularly published Helm chart. The Helm chart contains all the custom

--- a/docs/_index.md
+++ b/docs/_index.md
@@ -2,11 +2,13 @@
 title: "Overview"
 weight: -1
 toc_include: false
+aliases:
+    - /docs/master/index.html
 cascade:
     version: master
 ---
 
-![Crossplane](media/banner.png)
+![Crossplane](/docs/master/media/banner.png)
 
 Crossplane is an open source Kubernetes add-on that transforms your cluster into
 a **universal control plane**. Crossplane enables platform teams to assemble

--- a/docs/_index.md
+++ b/docs/_index.md
@@ -1,0 +1,27 @@
+---
+title: "Overview"
+weight: -1
+toc_include: false
+cascade:
+    version: master
+---
+
+![Crossplane](media/banner.png)
+
+Crossplane is an open source Kubernetes add-on that transforms your cluster into
+a **universal control plane**. Crossplane enables platform teams to assemble
+infrastructure from multiple vendors, and expose higher level self-service APIs
+for application teams to consume, without having to write any code.
+
+Crossplane extends your Kubernetes cluster to support orchestrating any
+infrastructure or managed service. Compose Crossplane's granular resources into
+higher level abstractions that can be versioned, managed, deployed and consumed
+using your favorite tools and existing processes. [Install Crossplane]({{<ref "getting-started/install-configure" >}}) into any
+Kubernetes cluster to get started.
+
+Crossplane is a [Cloud Native Compute Foundation][cncf] project.
+
+<!-- Named Links -->
+
+
+[cncf]: https://www.cncf.io/

--- a/docs/api-docs/_index.md
+++ b/docs/api-docs/_index.md
@@ -1,10 +1,7 @@
 ---
 title: API Documentation
-toc: true
 weight: 400
 ---
-
-# API Documentation
 
 The Crossplane ecosystem contains many CRDs that map to API types represented by
 external infrastructure providers. The documentation for these CRDs are

--- a/docs/api-docs/crossplane.md
+++ b/docs/api-docs/crossplane.md
@@ -1,7 +1,5 @@
 ---
-title: crossplane
-toc: true
-weight: 401
-indent: true
-redirect_to: https://doc.crds.dev/github.com/crossplane/crossplane
+title: Crossplane
+layout: redirect
+to: "https://crossplane.io/docs/v1.9/api-docs/crossplane.html"
 ---

--- a/docs/api-docs/crossplane.md
+++ b/docs/api-docs/crossplane.md
@@ -1,5 +1,5 @@
 ---
 title: Crossplane
 layout: redirect
-to: "https://crossplane.io/docs/v1.9/api-docs/crossplane.html"
+to: "https://doc.crds.dev/github.com/crossplane/crossplane"
 ---

--- a/docs/api-docs/provider-alibaba.md
+++ b/docs/api-docs/provider-alibaba.md
@@ -1,7 +1,5 @@
 ---
 title: provider-alibaba
-toc: true
-weight: 402
-indent: true
-redirect_to: https://doc.crds.dev/github.com/crossplane/provider-alibaba
+to: https://doc.crds.dev/github.com/crossplane/provider-alibaba
+layout: redirect
 ---

--- a/docs/api-docs/provider-aws.md
+++ b/docs/api-docs/provider-aws.md
@@ -1,7 +1,5 @@
 ---
 title: provider-aws
-toc: true
-weight: 403
-indent: true
-redirect_to: https://doc.crds.dev/github.com/crossplane/provider-aws
+layout: redirect
+to: https://doc.crds.dev/github.com/crossplane/provider-aws
 ---

--- a/docs/api-docs/provider-azure.md
+++ b/docs/api-docs/provider-azure.md
@@ -1,7 +1,5 @@
 ---
 title: provider-azure
-toc: true
-weight: 404
-indent: true
-redirect_to: https://doc.crds.dev/github.com/crossplane/provider-azure
+layout: redirect
+to: https://doc.crds.dev/github.com/crossplane/provider-azure
 ---

--- a/docs/api-docs/provider-gcp.md
+++ b/docs/api-docs/provider-gcp.md
@@ -1,7 +1,5 @@
 ---
 title: provider-gcp
-toc: true
-weight: 405
-indent: true
-redirect_to: https://doc.crds.dev/github.com/crossplane/provider-gcp
+layout: redirect
+to: https://doc.crds.dev/github.com/crossplane/provider-gcp
 ---

--- a/docs/api-docs/provider-helm.md
+++ b/docs/api-docs/provider-helm.md
@@ -1,7 +1,5 @@
 ---
 title: provider-helm
-toc: true
-weight: 407
-indent: true
-redirect_to: https://doc.crds.dev/github.com/crossplane-contrib/provider-helm
+layout: redirect
+to: https://doc.crds.dev/github.com/crossplane-contrib/provider-helm
 ---

--- a/docs/api-docs/provider-rook.md
+++ b/docs/api-docs/provider-rook.md
@@ -1,7 +1,5 @@
 ---
 title: provider-rook
-toc: true
-weight: 406
-indent: true
-redirect_to: https://doc.crds.dev/github.com/crossplane/provider-rook
+layout: redirect
+to: https://doc.crds.dev/github.com/crossplane/provider-rook
 ---

--- a/docs/cloud-providers/aws/aws-provider.md
+++ b/docs/cloud-providers/aws/aws-provider.md
@@ -129,7 +129,7 @@ all AWS resources.
 
 [`aws` command line tool]: https://aws.amazon.com/cli/
 [AWS SDK for GO]: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/setting-up.html
-[installed]: https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-install.html
+[installed]: https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html
 [configured]: https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-configure.html
 [AWS security credentials]: https://docs.aws.amazon.com/general/latest/gr/aws-security-credentials.html
 [secret]:https://kubernetes.io/docs/concepts/configuration/secret/
@@ -138,7 +138,7 @@ all AWS resources.
 [Access Key]: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html
 [AWS security credentials]: https://docs.aws.amazon.com/general/latest/gr/aws-security-credentials.html
 [aws command line tool]: https://aws.amazon.com/cli/
-[install-aws]: https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-install.html
+[install-aws]: https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html
 [aws-cli-configure]: https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-configure.html
 [kubernetes secret]: https://kubernetes.io/docs/concepts/configuration/secret/
 [AWS named profile]: https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-profiles.html

--- a/docs/cloud-providers/aws/aws-provider.md
+++ b/docs/cloud-providers/aws/aws-provider.md
@@ -1,4 +1,7 @@
-# Adding Amazon Web Services (AWS) to Crossplane
+---
+title: Adding Amazon Web Services (AWS) to Crossplane
+toc_hide: true
+---
 
 In this guide, we will walk through the steps necessary to configure your AWS
 account to be ready for integration with Crossplane. This will be done by adding

--- a/docs/cloud-providers/azure/azure-provider.md
+++ b/docs/cloud-providers/azure/azure-provider.md
@@ -1,4 +1,7 @@
-# Adding Microsoft Azure to Crossplane
+---
+title: Adding Microsoft Azure to Crossplane
+toc_hide: true
+---
 
 In this guide, we will walk through the steps necessary to configure your Azure
 account to be ready for integration with Crossplane. The general steps we will

--- a/docs/cloud-providers/gcp/gcp-provider.md
+++ b/docs/cloud-providers/gcp/gcp-provider.md
@@ -1,4 +1,8 @@
-# Adding Google Cloud Platform (GCP) to Crossplane
+---
+title: Adding Google Cloud Platform (GCP) to Crossplane
+toc_hide: true
+---
+
 
 In this guide, we will walk through the steps necessary to configure your GCP
 account to be ready for integration with Crossplane. The general steps we will

--- a/docs/concepts/_index.md
+++ b/docs/concepts/_index.md
@@ -1,10 +1,7 @@
 ---
 title: Concepts
-toc: true
 weight: 100
 ---
-
-# Overview
 
 Crossplane introduces multiple building blocks that enable you to provision,
 compose, and consume infrastructure using the Kubernetes API. These individual
@@ -49,10 +46,10 @@ learn more about all of these concepts in the [composition documentation].
 
 <!-- Named Links -->
 
-[Packages]: packages.md
+[Packages]: {{<ref "packages" >}}
 [CRDs]: https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/
 [controllers]: https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/#custom-controllers
-[providers documentation]: providers.md
+[providers documentation]: {{<ref "providers" >}}
 [doc.crds.dev]: https://doc.crds.dev
-[managed resources documentation]: managed-resources.md
-[composition documentation]: composition.md
+[managed resources documentation]: {{<ref "managed-resources" >}}
+[composition documentation]: {{<ref "composition" >}}

--- a/docs/concepts/composition.md
+++ b/docs/concepts/composition.md
@@ -1,13 +1,7 @@
 ---
 title: Composite Resources
-toc: true
 weight: 103
-indent: true
 ---
-
-# Composite Resources
-
-## Overview
 
 Crossplane Composite Resources are opinionated Kubernetes Custom Resources that
 are _composed_ of [Managed Resources][managed-resources]. We often call them XRs
@@ -246,11 +240,11 @@ scenarios, including:
   instantly claim infrastructure like database instances that would otherwise
   take minutes to provision on-demand.
 
-[managed-resources]: managed-resources.md
-[xrs-and-mrs]: ../media/composition-xrs-and-mrs.svg
-[xr-ref]: ../reference/composition.md
-[how-it-works]: ../media/composition-how-it-works.svg
+[managed-resources]: {{<ref "managed-resources" >}}
+[xrs-and-mrs]: ../../media/composition-xrs-and-mrs.svg
+[xr-ref]: {{<ref "../reference/composition" >}}
+[how-it-works]: ../../media/composition-how-it-works.svg
 [crd-docs]: https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/
 [provider-kubernetes]: https://github.com/crossplane-contrib/provider-kubernetes
 [provider-helm]: https://github.com/crossplane-contrib/provider-helm
-[claims-and-xrs]: ../media/composition-claims-and-xrs.svg
+[claims-and-xrs]: ../../media/composition-claims-and-xrs.svg

--- a/docs/concepts/composition.md
+++ b/docs/concepts/composition.md
@@ -241,10 +241,10 @@ scenarios, including:
   take minutes to provision on-demand.
 
 [managed-resources]: {{<ref "managed-resources" >}}
-[xrs-and-mrs]: ../../media/composition-xrs-and-mrs.svg
+[xrs-and-mrs]: /docs/master/media/composition-xrs-and-mrs.svg
 [xr-ref]: {{<ref "../reference/composition" >}}
-[how-it-works]: ../../media/composition-how-it-works.svg
+[how-it-works]: /docs/master/media/composition-how-it-works.svg
 [crd-docs]: https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/
 [provider-kubernetes]: https://github.com/crossplane-contrib/provider-kubernetes
 [provider-helm]: https://github.com/crossplane-contrib/provider-helm
-[claims-and-xrs]: ../../media/composition-claims-and-xrs.svg
+[claims-and-xrs]: /docs/master/media/composition-claims-and-xrs.svg

--- a/docs/concepts/managed-resources.md
+++ b/docs/concepts/managed-resources.md
@@ -1,13 +1,7 @@
 ---
 title: Managed Resources
-toc: true
 weight: 102
-indent: true
 ---
-
-# Managed Resources
-
-## Overview
 
 A Managed Resource (MR) is Crossplane's representation of a resource in an
 external system - most commonly a cloud provider. Managed Resources are
@@ -457,14 +451,14 @@ fields are there and those are enough to import a resource. The tool you're
 using needs to store `annotations` and `spec` fields, which most tools do
 including Velero.
 
-[term-xrm]: terminology.md#crossplane-resource-model
+[term-xrm]: {{<ref "terminology" >}}#crossplane-resource-model
 [rds]: https://aws.amazon.com/rds/
 [cloudsql]: https://cloud.google.com/sql
-[composition]: composition.md
-[api-versioning]: https://kubernetes.io/docs/reference/using-api/api-overview/#api-versioning
+[composition]: {{<ref "composition" >}}
+[api-versioning]: https://kubernetes.io/docs/reference/using-api/#api-versioning#api-versioning
 [velero]: https://velero.io/
-[api-reference]: ../api-docs/overview.md
-[provider]: providers.md
+[api-reference]: {{<ref "../api-docs" >}}
+[provider]: {{<ref "providers" >}}
 [issue-727]: https://github.com/crossplane/crossplane/issues/727
 [issue-1143]: https://github.com/crossplane/crossplane/issues/1143
 [managed-api-patterns]: https://github.com/crossplane/crossplane/blob/master/design/one-pager-managed-resource-api-design.md

--- a/docs/concepts/packages.md
+++ b/docs/concepts/packages.md
@@ -1,11 +1,7 @@
 ---
-title: Packages
-toc: true
+title: Crossplane Packages
 weight: 104
-indent: true
 ---
-
-# Crossplane Packages
 
 Crossplane packages are opinionated [OCI images] that contain a stream of YAML
 that can be parsed by the Crossplane package manager. Crossplane packages come
@@ -31,11 +27,20 @@ purposes of Crossplane packages are as follows:
 
 The following packaging operations are covered in detail below:
 
+- [Table of Contents](#table-of-contents)
 - [Building a Package](#building-a-package)
   - [Provider Packages](#provider-packages)
   - [Configuration Packages](#configuration-packages)
 - [Pushing a Package](#pushing-a-package)
 - [Installing a Package](#installing-a-package)
+  - [spec.package](#specpackage)
+  - [spec.packagePullPolicy](#specpackagepullpolicy)
+  - [spec.revisionActivationPolicy](#specrevisionactivationpolicy)
+  - [spec.revisionHistoryLimit](#specrevisionhistorylimit)
+  - [spec.packagePullSecrets](#specpackagepullsecrets)
+  - [spec.skipDependencyResolution](#specskipdependencyresolution)
+  - [spec.ignoreCrossplaneConstraints](#specignorecrossplaneconstraints)
+  - [spec.controllerConfigRef](#speccontrollerconfigref)
 - [Upgrading a Package](#upgrading-a-package)
   - [Package Upgrade Issues](#package-upgrade-issues)
 - [The Package Cache](#the-package-cache)
@@ -482,13 +487,13 @@ by [pre-pulling images] onto nodes in the cluster.
 <!-- Named Links -->
 
 [OCI images]: https://github.com/opencontainers/image-spec
-[Providers]: providers.md
+[Providers]: {{<ref "providers" >}}
 [provider-docs]: https://doc.crds.dev/github.com/crossplane/crossplane/meta.pkg.crossplane.io/Provider/v1
 [configuration-docs]: https://doc.crds.dev/github.com/crossplane/crossplane/meta.pkg.crossplane.io/Configuration/v1
 [lock-api]: https://doc.crds.dev/github.com/crossplane/crossplane/pkg.crossplane.io/Lock/v1beta1
 [getting-started-with-gcp]: https://github.com/crossplane/crossplane/tree/master/docs/snippets/package/gcp
 [specification]: https://github.com/Masterminds/semver#basic-comparisons
-[composition]: composition.md
+[composition]: {{<ref "composition" >}}
 [IAM Roles for Service Accounts]: https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html
 [controller-config-docs]: https://doc.crds.dev/github.com/crossplane/crossplane/pkg.crossplane.io/ControllerConfig/v1alpha1
 [package format]: https://github.com/crossplane/crossplane/blob/1aa83092172bdf0d2ed64754d33517c612ff7368/design/one-pager-package-format-v2.md

--- a/docs/concepts/providers.md
+++ b/docs/concepts/providers.md
@@ -1,11 +1,7 @@
 ---
 title: Providers
-toc: true
 weight: 101
-indent: true
 ---
-
-# Providers
 
 Providers are Crossplane packages that bundle a set of [Managed
 Resources][managed-resources] and their respective controllers to allow
@@ -121,12 +117,12 @@ will attempt to use a `ProviderConfig` named `default`.
 
 <!-- Named Links -->
 
-[getting-started]: ../getting-started/install-configure.md
-[Google Cloud Platform (GCP) Service Account]: ../cloud-providers/gcp/gcp-provider.md
-[Microsoft Azure Service Principal]: ../cloud-providers/azure/azure-provider.md
-[Amazon Web Services (AWS) IAM User]: ../cloud-providers/aws/aws-provider.md
-[managed-resources]: managed-resources.md
-[provider-aws]: https://github.com/crossplane/provider-aws
+[getting-started]: {{<ref "../getting-started/install-configure" >}}
+[Google Cloud Platform (GCP) Service Account]: {{<ref "../cloud-providers/gcp/gcp-provider" >}}
+[Microsoft Azure Service Principal]: {{<ref "../cloud-providers/azure/azure-provider" >}}
+[Amazon Web Services (AWS) IAM User]: {{<ref "../cloud-providers/aws/aws-provider" >}}
+[managed-resources]: {{<ref "managed-resources" >}}
+[provider-aws]: https://github.com/crossplane-contrib/provider-aws
 [provider-aws-api]: https://doc.crds.dev/github.com/crossplane/provider-aws
 [provider-jet-aws]: https://github.com/crossplane-contrib/provider-jet-aws
 [provider-jet-aws-api]: https://doc.crds.dev/github.com/crossplane-contrib/provider-jet-aws

--- a/docs/concepts/terminology.md
+++ b/docs/concepts/terminology.md
@@ -1,12 +1,7 @@
 ---
 title: Terminology
-toc: true
 weight: 110
-indent: true
 ---
-
-# Terminology
-
 ## A Note on Style
 
 Each type of Kubernetes resource has a ‘Pascal case’ name - i.e. a title case

--- a/docs/contributing/_index.md
+++ b/docs/contributing/_index.md
@@ -1,10 +1,7 @@
 ---
 title: Contributing
-toc: true
 weight: 1000
 ---
-
-# Contributing
 
 The best place to start if you're thinking about contributing to Crossplane is
 our [`CONTRIBUTING.md`] file. The following documents supplement that guide.
@@ -14,6 +11,6 @@ our [`CONTRIBUTING.md`] file. The following documents supplement that guide.
 3. [Release Process]
 
 [`CONTRIBUTING.md`]: https://github.com/crossplane/crossplane/blob/master/CONTRIBUTING.md
-[Provider Development Guide]: provider_development_guide.md
-[Observability Developer Guide]: observability_developer_guide.md
-[Release Process]: release-process.md
+[Provider Development Guide]: {{<ref "provider_development_guide" >}}
+[Observability Developer Guide]: {{<ref "observability_developer_guide" >}}
+[Release Process]: {{<ref "release-process" >}}

--- a/docs/contributing/adding_external_secret_store_support.md
+++ b/docs/contributing/adding_external_secret_store_support.md
@@ -1,11 +1,7 @@
 ---
 title: Adding Secret Store Support
-toc: true
 weight: 1004
-indent: true
 ---
-
-# Adding External Secret Store Support to an Existing Provider
 
 To add support for [External Secret Stores] in a provider, we need the following
 changes at a high level:
@@ -134,6 +130,6 @@ example.
 [External Secret Stores]: https://github.com/crossplane/crossplane/blob/master/design/design-doc-external-secret-stores.md
 [this PR as a complete example]: https://github.com/crossplane/provider-gcp/pull/421
 [this PR instead]: https://github.com/crossplane-contrib/provider-jet-template/pull/23/commits
-[this commit as an example on how to add the type]: https://github.com/crossplane/provider-aws/pull/1242/commits/d8a2df323fa2489d82bf1843d2fe338de033c61d
+[this commit as an example on how to add the type]: https://github.com/crossplane-contrib/provider-aws/pull/1242/commits/d8a2df323fa2489d82bf1843d2fe338de033c61d
 [this commit as an example for adding the feature flag]: https://github.com/crossplane/provider-gcp/pull/421/commits/b5898c62dc6668d9918496de8aa9bc365c371f82
 [this commit as an example for changes in Setup functions]: https://github.com/crossplane/provider-gcp/pull/421/commits/9700d0c4fdb7e1fba8805afa309c1b1c7aa167a6

--- a/docs/contributing/docs.md
+++ b/docs/contributing/docs.md
@@ -1,0 +1,187 @@
+---
+title: "Crossplane Documentation"
+weight: 2000
+---
+
+- [Code of Conduct](#code-of-conduct)
+  - [Reporting](#reporting)
+- [Licensing](#licensing)
+  - [Directory structure](#directory-structure)
+  - [Run Hugo](#run-hugo)
+  - [Documentation issues and feature requests](#documentation-issues-and-feature-requests)
+- [Contributing](#contributing)
+  - [Front matter](#front-matter)
+    - [New Crossplane versions](#new-crossplane-versions)
+    - [Excluding pages from the Table of Contents](#excluding-pages-from-the-table-of-contents)
+  - [Links](#links)
+    - [Linking between docs pages](#linking-between-docs-pages)
+    - [Linking to external sites](#linking-to-external-sites)
+  - [Tabs](#tabs)
+
+## Code of Conduct
+We follow the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/main/code-of-conduct.md).
+
+Taken directly from the CNCF CoC:
+>As contributors and maintainers in the CNCF community, and in the interest of fostering an open and welcoming community, we pledge to respect all people who contribute through reporting issues, posting feature requests, updating documentation, submitting pull requests or patches, and other activities.
+>  
+>We are committed to making participation in the CNCF community a harassment-free experience for everyone, regardless of level of experience, gender, gender identity and expression, sexual orientation, disability, personal appearance, body size, race, ethnicity, age, religion, or nationality.
+
+### Reporting
+To report violations contact the Crossplane maintainers at `info@crossplane.io` or the CNCF at `conduct@cncf.io`.
+
+## Licensing
+The Crossplane documentation is under the [Creative Commons Attribution](https://creativecommons.org/licenses/by/4.0/) license. CC-BY allows reuse, remixing and republishing of Crossplane documentation with attribution to the Crossplane organization.
+
+
+### Directory structure
+The relevant directories of the docs repository are:
+| Directory | Purpose |
+| ----- | ---- |
+| `content` | Markdown files for all individual pages. |
+| `static/images` | Location for all image files.  |
+| `themes` | HTML templates and Hugo tooling. |
+
+All markdown content exists within the `/content` directory.   
+All image files exist within `static/images`.
+
+### Run Hugo
+* Follow the [Hugo documentation](https://gohugo.io/getting-started/installing/) to install Hugo.
+* Run `hugo server`
+* Go to [http://localhost:1313](http://localhost:1313)
+
+Crossplane documentation uses [Hugo v0.101.0](https://github.com/gohugoio/hugo/releases/tag/v0.101.0), but newer versions are compatible.
+
+### Documentation issues and feature requests
+Use [GitHub Issues](https://github.com/crossplane/crossplane.github.io/issues) to report a problem or request documentation content.
+
+## Contributing
+
+The `/content` directory contains all documentation pages.  
+Each version of Crossplane software maintains a unique directory within `content`.
+
+### Front matter
+Each page contains metadata called [front matter](https://gohugo.io/content-management/front-matter/). Each page requires front matter to render.
+
+```yaml
+---
+title: "Troubleshooting Crossplane"
+weight: 610
+---
+```
+
+`title` defines the name of the page.  
+`weight` determines the ordering of the page in the table of contents. Lower weight pages come before higher weights in the table of contents. The value of `weight` is otherwise arbitrary.
+
+The `weight` of a directory's `_index.md` page moves the entire section of content in the table of contents.
+
+#### New Crossplane versions
+To create documentation for a new version of Crossplane copy the current `master` folder and rename it to the desired version. 
+The naming convention follows `v<major>.<minor>`. Maintenance release and individual builds do not have unique documentation. 
+
+After creating a new directory edit the `/content/<version>/_index.md` file to set the version for all sub-pages define `verison:` as a child element under `cascade:`. 
+For example, set the version to `v8.6`:
+```
+---
+title: "Overview"
+weight: 1
+toc_include: false
+cascade:
+    version: 8.6
+---
+```
+
+You **must** set the version number as a valid float to generate the version drop down menus within the docs.
+
+The version set in the front matter is independent from the directory name.
+
+#### Excluding pages from the Table of Contents
+Pages can be hidden from the left-side table of contents with front matter settings. 
+
+To exclude a page from the table of contents set  
+
+`toc_include: false`  
+
+in the page front matter. 
+
+For example, 
+
+```
+---
+title: "Overview"
+weight: 1
+toc_include: false
+---
+```
+
+The `/content/<version>/_index.md` page must have this set.
+
+### Links
+#### Linking between docs pages
+Link between pages or sections within the documentation using standard [markdown link syntax](https://www.markdownguide.org/basic-syntax/#links). Use the [Hugo ref shortcode](https://gohugo.io/content-management/shortcodes/#ref-and-relref) with the path of the file relative to `/content` for the link location.
+
+For example, to link to the "Official Providers" page create a markdown link like this:
+
+```markdown
+[a link to the Official Providers page]({{</* ref "providers/_index.md" */>}})
+```
+
+The `ref` value is of the markdown file, including `.md` extension. Don't link to a web address.
+
+If the `ref` value points to a page that doesn't exist, Hugo fails to start. 
+
+For example, providing `index.md` instead of `_index.md` would cause an error like the this:
+```shell
+Start building sites …
+hugo v0.101.0-466fa43c16709b4483689930a4f9ac8add5c9f66 darwin/arm64 BuildDate=2022-06-16T07:09:16Z VendorInfo=gohugoio
+ERROR 2022/09/13 13:53:46 [en] REF_NOT_FOUND: Ref "contributing/index.md": "/home/user/crossplane.github.io/content/contributing.md:64:41": page not found
+Error: Error building site: logged 1 error
+```
+
+Using `ref` ensures links render in the staging environment and prevents broken links.
+
+#### Linking to external sites
+Minimize linking to external sites. When linking to any page outside of `crossplane.io` use standard [markdown link syntax](https://www.markdownguide.org/basic-syntax/#links) without using the `ref` shortcode.
+
+For example, 
+```markdown
+[Go to Upbound](http://upbound.io)
+```
+
+### Tabs
+Use tabs to present information about a single topic with multiple exclusive options. For example, creating a resource via command-line or GUI. 
+
+To create a tab set, first create a `tabs` shortcode and use multiple `tab` shortcodes inside for each tab.
+
+Each `tabs` shortcode requires a name that's unique to the page it's on. Each `tab` name is the title of the tab on the webpage. 
+
+For example
+```
+{{</* tabs "my-unique-name" */>}}
+
+{{</* tab "Command-line" */>}}
+An example tab. Place anything inside a tab.
+{{</* /tab */>}}
+
+{{</* tab "GUI" */>}}
+A second example tab. 
+{{</* /tab */>}}
+
+{{</* /tabs */>}}
+```
+
+This code block renders the following tabs
+{{< tabs "my-unique-name" >}}
+
+{{< tab "Command-line" >}}
+An example tab. Place anything inside a tab.
+{{< /tab >}}
+
+{{< tab "GUI" >}}
+A second example tab. 
+{{< /tab >}}
+
+{{< /tabs >}}
+
+
+Both `tab` and `tabs` require opening and closing tags. Unclosed tags causes Hugo to fail.
+

--- a/docs/contributing/docs.md
+++ b/docs/contributing/docs.md
@@ -34,7 +34,7 @@ The Crossplane documentation is under the [Creative Commons Attribution](https:/
 
 
 ### Directory structure
-The relevant directories of the docs repository are:
+The relevant directories of the [docs repository](https://github.com/crossplane/crossplane.github.io) are:
 | Directory | Purpose |
 | ----- | ---- |
 | `content` | Markdown files for all individual pages. |

--- a/docs/contributing/docs.md
+++ b/docs/contributing/docs.md
@@ -34,7 +34,7 @@ The Crossplane documentation is under the [Creative Commons Attribution](https:/
 
 
 ### Directory structure
-The relevant directories of the [docs repository](https://github.com/crossplane/crossplane.github.io) are:
+The relevant directories of the docs repository are:
 | Directory | Purpose |
 | ----- | ---- |
 | `content` | Markdown files for all individual pages. |

--- a/docs/contributing/observability_developer_guide.md
+++ b/docs/contributing/observability_developer_guide.md
@@ -1,11 +1,7 @@
 ---
 title: Observability Developer Guide
-toc: true
 weight: 1002
-indent: true
 ---
-
-# Observability Developer Guide
 
 ## Introduction
 

--- a/docs/contributing/provider_development_guide.md
+++ b/docs/contributing/provider_development_guide.md
@@ -1,11 +1,7 @@
 ---
 title: Provider Development Guide
-toc: true
 weight: 1001
-indent: true
 ---
-
-# Provider Development Guide
 
 Crossplane allows you to manage infrastructure directly from Kubernetes. Each
 infrastructure API resource that Crossplane orchestrates is known as a "managed
@@ -622,7 +618,7 @@ feedback you may have about the development process!
 [crossplane-runtime v0.9.0]: https://github.com/crossplane/crossplane-runtime/releases/tag/v0.9.0
 [TBS Episode 18]: https://www.youtube.com/watch?v=rvQ8N0u3rkE&t=7s
 [What Makes a Crossplane Infrastructure Resource]: #what-makes-a-crossplane-infrastructure-resource
-[managed resource]: ../concepts/managed-resources.md
+[managed resource]: {{<ref "../concepts/managed-resources" >}}
 [`CloudMemorystoreInstance`]: https://github.com/crossplane/provider-gcp/blob/85a6ed3c669a021f1d61be51b2cbe2714b0bc70b/apis/cache/v1beta1/cloudmemorystore_instance_types.go#L184
 [`ProviderConfig`]: https://github.com/crossplane/provider-gcp/blob/be5aaf6/apis/v1beta1/providerconfig_types.go#L39
 [watching the API server]: https://kubernetes.io/docs/reference/using-api/api-concepts/#efficient-detection-of-changes
@@ -652,10 +648,10 @@ feedback you may have about the development process!
 [reach out]: https://github.com/crossplane/crossplane#get-involved
 [crossplane org]: https://github.com/crossplane
 [`angryjet`]: https://github.com/crossplane/crossplane-tools
-[Managed Resource API Patterns]: ../design/one-pager-managed-resource-api-design.md
+[Managed Resource API Patterns]: https://github.com/crossplane/crossplane/blob/master/design/one-pager-managed-resource-api-design.md
 [Crossplane CLI]: https://github.com/crossplane/crossplane-cli#quick-start-stacks
 [`angryjet` documentation]: https://github.com/crossplane/crossplane-tools/blob/master/README.md
-[code generation guide]: https://github.com/crossplane/provider-aws/blob/master/CODE_GENERATION.md
+[code generation guide]: https://github.com/crossplane-contrib/provider-aws/blob/master/CODE_GENERATION.md
 [Terrajet]: https://github.com/crossplane/terrajet
 [Generating a Crossplane Provider guide]: https://github.com/crossplane/terrajet/blob/main/docs/generating-a-provider.md
 [provider-template]: https://github.com/crossplane/provider-template

--- a/docs/contributing/release-process.md
+++ b/docs/contributing/release-process.md
@@ -1,11 +1,7 @@
 ---
 title: Release Process
-toc: true
 weight: 1003
-indent: true
 ---
-
-# Release Process
 
 This document is meant to be a complete end-to-end guide for how to release new
 versions of software for Crossplane and its related projects.
@@ -172,7 +168,7 @@ For all repos with Helm charts:
 
 For crossplane/crossplane:
 * [Docs website](https://crossplane.io/docs/latest)
-* [Configuration Packages](https://cloud.upbound.io/browse)
+* [Configuration Packages](https://marketplace.upbound.io)
 
 ### Tag Next Pre-release
 

--- a/docs/faqs/_index.md
+++ b/docs/faqs/_index.md
@@ -1,10 +1,7 @@
 ---
 title: FAQ
-toc: true
 weight: 1200
 ---
-
-# Frequently Asked Questions (FAQs)
 
 ### Where did the name Crossplane come from?
 
@@ -20,4 +17,4 @@ We believe in a multi-flavor cloud.
 ### Related Projects
 See [Related Projects].
 
-[Related Projects]: related_projects.md
+[Related Projects]: {{<ref "related_projects" >}}

--- a/docs/faqs/related_projects.md
+++ b/docs/faqs/related_projects.md
@@ -1,11 +1,7 @@
 ---
 title: Related Projects
-toc: true
 weight: 1201
-indent: true
 ---
-
-# Related Projects
 
 While there are many projects that address similar issues, none of them
 encapsulate the full use case that Crossplane addresses. This list is not

--- a/docs/getting-started/_index.md
+++ b/docs/getting-started/_index.md
@@ -3,7 +3,7 @@ title: Getting Started
 weight: 4
 ---
 
-![Crossplane](../media/banner.png)
+![Crossplane](/docs/master/media/banner.png)
 
 Crossplane is an open source Kubernetes add-on that transforms your cluster into
 a **universal control plane**. Crossplane enables platform teams to assemble

--- a/docs/getting-started/_index.md
+++ b/docs/getting-started/_index.md
@@ -1,0 +1,24 @@
+---
+title: Getting Started
+weight: 4
+---
+
+![Crossplane](../media/banner.png)
+
+Crossplane is an open source Kubernetes add-on that transforms your cluster into
+a **universal control plane**. Crossplane enables platform teams to assemble
+infrastructure from multiple vendors, and expose higher level self-service APIs
+for application teams to consume, without having to write any code.
+
+Crossplane extends your Kubernetes cluster to support orchestrating any
+infrastructure or managed service. Compose Crossplane's granular resources into
+higher level abstractions that can be versioned, managed, deployed and consumed
+using your favorite tools and existing processes. [Install Crossplane]({{<ref "install-configure" >}}) into any
+Kubernetes cluster to get started.
+
+Crossplane is a [Cloud Native Compute Foundation][cncf] project.
+
+<!-- Named Links -->
+
+
+[cncf]: https://www.cncf.io/

--- a/docs/getting-started/create-configuration.md
+++ b/docs/getting-started/create-configuration.md
@@ -1,11 +1,7 @@
 ---
 title: Create a Configuration
-toc: true
 weight: 4
-indent: true
 ---
-
-# Create a Configuration
 
 In the [previous section] we were able to create a PostgreSQL database because
 we had installed a configuration package that defined the `PostgreSQLInstance`
@@ -733,9 +729,9 @@ rm -rf crossplane-config
 
 <!-- Named Links -->
 
-[previous section]: provision-infrastructure.md
-[composed]: ../concepts/composition.md
-[composition]: ../concepts/composition.md
+[previous section]: {{<ref "provision-infrastructure" >}}
+[composed]: {{<ref "../concepts/composition" >}}
+[composition]: {{<ref "../concepts/composition" >}}
 [Docker Hub]: https://hub.docker.com/
-[packages]: ../concepts/packages.md
-[concepts]: ../concepts/overview.md
+[packages]: {{<ref "../concepts/packages" >}}
+[concepts]: {{<ref "../concepts" >}}

--- a/docs/getting-started/install-configure.md
+++ b/docs/getting-started/install-configure.md
@@ -1,11 +1,8 @@
 ---
 title: Install & Configure
-toc: true
 weight: 2
-indent: true
 ---
-
-# Choosing Your Crossplane Distribution
+## Choosing Your Crossplane Distribution
 
 Users looking to use Crossplane for the first time have two options available to
 them today. The first way is to use the version of Crossplane which is
@@ -16,15 +13,9 @@ distributions are [certified by the CNCF] to be conformant with Crossplane, but
 may include additional features or tooling around it that makes it easier to use
 in production environments.
 
-<ul class="nav nav-tabs">
-<li class="active"><a href="#using-upstream-crossplane" data-toggle="tab">Crossplane (upstream)</a></li>
-<li><a href="#using-a-downstream-distro" data-toggle="tab">Downstream Distributions</a></li>
-</ul>
-<br>
-<!-- Begin Distro Tabs -->
-<div class="tab-content">
-<!-- Begin Upstream Tab -->
-<div class="tab-pane fade in active" id="using-upstream-crossplane" markdown="1">
+{{% tabs "Crossplane Distros" %}}
+
+{{% tab "Crossplane (upstream)" %}}
 
 ## Start with Upstream Crossplane
 
@@ -32,91 +23,74 @@ Installing Crossplane into an existing Kubernetes cluster will require a bit
 more setup, but can provide more flexibility for users who need it.
 
 ### Get a Kubernetes Cluster
+<!-- inside Crossplane (upstream) -->
+{{% tabs "Kubernetes Clusters" %}}
 
-<ul class="nav nav-tabs">
-<li class="active"><a href="#setup-mac-brew" data-toggle="tab">macOS via Homebrew</a></li>
-<li><a href="#setup-mac-linux" data-toggle="tab">macOS / Linux</a></li>
-<li><a href="#setup-windows" data-toggle="tab">Windows</a></li>
-</ul>
-<br>
-<!-- Begin Get Cluster Tabs -->
-<div class="tab-content">
-<!-- Begin MacOS Tab -->
-<div class="tab-pane fade in active" id="setup-mac-brew" markdown="1">
+{{% tab "macOS via Homebrew" %}}
+
 For macOS via Homebrew use the following:
 
-```console
+```bash
 brew upgrade
 brew install kind
 brew install kubectl
 brew install helm
-
 kind create cluster --image kindest/node:v1.23.0 --wait 5m
 ```
-</div>
-<!-- End MacOS Tab -->
+<!-- close "macOS via Homebrew" -->
+{{% /tab  %}}
 
-<!-- Begin Linux Tab -->
-<div class="tab-pane fade" id="setup-mac-linux" markdown="1">
+{{% tab "macOS / Linux" %}}
+
 For macOS / Linux use the following:
 
-* [Kubernetes cluster]
-  * [Kind]
-  * [Minikube], minimum version `v0.28+`
-  * etc.
+* [Kubernetes cluster](https://kubernetes.io/docs/setup/)
+* [Kind](https://kind.sigs.k8s.io/docs/user/quick-start/)
+* [Minikube](https://minikube.sigs.k8s.io/docs/start/), minimum version `v0.28+`
+* etc.
+* [Helm](https://helm.sh/docs/intro/using_helm/), minimum version `v3.0.0+`.
 
-* [Helm], minimum version `v3.0.0+`.
+<!-- close "macOS / Linux" -->
+{{% /tab %}}
 
-</div>
-<!-- End Linux Tab -->
-
-<!-- Begin Windows Tab -->
-<div class="tab-pane fade" id="setup-windows" markdown="1">
+{{% tab "Windows" %}}
 For Windows use the following:
 
-* [Kubernetes cluster]
-  * [Kind]
-  * [Minikube], minimum version `v0.28+`
-  * etc.
+* [Kubernetes cluster](https://kubernetes.io/docs/setup/)
+* [Kind](https://kind.sigs.k8s.io/docs/user/quick-start/)
+* [Minikube](https://minikube.sigs.k8s.io/docs/start/), minimum version `v0.28+`
+* etc.
+* [Helm](https://helm.sh/docs/intro/using_helm/), minimum version `v3.0.0+`.
 
-* [Helm], minimum version `v3.0.0+`.
+<!-- close "Windows" -->
+{{% /tab %}}
 
-</div>
-<!-- End Windows Tab -->
-</div>
-<!-- End Get Cluster Tabs -->
+<!-- close "Kubernetes Clusters" -->
+{{% /tabs %}}
 
 ### Install Crossplane
 
-<ul class="nav nav-tabs">
-<li class="active"><a href="#install-tab-helm3" data-toggle="tab">Helm 3 (stable)</a></li>
-<li><a href="#install-tab-helm3-latest" data-toggle="tab">Helm 3 (latest)</a></li>
-</ul>
-<br>
-<!-- Begin Helm Tabs -->
-<div class="tab-content">
+{{% tabs "install with helm" %}}
 
-<!-- Begin Stable Tab -->
-<div class="tab-pane fade in active" id="install-tab-helm3" markdown="1">
+{{% tab "Helm 3 (stable)" %}}
 Use Helm 3 to install the latest official `stable` release of Crossplane, suitable for community use and testing:
 
-```console
+```bash
 kubectl create namespace crossplane-system
-
 helm repo add crossplane-stable https://charts.crossplane.io/stable
 helm repo update
 
 helm install crossplane --namespace crossplane-system crossplane-stable/crossplane
 ```
 
-</div>
-<!-- End Stable Tab -->
+<!-- close "Helm 3 (stable)" -->
+{{% /tab %}}
 
-<!-- Begin Latest Tab -->
-<div class="tab-pane fade" id="install-tab-helm3-latest" markdown="1">
+{{% tab "Helm 3 (latest)" %}}
+<!-- fold start -->
 Use Helm 3 to install the latest pre-release version of Crossplane:
 
-```console
+```bash
 kubectl create namespace crossplane-system
 
 helm repo add crossplane-master https://charts.crossplane.io/master/
@@ -129,20 +103,18 @@ helm install crossplane --namespace crossplane-system crossplane-master/crosspla
 
 For example:
 
-```console
+```bash
 helm install crossplane --namespace crossplane-system crossplane-master/crossplane \
   --version 0.11.0-rc.100.gbc5d311 --devel
 ```
-
-</div>
-<!-- End Latest Tab -->
-
-</div>
-<!-- End Helm Tabs -->
+<!-- close "Helm 3 (latest)" -->
+{{% /tab %}}
+<!-- close "install with helm" -->
+{{% /tabs %}}
 
 ### Check Crossplane Status
 
-```console
+```bash
 helm list -n crossplane-system
 
 kubectl get all -n crossplane-system
@@ -153,29 +125,18 @@ kubectl get all -n crossplane-system
 The Crossplane CLI extends `kubectl` with functionality to build, push, and
 install [Crossplane packages]:
 
-<ul class="nav nav-tabs">
-<li class="active"><a href="#install-tab-cli" data-toggle="tab">Stable</a></li>
-<li><a href="#install-tab-cli-latest" data-toggle="tab">Latest</a></li>
-</ul>
-<br>
+{{% tabs "crossplane CLI" %}}
 
-<!-- Begin CLI Tabs -->
-<div class="tab-content">
-
-<!-- Begin CLI Stable Tab -->
-<div class="tab-pane fade in active" id="install-tab-cli" markdown="1">
-
-```console
+{{% tab "Stable" %}}
+```bash
 curl -sL https://raw.githubusercontent.com/crossplane/crossplane/master/install.sh | sh
 ```
+<!-- close "Stable" -->
+{{% /tab %}}
 
-</div>
-<!-- End CLI Stable Tab -->
+{{% tab "Latest" %}}
 
-<!-- Begin CLI Latest Tab -->
-<div class="tab-pane fade" id="install-tab-cli-latest" markdown="1">
-
-```console
+```bash
 curl -sL https://raw.githubusercontent.com/crossplane/crossplane/master/install.sh | CHANNEL=master sh
 ```
 
@@ -183,15 +144,14 @@ You may also specify `VERSION` for download if you would like to select a
 specific version from the given release channel. If a version is not specified
 the latest version from the release channel will be used.
 
-```console
+```bash
 curl -sL https://raw.githubusercontent.com/crossplane/crossplane/master/install.sh | CHANNEL=master VERSION=v1.0.0-rc.0.130.g94f34fd3 sh
 ```
+<!-- close "Latest" -->
+{{% /tab %}}
 
-</div>
-<!-- End CLI Latest Tab -->
-
-</div>
-<!-- End CLI tabs -->
+<!-- close "crossplane CLI" -->
+{{% /tabs %}}
 
 ## Select a Getting Started Configuration
 
@@ -222,32 +182,21 @@ single `storageGB` parameter, and creates a connection `Secret` with keys for
 `username`, `password`, and `endpoint`. A `Configuration` exists for each
 provider that can satisfy a `PostgreSQLInstance`. Let's get started!
 
-<ul class="nav nav-tabs">
-<li class="active"><a href="#aws-tab-1" data-toggle="tab">AWS (Default VPC)</a></li>
-<li><a href="#aws-new-tab-1" data-toggle="tab">AWS (New VPC)</a></li>
-<li><a href="#gcp-tab-1" data-toggle="tab">GCP</a></li>
-<li><a href="#azure-tab-1" data-toggle="tab">Azure</a></li>
-</ul>
-<br>
+{{% tabs "getting started" %}}
 
-<!-- Begin Cloud Provider Tabs -->
-<div class="tab-content">
-
-<!-- Begin AWS Default VPC Tab -->
-<div class="tab-pane fade in active" id="aws-tab-1" markdown="1">
-
+{{% tab "AWS (Default VPC)" %}}
 ### Install Configuration Package
 
 > If you prefer to see the contents of this configuration package and how it is
 > constructed prior to install, skip ahead to the [create a configuration]
 > section.
 
-```console
+```bash
 kubectl crossplane install configuration registry.upbound.io/xp/getting-started-with-aws:latest
 ```
 
 Wait until all packages become healthy:
-```
+```bash
 watch kubectl get pkg
 ```
 
@@ -255,13 +204,13 @@ watch kubectl get pkg
 
 Using an AWS account with permissions to manage RDS databases:
 
-```console
+```bash
 AWS_PROFILE=default && echo -e "[default]\naws_access_key_id = $(aws configure get aws_access_key_id --profile $AWS_PROFILE)\naws_secret_access_key = $(aws configure get aws_secret_access_key --profile $AWS_PROFILE)" > creds.conf
 ```
 
 ### Create a Provider Secret
 
-```console
+```bash
 kubectl create secret generic aws-creds -n crossplane-system --from-file=creds=./creds.conf
 ```
 
@@ -283,28 +232,25 @@ spec:
       name: aws-creds
       key: creds
 ```
-```console
+```bash
 kubectl apply -f https://raw.githubusercontent.com/crossplane/crossplane/master/docs/snippets/configure/aws/providerconfig.yaml
 ```
+<!-- close "AWS (Default VPC)" -->
+{{% /tab %}}
 
-</div>
-<!-- End AWS Default VPC Tab -->
-
-<!-- Begin AWS New VPC Tab -->
-<div class="tab-pane fade" id="aws-new-tab-1" markdown="1">
-
+{{% tab "AWS (New VPC)" %}}
 ### Install Configuration Package
 
 > If you prefer to see the contents of this configuration package and how it is
 > constructed prior to install, skip ahead to the [create a configuration]
 > section.
 
-```console
+```bash
 kubectl crossplane install configuration registry.upbound.io/xp/getting-started-with-aws-with-vpc:latest
 ```
 
 Wait until all packages become healthy:
-```
+```bash
 watch kubectl get pkg
 ```
 
@@ -312,13 +258,13 @@ watch kubectl get pkg
 
 Using an AWS account with permissions to manage RDS databases:
 
-```console
+```bash
 AWS_PROFILE=default && echo -e "[default]\naws_access_key_id = $(aws configure get aws_access_key_id --profile $AWS_PROFILE)\naws_secret_access_key = $(aws configure get aws_secret_access_key --profile $AWS_PROFILE)" > creds.conf
 ```
 
 ### Create a Provider Secret
 
-```console
+```bash
 kubectl create secret generic aws-creds -n crossplane-system --from-file=creds=./creds.conf
 ```
 
@@ -340,15 +286,14 @@ spec:
       name: aws-creds
       key: creds
 ```
-```console
+
+```bash
 kubectl apply -f https://raw.githubusercontent.com/crossplane/crossplane/master/docs/snippets/configure/aws/providerconfig.yaml
 ```
+<!-- close "AWS (New VPC)" -->
+{{% /tab %}}
 
-</div>
-<!-- End AWS New VPC Tab -->
-
-<!-- Begin GCP Tab -->
-<div class="tab-pane fade" id="gcp-tab-1" markdown="1">
+{{% tab "GCP" %}}
 
 ### Install Configuration Package
 
@@ -356,7 +301,7 @@ kubectl apply -f https://raw.githubusercontent.com/crossplane/crossplane/master/
 > constructed prior to install, skip ahead to the [create a configuration]
 > section.
 
-```console
+```bash
 kubectl crossplane install configuration registry.upbound.io/xp/getting-started-with-gcp:latest
 ```
 
@@ -367,7 +312,7 @@ watch kubectl get pkg
 
 ### Get GCP Account Keyfile
 
-```console
+```bash
 # replace this with your own gcp project id and the name of the service account
 # that will be created.
 PROJECT_ID=my-project
@@ -391,7 +336,7 @@ gcloud iam service-accounts keys create creds.json --project $PROJECT_ID --iam-a
 
 ### Create a Provider Secret
 
-```console
+```bash
 kubectl create secret generic gcp-creds -n crossplane-system --from-file=creds=./creds.json
 ```
 
@@ -400,7 +345,7 @@ kubectl create secret generic gcp-creds -n crossplane-system --from-file=creds=.
 We will create the following `ProviderConfig` object to configure credentials
 for GCP Provider:
 
-```console
+```bash
 # replace this with your own gcp project id
 PROJECT_ID=my-project
 echo "apiVersion: gcp.crossplane.io/v1beta1
@@ -416,12 +361,10 @@ spec:
       name: gcp-creds
       key: creds" | kubectl apply -f -
 ```
+<!-- close "GCP" -->
+{{% /tab %}}
 
-</div>
-<!-- End GCP Tab -->
-
-<!-- Begin Azure Tab -->
-<div class="tab-pane fade" id="azure-tab-1" markdown="1">
+{{% tab "Azure" %}}
 
 ### Install Configuration Package
 
@@ -429,7 +372,7 @@ spec:
 > constructed prior to install, skip ahead to the [create a configuration]
 > section.
 
-```console
+```bash
 kubectl crossplane install configuration registry.upbound.io/xp/getting-started-with-azure:latest
 ```
 
@@ -440,14 +383,14 @@ watch kubectl get pkg
 
 ### Get Azure Principal Keyfile
 
-```console
+```bash
 # create service principal with Owner role
 az ad sp create-for-rbac --role Contributor --scopes /subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx > "creds.json"
 ```
 
 ### Create a Provider Secret
 
-```console
+```bash
 kubectl create secret generic azure-creds -n crossplane-system --from-file=creds=./creds.json
 ```
 
@@ -470,27 +413,22 @@ spec:
       key: creds
 ```
 
-```console
+```bash
 kubectl apply -f https://raw.githubusercontent.com/crossplane/crossplane/master/docs/snippets/configure/azure/providerconfig.yaml
 ```
+<!-- close "Azure" -->
+{{% /tab %}}
 
-</div>
-<!-- End Azure Tab -->
-
-</div>
-<!-- End Cloud Provider Tabs -->
+{{% /tabs %}}
 
 ## Next Steps
 
 Now that you have configured Crossplane with support for `PostgreSQLInstance`,
 you can [provision infrastructure].
+<!-- close "Crossplane (upstream)" -->
+{{% /tab %}}
 
-</div>
-<!-- End Upstream Tab -->
-
-<!-- Begin Downstream Tab -->
-<div class="tab-pane fade" id="using-a-downstream-distro" markdown="1">
-
+{{% tab "Downstream Distribution" %}}
 ## Start with a Downstream Distribution
 
 Upbound, the founders of Crossplane, maintains a free and open source downstream
@@ -504,11 +442,11 @@ and Configuration packages.
 <i>Want see another hosted Crossplane service listed? Please [reach out on
 Slack][Slack] and our community will highlight it here!</i>
 
-</div>
-<!-- End Downstream Tab -->
+<!-- close "Downstream Distribution" -->
+{{% /tab %}}
 
-</div>
-<!-- End Distro Tabs -->
+<!-- close "Crossplane Distros" -->
+{{% /tabs %}}
 
 ## More Info
 
@@ -523,22 +461,22 @@ Slack][Slack] and our community will highlight it here!</i>
 
 <!-- Named Links -->
 
-[package]: ../concepts/packages.md
-[provision infrastructure]: provision-infrastructure.md
-[create a configuration]: create-configuration.md
-[Install]: ../reference/install.md
-[Configure]: ../reference/configure.md
-[Uninstall]: ../reference/uninstall.md
+[package]: {{<ref "../concepts/packages" >}}
+[provision infrastructure]: {{<ref "provision-infrastructure" >}}
+[create a configuration]: {{<ref "create-configuration" >}}
+[Install]: {{<ref "../reference/install" >}}
+[Configure]: {{<ref "../reference/configure" >}}
+[Uninstall]: {{<ref "../reference/uninstall" >}}
 [Kubernetes cluster]: https://kubernetes.io/docs/setup/
-[Minikube]: https://kubernetes.io/docs/tasks/tools/install-minikube/
-[Helm]:https://docs.helm.sh/using_helm/
+[Minikube]: https://minikube.sigs.k8s.io/docs/start/
+[Helm]:https://helm.sh/docs/intro/using_helm/
 [Kind]: https://kind.sigs.k8s.io/docs/user/quick-start/
-[Crossplane packages]: ../concepts/packages.md
+[Crossplane packages]: {{<ref "../concepts/packages" >}}
 [Slack]: http://slack.crossplane.io/
 [up]: https://github.com/upbound/up
-[Upbound documentation]: https://cloud.upbound.io/docs
-[Providers]: ../concepts/providers.md
-[Universal Crossplane]: https://cloud.upbound.io/docs/uxp
-[Get started with Universal Crossplane]: https://cloud.upbound.io/docs/uxp/install
+[Upbound documentation]: https://https://docs.upbound.io//docs
+[Providers]: {{<ref "../concepts/providers" >}}
+[Universal Crossplane]: https://https://docs.upbound.io/uxp/
+[Get started with Universal Crossplane]: https://docs.upbound.io/uxp/install
 [certified by the CNCF]: https://github.com/cncf/crossplane-conformance
 [Crossplane GitHub]: https://github.com/crossplane/crossplane

--- a/docs/getting-started/provision-infrastructure.md
+++ b/docs/getting-started/provision-infrastructure.md
@@ -1,11 +1,7 @@
 ---
 title: Provision Infrastructure
-toc: true
 weight: 3
-indent: true
 ---
-
-# Provision Infrastructure
 
 Composite resources (XRs) are always cluster scoped - they exist outside of any
 namespace. This allows an XR to represent infrastructure that might be consumed
@@ -278,6 +274,6 @@ own infrastructure APIs.
 <!-- Named Links -->
 
 [Persistent Volumes (PV) and Persistent Volume Claims (PVC)]: https://kubernetes.io/docs/concepts/storage/persistent-volumes/
-[composition]: ../concepts/composition.md
-[setup]: install-configure.md
-[next section]: create-configuration.md
+[composition]: {{<ref "../concepts/composition" >}}
+[setup]: {{<ref "install-configure" >}}
+[next section]: {{<ref "create-configuration" >}}

--- a/docs/guides/_index.md
+++ b/docs/guides/_index.md
@@ -1,10 +1,7 @@
 ---
 title: Guides
-toc: true
 weight: 200
 ---
-
-# Guides
 
 This section contains guides for using Crossplane in specific scenarios or
 alongside other technologies. If you are interested in writing and
@@ -16,14 +13,15 @@ show off [demos] integrating with the projects they work on.
 - [Upgrading to v0.14]
 - [Upgrading to v1.x]
 - [Vault Provider Credential Injection]
-- [Using Managed Resources Directly]
+- 
 
 <!-- Named Links -->
 
 [open an issue]: https://github.com/crossplane/crossplane/issues/new
 [The Binding Status]: https://youtube.com/playlist?list=PL510POnNVaaYFuK-B_SIUrpIonCtLVOzT
 [demos]: https://github.com/crossplane/tbs
-[Upgrading to v0.14]: upgrading-to-v0.14.md
-[Upgrading to v1.x]: upgrading-to-v1.x.md
-[Vault Provider Credential Injection]: vault-injection.md
-[Using Managed Resources Directly]: direct-managed.md
+[Upgrading to v0.14]: {{<ref "upgrading-to-v0.14.md" >}}
+[Upgrading to v1.x]: {{<ref "upgrading-to-v1.x.md" >}}
+[Vault Provider Credential Injection]: {{<ref "vault-injection" >}}
+
+

--- a/docs/guides/argo-cd-crossplane.md
+++ b/docs/guides/argo-cd-crossplane.md
@@ -1,14 +1,8 @@
 ---  
-title: Argo CD
-toc: true  
-weight: 270  
-indent: true  
+title: Configuring Crossplane with Argo CD
+weight: 270
 ---  
 
-# Configuring Crossplane with Argo CD
- 
-## Overview
- 
 [Argo CD](https://argoproj.github.io/cd/) and [Crossplane](https://crossplane.io)
 are a great combination. Argo CD provides GitOps while Crossplane turns any Kubernetes
 cluster into a Universal Control Plane for all of your resources. There are

--- a/docs/guides/composition-revisions.md
+++ b/docs/guides/composition-revisions.md
@@ -1,11 +1,6 @@
 ---
 title: Composition Revisions
-toc: true
-weight: 260
-indent: true
 ---
-
-# Composition Revisions
 
 This guide discusses the use of "Composition Revisions" to safely make and roll
 back changes to a Crossplane [`Composition`][composition-type]. It assumes
@@ -152,7 +147,7 @@ spec:
     name: db-conn
 ```
 
-[composition-type]: ../concepts/composition.md
-[composition-term]: ../concepts/terminology.md#composition
+[composition-type]: {{<ref "../concepts/composition" >}}
+[composition-term]: {{<ref "../concepts/terminology" >}}#composition
 [canary]: https://martinfowler.com/bliki/CanaryRelease.html
-[install-guide]: ../getting-started/install-configure.md
+[install-guide]: {{<ref "../getting-started/install-configure" >}}

--- a/docs/guides/multi-tenant.md
+++ b/docs/guides/multi-tenant.md
@@ -1,11 +1,7 @@
 ---
 title: Multi-Tenant Crossplane
-toc: true
 weight: 240
-indent: true
 ---
-
-# Multi-Tenant Crossplane
 
 This guide describes how to use Crossplane effectively in multi-tenant
 environments by utilizing Kubernetes primitives and compatible policy
@@ -25,14 +21,15 @@ those with more complex environments, may choose to incorporate third-party
 policy engines, or scale to multiple Crossplane clusters. The following sections
 describe each of these scenarios in greater detail.
 
+- [TL;DR](#tldr)
 - [Background](#background)
-    - [Cluster Scoped Managed Resources](#cluster-scoped-managed-resources)
-    - [Namespace Scoped Claims](#namespace-scoped-claims)
-- [Single Cluster Multi Tenancy](#single-cluster-multi-tenancy)
+  - [Cluster-Scoped Managed Resources](#cluster-scoped-managed-resources)
+  - [Namespace Scoped Claims](#namespace-scoped-claims)
+- [Single Cluster Multi-Tenancy](#single-cluster-multi-tenancy)
   - [Composition as an Isolation Mechanism](#composition-as-an-isolation-mechanism)
   - [Namespaces as an Isolation Mechanism](#namespaces-as-an-isolation-mechanism)
   - [Policy Enforcement with Open Policy Agent](#policy-enforcement-with-open-policy-agent)
-- [Multi Cluster Multi Tenancy](#multi-cluster-multi-tenancy)
+- [Multi-Cluster Multi-Tenancy](#multi-cluster-multi-tenancy)
   - [Reproducible Platforms with Configuration Packages](#reproducible-platforms-with-configuration-packages)
   - [Control Plane of Control Planes](#control-plane-of-control-planes)
   - [Service Provisioning using Open Service Broker API](#service-provisioning-using-open-service-broker-api)
@@ -321,19 +318,19 @@ found under [vshn/application-catalog-demo].
 This way even a tight integration of Crossplane in to [Cloudfoundry] is possible.
 
 <!-- Named Links -->
-[managed resources]: ../concepts/managed-resources.md
+[managed resources]: {{<ref "../concepts/managed-resources" >}}
 [RBAC]: https://kubernetes.io/docs/reference/access-authn-authz/rbac/
-[Composition]: ../concepts/composition.md
+[Composition]: {{<ref "../concepts/composition" >}}
 [CustomResourceDefinitions]: https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/
 [Open Policy Agent]: https://www.openpolicyagent.org/
 [Rego]: https://www.openpolicyagent.org/docs/latest/policy-language/
 [Gatekeeper]: https://open-policy-agent.github.io/gatekeeper/website/docs/
 [here]: https://youtu.be/TaF0_syejXc
 [Multiple Source Field patching]: https://github.com/crossplane/crossplane/pull/2093
-[Configuration packages]: ../concepts/packages.md
+[Configuration packages]: {{<ref "../concepts/packages" >}}
 [OCI images]: https://github.com/opencontainers/image-spec
 [EKS Cluster]: https://doc.crds.dev/github.com/crossplane/provider-aws/eks.aws.crossplane.io/Cluster/v1beta1@v0.17.0
-[provider-aws]: https://github.com/crossplane/provider-aws
+[provider-aws]: https://github.com/crossplane-contrib/provider-aws
 [provider-helm]: https://github.com/crossplane-contrib/provider-helm
 [Open Service Broker API]: https://github.com/openservicebrokerapi/servicebroker
 [Crossplane Service Broker]: https://github.com/vshn/crossplane-service-broker

--- a/docs/guides/self-signed-ca-certs.md
+++ b/docs/guides/self-signed-ca-certs.md
@@ -1,13 +1,9 @@
 ---  
-title: Self-Signed CA Certs 
-toc: true  
-weight: 270  
-indent: true  
+title: Self-Signed CA Certs
+weight: 270   
 ---  
 
-# Overview of Crossplane for Registry with Self-Signed CA Certificate  
-
-> ! Using self-signed certificates is not advised in production, it is 
+>  Using self-signed certificates is not advised in production, it is 
 recommended to only use self-signed certificates for testing.
 
 When Crossplane loads Configuration and Provider Packages from private 
@@ -15,7 +11,7 @@ registries, it must be configured to trust the CA and Intermediate certs.
 
 Crossplane needs to be installed via the Helm chart with the 
 `registryCaBundleConfig.name` and `registryCaBundleConfig.key` parameters 
-defined. See [Install Crossplane].
+defined. See [Install Crossplane]({{<ref "../getting-started/install-configure" >}}).
 
 ## Configure
 
@@ -51,6 +47,3 @@ in an `override.yaml` file would look like this:
     name: ca-bundle-config
     key: ca-bundle
 ```
-
-
-[Install Crossplane]: ../reference/install.md

--- a/docs/guides/upgrading-to-v0.14.md
+++ b/docs/guides/upgrading-to-v0.14.md
@@ -1,11 +1,7 @@
 ---
 title: Upgrading to v0.14
-toc: true
 weight: 210
-indent: true
 ---
-
-# Upgrading to v0.14
 
 Crossplane made a small handful of breaking changes in v0.14. The most broadly
 impactful change was updating the `CompositeResourceDefinition` (XRD) schema to

--- a/docs/guides/upgrading-to-v1.x.md
+++ b/docs/guides/upgrading-to-v1.x.md
@@ -1,11 +1,7 @@
 ---
 title: Upgrading to v1.x
-toc: true
 weight: 220
-indent: true
 ---
-
-# Upgrading to v1.x
 
 Crossplane versions post v1.0 do not introduce any breaking changes, but may
 make some backward compatible changes to the core Crossplane CRDs. Helm [does

--- a/docs/guides/vault-as-secret-store.md
+++ b/docs/guides/vault-as-secret-store.md
@@ -1,11 +1,7 @@
 ---
 title: Vault as an External Secret Store 
-toc: true
 weight: 230
-indent: true
 ---
-
-# Using Vault as an External Secret Store
 
 This guide walks through the steps required to configure Crossplane and
 its Providers to use [Vault] as an [External Secret Store]. For the sake of
@@ -479,7 +475,7 @@ kubectl -n default delete claim my-ess
 
 [Vault]: https://www.vaultproject.io/
 [External Secret Store]: https://github.com/crossplane/crossplane/blob/master/design/design-doc-external-secret-stores.md
-[the previous guide]: vault-injection.md
+[the previous guide]: {{<ref "vault-injection" >}}
 [this issue]: https://github.com/crossplane/crossplane/issues/2985
 [Kubernetes Auth Method]: https://www.vaultproject.io/docs/auth/kubernetes
 [Unseal]: https://www.vaultproject.io/docs/concepts/seal

--- a/docs/guides/vault-injection.md
+++ b/docs/guides/vault-injection.md
@@ -1,11 +1,8 @@
 ---
 title: Vault Credential Injection
-toc: true
 weight: 230
-indent: true
 ---
 
-# Using Vault for Provider Credentials
 
 > This guide is adapted from the [Vault on Minikube] and [Vault Kubernetes
 > Sidecar] guides.

--- a/docs/media/README.md
+++ b/docs/media/README.md
@@ -1,3 +1,6 @@
+---
+toc_hide: true 
+---
 # Crossplane Documentation Media
 
 The sources of the images in this file are:

--- a/docs/reference/_index.md
+++ b/docs/reference/_index.md
@@ -1,10 +1,7 @@
 ---
 title: Reference
-toc: true
 weight: 300
 ---
-
-# Overview
 
 The reference documentation includes answers to frequently asked questions,
 information about similar projects, and links to resources that can help you
@@ -13,16 +10,16 @@ that you think would be valuable for the community, please feel free to [open a
 pull request] and add it.
 
 1. [Install]
-1. [Configure]
-1. [Uninstall]
-1. [Troubleshoot]
-1. [Learn More]
+2. [Configure]
+3. [Uninstall]
+4. [Troubleshoot]
+5. [Learn More]
 
 <!-- Named Links -->
 
 [open a pull request]: https://github.com/crossplane/crossplane/compare
-[Install]: install.md
-[Configure]: configure.md
-[Uninstall]: uninstall.md
-[Troubleshoot]: troubleshoot.md
-[Learn More]: learn_more.md
+[Install]: {{<ref "install" >}}
+[Configure]: {{<ref "configure" >}}
+[Uninstall]: {{<ref "uninstall" >}}
+[Troubleshoot]: {{<ref "troubleshoot" >}}
+[Learn More]: {{<ref "learn_more" >}}

--- a/docs/reference/composition.md
+++ b/docs/reference/composition.md
@@ -1,11 +1,8 @@
 ---
 title: Composition
-toc: true
 weight: 304
-indent: true
 ---
 
-# Overview
 
 This reference provides detailed examples of defining, configuring, and using
 Composite Resources in Crossplane. You can also refer to Crossplane's [API
@@ -829,14 +826,14 @@ so:
 1. Use a `FromCompositeFieldPath` patch to patch from the 'intermediary' field
    you patched to in step 1 to a field on the destination composed resource.
 
-[api-docs]: ../api-docs/crossplane.md
-[xr-concepts]: ../concepts/composition.md
+[api-docs]: {{<ref "../api-docs/crossplane" >}}
+[xr-concepts]: {{<ref "../concepts/composition" >}}
 [crd-docs]: https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/
 [raise an issue]: https://github.com/crossplane/crossplane/issues/new?assignees=&labels=enhancement&template=feature_request.md
 [issue-2524]: https://github.com/crossplane/crossplane/issues/2524
-[field-paths]:  https://github.com/kubernetes/community/blob/61f3d0/contributors/devel/sig-architecture/api-conventions.md#selecting-fields
-[pkg/fmt]: https://golang.org/pkg/fmt/
-[trouble-ref]: troubleshoot.md
+[field-paths]: https://github.com/kubernetes/community/blob/61f3d0/contributors/devel/sig-architecture/api-conventions.md#selecting-fields
+[pkg/fmt]: https://pkg.go.dev/fmt
+[trouble-ref]: {{<ref "troubleshoot" >}}
 [crossplane-contrib]: https://github.com/crossplane-contrib
 [helm-and-gcp]: https://github.com/crossplane-contrib/provider-helm/blob/2dcbdd0/examples/in-composition/composition.yaml
 [issue-2024]: https://github.com/crossplane/crossplane/issues/2024

--- a/docs/reference/configure.md
+++ b/docs/reference/configure.md
@@ -1,11 +1,7 @@
 ---
-title: Configure
-toc: true
+title: Configure Your Cloud Provider Account
 weight: 302
-indent: true
 ---
-
-# Configure Your Cloud Provider Account
 
 In order for Crossplane to be able to manage resources in a specific cloud
 provider, you will need to create an account for Crossplane to use. Use the
@@ -21,6 +17,6 @@ provisioning resources!
 
 <!-- Named Links -->
 
-[Google Cloud Platform (GCP) Service Account]: ../cloud-providers/gcp/gcp-provider.md
-[Microsoft Azure Service Principal]: ../cloud-providers/azure/azure-provider.md
-[Amazon Web Services (AWS) IAM User]: ../cloud-providers/aws/aws-provider.md
+[Google Cloud Platform (GCP) Service Account]: {{<ref "../cloud-providers/gcp/gcp-provider" >}}
+[Microsoft Azure Service Principal]: {{<ref "../cloud-providers/azure/azure-provider" >}}
+[Amazon Web Services (AWS) IAM User]: {{<ref "../cloud-providers/aws/aws-provider" >}}

--- a/docs/reference/install.md
+++ b/docs/reference/install.md
@@ -5,6 +5,10 @@ weight: 301
 
 Crossplane can be easily installed into any existing Kubernetes cluster using
 the regularly published Helm chart. The Helm chart contains all the custom
+
+
+Crossplane can be easily installed into any existing Kubernetes cluster using
+the regularly published Helm chart. The Helm chart contains all the custom
 resources and controllers needed to deploy and configure Crossplane.
 
 ## Pre-requisites
@@ -158,5 +162,5 @@ imagePullSecrets:
 <!-- Named Links -->
 
 [Kubernetes cluster]: https://kubernetes.io/docs/setup/
-[Minikube]: https://minikube.sigs.k8s.io/docs/start/
-[Helm]: https://helm.sh/docs/intro/using_helm/
+[Minikube]: https://kubernetes.io/docs/tasks/tools/install-minikube/
+[Helm]: https://docs.helm.sh/using_helm/

--- a/docs/reference/install.md
+++ b/docs/reference/install.md
@@ -1,11 +1,7 @@
 ---
-title: Install
-toc: true
+title: Install Crossplane
 weight: 301
-indent: true
 ---
-
-# Install Crossplane
 
 Crossplane can be easily installed into any existing Kubernetes cluster using
 the regularly published Helm chart. The Helm chart contains all the custom
@@ -162,5 +158,5 @@ imagePullSecrets:
 <!-- Named Links -->
 
 [Kubernetes cluster]: https://kubernetes.io/docs/setup/
-[Minikube]: https://kubernetes.io/docs/tasks/tools/install-minikube/
-[Helm]: https://docs.helm.sh/using_helm/
+[Minikube]: https://minikube.sigs.k8s.io/docs/start/
+[Helm]: https://helm.sh/docs/intro/using_helm/

--- a/docs/reference/learn_more.md
+++ b/docs/reference/learn_more.md
@@ -1,11 +1,7 @@
 ---
 title: Learn More
-toc: true
 weight: 307
-indent: true
 ---
-
-# Learn More
 
 If you have any questions, please drop us a note on [Crossplane Slack][join-crossplane-slack] or [contact us][contact-us]!
 

--- a/docs/reference/release-cycle.md
+++ b/docs/reference/release-cycle.md
@@ -1,11 +1,7 @@
 ---
 title: Release Cycle
-toc: true
 weight: 308
-indent: true
 ---
-
-# Release Cycle
 
 Starting with the v1.10.0 release, Crossplane is released on a quarterly (13
 week) cadence. A cycle is comprised of three general stages:

--- a/docs/reference/troubleshoot.md
+++ b/docs/reference/troubleshoot.md
@@ -1,11 +1,7 @@
 ---
 title: Troubleshoot
-toc: true
 weight: 306
-indent: true
 ---
-
-# Troubleshooting
 
 * [Requested Resource Not Found]
 * [Resource Status and Conditions]
@@ -281,7 +277,7 @@ spec:
 <!-- Named Links -->
 
 [Requested Resource Not Found]: #requested-resource-not-found
-[install Crossplane CLI]: ../getting-started/install-configure.md#install-crossplane-cli
+[install Crossplane CLI]: {{<ref "../getting-started/install-configure" >}}#install-crossplane-cli
 [Resource Status and Conditions]: #resource-status-and-conditions
 [Resource Events]: #resource-events
 [Crossplane Logs]: #crossplane-logs
@@ -290,6 +286,6 @@ spec:
 [Pausing Providers]: #pausing-providers
 [Deleting When a Resource Hangs]: #deleting-when-a-resource-hangs
 [Installing Crossplane Package]: #installing-crossplane-package
-[Crossplane package]: https://crossplane.io/docs/v1.3/concepts/packages.html
+[Crossplane package]: {{<ref "../concepts/packages" >}}
 [Handling Crossplane Package Dependency]: #handling-crossplane-package-dependency
 [semver spec]: https://github.com/Masterminds/semver#basic-comparisons

--- a/docs/reference/uninstall.md
+++ b/docs/reference/uninstall.md
@@ -1,11 +1,7 @@
 ---
-title: Uninstall
-toc: true
+title: Uninstall Crossplane
 weight: 303
-indent: true
 ---
-
-# Uninstalling
 
 Crossplane has a number of components that must be cleaned up in order to
 guarantee proper removal from the cluster. When deleting objects, it is best to
@@ -88,4 +84,4 @@ kubectl get crd -o name | grep crossplane.io | xargs kubectl delete
 <!-- Named Links -->
 
 [finalizers]: https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#finalizers
-[troubleshooting guide]: troubleshoot.md
+[troubleshooting guide]: {{<ref "troubleshoot" >}}

--- a/docs/reference/xpkg.md
+++ b/docs/reference/xpkg.md
@@ -1,11 +1,7 @@
 ---
 title: xpkg Specification
-toc: true
 weight: 305
-indent: true
 ---
-
-# Overview
 
 Crossplane supports two types of [packages]: Providers and Configurations. These
 packages are distributed as generic [OCI images], which contain [YAML] content
@@ -201,7 +197,7 @@ unmodified.
 
 <!-- Named Links -->
 
-[packages]: ../concepts/packages.md
+[packages]: {{<ref "../concepts/packages" >}}
 [OCI images]: https://github.com/opencontainers/image-spec
 [OCI image specification]: https://github.com/opencontainers/image-spec/blob/main/spec.md
 [YAML]: https://yaml.org/spec/1.2.2/


### PR DESCRIPTION
### Description of your changes

The work to migrate crossplane.github.io to Hugo has been completed in the site repo [PR #151](https://github.com/crossplane/crossplane.github.io/pull/151).

The content of the docs is pushed from /docs into the site repo via Make.

This PR provides the following updates:
1. Updates Makefile to use the correct directory for Hugo content (`/content`)
2. Updates all of the existing docs content to comply with Hugo's metadata (called `frontmatter`) and content organization expectations. This mainly involves moving files from `Overview.md` to `_index.md` at the root of all directories.
3. Creates a docs contributing guide to detail how to use Hugo, how we use `frontmatter` and our CoC and community guidelines. (in `docs/contributing/docs.md`)

I also verified that no changes seem to be required to`/build`.

Fixes # https://github.com/crossplane/crossplane.github.io/issues/149

This will need to be merged shortly after the site PR is merged.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested
Tested through manual verification in a Hugo environment. 

The changes to `Makefile` **haven't** been tested.

[contribution process]: https://git.io/fj2m9
