### PR TITLE
Drop default imagePullSecret dockerhub

### DIFF
--- a/cluster/charts/crossplane/values.yaml.tmpl
+++ b/cluster/charts/crossplane/values.yaml.tmpl
@@ -30,8 +30,7 @@ provider:
 configuration:
   packages: []
 
-imagePullSecrets:
-- dockerhub
+imagePullSecrets: {}
 
 registryCaBundleConfig: {}
 


### PR DESCRIPTION


<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Drops the default imagePullSecret named dockerhub that is set on the Crossplane ServiceAccount. We don't install a secret named dockerhub and it now causes package install to fail because the image fetcher cannot find the dockerhub secret to pull with.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

I verified this by running the e2e tests that are currently failing (https://github.com/crossplane/test/actions/runs/3105330470/jobs/5030815289) across a local build with this change.

Previously they were failing due to:

```
Events:
  Type     Reason         Age               From                                 Message
  ----     ------         ----              ----                                 -------
  Warning  UnpackPackage  1s (x5 over 16s)  packages/provider.pkg.crossplane.io  cannot unpack package: failed to fetch package digest from remote: secrets "dockerhub" not found
```

[contribution process]: https://git.io/fj2m9
