### PR TITLE
Use aggregation in ClusterRole of Crossplane only if rbac-manager is deployed

### DIFF
--- a/cluster/charts/crossplane/templates/clusterrole.yaml
+++ b/cluster/charts/crossplane/templates/clusterrole.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: {{ template "crossplane.name" . }}
     {{- include "crossplane.labels" . | indent 4 }}
+{{- if .Values.rbacManager.deploy }}
 aggregationRule:
   clusterRoleSelectors:
   - matchLabels:
@@ -19,6 +20,7 @@ metadata:
     {{- include "crossplane.labels" . | indent 4 }}
     crossplane.io/scope: "system"
     rbac.crossplane.io/aggregate-to-crossplane: "true"
+{{- end }}
 rules:
 - apiGroups:
   - ""


### PR DESCRIPTION
### Description of your changes

Currently, rbac-manager deals with all `ClusterRole`s that Crossplane and providers need to have for CRDs introduced during installation and runtime, i.e. CRDs created for XRDs and CRDs of installed providers. The mechanism it does all that is role aggregation, which requires elevated permissions for the rbac-manager.

We have an option to disable rbac-manager for folks who'd like to be super strict about how they manage their RBAC, hence `rbacManager.deploy` option. However, even when this is `false`, we have one remaining `ClusterRole` that does role aggregation, which is Crossplane's `ClusterRole` itself. If rbac-manager is not deployed, then there is no other `ClusterRole`s to be aggregated to the original one other then the static one in the Helm chart. So, this change proposes that we use aggregation on that `ClusterRole` only if rbac-manager is deployed so that Crossplane doesn't require elevated permissions required by aggregation when we can get away with static `ClusterRole` definition.

Related to https://github.com/crossplane/crossplane/issues/3339

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

Manually tested via `helm install --set rbacManager.deploy=false` and saw that it was able to install CRDs and provider, which is what that main `ClusterRole` allows it to do, so it's effective.

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
