### PR TITLE
Add note recommending usage of SPDX License Identifiers

### DIFF
--- a/docs/reference/xpkg.md
+++ b/docs/reference/xpkg.md
@@ -186,7 +186,7 @@ annotations by third-party consumers of Crossplane packages:
 - `meta.crossplane.io/source`: The URL at which the package's source can be
   found.
 - `meta.crossplane.io/license`: The license under which the package's source is
-  released.
+  released. This should be a valid [SPDX License Identifier].
 - `meta.crossplane.io/description`: A one sentence description of the package.
 - `meta.crossplane.io/readme`: A longer description, documentation, etc.
 
@@ -212,3 +212,4 @@ unmodified.
 [index]: https://github.com/opencontainers/image-spec/blob/main/image-index.md
 [annotation]: https://github.com/opencontainers/image-spec/blob/main/annotations.md
 [applying changesets]: https://github.com/opencontainers/image-spec/blob/main/layer.md#applying-changesets
+[SPDX License Identifier]: https://spdx.org/licenses/


### PR DESCRIPTION


<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Adds a note to the xpkg specification recommending that an SPDX License Identifier be used for the license annotation. This is not strictly required because it is not expected that tooling will reject a package that uses a non-valid SPDX License Identifier.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

Verified link renders correctly.

[contribution process]: https://git.io/fj2m9
