### PR TITLE
composite: use the new patch generation mechanism for patching existi…

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/crossplane/crossplane
 
 go 1.19
 
+replace github.com/crossplane/crossplane-runtime => github.com/muvaf/crossplane-runtime v0.0.0-20220929140930-33aa0b053273
+
 require (
 	github.com/Masterminds/semver v1.5.0
 	github.com/alecthomas/kong v0.2.17

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/crossplane/crossplane
 
 go 1.19
 
-replace github.com/crossplane/crossplane-runtime => github.com/muvaf/crossplane-runtime v0.0.0-20220929140930-33aa0b053273
+replace github.com/crossplane/crossplane-runtime => github.com/muvaf/crossplane-runtime v0.0.0-20220929183136-ef774452565e
 
 require (
 	github.com/Masterminds/semver v1.5.0

--- a/go.sum
+++ b/go.sum
@@ -776,8 +776,8 @@ github.com/mozilla/tls-observatory v0.0.0-20210609171429-7bc42856d2e5/go.mod h1:
 github.com/munnerz/goautoneg v0.0.0-20120707110453-a547fc61f48d/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
-github.com/muvaf/crossplane-runtime v0.0.0-20220929140930-33aa0b053273 h1:P6g+g92kKSejZLWtUwRYKeZEirgKtnq8OYjImOIi5jw=
-github.com/muvaf/crossplane-runtime v0.0.0-20220929140930-33aa0b053273/go.mod h1:o9ExoilV6k2M3qzSFoRVX4phuww0mLmjs1WrDTvsR4s=
+github.com/muvaf/crossplane-runtime v0.0.0-20220929183136-ef774452565e h1:bcWenje6JxfK5C3wnRpOxX03gftmtu7XylcwyCwWqAE=
+github.com/muvaf/crossplane-runtime v0.0.0-20220929183136-ef774452565e/go.mod h1:o9ExoilV6k2M3qzSFoRVX4phuww0mLmjs1WrDTvsR4s=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/mwitkow/go-proto-validators v0.0.0-20180403085117-0950a7990007/go.mod h1:m2XC9Qq0AlmmVksL6FktJCdTYyLk7V3fKyp0sl1yWQo=

--- a/go.sum
+++ b/go.sum
@@ -248,8 +248,6 @@ github.com/cpuguy83/go-md2man/v2 v2.0.1/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46t
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/creack/pty v1.1.11/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
-github.com/crossplane/crossplane-runtime v0.18.0-rc.0.0.20220722162506-9ea84ae53615 h1:QmfuKDoB8gXZfoo8ghPx/1z/xg8kOtyP+nYto1IFl/0=
-github.com/crossplane/crossplane-runtime v0.18.0-rc.0.0.20220722162506-9ea84ae53615/go.mod h1:o9ExoilV6k2M3qzSFoRVX4phuww0mLmjs1WrDTvsR4s=
 github.com/daixiang0/gci v0.2.9/go.mod h1:+4dZ7TISfSmqfAGv59ePaHfNzgGtIkHAhhdKggP1JAc=
 github.com/danieljoos/wincred v1.1.0/go.mod h1:XYlo+eRTsVA9aHGp7NGjFkPla4m+DCL7hqDjlFjiygg=
 github.com/davecgh/go-spew v0.0.0-20161028175848-04cdfd42973b/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -778,6 +776,8 @@ github.com/mozilla/tls-observatory v0.0.0-20210609171429-7bc42856d2e5/go.mod h1:
 github.com/munnerz/goautoneg v0.0.0-20120707110453-a547fc61f48d/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
+github.com/muvaf/crossplane-runtime v0.0.0-20220929140930-33aa0b053273 h1:P6g+g92kKSejZLWtUwRYKeZEirgKtnq8OYjImOIi5jw=
+github.com/muvaf/crossplane-runtime v0.0.0-20220929140930-33aa0b053273/go.mod h1:o9ExoilV6k2M3qzSFoRVX4phuww0mLmjs1WrDTvsR4s=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/mwitkow/go-proto-validators v0.0.0-20180403085117-0950a7990007/go.mod h1:m2XC9Qq0AlmmVksL6FktJCdTYyLk7V3fKyp0sl1yWQo=

--- a/internal/controller/apiextensions/composite/composed.go
+++ b/internal/controller/apiextensions/composite/composed.go
@@ -321,8 +321,14 @@ func (r *APIDryRunRenderer) Render(ctx context.Context, cp resource.Composite, c
 	name := cd.GetName()
 	namespace := cd.GetNamespace()
 
-	if err := json.Unmarshal(t.Base.Raw, cd); err != nil {
-		return errors.Wrap(err, errUnmarshal)
+	fps, err := resource.GeneratePatchesFromRaw(t.Base.Raw)
+	if err != nil {
+		return errors.Wrap(err, "cannot generate patches for the base composed object")
+	}
+
+	// TODO(muvaf): Handle the type conversion better.
+	if err := fps.Apply(cd.(*composed.Unstructured).GetUnstructured()); err != nil {
+		return errors.Wrap(err, "cannot apply field patches from raw base")
 	}
 
 	// We think this composed resource exists, but when we rendered its template

--- a/internal/controller/apiextensions/composite/composed.go
+++ b/internal/controller/apiextensions/composite/composed.go
@@ -321,14 +321,8 @@ func (r *APIDryRunRenderer) Render(ctx context.Context, cp resource.Composite, c
 	name := cd.GetName()
 	namespace := cd.GetNamespace()
 
-	fps, err := resource.GeneratePatchesFromRaw(t.Base.Raw)
-	if err != nil {
-		return errors.Wrap(err, "cannot generate patches for the base composed object")
-	}
-
-	// TODO(muvaf): Handle the type conversion better.
-	if err := fps.Apply(cd.(*composed.Unstructured).GetUnstructured()); err != nil {
-		return errors.Wrap(err, "cannot apply field patches from raw base")
+	if err := json.Unmarshal(t.Base.Raw, cd); err != nil {
+		return errors.Wrap(err, errUnmarshal)
 	}
 
 	// We think this composed resource exists, but when we rendered its template


### PR DESCRIPTION
### Description of your changes

Another experiment for https://github.com/crossplane/crossplane/issues/3335 . This one uses `UPDATE` instead of patching and to enable this, it uses the new utility from https://github.com/crossplane/crossplane-runtime/pull/359 to generate a set of field patch statements to apply onto the existing resources before the composition patches so that we don't have to start from base raw template and be forced to use `PATCH/PUT`.

I have:

- [ ] Read and followed Crossplane's [contribution process].
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
