### PR TITLE
Add support for a pause annotation on composite resources & claims, which pauses reconciliations

### DIFF
--- a/design/one-pager-managed-resource-api-design.md
+++ b/design/one-pager-managed-resource-api-design.md
@@ -24,6 +24,9 @@
 * 1.4 - Muvaffak Onus (@muvaf)
   * Expanded [immutability section](#immutable-properties) to cover selector fields..
   * Updated [labelling section](#external-resource-labeling) with current implementation.
+* 1.5 - Alper Rifat Ulucinar (@ulucinar)
+  * Added a new section on the [pause annotation](#pause-annotation) for
+  the managed resources.
 
 ## Terminology
 
@@ -667,6 +670,24 @@ type SubnetworkParameters struct {
 }
 ```
 
+### Pause Annotation
+Managed resources, which are reconciled with the [managed reconciler], support
+a special annotation named `crossplane.io/paused`. If a managed resource has
+this annotation with the value `true` such as the following resource:
+```yaml
+apiVersion: ec2.aws.upbound.io/v1beta1
+kind: VPC
+metadata:
+  name: paused-vpc
+  annotations:
+    crossplane.io/paused: "true"
+...
+```
+, then further reconciliations on the managed resource will be paused after
+emitting an event with the type `Synced`, the status `False`,
+and the reason `ReconcilePaused`. Reconciliations will resume when
+this annotation is removed, or set to some other value than `true`.
+
 ## Future Considerations
 
 ### Spec and Observation Drifts
@@ -688,3 +709,4 @@ one of the `Condition`s we already have or add a new one.
 [terminology]: https://github.com/crossplane/crossplane/blob/master/docs/concepts/terminology.md
 [from crossplane-runtime]: https://github.com/crossplane/crossplane-runtime/blob/ca4b6b4/apis/core/v1alpha1/resource.go#L77
 [Kubernetes API Conventions - Spec and Status]: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+[managed reconciler]: https://github.com/crossplane/crossplane-runtime/blob/84e629b9589852df1322ff1eae4c6e7639cf6e99/pkg/reconciler/managed/reconciler.go#L637

--- a/docs/concepts/managed-resources.md
+++ b/docs/concepts/managed-resources.md
@@ -316,6 +316,25 @@ never deletes the external resource in the provider.
 > means Crossplane will allow immutable fields to be changed, but will not
 > actually make the desired change. This is tracked in [this issue][issue-727].
 
+#### Pausing Reconciliations
+If a managed resource being reconciled by the [managed reconciler], has the
+`crossplane.io/paused` annotation with its value set to `true` as in the
+following example, then further reconciliations are paused on that resource
+after emitting an event with the type `Synced`, the status `False`,
+and the reason `ReconcilePaused`:
+```yaml
+apiVersion: ec2.aws.upbound.io/v1beta1
+kind: VPC
+metadata:
+  name: paused-vpc
+  annotations:
+    crossplane.io/paused: "true"
+...
+```
+Reconciliations on the managed resource will resume once the 
+`crossplane.io/paused` annotation is removed or its value is set
+to anything other than `true`.
+
 ### External Name
 
 By default the name of the managed resource is used as the name of the external
@@ -468,3 +487,4 @@ including Velero.
 [issue-727]: https://github.com/crossplane/crossplane/issues/727
 [issue-1143]: https://github.com/crossplane/crossplane/issues/1143
 [managed-api-patterns]: https://github.com/crossplane/crossplane/blob/master/design/one-pager-managed-resource-api-design.md
+[managed reconciler]: https://github.com/crossplane/crossplane-runtime/blob/84e629b9589852df1322ff1eae4c6e7639cf6e99/pkg/reconciler/managed/reconciler.go#L637

--- a/docs/reference/composition.md
+++ b/docs/reference/composition.md
@@ -376,6 +376,45 @@ spec:
       fromFieldPath: metadata.labels[some-important-label]
 ```
 
+### Pause Annotation
+There is an annotation named `crossplane.io/paused` that you can use on
+Composite Resources and Composite Resource Claims to temporarily pause
+reconciliations of their respective controllers on them. An example
+for a Composite Resource Claim is as follows:
+```yaml
+apiVersion: test.com/v1alpha1
+kind: MyResource
+metadata:
+  annotations:
+     crossplane.io/paused: true
+  namespace: upbound-system
+  name: my-resource
+spec:
+  parameters:
+    tagValue: demo-test
+  compositionRef:
+    name: example
+```
+where `MyResource` is a Composite Resource Claim kind.
+When a Composite Resource or a Claim has the `crossplane.io/paused` annotation
+with its value set to `true`, the Composite Resource controller or the Claim
+controller pauses reconciliations on the resource until
+the annotation is removed or its value set to something other than `true`.
+Before temporarily pausing reconciliations, an event with the type `Synced`,
+the status `False`, and the reason `ReconcilePaused` is emitted
+on the resource.
+Please also note that annotations on a Composite Resource Claim are propagated
+to the associated Composite Resource but when the
+`crossplane.io/paused: true` annotation is added to a Claim, because
+reconciliations on the Claim are now paused, this newly added annotation
+will not be propagated. However, whenever the annotation's value is set to a
+non-`true` value, reconciliations on the Claim will now resume, and thus the
+annotation will now be propagated to the associated Composite Resource
+with a non-`true` value. An implication of the described behavior is that
+pausing reconciliations on the Claim will not inherently pause reconciliations
+on the associated Composite Resource.
+
+
 ### Patch Types
 
 You can use the following types of patch in a `Composition`:

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.19
 require (
 	github.com/Masterminds/semver v1.5.0
 	github.com/alecthomas/kong v0.2.17
-	github.com/crossplane/crossplane-runtime v0.18.0-rc.0.0.20220722162506-9ea84ae53615
+	github.com/crossplane/crossplane-runtime v0.19.0-rc.0.0.20220930073209-84e629b95898
 	github.com/google/go-cmp v0.5.8
 	github.com/google/go-containerregistry v0.9.0
 	github.com/google/go-containerregistry/pkg/authn/k8schain v0.0.0-20220517194345-84eb52633e96

--- a/go.sum
+++ b/go.sum
@@ -248,10 +248,6 @@ github.com/cpuguy83/go-md2man/v2 v2.0.1/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46t
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/creack/pty v1.1.11/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
-github.com/crossplane/crossplane-runtime v0.18.0-rc.0.0.20220722162506-9ea84ae53615 h1:QmfuKDoB8gXZfoo8ghPx/1z/xg8kOtyP+nYto1IFl/0=
-github.com/crossplane/crossplane-runtime v0.18.0-rc.0.0.20220722162506-9ea84ae53615/go.mod h1:o9ExoilV6k2M3qzSFoRVX4phuww0mLmjs1WrDTvsR4s=
-github.com/crossplane/crossplane-runtime v0.18.0 h1:j1VxhKWp3iQKr1XNiMoBKmEvN2Z98E7rR0tyimu7dj4=
-github.com/crossplane/crossplane-runtime v0.18.0/go.mod h1:o9ExoilV6k2M3qzSFoRVX4phuww0mLmjs1WrDTvsR4s=
 github.com/crossplane/crossplane-runtime v0.19.0-rc.0.0.20220930073209-84e629b95898 h1:vzNAK/BejxhHTURzVUjeAusBPuv5K5Nf0ae0JdK69tQ=
 github.com/crossplane/crossplane-runtime v0.19.0-rc.0.0.20220930073209-84e629b95898/go.mod h1:o9ExoilV6k2M3qzSFoRVX4phuww0mLmjs1WrDTvsR4s=
 github.com/daixiang0/gci v0.2.9/go.mod h1:+4dZ7TISfSmqfAGv59ePaHfNzgGtIkHAhhdKggP1JAc=

--- a/go.sum
+++ b/go.sum
@@ -250,6 +250,10 @@ github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ3
 github.com/creack/pty v1.1.11/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/crossplane/crossplane-runtime v0.18.0-rc.0.0.20220722162506-9ea84ae53615 h1:QmfuKDoB8gXZfoo8ghPx/1z/xg8kOtyP+nYto1IFl/0=
 github.com/crossplane/crossplane-runtime v0.18.0-rc.0.0.20220722162506-9ea84ae53615/go.mod h1:o9ExoilV6k2M3qzSFoRVX4phuww0mLmjs1WrDTvsR4s=
+github.com/crossplane/crossplane-runtime v0.18.0 h1:j1VxhKWp3iQKr1XNiMoBKmEvN2Z98E7rR0tyimu7dj4=
+github.com/crossplane/crossplane-runtime v0.18.0/go.mod h1:o9ExoilV6k2M3qzSFoRVX4phuww0mLmjs1WrDTvsR4s=
+github.com/crossplane/crossplane-runtime v0.19.0-rc.0.0.20220930073209-84e629b95898 h1:vzNAK/BejxhHTURzVUjeAusBPuv5K5Nf0ae0JdK69tQ=
+github.com/crossplane/crossplane-runtime v0.19.0-rc.0.0.20220930073209-84e629b95898/go.mod h1:o9ExoilV6k2M3qzSFoRVX4phuww0mLmjs1WrDTvsR4s=
 github.com/daixiang0/gci v0.2.9/go.mod h1:+4dZ7TISfSmqfAGv59ePaHfNzgGtIkHAhhdKggP1JAc=
 github.com/danieljoos/wincred v1.1.0/go.mod h1:XYlo+eRTsVA9aHGp7NGjFkPla4m+DCL7hqDjlFjiygg=
 github.com/davecgh/go-spew v0.0.0-20161028175848-04cdfd42973b/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/internal/controller/apiextensions/claim/reconciler_test.go
+++ b/internal/controller/apiextensions/claim/reconciler_test.go
@@ -31,11 +31,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	"github.com/crossplane/crossplane-runtime/pkg/meta"
-
 	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
 	"github.com/crossplane/crossplane-runtime/pkg/errors"
 	"github.com/crossplane/crossplane-runtime/pkg/logging"
+	"github.com/crossplane/crossplane-runtime/pkg/meta"
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
 	"github.com/crossplane/crossplane-runtime/pkg/resource/fake"
 	"github.com/crossplane/crossplane-runtime/pkg/resource/unstructured/claim"

--- a/internal/controller/apiextensions/composite/reconciler.go
+++ b/internal/controller/apiextensions/composite/reconciler.go
@@ -75,6 +75,7 @@ const (
 	reasonPublish event.Reason = "PublishConnectionSecret"
 	reasonInit    event.Reason = "InitializeCompositeResource"
 	reasonDelete  event.Reason = "DeleteCompositeResource"
+	reasonPaused  event.Reason = "ReconciliationPaused"
 )
 
 // ControllerName returns the recommended name for controllers that use this
@@ -402,6 +403,17 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 		"version", cr.GetResourceVersion(),
 		"name", cr.GetName(),
 	)
+
+	// Check the pause annotation and return if it has the value "true"
+	// after logging, publishing an event and updating the SYNC status condition
+	if meta.IsPaused(cr) {
+		log.Debug("Reconciliation is paused via the pause annotation", "annotation", meta.AnnotationKeyReconciliationPaused, "value", "true")
+		r.record.Event(cr, event.Normal(reasonPaused, "Reconciliation is paused via the pause annotation"))
+		cr.SetConditions(xpv1.ReconcilePaused())
+		// If the pause annotation is removed, we will have a chance to reconcile again and resume
+		// and if status update fails, we will reconcile again to retry to update the status
+		return reconcile.Result{}, errors.Wrap(r.client.Status().Update(ctx, cr), errUpdateStatus)
+	}
 
 	if meta.WasDeleted(cr) {
 		log = log.WithValues("deletion-timestamp", cr.GetDeletionTimestamp())

--- a/internal/controller/apiextensions/composite/reconciler_test.go
+++ b/internal/controller/apiextensions/composite/reconciler_test.go
@@ -1048,6 +1048,72 @@ func TestReconcile(t *testing.T) {
 				r: reconcile.Result{RequeueAfter: defaultPollInterval},
 			},
 		},
+		"ReconciliationResumesAfterAnnotationRemoval": {
+			reason: `If a composite resource has the pause annotation removed and the Synced=False/ReconcilePaused status condition, reconciliation should resume with requeueing.`,
+			args: args{
+				mgr: &fake.Manager{},
+				composite: withComposite(func(o resource.Composite) {
+					// no annotation atm
+					// (but reconciliations were already paused)
+					o.SetConditions(xpv1.ReconcilePaused())
+				}),
+				opts: []ReconcilerOption{
+					WithClientApplicator(resource.ClientApplicator{
+						Client: &test.MockClient{
+							MockGet:          test.NewMockGetFn(nil),
+							MockUpdate:       test.NewMockUpdateFn(nil),
+							MockStatusUpdate: test.NewMockStatusUpdateFn(nil),
+						},
+						Applicator: resource.ApplyFn(func(c context.Context, r client.Object, ao ...resource.ApplyOption) error {
+							return nil
+						}),
+					}),
+					WithCompositeFinalizer(resource.NewNopFinalizer()),
+					WithCompositionSelector(CompositionSelectorFn(func(_ context.Context, cr resource.Composite) error {
+						cr.SetCompositionReference(&corev1.ObjectReference{})
+						return nil
+					})),
+					WithCompositionFetcher(CompositionFetcherFn(func(_ context.Context, _ resource.Composite) (*v1.Composition, error) {
+						c := &v1.Composition{Spec: v1.CompositionSpec{
+							Resources: []v1.ComposedTemplate{{}},
+						}}
+						return c, nil
+					})),
+					WithCompositionValidator(CompositionValidatorFn(func(_ *v1.Composition) error { return nil })),
+					WithConfigurator(ConfiguratorFn(func(_ context.Context, _ resource.Composite, _ *v1.Composition) error {
+						return nil
+					})),
+					WithRenderer(RendererFn(func(ctx context.Context, cp resource.Composite, cd resource.Composed, t v1.ComposedTemplate) error {
+						return nil
+					})),
+					WithConnectionDetailsFetcher(ConnectionDetailsFetcherFn(func(ctx context.Context, _ resource.Composed, t v1.ComposedTemplate) (managed.ConnectionDetails, error) {
+						return cd, nil
+					})),
+					WithReadinessChecker(ReadinessCheckerFn(func(ctx context.Context, cd resource.Composed, t v1.ComposedTemplate) (ready bool, err error) {
+						// Our one resource is ready.
+						return true, nil
+					})),
+					WithConnectionPublishers(managed.ConnectionPublisherFns{
+						PublishConnectionFn: func(ctx context.Context, o resource.ConnectionSecretOwner, got managed.ConnectionDetails) (published bool, err error) {
+							want := cd
+							if diff := cmp.Diff(want, got); diff != "" {
+								t.Errorf("PublishConnection(...): -want, +got:\n%s", diff)
+							}
+							return true, nil
+						},
+					}),
+				},
+			},
+			want: want{
+				composite: withComposite(func(o resource.Composite) {
+					o.SetConditions(xpv1.ReconcileSuccess(), xpv1.Available())
+					o.SetConnectionDetailsLastPublishedTime(&now)
+					o.SetCompositionReference(&corev1.ObjectReference{})
+					o.SetResourceReferences([]corev1.ObjectReference{})
+				}),
+				r: reconcile.Result{RequeueAfter: defaultPollInterval},
+			},
+		},
 	}
 
 	for name, tc := range cases {

--- a/internal/controller/apiextensions/composite/reconciler_test.go
+++ b/internal/controller/apiextensions/composite/reconciler_test.go
@@ -35,6 +35,7 @@ import (
 	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
 	"github.com/crossplane/crossplane-runtime/pkg/errors"
 	"github.com/crossplane/crossplane-runtime/pkg/logging"
+	"github.com/crossplane/crossplane-runtime/pkg/meta"
 	"github.com/crossplane/crossplane-runtime/pkg/reconciler/managed"
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
 	"github.com/crossplane/crossplane-runtime/pkg/resource/fake"
@@ -942,6 +943,111 @@ func TestReconcile(t *testing.T) {
 				r: reconcile.Result{RequeueAfter: defaultPollInterval},
 			},
 		},
+		"ReconciliationPausedSuccessful": {
+			reason: `If a composite resource has the pause annotation with value "true", there should be no further requeue requests.`,
+			args: args{
+				mgr: &fake.Manager{},
+				composite: withComposite(func(o resource.Composite) {
+					o.SetAnnotations(map[string]string{meta.AnnotationKeyReconciliationPaused: "true"})
+				}),
+			},
+			want: want{
+				r: reconcile.Result{},
+				composite: withComposite(func(o resource.Composite) {
+					o.SetAnnotations(map[string]string{meta.AnnotationKeyReconciliationPaused: "true"})
+					o.SetConditions(xpv1.ReconcilePaused())
+				}),
+			},
+		},
+		"ReconciliationPausedError": {
+			reason: `If a composite resource has the pause annotation with value "true" and the status update due to reconciliation being paused fails, error should be reported causing an exponentially backed-off requeue.`,
+			args: args{
+				mgr: &fake.Manager{},
+				composite: withComposite(func(o resource.Composite) {
+					o.SetAnnotations(map[string]string{meta.AnnotationKeyReconciliationPaused: "true"})
+				}),
+				opts: []ReconcilerOption{
+					WithClientApplicator(resource.ClientApplicator{
+						Client: &test.MockClient{
+							MockStatusUpdate: test.NewMockStatusUpdateFn(errBoom),
+						},
+					}),
+				},
+			},
+			want: want{
+				err: errors.Wrap(errBoom, errUpdateStatus),
+				composite: withComposite(func(o resource.Composite) {
+					o.SetAnnotations(map[string]string{meta.AnnotationKeyReconciliationPaused: "true"})
+					o.SetConditions(xpv1.ReconcilePaused())
+				}),
+			},
+		},
+		"ReconciliationResumes": {
+			reason: `If a composite resource has the pause annotation with some value other than "true" and the Synced=False/ReconcilePaused status condition, reconciliation should resume with requeueing.`,
+			args: args{
+				mgr: &fake.Manager{},
+				composite: withComposite(func(o resource.Composite) {
+					o.SetAnnotations(map[string]string{meta.AnnotationKeyReconciliationPaused: ""})
+					o.SetConditions(xpv1.ReconcilePaused())
+				}),
+				opts: []ReconcilerOption{
+					WithClientApplicator(resource.ClientApplicator{
+						Client: &test.MockClient{
+							MockGet:          test.NewMockGetFn(nil),
+							MockUpdate:       test.NewMockUpdateFn(nil),
+							MockStatusUpdate: test.NewMockStatusUpdateFn(nil),
+						},
+						Applicator: resource.ApplyFn(func(c context.Context, r client.Object, ao ...resource.ApplyOption) error {
+							return nil
+						}),
+					}),
+					WithCompositeFinalizer(resource.NewNopFinalizer()),
+					WithCompositionSelector(CompositionSelectorFn(func(_ context.Context, cr resource.Composite) error {
+						cr.SetCompositionReference(&corev1.ObjectReference{})
+						return nil
+					})),
+					WithCompositionFetcher(CompositionFetcherFn(func(_ context.Context, _ resource.Composite) (*v1.Composition, error) {
+						c := &v1.Composition{Spec: v1.CompositionSpec{
+							Resources: []v1.ComposedTemplate{{}},
+						}}
+						return c, nil
+					})),
+					WithCompositionValidator(CompositionValidatorFn(func(_ *v1.Composition) error { return nil })),
+					WithConfigurator(ConfiguratorFn(func(_ context.Context, _ resource.Composite, _ *v1.Composition) error {
+						return nil
+					})),
+					WithRenderer(RendererFn(func(ctx context.Context, cp resource.Composite, cd resource.Composed, t v1.ComposedTemplate) error {
+						return nil
+					})),
+					WithConnectionDetailsFetcher(ConnectionDetailsFetcherFn(func(ctx context.Context, _ resource.Composed, t v1.ComposedTemplate) (managed.ConnectionDetails, error) {
+						return cd, nil
+					})),
+					WithReadinessChecker(ReadinessCheckerFn(func(ctx context.Context, cd resource.Composed, t v1.ComposedTemplate) (ready bool, err error) {
+						// Our one resource is ready.
+						return true, nil
+					})),
+					WithConnectionPublishers(managed.ConnectionPublisherFns{
+						PublishConnectionFn: func(ctx context.Context, o resource.ConnectionSecretOwner, got managed.ConnectionDetails) (published bool, err error) {
+							want := cd
+							if diff := cmp.Diff(want, got); diff != "" {
+								t.Errorf("PublishConnection(...): -want, +got:\n%s", diff)
+							}
+							return true, nil
+						},
+					}),
+				},
+			},
+			want: want{
+				composite: withComposite(func(o resource.Composite) {
+					o.SetAnnotations(map[string]string{meta.AnnotationKeyReconciliationPaused: ""})
+					o.SetConditions(xpv1.ReconcileSuccess(), xpv1.Available())
+					o.SetConnectionDetailsLastPublishedTime(&now)
+					o.SetCompositionReference(&corev1.ObjectReference{})
+					o.SetResourceReferences([]corev1.ObjectReference{})
+				}),
+				r: reconcile.Result{RequeueAfter: defaultPollInterval},
+			},
+		},
 	}
 
 	for name, tc := range cases {
@@ -954,7 +1060,6 @@ func TestReconcile(t *testing.T) {
 				mockGet := func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
 					if o, ok := obj.(*composite.Unstructured); ok && tc.args.composite != nil {
 						tc.args.composite.DeepCopyInto(&o.Unstructured)
-						return nil
 					}
 					if customGet != nil {
 						return customGet(ctx, key, obj)
@@ -969,7 +1074,6 @@ func TestReconcile(t *testing.T) {
 						} else {
 							tc.args.composite = o
 						}
-						return nil
 					}
 					if customStatusUpdate != nil {
 						return customStatusUpdate(ctx, obj, opts...)


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Similar to https://github.com/crossplane/crossplane-runtime/issues/351 with this PR, if a composite resource has the `crossplane.io/paused` annotation with its value set to `true`, then the reconciler emits an event indicating that further reconciliations on that composite are paused and returns early after setting a `Synced` status condition with `False` status and `ReconcilePaused` reason. If the annotation is removed or its value is changed, reconciliation resumes.

*NOTE*: This PR also updates the crossplane-runtime Go mod dependency. 

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested
Manually tested using the following manifests:

```yaml
apiVersion: apiextensions.crossplane.io/v1
kind: CompositeResourceDefinition
metadata:
  name: xmyresources.test.com
spec:
  group: test.com
  names:
    kind: XMyResource
    plural: xmyresources
  claimNames:
    kind: MyResource
    plural: myresources
  versions:
  - name: v1alpha1
    served: true
    referenceable: true
    schema:
      openAPIV3Schema:
        type: object
        properties:
          spec:
            type: object
            properties:
              parameters:
                type: object
                properties:
                  tagValue:
                    type: string
                required:
                - tagValue
            required:
            - parameters
```

```yaml
apiVersion: apiextensions.crossplane.io/v1
kind: Composition
metadata:
  name: example
  labels:
    purpose: example
spec:
  compositeTypeRef:
    apiVersion: test.com/v1alpha1
    kind: XMyResource
  resources:
    - name: myrole
      base:
        apiVersion: iam.aws.crossplane.io/v1beta1
        kind: Role
        metadata:
        spec:
          forProvider:
            assumeRolePolicyDocument: |
              {
                "Version": "2012-10-17",
                "Statement": [
                    {
                        "Effect": "Allow",
                        "Principal": {
                            "Service": [
                                "ec2.amazonaws.com",
                                "eks.amazonaws.com",
                                "eks-fargate-pods.amazonaws.com",
                                "lambda.amazonaws.com",
                                "s3.amazonaws.com",
                                "rds.amazonaws.com",
                                "dax.amazonaws.com"
                            ]
                        },
                        "Action": [
                            "sts:AssumeRole"
                        ]
                    }
                ]
              }
            tags:
              - key: Name
                value: alper-fix-351
              - key: patch
      patches:
        - fromFieldPath: "spec.parameters.tagValue"
          toFieldPath: spec.forProvider.tags[1].value
```

```yaml
apiVersion: test.com/v1alpha1
kind: MyResource
metadata:
  namespace: test
  name: my-resource
spec:
  parameters:
    tagValue: alper-test
  compositionRef:
    name: example
```



<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

When the `crossplane.io/paused` annotation with value `true` is set on the composite resource of kind `XMyResource`, it acquires the following `Synced` status condition:

```
Status:
  Conditions:
    Last Transition Time:  2022-09-30T17:27:00Z
    Reason:                ReconcilePaused
    Status:                False
    Type:                  Synced
    Last Transition Time:  2022-09-30T16:01:10Z
    Reason:                Available
    Status:                True
    Type:                  Ready
```

and the following event with reason `ReconciliationPaused`:

```
Events:
  Type    Reason                Age                  From                                                             Message
  ----    ------                ----                 ----                                                             -------
  Normal  SelectComposition     26m (x52 over 100m)  defined/compositeresourcedefinition.apiextensions.crossplane.io  Successfully selected composition
  Normal  ReconciliationPaused  19m (x4 over 21m)    defined/compositeresourcedefinition.apiextensions.crossplane.io  Reconciliation is paused via the pause annotation
  Normal  ComposeResources      10m (x11 over 22m)   defined/compositeresourcedefinition.apiextensions.crossplane.io  Successfully composed resources
  Normal  SelectComposition     2m1s (x19 over 22m)  defined/compositeresourcedefinition.apiextensions.crossplane.io  Successfully selected composition
```

When the annotation is removed, reconciliation resumes and the `Synced` status condition either stays at `False` status with reason `ReconcileError` or transitions to `True` status with reason `ReconcileSuccess`:

```
Status:
  Conditions:
    Last Transition Time:  2022-09-30T17:32:29Z
    Reason:                ReconcileSuccess
    Status:                True
    Type:                  Synced
    Last Transition Time:  2022-09-30T16:01:10Z
    Reason:                Available
    Status:                True
    Type:                  Ready
```

The same set of experiments has also been performed on the claim. One notable observation regarding claims is that claim's annotations are normally passed on the associated XR. However:
- When we add the `crossplane.io/paused: true` annotation to the claim, because reconciliations on the claim are now paused, this new annotation does not get propagated to the XR, as expected. 
- If this value of the `crossplane.io/paused` annotation is changed from `true` to some other value, reconciliations on the claim resume, and thus the  `crossplane.io/paused` annotation is passed to the XR with the non-`true` value.
- If the `crossplane.io/paused` annotation is removed from the claim but has been set to a non-`true` value before being removed, this annotation stays on the XR but with a non-`true` value, thus not blocking reconciliations on the XR, as expected. 

[contribution process]: https://git.io/fj2m9
