### PR TITLE
feat(signature validation): Validate cosign signature of packages during fetch

### DIFF
--- a/cmd/crossplane/core/core.go
+++ b/cmd/crossplane/core/core.go
@@ -69,6 +69,7 @@ type startCommand struct {
 	LeaderElection       bool   `short:"l" help:"Use leader election for the controller manager." default:"false" env:"LEADER_ELECTION"`
 	Registry             string `short:"r" help:"Default registry used to fetch packages when not specified in tag." default:"${default_registry}" env:"REGISTRY"`
 	CABundlePath         string `help:"Additional CA bundle to use when fetching packages from registry." env:"CA_BUNDLE_PATH"`
+	ValidationPem        string `help:"Private key in PEM format to be used for package signature validation." env:"VALIDATION_PEM"`
 	WebhookTLSSecretName string `help:"The name of the TLS Secret that will be used by the webhook servers of core Crossplane and providers." env:"WEBHOOK_TLS_SECRET_NAME"`
 	WebhookTLSCertDir    string `help:"The directory of TLS certificate that will be used by the webhook server of core Crossplane. There should be tls.crt and tls.key files." env:"WEBHOOK_TLS_CERT_DIR"`
 	UserAgent            string `help:"The User-Agent header that will be set on all package requests." default:"${default_user_agent}" env:"USER_AGENT"`
@@ -153,6 +154,10 @@ func (c *startCommand) Run(s *runtime.Scheme, log logging.Logger) error { //noli
 			return errors.Wrap(err, "Cannot parse CA bundle")
 		}
 		po.FetcherOptions = append(po.FetcherOptions, xpkg.WithCustomCA(rootCAs))
+	}
+
+	if c.ValidationPem != "" {
+		po.FetcherOptions = []xpkg.FetcherOpt{xpkg.WithValidationPem(c.ValidationPem)}
 	}
 
 	if err := pkg.Setup(mgr, po); err != nil {


### PR DESCRIPTION
Signed-off-by: Jesse Sanford <jesse.sanford@autodesk.com>

<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

Fixes #3048 

Adds ability to pass in public key through Kong cli params to crossplane controller which will wire up the fetcher to use it for package validation with cosign. 

See One Pager: https://github.com/crossplane/crossplane/pull/3297


I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

Both positive and negative tests have been done on my local cluster.

Positive:
```
#start crossplane process locally passing validation-pem in:
./crossplane core start --validation-pem="`cat cosign.pub`" --debug

#sign crossplane configuration package:
cosign sign --key cosign.key docker.repo/xppoc/xppoc-iac-library/auto-crossplane-poc:v0.2.18

#attempt to install signed configuration package:
kubectl crossplane install configuration docker.repo/xppoc/xppoc-iac-library/auto-crossplane-poc:v0.2.18


#crossplane process debug logs show validation passing:
1.6640324893808908e+09	DEBUG	crossplane	Reconciling	{"controller": "packages/configuration.pkg.crossplane.io", "request": "/xppoc-xppoc-iac-library-auto-crossplane-poc"}
1.6640324893811176e+09	DEBUG	crossplane.events	Warning	{"object": {"kind":"Configuration","name":"xppoc-xppoc-iac-library-auto-crossplane-poc","uid":"78787994-cfcf-49ba-8d42-a03b03fe6e63","apiVersion":"pkg.crossplane.io/v1","resourceVersion":"99403"}, "reason": "InstallPackageRevision", "message": "current package revision health is unknown"}
2022/09/24 11:14:49 [INFO] Key Alias PEM: -----BEGIN PUBLIC KEY-----
MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEArjEqXEJXIMX1Fi1/6LqMPnUVVzl
Ml/t/gu7C+syyAixyNyfcGL6+7suuHiHMYJJmCadBjuFyl2YLLvGuUG74A==
-----END PUBLIC KEY-----
2022/09/24 11:14:49 [INFO] COSIGN Verifying sig
2022/09/24 11:14:50 [INFO] Image passed verification: [0xc000b318c0]
```

Negative:

```
#attempt to install helm provider package that has not been signed:
kubectl crossplane install provider crossplane/provider-helm:master

#crossplane process debug logs show validation failure... enter infinite loop of failure:
1.6640303642120502e+09	DEBUG	crossplane.events	Warning	{"object": {"kind":"ProviderRevision","name":"crossplane-provider-helm-19a2e442342c","uid":"77812cae-32e7-49ba-b896-acbcb86cb952","apiVersion":"pkg.crossplane.io/v1","resourceVersion":"45647"}, "reason": "ParsePackage", "message": "cannot initialize parser backend: failed to fetch package from remote: no matching signatures:\n"}
1.664030424213318e+09	DEBUG	crossplane	Reconciling	{"controller": "packages/providerrevision.pkg.crossplane.io", "request": "/crossplane-provider-helm-19a2e442342c"}
2022/09/24 10:40:24 [INFO] Key Alias PEM: -----BEGIN PUBLIC KEY-----
MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEArjEqXEJXIMX1Fi1/6LqMPnUVVzl
Ml/t/gu7C+syyAixyNyfcGL6+7suuHiHMYJJmCadBjuFyl2YLLvGuUG74A==
-----END PUBLIC KEY-----
2022/09/24 10:40:24 [INFO] COSIGN Verifying sig
2022/09/24 10:40:24 [ERROR] COSIGN error: no matching signatures:
```


[contribution process]: https://git.io/fj2m9
