### PR TITLE
updates version to match release

### DIFF
--- a/docs/_index.md
+++ b/docs/_index.md
@@ -3,9 +3,9 @@ title: "Overview"
 weight: -1
 toc_include: false
 aliases:
-    - /docs/master/index.html
+    - /docs/v1.10/index.html
 cascade:
-    version: master
+    version: 1.10
 ---
 
 ![Crossplane](/docs/master/media/banner.png)


### PR DESCRIPTION
Signed-off-by: Pete Lumbis <pete@upbound.io>

This corrects an issue where two versions of pages in "master" are generated in the docs.

A second fix needs to be made so that `v1.10` > `v1.9`. Today they are treated as floats and `v1.10` becomes `v1.1`

https://github.com/crossplane/crossplane.github.io/issues/165