### PR TITLE
helm: allow custom labels on service account

### DIFF
--- a/cluster/charts/crossplane/README.md
+++ b/cluster/charts/crossplane/README.md
@@ -79,7 +79,9 @@ and their default values.
 | `nodeSelector` | Enable nodeSelector for Crossplane pod | `{}` |
 | `customLabels` | Custom labels to add into metadata | `{}` |
 | `customAnnotations` | Custom annotations to add to the Crossplane deployment and pod | `{}` |
+| `serviceAccount.create` | Create serviceaccount for crossplane. If false, a own serviceAccount must be exists. | `true` |
 | `serviceAccount.customAnnotations` | Custom annotations to add to the serviceaccount of Crossplane | `{}` |
+| `serviceAccount.customLabels` | Custom labels to add to the serviceaccount of Crossplane | `{}` |
 | `priorityClassName` | Priority class name for Crossplane and RBAC Manager (if enabled) pods | `""` |
 | `resourcesCrossplane.limits.cpu` | CPU resource limits for Crossplane | `100m` |
 | `resourcesCrossplane.limits.memory` | Memory resource limits for Crossplane | `512Mi` |

--- a/cluster/charts/crossplane/templates/serviceaccount.yaml
+++ b/cluster/charts/crossplane/templates/serviceaccount.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.serviceAccount.create }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -5,6 +6,9 @@ metadata:
   labels:
     app: {{ template "crossplane.name" . }}
     {{- include "crossplane.labels" . | indent 4 }}
+  {{- with .Values.serviceAccount.customLabels }}
+    {{ toYaml . | nindent 4 }}
+  {{- end }}
   {{- with .Values.serviceAccount.customAnnotations }}
   annotations: {{ toYaml . | nindent 4 }}
   {{- end }}
@@ -13,4 +17,5 @@ imagePullSecrets:
 {{- range $index, $secret := .Values.imagePullSecrets }}
 - name: {{ $secret }}
 {{- end }}
-{{ end }}
+{{- end }}
+{{- end }}

--- a/cluster/charts/crossplane/values.yaml.tmpl
+++ b/cluster/charts/crossplane/values.yaml.tmpl
@@ -17,9 +17,13 @@ customLabels: {}
 # -- Custom annotations to add to the Crossplane deployment and pod
 customAnnotations: {}
 
-# -- Custom annotations to add to the serviceaccount of Crossplane
 serviceAccount:
+  # -- Create serviceaccount for crossplane. If false, a own serviceAccount must be exists.
+  create: true
+  # -- Custom annotations to add to the serviceaccount of Crossplane
   customAnnotations: {}
+  # -- Custom labels to add to the serviceaccount of Crossplane
+  customLabels: {}
 
 leaderElection: true
 args: {}


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

Allow to define custom labels on that service account. Additionally disable to creation of the serviceAccount. This is useful, if serviceAccounts needs to be created separatly

Fixes #

I have:

- [x] Read and followed Crossplane's [contribution process].
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
