### PR TITLE
Validate docs content in CI and support one-command local dev

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,28 @@
+name: Docs Validation
+
+on:
+  pull_request:
+    paths:
+      - 'docs/**'
+
+env:
+  # Common versions
+  GO_VERSION: '1.19'
+
+jobs:
+  validate:
+    runs-on: ubuntu-20.04
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+      with:
+        submodules: true
+
+    - name: Setup Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{ env.GO_VERSION }}
+
+    - name: Validate
+      run: make docs.validate

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -12,6 +12,9 @@ on:
         default: 'stable'
 
 env:
+  # Common versions
+  GO_VERSION: '1.19'
+
   # Common users. We can't run a step 'if secrets.AWS_USR != ""' but we can run
   # a step 'if env.AWS_USR' != ""', so we copy these to succinctly test whether
   # credentials have been provided before trying to run steps that need them.
@@ -27,6 +30,11 @@ jobs:
         uses: actions/checkout@v2
         with:
           submodules: true
+
+      - name: Setup Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ env.GO_VERSION }}
 
       - name: Fetch History
         run: git fetch --prune --unshallow

--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,8 @@ NPROCS ?= 1
 # to half the number of CPU cores.
 GO_TEST_PARALLEL := $(shell echo $$(( $(NPROCS) / 2 )))
 
+GO_REQUIRED_VERSION = 1.19
+
 GO_STATIC_PACKAGES = $(GO_PROJECT)/cmd/crossplane $(GO_PROJECT)/cmd/crank
 GO_LDFLAGS += -X $(GO_PROJECT)/internal/version.version=$(VERSION)
 GO_SUBDIRS += cmd internal apis

--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ OSBASEIMAGE = gcr.io/distroless/static:nonroot
 # Setup Docs
 
 SOURCE_DOCS_DIR = docs
-DEST_DOCS_DIR = content/docs/
+DEST_DOCS_DIR = content/docs
 DOCS_GIT_REPO = https://$(DOCS_GIT_USR):$(DOCS_GIT_PSW)@github.com/crossplane/crossplane.github.io.git
 -include build/makelib/docs.mk
 

--- a/docs/reference/learn_more.md
+++ b/docs/reference/learn_more.md
@@ -23,7 +23,6 @@ If you have any questions, please drop us a note on [Crossplane Slack][join-cros
 - Join our [Community Slack](https://slack.crossplane.io/)!
 - Submit an issue on [GitHub](https://github.com/crossplane/crossplane)
 - Attend our bi-weekly [Community Meeting](https://github.com/crossplane/crossplane#get-involved)
-- Join our bi-weekly live stream: [The Binding Status](https://github.com/crossplane/tbs)
 - Subscribe to our [YouTube Channel](https://www.youtube.com/channel/UC19FgzMBMqBro361HbE46Fw)
 - Drop us a note on Twitter: [@crossplane_io](https://twitter.com/crossplane_io)
 - Email us: [info@crossplane.io](mailto:info@crossplane.io)


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Consumes new docs functionality in `crossplane/crossplane.github.io` and `upbound/build` to allow for validating content in CI and running the site locally.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

```
🤖 (crossplane) DOCS_VERSION=master make docs.run
rm -rf /home/dan/code/github.com/crossplane/crossplane/.work/docs-repo
mkdir -p /home/dan/code/github.com/crossplane/crossplane/.work/docs-repo
git clone --depth=1 -b master https://:@github.com/crossplane/crossplane.github.io.git /home/dan/code/github.com/crossplane/crossplane/.work/docs-repo
Cloning into '/home/dan/code/github.com/crossplane/crossplane/.work/docs-repo'...
warning: redirecting to https://github.com/crossplane/crossplane.github.io.git/
remote: Enumerating objects: 380, done.
remote: Counting objects: 100% (380/380), done.
remote: Compressing objects: 100% (300/300), done.
remote: Total 380 (delta 106), reused 250 (delta 63), pack-reused 0
Receiving objects: 100% (380/380), 4.50 MiB | 21.75 MiB/s, done.
Resolving deltas: 100% (106/106), done.
rm -rf /home/dan/code/github.com/crossplane/crossplane/.work/docs-repo/content/docs/master
15:47:49 [ .. ] Including version in documentation
15:47:49 [ OK ] Version included in documentation
cd /home/dan/code/github.com/crossplane/crossplane/.work/docs-repo && DOCS_VERSION=master make run
15:47:49 [ .. ] installing hugo 0.104.3
15:47:51 [ OK ] finished installing hugo 0.104.3
15:47:51 [ .. ] starting hugo development server
Start building sites … 
hugo v0.104.3-58b824581360148f2d91f5cc83f69bd22c1aa331+extended linux/amd64 BuildDate=2022-10-04T14:25:23Z VendorInfo=gohugoio

                   | EN   
-------------------+------
  Pages            | 249  
  Paginator pages  |   0  
  Non-page files   | 158  
  Static files     | 104  
  Processed images |   0  
  Aliases          |   4  
  Sitemaps         |   1  
  Cleaned          |   0  

Built in 296 ms
Watching for changes in /home/dan/code/github.com/crossplane/crossplane/.work/docs-repo/{content,static,themes}
Watching for config changes in /home/dan/code/github.com/crossplane/crossplane/.work/docs-repo/config.yaml
Environment: "development"
Serving pages from memory
Running in Fast Render Mode. For full rebuilds on change: hugo server --disableFastRender
Web Server is available at //localhost:1313/ (bind address 127.0.0.1)
Press Ctrl+C to stop
```

```
🤖 (crossplane) make docs.validate
rm -rf /home/dan/code/github.com/crossplane/crossplane/.work/docs-repo
mkdir -p /home/dan/code/github.com/crossplane/crossplane/.work/docs-repo
git clone --depth=1 -b master https://:@github.com/crossplane/crossplane.github.io.git /home/dan/code/github.com/crossplane/crossplane/.work/docs-repo
Cloning into '/home/dan/code/github.com/crossplane/crossplane/.work/docs-repo'...
warning: redirecting to https://github.com/crossplane/crossplane.github.io.git/
remote: Enumerating objects: 380, done.
remote: Counting objects: 100% (380/380), done.
remote: Compressing objects: 100% (300/300), done.
remote: Total 380 (delta 106), reused 250 (delta 63), pack-reused 0
Receiving objects: 100% (380/380), 4.50 MiB | 21.06 MiB/s, done.
Resolving deltas: 100% (106/106), done.
rm -rf /home/dan/code/github.com/crossplane/crossplane/.work/docs-repo/content/docs/docs-validation
15:48:17 [ .. ] Including version in documentation
15:48:17 [ OK ] Version included in documentation
cd /home/dan/code/github.com/crossplane/crossplane/.work/docs-repo && DOCS_VERSION=docs-validation make validate
15:48:17 [ .. ] installing hugo 0.104.3
15:48:18 [ OK ] finished installing hugo 0.104.3
15:48:18 [ .. ] building hugo site
Start building sites … 
hugo v0.104.3-58b824581360148f2d91f5cc83f69bd22c1aa331+extended linux/amd64 BuildDate=2022-10-04T14:25:23Z VendorInfo=gohugoio

                   | EN   
-------------------+------
  Pages            | 300  
  Paginator pages  |   0  
  Non-page files   | 190  
  Static files     | 104  
  Processed images |   0  
  Aliases          |   5  
  Sitemaps         |   1  
  Cleaned          |   0  

Total in 462 ms
15:48:18 [ OK ] successfully built hugo site
```

[contribution process]: https://git.io/fj2m9
