### PR TITLE
Fix compositionRevision update conflict

### DIFF
--- a/internal/xcrd/schemas.go
+++ b/internal/xcrd/schemas.go
@@ -27,7 +27,7 @@ const (
 
 // PropagateSpecProps is the list of XRC spec properties to propagate
 // when translating an XRC into an XR and vice-versa.
-var PropagateSpecProps = []string{"compositionRef", "compositionSelector", "compositionRevisionRef", "compositionUpdatePolicy"}
+var PropagateSpecProps = []string{"compositionRef", "compositionSelector", "compositionUpdatePolicy"}
 
 // TODO(negz): Add descriptions to schema fields.
 


### PR DESCRIPTION
Signed-off-by: ezgidemirel <ezgidemirel91@gmail.com>

<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes
In this PR, I added custom logic to propagate compositionRevisionRef values based on compositionUpdatePolicy. Before this change, claim reconciler and composite reconciler were conflicting about setting this value. 
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #3263 #2954

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

- Enabled composition revision feature
- Created a composition
- Created claim-1 with update policy Manual and referencing to revision-1
- Created claim-2 with update policy Automatic
- Updated the composition to have revision-2
- Validated claim-1 and composite-1 stay the same and claim-2 and composite-2 updated to revision-2
- Updated claim-1 to Automatic and deleted the composition revision ref
- Validated that claim-1 and composite-1 updated to revision-2
- Updated claim-1 to Manual and referencing revision-1
- Validated claim-1 and composite-1 updated to revision-1

Related files can be found [here](https://gist.github.com/ezgidemirel/ac92d6a9df39d395ba394066a23ddac2). 


<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
