### PR TITLE
[release-1.9] Fix missing getting started section in docs

### DIFF
--- a/docs/getting-started/_index.md
+++ b/docs/getting-started/_index.md
@@ -1,9 +1,6 @@
 ---
 title: "Getting Started"
 weight: 1
-toc_include: false
-cascade:
-    version: 1.9
 ---
 
 ![Crossplane](/docs/v1.9/media/banner.png)


### PR DESCRIPTION


<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Removes front matter causing getting started section to be omitted in docs.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

Ran locally and verified that https://crossplane.io/docs/v1.9.html now works like https://crossplane.io/docs/v1.10.html

[contribution process]: https://git.io/fj2m9
