### PR TITLE
Create composition revision names with partial hash

### DIFF
--- a/apis/apiextensions/v1/composition_hash.go
+++ b/apis/apiextensions/v1/composition_hash.go
@@ -17,15 +17,15 @@ limitations under the License.
 package v1
 
 import (
+	"crypto/sha256"
 	"fmt"
-	"hash/fnv"
 
 	"sigs.k8s.io/yaml"
 )
 
 // Hash of the CompositionSpec.
 func (cs CompositionSpec) Hash() string {
-	h := fnv.New64a()
+	h := sha256.New()
 	y, err := yaml.Marshal(cs)
 	if err != nil {
 		// I believe this should be impossible given we're marshalling a
@@ -33,5 +33,5 @@ func (cs CompositionSpec) Hash() string {
 		return "unknown"
 	}
 	h.Write(y) //nolint:errcheck // Writing to a hash never errors.
-	return fmt.Sprintf("%x", h.Sum64())
+	return fmt.Sprintf("%x", h.Sum(nil))
 }

--- a/internal/controller/apiextensions/composition/revision.go
+++ b/internal/controller/apiextensions/composition/revision.go
@@ -17,6 +17,8 @@ limitations under the License.
 package composition
 
 import (
+	"fmt"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/crossplane/crossplane-runtime/pkg/meta"
@@ -29,7 +31,7 @@ import (
 func NewCompositionRevision(c *v1.Composition, revision int64, compSpecHash string) *v1alpha1.CompositionRevision {
 	cr := &v1alpha1.CompositionRevision{
 		ObjectMeta: metav1.ObjectMeta{
-			GenerateName: c.GetName() + "-",
+			Name: fmt.Sprintf("%s-%s", c.GetName(), compSpecHash[0:5]),
 			Labels: map[string]string{
 				v1alpha1.LabelCompositionName:     c.GetName(),
 				v1alpha1.LabelCompositionSpecHash: compSpecHash,

--- a/internal/controller/apiextensions/composition/revision.go
+++ b/internal/controller/apiextensions/composition/revision.go
@@ -31,10 +31,12 @@ import (
 func NewCompositionRevision(c *v1.Composition, revision int64, compSpecHash string) *v1alpha1.CompositionRevision {
 	cr := &v1alpha1.CompositionRevision{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: fmt.Sprintf("%s-%s", c.GetName(), compSpecHash[0:5]),
+			Name: fmt.Sprintf("%s-%s", c.GetName(), compSpecHash[0:7]),
 			Labels: map[string]string{
-				v1alpha1.LabelCompositionName:     c.GetName(),
-				v1alpha1.LabelCompositionSpecHash: compSpecHash,
+				v1alpha1.LabelCompositionName: c.GetName(),
+				// We cannot have a label value longer than 63 chars
+				// https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set
+				v1alpha1.LabelCompositionSpecHash: compSpecHash[0:63],
 			},
 		},
 		Spec: NewCompositionRevisionSpec(c.Spec, revision),

--- a/internal/controller/apiextensions/composition/revision_test.go
+++ b/internal/controller/apiextensions/composition/revision_test.go
@@ -194,16 +194,16 @@ func TestNewCompositionRevision(t *testing.T) {
 
 	var (
 		rev  int64  = 1
-		hash string = "comphash"
+		hash string = "1af1dfa857bf1d8814fe1af8983c18080019922e557f15a8a0d3db739d77aacb"
 	)
 
 	ctrl := true
 	want := &v1alpha1.CompositionRevision{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: fmt.Sprintf("%s-%s", comp.GetName(), hash[0:5]),
+			Name: fmt.Sprintf("%s-%s", comp.GetName(), hash[0:7]),
 			Labels: map[string]string{
 				v1alpha1.LabelCompositionName:     comp.GetName(),
-				v1alpha1.LabelCompositionSpecHash: hash,
+				v1alpha1.LabelCompositionSpecHash: hash[0:63],
 			},
 			OwnerReferences: []metav1.OwnerReference{{
 				APIVersion:         v1.SchemeGroupVersion.String(),

--- a/internal/controller/apiextensions/composition/revision_test.go
+++ b/internal/controller/apiextensions/composition/revision_test.go
@@ -18,6 +18,7 @@ package composition
 
 import (
 	"encoding/json"
+	"fmt"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -193,13 +194,13 @@ func TestNewCompositionRevision(t *testing.T) {
 
 	var (
 		rev  int64  = 1
-		hash string = "hash"
+		hash string = "comphash"
 	)
 
 	ctrl := true
 	want := &v1alpha1.CompositionRevision{
 		ObjectMeta: metav1.ObjectMeta{
-			GenerateName: comp.GetName() + "-",
+			Name: fmt.Sprintf("%s-%s", comp.GetName(), hash[0:5]),
 			Labels: map[string]string{
 				v1alpha1.LabelCompositionName:     comp.GetName(),
 				v1alpha1.LabelCompositionSpecHash: hash,


### PR DESCRIPTION
Signed-off-by: ezgidemirel <ezgidemirel91@gmail.com>

<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes
Instead of using GenerateName, with this change, we'll start adding a partial hash suffix to prevent duplicate revision creations.   
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #3011 

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested
Created/updated compositions to verify that revisions are created with the same name for the same compositions. 
<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
