### PR TITLE
Consume latest crossplane-runtime's fake.Composite to prevent panics caught by CNCF fuzzing tests

### DIFF
--- a/apis/apiextensions/v1/composition_patches.go
+++ b/apis/apiextensions/v1/composition_patches.go
@@ -26,6 +26,7 @@ import (
 
 	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
 	"github.com/crossplane/crossplane-runtime/pkg/fieldpath"
+	"github.com/crossplane/crossplane-runtime/pkg/resource"
 )
 
 const (
@@ -119,7 +120,7 @@ type Patch struct {
 
 // Apply executes a patching operation between the from and to resources.
 // Applies all patch types unless an 'only' filter is supplied.
-func (c *Patch) Apply(cp, cd runtime.Object, only ...PatchType) error {
+func (c *Patch) Apply(cp resource.Composite, cd resource.Composed, only ...PatchType) error {
 	if c.filterPatch(only...) {
 		return nil
 	}

--- a/apis/apiextensions/v1/composition_patches_test.go
+++ b/apis/apiextensions/v1/composition_patches_test.go
@@ -29,6 +29,7 @@ import (
 
 	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
 	"github.com/crossplane/crossplane-runtime/pkg/fieldpath"
+	"github.com/crossplane/crossplane-runtime/pkg/resource"
 	"github.com/crossplane/crossplane-runtime/pkg/resource/fake"
 	"github.com/crossplane/crossplane-runtime/pkg/test"
 )
@@ -108,6 +109,38 @@ func TestPatchApply(t *testing.T) {
 						},
 					},
 					ConnectionDetailsLastPublishedTimer: lpt,
+				},
+				cd: &fake.Composed{
+					ObjectMeta: metav1.ObjectMeta{Name: "cd"},
+				},
+			},
+			want: want{
+				cd: &fake.Composed{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "cd",
+						Labels: map[string]string{
+							"Test": "blah",
+						},
+					},
+				},
+				err: nil,
+			},
+		},
+		"ValidCompositeFieldPathPatchWithNilLastPublishTime": {
+			reason: "Should correctly apply a CompositeFieldPathPatch with valid settings",
+			args: args{
+				patch: Patch{
+					Type:          PatchTypeFromCompositeFieldPath,
+					FromFieldPath: pointer.StringPtr("objectMeta.labels"),
+					ToFieldPath:   pointer.StringPtr("objectMeta.labels"),
+				},
+				cp: &fake.Composite{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "cp",
+						Labels: map[string]string{
+							"Test": "blah",
+						},
+					},
 				},
 				cd: &fake.Composed{
 					ObjectMeta: metav1.ObjectMeta{Name: "cd"},
@@ -826,7 +859,7 @@ func TestPatchApply(t *testing.T) {
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			ncp := tc.args.cp.DeepCopyObject()
+			ncp := tc.args.cp.DeepCopyObject().(resource.Composite)
 			err := tc.args.patch.Apply(ncp, tc.args.cd, tc.args.only...)
 
 			if tc.want.cp != nil {

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.19
 require (
 	github.com/Masterminds/semver v1.5.0
 	github.com/alecthomas/kong v0.2.17
-	github.com/crossplane/crossplane-runtime v0.19.0-rc.0.0.20221012013934-bce61005a175
+	github.com/crossplane/crossplane-runtime v0.19.0-rc.0.0.20221020071948-fa5545f26b04
 	github.com/google/go-cmp v0.5.8
 	github.com/google/go-containerregistry v0.9.0
 	github.com/google/go-containerregistry/pkg/authn/k8schain v0.0.0-20220517194345-84eb52633e96

--- a/go.sum
+++ b/go.sum
@@ -248,8 +248,8 @@ github.com/cpuguy83/go-md2man/v2 v2.0.1/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46t
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/creack/pty v1.1.11/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
-github.com/crossplane/crossplane-runtime v0.19.0-rc.0.0.20221012013934-bce61005a175 h1:qGLew6IazCwfgvY4/xh5lQiumip/WrULpQfW4duol6g=
-github.com/crossplane/crossplane-runtime v0.19.0-rc.0.0.20221012013934-bce61005a175/go.mod h1:o9ExoilV6k2M3qzSFoRVX4phuww0mLmjs1WrDTvsR4s=
+github.com/crossplane/crossplane-runtime v0.19.0-rc.0.0.20221020071948-fa5545f26b04 h1:DGu6CsdRk1Eg2BC77pgLqb6qCjw6Ju0c6UIdxfyT6qs=
+github.com/crossplane/crossplane-runtime v0.19.0-rc.0.0.20221020071948-fa5545f26b04/go.mod h1:o9ExoilV6k2M3qzSFoRVX4phuww0mLmjs1WrDTvsR4s=
 github.com/daixiang0/gci v0.2.9/go.mod h1:+4dZ7TISfSmqfAGv59ePaHfNzgGtIkHAhhdKggP1JAc=
 github.com/danieljoos/wincred v1.1.0/go.mod h1:XYlo+eRTsVA9aHGp7NGjFkPla4m+DCL7hqDjlFjiygg=
 github.com/davecgh/go-spew v0.0.0-20161028175848-04cdfd42973b/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Depends on: https://github.com/crossplane/crossplane-runtime/pull/361

[CNCF Crossplane fuzzing tests](https://github.com/cncf/cncf-fuzzing/tree/main/projects/crossplane) are currently failing (specifically the `fuzz_patch_apply` test) because if we pass a `resource.Composite` with a nil connection details last published time to `Patch.Apply`, subsequent calls to `runtime.DefaultUnstructuredConverter.ToUnstructured` to convert it to an `unstructured.Unstructured` panic. This PR proposes a change to the `Patch.Apply` signature so that we make sure the first arg is actually a `resource.Composite` and consumes a new implementation from crossplane-runtime's `fake.Composite`, which annotates the `fake.ConnectionDetailsLastPublishedTimer.Time` field with an `omitempty` json tag so that `runtime.DefaultUnstructuredConverter.ToUnstructured` does not attempt to convert it.

The function signature change has been motivated by observing that the fuzzer passes a `resource.Composed` as the first argument to `Patch.Apply` but what `Patch.Apply` expects is a `resource.Composite` and we can enforce this at compile-time.

Note: I've also reported an upstream issue [here](https://github.com/kubernetes-sigs/structured-merge-diff/issues/229).

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
Tested against the `fuzz_patch_apply` fuzzer using the provided minimized testcase.

Also tested with the following XRD, composition and claim:

```yaml
apiVersion: apiextensions.crossplane.io/v1
kind: CompositeResourceDefinition
metadata:
  name: xmyresources.test.com
spec:
  group: test.com
  names:
    kind: XMyResource
    plural: xmyresources
  claimNames:
    kind: MyResource
    plural: myresources
  versions:
  - name: v1alpha1
    served: true
    referenceable: true
    schema:
      openAPIV3Schema:
        type: object
        properties:
          spec:
            type: object
            properties:
              parameters:
                type: object
                properties:
                  tagValue:
                    type: string
                required:
                - tagValue
            required:
            - parameters

---

apiVersion: apiextensions.crossplane.io/v1
kind: Composition
metadata:
  name: example
  labels:
    purpose: example
spec:
  compositeTypeRef:
    apiVersion: test.com/v1alpha1
    kind: XMyResource
  resources:
    - name: myrole
      base:
        apiVersion: azure.upbound.io/v1beta1
        kind: ResourceGroup
        spec:
          forProvider:
            location: "West Europe"
            tags:
              key: ""
      patches:
        - fromFieldPath: "spec.parameters.tagValue"
          toFieldPath: spec.forProvider.tags["key"]

---

apiVersion: test.com/v1alpha1
kind: MyResource
metadata:
  namespace: upbound-system
  name: my-resource
spec:
  parameters:
    tagValue: demo-test
  compositionRef:
    name: example
```

[contribution process]: https://git.io/fj2m9
