### PR TITLE
Add AWS,GCP,Azure quickstarts and adjust section weights

### DIFF
--- a/docs/contributing/docs.md
+++ b/docs/contributing/docs.md
@@ -17,6 +17,9 @@ weight: 2000
     - [Linking between docs pages](#linking-between-docs-pages)
     - [Linking to external sites](#linking-to-external-sites)
   - [Tabs](#tabs)
+  - [Code blocks](#code-blocks)
+    - [Hover to highlight](#hover-to-highlight)
+    - [Copying code](#copying-code)
 
 ## Code of Conduct
 We follow the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/main/code-of-conduct.md).
@@ -184,4 +187,73 @@ A second example tab.
 
 
 Both `tab` and `tabs` require opening and closing tags. Unclosed tags causes Hugo to fail.
+
+### Code blocks
+Hugo supports standard markdown code fences with ` ``` `
+
+Specify the language of the code block after the code fence with no space, for example ` ```yaml `.
+
+{{< hint type="important" >}}
+Not providing a language renders no line numbers or styling.
+{{< /hint >}}
+
+Hugo has a [full list](https://gohugo.io/content-management/syntax-highlighting/#list-of-chroma-highlighting-languages) of supported languages.
+
+The language hint determines the styling and may not match the exact code represented.
+For example, using a `yaml` highlight hint provides greater readability for a block that is technically a `bash` command.
+
+Using the `yaml` hint:
+```yaml
+cat <<EOF | kubectl apply -f -
+apiVersion: aws.upbound.io/v1beta1
+kind: ProviderConfig
+metadata:
+  name: default
+```
+
+Using the `bash` hint:
+```bash
+cat <<EOF | kubectl apply -f -
+apiVersion: aws.upbound.io/v1beta1
+kind: ProviderConfig
+metadata:
+  name: default
+```
+
+
+#### Hover to highlight
+{{< hint type="warning" >}}
+This is a future capability for the Crossplane documentation and isn't supported today. You can add the `hover` tag and shortcode today to automatically enable highlighting when supported.
+{{< /hint >}}
+A single line in a code block can be highlighted on mouseover of another command with the `{{</* hover */>}}` shortcode.
+
+A command inside the shortcode highlights lines in an associated code block.
+
+To enable hover to highlight, first apply a `{label="<label>"}` tag on a code block.
+
+````markdown
+```shell {label="an_example"}
+echo hello
+hello
+```
+````
+
+Outside of the code block, reference the `label` and line number to provide highlighting.
+
+For example:
+````markdown
+```shell {label="an_example"}
+echo hello
+hello
+```
+````
+Hover over <code>&#123;&#123;< hover label="an_example" line="2">&#125;&#125;</code> hello <code>&#123;&#123;< hover >&#125;&#125;</code> to see it in action.
+
+The command must include a closing shortcode of <code>&#123;&#123;< hover >&#125;&#125;</code>.  
+
+#### Copying code
+{{< hint type="warning" >}}
+This is a future capability for the Crossplane documentation and isn't supported today. You can add the `copy-lines` tag today to automatically enable copying when supported.
+{{< /hint >}}
+By default the copy button copies the first line of the code block. Attach a `copy-lines=<start>-<end>` tag to the code block.
 

--- a/docs/getting-started/create-configuration.md
+++ b/docs/getting-started/create-configuration.md
@@ -1,6 +1,6 @@
 ---
 title: Create a Configuration
-weight: 4
+weight: 14
 ---
 
 In the [previous section] we were able to create a PostgreSQL database because

--- a/docs/getting-started/install-configure.md
+++ b/docs/getting-started/install-configure.md
@@ -17,78 +17,11 @@ in production environments.
 
 {{% tab "Crossplane (upstream)" %}}
 
-## Start with Upstream Crossplane
+{{< include file="install-crossplane.md" type="page" >}}
 
-Installing Crossplane into an existing Kubernetes cluster will require a bit
-more setup, but can provide more flexibility for users who need it.
+### Install a pre-release version of Crossplane
 
-### Get a Kubernetes Cluster
-<!-- inside Crossplane (upstream) -->
-{{% tabs "Kubernetes Clusters" %}}
-
-{{% tab "macOS via Homebrew" %}}
-
-For macOS via Homebrew use the following:
-
-```bash
-brew upgrade
-brew install kind
-brew install kubectl
-brew install helm
-kind create cluster --image kindest/node:v1.23.0 --wait 5m
-```
-<!-- close "macOS via Homebrew" -->
-{{% /tab  %}}
-
-{{% tab "macOS / Linux" %}}
-
-For macOS / Linux use the following:
-
-* [Kubernetes cluster](https://kubernetes.io/docs/setup/)
-* [Kind](https://kind.sigs.k8s.io/docs/user/quick-start/)
-* [Minikube](https://minikube.sigs.k8s.io/docs/start/), minimum version `v0.28+`
-* etc.
-* [Helm](https://helm.sh/docs/intro/using_helm/), minimum version `v3.0.0+`.
-
-<!-- close "macOS / Linux" -->
-{{% /tab %}}
-
-{{% tab "Windows" %}}
-For Windows use the following:
-
-* [Kubernetes cluster](https://kubernetes.io/docs/setup/)
-* [Kind](https://kind.sigs.k8s.io/docs/user/quick-start/)
-* [Minikube](https://minikube.sigs.k8s.io/docs/start/), minimum version `v0.28+`
-* etc.
-* [Helm](https://helm.sh/docs/intro/using_helm/), minimum version `v3.0.0+`.
-
-<!-- close "Windows" -->
-{{% /tab %}}
-
-<!-- close "Kubernetes Clusters" -->
-{{% /tabs %}}
-
-### Install Crossplane
-
-{{% tabs "install with helm" %}}
-
-{{% tab "Helm 3 (stable)" %}}
-Use Helm 3 to install the latest official `stable` release of Crossplane, suitable for community use and testing:
-
-```bash
-kubectl create namespace crossplane-system
-helm repo add crossplane-stable https://charts.crossplane.io/stable
-helm repo update
-
-helm install crossplane --namespace crossplane-system crossplane-stable/crossplane
-```
-
-<!-- close "Helm 3 (stable)" -->
-{{% /tab %}}
-
-{{% tab "Helm 3 (latest)" %}}
-<!-- fold start -->
-Use Helm 3 to install the latest pre-release version of Crossplane:
+To install a pre-release version of Crossplane use `--devel` with `helm install`.
 
 ```bash
 kubectl create namespace crossplane-system
@@ -107,11 +40,6 @@ For example:
 helm install crossplane --namespace crossplane-system crossplane-master/crossplane \
   --version 0.11.0-rc.100.gbc5d311 --devel
 ```
-<!-- close "Helm 3 (latest)" -->
-{{% /tab %}}
-<!-- close "install with helm" -->
-{{% /tabs %}}
-
 ### Check Crossplane Status
 
 ```bash

--- a/docs/getting-started/install-configure.md
+++ b/docs/getting-started/install-configure.md
@@ -1,6 +1,6 @@
 ---
 title: Install & Configure
-weight: 2
+weight: 10
 ---
 ## Choosing Your Crossplane Distribution
 

--- a/docs/getting-started/install-crossplane.md
+++ b/docs/getting-started/install-crossplane.md
@@ -6,21 +6,13 @@ toc_hide: true
 
 Crossplane installs into an existing Kubernetes cluster. 
 
-Install Crossplane either as an upstream open source distribution or from a [CNCF certified](https://github.com/cncf/crossplane-conformance) vendor distribution.
-
-The Crossplane community supports the upstream distribution.  
-The Crossplane vendor supports their specific Crossplane distribution. 
-
 {{< hint type="tip" >}}
 If you don't have a Kubernetes cluster create one locally with [minikube](https://minikube.sigs.k8s.io/docs/start/) or [kind](https://kind.sigs.k8s.io/).
 {{< /hint >}}
 
-{{< tabs "distros" >}}
-
-{{< tab "Community Supported" >}}
 ### Install the Crossplane Helm chart
 
-Helm enables Crossplane to install all its Kubernetes components through a single _Helm Chart_.
+Helm enables Crossplane to install all its Kubernetes components through a _Helm Chart_.
 
 Enable the Crossplane Helm Chart repository:
 
@@ -34,17 +26,19 @@ Helm supports a `dry-run` to see the changes Helm makes. Run the Helm dry-run to
 
 ```shell
 helm install crossplane \
+crossplane-stable/crossplane \
 --dry-run --debug \
 --namespace crossplane-system \
-crossplane-stable/crossplane
+--create-namespace
 ```
 
 Last, install the Crossplane components using `helm install`.
 
 ```shell
 helm install crossplane \
+crossplane-stable/crossplane \
 --namespace crossplane-system \
-crossplane-stable/crossplane
+--create-namespace
 
 NAME: crossplane
 LAST DEPLOYED: Sun Oct 16 19:11:27 2022
@@ -66,56 +60,13 @@ Kube Version: v1.25.2
 Verify Crossplane installed with `kubectl get pods`.
 
 ```shell
-kubectl get pods -n crossplane-system                                                                  
+kubectl get pods -n crossplane-system
 NAME                                      READY   STATUS    RESTARTS   AGE
 crossplane-d4cd8d784-ldcgb                1/1     Running   0          54s
 crossplane-rbac-manager-84769b574-6mw6f   1/1     Running   0          54s
 ```
 
-{{< /tab >}}
-
-{{< tab "Vendor Distributions" >}}
-
-## Upbound
-Upbound are the founders of Crossplane. Upbound maintains and supports an open source distribution of Crossplane called [Upbound Universal Crossplane](https://github.com/upbound/universal-crossplane) (_UXP_).
-
-More details about installing and configuring UXP are available in the [Upbound documentation](https://docs.upbound.io)
-
-### Install the Up command-line
-The Up command-line helps manage UXP and manage Upbound user accounts. 
-
-Download and install the Upbound `up` command-line.
-
-```shell {copy-lines="all"}
-curl -sL "https://cli.upbound.io" | sh
-sudo mv up /usr/local/bin/
-```
-
-### Install Upbound Universal Crossplane
-_UXP_ consists of upstream Crossplane and Upbound-specific enhancements and patches. It's [open source](https://github.com/upbound/universal-crossplane) and maintained by Upbound. 
-
-Install UXP with the Up command-line `up uxp install` command.
-
-```shell
-up uxp install
-UXP 1.9.1-up.2 installed
-```
-
-Verify all UXP pods are `Running` with `kubectl get pods -n upbound-system`. This may take up to five minutes depending on your Kubernetes cluster.
-
-```shell {label="pods"}
-kubectl get pods -n upbound-system
-NAME                                        READY   STATUS    RESTARTS      AGE
-crossplane-7fdfbd897c-pmrml                 1/1     Running   0             68m
-crossplane-rbac-manager-7d6867bc4d-v7wpb    1/1     Running   0             68m
-upbound-bootstrapper-5f47977d54-t8kvk       1/1     Running   0             68m
-xgql-7c4b74c458-5bf2q                       1/1     Running   3 (67m ago)   68m
-```
-{{< /tab >}}
-
-{{< /tabs >}}
-
-Installing Crossplane creates new Kubernetes API end-points. Take a look at the new API end-points with `kubectl api-resources  | grep crossplane`. In a later step you use the {{< hover label="grep" line="10">}}Provider{{< /hover >}} resource install the Official Provider.
+Installing Crossplane creates new Kubernetes API end-points. Look at the new API end-points with `kubectl api-resources  | grep crossplane`. In a later step you use the {{< hover label="grep" line="10">}}Provider{{< /hover >}} resource install the Official Provider.
 
 ```shell  {label="grep"}
 kubectl api-resources  | grep crossplane

--- a/docs/getting-started/install-crossplane.md
+++ b/docs/getting-started/install-crossplane.md
@@ -74,7 +74,7 @@ crossplane-rbac-manager-84769b574-6mw6f   1/1     Running   0          54s
 
 {{< /tab >}}
 
-{{< tab "Vendor distributions" >}}
+{{< tab "Vendor Distributions" >}}
 
 ## Upbound
 Upbound are the founders of Crossplane. Upbound maintains and supports an open source distribution of Crossplane called [Upbound Universal Crossplane](https://github.com/upbound/universal-crossplane) (_UXP_).

--- a/docs/getting-started/install-crossplane.md
+++ b/docs/getting-started/install-crossplane.md
@@ -1,0 +1,132 @@
+---
+toc_hide: true
+---
+
+## Install Crossplane
+
+Crossplane installs into an existing Kubernetes cluster. 
+
+Install Crossplane either as an upstream open source distribution or from a [CNCF certified](https://github.com/cncf/crossplane-conformance) vendor distribution.
+
+The Crossplane community supports the upstream distribution.  
+The Crossplane vendor supports their specific Crossplane distribution. 
+
+{{< hint type="tip" >}}
+If you don't have a Kubernetes cluster create one locally with [minikube](https://minikube.sigs.k8s.io/docs/start/) or [kind](https://kind.sigs.k8s.io/).
+{{< /hint >}}
+
+{{< tabs "distros" >}}
+
+{{< tab "Community Supported" >}}
+### Install the Crossplane Helm chart
+
+Helm enables Crossplane to install all its Kubernetes components through a single _Helm Chart_.
+
+Enable the Crossplane Helm Chart repository:
+
+```shell
+helm repo add \
+crossplane-stable https://charts.crossplane.io/stable
+helm repo update
+```
+
+Helm supports a `dry-run` to see the changes Helm makes. Run the Helm dry-run to see all the Crossplane components.
+
+```shell
+helm install crossplane \
+--dry-run --debug \
+--namespace crossplane-system \
+crossplane-stable/crossplane
+```
+
+Last, install the Crossplane components using `helm install`.
+
+```shell
+helm install crossplane \
+--namespace crossplane-system \
+crossplane-stable/crossplane
+
+NAME: crossplane
+LAST DEPLOYED: Sun Oct 16 19:11:27 2022
+NAMESPACE: crossplane-system
+STATUS: deployed
+REVISION: 1
+TEST SUITE: None
+NOTES:
+Release: crossplane
+
+Chart Name: crossplane
+Chart Description: Crossplane is an open source Kubernetes add-on that enables platform teams to assemble infrastructure from multiple vendors, and expose higher level self-service APIs for application teams to consume.
+Chart Version: 1.9.1
+Chart Application Version: 1.9.1
+
+Kube Version: v1.25.2
+```
+
+Verify Crossplane installed with `kubectl get pods`.
+
+```shell
+kubectl get pods -n crossplane-system                                                                  
+NAME                                      READY   STATUS    RESTARTS   AGE
+crossplane-d4cd8d784-ldcgb                1/1     Running   0          54s
+crossplane-rbac-manager-84769b574-6mw6f   1/1     Running   0          54s
+```
+
+{{< /tab >}}
+
+{{< tab "Vendor distributions" >}}
+
+## Upbound
+Upbound are the founders of Crossplane. Upbound maintains and supports an open source distribution of Crossplane called [Upbound Universal Crossplane](https://github.com/upbound/universal-crossplane) (_UXP_).
+
+More details about installing and configuring UXP are available in the [Upbound documentation](https://docs.upbound.io)
+
+### Install the Up command-line
+The Up command-line helps manage UXP and manage Upbound user accounts. 
+
+Download and install the Upbound `up` command-line.
+
+```shell {copy-lines="all"}
+curl -sL "https://cli.upbound.io" | sh
+sudo mv up /usr/local/bin/
+```
+
+### Install Upbound Universal Crossplane
+_UXP_ consists of upstream Crossplane and Upbound-specific enhancements and patches. It's [open source](https://github.com/upbound/universal-crossplane) and maintained by Upbound. 
+
+Install UXP with the Up command-line `up uxp install` command.
+
+```shell
+up uxp install
+UXP 1.9.1-up.2 installed
+```
+
+Verify all UXP pods are `Running` with `kubectl get pods -n upbound-system`. This may take up to five minutes depending on your Kubernetes cluster.
+
+```shell {label="pods"}
+kubectl get pods -n upbound-system
+NAME                                        READY   STATUS    RESTARTS      AGE
+crossplane-7fdfbd897c-pmrml                 1/1     Running   0             68m
+crossplane-rbac-manager-7d6867bc4d-v7wpb    1/1     Running   0             68m
+upbound-bootstrapper-5f47977d54-t8kvk       1/1     Running   0             68m
+xgql-7c4b74c458-5bf2q                       1/1     Running   3 (67m ago)   68m
+```
+{{< /tab >}}
+
+{{< /tabs >}}
+
+Installing Crossplane creates new Kubernetes API end-points. Take a look at the new API end-points with `kubectl api-resources  | grep crossplane`. In a later step you use the {{< hover label="grep" line="10">}}Provider{{< /hover >}} resource install the Official Provider.
+
+```shell  {label="grep"}
+kubectl api-resources  | grep crossplane
+compositeresourcedefinitions      xrd,xrds     apiextensions.crossplane.io/v1         false        CompositeResourceDefinition
+compositionrevisions                           apiextensions.crossplane.io/v1alpha1   false        CompositionRevision
+compositions                                   apiextensions.crossplane.io/v1         false        Composition
+configurationrevisions                         pkg.crossplane.io/v1                   false        ConfigurationRevision
+configurations                                 pkg.crossplane.io/v1                   false        Configuration
+controllerconfigs                              pkg.crossplane.io/v1alpha1             false        ControllerConfig
+locks                                          pkg.crossplane.io/v1beta1              false        Lock
+providerrevisions                              pkg.crossplane.io/v1                   false        ProviderRevision
+providers                                      pkg.crossplane.io/v1                   false        Provider
+storeconfigs                                   secrets.crossplane.io/v1alpha1         false        StoreConfig
+```

--- a/docs/getting-started/install-crossplane.md
+++ b/docs/getting-started/install-crossplane.md
@@ -7,7 +7,7 @@ toc_hide: true
 Crossplane installs into an existing Kubernetes cluster. 
 
 {{< hint type="tip" >}}
-If you don't have a Kubernetes cluster create one locally with [minikube](https://minikube.sigs.k8s.io/docs/start/) or [kind](https://kind.sigs.k8s.io/).
+If you don't have a Kubernetes cluster create one locally with [kind](https://kind.sigs.k8s.io/).
 {{< /hint >}}
 
 ### Install the Crossplane Helm chart

--- a/docs/getting-started/provider-aws.md
+++ b/docs/getting-started/provider-aws.md
@@ -1,0 +1,226 @@
+---
+title: AWS Quickstart
+weight: 2
+---
+
+Connect Crossplane to AWS to create and manage cloud resources from Kubernetes with the [AWS Official Provider](https://marketplace.upbound.io/providers/upbound/provider-aws).
+
+This guide walks you through the steps required to get started with the AWS Official Provider. This includes installing Crossplane, configuring the provider to authenticate to AWS and creating a _Managed Resource_ in AWS directly from your Kubernetes cluster.
+
+- [Prerequisites](#prerequisites)
+  - [Install the official AWS provider](#install-the-official-aws-provider)
+  - [Create a Kubernetes secret for AWS](#create-a-kubernetes-secret-for-aws)
+    - [Generate an AWS key-pair file](#generate-an-aws-key-pair-file)
+    - [Create a Kubernetes secret with the AWS credentials](#create-a-kubernetes-secret-with-the-aws-credentials)
+  - [Create a ProviderConfig](#create-a-providerconfig)
+  - [Create a managed resource](#create-a-managed-resource)
+  - [Delete the managed resource](#delete-the-managed-resource)
+- [Next steps](#next-steps)
+
+## Prerequisites
+This quickstart requires:
+* a Kubernetes cluster with at least 3 GB of RAM
+* permissions to create pods and secrets in the Kubernetes cluster
+* [Helm] version `v3.0.0` or later
+* an AWS account with permissions to create an S3 storage bucket
+* AWS [access keys](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-quickstart.html#cli-configure-quickstart-creds)
+
+{{< hint type="tip" >}}
+If you don't have a Kubernetes cluster create one locally with [minikube](https://minikube.sigs.k8s.io/docs/start/) or [kind](https://kind.sigs.k8s.io/).
+{{< /hint >}}
+
+
+{{< hint type="note" >}}
+All commands use the current `kubeconfig` context and configuration. 
+{{< /hint >}}
+
+{{< include file="/docs/master/quickstart/install-crossplane.md" type="page" >}}
+
+### Install the official AWS provider
+
+Install the official provider into the Kubernetes cluster with the `up` command-line or a Kubernetes configuration file. 
+{{< tabs "provider-install" >}}
+
+{{< tab "with the Up command-line" >}}
+```shell {copy-lines="all"}
+up controlplane \
+provider install \
+xpkg.upbound.io/upbound/provider-aws:v0.17.0
+```
+{{< /tab >}}
+
+{{< tab "with a Kubernetes manifest" >}}
+```shell {label="provider",copy-lines="all"}
+cat <<EOF | kubectl apply -f -
+apiVersion: pkg.crossplane.io/v1
+kind: Provider
+metadata:
+  name: upbound-provider-aws
+spec:
+  package: xpkg.upbound.io/upbound/provider-aws:v0.17.0
+EOF
+```
+
+The {{< hover label="provider" line="3">}}kind: Provider{{< /hover >}} uses the Crossplane `Provider` _Custom Resource Definition_ to connect your Kubernetes cluster to your cloud provider.  
+
+{{< /tab >}}
+
+{{< /tabs >}}
+
+Verify the provider installed with `kubectl get providers`. 
+
+{{< hint type="note" >}}
+It may take up to five minutes for the provider to list `HEALTHY` as `True`. 
+{{< /hint >}}
+
+```shell 
+kubectl get providers
+NAME                   INSTALLED   HEALTHY   PACKAGE                                        AGE
+upbound-provider-aws   True        True      xpkg.upbound.io/upbound/provider-aws:v0.17.0   73s
+```
+
+A provider installs their own Kubernetes _Custom Resource Definitions_ (CRDs). These CRDs allow you to create AWS resources directly inside Kubernetes.
+
+You can view the new CRDs with `kubectl get crds`. Every CRD maps to a unique AWS service Crossplane can provision and manage.
+
+All the supported CRDs are also available in the [Upbound Marketplace](https://marketplace.upbound.io/providers/upbound/provider-aws/v0.17.0/crds).
+
+### Create a Kubernetes secret for AWS
+The provider requires credentials to create and manage AWS resources. Providers use a Kubernetes _Secret_ to connect the credentials to the provider.
+
+First generate a Kubernetes _Secret_ from your AWS key-pair and then configure the Provider to use it.
+
+#### Generate an AWS key-pair file
+For basic user authentication, use an AWS Access keys key-pair file. 
+
+{{< hint type="tip" >}}
+The [AWS documentation](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-quickstart.html#cli-configure-quickstart-creds) provides information on how to generate AWS Access keys.
+{{< /hint >}}
+
+Create a text file containing the AWS account `aws_access_key_id` and `aws_secret_access_key`.  
+
+```ini {copy-lines="all"}
+[default]
+aws_access_key_id = <aws_access_key>
+aws_secret_access_key = <aws_secret_key>
+```
+
+Save this text file as `aws-credentials.txt`.
+
+{{< hint type="note" >}}
+The [Configuration](https://marketplace.upbound.io/providers/upbound/provider-aws/latest/docs/configuration) section of the Provider documentation describes other authentication methods.
+{{< /hint >}}
+
+#### Create a Kubernetes secret with the AWS credentials
+A Kubernetes generic secret has a name and contents. Use {{< hover label="kube-create-secret" line="1">}}kubectl create secret{{< /hover >}} to generate the secret object named {{< hover label="kube-create-secret" line="2">}}aws-secret{{< /hover >}} in the {{< hover label="kube-create-secret" line="3">}}crossplane-system{{</ hover >}} namespace.  
+Use the {{< hover label="kube-create-secret" line="4">}}--from-file={{</hover>}} argument to set the value to the contents of the  {{< hover label="kube-create-secret" line="4">}}aws-credentials.txt{{< /hover >}} file.
+
+```shell {label="kube-create-secret",copy-lines="all"}
+kubectl create secret \
+generic aws-secret \
+-n crossplane-system \
+--from-file=creds=./aws-credentials.txt
+```
+
+View the secret with `kubectl describe secret`
+
+{{< hint type="note" >}}
+The size may be larger if there are extra blank spaces in your text file.
+{{< /hint >}}
+
+```shell
+kubectl describe secret aws-secret -n crossplane-system
+Name:         aws-secret
+Namespace:    crossplane-system
+Labels:       <none>
+Annotations:  <none>
+
+Type:  Opaque
+
+Data
+====
+creds:  114 bytes
+```
+
+### Create a ProviderConfig
+A `ProviderConfig` customizes the settings of the AWS Provider.  
+
+Apply the {{< hover label="providerconfig" line="2">}}ProviderConfig{{</ hover >}} with the command:
+```yaml {label="providerconfig",copy-lines="all"}
+cat <<EOF | kubectl apply -f -
+apiVersion: aws.upbound.io/v1beta1
+kind: ProviderConfig
+metadata:
+  name: default
+spec:
+  credentials:
+    source: Secret
+    secretRef:
+      namespace: crossplane-system
+      name: aws-secret
+      key: creds
+EOF
+```
+
+This attaches the AWS credentials, saved as a Kubernetes secret, as a {{< hover label="providerconfig" line="9">}}secretRef{{</ hover>}}.
+
+The {{< hover label="providerconfig" line="11">}}spec.credentials.secretRef.name{{< /hover >}} value is the name of the Kubernetes secret containing the AWS credentials in the {{< hover label="providerconfig" line="10">}}spec.credentials.secretRef.namespace{{< /hover >}}.
+
+
+### Create a managed resource
+A _managed resource_ is anything Crossplane creates and manages outside of the Kubernetes cluster. This creates an AWS S3 bucket with Crossplane. The S3 bucket is a _managed resource_.
+
+{{< hint type="note" >}}
+AWS S3 bucket names must be globally unique. To generate a unique name the example uses a random hash. 
+Any unique name is acceptable.
+{{< /hint >}}
+
+```yaml {label="xr"}
+bucket=$(echo "crossplane-bucket-"$(head -n 4096 /dev/urandom | openssl sha1 | tail -c 10))
+cat <<EOF | kubectl apply -f -
+apiVersion: s3.aws.upbound.io/v1beta1
+kind: Bucket
+metadata:
+  name: $bucket
+spec:
+  forProvider:
+    region: us-east-1
+  providerConfigRef:
+    name: default
+EOF
+```
+
+Notice the {{< hover label="xr" line="3">}}apiVersion{{< /hover >}} and {{< hover label="xr" line="4">}}kind{{</hover >}} are from the `Provider's` CRDs.
+
+
+The {{< hover label="xr" line="6">}}metadata.name{{< /hover >}} value is the name of the created S3 bucket in AWS.  
+This example uses the generated name `crossplane-bucket-<hash>` in the {{< hover label="xr" line="6">}}`$bucket`{{</hover >}} variable.
+
+The {{< hover label="xr" line="9">}}spec.forProvider.region{{< /hover >}} tells AWS which AWS region to use when deploying resources. The region can be any [AWS Regional endpoint](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints) code.
+
+Use `kubectl get buckets` to verify Crossplane created the bucket.
+
+{{< hint type="tip" >}}
+Crossplane created the bucket when the values `READY` and `SYNCED` are `True`.  
+This may take up to 5 minutes.  
+{{< /hint >}}
+
+```shell
+kubectl get buckets
+NAME                          READY   SYNCED   EXTERNAL-NAME                 AGE
+crossplane-bucket-45eed4ae0   True    True     crossplane-bucket-45eed4ae0   61s
+```
+
+### Delete the managed resource
+Before shutting down your Kubernetes cluster, delete the S3 bucket just created.
+
+Use `kubectl delete bucket <bucketname>` to remove the bucket.
+
+```shell
+kubectl delete bucket $bucket
+bucket.s3.aws.upbound.io "crossplane-bucket-45eed4ae0" deleted
+```
+
+## Next steps
+* Explore AWS resources that can Crossplane can configure in the [Provider CRD reference](https://marketplace.upbound.io/providers/upbound/provider-aws/v0.15.0/crds).
+* Join the [Crossplane Slack](https://slack.crossplane.io/) and connect with Crossplane users and contributors.

--- a/docs/getting-started/provider-aws.md
+++ b/docs/getting-started/provider-aws.md
@@ -3,12 +3,12 @@ title: AWS Quickstart
 weight: 2
 ---
 
-Connect Crossplane to AWS to create and manage cloud resources from Kubernetes with the [AWS Official Provider](https://marketplace.upbound.io/providers/upbound/provider-aws).
+Connect Crossplane to AWS to create and manage cloud resources from Kubernetes with the [Upbound AWS Provider](https://marketplace.upbound.io/providers/upbound/provider-aws).
 
-This guide walks you through the steps required to get started with the AWS Official Provider. This includes installing Crossplane, configuring the provider to authenticate to AWS and creating a _Managed Resource_ in AWS directly from your Kubernetes cluster.
+This guide walks you through the steps required to get started with the Upbound AWS Provider. This includes installing Crossplane, configuring the provider to authenticate to AWS and creating a _Managed Resource_ in AWS directly from your Kubernetes cluster.
 
 - [Prerequisites](#prerequisites)
-  - [Install the official AWS provider](#install-the-official-aws-provider)
+  - [Install the AWS provider](#install-the-aws-provider)
   - [Create a Kubernetes secret for AWS](#create-a-kubernetes-secret-for-aws)
     - [Generate an AWS key-pair file](#generate-an-aws-key-pair-file)
     - [Create a Kubernetes secret with the AWS credentials](#create-a-kubernetes-secret-with-the-aws-credentials)
@@ -21,7 +21,7 @@ This guide walks you through the steps required to get started with the AWS Offi
 This quickstart requires:
 * a Kubernetes cluster with at least 3 GB of RAM
 * permissions to create pods and secrets in the Kubernetes cluster
-* [Helm] version `v3.0.0` or later
+* [Helm] version `v3.2.0` or later
 * an AWS account with permissions to create an S3 storage bucket
 * AWS [access keys](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-quickstart.html#cli-configure-quickstart-creds)
 
@@ -36,20 +36,10 @@ All commands use the current `kubeconfig` context and configuration.
 
 {{< include file="/docs/master/getting-started/install-crossplane.md" type="page" >}}
 
-### Install the official AWS provider
+### Install the AWS provider
 
-Install the official provider into the Kubernetes cluster with the `up` command-line or a Kubernetes configuration file. 
-{{< tabs "provider-install" >}}
+Install the provider into the Kubernetes cluster with a Kubernetes configuration file. 
 
-{{< tab "with the Up command-line" >}}
-```shell {copy-lines="all"}
-up controlplane \
-provider install \
-xpkg.upbound.io/upbound/provider-aws:v0.17.0
-```
-{{< /tab >}}
-
-{{< tab "with a Kubernetes manifest" >}}
 ```shell {label="provider",copy-lines="all"}
 cat <<EOF | kubectl apply -f -
 apiVersion: pkg.crossplane.io/v1
@@ -62,10 +52,6 @@ EOF
 ```
 
 The {{< hover label="provider" line="3">}}kind: Provider{{< /hover >}} uses the Crossplane `Provider` _Custom Resource Definition_ to connect your Kubernetes cluster to your cloud provider.  
-
-{{< /tab >}}
-
-{{< /tabs >}}
 
 Verify the provider installed with `kubectl get providers`. 
 
@@ -83,12 +69,19 @@ A provider installs their own Kubernetes _Custom Resource Definitions_ (CRDs). T
 
 You can view the new CRDs with `kubectl get crds`. Every CRD maps to a unique AWS service Crossplane can provision and manage.
 
-All the supported CRDs are also available in the [Upbound Marketplace](https://marketplace.upbound.io/providers/upbound/provider-aws/v0.17.0/crds).
+
+{{< hint type="tip" >}}
+See details about all the supported CRDs in the [Upbound Marketplace](https://marketplace.upbound.io/providers/upbound/provider-aws/latest/crds).
+{{< /hint >}}
 
 ### Create a Kubernetes secret for AWS
 The provider requires credentials to create and manage AWS resources. Providers use a Kubernetes _Secret_ to connect the credentials to the provider.
 
 First generate a Kubernetes _Secret_ from your AWS key-pair and then configure the Provider to use it.
+
+{{< hint type="note" >}}
+Other authentication methods exist and are beyond the scope of this guide. The [Provider documentation](https://marketplace.upbound.io/providers/upbound/provider-aws/latest/docs/configuration) contains information on alternative authentication methods. 
+{{< /hint >}}
 
 #### Generate an AWS key-pair file
 For basic user authentication, use an AWS Access keys key-pair file. 
@@ -222,5 +215,5 @@ bucket.s3.aws.upbound.io "crossplane-bucket-45eed4ae0" deleted
 ```
 
 ## Next steps
-* Explore AWS resources that can Crossplane can configure in the [Provider CRD reference](https://marketplace.upbound.io/providers/upbound/provider-aws/v0.15.0/crds).
+* Explore AWS resources that can Crossplane can configure in the [Provider CRD reference](https://marketplace.upbound.io/providers/upbound/provider-aws/latest/crds).
 * Join the [Crossplane Slack](https://slack.crossplane.io/) and connect with Crossplane users and contributors.

--- a/docs/getting-started/provider-aws.md
+++ b/docs/getting-started/provider-aws.md
@@ -34,7 +34,7 @@ If you don't have a Kubernetes cluster create one locally with [minikube](https:
 All commands use the current `kubeconfig` context and configuration. 
 {{< /hint >}}
 
-{{< include file="/docs/master/quickstart/install-crossplane.md" type="page" >}}
+{{< include file="/docs/master/getting-started/install-crossplane.md" type="page" >}}
 
 ### Install the official AWS provider
 

--- a/docs/getting-started/provider-aws.md
+++ b/docs/getting-started/provider-aws.md
@@ -8,13 +8,13 @@ Connect Crossplane to AWS to create and manage cloud resources from Kubernetes w
 This guide walks you through the steps required to get started with the Upbound AWS Provider. This includes installing Crossplane, configuring the provider to authenticate to AWS and creating a _Managed Resource_ in AWS directly from your Kubernetes cluster.
 
 - [Prerequisites](#prerequisites)
-  - [Install the AWS provider](#install-the-aws-provider)
-  - [Create a Kubernetes secret for AWS](#create-a-kubernetes-secret-for-aws)
-    - [Generate an AWS key-pair file](#generate-an-aws-key-pair-file)
-    - [Create a Kubernetes secret with the AWS credentials](#create-a-kubernetes-secret-with-the-aws-credentials)
-  - [Create a ProviderConfig](#create-a-providerconfig)
-  - [Create a managed resource](#create-a-managed-resource)
-  - [Delete the managed resource](#delete-the-managed-resource)
+- [Install the AWS provider](#install-the-aws-provider)
+- [Create a Kubernetes secret for AWS](#create-a-kubernetes-secret-for-aws)
+  - [Generate an AWS key-pair file](#generate-an-aws-key-pair-file)
+  - [Create a Kubernetes secret with the AWS credentials](#create-a-kubernetes-secret-with-the-aws-credentials)
+- [Create a ProviderConfig](#create-a-providerconfig)
+- [Create a managed resource](#create-a-managed-resource)
+- [Delete the managed resource](#delete-the-managed-resource)
 - [Next steps](#next-steps)
 
 ## Prerequisites
@@ -36,7 +36,7 @@ All commands use the current `kubeconfig` context and configuration.
 
 {{< include file="/docs/master/getting-started/install-crossplane.md" type="page" >}}
 
-### Install the AWS provider
+## Install the AWS provider
 
 Install the provider into the Kubernetes cluster with a Kubernetes configuration file. 
 
@@ -74,7 +74,7 @@ You can view the new CRDs with `kubectl get crds`. Every CRD maps to a unique AW
 See details about all the supported CRDs in the [Upbound Marketplace](https://marketplace.upbound.io/providers/upbound/provider-aws/latest/crds).
 {{< /hint >}}
 
-### Create a Kubernetes secret for AWS
+## Create a Kubernetes secret for AWS
 The provider requires credentials to create and manage AWS resources. Providers use a Kubernetes _Secret_ to connect the credentials to the provider.
 
 First generate a Kubernetes _Secret_ from your AWS key-pair and then configure the Provider to use it.
@@ -83,7 +83,7 @@ First generate a Kubernetes _Secret_ from your AWS key-pair and then configure t
 Other authentication methods exist and are beyond the scope of this guide. The [Provider documentation](https://marketplace.upbound.io/providers/upbound/provider-aws/latest/docs/configuration) contains information on alternative authentication methods. 
 {{< /hint >}}
 
-#### Generate an AWS key-pair file
+### Generate an AWS key-pair file
 For basic user authentication, use an AWS Access keys key-pair file. 
 
 {{< hint type="tip" >}}
@@ -104,7 +104,7 @@ Save this text file as `aws-credentials.txt`.
 The [Configuration](https://marketplace.upbound.io/providers/upbound/provider-aws/latest/docs/configuration) section of the Provider documentation describes other authentication methods.
 {{< /hint >}}
 
-#### Create a Kubernetes secret with the AWS credentials
+### Create a Kubernetes secret with the AWS credentials
 A Kubernetes generic secret has a name and contents. Use {{< hover label="kube-create-secret" line="1">}}kubectl create secret{{< /hover >}} to generate the secret object named {{< hover label="kube-create-secret" line="2">}}aws-secret{{< /hover >}} in the {{< hover label="kube-create-secret" line="3">}}crossplane-system{{</ hover >}} namespace.  
 Use the {{< hover label="kube-create-secret" line="4">}}--from-file={{</hover>}} argument to set the value to the contents of the  {{< hover label="kube-create-secret" line="4">}}aws-credentials.txt{{< /hover >}} file.
 
@@ -135,7 +135,7 @@ Data
 creds:  114 bytes
 ```
 
-### Create a ProviderConfig
+## Create a ProviderConfig
 A `ProviderConfig` customizes the settings of the AWS Provider.  
 
 Apply the {{< hover label="providerconfig" line="2">}}ProviderConfig{{</ hover >}} with the command:
@@ -160,7 +160,7 @@ This attaches the AWS credentials, saved as a Kubernetes secret, as a {{< hover 
 The {{< hover label="providerconfig" line="11">}}spec.credentials.secretRef.name{{< /hover >}} value is the name of the Kubernetes secret containing the AWS credentials in the {{< hover label="providerconfig" line="10">}}spec.credentials.secretRef.namespace{{< /hover >}}.
 
 
-### Create a managed resource
+## Create a managed resource
 A _managed resource_ is anything Crossplane creates and manages outside of the Kubernetes cluster. This creates an AWS S3 bucket with Crossplane. The S3 bucket is a _managed resource_.
 
 {{< hint type="note" >}}
@@ -204,7 +204,7 @@ NAME                          READY   SYNCED   EXTERNAL-NAME                 AGE
 crossplane-bucket-45eed4ae0   True    True     crossplane-bucket-45eed4ae0   61s
 ```
 
-### Delete the managed resource
+## Delete the managed resource
 Before shutting down your Kubernetes cluster, delete the S3 bucket just created.
 
 Use `kubectl delete bucket <bucketname>` to remove the bucket.

--- a/docs/getting-started/provider-aws.md
+++ b/docs/getting-started/provider-aws.md
@@ -183,7 +183,7 @@ spec:
 EOF
 ```
 
-Notice the {{< hover label="xr" line="3">}}apiVersion{{< /hover >}} and {{< hover label="xr" line="4">}}kind{{</hover >}} are from the `Provider's` CRDs.
+Notice the {{< hover label="xr" line="3">}}apiVersion{{< /hover >}} and {{< hover label="xr" line="4">}}kind{{</hover >}} are from the provider's CRDs.
 
 
 The {{< hover label="xr" line="6">}}metadata.name{{< /hover >}} value is the name of the created S3 bucket in AWS.  

--- a/docs/getting-started/provider-aws.md
+++ b/docs/getting-started/provider-aws.md
@@ -34,7 +34,7 @@ If you don't have a Kubernetes cluster create one locally with [minikube](https:
 All commands use the current `kubeconfig` context and configuration. 
 {{< /hint >}}
 
-{{< include file="/docs/master/getting-started/install-crossplane.md" type="page" >}}
+{{< include file="install-crossplane.md" type="page" >}}
 
 ## Install the AWS provider
 

--- a/docs/getting-started/provider-azure.md
+++ b/docs/getting-started/provider-azure.md
@@ -3,13 +3,12 @@ title: Azure Quickstart
 weight: 3
 ---
 
-Connect Crossplane to Microsoft Azure to create and manage cloud resources from Kubernetes with the [Azure Official Provider](https://marketplace.upbound.io/providers/upbound/provider-azure).
+Connect Crossplane to Microsoft Azure to create and manage cloud resources from Kubernetes with the [Upbound Azure Provider](https://marketplace.upbound.io/providers/upbound/provider-azure).
 
-This guide walks you through the steps required to get started with the Azure Official Provider. This includes installing Crossplane, configuring the provider to authenticate to Azure and creating a _Managed Resource_ in Azure directly from your Kubernetes cluster.
+This guide walks you through the steps required to get started with the Upbound Azure Provider. This includes installing Crossplane, configuring the provider to authenticate to Azure and creating a _Managed Resource_ in Azure directly from your Kubernetes cluster.
 
 - [Prerequisites](#prerequisites)
-- [Guided tour](#guided-tour)
-  - [Install the official Azure provider](#install-the-official-azure-provider)
+  - [Install the Azure provider](#install-the-azure-provider)
   - [Create a Kubernetes secret for Azure](#create-a-kubernetes-secret-for-azure)
     - [Install the Azure command-line](#install-the-azure-command-line)
     - [Create an Azure service principal](#create-an-azure-service-principal)
@@ -23,35 +22,24 @@ This guide walks you through the steps required to get started with the Azure Of
 This quickstart requires:
 * a Kubernetes cluster with at least 3 GB of RAM
 * permissions to create pods and secrets in the Kubernetes cluster
+* [Helm] version `v3.2.0` or later
 * an Azure account with permissions to create an Azure [service principal](https://learn.microsoft.com/en-us/azure/active-directory/develop/app-objects-and-service-principals#service-principal-object) and an [Azure Resource Group](https://learn.microsoft.com/en-us/azure/azure-resource-manager/management/manage-resource-groups-portal)
 
 {{< hint type="tip" >}}
 If you don't have a Kubernetes cluster create one locally with [minikube](https://minikube.sigs.k8s.io/docs/start/) or [kind](https://kind.sigs.k8s.io/).
 {{< /hint >}}
 
-<!-- due to Azure CLI auth, this can't be automated -->
 
-## Guided tour
 {{< hint type="note" >}}
 All commands use the current `kubeconfig` context and configuration. 
 {{< /hint >}}
 
 {{< include file="/docs/master/getting-started/install-crossplane.md" type="page" >}}
 
-### Install the official Azure provider
+### Install the Azure provider
 
-Install the official provider into the Kubernetes cluster with the `up` command-line or a Kubernetes configuration file. 
-{{< tabs "provider-install" >}}
+Install the provider into the Kubernetes cluster with a Kubernetes configuration file. 
 
-{{< tab "with the Up command-line" >}}
-```shell {copy-lines="all"}
-up controlplane \
-provider install \
-xpkg.upbound.io/upbound/provider-azure:v0.16.0
-```
-{{< /tab >}}
-
-{{< tab "with a Kubernetes manifest" >}}
 ```shell {label="provider",copy-lines="all"}
 cat <<EOF | kubectl apply -f -
 apiVersion: pkg.crossplane.io/v1
@@ -64,10 +52,6 @@ EOF
 ```
 
 The {{< hover label="provider" line="3">}}kind: Provider{{< /hover >}} uses the Crossplane `Provider` _Custom Resource Definition_ to connect your Kubernetes cluster to your cloud provider.  
-
-{{< /tab >}}
-
-{{< /tabs >}}
 
 Verify the provider installed with `kubectl get providers`. 
 
@@ -85,7 +69,10 @@ A provider installs their own Kubernetes _Custom Resource Definitions_ (CRDs). T
 
 You can view the new CRDs with `kubectl get crds`. Every CRD maps to a unique Azure service Crossplane can provision and manage.
 
-All the supported CRDs are also available in the [Upbound Marketplace](https://marketplace.upbound.io/providers/upbound/provider-azure/v0.16.0/crds).
+{{< hint type="tip" >}}
+All the supported CRDs are also available in the [Upbound Marketplace](https://marketplace.upbound.io/providers/upbound/provider-azure/latest/crds).
+{{< /hint >}}
+
 
 ### Create a Kubernetes secret for Azure
 The provider requires credentials to create and manage Azure resources. Providers use a Kubernetes _Secret_ to connect the credentials to the provider.
@@ -225,5 +212,5 @@ resourcegroup.azure.upbound.io "example-rg" deleted
 ```
 
 ### Next steps 
-* Explore Azure resources that can Crossplane can configure in the [Provider CRD reference](https://marketplace.upbound.io/providers/upbound/provider-azure/v0.16.0/crds).
+* Explore Azure resources that can Crossplane can configure in the [Provider CRD reference](https://marketplace.upbound.io/providers/upbound/provider-azure/latest/crds).
 * Join the [Crossplane Slack](https://slack.crossplane.io/) and connect with Crossplane users and contributors.

--- a/docs/getting-started/provider-azure.md
+++ b/docs/getting-started/provider-azure.md
@@ -36,7 +36,7 @@ If you don't have a Kubernetes cluster create one locally with [minikube](https:
 All commands use the current `kubeconfig` context and configuration. 
 {{< /hint >}}
 
-{{< include file="quickstart/quickstart-common.md" type="page" >}}
+{{< include file="/docs/master/getting-started/install-crossplane.md" type="page" >}}
 
 ### Install the official Azure provider
 

--- a/docs/getting-started/provider-azure.md
+++ b/docs/getting-started/provider-azure.md
@@ -77,6 +77,10 @@ All the supported CRDs are also available in the [Upbound Marketplace](https://m
 ## Create a Kubernetes secret for Azure
 The provider requires credentials to create and manage Azure resources. Providers use a Kubernetes _Secret_ to connect the credentials to the provider.
 
+{{< hint type="note" >}}
+Other authentication methods exist and are beyond the scope of this guide. The [Provider documentation](https://marketplace.upbound.io/providers/upbound/provider-azure/latest/docs/configuration) contains information on alternative authentication methods. 
+{{< /hint >}}
+
 First generate a Kubernetes _Secret_ from your Azure JSON file and then configure the Provider to use it.
 
 ### Install the Azure command-line

--- a/docs/getting-started/provider-azure.md
+++ b/docs/getting-started/provider-azure.md
@@ -34,7 +34,7 @@ If you don't have a Kubernetes cluster create one locally with [minikube](https:
 All commands use the current `kubeconfig` context and configuration. 
 {{< /hint >}}
 
-{{< include file="/docs/master/getting-started/install-crossplane.md" type="page" >}}
+{{< include file="install-crossplane.md" type="page" >}}
 
 ### Install the Azure provider
 

--- a/docs/getting-started/provider-azure.md
+++ b/docs/getting-started/provider-azure.md
@@ -1,0 +1,229 @@
+---
+title: Azure Quickstart 
+weight: 3
+---
+
+Connect Crossplane to Microsoft Azure to create and manage cloud resources from Kubernetes with the [Azure Official Provider](https://marketplace.upbound.io/providers/upbound/provider-azure).
+
+This guide walks you through the steps required to get started with the Azure Official Provider. This includes installing Crossplane, configuring the provider to authenticate to Azure and creating a _Managed Resource_ in Azure directly from your Kubernetes cluster.
+
+- [Prerequisites](#prerequisites)
+- [Guided tour](#guided-tour)
+  - [Install the official Azure provider](#install-the-official-azure-provider)
+  - [Create a Kubernetes secret for Azure](#create-a-kubernetes-secret-for-azure)
+    - [Install the Azure command-line](#install-the-azure-command-line)
+    - [Create an Azure service principal](#create-an-azure-service-principal)
+    - [Create a Kubernetes secret with the Azure credentials](#create-a-kubernetes-secret-with-the-azure-credentials)
+  - [Create a ProviderConfig](#create-a-providerconfig)
+  - [Create a managed resource](#create-a-managed-resource)
+  - [Delete the managed resource](#delete-the-managed-resource)
+  - [Next steps](#next-steps)
+
+## Prerequisites
+This quickstart requires:
+* a Kubernetes cluster with at least 3 GB of RAM
+* permissions to create pods and secrets in the Kubernetes cluster
+* an Azure account with permissions to create an Azure [service principal](https://learn.microsoft.com/en-us/azure/active-directory/develop/app-objects-and-service-principals#service-principal-object) and an [Azure Resource Group](https://learn.microsoft.com/en-us/azure/azure-resource-manager/management/manage-resource-groups-portal)
+
+{{< hint type="tip" >}}
+If you don't have a Kubernetes cluster create one locally with [minikube](https://minikube.sigs.k8s.io/docs/start/) or [kind](https://kind.sigs.k8s.io/).
+{{< /hint >}}
+
+<!-- due to Azure CLI auth, this can't be automated -->
+
+## Guided tour
+{{< hint type="note" >}}
+All commands use the current `kubeconfig` context and configuration. 
+{{< /hint >}}
+
+{{< include file="quickstart/quickstart-common.md" type="page" >}}
+
+### Install the official Azure provider
+
+Install the official provider into the Kubernetes cluster with the `up` command-line or a Kubernetes configuration file. 
+{{< tabs "provider-install" >}}
+
+{{< tab "with the Up command-line" >}}
+```shell {copy-lines="all"}
+up controlplane \
+provider install \
+xpkg.upbound.io/upbound/provider-azure:v0.16.0
+```
+{{< /tab >}}
+
+{{< tab "with a Kubernetes manifest" >}}
+```shell {label="provider",copy-lines="all"}
+cat <<EOF | kubectl apply -f -
+apiVersion: pkg.crossplane.io/v1
+kind: Provider
+metadata:
+  name: upbound-provider-azure
+spec:
+  package: xpkg.upbound.io/upbound/provider-azure:v0.16.0
+EOF
+```
+
+The {{< hover label="provider" line="3">}}kind: Provider{{< /hover >}} uses the Crossplane `Provider` _Custom Resource Definition_ to connect your Kubernetes cluster to your cloud provider.  
+
+{{< /tab >}}
+
+{{< /tabs >}}
+
+Verify the provider installed with `kubectl get providers`. 
+
+{{< hint type="note" >}}
+It may take up to five minutes for the provider to list `HEALTHY` as `True`. 
+{{< /hint >}}
+
+```shell
+kubectl get providers 
+NAME                     INSTALLED   HEALTHY   PACKAGE                                          AGE
+upbound-provider-azure   True        True      xpkg.upbound.io/upbound/provider-azure:v0.16.0   3m3s
+```
+
+A provider installs their own Kubernetes _Custom Resource Definitions_ (CRDs). These CRDs allow you to create Azure resources directly inside Kubernetes.
+
+You can view the new CRDs with `kubectl get crds`. Every CRD maps to a unique Azure service Crossplane can provision and manage.
+
+All the supported CRDs are also available in the [Upbound Marketplace](https://marketplace.upbound.io/providers/upbound/provider-azure/v0.16.0/crds).
+
+### Create a Kubernetes secret for Azure
+The provider requires credentials to create and manage Azure resources. Providers use a Kubernetes _Secret_ to connect the credentials to the provider.
+
+First generate a Kubernetes _Secret_ from your Azure JSON file and then configure the Provider to use it.
+
+#### Install the Azure command-line
+Generating an [authentication file](https://docs.microsoft.com/en-us/azure/developer/go/azure-sdk-authorization#use-file-based-authentication) requires the Azure command-line.  
+Follow the documentation from Microsoft to [Download and install the Azure command-line](https://docs.microsoft.com/en-us/cli/azure/install-azure-cli).
+
+Log in to the Azure command-line.
+
+```command
+az login
+```
+#### Create an Azure service principal
+Follow the Azure documentation to [find your Subscription ID](https://docs.microsoft.com/en-us/azure/azure-portal/get-subscription-tenant-id) from the Azure Portal.
+
+Using the Azure command-line and provide your Subscription ID create a service principal and authentication file.
+
+```shell {copy-lines="all"}
+az ad sp create-for-rbac \
+--sdk-auth \
+--role Owner \
+--scopes /subscriptions/<Subscription ID> 
+```
+
+Save your Azure JSON output as `azure-credentials.json`.
+
+{{< hint type="note" >}}
+The [Configuration](https://marketplace.upbound.io/providers/upbound/provider-azure/latest/docs/configuration) section of the Provider documentation describes other authentication methods.
+{{< /hint >}}
+
+#### Create a Kubernetes secret with the Azure credentials
+A Kubernetes generic secret has a name and contents. Use {{< hover label="kube-create-secret" line="1">}}kubectl create secret{{< /hover >}} to generate the secret object named {{< hover label="kube-create-secret" line="2">}}azure-secret{{< /hover >}} in the {{< hover label="kube-create-secret" line="3">}}crossplane-system{{</ hover >}} namespace.  
+
+<!-- vale gitlab.Substitutions = NO -->
+<!-- ignore .json file name -->
+Use the {{< hover label="kube-create-secret" line="4">}}--from-file={{</hover>}} argument to set the value to the contents of the  {{< hover label="kube-create-secret" line="4">}}azure-credentials.json{{< /hover >}} file.
+<!-- vale gitlab.Substitutions = YES -->
+```shell {label="kube-create-secret",copy-lines="all"}
+kubectl create secret \
+generic azure-secret \
+-n crossplane-system \
+--from-file=creds=./azure-credentials.json
+```
+
+View the secret with `kubectl describe secret`
+
+{{< hint type="note" >}}
+The size may be larger if there are extra blank spaces in your text file.
+{{< /hint >}}
+
+```shell
+kubectl describe secret azure-secret -n crossplane-system
+Name:         azure-secret
+Namespace:    crossplane-system
+Labels:       <none>
+Annotations:  <none>
+
+Type:  Opaque
+
+Data
+====
+creds:  629 bytes
+```
+
+### Create a ProviderConfig
+A `ProviderConfig` customizes the settings of the Azure Provider.  
+
+Apply the {{< hover label="providerconfig" line="2">}}ProviderConfig{{</ hover >}} with the command:
+```yaml {label="providerconfig",copy-lines="all"}
+cat <<EOF | kubectl apply -f -
+apiVersion: azure.upbound.io/v1beta1
+metadata:
+  name: default
+kind: ProviderConfig
+spec:
+  credentials:
+    source: Secret
+    secretRef:
+      namespace: crossplane-system
+      name: azure-secret
+      key: creds
+EOF
+```
+
+This attaches the Azure credentials, saved as a Kubernetes secret, as a {{< hover label="providerconfig" line="9">}}secretRef{{</ hover>}}.
+
+The {{< hover label="providerconfig" line="11">}}spec.credentials.secretRef.name{{< /hover >}} value is the name of the Kubernetes secret containing the Azure credentials in the {{< hover label="providerconfig" line="10">}}spec.credentials.secretRef.namespace{{< /hover >}}.
+
+
+### Create a managed resource
+A _managed resource_ is anything Crossplane creates and manages outside of the Kubernetes cluster. This creates an Azure Resource group with Crossplane. The Resource group is a _managed resource_.
+
+{{< hint type="tip" >}}
+A resource group is one of the fastest Azure resources to provision.
+{{< /hint >}}
+
+```yaml {label="xr",copy-lines="all"}
+cat <<EOF | kubectl apply -f -
+apiVersion: azure.upbound.io/v1beta1
+kind: ResourceGroup
+metadata:
+  name: example-rg
+spec:
+  forProvider:
+    location: "East US"
+  providerConfigRef:
+    name: default
+EOF
+```
+
+Notice the {{< hover label="xr" line="2">}}apiVersion{{< /hover >}} and {{< hover label="xr" line="3">}}kind{{</hover >}} are from the `Provider's` CRDs.
+
+The {{< hover label="xr" line="5">}}metadata.name{{< /hover >}} value is the name of the created resource group in Azure.  
+This example uses the name `example-rg`.
+
+The {{< hover label="xr" line="8">}}spec.forProvider.location{{< /hover >}} tells Azure which Azure region to use when deploying resources. The region can be any [Azure geography](https://azure.microsoft.com/en-us/explore/global-infrastructure/geographies/) code.
+
+Use `kubectl get resourcegroup` to verify Crossplane created the resource group.
+
+```shell
+kubectl get ResourceGroup
+NAME         READY   SYNCED   EXTERNAL-NAME   AGE
+example-rg   True    True     example-rg      4m58s
+```
+
+### Delete the managed resource
+Before shutting down your Kubernetes cluster, delete the resource group just created.
+
+Use `kubectl delete resource-group` to remove the bucket.
+
+```shell
+kubectl delete resourcegroup example-rg
+resourcegroup.azure.upbound.io "example-rg" deleted
+```
+
+### Next steps 
+* Explore Azure resources that can Crossplane can configure in the [Provider CRD reference](https://marketplace.upbound.io/providers/upbound/provider-azure/v0.16.0/crds).
+* Join the [Crossplane Slack](https://slack.crossplane.io/) and connect with Crossplane users and contributors.

--- a/docs/getting-started/provider-azure.md
+++ b/docs/getting-started/provider-azure.md
@@ -8,15 +8,15 @@ Connect Crossplane to Microsoft Azure to create and manage cloud resources from 
 This guide walks you through the steps required to get started with the Upbound Azure Provider. This includes installing Crossplane, configuring the provider to authenticate to Azure and creating a _Managed Resource_ in Azure directly from your Kubernetes cluster.
 
 - [Prerequisites](#prerequisites)
-  - [Install the Azure provider](#install-the-azure-provider)
-  - [Create a Kubernetes secret for Azure](#create-a-kubernetes-secret-for-azure)
-    - [Install the Azure command-line](#install-the-azure-command-line)
-    - [Create an Azure service principal](#create-an-azure-service-principal)
-    - [Create a Kubernetes secret with the Azure credentials](#create-a-kubernetes-secret-with-the-azure-credentials)
-  - [Create a ProviderConfig](#create-a-providerconfig)
-  - [Create a managed resource](#create-a-managed-resource)
-  - [Delete the managed resource](#delete-the-managed-resource)
-  - [Next steps](#next-steps)
+- [Install the Azure provider](#install-the-azure-provider)
+- [Create a Kubernetes secret for Azure](#create-a-kubernetes-secret-for-azure)
+  - [Install the Azure command-line](#install-the-azure-command-line)
+  - [Create an Azure service principal](#create-an-azure-service-principal)
+  - [Create a Kubernetes secret with the Azure credentials](#create-a-kubernetes-secret-with-the-azure-credentials)
+- [Create a ProviderConfig](#create-a-providerconfig)
+- [Create a managed resource](#create-a-managed-resource)
+- [Delete the managed resource](#delete-the-managed-resource)
+- [Next steps](#next-steps)
 
 ## Prerequisites
 This quickstart requires:
@@ -36,7 +36,7 @@ All commands use the current `kubeconfig` context and configuration.
 
 {{< include file="install-crossplane.md" type="page" >}}
 
-### Install the Azure provider
+## Install the Azure provider
 
 Install the provider into the Kubernetes cluster with a Kubernetes configuration file. 
 
@@ -74,12 +74,12 @@ All the supported CRDs are also available in the [Upbound Marketplace](https://m
 {{< /hint >}}
 
 
-### Create a Kubernetes secret for Azure
+## Create a Kubernetes secret for Azure
 The provider requires credentials to create and manage Azure resources. Providers use a Kubernetes _Secret_ to connect the credentials to the provider.
 
 First generate a Kubernetes _Secret_ from your Azure JSON file and then configure the Provider to use it.
 
-#### Install the Azure command-line
+### Install the Azure command-line
 Generating an [authentication file](https://docs.microsoft.com/en-us/azure/developer/go/azure-sdk-authorization#use-file-based-authentication) requires the Azure command-line.  
 Follow the documentation from Microsoft to [Download and install the Azure command-line](https://docs.microsoft.com/en-us/cli/azure/install-azure-cli).
 
@@ -88,7 +88,7 @@ Log in to the Azure command-line.
 ```command
 az login
 ```
-#### Create an Azure service principal
+### Create an Azure service principal
 Follow the Azure documentation to [find your Subscription ID](https://docs.microsoft.com/en-us/azure/azure-portal/get-subscription-tenant-id) from the Azure Portal.
 
 Using the Azure command-line and provide your Subscription ID create a service principal and authentication file.
@@ -106,7 +106,7 @@ Save your Azure JSON output as `azure-credentials.json`.
 The [Configuration](https://marketplace.upbound.io/providers/upbound/provider-azure/latest/docs/configuration) section of the Provider documentation describes other authentication methods.
 {{< /hint >}}
 
-#### Create a Kubernetes secret with the Azure credentials
+### Create a Kubernetes secret with the Azure credentials
 A Kubernetes generic secret has a name and contents. Use {{< hover label="kube-create-secret" line="1">}}kubectl create secret{{< /hover >}} to generate the secret object named {{< hover label="kube-create-secret" line="2">}}azure-secret{{< /hover >}} in the {{< hover label="kube-create-secret" line="3">}}crossplane-system{{</ hover >}} namespace.  
 
 <!-- vale gitlab.Substitutions = NO -->
@@ -140,7 +140,7 @@ Data
 creds:  629 bytes
 ```
 
-### Create a ProviderConfig
+## Create a ProviderConfig
 A `ProviderConfig` customizes the settings of the Azure Provider.  
 
 Apply the {{< hover label="providerconfig" line="2">}}ProviderConfig{{</ hover >}} with the command:
@@ -165,7 +165,7 @@ This attaches the Azure credentials, saved as a Kubernetes secret, as a {{< hove
 The {{< hover label="providerconfig" line="11">}}spec.credentials.secretRef.name{{< /hover >}} value is the name of the Kubernetes secret containing the Azure credentials in the {{< hover label="providerconfig" line="10">}}spec.credentials.secretRef.namespace{{< /hover >}}.
 
 
-### Create a managed resource
+## Create a managed resource
 A _managed resource_ is anything Crossplane creates and manages outside of the Kubernetes cluster. This creates an Azure Resource group with Crossplane. The Resource group is a _managed resource_.
 
 {{< hint type="tip" >}}
@@ -201,7 +201,7 @@ NAME         READY   SYNCED   EXTERNAL-NAME   AGE
 example-rg   True    True     example-rg      4m58s
 ```
 
-### Delete the managed resource
+## Delete the managed resource
 Before shutting down your Kubernetes cluster, delete the resource group just created.
 
 Use `kubectl delete resource-group` to remove the bucket.
@@ -211,6 +211,6 @@ kubectl delete resourcegroup example-rg
 resourcegroup.azure.upbound.io "example-rg" deleted
 ```
 
-### Next steps 
+## Next steps 
 * Explore Azure resources that can Crossplane can configure in the [Provider CRD reference](https://marketplace.upbound.io/providers/upbound/provider-azure/latest/crds).
 * Join the [Crossplane Slack](https://slack.crossplane.io/) and connect with Crossplane users and contributors.

--- a/docs/getting-started/provider-gcp.md
+++ b/docs/getting-started/provider-gcp.md
@@ -8,14 +8,14 @@ Connect Crossplane to Google GCP to create and manage cloud resources from Kuber
 This guide walks you through the steps required to get started with the Upbound GCP Provider. This includes installing Crossplane, configuring the provider to authenticate to GCP and creating a _Managed Resource_ in GCP directly from your Kubernetes cluster.
 
 - [Prerequisites](#prerequisites)
-  - [Install the GCP provider](#install-the-gcp-provider)
-  - [Create a Kubernetes secret for GCP](#create-a-kubernetes-secret-for-gcp)
-    - [Generate a GCP service account JSON file](#generate-a-gcp-service-account-json-file)
-    - [Create a Kubernetes secret with the GCP credentials](#create-a-kubernetes-secret-with-the-gcp-credentials)
-  - [Create a ProviderConfig](#create-a-providerconfig)
-  - [Create a managed resource](#create-a-managed-resource)
-  - [Delete the managed resource](#delete-the-managed-resource)
-  - [Next steps](#next-steps)
+- [Install the GCP provider](#install-the-gcp-provider)
+- [Create a Kubernetes secret for GCP](#create-a-kubernetes-secret-for-gcp)
+  - [Generate a GCP service account JSON file](#generate-a-gcp-service-account-json-file)
+  - [Create a Kubernetes secret with the GCP credentials](#create-a-kubernetes-secret-with-the-gcp-credentials)
+- [Create a ProviderConfig](#create-a-providerconfig)
+- [Create a managed resource](#create-a-managed-resource)
+- [Delete the managed resource](#delete-the-managed-resource)
+- [Next steps](#next-steps)
 
 ## Prerequisites
 This quickstart requires:
@@ -38,7 +38,7 @@ All commands use the current `kubeconfig` context and configuration.
 
 {{< include file="/docs/master/getting-started/install-crossplane.md" type="page" >}}
 
-### Install the GCP provider
+## Install the GCP provider
 
 Install the provider into the Kubernetes cluster with a Kubernetes configuration file. 
 
@@ -75,7 +75,7 @@ You can view the new CRDs with `kubectl get crds`. Every CRD maps to a unique GC
 All the supported CRDs are also available in the [Upbound Marketplace](https://marketplace.upbound.io/providers/upbound/provider-gcp/latest/crds).
 {{< /hint >}}
 
-### Create a Kubernetes secret for GCP
+## Create a Kubernetes secret for GCP
 The provider requires credentials to create and manage GCP resources. Providers use a Kubernetes _Secret_ to connect the credentials to the provider.
 
 First generate a Kubernetes _Secret_ from a Google Cloud service account JSON file and then configure the Provider to use it.
@@ -84,7 +84,7 @@ First generate a Kubernetes _Secret_ from a Google Cloud service account JSON fi
 Other authentication methods exist and are beyond the scope of this guide. The [Provider documentation](https://marketplace.upbound.io/providers/upbound/provider-gcp/latest/docs/configuration) contains information on alternative authentication methods. 
 {{< /hint >}}
 
-#### Generate a GCP service account JSON file
+### Generate a GCP service account JSON file
 For basic user authentication, use a Google Cloud service account JSON file. 
 
 {{< hint type="tip" >}}
@@ -97,7 +97,7 @@ Save this JSON file as `gcp-credentials.json`
 The [Configuration](https://marketplace.upbound.io/providers/upbound/provider-gcp/latest/docs/configuration) section of the Provider documentation describes other authentication methods.
 {{< /hint >}}
 
-#### Create a Kubernetes secret with the GCP credentials
+### Create a Kubernetes secret with the GCP credentials
 <!-- vale gitlab.Substitutions = NO -->
 <!-- ignore .json file name -->
 A Kubernetes generic secret has a name and contents. Use {{< hover label="kube-create-secret" line="1">}}kubectl create secret{{< /hover >}} to generate the secret object named {{< hover label="kube-create-secret" line="2">}}gcp-secret{{< /hover >}} in the {{< hover label="kube-create-secret" line="3">}}crossplane-system{{</ hover >}} namespace.  
@@ -131,7 +131,7 @@ Data
 creds:  2330 bytes
 ```
 
-### Create a ProviderConfig
+## Create a ProviderConfig
 A `ProviderConfig` customizes the settings of the GCP Provider.  
 
 Apply the {{< hover label="providerconfig" line="2">}}ProviderConfig{{</ hover >}}. Include your {{< hover label="providerconfig" line="7" >}}GCP project ID{{< /hover >}}.
@@ -162,7 +162,7 @@ This attaches the GCP credentials, saved as a Kubernetes secret, as a {{< hover 
 The {{< hover label="providerconfig" line="12">}}spec.credentials.secretRef.name{{< /hover >}} value is the name of the Kubernetes secret containing the GCP credentials in the {{< hover label="providerconfig" line="11">}}spec.credentials.secretRef.namespace{{< /hover >}}.
 
 
-### Create a managed resource
+## Create a managed resource
 A _managed resource_ is anything Crossplane creates and manages outside of the Kubernetes cluster. This creates a GCP storage bucket with Crossplane. The storage bucket is a _managed resource_.
 
 This generates a random name for the storage bucket starting with {{< hover label="xr" line="1" >}}crossplane-bucket{{< /hover >}}
@@ -209,7 +209,7 @@ crossplane-bucket-cf2b6d853   True    True     crossplane-bucket-cf2b6d853   3m3
 
 Optionally, log into the [GCP Console](https://console.cloud.google.com/) and see the storage bucket inside GCP.
 
-### Delete the managed resource
+## Delete the managed resource
 Before shutting down your Kubernetes cluster, delete the S3 bucket just created.
 
 Use `kubectl delete bucket <bucketname>` to remove the bucket.
@@ -222,6 +222,6 @@ bucket.storage.gcp.upbound.io "crossplane-bucket-b7cf6b590" deleted
 Look in the [GCP Console](https://console.cloud.google.com/) to confirm Crossplane deleted the bucket from GCP.
 
 
-### Next steps 
+## Next steps 
 * Explore GCP resources that can Crossplane can configure in the [Provider CRD reference](https://marketplace.upbound.io/providers/upbound/provider-gcp/latest/crds).
 * Join the [Crossplane Slack](https://slack.crossplane.io/) and connect with Crossplane users and contributors.

--- a/docs/getting-started/provider-gcp.md
+++ b/docs/getting-started/provider-gcp.md
@@ -3,13 +3,12 @@ title: GCP Quickstart
 weight: 4
 ---
 
-Connect Crossplane to Google GCP to create and manage cloud resources from Kubernetes with the [GCP Official Provider](https://marketplace.upbound.io/providers/upbound/provider-gcp/).
+Connect Crossplane to Google GCP to create and manage cloud resources from Kubernetes with the [Upbound GCP Provider](https://marketplace.upbound.io/providers/upbound/provider-gcp/).
 
-This guide walks you through the steps required to get started with the GCP Official Provider. This includes installing Crossplane, configuring the provider to authenticate to GCP and creating a _Managed Resource_ in GCP directly from your Kubernetes cluster.
+This guide walks you through the steps required to get started with the Upbound GCP Provider. This includes installing Crossplane, configuring the provider to authenticate to GCP and creating a _Managed Resource_ in GCP directly from your Kubernetes cluster.
 
 - [Prerequisites](#prerequisites)
-- [Guided tour](#guided-tour)
-  - [Install the official GCP provider](#install-the-official-gcp-provider)
+  - [Install the GCP provider](#install-the-gcp-provider)
   - [Create a Kubernetes secret for GCP](#create-a-kubernetes-secret-for-gcp)
     - [Generate a GCP service account JSON file](#generate-a-gcp-service-account-json-file)
     - [Create a Kubernetes secret with the GCP credentials](#create-a-kubernetes-secret-with-the-gcp-credentials)
@@ -22,6 +21,7 @@ This guide walks you through the steps required to get started with the GCP Offi
 This quickstart requires:
 * a Kubernetes cluster with at least 3 GB of RAM
 * permissions to create pods and secrets in the Kubernetes cluster
+* [Helm] version `v3.2.0` or later
 * a GCP account with permissions to create a storage bucket
 * GCP [account keys](https://cloud.google.com/iam/docs/creating-managing-service-account-keys)
 * GCP [Project ID](https://support.google.com/googleapi/answer/7014113?hl=en)
@@ -30,30 +30,18 @@ This quickstart requires:
 If you don't have a Kubernetes cluster create one locally with [minikube](https://minikube.sigs.k8s.io/docs/start/) or [kind](https://kind.sigs.k8s.io/).
 {{< /hint >}}
 
-## Guided tour
+
 {{< hint type="note" >}}
 All commands use the current `kubeconfig` context and configuration. 
 {{< /hint >}}
 
-You need your:
-* GCP service account key
 
 {{< include file="/docs/master/getting-started/install-crossplane.md" type="page" >}}
 
-### Install the official GCP provider
+### Install the GCP provider
 
-Install the official provider into the Kubernetes cluster with the `up` command-line or a Kubernetes configuration file. 
-{{< tabs "provider-install" >}}
+Install the provider into the Kubernetes cluster with a Kubernetes configuration file. 
 
-{{< tab "with the Up command-line" >}}
-```shell {copy-lines="all"}
-up controlplane \
-provider install \
-xpkg.upbound.io/upbound/provider-gcp:v0.15.0
-```
-{{< /tab >}}
-
-{{< tab "with a Kubernetes manifest" >}}
 ```shell {label="provider",copy-lines="all"}
 cat <<EOF | kubectl apply -f -
 apiVersion: pkg.crossplane.io/v1
@@ -66,10 +54,6 @@ EOF
 ```
 
 The {{< hover label="provider" line="3">}}kind: Provider{{< /hover >}} uses the Crossplane `Provider` _Custom Resource Definition_ to connect your Kubernetes cluster to your cloud provider.  
-
-{{< /tab >}}
-
-{{< /tabs >}}
 
 Verify the provider installed with `kubectl get providers`. 
 
@@ -87,12 +71,18 @@ A provider installs their own Kubernetes _Custom Resource Definitions_ (CRDs). T
 
 You can view the new CRDs with `kubectl get crds`. Every CRD maps to a unique GCP service Crossplane can provision and manage.
 
-All the supported CRDs are also available in the [Upbound Marketplace](https://marketplace.upbound.io/providers/upbound/provider-gcp/v0.15.0/crds).
+{{< hint type="tip" >}}
+All the supported CRDs are also available in the [Upbound Marketplace](https://marketplace.upbound.io/providers/upbound/provider-gcp/latest/crds).
+{{< /hint >}}
 
 ### Create a Kubernetes secret for GCP
 The provider requires credentials to create and manage GCP resources. Providers use a Kubernetes _Secret_ to connect the credentials to the provider.
 
 First generate a Kubernetes _Secret_ from a Google Cloud service account JSON file and then configure the Provider to use it.
+
+{{< hint type="note" >}}
+Other authentication methods exist and are beyond the scope of this guide. The [Provider documentation](https://marketplace.upbound.io/providers/upbound/provider-gcp/latest/docs/configuration) contains information on alternative authentication methods. 
+{{< /hint >}}
 
 #### Generate a GCP service account JSON file
 For basic user authentication, use a Google Cloud service account JSON file. 
@@ -104,12 +94,15 @@ The [GCP documentation](https://cloud.google.com/iam/docs/creating-managing-serv
 Save this JSON file as `gcp-credentials.json`
 
 {{< hint type="note" >}}
-The [Configuration](https://marketplace.upbound.io/providers/upbound/provider-gcp/v0.15.0/docs/configuration) section of the Provider documentation describes other authentication methods.
+The [Configuration](https://marketplace.upbound.io/providers/upbound/provider-gcp/latest/docs/configuration) section of the Provider documentation describes other authentication methods.
 {{< /hint >}}
 
 #### Create a Kubernetes secret with the GCP credentials
+<!-- vale gitlab.Substitutions = NO -->
+<!-- ignore .json file name -->
 A Kubernetes generic secret has a name and contents. Use {{< hover label="kube-create-secret" line="1">}}kubectl create secret{{< /hover >}} to generate the secret object named {{< hover label="kube-create-secret" line="2">}}gcp-secret{{< /hover >}} in the {{< hover label="kube-create-secret" line="3">}}crossplane-system{{</ hover >}} namespace.  
 Use the {{< hover label="kube-create-secret" line="4">}}--from-file={{</hover>}} argument to set the value to the contents of the  {{< hover label="kube-create-secret" line="4">}}gcp-credentials.json{{< /hover >}} file.
+<!-- vale gitlab.Substitutions = YES -->
 
 ```shell {label="kube-create-secret",copy-lines="all"}
 kubectl create secret \

--- a/docs/getting-started/provider-gcp.md
+++ b/docs/getting-started/provider-gcp.md
@@ -36,7 +36,7 @@ All commands use the current `kubeconfig` context and configuration.
 {{< /hint >}}
 
 
-{{< include file="/docs/master/getting-started/install-crossplane.md" type="page" >}}
+{{< include file="install-crossplane.md" type="page" >}}
 
 ## Install the GCP provider
 

--- a/docs/getting-started/provider-gcp.md
+++ b/docs/getting-started/provider-gcp.md
@@ -1,0 +1,234 @@
+---
+title: GCP Quickstart
+weight: 4
+---
+
+Connect Crossplane to Google GCP to create and manage cloud resources from Kubernetes with the [GCP Official Provider](https://marketplace.upbound.io/providers/upbound/provider-gcp/).
+
+This guide walks you through the steps required to get started with the GCP Official Provider. This includes installing Crossplane, configuring the provider to authenticate to GCP and creating a _Managed Resource_ in GCP directly from your Kubernetes cluster.
+
+- [Prerequisites](#prerequisites)
+- [Guided tour](#guided-tour)
+  - [Install the official GCP provider](#install-the-official-gcp-provider)
+  - [Create a Kubernetes secret for GCP](#create-a-kubernetes-secret-for-gcp)
+    - [Generate a GCP service account JSON file](#generate-a-gcp-service-account-json-file)
+    - [Create a Kubernetes secret with the GCP credentials](#create-a-kubernetes-secret-with-the-gcp-credentials)
+  - [Create a ProviderConfig](#create-a-providerconfig)
+  - [Create a managed resource](#create-a-managed-resource)
+  - [Delete the managed resource](#delete-the-managed-resource)
+  - [Next steps](#next-steps)
+
+## Prerequisites
+This quickstart requires:
+* a Kubernetes cluster with at least 3 GB of RAM
+* permissions to create pods and secrets in the Kubernetes cluster
+* a GCP account with permissions to create a storage bucket
+* GCP [account keys](https://cloud.google.com/iam/docs/creating-managing-service-account-keys)
+* GCP [Project ID](https://support.google.com/googleapi/answer/7014113?hl=en)
+
+{{< hint type="tip" >}}
+If you don't have a Kubernetes cluster create one locally with [minikube](https://minikube.sigs.k8s.io/docs/start/) or [kind](https://kind.sigs.k8s.io/).
+{{< /hint >}}
+
+## Guided tour
+{{< hint type="note" >}}
+All commands use the current `kubeconfig` context and configuration. 
+{{< /hint >}}
+
+You need your:
+* GCP service account key
+
+{{< include file="quickstart/quickstart-common.md" type="page" >}}
+
+### Install the official GCP provider
+
+Install the official provider into the Kubernetes cluster with the `up` command-line or a Kubernetes configuration file. 
+{{< tabs "provider-install" >}}
+
+{{< tab "with the Up command-line" >}}
+```shell {copy-lines="all"}
+up controlplane \
+provider install \
+xpkg.upbound.io/upbound/provider-gcp:v0.15.0
+```
+{{< /tab >}}
+
+{{< tab "with a Kubernetes manifest" >}}
+```shell {label="provider",copy-lines="all"}
+cat <<EOF | kubectl apply -f -
+apiVersion: pkg.crossplane.io/v1
+kind: Provider
+metadata:
+  name: upbound-provider-gcp
+spec:
+  package: xpkg.upbound.io/upbound/provider-gcp:v0.15.0
+EOF
+```
+
+The {{< hover label="provider" line="3">}}kind: Provider{{< /hover >}} uses the Crossplane `Provider` _Custom Resource Definition_ to connect your Kubernetes cluster to your cloud provider.  
+
+{{< /tab >}}
+
+{{< /tabs >}}
+
+Verify the provider installed with `kubectl get providers`. 
+
+{{< hint type="note" >}}
+It may take up to five minutes for the provider to list `HEALTHY` as `True`. 
+{{< /hint >}}
+
+```shell 
+kubectl get providers
+NAME                   INSTALLED   HEALTHY   PACKAGE                                        AGE
+upbound-provider-gcp   True        False     xpkg.upbound.io/upbound/provider-gcp:v0.15.0   8s
+```
+
+A provider installs their own Kubernetes _Custom Resource Definitions_ (CRDs). These CRDs allow you to create GCP resources directly inside Kubernetes.
+
+You can view the new CRDs with `kubectl get crds`. Every CRD maps to a unique GCP service Crossplane can provision and manage.
+
+All the supported CRDs are also available in the [Upbound Marketplace](https://marketplace.upbound.io/providers/upbound/provider-gcp/v0.15.0/crds).
+
+### Create a Kubernetes secret for GCP
+The provider requires credentials to create and manage GCP resources. Providers use a Kubernetes _Secret_ to connect the credentials to the provider.
+
+First generate a Kubernetes _Secret_ from a Google Cloud service account JSON file and then configure the Provider to use it.
+
+#### Generate a GCP service account JSON file
+For basic user authentication, use a Google Cloud service account JSON file. 
+
+{{< hint type="tip" >}}
+The [GCP documentation](https://cloud.google.com/iam/docs/creating-managing-service-account-keys) provides information on how to generate a service account JSON file.
+{{< /hint >}}
+
+Save this JSON file as `gcp-credentials.json`
+
+{{< hint type="note" >}}
+The [Configuration](https://marketplace.upbound.io/providers/upbound/provider-gcp/v0.15.0/docs/configuration) section of the Provider documentation describes other authentication methods.
+{{< /hint >}}
+
+#### Create a Kubernetes secret with the GCP credentials
+A Kubernetes generic secret has a name and contents. Use {{< hover label="kube-create-secret" line="1">}}kubectl create secret{{< /hover >}} to generate the secret object named {{< hover label="kube-create-secret" line="2">}}gcp-secret{{< /hover >}} in the {{< hover label="kube-create-secret" line="3">}}crossplane-system{{</ hover >}} namespace.  
+Use the {{< hover label="kube-create-secret" line="4">}}--from-file={{</hover>}} argument to set the value to the contents of the  {{< hover label="kube-create-secret" line="4">}}gcp-credentials.json{{< /hover >}} file.
+
+```shell {label="kube-create-secret",copy-lines="all"}
+kubectl create secret \
+generic gcp-secret \
+-n crossplane-system \
+--from-file=creds=./gcp-credentials.json
+```
+
+View the secret with `kubectl describe secret`
+
+{{< hint type="note" >}}
+The size may be larger if there are extra blank spaces in your text file.
+{{< /hint >}}
+
+```shell
+kubectl describe secret gcp-secret -n crossplane-system
+Name:         gcp-secret
+Namespace:    crossplane-system
+Labels:       <none>
+Annotations:  <none>
+
+Type:  Opaque
+
+Data
+====
+creds:  2330 bytes
+```
+
+### Create a ProviderConfig
+A `ProviderConfig` customizes the settings of the GCP Provider.  
+
+Apply the {{< hover label="providerconfig" line="2">}}ProviderConfig{{</ hover >}}. Include your {{< hover label="providerconfig" line="7" >}}GCP project ID{{< /hover >}}.
+
+{{< hint type="warning" >}}
+Add your GCP `project ID` into the output below. 
+{{< /hint >}}
+
+```yaml {label="providerconfig",copy-lines="all"}
+cat <<EOF | kubectl apply -f -
+apiVersion: gcp.upbound.io/v1beta1
+kind: ProviderConfig
+metadata:
+  name: default
+spec:
+  projectID: <PROJECT_ID>
+  credentials:
+    source: Secret
+    secretRef:
+      namespace: crossplane-system
+      name: gcp-secret
+      key: creds
+EOF
+```
+
+This attaches the GCP credentials, saved as a Kubernetes secret, as a {{< hover label="providerconfig" line="9">}}secretRef{{</ hover>}}.
+
+The {{< hover label="providerconfig" line="12">}}spec.credentials.secretRef.name{{< /hover >}} value is the name of the Kubernetes secret containing the GCP credentials in the {{< hover label="providerconfig" line="11">}}spec.credentials.secretRef.namespace{{< /hover >}}.
+
+
+### Create a managed resource
+A _managed resource_ is anything Crossplane creates and manages outside of the Kubernetes cluster. This creates a GCP storage bucket with Crossplane. The storage bucket is a _managed resource_.
+
+This generates a random name for the storage bucket starting with {{< hover label="xr" line="1" >}}crossplane-bucket{{< /hover >}}
+
+```yaml {label="xr",copy-lines="all"}
+bucket=$(echo "crossplane-bucket-"$(head -n 4096 /dev/urandom | openssl sha1 | tail -c 10))
+cat <<EOF | kubectl apply -f -
+apiVersion: storage.gcp.upbound.io/v1beta1
+kind: Bucket
+metadata:
+  name: $bucket
+spec:
+  forProvider:
+    location: US
+    storageClass: MULTI_REGIONAL
+  providerConfigRef:
+    name: default
+  deletionPolicy: Delete
+EOF
+```
+
+Notice the {{< hover label="xr" line="3">}}apiVersion{{< /hover >}} and {{< hover label="xr" line="4">}}kind{{</hover >}} are from the `Provider's` CRDs.
+
+
+The {{< hover label="xr" line="6">}}metadata.name{{< /hover >}} value is the name of the created GCP storage bucket.  
+This example uses the generated name `crossplane-bucket-<hash>` in the {{< hover label="xr" line="6">}}$bucket{{</hover >}} variable.
+
+{{< hover label="xr" line="10" >}}spec.storageClass{{< /hover >}} defines the GCP storage bucket is [single-region, dual-region or multi-region](https://cloud.google.com/storage/docs/locations#key-concepts). 
+
+{{< hover label="xr" line="9">}}spec.forProvider.location{{< /hover >}} is a [GCP location based](https://cloud.google.com/storage/docs/locations) on the {{< hover label="xr" line="10" >}}storageClass{{< /hover >}}. 
+
+Use `kubectl get buckets` to verify Crossplane created the bucket.
+
+{{< hint type="tip" >}}
+Crossplane created the bucket when the values `READY` and `SYNCED` are `True`.  
+This may take up to 5 minutes.  
+{{< /hint >}}
+
+```shell
+kubectl get bucket
+NAME                          READY   SYNCED   EXTERNAL-NAME                 AGE
+crossplane-bucket-cf2b6d853   True    True     crossplane-bucket-cf2b6d853   3m3s
+```
+
+Optionally, log into the [GCP Console](https://console.cloud.google.com/) and see the storage bucket inside GCP.
+
+### Delete the managed resource
+Before shutting down your Kubernetes cluster, delete the S3 bucket just created.
+
+Use `kubectl delete bucket <bucketname>` to remove the bucket.
+
+```shell
+kubectl delete bucket $bucket
+bucket.storage.gcp.upbound.io "crossplane-bucket-b7cf6b590" deleted
+```
+
+Look in the [GCP Console](https://console.cloud.google.com/) to confirm Crossplane deleted the bucket from GCP.
+
+
+### Next steps 
+* Explore GCP resources that can Crossplane can configure in the [Provider CRD reference](https://marketplace.upbound.io/providers/upbound/provider-gcp/latest/crds).
+* Join the [Crossplane Slack](https://slack.crossplane.io/) and connect with Crossplane users and contributors.

--- a/docs/getting-started/provider-gcp.md
+++ b/docs/getting-started/provider-gcp.md
@@ -38,7 +38,7 @@ All commands use the current `kubeconfig` context and configuration.
 You need your:
 * GCP service account key
 
-{{< include file="quickstart/quickstart-common.md" type="page" >}}
+{{< include file="/docs/master/getting-started/install-crossplane.md" type="page" >}}
 
 ### Install the official GCP provider
 

--- a/docs/getting-started/provision-infrastructure.md
+++ b/docs/getting-started/provision-infrastructure.md
@@ -1,6 +1,6 @@
 ---
 title: Provision Infrastructure
-weight: 3
+weight: 11
 ---
 
 Composite resources (XRs) are always cluster scoped - they exist outside of any


### PR DESCRIPTION
Signed-off-by: Pete Lumbis <pete@upbound.io>

Contributes quickstart guides for AWS, GCP and Azure.

Each quickstart walks through:
* installing Crossplane via Helm or via upstream distribution
* installing the provider
* Creating cloud secrets and creating a providerconfig
* creating and verifying a simple managed resource

This also adjusts the weights of the existing "getting started guides" to come after these quick start guides.

The file `docs/getting-started/install-crossplane.md` is a "common include" to document installing Crossplane for any provider. This file is hidden from the table of contents with `toc_hide: true`. It is imported into a file with the `include` shortcode introduced via [site PR #169](https://github.com/crossplane/crossplane.github.io/pull/169).
