### PR TITLE
Only match steering committee files in root

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -25,13 +25,13 @@
 *                                   @crossplane/crossplane-maintainers @crossplane/crossplane-reviewers
 
 # Governance owners - steering committee
-README.md                           @crossplane/steering-committee
-OWNERS.md                           @crossplane/steering-committee
-CHARTER.md                          @crossplane/steering-committee
-CODE_OF_CONDUCT.md                  @crossplane/steering-committee
-GOVERNANCE.md                       @crossplane/steering-committee
-ROADMAP.md                          @crossplane/steering-committee
-LICENSE                             @crossplane/steering-committee
+/README.md                           @crossplane/steering-committee
+/OWNERS.md                           @crossplane/steering-committee
+/CHARTER.md                          @crossplane/steering-committee
+/CODE_OF_CONDUCT.md                  @crossplane/steering-committee
+/GOVERNANCE.md                       @crossplane/steering-committee
+/ROADMAP.md                          @crossplane/steering-committee
+/LICENSE                             @crossplane/steering-committee
 
 # Design documents
 /design/                             @crossplane/crossplane-maintainers @negz


### PR DESCRIPTION


<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Currently any file that matches the names of those in the root directory that require steering committee approval also require steering committee approval, even though they are not impacting the charter or policies of the project. This refines the rules to only match the files in the root directory.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

`CODEOWNERS` files use `gitignore` syntax and I verified the syntax here does correctly match on the intended files.

[contribution process]: https://git.io/fj2m9
