### PR TITLE
Set crossplane user agent on package requests

### DIFF
--- a/cmd/crossplane/core/core.go
+++ b/cmd/crossplane/core/core.go
@@ -50,7 +50,8 @@ type Command struct {
 // KongVars represent the kong variables associated with the CLI parser
 // required for the Registry default variable interpolation.
 var KongVars = kong.Vars{
-	"default_registry": name.DefaultRegistry,
+	"default_registry":   name.DefaultRegistry,
+	"default_user_agent": transport.DefaultUserAgent,
 }
 
 // Run is the no-op method required for kong call tree
@@ -69,6 +70,7 @@ type startCommand struct {
 	CABundlePath         string `help:"Additional CA bundle to use when fetching packages from registry." env:"CA_BUNDLE_PATH"`
 	WebhookTLSSecretName string `help:"The name of the TLS Secret that will be used by the webhook servers of core Crossplane and providers." env:"WEBHOOK_TLS_SECRET_NAME"`
 	WebhookTLSCertDir    string `help:"The directory of TLS certificate that will be used by the webhook server of core Crossplane. There should be tls.crt and tls.key files." env:"WEBHOOK_TLS_CERT_DIR"`
+	UserAgent            string `help:"The User-Agent header that will be set on all package requests." default:"${default_user_agent}" env:"USER_AGENT"`
 
 	SyncInterval     time.Duration `short:"s" help:"How often all resources will be double-checked for drift from the desired state." default:"1h"`
 	PollInterval     time.Duration `help:"How often individual resources will be checked for drift from the desired state." default:"1m"`
@@ -135,7 +137,7 @@ func (c *startCommand) Run(s *runtime.Scheme, log logging.Logger) error { //noli
 		ServiceAccount:       c.ServiceAccount,
 		DefaultRegistry:      c.Registry,
 		Features:             feats,
-		FetcherOptions:       []xpkg.FetcherOpt{xpkg.WithUserAgent(transport.DefaultUserAgent)},
+		FetcherOptions:       []xpkg.FetcherOpt{xpkg.WithUserAgent(c.UserAgent)},
 		WebhookTLSSecretName: c.WebhookTLSSecretName,
 	}
 

--- a/cmd/crossplane/core/core.go
+++ b/cmd/crossplane/core/core.go
@@ -37,6 +37,7 @@ import (
 	"github.com/crossplane/crossplane/internal/controller/pkg"
 	pkgcontroller "github.com/crossplane/crossplane/internal/controller/pkg/controller"
 	"github.com/crossplane/crossplane/internal/features"
+	"github.com/crossplane/crossplane/internal/transport"
 	"github.com/crossplane/crossplane/internal/xpkg"
 )
 
@@ -134,6 +135,7 @@ func (c *startCommand) Run(s *runtime.Scheme, log logging.Logger) error { //noli
 		ServiceAccount:       c.ServiceAccount,
 		DefaultRegistry:      c.Registry,
 		Features:             feats,
+		FetcherOptions:       []xpkg.FetcherOpt{xpkg.WithUserAgent(transport.DefaultUserAgent)},
 		WebhookTLSSecretName: c.WebhookTLSSecretName,
 	}
 
@@ -142,7 +144,7 @@ func (c *startCommand) Run(s *runtime.Scheme, log logging.Logger) error { //noli
 		if err != nil {
 			return errors.Wrap(err, "Cannot parse CA bundle")
 		}
-		po.FetcherOptions = []xpkg.FetcherOpt{xpkg.WithCustomCA(rootCAs)}
+		po.FetcherOptions = append(po.FetcherOptions, xpkg.WithCustomCA(rootCAs))
 	}
 
 	if err := pkg.Setup(mgr, po); err != nil {

--- a/internal/transport/transport.go
+++ b/internal/transport/transport.go
@@ -1,0 +1,48 @@
+/*
+Copyright 2022 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package transport
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/crossplane/crossplane/internal/version"
+)
+
+// DefaultUserAgent is the default User-Agent header that is set when making
+// HTTP requests for packages.
+var DefaultUserAgent = fmt.Sprintf("%s/%s", "crossplane", version.New().GetVersionString())
+
+// UserAgent wraps a RoundTripper and injects a user agent header.
+type UserAgent struct {
+	rt        http.RoundTripper
+	userAgent string
+}
+
+// NewUserAgent constructs a new UserAgent transport.
+func NewUserAgent(rt http.RoundTripper, userAgent string) *UserAgent {
+	return &UserAgent{
+		rt:        rt,
+		userAgent: userAgent,
+	}
+}
+
+// RoundTrip injects a User-Agent header into every request.
+func (u *UserAgent) RoundTrip(req *http.Request) (*http.Response, error) {
+	req.Header.Set("User-Agent", u.userAgent)
+	return u.rt.RoundTrip(req)
+}

--- a/internal/transport/transport_test.go
+++ b/internal/transport/transport_test.go
@@ -1,0 +1,136 @@
+/*
+Copyright 2022 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package transport
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	"github.com/crossplane/crossplane-runtime/pkg/errors"
+	"github.com/crossplane/crossplane-runtime/pkg/test"
+)
+
+// validatingRoundTripper is a round tripper that validates attributes of the
+// request.
+type validatingRoundTripper struct {
+	validations []requestValidationFn
+}
+
+// RoundTrip validates a request and returns an error if a validation fails.
+func (v *validatingRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	for _, v := range v.validations {
+		if err := v(req); err != nil {
+			return nil, err
+		}
+	}
+	return nil, nil
+}
+
+// requestValidationFn validates some aspect of a request in a round tripper.
+type requestValidationFn func(*http.Request) error
+
+// userAgentValidator validates the user agent header on a request.
+func userAgentValidator(userAgent string) requestValidationFn {
+	return func(r *http.Request) error {
+		if diff := cmp.Diff(r.Header.Get("User-Agent"), userAgent); diff != "" {
+			return errors.Errorf("expected User-Agent %s but got %s", userAgent, r.Header.Get("User-Agent"))
+		}
+		return nil
+	}
+}
+
+var _ http.RoundTripper = &UserAgent{}
+var _ http.RoundTripper = &validatingRoundTripper{}
+
+func TestUserAgent(t *testing.T) {
+	cases := map[string]struct {
+		reason      string
+		req         *http.Request
+		validations []requestValidationFn
+		userAgent   string
+		err         error
+	}{
+		"NoExistingNoProvided": {
+			reason: "If no user agent is provided and none exists, there should be no user agent present.",
+			req: &http.Request{
+				Header: http.Header{},
+			},
+			validations: []requestValidationFn{
+				userAgentValidator(""),
+			},
+		},
+		"OneExistingNoProvided": {
+			reason: "If no user agent is provided and one exists, it should be cleared.",
+			req: &http.Request{
+				Header: http.Header{
+					"User-Agent": []string{"something"},
+				},
+			},
+			validations: []requestValidationFn{
+				userAgentValidator(""),
+			},
+		},
+		"NoExistingProvided": {
+			reason: "If a user agent is provided and none exists, it should be set to the provided.",
+			req: &http.Request{
+				Header: http.Header{},
+			},
+			validations: []requestValidationFn{
+				userAgentValidator("test"),
+			},
+			userAgent: "test",
+		},
+		"OneExistingProvided": {
+			reason: "If user agent is provided and one exists, it should be replaced.",
+			req: &http.Request{
+				Header: http.Header{
+					"User-Agent": []string{"something"},
+				},
+			},
+			validations: []requestValidationFn{
+				userAgentValidator("test"),
+			},
+			userAgent: "test",
+		},
+		"MultipleExistingProvided": {
+			reason: "If user agent is provided and multiple exist, they should be replaced.",
+			req: &http.Request{
+				Header: http.Header{
+					"User-Agent": []string{"something", "else"},
+				},
+			},
+			validations: []requestValidationFn{
+				userAgentValidator("test"),
+			},
+			userAgent: "test",
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			u := NewUserAgent(&validatingRoundTripper{
+				validations: tc.validations,
+			}, tc.userAgent)
+			_, err := u.RoundTrip(tc.req) //nolint:bodyclose
+			if diff := cmp.Diff(tc.err, err, test.EquateErrors()); diff != "" {
+				t.Errorf("\n%s\nRoundTrip(...): -want err, +got err:\n%s", tc.reason, diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Sets `crossplane/<version>` user agent header on all requests made for packages. This is more explicit than the `go-containerregistry/<version>` that is utilized currently. 

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

Ran against local registry and verified that user agent is set to `crossplane/v1.11.0-rc.0.27.gf447ebe1.dirty go-containerregistry/v0.9.0`.

**Update:** `go-containerregistry` currently does not allow removal of the default `go-containerregistry/<version>` `User-Agent` header, so the Crossplane one is appended for the time-being.

[contribution process]: https://git.io/fj2m9
