### PR TITLE
More granular comparison of Roles annotations during reconciliation.

### DIFF
--- a/internal/controller/rbac/namespace/reconciler_test.go
+++ b/internal/controller/rbac/namespace/reconciler_test.go
@@ -224,13 +224,31 @@ func TestRolesDiffer(t *testing.T) {
 		"Equal": {
 			current: &rbacv1.Role{
 				ObjectMeta: metav1.ObjectMeta{
-					Annotations: map[string]string{"a": "a"},
+					Annotations: map[string]string{"rbac.crossplane.io/a": "a"},
 				},
 				Rules: []rbacv1.PolicyRule{{}},
 			},
 			desired: &rbacv1.Role{
 				ObjectMeta: metav1.ObjectMeta{
-					Annotations: map[string]string{"a": "a"},
+					Annotations: map[string]string{"rbac.crossplane.io/a": "a"},
+				},
+				Rules: []rbacv1.PolicyRule{{}},
+			},
+			want: false,
+		},
+		"EqualMixedNonCrossplane": {
+			current: &rbacv1.Role{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{"rbac.crossplane.io/a": "a"},
+				},
+				Rules: []rbacv1.PolicyRule{{}},
+			},
+			desired: &rbacv1.Role{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"rbac.crossplane.io/a":        "a",
+						"not-managed-by-crossplane/b": "b",
+					},
 				},
 				Rules: []rbacv1.PolicyRule{{}},
 			},
@@ -239,13 +257,13 @@ func TestRolesDiffer(t *testing.T) {
 		"AnnotationsDiffer": {
 			current: &rbacv1.Role{
 				ObjectMeta: metav1.ObjectMeta{
-					Annotations: map[string]string{"a": "a"},
+					Annotations: map[string]string{"rbac.crossplane.io/a": "a"},
 				},
 				Rules: []rbacv1.PolicyRule{{}},
 			},
 			desired: &rbacv1.Role{
 				ObjectMeta: metav1.ObjectMeta{
-					Annotations: map[string]string{"b": "b"},
+					Annotations: map[string]string{"rbac.crossplane.io/b": "b"},
 				},
 				Rules: []rbacv1.PolicyRule{{}},
 			},
@@ -254,13 +272,13 @@ func TestRolesDiffer(t *testing.T) {
 		"RulesDiffer": {
 			current: &rbacv1.Role{
 				ObjectMeta: metav1.ObjectMeta{
-					Annotations: map[string]string{"a": "a"},
+					Annotations: map[string]string{"rbac.crossplane.io/a": "a"},
 				},
 				Rules: []rbacv1.PolicyRule{{}},
 			},
 			desired: &rbacv1.Role{
 				ObjectMeta: metav1.ObjectMeta{
-					Annotations: map[string]string{"a": "a"},
+					Annotations: map[string]string{"rbac.crossplane.io/a": "a"},
 				},
 			},
 			want: true,


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

This PR changes how roles are reconciled by comparing only the crossplane RBAC annotations (pre fixed by `rbac.crossplane.io/`) instead of all the annotations of the Role objects.

This change will allow the RBAC namespace reconciler to play along with other controllers that set annotations on the same resources, avoiding a reconciliation loop between them. 

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

I have:

- [X] Read and followed Crossplane's [contribution process].
- [X] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

1. Updated unit-tests to reflect the changes.
1. Deployed the change on a local cluster (image: jmprusi/crossplane-778e92a53dbc12731015f0486c2909a6@sha256:37b493d4854ae1946d922f6fea7524270f5282e9cf4aaf90530abd5ad4437fee)
1. Added a new annotation to the `default/crossplane-view` rbac role.
2. `crossplane-rbac-manager` shows in the log that no change has been detected: `Skipped no-op RBAC Role apply`.
1. Remove crossplane-view rbac.crossplane.io annotation.
1. Role is reconcile and `crossplane-rbac-manager` shows in the log "Applied RBAC Role".

[contribution process]: https://git.io/fj2m9
