### PR TITLE
helm tolerations map > list

### DIFF
--- a/cluster/charts/crossplane/README.md
+++ b/cluster/charts/crossplane/README.md
@@ -94,7 +94,7 @@ and their default values.
 | `packageCache.medium` | Storage medium for package cache. `Memory` means volume will be backed by tmpfs, which can be useful for development. | `""` |
 | `packageCache.sizeLimit` | Size limit for package cache. If medium is `Memory` then maximum usage would be the minimum of this value the sum of all memory limits on containers in the Crossplane pod. | `5Mi` |
 | `packageCache.pvc` | Name of the PersistentVolumeClaim to be used as the package cache. Providing a value will cause the default emptyDir volume to not be mounted. | `""` |
-| `tolerations` | Enable tolerations for Crossplane pod | `{}` |
+| `tolerations` | Enable tolerations for Crossplane pod | `[]` |
 | `resourcesRBACManager.limits.cpu` | CPU resource limits for RBAC Manager | `100m` |
 | `resourcesRBACManager.limits.memory` | Memory resource limits for RBAC Manager | `512Mi` |
 | `resourcesRBACManager.requests.cpu` | CPU resource requests for RBAC Manager | `100m` |
@@ -109,7 +109,7 @@ and their default values.
 | `rbacManager.replicas` | The number of replicas to run for the RBAC Manager pods | `1` |
 | `rbacManager.leaderElection` | Enable leader election for RBAC Managers pod | `true` |
 | `rbacManager.managementPolicy`| The extent to which the RBAC manager will manage permissions. `All` indicates to manage all Crossplane controller and user roles. `Basic` indicates to only manage Crossplane controller roles and the `crossplane-admin`, `crossplane-edit`, and `crossplane-view` user roles. | `All` |
-| `rbacManager.tolerations` | Enable tolerations for RBAC Managers pod | `{}` |
+| `rbacManager.tolerations` | Enable tolerations for RBAC Managers pod | `[]` |
 | `rbacManager.skipAggregatedClusterRoles` | Opt out of deploying aggregated ClusterRoles | `false` |
 | `metrics.enabled` | Expose Crossplane and RBAC Manager metrics endpoint | `false` |
 | `extraEnvVarsCrossplane` | List of extra environment variables to set in the crossplane deployment. Any `.` in variable names will be replaced with `_` (example: `SAMPLE.KEY=value1` becomes `SAMPLE_KEY=value1`). | `{}` |

--- a/cluster/charts/crossplane/templates/deployment.yaml
+++ b/cluster/charts/crossplane/templates/deployment.yaml
@@ -172,7 +172,7 @@ spec:
       nodeSelector: {{ toYaml .Values.nodeSelector | nindent 8 }}
       {{- end }}
       {{- if .Values.tolerations }}
-      tolerations: {{ toYaml .Values.tolerations | nindent 8 }}
+      tolerations: {{ toYaml .Values.tolerations | nindent 6 }}
       {{- end }}
       {{- if .Values.affinity }}
       affinity: {{ toYaml .Values.affinity | nindent 8 }}

--- a/cluster/charts/crossplane/templates/rbac-manager-deployment.yaml
+++ b/cluster/charts/crossplane/templates/rbac-manager-deployment.yaml
@@ -79,7 +79,7 @@ spec:
       nodeSelector: {{ toYaml .Values.rbacManager.nodeSelector | nindent 8 }}
       {{- end }}
       {{- if .Values.rbacManager.tolerations }}
-      tolerations: {{ toYaml .Values.rbacManager.tolerations | nindent 8 }}
+      tolerations: {{ toYaml .Values.rbacManager.tolerations | nindent 6 }}
       {{- end }}
       {{- if .Values.rbacManager.affinity }}
       affinity: {{ toYaml .Values.rbacManager.affinity | nindent 8 }}

--- a/cluster/charts/crossplane/values.yaml.tmpl
+++ b/cluster/charts/crossplane/values.yaml.tmpl
@@ -8,7 +8,7 @@ image:
   pullPolicy: IfNotPresent
 
 nodeSelector: {}
-tolerations: {}
+tolerations: []
 affinity: {}
 
 # -- Custom labels to add into metadata
@@ -45,7 +45,7 @@ rbacManager:
   leaderElection: true
   args: {}
   nodeSelector: {}
-  tolerations: {}
+  tolerations: []
   affinity: {}
 
 priorityClassName: ""

--- a/docs/reference/install.md
+++ b/docs/reference/install.md
@@ -101,7 +101,7 @@ and their default values.
 | `packageCache.medium` | Storage medium for package cache. `Memory` means volume will be backed by tmpfs, which can be useful for development. | `""` |
 | `packageCache.sizeLimit` | Size limit for package cache. If medium is `Memory` then maximum usage would be the minimum of this value the sum of all memory limits on containers in the Crossplane pod. | `5Mi` |
 | `packageCache.pvc` | Name of the PersistentVolumeClaim to be used as the package cache. Providing a value will cause the default emptyDir volume to not be mounted. | `""` |
-| `tolerations` | Enable tolerations for Crossplane pod | `{}` |
+| `tolerations` | Enable tolerations for Crossplane pod | `[]` |
 | `resourcesRBACManager.limits.cpu` | CPU resource limits for RBAC Manager | `100m` |
 | `resourcesRBACManager.limits.memory` | Memory resource limits for RBAC Manager | `512Mi` |
 | `resourcesRBACManager.requests.cpu` | CPU resource requests for RBAC Manager | `100m` |
@@ -116,7 +116,7 @@ and their default values.
 | `rbacManager.replicas` | The number of replicas to run for the RBAC Manager pods | `1` |
 | `rbacManager.leaderElection` | Enable leader election for RBAC Managers pod | `true` |
 | `rbacManager.managementPolicy`| The extent to which the RBAC manager will manage permissions. `All` indicates to manage all Crossplane controller and user roles. `Basic` indicates to only manage Crossplane controller roles and the `crossplane-admin`, `crossplane-edit`, and `crossplane-view` user roles. | `All` |
-| `rbacManager.tolerations` | Enable tolerations for RBAC Managers pod | `{}` |
+| `rbacManager.tolerations` | Enable tolerations for RBAC Managers pod | `[]` |
 | `rbacManager.skipAggregatedClusterRoles` | Opt out of deploying aggregated ClusterRoles | `false` |
 | `metrics.enabled` | Expose Crossplane and RBAC Manager metrics endpoint | `false` |
 | `extraEnvVarsCrossplane` | List of extra environment variables to set in the crossplane deployment. Any `.` in variable names will be replaced with `_` (example: `SAMPLE.KEY=value1` becomes `SAMPLE_KEY=value1`). | `{}` |


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

Tolerations default value for both deployment and rbac deployment is currently of type map.
Tolerations are a list e.g.
```
 tolerations:
   - key: arch
      operator: Equal
      value: arm64
```
This PR changes the default type to list therefore allowing specifying tolerations (currently this is not possible)

Fixes #

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

Created a values file containing tolerations for both deployment + rbac-manager deployment and successfully applied to a Kubernetes cluster.

[contribution process]: https://git.io/fj2m9
