### PR TITLE
Change "Compute" to "Compute" in CNCF

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ build a control plane that can orchestrate applications and infrastructure no
 matter where they run, and a highly configurable frontend that puts you in
 control of the schema of the declarative API it offers.
 
-Crossplane is a [Cloud Native Compute Foundation][cncf] project.
+Crossplane is a [Cloud Native Computing Foundation][cncf] project.
 
 ## Releases
 


### PR DESCRIPTION
CNCF stands for "Cloud Native Computing Foundation" (not "Compute")
See the home page: https://www.cncf.io

### Description of your changes

Just a documentation change. Hopefully not a big deal, but will mean that newbies to your page don't think "what the heck" when they read that.

I have:

- [ X] Read and followed Crossplane's [contribution process].
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested
N/A - it's a pure documentation change.

[contribution process]: https://git.io/fj2m9
