### PR TITLE
[helm chart] Set `GOMAXPROCS` and `GOMEMLIMIT` based on resource limits

### DIFF
--- a/cluster/charts/crossplane/templates/deployment.yaml
+++ b/cluster/charts/crossplane/templates/deployment.yaml
@@ -61,6 +61,16 @@ spec:
           securityContext:
             {{- toYaml .Values.securityContextCrossplane | nindent 12 }}
           env:
+          - name: GOMAXPROCS
+            valueFrom:
+              resourceFieldRef:
+                containerName: {{ .Chart.Name }}-init
+                resource: limits.cpu
+          - name: GOMEMLIMIT
+            valueFrom:
+              resourceFieldRef:
+                containerName: {{ .Chart.Name }}-init
+                resource: limits.memory
           - name: POD_NAMESPACE
             valueFrom:
               fieldRef:
@@ -107,6 +117,16 @@ spec:
         securityContext:
           {{- toYaml .Values.securityContextCrossplane | nindent 12 }}
         env:
+          - name: GOMAXPROCS
+            valueFrom:
+              resourceFieldRef:
+                containerName: {{ .Chart.Name }}
+                resource: limits.cpu
+          - name: GOMEMLIMIT
+            valueFrom:
+              resourceFieldRef:
+                containerName: {{ .Chart.Name }}
+                resource: limits.memory
           - name: POD_NAMESPACE
             valueFrom:
               fieldRef:

--- a/cluster/charts/crossplane/templates/rbac-manager-deployment.yaml
+++ b/cluster/charts/crossplane/templates/rbac-manager-deployment.yaml
@@ -45,6 +45,17 @@ spec:
           {{- toYaml .Values.resourcesRBACManager | nindent 12 }}
         securityContext:
           {{- toYaml .Values.securityContextRBACManager | nindent 12 }}
+        env:
+          - name: GOMAXPROCS
+            valueFrom:
+              resourceFieldRef:
+                containerName: {{ .Chart.Name }}-init
+                resource: limits.cpu
+          - name: GOMEMLIMIT
+            valueFrom:
+              resourceFieldRef:
+                containerName: {{ .Chart.Name }}-init
+                resource: limits.memory
       containers:
       - image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
         args:
@@ -69,6 +80,16 @@ spec:
         securityContext:
           {{- toYaml .Values.securityContextRBACManager | nindent 12 }}
         env:
+          - name: GOMAXPROCS
+            valueFrom:
+              resourceFieldRef:
+                containerName: {{ .Chart.Name }}
+                resource: limits.cpu
+          - name: GOMEMLIMIT
+            valueFrom:
+              resourceFieldRef:
+                containerName: {{ .Chart.Name }}
+                resource: limits.memory
           - name: LEADER_ELECTION
             value: "{{ .Values.rbacManager.leaderElection }}"
         {{- range $key, $value := .Values.extraEnvVarsRBACManager }}


### PR DESCRIPTION
Signed-off-by: Aditya Sharma <git@adi.run>


### Description of your changes

Sets `GOMAXPROCS` and `GOMEMLIMIT` env vars for crossplane and rbac-manager deployments based on the resource limits.

This should alleviate CPU throttling and reduce OOM likelihood. 

An alternative to this approach would be to use https://github.com/uber-go/automaxprocs in code

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

n/a
