### PR TITLE
Change the composition name to `production`

### DIFF
--- a/docs/concepts/composition.md
+++ b/docs/concepts/composition.md
@@ -128,7 +128,7 @@ A basic `Composition` for the above `XPostgreSQLInstance` might look like this:
 apiVersion: apiextensions.crossplane.io/v1
 kind: Composition
 metadata:
-  name: example
+  name: production
   labels:
     crossplane.io/xrd: xpostgresqlinstances.database.example.org
     provider: gcp


### PR DESCRIPTION
All the other resources refer to a Composition called `production` which does not exist and nothing refers to `example`, making it inconsistent. This PR proposes fixing that by renaming the Composition.