### PR TITLE
feat(chart): Allow prepopulating cache from ConfigMap

### DIFF
--- a/cluster/charts/crossplane/templates/deployment.yaml
+++ b/cluster/charts/crossplane/templates/deployment.yaml
@@ -164,6 +164,9 @@ spec:
         {{- if .Values.packageCache.pvc }}
         persistentVolumeClaim:
           claimName: {{ .Values.packageCache.pvc }}
+        {{- else if .Values.packageCache.configMap }}
+        configMap:
+          name: {{ .Values.packageCache.configMap }}
         {{- else }}
         emptyDir:
           medium: {{ .Values.packageCache.medium }}

--- a/cluster/charts/crossplane/values.yaml.tmpl
+++ b/cluster/charts/crossplane/values.yaml.tmpl
@@ -68,6 +68,7 @@ packageCache:
   medium: ""
   sizeLimit: 5Mi
   pvc: ""
+  configMap: ""
 
 resourcesRBACManager:
   limits:


### PR DESCRIPTION
### Description of your changes

This adds an option to the Crossplane Helm chart that allows to load cached images from a `ConfigMap` as described [here](https://danielmangum.com/posts/config-map-oci-image-cache/).

Related to #2647

```yaml
packageCache:
  configMap: "example-configmap"
```

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

Manually

[contribution process]: https://git.io/fj2m9
