### PR TITLE
Add finalizers for rbac provider and definition

### DIFF
--- a/cluster/charts/crossplane/templates/rbac-manager-clusterrole.yaml
+++ b/cluster/charts/crossplane/templates/rbac-manager-clusterrole.yaml
@@ -25,6 +25,18 @@ rules:
   - get
   - list
   - watch
+# The RBAC manager creates a series of RBAC roles for each namespace it sees.
+# These RBAC roles are controlled (in the owner reference sense) by the namespace.
+# The RBAC manager needs permission to set finalizers on Namespaces in order to
+# create resources that block their deletion when the
+# OwnerReferencesPermissionEnforcement admission controller is enabled.
+# See https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#ownerreferencespermissionenforcement
+- apiGroups:
+  - ""
+  resources:
+  - namespaces/finalizers
+  verbs:
+  - update
 - apiGroups:
   - apiextensions.crossplane.io
   resources:
@@ -33,6 +45,18 @@ rules:
   - get
   - list
   - watch
+# The RBAC manager creates a series of RBAC cluster roles for each XRD it sees.
+# These cluster roles are controlled (in the owner reference sense) by the XRD.
+# The RBAC manager needs permission to set finalizers on XRDs in order to
+# create resources that block their deletion when the 
+# OwnerReferencesPermissionEnforcement admission controller is enabled.
+# See https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#ownerreferencespermissionenforcement
+- apiGroups:
+  - apiextensions.crossplane.io
+  resources:
+  - compositeresourcedefinitions/finalizers
+  verbs:
+  - update
 - apiGroups:
   - pkg.crossplane.io
   resources:
@@ -41,6 +65,18 @@ rules:
   - get
   - list
   - watch
+# The RBAC manager creates a series of RBAC cluster roles for each ProviderRevision
+# it sees. These cluster roles are controlled (in the owner reference sense) by the
+# ProviderRevision. The RBAC manager needs permission to set finalizers on
+# ProviderRevisions in order to create resources that block their deletion when the 
+# OwnerReferencesPermissionEnforcement admission controller is enabled.
+# See https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#ownerreferencespermissionenforcement
+- apiGroups:
+  - pkg.crossplane.io
+  resources:
+  - providerrevisions/finalizers
+  verbs:
+  - update
 - apiGroups:
   - apiextensions.k8s.io
   resources:

--- a/internal/controller/rbac/definition/roles.go
+++ b/internal/controller/rbac/definition/roles.go
@@ -48,13 +48,15 @@ const (
 
 	valTrue = "true"
 
-	suffixStatus = "/status"
+	suffixStatus     = "/status"
+	suffixFinalizers = "/finalizers"
 )
 
 var (
 	verbsEdit   = []string{rbacv1.VerbAll}
 	verbsView   = []string{"get", "list", "watch"}
 	verbsBrowse = []string{"get", "list", "watch"}
+	verbsUpdate = []string{"update"}
 )
 
 // RenderClusterRoles returns ClusterRoles for the supplied XRD.
@@ -74,6 +76,17 @@ func RenderClusterRoles(d *v1.CompositeResourceDefinition) []rbacv1.ClusterRole 
 					d.Spec.Names.Plural + suffixStatus,
 				},
 				Verbs: verbsEdit,
+			},
+			{
+				// Crossplane reconciles an XR by creating one or more composed resources.
+				// These composed resources are controlled (in the owner reference sense) by the XR.
+				// Crossplane needs permission to set finalizers on XRs in order to create resources
+				// that block their deletion when the OwnerReferencesPermissionEnforcement admission controller is enabled.
+				APIGroups: []string{d.Spec.Group},
+				Resources: []string{
+					d.Spec.Names.Plural + suffixFinalizers,
+				},
+				Verbs: verbsUpdate,
 			},
 		},
 	}

--- a/internal/controller/rbac/definition/roles_test.go
+++ b/internal/controller/rbac/definition/roles_test.go
@@ -74,6 +74,11 @@ func TestRenderClusterRoles(t *testing.T) {
 							Resources: []string{pluralXR, pluralXR + suffixStatus},
 							Verbs:     verbsEdit,
 						},
+						{
+							APIGroups: []string{group},
+							Resources: []string{pluralXR + suffixFinalizers},
+							Verbs:     verbsUpdate,
+						},
 					},
 				},
 				{
@@ -157,6 +162,11 @@ func TestRenderClusterRoles(t *testing.T) {
 							APIGroups: []string{group},
 							Resources: []string{pluralXR, pluralXR + suffixStatus},
 							Verbs:     verbsEdit,
+						},
+						{
+							APIGroups: []string{group},
+							Resources: []string{pluralXR + suffixFinalizers},
+							Verbs:     verbsUpdate,
 						},
 						{
 							APIGroups: []string{group},

--- a/internal/controller/rbac/provider/roles/roles_test.go
+++ b/internal/controller/rbac/provider/roles/roles_test.go
@@ -150,6 +150,11 @@ func TestRenderClusterRoles(t *testing.T) {
 							Resources: []string{pluralCRDC, pluralCRDC + suffixStatus},
 							Verbs:     verbsSystem,
 						},
+						{
+							APIGroups: []string{groupCRDA, groupCRDC},
+							Resources: []string{rbacv1.ResourceAll + suffixFinalizers},
+							Verbs:     verbsUpdate,
+						},
 					}, rulesSystemExtra...),
 				},
 			},


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes
Sets `<resource>/finalizers` on RBAC for provider and definition
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #3443

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

- Ran e2e tests with the following KIND_CONFIG: 
```
export KIND_CONFIG="kind: Cluster
  apiVersion: kind.x-k8s.io/v1alpha4
  nodes:
  - role: control-plane
    kubeadmConfigPatches:
    - |
      kind: ClusterConfiguration
      apiServer:
          extraArgs:
            enable-admission-plugins: OwnerReferencesPermissionEnforcement"
```
- Created Docker image from this branch. (https://hub.docker.com/u/qwzar)
- I've run this image on a private Opesnfhit (v4.10.*) cluster
- I tested by creating and deleting a Provider and seeing that the controllers logged and reconciled successfully.
- I've checked Providers, Managed Resources, and CRD's on existing errors from issue https://github.com/crossplane/crossplane/issues/3443#issuecomment-1306828892

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
