### PR TITLE
[Backport 3440 to release 1.9] CLI install script: prefix variables

### DIFF
--- a/docs/getting-started/install-configure.md
+++ b/docs/getting-started/install-configure.md
@@ -174,15 +174,15 @@ curl -sL https://raw.githubusercontent.com/crossplane/crossplane/master/install.
 <div class="tab-pane fade" id="install-tab-cli-latest" markdown="1">
 
 ```console
-curl -sL https://raw.githubusercontent.com/crossplane/crossplane/master/install.sh | CHANNEL=master sh
+curl -sL https://raw.githubusercontent.com/crossplane/crossplane/master/install.sh | XP_CHANNEL=master sh
 ```
 
-You may also specify `VERSION` for download if you would like to select a
+You may also specify `XP_VERSION` for download if you would like to select a
 specific version from the given release channel. If a version is not specified
 the latest version from the release channel will be used.
 
 ```console
-curl -sL https://raw.githubusercontent.com/crossplane/crossplane/master/install.sh | CHANNEL=master VERSION=v1.0.0-rc.0.130.g94f34fd3 sh
+curl -sL https://raw.githubusercontent.com/crossplane/crossplane/master/install.sh | XP_CHANNEL=master XP_VERSION=v1.0.0-rc.0.130.g94f34fd3 sh
 ```
 
 </div>

--- a/install.sh
+++ b/install.sh
@@ -2,8 +2,8 @@
 
 set -eu
 
-CHANNEL=${CHANNEL:-stable}
-VERSION=${VERSION:-current}
+XP_CHANNEL=${XP_CHANNEL:-stable}
+XP_VERSION=${XP_VERSION:-current}
 
 os=$(uname -s)
 arch=$(uname -m)
@@ -61,9 +61,9 @@ case $OS in
     ;;
 esac
 
-url="https://releases.crossplane.io/${CHANNEL}/${VERSION}/bin/${OS_ARCH}/${BIN}"
+url="https://releases.crossplane.io/${XP_CHANNEL}/${XP_VERSION}/bin/${OS_ARCH}/${BIN}"
 if ! curl -sLo kubectl-crossplane "${url}"; then
-  echo "Failed to download Crossplane CLI. Please make sure version ${VERSION} exists on channel ${CHANNEL}."
+  echo "Failed to download Crossplane CLI. Please make sure version ${XP_VERSION} exists on channel ${XP_CHANNEL}."
   exit 1
 fi
 


### PR DESCRIPTION
User reported an issue installing kubectl plugin due to environment variable $VERSION set to unexpected value. Prefix the environment variables install.sh reads with XP_.

Fixes
https://github.com/crossplane/crossplane/issues/3345

Signed-off-by: Petr Benas <petr.benas@oracle.com>

<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
