### PR TITLE
Add a docs issue template to auto tag doc bugs

### DIFF
--- a/.github/ISSUE_TEMPLATE/docs_issue.md
+++ b/.github/ISSUE_TEMPLATE/docs_issue.md
@@ -1,0 +1,20 @@
+---
+name: Docs Issue
+about: Report issues or request new content in the Crossplane documentation.
+labels: ["docs", "exempt-from-stale"]
+---
+
+<!-- If it's a bug tell us where you found it -->
+## Docs URL
+<!-- Provide the URL to the page that has a bug. Use the nearest anchor if possible -->
+<!-- for example 
+https://crossplane.io/docs/master/getting-started/install-configure.html#start-with-upstream-crossplane
+-->
+
+<!-- This is only needed for bugs -->
+## Affected versions
+<!-- If you can, check if this problem exists in the other versions -->
+
+## What's wrong?
+<!-- tell us the error or problem you found in the documentation -->
+<!-- for content requests tell us what content you'd like to see created -->

--- a/.github/ISSUE_TEMPLATE/docs_issue.md
+++ b/.github/ISSUE_TEMPLATE/docs_issue.md
@@ -1,7 +1,7 @@
 ---
 name: Docs Issue
 about: Report issues or request new content in the Crossplane documentation.
-labels: ["docs", "exempt-from-stale"]
+labels: ["docs"]
 ---
 
 <!-- If it's a bug tell us where you found it -->


### PR DESCRIPTION
### Description of your changes
This creates a unique docs issue template. Docs issues are auto tagged with `docs` and `exempt-from-stale` labels.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.


Signed-off-by: Pete Lumbis <pete@upbound.io>