### PR TITLE
Remove notices that Composition Revision related fields are alpha

### DIFF
--- a/internal/xcrd/crd_test.go
+++ b/internal/xcrd/crd_test.go
@@ -247,12 +247,10 @@ func TestForCompositeResource(t *testing.T) {
 										Properties: map[string]extv1.JSONSchemaProps{
 											"name": {Type: "string"},
 										},
-										Description: "Alpha: This field may be deprecated or changed without notice.",
 									},
 									"compositionRevisionSelector": {
-										Description: "Alpha: This field may be deprecated or changed without notice.",
-										Type:        "object",
-										Required:    []string{"matchLabels"},
+										Type:     "object",
+										Required: []string{"matchLabels"},
 										Properties: map[string]extv1.JSONSchemaProps{
 											"matchLabels": {
 												Type: "object",
@@ -269,8 +267,7 @@ func TestForCompositeResource(t *testing.T) {
 											{Raw: []byte(`"Automatic"`)},
 											{Raw: []byte(`"Manual"`)},
 										},
-										Default:     &extv1.JSON{Raw: []byte(`"Automatic"`)},
-										Description: "Alpha: This field may be deprecated or changed without notice.",
+										Default: &extv1.JSON{Raw: []byte(`"Automatic"`)},
 									},
 									"claimRef": {
 										Type:     "object",
@@ -686,9 +683,8 @@ func TestForCompositeResourceClaim(t *testing.T) {
 											},
 										},
 										"compositionRevisionSelector": {
-											Description: "Alpha: This field may be deprecated or changed without notice.",
-											Type:        "object",
-											Required:    []string{"matchLabels"},
+											Type:     "object",
+											Required: []string{"matchLabels"},
 											Properties: map[string]extv1.JSONSchemaProps{
 												"matchLabels": {
 													Type: "object",

--- a/internal/xcrd/schemas.go
+++ b/internal/xcrd/schemas.go
@@ -92,7 +92,6 @@ func CompositeResourceSpecProps() map[string]extv1.JSONSchemaProps {
 			Properties: map[string]extv1.JSONSchemaProps{
 				"name": {Type: "string"},
 			},
-			Description: "Alpha: This field may be deprecated or changed without notice.",
 		},
 		"compositionRevisionSelector": {
 			Type:     "object",
@@ -106,7 +105,6 @@ func CompositeResourceSpecProps() map[string]extv1.JSONSchemaProps {
 					},
 				},
 			},
-			Description: "Alpha: This field may be deprecated or changed without notice.",
 		},
 		"compositionUpdatePolicy": {
 			Type: "string",
@@ -114,8 +112,7 @@ func CompositeResourceSpecProps() map[string]extv1.JSONSchemaProps {
 				{Raw: []byte(`"Automatic"`)},
 				{Raw: []byte(`"Manual"`)},
 			},
-			Default:     &extv1.JSON{Raw: []byte(`"Automatic"`)},
-			Description: "Alpha: This field may be deprecated or changed without notice.",
+			Default: &extv1.JSON{Raw: []byte(`"Automatic"`)},
 		},
 		"claimRef": {
 			Type:     "object",
@@ -234,7 +231,6 @@ func CompositeResourceClaimSpecProps() map[string]extv1.JSONSchemaProps {
 					},
 				},
 			},
-			Description: "Alpha: This field may be deprecated or changed without notice.",
 		},
 		"compositionUpdatePolicy": {
 			Type: "string",


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
A small follow-up to https://github.com/crossplane/crossplane/pull/3453 that I forgot about until just now.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9

I haven't. 😬 I'm hoping unit tests are sufficient given this is just an OpenAPI schema field change.