### PR TITLE
Update v1.8 docs content to conform to new docs.crossplane.io

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ OSBASEIMAGE = gcr.io/distroless/static:nonroot
 # Setup Docs
 
 SOURCE_DOCS_DIR = docs
-DEST_DOCS_DIR = content/docs/
+DEST_DOCS_DIR = content
 DOCS_GIT_REPO = https://$(DOCS_GIT_USR):$(DOCS_GIT_PSW)@github.com/crossplane/crossplane.github.io.git
 -include build/makelib/docs.mk
 

--- a/docs/_index.md
+++ b/docs/_index.md
@@ -1,14 +1,12 @@
 ---
 title: "Overview"
-toc_include: false
 weight: -1
-aliases:
-    - /docs/v1.8/index.html
 cascade:
     version: "1.8"
 ---
 
-![Crossplane](/docs/v1.8/media/banner.png)
+{{< img src="../media/banner.png" alt="Crossplane Popsicle Truck" size="large" >}}
+
 
 Crossplane is an open source Kubernetes add-on that transforms your cluster into
 a **universal control plane**. Crossplane enables platform teams to assemble

--- a/docs/cloud-providers/aws/aws-provider.md
+++ b/docs/cloud-providers/aws/aws-provider.md
@@ -1,6 +1,6 @@
 ---
 title: Adding Amazon Web Services (AWS) to Crossplane
-toc_hide: true
+tocHidden: true
 ---
 
 In this guide, we will walk through the steps necessary to configure your AWS

--- a/docs/cloud-providers/azure/azure-provider.md
+++ b/docs/cloud-providers/azure/azure-provider.md
@@ -1,6 +1,6 @@
 ---
 title: Adding Microsoft Azure to Crossplane
-toc_hide: true
+tocHidden: true
 ---
 
 In this guide, we will walk through the steps necessary to configure your Azure

--- a/docs/cloud-providers/gcp/gcp-provider.md
+++ b/docs/cloud-providers/gcp/gcp-provider.md
@@ -1,6 +1,6 @@
 ---
 title: Adding Google Cloud Platform (GCP) to Crossplane
-toc_hide: true
+tocHidden: true
 ---
 
 

--- a/docs/concepts/composition.md
+++ b/docs/concepts/composition.md
@@ -241,10 +241,10 @@ scenarios, including:
   take minutes to provision on-demand.
 
 [managed-resources]: {{<ref "managed-resources" >}}
-[xrs-and-mrs]: /docs/v1.8/media/composition-xrs-and-mrs.svg
+[xrs-and-mrs]: /v1.8/media/composition-xrs-and-mrs.svg
 [xr-ref]: {{<ref "../reference/composition" >}}
-[how-it-works]: /docs/v1.8/media/composition-how-it-works.svg
+[how-it-works]: /v1.8/media/composition-how-it-works.svg
 [crd-docs]: https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/
 [provider-kubernetes]: https://github.com/crossplane-contrib/provider-kubernetes
 [provider-helm]: https://github.com/crossplane-contrib/provider-helm
-[claims-and-xrs]: /docs/v1.8/media/composition-claims-and-xrs.svg
+[claims-and-xrs]: /v1.8/media/composition-claims-and-xrs.svg

--- a/docs/concepts/managed-resources.md
+++ b/docs/concepts/managed-resources.md
@@ -26,14 +26,8 @@ Composite Resources or XRs - not used directly. See the
 Crossplane API conventions extend the Kubernetes API conventions for the schema
 of Crossplane managed resources. Following is an example of a managed resource:
 
-<ul class="nav nav-tabs">
-<li class="active"><a href="#aws-tab-1" data-toggle="tab">AWS</a></li>
-<li><a href="#gcp-tab-1" data-toggle="tab">GCP</a></li>
-<li><a href="#azure-tab-1" data-toggle="tab">Azure</a></li>
-</ul>
-<br>
-<div class="tab-content">
-<div class="tab-pane fade in active" id="aws-tab-1" markdown="1">
+{{< tabs >}}
+{{< tab "AWS" >}}
 
 The AWS provider supports provisioning an [RDS][rds] instance via the `RDSInstance`
 managed resource it adds to Crossplane.
@@ -82,8 +76,8 @@ You can then delete the `RDSInstance`:
 kubectl delete rdsinstance rdspostgresql
 ```
 
-</div>
-<div class="tab-pane fade" id="gcp-tab-1" markdown="1">
+{{< /tab >}}
+{{< tab "GCP" >}}
 
 The GCP provider supports provisioning a [CloudSQL][cloudsql] instance with the
 `CloudSQLInstance` managed resource it adds to Crossplane.
@@ -131,8 +125,8 @@ You can then delete the `CloudSQLInstance`:
 kubectl delete cloudsqlinstance cloudsqlpostgresql
 ```
 
-</div>
-<div class="tab-pane fade" id="azure-tab-1" markdown="1">
+{{< /tab >}}
+{{< tab "Azure" >}}
 
 The Azure provider supports provisioning an [Azure Database for PostgreSQL]
 instance with the `PostgreSQLServer` managed resource it adds to Crossplane.
@@ -200,8 +194,8 @@ kubectl delete postgresqlserver sqlserverpostgresql
 kubectl delete resourcegroup sqlserverpostgresql-rg
 ```
 
-</div>
-</div>
+{{< /tab >}}
+{{< /tabs >}}
 
 In Kubernetes, `spec` top field represents the desired state of the user.
 Crossplane adheres to that and has its own conventions about how the fields

--- a/docs/contributing/release-process.md
+++ b/docs/contributing/release-process.md
@@ -45,10 +45,7 @@ prescriptive detail.
 Feature freeze should be performed on all repos.  In order to start the feature
 freeze period, the following conditions should be met:
 
-* All expected features should be
-  ["complete"](https://github.com/crossplane/crossplane/blob/master/design/one-pager-definition-of-done.md)
-  and merged into main development branch. This includes user guides, examples,
-  API documentation, and test updates.
+
 * All issues in the
   [milestone](https://github.com/crossplane/crossplane/milestones) should be
   closed
@@ -167,7 +164,7 @@ For all repos with Helm charts:
 * [Helm chart repository](https://charts.crossplane.io/)
 
 For crossplane/crossplane:
-* [Docs website](https://crossplane.io/docs/latest)
+* [Docs website](https://docs.crossplane.io)
 * [Configuration Packages](https://marketplace.upbound.io)
 
 ### Tag Next Pre-release

--- a/docs/faqs/related_projects.md
+++ b/docs/faqs/related_projects.md
@@ -75,7 +75,7 @@ plane.
 <!-- Named Links -->
 
 [Open Service Broker]: https://www.openservicebrokerapi.org/
-[Kubernetes Service Catalog]: https://kubernetes.io/docs/concepts/extend-kubernetes/service-catalog/
+[Kubernetes Service Catalog]: https://github.com/kubernetes-retired/service-catalog
 [GCP OSB]: https://cloud.google.com/kubernetes-engine/docs/concepts/google-cloud-platform-service-broker
 [GCP Config Connector]: https://github.com/GoogleCloudPlatform/k8s-config-connector
 [AWS Controllers for Kubernetes]: https://github.com/aws-controllers-k8s/community

--- a/docs/getting-started/_index.md
+++ b/docs/getting-started/_index.md
@@ -2,11 +2,10 @@
 title: "Getting Started"
 toc_include: false
 weight: 1
-cascade:
-    version: 1.8
 ---
 
-![Crossplane](/docs/v1.8/media/banner.png)
+{{< img src="../media/banner.png" alt="Crossplane Popsicle Truck" size="large" >}}
+
 
 Crossplane is an open source Kubernetes add-on that transforms your cluster into
 a **universal control plane**. Crossplane enables platform teams to assemble

--- a/docs/getting-started/create-configuration.md
+++ b/docs/getting-started/create-configuration.md
@@ -104,15 +104,8 @@ this by defining a `Composition` that can satisfy the XR we defined above. In
 this case, our `Composition` will specify how to provision a public PostgreSQL
 instance on the chosen provider.
 
-<ul class="nav nav-tabs">
-<li class="active"><a href="#aws-tab-2" data-toggle="tab">AWS (Default VPC)</a></li>
-<li><a href="#aws-new-tab-2" data-toggle="tab">AWS (New VPC)</a></li>
-<li><a href="#gcp-tab-2" data-toggle="tab">GCP</a></li>
-<li><a href="#azure-tab-2" data-toggle="tab">Azure</a></li>
-</ul>
-<br>
-<div class="tab-content">
-<div class="tab-pane fade in active" id="aws-tab-2" markdown="1">
+{{< tabs >}}
+{{< tab "AWS (Default VPC)" >}}
 
 > Note that this Composition will create an RDS instance using your default VPC,
 > which may or may not allow connections from the internet depending on how it
@@ -169,8 +162,8 @@ spec:
 curl -OL https://raw.githubusercontent.com/crossplane/crossplane/release-1.8/docs/snippets/package/aws/composition.yaml
 ```
 
-</div>
-<div class="tab-pane fade" id="aws-new-tab-2" markdown="1">
+{{< /tab >}}
+{{< tab "AWS (New VPC)" >}}
 
 > Note: this `Composition` for AWS also includes several networking managed
 > resources that are required to provision a publicly available PostgreSQL
@@ -343,8 +336,8 @@ spec:
 curl -OL https://raw.githubusercontent.com/crossplane/crossplane/release-1.8/docs/snippets/package/aws-with-vpc/composition.yaml
 ```
 
-</div>
-<div class="tab-pane fade" id="gcp-tab-2" markdown="1">
+{{< /tab >}}
+{{< tab "GCP" >}}
 
 ```yaml
 apiVersion: apiextensions.crossplane.io/v1
@@ -399,8 +392,8 @@ spec:
 curl -OL https://raw.githubusercontent.com/crossplane/crossplane/release-1.8/docs/snippets/package/gcp/composition.yaml
 ```
 
-</div>
-<div class="tab-pane fade" id="azure-tab-2" markdown="1">
+{{< /tab >}}
+{{< tab "Azure" >}}
 
 > Note: the `Composition` for Azure also includes a `ResourceGroup` and
 > `PostgreSQLServerFirewallRule` that are required to provision a publicly
@@ -485,58 +478,9 @@ spec:
 curl -OL https://raw.githubusercontent.com/crossplane/crossplane/release-1.8/docs/snippets/package/azure/composition.yaml
 ```
 
-</div>
-<div class="tab-pane fade" id="alibaba-tab-2" markdown="1">
 
-```yaml
-apiVersion: apiextensions.crossplane.io/v1
-kind: Composition
-metadata:
-  name: xpostgresqlinstances.alibaba.database.example.org
-  labels:
-    provider: alibaba
-    guide: quickstart
-spec:
-  writeConnectionSecretsToNamespace: crossplane-system
-  compositeTypeRef:
-    apiVersion: database.example.org/v1alpha1
-    kind: XPostgreSQLInstance
-  resources:
-    - name: rdsinstance
-      base:
-        apiVersion: database.alibaba.crossplane.io/v1alpha1
-        kind: RDSInstance
-        spec:
-          forProvider:
-            engine: PostgreSQL
-            engineVersion: "9.4"
-            dbInstanceClass: rds.pg.s1.small
-            securityIPList: "0.0.0.0/0"
-            masterUsername: "myuser"
-          writeConnectionSecretToRef:
-            namespace: crossplane-system
-      patches:
-        - fromFieldPath: "metadata.uid"
-          toFieldPath: "spec.writeConnectionSecretToRef.name"
-          transforms:
-            - type: string
-              string:
-                fmt: "%s-postgresql"
-        - fromFieldPath: "spec.parameters.storageGB"
-          toFieldPath: "spec.forProvider.dbInstanceStorageInGB"
-      connectionDetails:
-        - fromConnectionSecretKey: username
-        - fromConnectionSecretKey: password
-        - fromConnectionSecretKey: endpoint
-        - fromConnectionSecretKey: port
-```
-
-```console
-curl -OL https://raw.githubusercontent.com/crossplane/crossplane/release-1.8/docs/snippets/package/alibaba/composition.yaml
-```
-
-</div>
-</div>
+{{< /tab >}}
+{{< /tabs >}}
 
 ## Build and Push The Configuration
 
@@ -547,15 +491,8 @@ so that Crossplane users may install it.
 > Hub] by default. You may need to run `docker login` before you are able to
 > push a package.
 
-<ul class="nav nav-tabs">
-<li class="active"><a href="#aws-tab-3" data-toggle="tab">AWS (Default VPC)</a></li>
-<li><a href="#aws-new-tab-3" data-toggle="tab">AWS (New VPC)</a></li>
-<li><a href="#gcp-tab-3" data-toggle="tab">GCP</a></li>
-<li><a href="#azure-tab-3" data-toggle="tab">Azure</a></li>
-</ul>
-<br>
-<div class="tab-content">
-<div class="tab-pane fade in active" id="aws-tab-3" markdown="1">
+{{< tabs >}}
+{{< tab "AWS (Default VPC)" >}}
 
 ```yaml
 apiVersion: meta.pkg.crossplane.io/v1
@@ -594,8 +531,8 @@ kubectl crossplane push configuration ${REG}/getting-started-with-aws:v1.8.2
 > Note that the Crossplane CLI will not follow symbolic links for files in the
 > root package directory.
 
-</div>
-<div class="tab-pane fade" id="aws-new-tab-3" markdown="1">
+{{< /tab >}}
+{{< tab "AWS (Default VPC)" >}}
 
 ```yaml
 apiVersion: meta.pkg.crossplane.io/v1
@@ -634,8 +571,8 @@ kubectl crossplane push configuration ${REG}/getting-started-with-aws-with-vpc:v
 > Note that the Crossplane CLI will not follow symbolic links for files in the
 > root package directory.
 
-</div>
-<div class="tab-pane fade" id="gcp-tab-3" markdown="1">
+{{< /tab >}}
+{{< tab "GCP" >}}
 
 ```yaml
 apiVersion: meta.pkg.crossplane.io/v1
@@ -673,8 +610,8 @@ kubectl crossplane push configuration ${REG}/getting-started-with-gcp:v1.8.2
 > Note that the Crossplane CLI will not follow symbolic links for files in the
 > root package directory.
 
-</div>
-<div class="tab-pane fade" id="azure-tab-3" markdown="1">
+{{< /tab >}}
+{{< tab "Azure" >}}
 
 ```yaml
 apiVersion: meta.pkg.crossplane.io/v1
@@ -712,8 +649,8 @@ kubectl crossplane push configuration ${REG}/getting-started-with-azure:v1.8.2
 > Note that the Crossplane CLI will not follow symbolic links for files in the
 > root package directory.
 
-</div>
-</div>
+{{< /tab >}}
+{{< /tabs >}}
 
 That's it! You've now built and pushed your package. Take a look at the
 Crossplane [packages] documentation for more information about installing and

--- a/docs/getting-started/install-configure.md
+++ b/docs/getting-started/install-configure.md
@@ -2,7 +2,6 @@
 title: Install & Configure
 weight: 2
 ---
-
 ## Choosing Your Crossplane Distribution
 
 Users looking to use Crossplane for the first time have two options available to
@@ -14,48 +13,35 @@ distributions are [certified by the CNCF] to be conformant with Crossplane, but
 may include additional features or tooling around it that makes it easier to use
 in production environments.
 
-<ul class="nav nav-tabs">
-<li class="active"><a href="#using-upstream-crossplane" data-toggle="tab">Crossplane (upstream)</a></li>
-<li><a href="#using-a-downstream-distro" data-toggle="tab">Downstream Distributions</a></li>
-</ul>
-<br>
-<!-- Begin Distro Tabs -->
-<div class="tab-content">
-<!-- Begin Upstream Tab -->
-<div class="tab-pane fade in active" id="using-upstream-crossplane" markdown="1">
+{{% tabs "Crossplane Distros" %}}
+
+{{% tab "Crossplane (upstream)" %}}
 
 ## Start with Upstream Crossplane
 
 Installing Crossplane into an existing Kubernetes cluster will require a bit
-more setup, but can provide more flexibility for users who need it. 
+more setup, but can provide more flexibility for users who need it.
 
 ### Get a Kubernetes Cluster
+<!-- inside Crossplane (upstream) -->
+{{% tabs "Kubernetes Clusters" %}}
 
-<ul class="nav nav-tabs">
-<li class="active"><a href="#setup-mac-brew" data-toggle="tab">macOS via Homebrew</a></li>
-<li><a href="#setup-mac-linux" data-toggle="tab">macOS / Linux</a></li>
-<li><a href="#setup-windows" data-toggle="tab">Windows</a></li>
-</ul>
-<br>
-<!-- Begin Get Cluster Tabs -->
-<div class="tab-content">
-<!-- Begin MacOS Tab -->
-<div class="tab-pane fade in active" id="setup-mac-brew" markdown="1">
+{{% tab "macOS via Homebrew" %}}
+
 For macOS via Homebrew use the following:
 
-```console
+```bash
 brew upgrade
 brew install kind
 brew install kubectl
 brew install helm
-
 kind create cluster --image kindest/node:v1.23.0 --wait 5m
 ```
-</div>
-<!-- End MacOS Tab -->
+<!-- close "macOS via Homebrew" -->
+{{% /tab  %}}
 
-<!-- Begin Linux Tab -->
-<div class="tab-pane fade" id="setup-mac-linux" markdown="1">
+{{% tab "macOS / Linux" %}}
+
 For macOS / Linux use the following:
 
 * [Kubernetes cluster]
@@ -65,11 +51,10 @@ For macOS / Linux use the following:
 
 * [Helm], minimum version `v3.0.0+`.
 
-</div>
-<!-- End Linux Tab -->
+<!-- close "macOS / Linux" -->
+{{% /tab %}}
 
-<!-- Begin Windows Tab -->
-<div class="tab-pane fade" id="setup-windows" markdown="1">
+{{% tab "Windows" %}}
 For Windows use the following:
 
 * [Kubernetes cluster]
@@ -79,42 +64,35 @@ For Windows use the following:
 
 * [Helm], minimum version `v3.0.0+`.
 
-</div>
-<!-- End Windows Tab -->
-</div>
-<!-- End Get Cluster Tabs -->
+<!-- close "Windows" -->
+{{% /tab %}}
+
+<!-- close "Kubernetes Clusters" -->
+{{% /tabs %}}
 
 ### Install Crossplane
 
-<ul class="nav nav-tabs">
-<li class="active"><a href="#install-tab-helm3" data-toggle="tab">Helm 3 (stable)</a></li>
-<li><a href="#install-tab-helm3-latest" data-toggle="tab">Helm 3 (latest)</a></li>
-</ul>
-<br>
-<!-- Begin Helm Tabs -->
-<div class="tab-content">
+{{% tabs "install with helm" %}}
 
-<!-- Begin Stable Tab -->
-<div class="tab-pane fade in active" id="install-tab-helm3" markdown="1">
+{{% tab "Helm 3 (stable)" %}}
 Use Helm 3 to install the latest official `stable` release of Crossplane, suitable for community use and testing:
 
-```console
+```bash
 kubectl create namespace crossplane-system
-
 helm repo add crossplane-stable https://charts.crossplane.io/stable
 helm repo update
 
 helm install crossplane --namespace crossplane-system crossplane-stable/crossplane
 ```
 
-</div>
-<!-- End Stable Tab -->
+<!-- close "Helm 3 (stable)" -->
+{{% /tab %}}
 
-<!-- Begin Latest Tab -->
-<div class="tab-pane fade" id="install-tab-helm3-latest" markdown="1">
+{{% tab "Helm 3 (latest)" %}}
+<!-- fold start -->
 Use Helm 3 to install the latest pre-release version of Crossplane:
 
-```console
+```bash
 kubectl create namespace crossplane-system
 
 helm repo add crossplane-master https://charts.crossplane.io/master/
@@ -127,20 +105,18 @@ helm install crossplane --namespace crossplane-system crossplane-master/crosspla
 
 For example:
 
-```console
+```bash
 helm install crossplane --namespace crossplane-system crossplane-master/crossplane \
   --version 0.11.0-rc.100.gbc5d311 --devel
 ```
-
-</div>
-<!-- End Latest Tab -->
-
-</div>
-<!-- End Helm Tabs -->
+<!-- close "Helm 3 (latest)" -->
+{{% /tab %}}
+<!-- close "install with helm" -->
+{{% /tabs %}}
 
 ### Check Crossplane Status
 
-```console
+```bash
 helm list -n crossplane-system
 
 kubectl get all -n crossplane-system
@@ -151,29 +127,18 @@ kubectl get all -n crossplane-system
 The Crossplane CLI extends `kubectl` with functionality to build, push, and
 install [Crossplane packages]:
 
-<ul class="nav nav-tabs">
-<li class="active"><a href="#install-tab-cli" data-toggle="tab">Stable</a></li>
-<li><a href="#install-tab-cli-latest" data-toggle="tab">Latest</a></li>
-</ul>
-<br>
+{{% tabs "crossplane CLI" %}}
 
-<!-- Begin CLI Tabs -->
-<div class="tab-content">
-
-<!-- Begin CLI Stable Tab -->
-<div class="tab-pane fade in active" id="install-tab-cli" markdown="1">
-
-```console
+{{% tab "Stable" %}}
+```bash
 curl -sL https://raw.githubusercontent.com/crossplane/crossplane/master/install.sh | sh
 ```
+<!-- close "Stable" -->
+{{% /tab %}}
 
-</div>
-<!-- End CLI Stable Tab -->
+{{% tab "Latest" %}}
 
-<!-- Begin CLI Latest Tab -->
-<div class="tab-pane fade" id="install-tab-cli-latest" markdown="1">
-
-```console
+```bash
 curl -sL https://raw.githubusercontent.com/crossplane/crossplane/master/install.sh | CHANNEL=master sh
 ```
 
@@ -181,15 +146,14 @@ You may also specify `VERSION` for download if you would like to select a
 specific version from the given release channel. If a version is not specified
 the latest version from the release channel will be used.
 
-```console
+```bash
 curl -sL https://raw.githubusercontent.com/crossplane/crossplane/master/install.sh | CHANNEL=master VERSION=v1.0.0-rc.0.130.g94f34fd3 sh
 ```
+<!-- close "Latest" -->
+{{% /tab %}}
 
-</div>
-<!-- End CLI Latest Tab -->
-
-</div>
-<!-- End CLI tabs -->
+<!-- close "crossplane CLI" -->
+{{% /tabs %}}
 
 ## Select a Getting Started Configuration
 
@@ -220,32 +184,21 @@ single `storageGB` parameter, and creates a connection `Secret` with keys for
 `username`, `password`, and `endpoint`. A `Configuration` exists for each
 provider that can satisfy a `PostgreSQLInstance`. Let's get started!
 
-<ul class="nav nav-tabs">
-<li class="active"><a href="#aws-tab-1" data-toggle="tab">AWS (Default VPC)</a></li>
-<li><a href="#aws-new-tab-1" data-toggle="tab">AWS (New VPC)</a></li>
-<li><a href="#gcp-tab-1" data-toggle="tab">GCP</a></li>
-<li><a href="#azure-tab-1" data-toggle="tab">Azure</a></li>
-</ul>
-<br>
+{{% tabs "getting started" %}}
 
-<!-- Begin Cloud Provider Tabs -->
-<div class="tab-content">
-
-<!-- Begin AWS Default VPC Tab -->
-<div class="tab-pane fade in active" id="aws-tab-1" markdown="1">
-
+{{% tab "AWS (Default VPC)" %}}
 ### Install Configuration Package
 
 > If you prefer to see the contents of this configuration package and how it is
 > constructed prior to install, skip ahead to the [create a configuration]
 > section.
 
-```console
-kubectl crossplane install configuration registry.upbound.io/xp/getting-started-with-aws:v1.8.2
+```bash
+kubectl crossplane install configuration registry.upbound.io/xp/getting-started-with-aws:v1.10.1
 ```
 
 Wait until all packages become healthy:
-```
+```bash
 watch kubectl get pkg
 ```
 
@@ -253,13 +206,67 @@ watch kubectl get pkg
 
 Using an AWS account with permissions to manage RDS databases:
 
-```console
+```bash
 AWS_PROFILE=default && echo -e "[default]\naws_access_key_id = $(aws configure get aws_access_key_id --profile $AWS_PROFILE)\naws_secret_access_key = $(aws configure get aws_secret_access_key --profile $AWS_PROFILE)" > creds.conf
 ```
 
 ### Create a Provider Secret
 
+```bash
+kubectl create secret generic aws-creds -n crossplane-system --from-file=creds=./creds.conf
+```
+
+### Configure the Provider
+
+We will create the following `ProviderConfig` object to configure credentials
+for AWS Provider:
+
+```yaml
+apiVersion: aws.crossplane.io/v1beta1
+kind: ProviderConfig
+metadata:
+  name: default
+spec:
+  credentials:
+    source: Secret
+    secretRef:
+      namespace: crossplane-system
+      name: aws-creds
+      key: creds
+```
 ```console
+kubectl apply -f https://raw.githubusercontent.com/crossplane/crossplane/release-1.9/docs/snippets/configure/aws/providerconfig.yaml
+```
+<!-- close "AWS (Default VPC)" -->
+{{% /tab %}}
+
+{{% tab "AWS (New VPC)" %}}
+### Install Configuration Package
+
+> If you prefer to see the contents of this configuration package and how it is
+> constructed prior to install, skip ahead to the [create a configuration]
+> section.
+
+```bash
+kubectl crossplane install configuration registry.upbound.io/xp/getting-started-with-aws-with-vpc:v1.10.1
+```
+
+Wait until all packages become healthy:
+```bash
+watch kubectl get pkg
+```
+
+### Get AWS Account Keyfile
+
+Using an AWS account with permissions to manage RDS databases:
+
+```bash
+AWS_PROFILE=default && echo -e "[default]\naws_access_key_id = $(aws configure get aws_access_key_id --profile $AWS_PROFILE)\naws_secret_access_key = $(aws configure get aws_secret_access_key --profile $AWS_PROFILE)" > creds.conf
+```
+
+### Create a Provider Secret
+
+```bash
 kubectl create secret generic aws-creds -n crossplane-system --from-file=creds=./creds.conf
 ```
 
@@ -284,12 +291,10 @@ spec:
 ```console
 kubectl apply -f https://raw.githubusercontent.com/crossplane/crossplane/release-1.8/docs/snippets/configure/aws/providerconfig.yaml
 ```
+<!-- close "AWS (New VPC)" -->
+{{% /tab %}}
 
-</div>
-<!-- End AWS Default VPC Tab -->
-
-<!-- Begin AWS New VPC Tab -->
-<div class="tab-pane fade" id="aws-new-tab-1" markdown="1">
+{{% tab "GCP" %}}
 
 ### Install Configuration Package
 
@@ -297,65 +302,8 @@ kubectl apply -f https://raw.githubusercontent.com/crossplane/crossplane/release
 > constructed prior to install, skip ahead to the [create a configuration]
 > section.
 
-```console
-kubectl crossplane install configuration registry.upbound.io/xp/getting-started-with-aws-with-vpc:v1.8.2
-```
-
-Wait until all packages become healthy:
-```
-watch kubectl get pkg
-```
-
-### Get AWS Account Keyfile
-
-Using an AWS account with permissions to manage RDS databases:
-
-```console
-AWS_PROFILE=default && echo -e "[default]\naws_access_key_id = $(aws configure get aws_access_key_id --profile $AWS_PROFILE)\naws_secret_access_key = $(aws configure get aws_secret_access_key --profile $AWS_PROFILE)" > creds.conf
-```
-
-### Create a Provider Secret
-
-```console
-kubectl create secret generic aws-creds -n crossplane-system --from-file=creds=./creds.conf
-```
-
-### Configure the Provider
-
-We will create the following `ProviderConfig` object to configure credentials
-for AWS Provider:
-
-```yaml
-apiVersion: aws.crossplane.io/v1beta1
-kind: ProviderConfig
-metadata:
-  name: default
-spec:
-  credentials:
-    source: Secret
-    secretRef:
-      namespace: crossplane-system
-      name: aws-creds
-      key: creds
-```
-```console
-kubectl apply -f https://raw.githubusercontent.com/crossplane/crossplane/release-1.8/docs/snippets/configure/aws/providerconfig.yaml
-```
-
-</div>
-<!-- End AWS New VPC Tab -->
-
-<!-- Begin GCP Tab -->
-<div class="tab-pane fade" id="gcp-tab-1" markdown="1">
-
-### Install Configuration Package
-
-> If you prefer to see the contents of this configuration package and how it is
-> constructed prior to install, skip ahead to the [create a configuration]
-> section.
-
-```console
-kubectl crossplane install configuration registry.upbound.io/xp/getting-started-with-gcp:v1.8.2
+```bash
+kubectl crossplane install configuration registry.upbound.io/xp/getting-started-with-gcp:v1.10.1
 ```
 
 Wait until all packages become healthy:
@@ -365,7 +313,7 @@ watch kubectl get pkg
 
 ### Get GCP Account Keyfile
 
-```console
+```bash
 # replace this with your own gcp project id and the name of the service account
 # that will be created.
 PROJECT_ID=my-project
@@ -389,7 +337,7 @@ gcloud iam service-accounts keys create creds.json --project $PROJECT_ID --iam-a
 
 ### Create a Provider Secret
 
-```console
+```bash
 kubectl create secret generic gcp-creds -n crossplane-system --from-file=creds=./creds.json
 ```
 
@@ -398,7 +346,7 @@ kubectl create secret generic gcp-creds -n crossplane-system --from-file=creds=.
 We will create the following `ProviderConfig` object to configure credentials
 for GCP Provider:
 
-```console
+```bash
 # replace this with your own gcp project id
 PROJECT_ID=my-project
 echo "apiVersion: gcp.crossplane.io/v1beta1
@@ -414,12 +362,10 @@ spec:
       name: gcp-creds
       key: creds" | kubectl apply -f -
 ```
+<!-- close "GCP" -->
+{{% /tab %}}
 
-</div>
-<!-- End GCP Tab -->
-
-<!-- Begin Azure Tab -->
-<div class="tab-pane fade" id="azure-tab-1" markdown="1">
+{{% tab "Azure" %}}
 
 ### Install Configuration Package
 
@@ -427,8 +373,8 @@ spec:
 > constructed prior to install, skip ahead to the [create a configuration]
 > section.
 
-```console
-kubectl crossplane install configuration registry.upbound.io/xp/getting-started-with-azure:v1.8.2
+```bash
+kubectl crossplane install configuration registry.upbound.io/xp/getting-started-with-azure:v1.10.1
 ```
 
 Wait until all packages become healthy:
@@ -438,14 +384,14 @@ watch kubectl get pkg
 
 ### Get Azure Principal Keyfile
 
-```console
+```bash
 # create service principal with Owner role
-az ad sp create-for-rbac --sdk-auth --role Owner > "creds.json"
+az ad sp create-for-rbac --role Contributor --scopes /subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx > "creds.json"
 ```
 
 ### Create a Provider Secret
 
-```console
+```bash
 kubectl create secret generic azure-creds -n crossplane-system --from-file=creds=./creds.json
 ```
 
@@ -468,27 +414,22 @@ spec:
       key: creds
 ```
 
-```console
-kubectl apply -f https://raw.githubusercontent.com/crossplane/crossplane/release-1.8/docs/snippets/configure/azure/providerconfig.yaml
+```bash
+kubectl apply -f https://raw.githubusercontent.com/crossplane/crossplane/release-1.10/docs/snippets/configure/azure/providerconfig.yaml
 ```
+<!-- close "Azure" -->
+{{% /tab %}}
 
-</div>
-<!-- End Azure Tab -->
-
-</div>
-<!-- End Cloud Provider Tabs -->
+{{% /tabs %}}
 
 ## Next Steps
 
 Now that you have configured Crossplane with support for `PostgreSQLInstance`,
 you can [provision infrastructure].
+<!-- close "Crossplane (upstream)" -->
+{{% /tab %}}
 
-</div>
-<!-- End Upstream Tab -->
-
-<!-- Begin Downstream Tab -->
-<div class="tab-pane fade" id="using-a-downstream-distro" markdown="1">
-
+{{% tab "Downstream Distribution" %}}
 ## Start with a Downstream Distribution
 
 Upbound, the founders of Crossplane, maintains a free and open source downstream
@@ -502,11 +443,11 @@ and Configuration packages.
 <i>Want see another hosted Crossplane service listed? Please [reach out on
 Slack][Slack] and our community will highlight it here!</i>
 
-</div>
-<!-- End Downstream Tab -->
+<!-- close "Downstream Distribution" -->
+{{% /tab %}}
 
-</div>
-<!-- End Distro Tabs -->
+<!-- close "Crossplane Distros" -->
+{{% /tabs %}}
 
 ## More Info
 

--- a/docs/getting-started/install-configure.md
+++ b/docs/getting-started/install-configure.md
@@ -139,15 +139,15 @@ curl -sL https://raw.githubusercontent.com/crossplane/crossplane/master/install.
 {{% tab "Latest" %}}
 
 ```bash
-curl -sL https://raw.githubusercontent.com/crossplane/crossplane/master/install.sh | CHANNEL=master sh
+curl -sL https://raw.githubusercontent.com/crossplane/crossplane/master/install.sh | XP_CHANNEL=master XP_VERSION=v1.0.0-rc.0.130.g94f34fd3 sh
 ```
 
-You may also specify `VERSION` for download if you would like to select a
+You may also specify `XP_VERSION` for download if you would like to select a
 specific version from the given release channel. If a version is not specified
 the latest version from the release channel will be used.
 
 ```bash
-curl -sL https://raw.githubusercontent.com/crossplane/crossplane/master/install.sh | CHANNEL=master VERSION=v1.0.0-rc.0.130.g94f34fd3 sh
+curl -sL https://raw.githubusercontent.com/crossplane/crossplane/master/install.sh | XP_CHANNEL=master XP_VERSION=v1.0.0-rc.0.130.g94f34fd3 sh
 ```
 <!-- close "Latest" -->
 {{% /tab %}}
@@ -415,7 +415,7 @@ spec:
 ```
 
 ```bash
-kubectl apply -f https://raw.githubusercontent.com/crossplane/crossplane/release-1.10/docs/snippets/configure/azure/providerconfig.yaml
+kubectl apply -f https://raw.githubusercontent.com/crossplane/crossplane/release-1.8/docs/snippets/configure/azure/providerconfig.yaml
 ```
 <!-- close "Azure" -->
 {{% /tab %}}

--- a/docs/getting-started/install-configure.md
+++ b/docs/getting-started/install-configure.md
@@ -194,7 +194,7 @@ provider that can satisfy a `PostgreSQLInstance`. Let's get started!
 > section.
 
 ```bash
-kubectl crossplane install configuration registry.upbound.io/xp/getting-started-with-aws:v1.10.1
+kubectl crossplane install configuration registry.upbound.io/xp/getting-started-with-aws:v1.8.2
 ```
 
 Wait until all packages become healthy:
@@ -235,7 +235,7 @@ spec:
       key: creds
 ```
 ```console
-kubectl apply -f https://raw.githubusercontent.com/crossplane/crossplane/release-1.9/docs/snippets/configure/aws/providerconfig.yaml
+kubectl apply -f https://raw.githubusercontent.com/crossplane/crossplane/release-1.8/docs/snippets/configure/aws/providerconfig.yaml
 ```
 <!-- close "AWS (Default VPC)" -->
 {{% /tab %}}
@@ -248,7 +248,7 @@ kubectl apply -f https://raw.githubusercontent.com/crossplane/crossplane/release
 > section.
 
 ```bash
-kubectl crossplane install configuration registry.upbound.io/xp/getting-started-with-aws-with-vpc:v1.10.1
+kubectl crossplane install configuration registry.upbound.io/xp/getting-started-with-aws-with-vpc:v1.8.2
 ```
 
 Wait until all packages become healthy:
@@ -303,7 +303,7 @@ kubectl apply -f https://raw.githubusercontent.com/crossplane/crossplane/release
 > section.
 
 ```bash
-kubectl crossplane install configuration registry.upbound.io/xp/getting-started-with-gcp:v1.10.1
+kubectl crossplane install configuration registry.upbound.io/xp/getting-started-with-gcp:v1.8.2
 ```
 
 Wait until all packages become healthy:
@@ -374,7 +374,7 @@ spec:
 > section.
 
 ```bash
-kubectl crossplane install configuration registry.upbound.io/xp/getting-started-with-azure:v1.10.1
+kubectl crossplane install configuration registry.upbound.io/xp/getting-started-with-azure:v1.8.2
 ```
 
 Wait until all packages become healthy:
@@ -386,7 +386,7 @@ watch kubectl get pkg
 
 ```bash
 # create service principal with Owner role
-az ad sp create-for-rbac --role Contributor --scopes /subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx > "creds.json"
+az ad sp create-for-rbac --sdk-auth --role Owner > "creds.json"
 ```
 
 ### Create a Provider Secret

--- a/docs/getting-started/provision-infrastructure.md
+++ b/docs/getting-started/provision-infrastructure.md
@@ -30,15 +30,8 @@ This means that we can create a `PostgreSQLInstance` XRC in the `default`
 namespace to provision a PostgreSQL instance and all the supporting
 infrastructure (VPCs, firewall rules, resource groups, etc) that it may need!
 
-<ul class="nav nav-tabs">
-<li class="active"><a href="#aws-tab-2" data-toggle="tab">AWS (Default VPC)</a></li>
-<li><a href="#aws-new-tab-2" data-toggle="tab">AWS (New VPC)</a></li>
-<li><a href="#gcp-tab-2" data-toggle="tab">GCP</a></li>
-<li><a href="#azure-tab-2" data-toggle="tab">Azure</a></li>
-</ul>
-<br>
-<div class="tab-content">
-<div class="tab-pane fade in active" id="aws-tab-2" markdown="1">
+{{< tabs >}}
+{{< tab "AWS (Default VPC)" >}}
 
 > Note that this resource will create an RDS instance using your default VPC,
 > which may or may not allow connections from the internet depending on how it
@@ -65,8 +58,8 @@ spec:
 kubectl apply -f https://raw.githubusercontent.com/crossplane/crossplane/release-1.8/docs/snippets/compose/claim-aws.yaml
 ```
 
-</div>
-<div class="tab-pane fade" id="aws-new-tab-2" markdown="1">
+{{< /tab >}}
+{{< tab "AWS (New VPC)" >}}
 
 > Note that this resource also includes several networking managed resources
 > that are required to provision a publicly available PostgreSQL instance.
@@ -94,8 +87,8 @@ spec:
 kubectl apply -f https://raw.githubusercontent.com/crossplane/crossplane/release-1.8/docs/snippets/compose/claim-aws.yaml
 ```
 
-</div>
-<div class="tab-pane fade" id="gcp-tab-2" markdown="1">
+{{< /tab >}}
+{{< tab "GCP" >}}
 
 ```yaml
 apiVersion: database.example.org/v1alpha1
@@ -117,8 +110,8 @@ spec:
 kubectl apply -f https://raw.githubusercontent.com/crossplane/crossplane/release-1.8/docs/snippets/compose/claim-gcp.yaml
 ```
 
-</div>
-<div class="tab-pane fade" id="azure-tab-2" markdown="1">
+{{< /tab >}}
+{{< tab "Azure" >}}
 
 ```yaml
 apiVersion: database.example.org/v1alpha1
@@ -140,8 +133,8 @@ spec:
 kubectl apply -f https://raw.githubusercontent.com/crossplane/crossplane/release-1.8/docs/snippets/compose/claim-azure.yaml
 ```
 
-</div>
-</div>
+{{< /tab >}}
+{{< /tabs >}}
 
 After creating the `PostgreSQLInstance` Crossplane will begin provisioning a
 database instance on your provider of choice. Once provisioning is complete, you

--- a/docs/media/README.md
+++ b/docs/media/README.md
@@ -1,5 +1,5 @@
 ---
-toc_hide: true 
+tocHidden: true 
 ---
 
 # Crossplane Documentation Media


### PR DESCRIPTION
### Description of your changes
This PR updates the docs content to conform with changes required for the new docs.crossplane site deployment. 
This includes changes to front matter and tab generation. 

Functional changes include:
* replacing markdown images with image shortcode to convert images to webp and lazy load at build time.
* `docs/faqs/related_projects.md` - Fixes broken k8s link
* `Makefile` -  moves docs into `/content` instead of `/content/docs` on the website
* `docs/contributing/release-process.md` - Removes reference to "complete"
* `docs/getting-started/create-configuration.md` removes incomplete Alibaba configuration

**Do not merge this PR until /after/ the new docs site has been deployed.**