### PR TITLE
feat(transform): Add hash string conversion

### DIFF
--- a/apis/apiextensions/v1/composition_transforms.go
+++ b/apis/apiextensions/v1/composition_transforms.go
@@ -171,6 +171,9 @@ const (
 	StringConversionTypeToJSON     StringConversionType = "ToJson"
 	StringConversionTypeToBase64   StringConversionType = "ToBase64"
 	StringConversionTypeFromBase64 StringConversionType = "FromBase64"
+	StringConversionTypeToSHA1     StringConversionType = "ToSha1"
+	StringConversionTypeToSHA256   StringConversionType = "ToSha256"
+	StringConversionTypeToSHA512   StringConversionType = "ToSha512"
 )
 
 // A StringTransform returns a string given the supplied input.
@@ -191,8 +194,10 @@ type StringTransform struct {
 	// `ToUpper` and `ToLower` change the letter case of the input string.
 	// `ToBase64` and `FromBase64` perform a base64 conversion based on the input string.
 	// `ToJson` converts any input value into its raw JSON representation.
+	// `ToSha1`, `ToSha256` and `ToSha512` generate a hash value based on the input
+	// converted to JSON.
 	// +optional
-	// +kubebuilder:validation:Enum=ToUpper;ToLower;ToBase64;FromBase64;ToJson
+	// +kubebuilder:validation:Enum=ToUpper;ToLower;ToBase64;FromBase64;ToJson;ToSha1;ToSha256;ToSha512
 	Convert *StringConversionType `json:"convert,omitempty"`
 
 	// Trim the prefix or suffix from the input

--- a/apis/apiextensions/v1alpha1/zz_generated.revision_types.go
+++ b/apis/apiextensions/v1alpha1/zz_generated.revision_types.go
@@ -641,6 +641,9 @@ const (
 	StringConversionTypeToLower    StringConversionType = "ToLower"
 	StringConversionTypeToBase64   StringConversionType = "ToBase64"
 	StringConversionTypeFromBase64 StringConversionType = "FromBase64"
+	StringConversionTypeToSHA1     StringConversionType = "ToSha1"
+	StringConversionTypeToSHA256   StringConversionType = "ToSha256"
+	StringConversionTypeToSHA512   StringConversionType = "ToSha512"
 )
 
 // A StringTransform returns a string given the supplied input.
@@ -655,12 +658,16 @@ type StringTransform struct {
 	// Format the input using a Go format string. See
 	// https://golang.org/pkg/fmt/ for details.
 	// +optional
-	// +immutable
 	Format *string `json:"fmt,omitempty"`
 
-	// Convert the type of conversion to Upper/Lower case.
+	// Optional conversion method to be used.
+	// `ToUpper` and `ToLower` convert the letter case of the input string.
+	// `ToBase64` and `FromBase64` create / read a base64 representation of the
+	// input value.
+	// `ToSha1`, `ToSha256` and `ToSha512` generate a hash value based on the input
+	// converted to JSON.
 	// +optional
-	// +kubebuilder:validation:Enum=ToUpper;ToLower;ToBase64;FromBase64
+	// +kubebuilder:validation:Enum=ToUpper;ToLower;ToBase64;FromBase64;ToSha1;ToSha256;ToSha512
 	Convert *StringConversionType `json:"convert,omitempty"`
 
 	// Trim the prefix or suffix from the input

--- a/apis/apiextensions/v1alpha1/zz_generated.revision_types.go
+++ b/apis/apiextensions/v1alpha1/zz_generated.revision_types.go
@@ -639,6 +639,7 @@ type StringConversionType string
 const (
 	StringConversionTypeToUpper    StringConversionType = "ToUpper"
 	StringConversionTypeToLower    StringConversionType = "ToLower"
+	StringConversionTypeToJSON     StringConversionType = "ToJson"
 	StringConversionTypeToBase64   StringConversionType = "ToBase64"
 	StringConversionTypeFromBase64 StringConversionType = "FromBase64"
 	StringConversionTypeToSHA1     StringConversionType = "ToSha1"
@@ -660,14 +661,14 @@ type StringTransform struct {
 	// +optional
 	Format *string `json:"fmt,omitempty"`
 
-	// Optional conversion method to be used.
-	// `ToUpper` and `ToLower` convert the letter case of the input string.
-	// `ToBase64` and `FromBase64` create / read a base64 representation of the
-	// input value.
+	// Optional conversion method to be specified.
+	// `ToUpper` and `ToLower` change the letter case of the input string.
+	// `ToBase64` and `FromBase64` perform a base64 conversion based on the input string.
+	// `ToJson` converts any input value into its raw JSON representation.
 	// `ToSha1`, `ToSha256` and `ToSha512` generate a hash value based on the input
 	// converted to JSON.
 	// +optional
-	// +kubebuilder:validation:Enum=ToUpper;ToLower;ToBase64;FromBase64;ToSha1;ToSha256;ToSha512
+	// +kubebuilder:validation:Enum=ToUpper;ToLower;ToBase64;FromBase64;ToJson;ToSha1;ToSha256;ToSha512
 	Convert *StringConversionType `json:"convert,omitempty"`
 
 	// Trim the prefix or suffix from the input

--- a/apis/apiextensions/v1beta1/revision_types.go
+++ b/apis/apiextensions/v1beta1/revision_types.go
@@ -639,6 +639,9 @@ const (
 	StringConversionTypeToLower    StringConversionType = "ToLower"
 	StringConversionTypeToBase64   StringConversionType = "ToBase64"
 	StringConversionTypeFromBase64 StringConversionType = "FromBase64"
+	StringConversionTypeToSHA1     StringConversionType = "ToSha1"
+	StringConversionTypeToSHA256   StringConversionType = "ToSha256"
+	StringConversionTypeToSHA512   StringConversionType = "ToSha512"
 )
 
 // A StringTransform returns a string given the supplied input.
@@ -653,12 +656,16 @@ type StringTransform struct {
 	// Format the input using a Go format string. See
 	// https://golang.org/pkg/fmt/ for details.
 	// +optional
-	// +immutable
 	Format *string `json:"fmt,omitempty"`
 
-	// Convert the type of conversion to Upper/Lower case.
+	// Optional conversion method to be used.
+	// `ToUpper` and `ToLower` convert the letter case of the input string.
+	// `ToBase64` and `FromBase64` create / read a base64 representation of the
+	// input value.
+	// `ToSha1`, `ToSha256` and `ToSha512` generate a hash value based on the input
+	// converted to JSON.
 	// +optional
-	// +kubebuilder:validation:Enum=ToUpper;ToLower;ToBase64;FromBase64
+	// +kubebuilder:validation:Enum=ToUpper;ToLower;ToBase64;FromBase64;ToSha1;ToSha256;ToSha512
 	Convert *StringConversionType `json:"convert,omitempty"`
 
 	// Trim the prefix or suffix from the input

--- a/apis/apiextensions/v1beta1/revision_types.go
+++ b/apis/apiextensions/v1beta1/revision_types.go
@@ -637,6 +637,7 @@ type StringConversionType string
 const (
 	StringConversionTypeToUpper    StringConversionType = "ToUpper"
 	StringConversionTypeToLower    StringConversionType = "ToLower"
+	StringConversionTypeToJSON     StringConversionType = "ToJson"
 	StringConversionTypeToBase64   StringConversionType = "ToBase64"
 	StringConversionTypeFromBase64 StringConversionType = "FromBase64"
 	StringConversionTypeToSHA1     StringConversionType = "ToSha1"
@@ -658,14 +659,14 @@ type StringTransform struct {
 	// +optional
 	Format *string `json:"fmt,omitempty"`
 
-	// Optional conversion method to be used.
-	// `ToUpper` and `ToLower` convert the letter case of the input string.
-	// `ToBase64` and `FromBase64` create / read a base64 representation of the
-	// input value.
+	// Optional conversion method to be specified.
+	// `ToUpper` and `ToLower` change the letter case of the input string.
+	// `ToBase64` and `FromBase64` perform a base64 conversion based on the input string.
+	// `ToJson` converts any input value into its raw JSON representation.
 	// `ToSha1`, `ToSha256` and `ToSha512` generate a hash value based on the input
 	// converted to JSON.
 	// +optional
-	// +kubebuilder:validation:Enum=ToUpper;ToLower;ToBase64;FromBase64;ToSha1;ToSha256;ToSha512
+	// +kubebuilder:validation:Enum=ToUpper;ToLower;ToBase64;FromBase64;ToJson;ToSha1;ToSha256;ToSha512
 	Convert *StringConversionType `json:"convert,omitempty"`
 
 	// Trim the prefix or suffix from the input

--- a/cluster/crds/apiextensions.crossplane.io_compositionrevisions.yaml
+++ b/cluster/crds/apiextensions.crossplane.io_compositionrevisions.yaml
@@ -330,13 +330,21 @@ spec:
                                   string.
                                 properties:
                                   convert:
-                                    description: Convert the type of conversion to
-                                      Upper/Lower case.
+                                    description: Optional conversion method to be
+                                      used. `ToUpper` and `ToLower` convert the letter
+                                      case of the input string. `ToBase64` and `FromBase64`
+                                      create / read a base64 representation of the
+                                      input value. `ToSha1`, `ToSha256` and `ToSha512`
+                                      generate a hash value based on the input converted
+                                      to JSON.
                                     enum:
                                     - ToUpper
                                     - ToLower
                                     - ToBase64
                                     - FromBase64
+                                    - ToSha1
+                                    - ToSha256
+                                    - ToSha512
                                     type: string
                                   fmt:
                                     description: Format the input using a Go format
@@ -732,13 +740,21 @@ spec:
                                     a string.
                                   properties:
                                     convert:
-                                      description: Convert the type of conversion
-                                        to Upper/Lower case.
+                                      description: Optional conversion method to be
+                                        used. `ToUpper` and `ToLower` convert the
+                                        letter case of the input string. `ToBase64`
+                                        and `FromBase64` create / read a base64 representation
+                                        of the input value. `ToSha1`, `ToSha256` and
+                                        `ToSha512` generate a hash value based on
+                                        the input converted to JSON.
                                       enum:
                                       - ToUpper
                                       - ToLower
                                       - ToBase64
                                       - FromBase64
+                                      - ToSha1
+                                      - ToSha256
+                                      - ToSha512
                                       type: string
                                     fmt:
                                       description: Format the input using a Go format
@@ -1107,13 +1123,21 @@ spec:
                                     a string.
                                   properties:
                                     convert:
-                                      description: Convert the type of conversion
-                                        to Upper/Lower case.
+                                      description: Optional conversion method to be
+                                        used. `ToUpper` and `ToLower` convert the
+                                        letter case of the input string. `ToBase64`
+                                        and `FromBase64` create / read a base64 representation
+                                        of the input value. `ToSha1`, `ToSha256` and
+                                        `ToSha512` generate a hash value based on
+                                        the input converted to JSON.
                                       enum:
                                       - ToUpper
                                       - ToLower
                                       - ToBase64
                                       - FromBase64
+                                      - ToSha1
+                                      - ToSha256
+                                      - ToSha512
                                       type: string
                                     fmt:
                                       description: Format the input using a Go format
@@ -1596,13 +1620,21 @@ spec:
                                   string.
                                 properties:
                                   convert:
-                                    description: Convert the type of conversion to
-                                      Upper/Lower case.
+                                    description: Optional conversion method to be
+                                      used. `ToUpper` and `ToLower` convert the letter
+                                      case of the input string. `ToBase64` and `FromBase64`
+                                      create / read a base64 representation of the
+                                      input value. `ToSha1`, `ToSha256` and `ToSha512`
+                                      generate a hash value based on the input converted
+                                      to JSON.
                                     enum:
                                     - ToUpper
                                     - ToLower
                                     - ToBase64
                                     - FromBase64
+                                    - ToSha1
+                                    - ToSha256
+                                    - ToSha512
                                     type: string
                                   fmt:
                                     description: Format the input using a Go format
@@ -1998,13 +2030,21 @@ spec:
                                     a string.
                                   properties:
                                     convert:
-                                      description: Convert the type of conversion
-                                        to Upper/Lower case.
+                                      description: Optional conversion method to be
+                                        used. `ToUpper` and `ToLower` convert the
+                                        letter case of the input string. `ToBase64`
+                                        and `FromBase64` create / read a base64 representation
+                                        of the input value. `ToSha1`, `ToSha256` and
+                                        `ToSha512` generate a hash value based on
+                                        the input converted to JSON.
                                       enum:
                                       - ToUpper
                                       - ToLower
                                       - ToBase64
                                       - FromBase64
+                                      - ToSha1
+                                      - ToSha256
+                                      - ToSha512
                                       type: string
                                     fmt:
                                       description: Format the input using a Go format
@@ -2373,13 +2413,21 @@ spec:
                                     a string.
                                   properties:
                                     convert:
-                                      description: Convert the type of conversion
-                                        to Upper/Lower case.
+                                      description: Optional conversion method to be
+                                        used. `ToUpper` and `ToLower` convert the
+                                        letter case of the input string. `ToBase64`
+                                        and `FromBase64` create / read a base64 representation
+                                        of the input value. `ToSha1`, `ToSha256` and
+                                        `ToSha512` generate a hash value based on
+                                        the input converted to JSON.
                                       enum:
                                       - ToUpper
                                       - ToLower
                                       - ToBase64
                                       - FromBase64
+                                      - ToSha1
+                                      - ToSha256
+                                      - ToSha512
                                       type: string
                                     fmt:
                                       description: Format the input using a Go format

--- a/cluster/crds/apiextensions.crossplane.io_compositionrevisions.yaml
+++ b/cluster/crds/apiextensions.crossplane.io_compositionrevisions.yaml
@@ -331,17 +331,20 @@ spec:
                                 properties:
                                   convert:
                                     description: Optional conversion method to be
-                                      used. `ToUpper` and `ToLower` convert the letter
-                                      case of the input string. `ToBase64` and `FromBase64`
-                                      create / read a base64 representation of the
-                                      input value. `ToSha1`, `ToSha256` and `ToSha512`
-                                      generate a hash value based on the input converted
-                                      to JSON.
+                                      specified. `ToUpper` and `ToLower` change the
+                                      letter case of the input string. `ToBase64`
+                                      and `FromBase64` perform a base64 conversion
+                                      based on the input string. `ToJson` converts
+                                      any input value into its raw JSON representation.
+                                      `ToSha1`, `ToSha256` and `ToSha512` generate
+                                      a hash value based on the input converted to
+                                      JSON.
                                     enum:
                                     - ToUpper
                                     - ToLower
                                     - ToBase64
                                     - FromBase64
+                                    - ToJson
                                     - ToSha1
                                     - ToSha256
                                     - ToSha512
@@ -741,17 +744,20 @@ spec:
                                   properties:
                                     convert:
                                       description: Optional conversion method to be
-                                        used. `ToUpper` and `ToLower` convert the
-                                        letter case of the input string. `ToBase64`
-                                        and `FromBase64` create / read a base64 representation
-                                        of the input value. `ToSha1`, `ToSha256` and
-                                        `ToSha512` generate a hash value based on
-                                        the input converted to JSON.
+                                        specified. `ToUpper` and `ToLower` change
+                                        the letter case of the input string. `ToBase64`
+                                        and `FromBase64` perform a base64 conversion
+                                        based on the input string. `ToJson` converts
+                                        any input value into its raw JSON representation.
+                                        `ToSha1`, `ToSha256` and `ToSha512` generate
+                                        a hash value based on the input converted
+                                        to JSON.
                                       enum:
                                       - ToUpper
                                       - ToLower
                                       - ToBase64
                                       - FromBase64
+                                      - ToJson
                                       - ToSha1
                                       - ToSha256
                                       - ToSha512
@@ -1124,17 +1130,20 @@ spec:
                                   properties:
                                     convert:
                                       description: Optional conversion method to be
-                                        used. `ToUpper` and `ToLower` convert the
-                                        letter case of the input string. `ToBase64`
-                                        and `FromBase64` create / read a base64 representation
-                                        of the input value. `ToSha1`, `ToSha256` and
-                                        `ToSha512` generate a hash value based on
-                                        the input converted to JSON.
+                                        specified. `ToUpper` and `ToLower` change
+                                        the letter case of the input string. `ToBase64`
+                                        and `FromBase64` perform a base64 conversion
+                                        based on the input string. `ToJson` converts
+                                        any input value into its raw JSON representation.
+                                        `ToSha1`, `ToSha256` and `ToSha512` generate
+                                        a hash value based on the input converted
+                                        to JSON.
                                       enum:
                                       - ToUpper
                                       - ToLower
                                       - ToBase64
                                       - FromBase64
+                                      - ToJson
                                       - ToSha1
                                       - ToSha256
                                       - ToSha512
@@ -1621,17 +1630,20 @@ spec:
                                 properties:
                                   convert:
                                     description: Optional conversion method to be
-                                      used. `ToUpper` and `ToLower` convert the letter
-                                      case of the input string. `ToBase64` and `FromBase64`
-                                      create / read a base64 representation of the
-                                      input value. `ToSha1`, `ToSha256` and `ToSha512`
-                                      generate a hash value based on the input converted
-                                      to JSON.
+                                      specified. `ToUpper` and `ToLower` change the
+                                      letter case of the input string. `ToBase64`
+                                      and `FromBase64` perform a base64 conversion
+                                      based on the input string. `ToJson` converts
+                                      any input value into its raw JSON representation.
+                                      `ToSha1`, `ToSha256` and `ToSha512` generate
+                                      a hash value based on the input converted to
+                                      JSON.
                                     enum:
                                     - ToUpper
                                     - ToLower
                                     - ToBase64
                                     - FromBase64
+                                    - ToJson
                                     - ToSha1
                                     - ToSha256
                                     - ToSha512
@@ -2031,17 +2043,20 @@ spec:
                                   properties:
                                     convert:
                                       description: Optional conversion method to be
-                                        used. `ToUpper` and `ToLower` convert the
-                                        letter case of the input string. `ToBase64`
-                                        and `FromBase64` create / read a base64 representation
-                                        of the input value. `ToSha1`, `ToSha256` and
-                                        `ToSha512` generate a hash value based on
-                                        the input converted to JSON.
+                                        specified. `ToUpper` and `ToLower` change
+                                        the letter case of the input string. `ToBase64`
+                                        and `FromBase64` perform a base64 conversion
+                                        based on the input string. `ToJson` converts
+                                        any input value into its raw JSON representation.
+                                        `ToSha1`, `ToSha256` and `ToSha512` generate
+                                        a hash value based on the input converted
+                                        to JSON.
                                       enum:
                                       - ToUpper
                                       - ToLower
                                       - ToBase64
                                       - FromBase64
+                                      - ToJson
                                       - ToSha1
                                       - ToSha256
                                       - ToSha512
@@ -2414,17 +2429,20 @@ spec:
                                   properties:
                                     convert:
                                       description: Optional conversion method to be
-                                        used. `ToUpper` and `ToLower` convert the
-                                        letter case of the input string. `ToBase64`
-                                        and `FromBase64` create / read a base64 representation
-                                        of the input value. `ToSha1`, `ToSha256` and
-                                        `ToSha512` generate a hash value based on
-                                        the input converted to JSON.
+                                        specified. `ToUpper` and `ToLower` change
+                                        the letter case of the input string. `ToBase64`
+                                        and `FromBase64` perform a base64 conversion
+                                        based on the input string. `ToJson` converts
+                                        any input value into its raw JSON representation.
+                                        `ToSha1`, `ToSha256` and `ToSha512` generate
+                                        a hash value based on the input converted
+                                        to JSON.
                                       enum:
                                       - ToUpper
                                       - ToLower
                                       - ToBase64
                                       - FromBase64
+                                      - ToJson
                                       - ToSha1
                                       - ToSha256
                                       - ToSha512

--- a/cluster/crds/apiextensions.crossplane.io_compositions.yaml
+++ b/cluster/crds/apiextensions.crossplane.io_compositions.yaml
@@ -334,12 +334,18 @@ spec:
                                       and `FromBase64` perform a base64 conversion
                                       based on the input string. `ToJson` converts
                                       any input value into its raw JSON representation.
+                                      `ToSha1`, `ToSha256` and `ToSha512` generate
+                                      a hash value based on the input converted to
+                                      JSON.
                                     enum:
                                     - ToUpper
                                     - ToLower
                                     - ToBase64
                                     - FromBase64
                                     - ToJson
+                                    - ToSha1
+                                    - ToSha256
+                                    - ToSha512
                                     type: string
                                   fmt:
                                     description: Format the input using a Go format
@@ -747,12 +753,18 @@ spec:
                                         and `FromBase64` perform a base64 conversion
                                         based on the input string. `ToJson` converts
                                         any input value into its raw JSON representation.
+                                        `ToSha1`, `ToSha256` and `ToSha512` generate
+                                        a hash value based on the input converted
+                                        to JSON.
                                       enum:
                                       - ToUpper
                                       - ToLower
                                       - ToBase64
                                       - FromBase64
                                       - ToJson
+                                      - ToSha1
+                                      - ToSha256
+                                      - ToSha512
                                       type: string
                                     fmt:
                                       description: Format the input using a Go format
@@ -1133,12 +1145,18 @@ spec:
                                         and `FromBase64` perform a base64 conversion
                                         based on the input string. `ToJson` converts
                                         any input value into its raw JSON representation.
+                                        `ToSha1`, `ToSha256` and `ToSha512` generate
+                                        a hash value based on the input converted
+                                        to JSON.
                                       enum:
                                       - ToUpper
                                       - ToLower
                                       - ToBase64
                                       - FromBase64
                                       - ToJson
+                                      - ToSha1
+                                      - ToSha256
+                                      - ToSha512
                                       type: string
                                     fmt:
                                       description: Format the input using a Go format

--- a/internal/controller/apiextensions/composite/composition_transforms_test.go
+++ b/internal/controller/apiextensions/composite/composition_transforms_test.go
@@ -495,6 +495,9 @@ func TestStringResolve(t *testing.T) {
 	frombase64 := v1.StringConversionTypeFromBase64
 	toJSON := v1.StringConversionTypeToJSON
 	wrongConvertType := v1.StringConversionType("Something")
+	toSha1 := v1.StringConversionTypeToSHA1
+	toSha256 := v1.StringConversionTypeToSHA256
+	toSha512 := v1.StringConversionTypeToSHA512
 
 	prefix := "https://"
 	suffix := "-test"
@@ -609,6 +612,69 @@ func TestStringResolve(t *testing.T) {
 			want: want{
 				o:   "N\x18\xacJ\xda\xe2\x9e\x02,6\x8bAjǺ",
 				err: errors.Wrap(errors.New("illegal base64 data at input byte 20"), errDecodeString),
+			},
+		},
+		"ConvertToSha1": {
+			args: args{
+				stype:   v1.StringTransformTypeConvert,
+				convert: &toSha1,
+				i:       "Crossplane",
+			},
+			want: want{
+				o: "f9fd1da3c0cc298643ff098a0c59febf1d8b7b84",
+			},
+		},
+		"ConvertToSha1Error": {
+			args: args{
+				stype:   v1.StringTransformTypeConvert,
+				convert: &toSha1,
+				i:       func() {},
+			},
+			want: want{
+				o:   "0000000000000000000000000000000000000000",
+				err: errors.Wrap(errors.Wrap(errors.New("json: unsupported type: func()"), errMarshalJSON), errHash),
+			},
+		},
+		"ConvertToSha256": {
+			args: args{
+				stype:   v1.StringTransformTypeConvert,
+				convert: &toSha256,
+				i:       "Crossplane",
+			},
+			want: want{
+				o: "e84ae541a0725d73154ee76b7ac3fec4b007dd01ed701d506cd7e7a45bb48935",
+			},
+		},
+		"ConvertToSha256Error": {
+			args: args{
+				stype:   v1.StringTransformTypeConvert,
+				convert: &toSha256,
+				i:       func() {},
+			},
+			want: want{
+				o:   "0000000000000000000000000000000000000000000000000000000000000000",
+				err: errors.Wrap(errors.Wrap(errors.New("json: unsupported type: func()"), errMarshalJSON), errHash),
+			},
+		},
+		"ConvertToSha512": {
+			args: args{
+				stype:   v1.StringTransformTypeConvert,
+				convert: &toSha512,
+				i:       "Crossplane",
+			},
+			want: want{
+				o: "b48622a3f487b8cb7748b356c9531cf54d9125c1456689c115744821f3dafd59c8c7d4dc5627c4a1e4082c67ee9f4528365a644a01a0c46d6dd0a6d979c8f51f",
+			},
+		},
+		"ConvertToSha512Error": {
+			args: args{
+				stype:   v1.StringTransformTypeConvert,
+				convert: &toSha512,
+				i:       func() {},
+			},
+			want: want{
+				o:   "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+				err: errors.Wrap(errors.Wrap(errors.New("json: unsupported type: func()"), errMarshalJSON), errHash),
 			},
 		},
 		"TrimPrefix": {


### PR DESCRIPTION
### Description of your changes

This adds three new string conversion function to patch transforms, `ToSha1`, `ToSha256`, `ToSha512`, that generate a hash from the JSON representation of the input value.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

`composition.yaml`

```yaml
---
apiVersion: apiextensions.crossplane.io/v1
kind: Composition
metadata:
  name: test-string-tojson
spec:
  compositeTypeRef:
    apiVersion: example.org/v1alpha1
    kind: XSecret
  resources:
    - name: secret
      base:
        apiVersion: secretsmanager.aws.crossplane.io/v1beta1
        kind: Secret
        metadata:
          name: # patched
          annotations:
            hash: # patched
        spec:
          forProvider:
            region: eu-central-1
            stringSecretRef:
              name: # patched
              namespace: # patched
              key: # patched
          providerConfigRef:
            name: example
      patches:
        # Policy
        - fromFieldPath: "spec.parameters"
          toFieldPath: "metadata.annotations[hash]"
          transforms:
            - type: string
              string:
                type: Convert
                convert: ToSha1
        # SecretRef
        - fromFieldPath: "spec.parameters.secretRef.name"
          toFieldPath: "spec.forProvider.stringSecretRef.name"
        - fromFieldPath: "spec.parameters.secretRef.key"
          toFieldPath: "spec.forProvider.stringSecretRef.key"
        - fromFieldPath: "metadata.labels[crossplane.io/claim-namespace]"
          toFieldPath: "spec.forProvider.stringSecretRef.namespace"
```

`xrd.yaml`

```yaml
---
apiVersion: apiextensions.crossplane.io/v1
kind: CompositeResourceDefinition
metadata:
  name: xsecrets.example.org
spec:
  group: example.org
  claimNames:
    kind: Secret
    plural: secrets
  names:
    kind: XSecret
    plural: xsecrets
  versions:
    - name: v1alpha1
      served: true
      referenceable: true
      schema:
        openAPIV3Schema:
          type: object
          properties:
            spec:
              type: object
              properties:
                parameters:
                  type: object
                  properties:
                    secretRef:
                      type: object
                      description: The Kubernetes Secret whose data will be sent as string to AWS.
                        The secret needs to exist in the same namespace as this claim.
                      properties:
                        key:
                          type: string
                          description: Optional key whose value should be uploaded. If not set, the
                            whole map in the Secret data will be used.
                        name:
                          type: string
                          description: Name of the Kubernetes Secret resource in the same namespace
                            as this claim.
                      required:
                        - name
              required:
                - parameters
```

`xrc.yaml`

```yaml
---
apiVersion: v1
kind: Secret
metadata:
  name: example-secret
  namespace: default
type: Opaque
stringData:
  password: passw0rd
---
apiVersion: example.org/v1alpha1
kind: Secret
metadata:
  name: example-secret
  namespace: default
spec:
  parameters:
    secretRef:
      name: example-secret
```

[contribution process]: https://git.io/fj2m9
