### PR TITLE
Rename docs repo

### DIFF
--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -52,7 +52,7 @@ examples of each step.
 [xpkg.upbound.io]: https://cloud.upbound.io/browse
 [new release]: https://github.com/crossplane/crossplane/releases/new
 [releases table]: https://github.com/crossplane/crossplane#releases
-[Crossplane docs website repo]: https://github.com/crossplane/crossplane.github.io
+[Crossplane docs website repo]: https://github.com/crossplane/docs
 [docs removal directive]: https://github.com/crossplane/crossplane/pull/3003
 [tag-workflow]: https://github.com/crossplane/crossplane/actions/workflows/tag.yml
 [ci-workflow]: https://github.com/crossplane/crossplane/actions/workflows/ci.yml

--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ OSBASEIMAGE = gcr.io/distroless/static:nonroot
 
 SOURCE_DOCS_DIR = docs
 DEST_DOCS_DIR = content
-DOCS_GIT_REPO = https://$(DOCS_GIT_USR):$(DOCS_GIT_PSW)@github.com/crossplane/crossplane.github.io.git
+DOCS_GIT_REPO = https://$(DOCS_GIT_USR):$(DOCS_GIT_PSW)@github.com/crossplane/docs
 -include build/makelib/docs.mk
 
 # ====================================================================================

--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ OSBASEIMAGE = gcr.io/distroless/static:nonroot
 
 SOURCE_DOCS_DIR = docs
 DEST_DOCS_DIR = content
-DOCS_GIT_REPO = https://$(DOCS_GIT_USR):$(DOCS_GIT_PSW)@github.com/crossplane/docs
+DOCS_GIT_REPO = https://$(DOCS_GIT_USR):$(DOCS_GIT_PSW)@github.com/crossplane/docs.git
 -include build/makelib/docs.mk
 
 # ====================================================================================

--- a/docs/contributing/docs.md
+++ b/docs/contributing/docs.md
@@ -30,11 +30,11 @@ Crossplane documentation lives in two repositories:
 repository](https://github.com/crossplane/crossplane) `/docs` directory. 
 
 * The Crossplane docs website is in the
-  [crossplane.github.io](https://github.com/crossplane/crossplane.github.io)
+  [docs](https://github.com/crossplane/docs)
 repository.
 
 Use `crossplane/crossplane` for documentation contributions.  
-Use `crossplane/crossplane.github.io` for local development or updates involving
+Use `crossplane/docs` for local development or updates involving
 HTML, CSS or Hugo.
 
 ### Licensing
@@ -369,7 +369,7 @@ matter of the page. The docs website skips pages with `tocHidden:true` when buil
 
 ## Docs website
 The Crossplane document website is in a unique [website GitHub
-repository](https://github.com/crossplane/crossplane.github.io).
+repository](https://github.com/crossplane/docs).
 
 Crossplane uses [Hugo](https://gohugo.io/), a static site generator. Hugo
 influences the directory structure of the website repository.


### PR DESCRIPTION
Signed-off-by: Pete Lumbis <pete@upbound.io>

### Description of your changes
The docs website is no longer a github page and the repo [has been renamed](https://github.com/crossplane/docs/issues/152).

Fixes [Docs issue #152](https://github.com/crossplane/docs/issues/152)


