### PR TITLE
fix(transforms): add match to kubebuilder enum

### DIFF
--- a/apis/apiextensions/v1/composition_transforms.go
+++ b/apis/apiextensions/v1/composition_transforms.go
@@ -80,7 +80,7 @@ const (
 type Transform struct {
 
 	// Type of the transform to be run.
-	// +kubebuilder:validation:Enum=map;math;string;convert
+	// +kubebuilder:validation:Enum=map;match;math;string;convert
 	Type TransformType `json:"type"`
 
 	// Math is used to transform the input via mathematical operations such as

--- a/apis/apiextensions/v1alpha1/zz_generated.revision_types.go
+++ b/apis/apiextensions/v1alpha1/zz_generated.revision_types.go
@@ -343,7 +343,7 @@ const (
 type Transform struct {
 
 	// Type of the transform to be run.
-	// +kubebuilder:validation:Enum=map;math;string;convert
+	// +kubebuilder:validation:Enum=map;match;math;string;convert
 	// +immutable
 	Type TransformType `json:"type"`
 

--- a/apis/apiextensions/v1beta1/revision_types.go
+++ b/apis/apiextensions/v1beta1/revision_types.go
@@ -341,7 +341,7 @@ const (
 type Transform struct {
 
 	// Type of the transform to be run.
-	// +kubebuilder:validation:Enum=map;math;string;convert
+	// +kubebuilder:validation:Enum=map;match;math;string;convert
 	// +immutable
 	Type TransformType `json:"type"`
 

--- a/cluster/crds/apiextensions.crossplane.io_compositionrevisions.yaml
+++ b/cluster/crds/apiextensions.crossplane.io_compositionrevisions.yaml
@@ -320,6 +320,7 @@ spec:
                                   description: Type of the transform to be run.
                                   enum:
                                   - map
+                                  - match
                                   - math
                                   - string
                                   - convert
@@ -681,6 +682,7 @@ spec:
                                   description: Type of the transform to be run.
                                   enum:
                                   - map
+                                  - match
                                   - math
                                   - string
                                   - convert
@@ -1107,6 +1109,7 @@ spec:
                                   description: Type of the transform to be run.
                                   enum:
                                   - map
+                                  - match
                                   - math
                                   - string
                                   - convert
@@ -1468,6 +1471,7 @@ spec:
                                   description: Type of the transform to be run.
                                   enum:
                                   - map
+                                  - match
                                   - math
                                   - string
                                   - convert

--- a/cluster/crds/apiextensions.crossplane.io_compositions.yaml
+++ b/cluster/crds/apiextensions.crossplane.io_compositions.yaml
@@ -315,6 +315,7 @@ spec:
                                   description: Type of the transform to be run.
                                   enum:
                                   - map
+                                  - match
                                   - math
                                   - string
                                   - convert
@@ -676,6 +677,7 @@ spec:
                                   description: Type of the transform to be run.
                                   enum:
                                   - map
+                                  - match
                                   - math
                                   - string
                                   - convert


### PR DESCRIPTION
Seems that `match` is missing from the kubebuilder-generated CRD. This fixes that.