### PR TITLE
Add agent-inject to crossplane itself

### DIFF
--- a/docs/guides/vault-as-secret-store.md
+++ b/docs/guides/vault-as-secret-store.md
@@ -149,6 +149,7 @@ cat << EOF > values.yaml
 args:
 - --enable-external-secret-stores
 customAnnotations:
+  vault.hashicorp.com/agent-inject: \"true\"
   vault.hashicorp.com/agent-inject-token: "true"
   vault.hashicorp.com/role: "crossplane"
   vault.hashicorp.com/agent-run-as-user: "65532"

--- a/docs/guides/vault-as-secret-store.md
+++ b/docs/guides/vault-as-secret-store.md
@@ -149,7 +149,7 @@ cat << EOF > values.yaml
 args:
 - --enable-external-secret-stores
 customAnnotations:
-  vault.hashicorp.com/agent-inject: \"true\"
+  vault.hashicorp.com/agent-inject: "true"
   vault.hashicorp.com/agent-inject-token: "true"
   vault.hashicorp.com/role: "crossplane"
   vault.hashicorp.com/agent-run-as-user: "65532"


### PR DESCRIPTION
If you only set `` on the composition, then the XRD shows the following warning:
```
cannot publish connection details: cannot connect to secret store: cannot extract token: open /vault/secrets/token: no such file or directory
```

That is because the crossplane container itself didn't get the agent injected and therefore `/vault/secrets/token` wasn't written.

<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
