### PR TITLE
Docs: Fiz docs about readinessChecks in the MatchInteger code snippet…

### DIFF
--- a/docs/reference/composition.md
+++ b/docs/reference/composition.md
@@ -756,7 +756,7 @@ field within that resource matches a specified integer.
 ```yaml
 # The composed resource will be considered ready when the 'state' status field
 # matches the integer 4.
-- type: MatchString
+- type: MatchInteger
   fieldPath: status.atProvider.state
   matchInteger: 4
 ```


### PR DESCRIPTION
The code snippet about the MatchInteger readinessCheck is wrong, fix the example.

Signed-off-by: Rafael Domiciano <rafael.domiciano@gmail.com>

<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

Fiz docs in the code snippet regarding the MatchInteger example.
I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
