### PR TITLE
Validate Composition and configure XR before fetching environment

### DIFF
--- a/internal/controller/apiextensions/composite/api.go
+++ b/internal/controller/apiextensions/composite/api.go
@@ -410,7 +410,7 @@ func (c *APIConfigurator) Configure(ctx context.Context, cp resource.Composite, 
 	return errors.Wrap(c.client.Update(ctx, cp), errUpdateComposite)
 }
 
-// NewAPINamingConfigurator returns a Configurator that sets the root name prefixKu
+// NewAPINamingConfigurator returns a Configurator that sets the root name prefix
 // to its own name if it is not already set.
 func NewAPINamingConfigurator(c client.Client) *APINamingConfigurator {
 	return &APINamingConfigurator{client: c}

--- a/internal/controller/apiextensions/composite/reconciler_test.go
+++ b/internal/controller/apiextensions/composite/reconciler_test.go
@@ -1138,6 +1138,8 @@ func TestReconcile(t *testing.T) {
 						c := &v1.Composition{Spec: v1.CompositionSpec{}}
 						return c, nil
 					})),
+					WithCompositionValidator(CompositionValidatorFn(func(comp *v1.Composition) error { return nil })),
+					WithConfigurator(ConfiguratorFn(func(ctx context.Context, cr resource.Composite, cp *v1.Composition) error { return nil })),
 					WithEnvironmentSelector(EnvironmentSelectorFn(func(ctx context.Context, cr resource.Composite, cp *v1.Composition) error {
 						return errBoom
 					})),
@@ -1166,6 +1168,8 @@ func TestReconcile(t *testing.T) {
 					WithCompositionSelector(CompositionSelectorFn(func(_ context.Context, cr resource.Composite) error {
 						return nil
 					})),
+					WithCompositionValidator(CompositionValidatorFn(func(comp *v1.Composition) error { return nil })),
+					WithConfigurator(ConfiguratorFn(func(ctx context.Context, cr resource.Composite, cp *v1.Composition) error { return nil })),
 					WithCompositionFetcher(CompositionFetcherFn(func(_ context.Context, _ resource.Composite) (*v1.Composition, error) {
 						c := &v1.Composition{Spec: v1.CompositionSpec{}}
 						return c, nil


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
This way if our Composition is invalid or we fail to configure the XR (often using the Composition) we'll fail early without hitting the environment select/fetch logic unnecessarily.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9

I haven't tested this, so I'm opening it as a draft to get feedback from folks who know the implementation better before I do. @MisterMX @ytsarev do you think this makes sense?