### PR TITLE
Add commentary for spec.serviceAccountName in ControllerConfig

### DIFF
--- a/apis/pkg/v1alpha1/config.go
+++ b/apis/pkg/v1alpha1/config.go
@@ -49,6 +49,16 @@ type ControllerConfigSpec struct {
 	NodeSelector map[string]string `json:"nodeSelector,omitempty"`
 	// ServiceAccountName is the name of the ServiceAccount to use to run this pod.
 	// More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
+	// If specified, a ServiceAccount named this ServiceAccountName will be used for
+	// the spec.serviceAccountName field in Pods to be created and for the subjects.name field
+	// in a ClusterRoleBinding to be created.
+	// If there is no ServiceAccount named this ServiceAccountName, a new ServiceAccount
+	// will be created.
+	// If there is a pre-existing ServiceAccount named this ServiceAccountName, the ServiceAccount
+	// will be used. The annotations in the ControllerConfig will be copied to the ServiceAccount
+	// and pre-existing annotations will be kept.
+	// Regardless of whether there is a ServiceAccount created by Crossplane or is in place already,
+	// the ServiceAccount will be deleted once the Provider and ControllerConfig are deleted.
 	// +optional
 	ServiceAccountName *string `json:"serviceAccountName,omitempty"`
 	// NodeName is a request to schedule this pod onto a specific node. If it is non-empty,

--- a/cluster/crds/pkg.crossplane.io_controllerconfigs.yaml
+++ b/cluster/crds/pkg.crossplane.io_controllerconfigs.yaml
@@ -1493,7 +1493,18 @@ spec:
                 type: object
               serviceAccountName:
                 description: 'ServiceAccountName is the name of the ServiceAccount
-                  to use to run this pod. More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/'
+                  to use to run this pod. More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
+                  If specified, a ServiceAccount named this ServiceAccountName will
+                  be used for the spec.serviceAccountName field in Pods to be created
+                  and for the subjects.name field in a ClusterRoleBinding to be created.
+                  If there is no ServiceAccount named this ServiceAccountName, a new
+                  ServiceAccount will be created. If there is a pre-existing ServiceAccount
+                  named this ServiceAccountName, the ServiceAccount will be used.
+                  The annotations in the ControllerConfig will be copied to the ServiceAccount
+                  and pre-existing annotations will be kept. Regardless of whether
+                  there is a ServiceAccount created by Crossplane or is in place already,
+                  the ServiceAccount will be deleted once the Provider and ControllerConfig
+                  are deleted.'
                 type: string
               tolerations:
                 description: If specified, the pod's tolerations.


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Adds a description to explain the field's general behavior and how it works depending on when there is a pre-existing ServiceAccount or not.

This is a follow-up for the recent update on the field: https://github.com/crossplane/crossplane/pull/2880

Fixes #

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
