### PR TITLE
docs: fix typo

### DIFF
--- a/docs/reference/composition.md
+++ b/docs/reference/composition.md
@@ -510,7 +510,7 @@ the `--enable-environment-configs` flag on startup.
 # spec.forProvider.settings.tier field.
 - type: FromEnvironmentFieldPath
   fromFieldPath: tier.name
-  toF/ieldPath: spec.forProvider.settings.tier
+  toFieldPath: spec.forProvider.settings.tier
 ```
 
 `ToEnvironmentFieldPath`. This type patches from a composed field to the


### PR DESCRIPTION
Signed-off-by: Philippe Scorsolini <p.scorsolini@gmail.com>

### Description of your changes

Just fixing a typo in an example from the docs.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

[contribution process]: https://git.io/fj2m9
