### PR TITLE
ci: introduce dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+version: 2
+updates:
+  # Keep go modules up to date
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "daily"
+  # Keep github actions up to date
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+  # Keep docker image up to date
+  - package-ecosystem: "docker"
+    directory: "/cluster/images/crossplane"
+    schedule:
+      interval: "daily"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,15 +3,75 @@ updates:
   # Keep go modules up to date
   - package-ecosystem: "gomod"
     directory: "/"
+    target-branch: "master"
     schedule:
       interval: "daily"
   # Keep github actions up to date
   - package-ecosystem: "github-actions"
     directory: "/"
+    target-branch: "master"
     schedule:
       interval: "daily"
   # Keep docker image up to date
   - package-ecosystem: "docker"
     directory: "/cluster/images/crossplane"
+    target-branch: "master"
+    schedule:
+      interval: "daily"
+
+  # Keep go modules up to date
+  - package-ecosystem: "gomod"
+    directory: "/"
+    target-branch: "release-1.8"
+    schedule:
+      interval: "daily"
+  # Keep github actions up to date
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    target-branch: "release-1.8"
+    schedule:
+      interval: "daily"
+  # Keep docker image up to date
+  - package-ecosystem: "docker"
+    directory: "/cluster/images/crossplane"
+    target-branch: "release-1.8"
+    schedule:
+      interval: "daily"
+
+  # Keep go modules up to date
+  - package-ecosystem: "gomod"
+    directory: "/"
+    target-branch: "release-1.9"
+    schedule:
+      interval: "daily"
+  # Keep github actions up to date
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    target-branch: "release-1.9"
+    schedule:
+      interval: "daily"
+  # Keep docker image up to date
+  - package-ecosystem: "docker"
+    directory: "/cluster/images/crossplane"
+    target-branch: "release-1.9"
+    schedule:
+      interval: "daily"
+
+  # Keep go modules up to date
+  - package-ecosystem: "gomod"
+    directory: "/"
+    target-branch: "release-1.10"
+    schedule:
+      interval: "daily"
+  # Keep github actions up to date
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    target-branch: "release-1.10"
+    schedule:
+      interval: "daily"
+  # Keep docker image up to date
+  - package-ecosystem: "docker"
+    directory: "/cluster/images/crossplane"
+    target-branch: "release-1.10"
     schedule:
       interval: "daily"


### PR DESCRIPTION
Signed-off-by: Philippe Scorsolini <p.scorsolini@gmail.com>

### Description of your changes

Adding dependabot configuration to be sure we keep updated Go, Docker and Github Actions dependencies.
Might require a user with enough permissions to enable it through the settings panel too.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

Didn't really require testing, the configuration is pretty straight forward and comes from working examples found on other repositories.

[contribution process]: https://git.io/fj2m9
