### PR TITLE
[release-1.10] Do not publish docs to documentation repo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,14 +63,6 @@ OSBASEIMAGE = gcr.io/distroless/static:nonroot
 -include build/makelib/imagelight.mk
 
 # ====================================================================================
-# Setup Docs
-
-SOURCE_DOCS_DIR = docs
-DEST_DOCS_DIR = content
-DOCS_GIT_REPO = https://$(DOCS_GIT_USR):$(DOCS_GIT_PSW)@github.com/crossplane/docs.git
--include build/makelib/docs.mk
-
-# ====================================================================================
 # Targets
 
 # run `make help` to see the targets and options


### PR DESCRIPTION

<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->


Removes the docs publishing step as documentation is no longer maintained in this repo.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

Similar to #3538 but only drops components necessary to let CI pass on this branch.


I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

Fixes issue seen in https://github.com/crossplane/crossplane/actions/runs/3916515136/jobs/6695690603

[contribution process]: https://git.io/fj2m9
