### PR TITLE
Fix constant reconciles on inactive package revisions

### DIFF
--- a/internal/controller/pkg/revision/reconciler.go
+++ b/internal/controller/pkg/revision/reconciler.go
@@ -34,6 +34,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
+	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
 	"github.com/crossplane/crossplane-runtime/pkg/errors"
 	"github.com/crossplane/crossplane-runtime/pkg/event"
 	"github.com/crossplane/crossplane-runtime/pkg/logging"
@@ -192,6 +193,12 @@ func WithVersioner(v version.Operations) ReconcilerOption {
 	return func(r *Reconciler) {
 		r.versioner = v
 	}
+}
+
+// uniqueResourceIdentifier returns a unique identifier for a resource in a
+// package, consisting of the group, version, kind, and name.
+func uniqueResourceIdentifier(ref xpv1.TypedReference) string {
+	return strings.Join([]string{ref.GroupVersionKind().String(), ref.Name}, "/")
 }
 
 // Reconciler reconciles packages.
@@ -589,7 +596,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 	// non-deterministic due to concurrent establishment, so we perform a stable
 	// sort to avoid constant status changes.
 	sort.SliceStable(refs, func(i, j int) bool {
-		return string(refs[i].UID) < string(refs[j].UID)
+		return uniqueResourceIdentifier(refs[i]) > uniqueResourceIdentifier(refs[j])
 	})
 	pr.SetObjects(refs)
 


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Sorting of object references became necessary after introducing
concurrent establishment of package resources because the reference
order was no longer deterministic. To fix the issue, sorting references
based on UUID was introduced. However, inactive package revisions do not
include object UUIDs in their references, causing sorting based on UUID
to be unpredictable.

This updates sort to be based on Group, Version, Kind, and Name, which
is guaranteed to be unique in a cluster. It also has the nice property
of ensuring that the object references preserve the same order any time
a given package is installed in any cluster, which is not an attribue of
UUID-based sort.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

Switches to using unstable sort when sort object references for a
package revision. Stable sort does provider any additional value in this
case as we are not concerned with preserving existing order in the
slice, which is non-deterministic across reconciles, but rather in the
status of the package revision. We also should not have duplicate
resources in a single package, but if we do the sort order of equivalent
references would not matter as the references would be identical (i.e.
switching their order would not cause a diff in the package revision
status).

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

Fixes #3540

> Note: this is only being backported to Crossplane `v1.10` as this behavior was introduced as part of the concurrent reconciliation feature.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

Verified running locally via the following steps:
1. Created kind cluster.
2. Installed Crossplane CRDs.
3. Started core crossplane.
4. Installed provider-aws `v0.34.0`.
5. Waited for revision to become healthy.
6. Upgraded to `v0.35.0`.
7. Waited for new revision to become healthy.
8. Verified that reconciliation stopped after both revisions reached healthy status.

```
1.6738205048133953e+09	DEBUG	crossplane	Reconciling	{"controller": "packages/provider.pkg.crossplane.io", "request": "/crossplane-contrib-provider-aws"}
1.6738205048135202e+09	DEBUG	crossplane.events	Normal	{"object": {"kind":"Provider","name":"crossplane-contrib-provider-aws","uid":"3b1edc07-0aa7-4c01-92bb-0da1ae748f07","apiVersion":"pkg.crossplane.io/v1","resourceVersion":"13524"}, "reason": "InstallPackageRevision", "message": "Successfully installed package revision"}
1.6738205054926245e+09	DEBUG	crossplane	cannot update annotations for package revision	{"controller": "packages/providerrevision.pkg.crossplane.io", "request": "/crossplane-contrib-provider-aws-ef4d4b55bf5a", "uid": "29626a4b-4e83-49ef-a792-50e40116f36f", "version": "13513", "name": "crossplane-contrib-provider-aws-ef4d4b55bf5a", "error": "Operation cannot be fulfilled on providerrevisions.pkg.crossplane.io \"crossplane-contrib-provider-aws-ef4d4b55bf5a\": the object has been modified; please apply your changes to the latest version and try again"}
1.6738205054926894e+09	ERROR	crossplane.controller.packages/providerrevision.pkg.crossplane.io	Reconciler error	{"reconciler group": "pkg.crossplane.io", "reconciler kind": "ProviderRevision", "name": "crossplane-contrib-provider-aws-ef4d4b55bf5a", "namespace": "", "error": "cannot update annotations for package revision: Operation cannot be fulfilled on providerrevisions.pkg.crossplane.io \"crossplane-contrib-provider-aws-ef4d4b55bf5a\": the object has been modified; please apply your changes to the latest version and try again"}
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem
	/home/dan/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.11.0/pkg/internal/controller/controller.go:266
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2
	/home/dan/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.11.0/pkg/internal/controller/controller.go:227
1.6738205054927452e+09	DEBUG	crossplane	Reconciling	{"controller": "packages/providerrevision.pkg.crossplane.io", "request": "/crossplane-contrib-provider-aws-ef4d4b55bf5a"}
1.6738205054927256e+09	DEBUG	crossplane.events	Warning	{"object": {"kind":"ProviderRevision","name":"crossplane-contrib-provider-aws-ef4d4b55bf5a","uid":"29626a4b-4e83-49ef-a792-50e40116f36f","apiVersion":"pkg.crossplane.io/v1","resourceVersion":"13513"}, "reason": "SyncPackage", "message": "cannot update annotations for package revision: Operation cannot be fulfilled on providerrevisions.pkg.crossplane.io \"crossplane-contrib-provider-aws-ef4d4b55bf5a\": the object has been modified; please apply your changes to the latest version and try again"}
1.673820517395611e+09	DEBUG	crossplane.events	Normal	{"object": {"kind":"ProviderRevision","name":"crossplane-contrib-provider-aws-6707d06fe75f","uid":"eed63733-d6d9-471e-8866-0cdcb1db698c","apiVersion":"pkg.crossplane.io/v1","resourceVersion":"13553"}, "reason": "SyncPackage", "message": "Successfully configured package revision"}
1.6738205174090123e+09	DEBUG	crossplane	Reconciling	{"controller": "packages/providerrevision.pkg.crossplane.io", "request": "/crossplane-contrib-provider-aws-6707d06fe75f"}
1.6738205197691755e+09	DEBUG	crossplane.events	Normal	{"object": {"kind":"ProviderRevision","name":"crossplane-contrib-provider-aws-ef4d4b55bf5a","uid":"29626a4b-4e83-49ef-a792-50e40116f36f","apiVersion":"pkg.crossplane.io/v1","resourceVersion":"13560"}, "reason": "SyncPackage", "message": "Successfully configured package revision"}
1.673820519784456e+09	DEBUG	crossplane	Reconciling	{"controller": "packages/providerrevision.pkg.crossplane.io", "request": "/crossplane-contrib-provider-aws-ef4d4b55bf5a"}
1.6738205315629022e+09	DEBUG	crossplane.events	Normal	{"object": {"kind":"ProviderRevision","name":"crossplane-contrib-provider-aws-6707d06fe75f","uid":"eed63733-d6d9-471e-8866-0cdcb1db698c","apiVersion":"pkg.crossplane.io/v1","resourceVersion":"13553"}, "reason": "SyncPackage", "message": "Successfully configured package revision"}
1.673820533139708e+09	DEBUG	crossplane.events	Normal	{"object": {"kind":"ProviderRevision","name":"crossplane-contrib-provider-aws-ef4d4b55bf5a","uid":"29626a4b-4e83-49ef-a792-50e40116f36f","apiVersion":"pkg.crossplane.io/v1","resourceVersion":"13560"}, "reason": "SyncPackage", "message": "Successfully configured package revision"}
```

```
🤖 (crossplane) k get providerrevisions.pkg -w
NAME                                           HEALTHY   REVISION   IMAGE                                                     STATE      DEP-FOUND   DEP-INSTALLED   AGE
crossplane-contrib-provider-aws-6707d06fe75f   True      1          xpkg.upbound.io/crossplane-contrib/provider-aws:v0.34.0   Inactive                               2m
crossplane-contrib-provider-aws-ef4d4b55bf5a   False     2          xpkg.upbound.io/crossplane-contrib/provider-aws:v0.35.0   Active                                 8s
crossplane-contrib-provider-aws-6707d06fe75f   False     1          xpkg.upbound.io/crossplane-contrib/provider-aws:v0.34.0   Inactive                               2m8s
crossplane-contrib-provider-aws-ef4d4b55bf5a   True      2          xpkg.upbound.io/crossplane-contrib/provider-aws:v0.35.0   Active                                 17s
crossplane-contrib-provider-aws-6707d06fe75f   True      1          xpkg.upbound.io/crossplane-contrib/provider-aws:v0.34.0   Inactive                               2m22s
crossplane-contrib-provider-aws-ef4d4b55bf5a   True      2          xpkg.upbound.io/crossplane-contrib/provider-aws:v0.35.0   Active                                 31s
```

I also verified that the same steps on latest Crossplane build results in constant reconciliation of the provider and inactive provider revision.

[contribution process]: https://git.io/fj2m9
