### PR TITLE
Fix 404 on Helm chart icon

### DIFF
--- a/cluster/charts/crossplane/Chart.yaml
+++ b/cluster/charts/crossplane/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 0.0.1
 description: Crossplane is an open source Kubernetes add-on that enables platform teams to assemble infrastructure from multiple vendors, and expose higher level self-service APIs for application teams to consume.
 name: crossplane
 version: 0.0.1
-icon: https://crossplane.io/images/favicon_192x192.png
+icon: https://docs.crossplane.io/android-chrome-192x192.png
 home: https://crossplane.io
 maintainers:
   - name: Crossplane Maintainers


### PR DESCRIPTION
The old icon URL seem to be dead. Favicon is large enough to serve the purpose.

<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

Just a cosmetic change in chart metadata.

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

I have:

- [ ] Read and followed Crossplane's [contribution process].
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
