### PR TITLE
ci: set xfn base image tag too

### DIFF
--- a/cluster/images/xfn/Dockerfile
+++ b/cluster/images/xfn/Dockerfile
@@ -1,5 +1,5 @@
 # This is debian:bookworm-slim (i.e. Debian 12, testing), which has crun v1.5.
-FROM debian@sha256:9b8b22f153dc2099e609f56ec3790e5952f89d3e187e42686c0b95ad1f378d01
+FROM debian:bookworm-slim@sha256:9b8b22f153dc2099e609f56ec3790e5952f89d3e187e42686c0b95ad1f378d01
 
 ARG TARGETOS
 ARG TARGETARCH


### PR DESCRIPTION
This allows Renovate to know which version to use to propose new digests, as otherwise it would default to the latest image instead of bookworm-slim as required.

Signed-off-by: Philippe Scorsolini <p.scorsolini@gmail.com>

### Description of your changes

Fixes #3609 

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

[contribution process]: https://git.io/fj2m9
