### PR TITLE
ci: set renovate to also handle go digests

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -59,7 +59,8 @@
       ],
       "groupName": "kubernetes patches",
       "matchUpdateTypes": [
-        "patch"
+        "patch",
+        "digest"
       ],
       "matchPackagePrefixes": [
         "k8s.io",
@@ -113,7 +114,8 @@
       ],
       "matchUpdateTypes": [
         "minor",
-        "patch"
+        "patch",
+        "digest"
       ],
       "groupName": "all non-major go dependencies"
     }, {


### PR DESCRIPTION
Renovate should bump digest pinned Go dependencies only in case of vulnerabilities, as already configured for minor and patches updates to non kubernetes related dependencies.

Signed-off-by: Philippe Scorsolini <p.scorsolini@gmail.com>

### Description of your changes

Fixes #3611

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

[contribution process]: https://git.io/fj2m9
