### PR TITLE
ci: remove 1.8 from renovate's target branches

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -7,7 +7,7 @@
   "prConcurrentLimit": 5,
 // The branches renovate should target
 // PLEASE UPDATE THIS WHEN RELEASING.
-  "baseBranches": ["master","release-1.8","release-1.9","release-1.10"],
+  "baseBranches": ["master","release-1.9","release-1.10"],
   "ignorePaths": ["design/**"],
   "postUpdateOptions": ["gomodTidy"],
 // By default renovate will auto detect whether semantic commits have been used


### PR DESCRIPTION
Signed-off-by: Philippe Scorsolini <p.scorsolini@gmail.com>

### Description of your changes

Release 1.8 EOL is due end of this week, therefore there is no need to have it as a target for Renovate's PRs. We'll add release-1.11 once it's created.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

N.A.

[contribution process]: https://git.io/fj2m9
