### PR TITLE
chore: renovate handling golangci-lint version in makefile

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -26,23 +26,17 @@
       "datasourceTemplate": "golang-version",
       "depNameTemplate": "golang"
     }, {
-// We want a PR to bump golangci-lint versions used in the Makefile, taking it
-// from the official Github repository.
-       "fileMatch": ["^Makefile$"],
+// We want a PR to bump golangci-lint versions used through env variables in
+// any Github Actions or Makefile, taking it from the official Github
+// repository tags.
+      "fileMatch": ["^\\.github\\/workflows\\/[^/]+\\.ya?ml$","^Makefile$"],
       "matchStrings": [
+        "GOLANGCI_VERSION: 'v(?<currentValue>.*?)'\\n",
         "GOLANGCILINT_VERSION = (?<currentValue>.*?)\\n"
       ],
       "datasourceTemplate": "github-tags",
-      "depNameTemplate": "golangci/golangci-lint"
-    }, {
-// We want a PR to bump golangci-lint versions used through env variables in
-// any Github Actions, taking it from the official Github repository tags.
-      "fileMatch": ["^\\.github\\/workflows\\/[^/]+\\.ya?ml$"],
-      "matchStrings": [
-        "GOLANGCI_VERSION: '(?<currentValue>.*?)'\\n"
-      ],
-      "datasourceTemplate": "github-tags",
-      "depNameTemplate": "golangci/golangci-lint"
+      "depNameTemplate": "golangci/golangci-lint",
+      "extractVersionTemplate": "^v(?<version>.*)$"
     }
   ],
 // PackageRules disabled below should be enabled in case of vulnerabilities

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -26,6 +26,15 @@
       "datasourceTemplate": "golang-version",
       "depNameTemplate": "golang"
     }, {
+// We want a PR to bump golangci-lint versions used in the Makefile, taking it
+// from the official Github repository.
+       "fileMatch": ["^Makefile$"],
+      "matchStrings": [
+        "GOLANGCILINT_VERSION = (?<currentValue>.*?)\\n"
+      ],
+      "datasourceTemplate": "github-tags",
+      "depNameTemplate": "golangci/golangci-lint"
+    }, {
 // We want a PR to bump golangci-lint versions used through env variables in
 // any Github Actions, taking it from the official Github repository tags.
       "fileMatch": ["^\\.github\\/workflows\\/[^/]+\\.ya?ml$"],


### PR DESCRIPTION
Signed-off-by: Philippe Scorsolini <p.scorsolini@gmail.com>

### Description of your changes

Keep golangci-lint version updated also in the Makefile.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

N.A.

[contribution process]: https://git.io/fj2m9
