### PR TITLE
Tell golangci-lint action not to try to cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,7 +118,7 @@ jobs:
         uses: golangci/golangci-lint-action@07db5389c99593f11ad7b44463c2d4233066a9b1 # v3
         with:
           version: ${{ env.GOLANGCI_VERSION }}
-          skip-go-installation: true
+          skip-cache: true # We do our own caching.
 
   codeql:
     runs-on: ubuntu-20.04


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
This is conflicting with the caching we already do ourselves:

```console
Error: /usr/bin/tar: ../../../go/pkg/mod/github.com/morikuni/aec@v1.0.0/sgr.go: Cannot open: File exists
[85](https://github.com/crossplane/crossplane/actions/runs/4000923993/jobs/6866624913#step:8:86)
  /usr/bin/tar: ../../../go/pkg/mod/github.com/morikuni/aec@v1.0.0/sample.gif: Cannot open: File exists
```

You can see an example at https://github.com/crossplane/crossplane/actions/runs/4000923993/jobs/6866624913

I have:

- [x] Read and followed Crossplane's [contribution process].
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9

N/A