### PR TITLE
Enhanced `multiply` of transform `math` type to support `float64` 

### DIFF
--- a/apis/apiextensions/v1/composition_transforms.go
+++ b/apis/apiextensions/v1/composition_transforms.go
@@ -73,6 +73,21 @@ type MathTransform struct {
 	Multiply *int64 `json:"multiply,omitempty"`
 }
 
+// Resolve runs the Math transform.
+func (m *MathTransform) Resolve(input interface{}) (interface{}, error) {
+	if m.Multiply == nil {
+		return nil, errors.New(errMathNoMultiplier)
+	}
+	switch i := input.(type) {
+	case int64:
+		return float64(*m.Multiply) * float64(i), nil
+	case int:
+		return float64(*m.Multiply) * float64(i), nil
+	default:
+		return nil, errors.New(errMathInputNonNumber)
+	}
+}
+
 // MapTransform returns a value for the input from the given map.
 type MapTransform struct {
 	// TODO(negz): Are Pairs really optional if a MapTransform was specified?

--- a/apis/apiextensions/v1/composition_transforms.go
+++ b/apis/apiextensions/v1/composition_transforms.go
@@ -73,10 +73,18 @@ type MathTransform struct {
 	Multiply *int64 `json:"multiply,omitempty"`
 }
 
+type customError struct {
+    err string
+}
+
+func (e customError) Error() string {
+    return e.err
+}
+
 // Resolve runs the Math transform.
 func (m *MathTransform) Resolve(input interface{}) (interface{}, error) {
 	if m.Multiply == nil {
-		return nil, fmt.Errorf("no multiplier provided for math transform")
+		return nil, customError{err:"no multiplier provided for math transform"}
 	}
 	switch i := input.(type) {
 	case int64:
@@ -84,7 +92,7 @@ func (m *MathTransform) Resolve(input interface{}) (interface{}, error) {
 	case int:
 		return float64(*m.Multiply) * float64(i), nil
 	default:
-		return nil, fmt.Errorf("input for math transform is not a number")
+		return nil, customError{err:"input for math transform is not a number"}
 	}
 }
 

--- a/apis/apiextensions/v1/composition_transforms.go
+++ b/apis/apiextensions/v1/composition_transforms.go
@@ -73,15 +73,10 @@ type MathTransform struct {
 	Multiply *int64 `json:"multiply,omitempty"`
 }
 
-const (
-	errMathNoMultiplier = "no multiplier provided for math transform"
-	errMathInputNonNumber = "input for math transform is not a number"
-)
-
 // Resolve runs the Math transform.
 func (m *MathTransform) Resolve(input interface{}) (interface{}, error) {
 	if m.Multiply == nil {
-		return nil, errors.New(errMathNoMultiplier)
+		return nil, fmt.Errorf("no multiplier provided for math transform")
 	}
 	switch i := input.(type) {
 	case int64:
@@ -89,7 +84,7 @@ func (m *MathTransform) Resolve(input interface{}) (interface{}, error) {
 	case int:
 		return float64(*m.Multiply) * float64(i), nil
 	default:
-		return nil, errors.New(errMathInputNonNumber)
+		return nil, fmt.Errorf("input for math transform is not a number")
 	}
 }
 

--- a/apis/apiextensions/v1/composition_transforms.go
+++ b/apis/apiextensions/v1/composition_transforms.go
@@ -17,6 +17,7 @@ limitations under the License.
 package v1
 
 import (
+	"errors"
 	"encoding/json"
 
 	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -73,18 +74,15 @@ type MathTransform struct {
 	Multiply *int64 `json:"multiply,omitempty"`
 }
 
-type customError struct {
-    err string
-}
-
-func (e customError) Error() string {
-    return e.err
-}
+const (
+	errMathNoMultiplier   = "no multiplier provided for math transform"
+	errMathInputNonNumber = "input for math transform is not a number"
+)
 
 // Resolve runs the Math transform.
 func (m *MathTransform) Resolve(input interface{}) (interface{}, error) {
 	if m.Multiply == nil {
-		return nil, customError{err:"no multiplier provided for math transform"}
+		return nil, errors.New(errMathNoMultiplier)
 	}
 	switch i := input.(type) {
 	case int64:
@@ -92,7 +90,7 @@ func (m *MathTransform) Resolve(input interface{}) (interface{}, error) {
 	case int:
 		return float64(*m.Multiply) * float64(i), nil
 	default:
-		return nil, customError{err:"input for math transform is not a number"}
+		return nil, errors.New(errMathInputNonNumber)
 	}
 }
 

--- a/apis/apiextensions/v1/composition_transforms.go
+++ b/apis/apiextensions/v1/composition_transforms.go
@@ -73,6 +73,11 @@ type MathTransform struct {
 	Multiply *int64 `json:"multiply,omitempty"`
 }
 
+const (
+	errMathNoMultiplier = "no multiplier provided for math transform"
+	errMathInputNonNumber = "input for math transform is not a number"
+)
+
 // Resolve runs the Math transform.
 func (m *MathTransform) Resolve(input interface{}) (interface{}, error) {
 	if m.Multiply == nil {


### PR DESCRIPTION
### Description of your changes

before: `multiply` of transform `math` type is limited to work with `int` and `int64` only.
after: Enabled `multiply` to support `float64`

Fixes #3059 

I have:

- [ x] Read and followed Crossplane's [contribution process].