### PR TITLE
ci: configure renovate to ignore oss-fuzz action updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -138,6 +138,16 @@
         "action"
       ],
       "pinDigests": true
+    },{
+// We disable updates actions for oss-fuzz, as it's not using tags, we'll just
+// point to master branch
+      "matchDepTypes": [
+        "action"
+      ],
+      "matchDepNames": [
+        "google/oss-fuzz"
+      ],
+      "enabled": false
     }
   ]
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -386,14 +386,14 @@ jobs:
       # seems to build Crossplane inside of a Docker image.
       - name: Build Fuzzers
         id: build
-        uses: google/oss-fuzz/infra/cifuzz/actions/build_fuzzers@700fd90d10cf656bd08a250c2ed19555a9cfc4ef
+        uses: google/oss-fuzz/infra/cifuzz/actions/build_fuzzers@master
         with:
           oss-fuzz-project-name: "crossplane"
           dry-run: false
           language: go
 
       - name: Run Fuzzers
-        uses: google/oss-fuzz/infra/cifuzz/actions/run_fuzzers@700fd90d10cf656bd08a250c2ed19555a9cfc4ef
+        uses: google/oss-fuzz/infra/cifuzz/actions/run_fuzzers@master
         with:
           oss-fuzz-project-name: "crossplane"
           fuzz-seconds: 300


### PR DESCRIPTION
Signed-off-by: Philippe Scorsolini <p.scorsolini@gmail.com>

### Description of your changes

Given that oss-fuzz is not tagging releases we'll default to referencing it by branch, pointing only to `master` in the ci workflow.

Closes #3649
Closes #3661
Closes #3664

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

Configured on my local repo.

[contribution process]: https://git.io/fj2m9
