### PR TITLE
ci: add trivy filesystem scan job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,6 +165,25 @@ jobs:
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@a34ca99b4610d924e04c68db79e503e1f79f9f02 # v2
 
+  trivy-scan-fs:
+    runs-on: ubuntu-20.04
+    needs: detect-noop
+    if: needs.detect-noop.outputs.noop != 'true'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3
+        with:
+          submodules: true
+
+      - name: Run Trivy vulnerability scanner in fs mode
+        uses: aquasecurity/trivy-action@0.8.0
+        with:
+          scan-type: 'fs'
+          ignore-unfixed: true
+          skip-dirs: design
+          scan-ref: '.'
+          severity: 'CRITICAL,HIGH'
+
   unit-tests:
     runs-on: ubuntu-20.04
     needs: detect-noop


### PR DESCRIPTION
Signed-off-by: Philippe Scorsolini <p.scorsolini@gmail.com>

### Description of your changes

Introduce a step running a trivy [filesystem scan](https://aquasecurity.github.io/trivy/v0.19.2/vulnerability/scanning/filesystem/), this will avoid adding dependencies with know fixed vulnerabilities at the time the pipeline is run.

This should be also paired with daily scans against all the supported built images performed either through the registry of choice or a scheduled github action, see [example](https://github.com/goharbor/harbor/blob/main/.github/workflows/nightly-trivy-scan.yml).

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

N.A.

[contribution process]: https://git.io/fj2m9
