### PR TITLE
Enhanced `multiply` of transform `math` type to support `float64`

### DIFF
--- a/apis/apiextensions/v1/composition_transforms.go
+++ b/apis/apiextensions/v1/composition_transforms.go
@@ -73,6 +73,26 @@ type MathTransform struct {
 	Multiply *int64 `json:"multiply,omitempty"`
 }
 
+const (
+	errMathNoMultiplier   = "no input provided"
+	errMathInputNonNumber = "input is not a number"
+)
+
+// Resolve runs the Math transform.
+func (m *MathTransform) Resolve(input interface{}) (interface{}, error) {
+	if m.Multiply == nil {
+		return nil, errors.New(errMathNoMultiplier)
+	}
+	switch i := input.(type) {
+	case int64:
+		return float64(*m.Multiply) * float64(i), nil
+	case int:
+		return float64(*m.Multiply) * float64(i), nil
+	default:
+		return nil, errors.New(errMathInputNonNumber)
+	}
+}
+
 // MapTransform returns a value for the input from the given map.
 type MapTransform struct {
 	// TODO(negz): Are Pairs really optional if a MapTransform was specified?


### PR DESCRIPTION
Enabled `multiply` of transform type `math` to support `float64` without colluding with the API conventions.  
Added error reporting that is consistent with the codebase

Fixes #3059 

I have:

- [x] Read and followed Crossplane's [contribution process].
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

`make`, `make e2e` and `make submodule` ran successfully without any errors