### PR TITLE
Add ADOPTERS.md file to capture all known users of Crossplane

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -1,0 +1,32 @@
+# Adopters
+
+This list captures the set of organizations that are using Crossplane within their environments. If
+you are an adopter of Crossplane and not yet on this list, we encourage you to add your organization
+here as well!
+
+The goal for this list is to be the complete and authoritative source for the entire community of
+Crossplane adopters, and give inspiration to others that are earlier in their Crossplane journey.
+
+Contributing to this list is a small effort that has a **big impact** to the project's growth,
+maturity, and momentum.  Thank you to all adopters and contributors of the Crossplane project!
+
+## Updating this list
+
+To add your organization to this list, you can choose any of the following options:
+
+1. [Open a PR](https://github.com/crossplane/crossplane/pulls) to directly update this list, or
+   [edit this file](https://github.com/crossplane/crossplane/edit/master/ADOPTERS.md) directly in
+   Github
+1. Fill out the [adopters form](https://forms.gle/dBQhiyYkYSdzXovN6)
+1. Send an email to <steering@crossplane.io> with your information for the table below
+
+Feel free to reach out to <steering@crossplane.io> with any questions and/or assistance with
+updating this list.
+
+## Crossplane Adopters
+
+This list is sorted in the order that organizations were added to it.
+
+| Organization | Contact | Description of Use |
+| ------------ | ------- | ------------------ |
+| [Upbound](https://upbound.io) | @jbw976 | Main control plane and infrastructure management solution for [Upbound Cloud](https://upbound.io). Crossplane powers the internal developer platforms for all dev, staging, and production environments. |

--- a/README.md
+++ b/README.md
@@ -49,6 +49,12 @@ with the broader community is encouraged to join.
 * [Past meeting recordings]
 * [Community Calendar][community calendar]
 
+## Adopters
+
+A list of publicly known users of the Crossplane project can be found in [ADOPTERS.md].  We
+encourage all users of Crossplane to add themselves to this list - we want to see the community's
+growing success!
+
 ## License
 
 Crossplane is under the Apache 2.0 license.
@@ -73,3 +79,4 @@ Crossplane is under the Apache 2.0 license.
 [cncf]: https://www.cncf.io/
 [community calendar]: https://calendar.google.com/calendar/embed?src=c_2cdn0hs9e2m05rrv1233cjoj1k%40group.calendar.google.com
 [releases]: https://github.com/crossplane/crossplane/releases
+[ADOPTERS.md]: ADOPTERS.md


### PR DESCRIPTION
### Description of your changes

This PR adds a new ADOPTERS.md file to the root of the repo to capture all known users of the Crossplane project.  This will be an important piece of data for our CNCF Graduation effort.

The idea is to lower the bar for Crossplane users to be added to this list by giving themmultiple self-service options.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

I have tested the rendered markdown and links within my fork 💪 