### PR TITLE
ci(renovate): disable updates for kubernetes deps on release branches

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -44,7 +44,19 @@
     "enabled": true
   },
   "packageRules": [
+// We don't want K8s dependencies updates which are not security related
+// for release branches
     {
+      "matchDatasources": [
+        "go"
+      ],
+      "matchPackagePrefixes": [
+        "k8s.io",
+        "sigs.k8s.io"
+      ],
+      matchBaseBranches: [ "/^release-.*/"],
+      enabled: false,
+    }, {
 // We need to ignore k8s.io/client-go older versions as they switched to
 // semantic version and old tags are still available in the repo.
       "matchDatasources": [


### PR DESCRIPTION
Signed-off-by: Philippe Scorsolini <p.scorsolini@gmail.com>

### Description of your changes

There is no need to upgrade kubernetes dependencies on release branches if these are not due to security issues.

Closes #3662
Closes #3674
Closes #3677
Closes #3679

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

Configured on my fork.

[contribution process]: https://git.io/fj2m9
