### PR TITLE
Feature: Allow service account to be not be created and custom service account name

### DIFF
--- a/cluster/charts/crossplane/README.md
+++ b/cluster/charts/crossplane/README.md
@@ -78,7 +78,8 @@ and their default values.
 | `nodeSelector` | Enable nodeSelector for Crossplane pod | `{}` |
 | `customLabels` | Custom labels to add into metadata | `{}` |
 | `customAnnotations` | Custom annotations to add to the Crossplane deployment and pod | `{}` |
-| `serviceAccount.name` | Custom name to give to the serviceaccount of Crossplane, defaults to Release name. Does not create the serviceAccount if set | `""` |
+| `serviceAccount.create` | Create the serviceaccount for Crossplane | `true` |
+| `serviceAccount.name` | Custom name to give to the serviceaccount of Crossplane, defaults to Release name | `""` |
 | `serviceAccount.customAnnotations` | Custom annotations to add to the serviceaccount of Crossplane | `{}` |
 | `priorityClassName` | Priority class name for Crossplane and RBAC Manager (if enabled) pods | `""` |
 | `resourcesCrossplane.limits.cpu` | CPU resource limits for Crossplane | `100m` |

--- a/cluster/charts/crossplane/README.md
+++ b/cluster/charts/crossplane/README.md
@@ -78,6 +78,7 @@ and their default values.
 | `nodeSelector` | Enable nodeSelector for Crossplane pod | `{}` |
 | `customLabels` | Custom labels to add into metadata | `{}` |
 | `customAnnotations` | Custom annotations to add to the Crossplane deployment and pod | `{}` |
+| `serviceAccount.name` | Custom name to give to the serviceaccount of Crossplane, defaults to Release name. Does not create the serviceAccount if set | `""` |
 | `serviceAccount.customAnnotations` | Custom annotations to add to the serviceaccount of Crossplane | `{}` |
 | `priorityClassName` | Priority class name for Crossplane and RBAC Manager (if enabled) pods | `""` |
 | `resourcesCrossplane.limits.cpu` | CPU resource limits for Crossplane | `100m` |

--- a/cluster/charts/crossplane/templates/_helpers.tpl
+++ b/cluster/charts/crossplane/templates/_helpers.tpl
@@ -30,3 +30,10 @@ app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{ toYaml .Values.customLabels }}
 {{- end }}
 {{- end }}
+
+{{/*
+Create service account name.
+*/}}
+{{- define "crossplane.serviceAccountName" -}}
+{{- .Values.serviceAccount.name | default (include "crossplane.name" .) -}}
+{{- end -}}

--- a/cluster/charts/crossplane/templates/clusterrolebinding.yaml
+++ b/cluster/charts/crossplane/templates/clusterrolebinding.yaml
@@ -11,5 +11,5 @@ roleRef:
   name: {{ template "crossplane.name" . }}
 subjects:
 - kind: ServiceAccount
-  name: {{ template "crossplane.name" . }}
+  name: {{ template "crossplane.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}

--- a/cluster/charts/crossplane/templates/deployment.yaml
+++ b/cluster/charts/crossplane/templates/deployment.yaml
@@ -41,7 +41,7 @@ spec:
       {{- if .Values.priorityClassName }}
       priorityClassName: {{ .Values.priorityClassName  | quote }}
       {{- end }}
-      serviceAccountName: {{ template "crossplane.name" . }}
+      serviceAccountName: {{ template "crossplane.serviceAccountName" . }}
       initContainers:
         - image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
           args:

--- a/cluster/charts/crossplane/templates/serviceaccount.yaml
+++ b/cluster/charts/crossplane/templates/serviceaccount.yaml
@@ -1,4 +1,4 @@
-{{- if not .Values.serviceAccount.name -}}
+{{- if .Values.serviceAccount.create -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/cluster/charts/crossplane/templates/serviceaccount.yaml
+++ b/cluster/charts/crossplane/templates/serviceaccount.yaml
@@ -1,7 +1,8 @@
+{{- if not .Values.serviceAccount.name -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ template "crossplane.name" . }}
+  name: {{ template "crossplane.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "crossplane.name" . }}
@@ -15,3 +16,4 @@ imagePullSecrets:
 - name: {{ $secret }}
 {{- end }}
 {{ end }}
+{{- end -}}

--- a/cluster/charts/crossplane/values.yaml.tmpl
+++ b/cluster/charts/crossplane/values.yaml.tmpl
@@ -17,8 +17,10 @@ customLabels: {}
 # -- Custom annotations to add to the Crossplane deployment and pod
 customAnnotations: {}
 
-# -- Custom annotations to add to the serviceaccount of Crossplane
 serviceAccount:
+  # -- Custom name to give to the serviceaccount of Crossplane, defaults to Release name. Does not create the serviceAccount if set
+  name: ""
+  # -- Custom annotations to add to the serviceaccount of Crossplane
   customAnnotations: {}
 
 leaderElection: true

--- a/cluster/charts/crossplane/values.yaml.tmpl
+++ b/cluster/charts/crossplane/values.yaml.tmpl
@@ -18,6 +18,7 @@ customLabels: {}
 customAnnotations: {}
 
 serviceAccount:
+  create: true
   # -- Custom name to give to the serviceaccount of Crossplane, defaults to Release name. Does not create the serviceAccount if set
   name: ""
   # -- Custom annotations to add to the serviceaccount of Crossplane


### PR DESCRIPTION
Signed-off-by: Mark Anderson-Trocme <mark.anderson@altitude-sports.com>

<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

As discussed in https://github.com/crossplane/crossplane/pull/2756#discussion_r766759008 when `serviceAccount.name` is provided no serviceAccount is created.
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #2755

I have:

- [x] Read and followed Crossplane's [contribution process].
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested
 I ran `helm template . -f values.yaml --debug` with a `serviceAccount.name` set and not set and output was as expected.
<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
