### PR TITLE
chore(renovate): disable non security gha updates to release branches

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -57,6 +57,14 @@
       matchBaseBranches: [ "/^release-.*/"],
       enabled: false,
     }, {
+// We don't want github actions updates which are not security related for
+// release branches
+      "matchDatasources": [
+        "action"
+      ],
+      matchBaseBranches: [ "/^release-.*/"],
+      enabled: false,
+    }, {
 // We need to ignore k8s.io/client-go older versions as they switched to
 // semantic version and old tags are still available in the repo.
       "matchDatasources": [


### PR DESCRIPTION
Signed-off-by: Philippe Scorsolini <p.scorsolini@gmail.com>

### Description of your changes

To reduce noise, we can disable non security related github actions' updates to release branches.

Closes #3684 
Closes #3685

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

N.A.

[contribution process]: https://git.io/fj2m9
