### PR TITLE
chore(renovate): disable everything except images on release branches

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -44,26 +44,15 @@
     "enabled": true
   },
   "packageRules": [
-// We don't want K8s dependencies updates which are not security related
-// for release branches
+// We don't want dependency updates which are not security related for
+// release branches, except for docker images
     {
-      "matchDatasources": [
-        "go"
-      ],
-      "matchPackagePrefixes": [
-        "k8s.io",
-        "sigs.k8s.io"
-      ],
       matchBaseBranches: [ "/^release-.*/"],
       enabled: false,
     }, {
-// We don't want github actions updates which are not security related for
-// release branches
-      "matchDatasources": [
-        "action"
-      ],
+      "matchDatasources": ["docker"],
       matchBaseBranches: [ "/^release-.*/"],
-      enabled: false,
+      enabled: true,
     }, {
 // We need to ignore k8s.io/client-go older versions as they switched to
 // semantic version and old tags are still available in the repo.


### PR DESCRIPTION
Signed-off-by: Philippe Scorsolini <p.scorsolini@gmail.com>

### Description of your changes

As discussed it makes sense to only have security related updates on release branches, except for docker images.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

Configured on my fork.

[contribution process]: https://git.io/fj2m9
