### PR TITLE
Add release-1.11 to baseBranches of renovate config

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -7,7 +7,7 @@
   "prConcurrentLimit": 5,
 // The branches renovate should target
 // PLEASE UPDATE THIS WHEN RELEASING.
-  "baseBranches": ["master","release-1.9","release-1.10"],
+  "baseBranches": ["master","release-1.9","release-1.10","release-1.11"],
   "ignorePaths": ["design/**"],
   "postUpdateOptions": ["gomodTidy"],
 // By default renovate will auto detect whether semantic commits have been used


### PR DESCRIPTION
### Description of your changes

This PR simply adds the release branch for v1.11 (release-1.11) to the `baseBranches` of Renovate's config file.  This is part of the release issue template we are following for the v1.11 release in #3600.

I followed the model from #3637

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

This will be verified by the subsequent CI runs.

[contribution process]: https://git.io/fj2m9
