### PR TITLE
Update releases table in README.md for v1.11 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,10 +19,10 @@ documentation].
 
 | Release | Release Date |      EOL      |
 |:-------:|:------------:|:-------------:|
-|   v1.8  | May 17, 2022 |    Jan 2023   |
 |   v1.9  | Jul 14, 2022 |    Apr 2023   |
 |   v1.10 | Oct 18, 2022 |    Jul 2023   |
 |   v1.11 | Jan 31, 2023 |    Oct 2023   |
+|   v1.12 | Apr 25, 2023 |    Jan 2024   |
 
 You can subscribe to the [community calendar] to track all release dates, and
 find the most recent releases on the [releases] page.


### PR DESCRIPTION
### Description of your changes

This PR updates the releases table in the main README.md for the v1.11 release.  The following changes are made:

* Drop v1.8 as it is now officially at EOL
* Add v1.12 as the next release scheduled for Apr 25, 2023 and EOL for Jan 2024.

This is part of the release checklist in #3600 

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

I verified the table is rendering well in [my fork](https://github.com/jbw976/crossplane/blob/release-table-v1.11/README.md#releases) and the release information is correct as per the [community calendar](https://calendar.google.com/calendar/embed?src=c_2cdn0hs9e2m05rrv1233cjoj1k%40group.calendar.google.com).

[contribution process]: https://git.io/fj2m9
