### PR TITLE
Add explanation and help text for signing DCO

### DIFF
--- a/contributing/README.md
+++ b/contributing/README.md
@@ -85,6 +85,39 @@ the time to ensure your contributions are high quality and easy for our
 community to review and accept. Please don't hesitate to [reach out to
 us][Slack] if you have any questions about contributing!
 
+## Certificate of Origin
+
+By contributing to this project you agree to the Developer Certificate of Origin
+(DCO). This document was created by the Linux Kernel community and is a simple
+statement that you, as a contributor, have the legal right to make the
+contribution. See the [DCO](../DCO) file for details.
+
+Contributors sign-off that they adhere to these requirements by adding a
+Signed-off-by line to commit messages. For example:
+
+```
+This is my commit message
+
+Signed-off-by: Random J Developer <random@developer.example.org>
+```
+
+Git even has a -s command line option to append this automatically to your
+commit message:
+
+```
+$ git commit -s -m 'This is my commit message'
+```
+
+If you have already made a commit and forgot to include the sign-off, you can
+amend your last commit to add the sign-off with the following command, which can
+then be force pushed.
+
+```
+git commit --amend -s
+```
+
+We use a [DCO bot] to enforce the DCO on all commits in every pull request.
+
 ## Coding Style
 
 The Crossplane project prefers not to maintain its own style guide, but we do
@@ -518,3 +551,4 @@ make run
 [Dave Cheney's blog]: https://dave.cheney.net/2014/10/17/functional-options-for-friendly-apis
 [`crossplane-runtime/pkg/errors`]: https://pkg.go.dev/github.com/crossplane/crossplane-runtime/pkg/errors
 [golangci-lint]: https://golangci-lint.run/
+[DCO bot]: https://probot.github.io/apps/dco/


### PR DESCRIPTION
### Description of your changes

This PR adds some helpful explanation text about the DCO, e.g. what it means and how to adhere to it.

Potentially most helpful is some quick guidance (git commands) for signing-off your commits, especially after they've already been committed.  We very commonly see folks forget to do the DCO, so having a direct link to this helpful section in the contributing guide could be a time and headache saver for new contributors 🙏 

This text came from [the upbound/build submodule ](https://github.com/upbound/build/blob/master/CONTRIBUTING.md#certificate-of-origin), with very limited style and formatting updates.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

I've verified the rendered markdown and clicked the links in my fork: https://github.com/jbw976/crossplane/blob/dco-help/contributing/README.md#certificate-of-origin

[contribution process]: https://git.io/fj2m9
