### PR TITLE
Add jbw976 as a reviewer

### DIFF
--- a/OWNERS.md
+++ b/OWNERS.md
@@ -38,6 +38,7 @@ See [CODEOWNERS](CODEOWNERS) for automatic PR assignment.
 * Ezgi Demirel <ezgi@upbound.io> ([ezgidemirel](https://github.com/ezgidemirel))
 * Max Blatt ([MisterMX](https://github.com/MisterMX))
 * Philippe Scorsolini <philippe.scorsolini@upbound.io> ([phisco](https://github.com/phisco))
+* Jared Watts <jared@upbound.io> ([jbw976](https://github.com/jbw976))
 
 ## Emeritus maintainers
 


### PR DESCRIPTION
### Description of your changes

Now that we have enabled the enforcement of CODEOWNERS on PRs, I see that I am not included in the reviewers that can review changes in general.  I'm in the steering-committee group, which enables review of governance/charter/etc., but not code in general.

As I'm getting heavily involved in the day to day of the project again, I propose to start reviewing PRs regularly again by joining the reviewers group.  The maintainer team and steering committee can discuss down the road if we want to move me to full maintainer again instead of emeritus maintainer.

If this PR is approved, I would then add myself to the crossplane-reviewers group/team.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

No testing has been performed.

[contribution process]: https://git.io/fj2m9
