### PR TITLE
chore(renovate): set monthly digest updates for kubernetes deps and every two weeks for docker images

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -64,6 +64,21 @@
       ],
       "allowedVersions": "<1.0"
     }, {
+// We don't want digest updates for kubernetes dependencies, as they are too
+// noisy
+      "matchDatasources": [
+        "go"
+      ],
+      "groupName": "kubernetes patches",
+      "matchUpdateTypes": [
+        "digest",
+      ],
+      "extends": ['schedule:monthly'],
+      "matchPackagePrefixes": [
+        "k8s.io",
+        "sigs.k8s.io"
+      ]
+    }, {
 // We want a single PR for all the patches bumps of kubernetes related
 // dependencies, as most of the times these are all strictly related.
       "matchDatasources": [
@@ -72,7 +87,6 @@
       "groupName": "kubernetes patches",
       "matchUpdateTypes": [
         "patch",
-        "digest"
       ],
       "matchPackagePrefixes": [
         "k8s.io",

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -54,6 +54,10 @@
       matchBaseBranches: [ "/^release-.*/"],
       enabled: true,
     }, {
+      "matchDatasources": ["docker"],
+      "schedule": ["every 2 week on monday"],
+      enabled: true,
+    }, {
 // We need to ignore k8s.io/client-go older versions as they switched to
 // semantic version and old tags are still available in the repo.
       "matchDatasources": [


### PR DESCRIPTION
Signed-off-by: Philippe Scorsolini <p.scorsolini@gmail.com>

### Description of your changes

With this patch Renovate will only open PRs to bump digest updates once a month and docker ones every two weeks, if required due to security reasons.
See [here](https://docs.renovatebot.com/key-concepts/scheduling/#schedule-when-to-update-specific-dependencies) for more information about Renovate's scheduling.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

Configured on my fork, the existing PR #3683 won't drop the digest update as it is the one due for this month, but it should not open another one until next month.

[contribution process]: https://git.io/fj2m9
