### PR TITLE
fix(chart): Satisfy the Kubernetes PSS (Restricted) by default

### DIFF
--- a/cluster/charts/crossplane/values.yaml.tmpl
+++ b/cluster/charts/crossplane/values.yaml.tmpl
@@ -59,10 +59,16 @@ resourcesCrossplane:
     memory: 256Mi
 
 securityContextCrossplane:
+  capabilities:
+    drop:
+    - ALL
+  runAsNonRoot: true
   runAsUser: 65532
   runAsGroup: 65532
   allowPrivilegeEscalation: false
   readOnlyRootFilesystem: true
+  seccompProfile:
+    type: RuntimeDefault
 
 packageCache:
   medium: ""
@@ -79,10 +85,16 @@ resourcesRBACManager:
     memory: 256Mi
 
 securityContextRBACManager:
+  capabilities:
+    drop:
+    - ALL
+  runAsNonRoot: true
   runAsUser: 65532
   runAsGroup: 65532
   allowPrivilegeEscalation: false
   readOnlyRootFilesystem: true
+  seccompProfile:
+    type: RuntimeDefault
 
 metrics:
   enabled: false
@@ -91,9 +103,15 @@ extraEnvVarsCrossplane: {}
 
 extraEnvVarsRBACManager: {}
 
-podSecurityContextCrossplane: {}
+podSecurityContextCrossplane:
+  runAsNonRoot: true
+  seccompProfile:
+    type: RuntimeDefault
 
-podSecurityContextRBACManager: {}
+podSecurityContextRBACManager:
+  runAsNonRoot: true
+  seccompProfile:
+    type: RuntimeDefault
 
 # The alpha xfn sidecar container that runs Composition Functions. Note you also
 # need to run Crossplane with --enable-composition-functions for it to call xfn.


### PR DESCRIPTION

<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
These changes aim to satisfy https://kubernetes.io/docs/concepts/security/pod-security-standards/#restricted by default.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [ ] Run `make reviewable` to ensure this PR is ready for review.
```
✗ make reviewable
make: *** No rule to make target `reviewable'.  Stop.
```
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

We're currently running with these settings in our installation of Crossplane.

[contribution process]: https://git.io/fj2m9
