### PR TITLE
Apply pollInterval to Claim and Composite reconcilers

### DIFF
--- a/internal/controller/apiextensions/claim/reconciler.go
+++ b/internal/controller/apiextensions/claim/reconciler.go
@@ -183,8 +183,9 @@ type Reconciler struct {
 	composite crComposite
 	claim     crClaim
 
-	log    logging.Logger
-	record event.Recorder
+	log          logging.Logger
+	record       event.Recorder
+	pollInterval time.Duration
 }
 
 type crComposite struct {
@@ -285,6 +286,17 @@ func WithLogger(l logging.Logger) ReconcilerOption {
 func WithRecorder(er event.Recorder) ReconcilerOption {
 	return func(r *Reconciler) {
 		r.record = er
+	}
+}
+
+// WithPollInterval specifies how long the Reconciler should wait before queueing
+// a new reconciliation after a successful reconcile. The Reconciler requeues
+// after a specified duration when it is not actively waiting for an external
+// operation, but wishes to check whether resources it does not have a watch on
+// (i.e. composed resources) need to be reconciled.
+func WithPollInterval(after time.Duration) ReconcilerOption {
+	return func(r *Reconciler) {
+		r.pollInterval = after
 	}
 }
 

--- a/internal/controller/apiextensions/offered/reconciler.go
+++ b/internal/controller/apiextensions/offered/reconciler.go
@@ -392,6 +392,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 	o := []claim.ReconcilerOption{
 		claim.WithLogger(log.WithValues("controller", claim.ControllerName(d.GetName()))),
 		claim.WithRecorder(r.record.WithAnnotations("controller", claim.ControllerName(d.GetName()))),
+		claim.WithPollInterval(r.options.PollInterval),
 	}
 
 	// We only want to enable ExternalSecretStore support if the relevant


### PR DESCRIPTION
Signed-off-by: Bob Haddleton <bob.haddleton@nokia.com>

### Description of your changes
Add pollInterval option to the Claim and Composite Reconcilers

Fixes #3761 

I have:

- [X] Read and followed Crossplane's [contribution process].
- [X] Run `make reviewable` to ensure this PR is ready for review.
- [X] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested
Tested in a development environment and verified that claim and composite resources are reconciled every 5m when the --poll-interval=5m parameter is included in the Crossplane args

[contribution process]: https://git.io/fj2m9
