### PR TITLE
Use NewAPIPatchingApplicator in PTF composite

### DIFF
--- a/internal/controller/apiextensions/composite/composition_ptf.go
+++ b/internal/controller/apiextensions/composite/composition_ptf.go
@@ -237,7 +237,7 @@ func NewPTFComposer(kube client.Client, o ...PTFComposerOption) *PTFComposer {
 	f := NewSecretConnectionDetailsFetcher(kube)
 
 	c := &PTFComposer{
-		client: resource.ClientApplicator{Client: kube, Applicator: resource.NewAPIUpdatingApplicator(kube)},
+		client: resource.ClientApplicator{Client: kube, Applicator: resource.NewAPIPatchingApplicator(kube)},
 
 		composite: ptfComposite{
 			ConnectionDetailsFetcher: f,

--- a/internal/controller/apiextensions/composite/composition_ptf_test.go
+++ b/internal/controller/apiextensions/composite/composition_ptf_test.go
@@ -287,7 +287,7 @@ func TestPTFCompose(t *testing.T) {
 						return nil
 					}),
 					// The ClientApplicator will call Update for the XR.
-					MockUpdate: test.NewMockUpdateFn(nil),
+					MockPatch: test.NewMockPatchFn(nil),
 				},
 				o: []PTFComposerOption{
 					WithCompositeConnectionDetailsFetcher(ConnectionDetailsFetcherFn(func(ctx context.Context, o resource.ConnectionSecretOwner) (managed.ConnectionDetails, error) {
@@ -341,7 +341,7 @@ func TestPTFCompose(t *testing.T) {
 						return nil
 					}),
 					// The ClientApplicator will call Update for the XR.
-					MockUpdate: test.NewMockUpdateFn(nil),
+					MockPatch: test.NewMockPatchFn(nil),
 				},
 				o: []PTFComposerOption{
 					WithCompositeConnectionDetailsFetcher(ConnectionDetailsFetcherFn(func(ctx context.Context, o resource.ConnectionSecretOwner) (managed.ConnectionDetails, error) {
@@ -382,8 +382,8 @@ func TestPTFCompose(t *testing.T) {
 			params: params{
 				kube: &test.MockClient{
 					// These are both called by Apply.
-					MockGet:    test.NewMockGetFn(nil),
-					MockUpdate: test.NewMockUpdateFn(nil),
+					MockGet:   test.NewMockGetFn(nil),
+					MockPatch: test.NewMockPatchFn(nil),
 				},
 				o: []PTFComposerOption{
 					WithCompositeConnectionDetailsFetcher(ConnectionDetailsFetcherFn(func(ctx context.Context, o resource.ConnectionSecretOwner) (managed.ConnectionDetails, error) {
@@ -418,8 +418,8 @@ func TestPTFCompose(t *testing.T) {
 			params: params{
 				kube: &test.MockClient{
 					// These are both called by Apply.
-					MockGet:    test.NewMockGetFn(nil),
-					MockUpdate: test.NewMockUpdateFn(nil),
+					MockGet:   test.NewMockGetFn(nil),
+					MockPatch: test.NewMockPatchFn(nil),
 				},
 				o: []PTFComposerOption{
 					WithCompositeConnectionDetailsFetcher(ConnectionDetailsFetcherFn(func(ctx context.Context, o resource.ConnectionSecretOwner) (managed.ConnectionDetails, error) {


### PR DESCRIPTION
### Description of your changes
Updates NewPTFComposer to use NewAPIPatchingApplicator instead of NewAPIUpdatingApplicator as suggested by @negz 

Fixes #3747 

I have:

- [X] Read and followed Crossplane's [contribution process].
- [X] Run `make reviewable` to ensure this PR is ready for review.
- [X] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested
Deployed composites successfully in a Crossplane deployment with Composition Functions enabled, and  no duplicate resources were created.

[contribution process]: https://git.io/fj2m9
