### PR TITLE
Add compositeTypeRef kind and apiVersion to Composition output columns

### DIFF
--- a/apis/apiextensions/v1/composition_types.go
+++ b/apis/apiextensions/v1/composition_types.go
@@ -378,6 +378,8 @@ type ContainerFunctionRunner struct {
 // +genclient:nonNamespaced
 
 // A Composition specifies how a composite resource should be composed.
+// +kubebuilder:printcolumn:name="XR-KIND",type="string",JSONPath=".spec.compositeTypeRef.kind"
+// +kubebuilder:printcolumn:name="XR-APIVERSION",type="string",JSONPath=".spec.compositeTypeRef.apiVersion"
 // +kubebuilder:printcolumn:name="AGE",type="date",JSONPath=".metadata.creationTimestamp"
 // +kubebuilder:resource:scope=Cluster,categories=crossplane
 type Composition struct {

--- a/apis/apiextensions/v1alpha1/zz_generated.revision_types.go
+++ b/apis/apiextensions/v1alpha1/zz_generated.revision_types.go
@@ -922,6 +922,8 @@ type CompositionRevisionStatus struct {
 // A CompositionRevision represents a revision in time of a Composition.
 // Revisions are created by Crossplane; they should be treated as immutable.
 // +kubebuilder:printcolumn:name="REVISION",type="string",JSONPath=".spec.revision"
+// +kubebuilder:printcolumn:name="XR-KIND",type="string",JSONPath=".spec.compositeTypeRef.kind"
+// +kubebuilder:printcolumn:name="XR-APIVERSION",type="string",JSONPath=".spec.compositeTypeRef.apiVersion"
 // +kubebuilder:printcolumn:name="AGE",type="date",JSONPath=".metadata.creationTimestamp"
 // +kubebuilder:resource:scope=Cluster,categories=crossplane
 // +kubebuilder:subresource:status

--- a/apis/apiextensions/v1beta1/revision_types.go
+++ b/apis/apiextensions/v1beta1/revision_types.go
@@ -921,6 +921,8 @@ type CompositionRevisionStatus struct {
 // A CompositionRevision represents a revision in time of a Composition.
 // Revisions are created by Crossplane; they should be treated as immutable.
 // +kubebuilder:printcolumn:name="REVISION",type="string",JSONPath=".spec.revision"
+// +kubebuilder:printcolumn:name="XR-KIND",type="string",JSONPath=".spec.compositeTypeRef.kind"
+// +kubebuilder:printcolumn:name="XR-APIVERSION",type="string",JSONPath=".spec.compositeTypeRef.apiVersion"
 // +kubebuilder:printcolumn:name="AGE",type="date",JSONPath=".metadata.creationTimestamp"
 // +kubebuilder:resource:scope=Cluster,categories=crossplane
 // +kubebuilder:subresource:status

--- a/cluster/crds/apiextensions.crossplane.io_compositionrevisions.yaml
+++ b/cluster/crds/apiextensions.crossplane.io_compositionrevisions.yaml
@@ -20,6 +20,12 @@ spec:
     - jsonPath: .spec.revision
       name: REVISION
       type: string
+    - jsonPath: .spec.compositeTypeRef.kind
+      name: XR-KIND
+      type: string
+    - jsonPath: .spec.compositeTypeRef.apiVersion
+      name: XR-APIVERSION
+      type: string
     - jsonPath: .metadata.creationTimestamp
       name: AGE
       type: date
@@ -1318,6 +1324,12 @@ spec:
   - additionalPrinterColumns:
     - jsonPath: .spec.revision
       name: REVISION
+      type: string
+    - jsonPath: .spec.compositeTypeRef.kind
+      name: XR-KIND
+      type: string
+    - jsonPath: .spec.compositeTypeRef.apiVersion
+      name: XR-APIVERSION
       type: string
     - jsonPath: .metadata.creationTimestamp
       name: AGE

--- a/cluster/crds/apiextensions.crossplane.io_compositions.yaml
+++ b/cluster/crds/apiextensions.crossplane.io_compositions.yaml
@@ -17,6 +17,12 @@ spec:
   scope: Cluster
   versions:
   - additionalPrinterColumns:
+    - jsonPath: .spec.compositeTypeRef.kind
+      name: XR-KIND
+      type: string
+    - jsonPath: .spec.compositeTypeRef.apiVersion
+      name: XR-APIVERSION
+      type: string
     - jsonPath: .metadata.creationTimestamp
       name: AGE
       type: date


### PR DESCRIPTION
### Description of your changes
Added the compositeTypeRef.kind and compositeTypeRef.apiVersion print columns to the Composition output

Fixes #3775 

I have:

- [X] Read and followed Crossplane's [contribution process].
- [X] Run `make reviewable` to ensure this PR is ready for review.
- [X] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested
Verified the output is correct in a running Crossplane cluster

[contribution process]: https://git.io/fj2m9
