### PR TITLE
[Release 1.11] Bump runtime to v0.19.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.19
 require (
 	github.com/Masterminds/semver v1.5.0
 	github.com/alecthomas/kong v0.7.2-0.20221130112736-919e70103f7a
-	github.com/crossplane/crossplane-runtime v0.19.0
+	github.com/crossplane/crossplane-runtime v0.19.1
 	github.com/google/go-cmp v0.5.9
 	github.com/google/go-containerregistry v0.9.0
 	github.com/google/go-containerregistry/pkg/authn/k8schain v0.0.0-20220517194345-84eb52633e96

--- a/go.sum
+++ b/go.sum
@@ -193,8 +193,8 @@ github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46t
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/creack/pty v1.1.11 h1:07n33Z8lZxZ2qwegKbObQohDhXDQxiMMz1NOUGYlesw=
 github.com/creack/pty v1.1.11/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
-github.com/crossplane/crossplane-runtime v0.19.0 h1:+NuhkbW3oKnRKcIBTApw34HQ4m2guxZR84m0iNGJGJg=
-github.com/crossplane/crossplane-runtime v0.19.0/go.mod h1:OJQ1NxtQK2ZTRmvtnQPoy8LsXsARTnVydRVDQEgIuz4=
+github.com/crossplane/crossplane-runtime v0.19.1 h1:KpDwO5XlKeDfPpms0P57W77YcRHDM/nE3A82ZlYGsyA=
+github.com/crossplane/crossplane-runtime v0.19.1/go.mod h1:OJQ1NxtQK2ZTRmvtnQPoy8LsXsARTnVydRVDQEgIuz4=
 github.com/cyphar/filepath-securejoin v0.2.3 h1:YX6ebbZCZP7VkM3scTTokDgBL2TY741X51MTk3ycuNI=
 github.com/cyphar/filepath-securejoin v0.2.3/go.mod h1:aPGpWjXOXUn2NCNjFvBE6aRxGGx79pTxQpKOJNYHHl4=
 github.com/danieljoos/wincred v1.1.0/go.mod h1:XYlo+eRTsVA9aHGp7NGjFkPla4m+DCL7hqDjlFjiygg=


### PR DESCRIPTION
### Description of your changes

Bumps crossplane runtime to v0.19.1 to get https://github.com/crossplane/crossplane-runtime/pull/383
Fixes https://github.com/crossplane/crossplane/issues/3520

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

See https://github.com/crossplane/crossplane-runtime/pull/380

[contribution process]: https://git.io/fj2m9
