### PR TITLE
Bump Ubuntu version to 22.04 in CI

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -18,7 +18,7 @@ jobs:
   # The main gotchas with this action are that it _only_ supports merge commits,
   # and that PRs _must_ be labelled before they're merged to trigger a backport.
   open-pr:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     if: github.event.pull_request.merged
     steps:
       - name: Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ env:
 
 jobs:
   check-diff:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Checkout
@@ -61,7 +61,7 @@ jobs:
         run: make check-diff
 
   detect-noop:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     outputs:
       noop: ${{ steps.noop.outputs.should_skip }}
     steps:
@@ -75,7 +75,7 @@ jobs:
           concurrent_skipping: false
 
   lint:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: detect-noop
     if: needs.detect-noop.outputs.noop != 'true'
 
@@ -121,7 +121,7 @@ jobs:
           skip-cache: true # We do our own caching.
 
   codeql:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: detect-noop
     if: needs.detect-noop.outputs.noop != 'true'
 
@@ -166,7 +166,7 @@ jobs:
         uses: github/codeql-action/analyze@17573ee1cc1b9d061760f3a006fc4aac4f944fd5 # v2
 
   trivy-scan-fs:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: detect-noop
     if: needs.detect-noop.outputs.noop != 'true'
     steps:
@@ -185,7 +185,7 @@ jobs:
           severity: 'CRITICAL,HIGH'
 
   unit-tests:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: detect-noop
     if: needs.detect-noop.outputs.noop != 'true'
 
@@ -234,7 +234,7 @@ jobs:
           file: _output/tests/linux_amd64/coverage.txt
 
   e2e-tests:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: detect-noop
     if: needs.detect-noop.outputs.noop != 'true'
 
@@ -296,7 +296,7 @@ jobs:
         run: make e2e USE_HELM3=true
 
   publish-artifacts:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: detect-noop
     if: needs.detect-noop.outputs.noop != 'true'
 
@@ -396,7 +396,7 @@ jobs:
           AWS_DEFAULT_REGION: us-east-1
 
   fuzz-test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: detect-noop
     if: needs.detect-noop.outputs.noop != 'true'
 

--- a/.github/workflows/commands.yml
+++ b/.github/workflows/commands.yml
@@ -6,7 +6,7 @@ jobs:
   # NOTE(negz): See also backport.yml, which is the variant that triggers on PR
   # merge rather than on comment.
   backport:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     if: github.event.issue.pull_request && startsWith(github.event.comment.body, '/backport')
     steps:
     - name: Extract Command
@@ -33,7 +33,7 @@ jobs:
         version: v0.0.4
 
   fresh:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     if: startsWith(github.event.comment.body, '/fresh')
 
     steps:

--- a/.github/workflows/configurations.yml
+++ b/.github/workflows/configurations.yml
@@ -12,7 +12,7 @@ env:
 
 jobs:
   getting-started-with-aws:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3
@@ -43,7 +43,7 @@ jobs:
           command: push configuration -f cluster/packages/aws/getting-started-with-aws.xpkg registry.upbound.io/xp/getting-started-with-aws:${{ steps.tagger.outputs.VERSION_TAG }}
 
   getting-started-with-aws-with-vpc:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3
@@ -72,7 +72,7 @@ jobs:
           command: push configuration -f cluster/packages/aws-with-vpc/getting-started-with-aws-with-vpc.xpkg registry.upbound.io/xp/getting-started-with-aws-with-vpc:${{ steps.tagger.outputs.VERSION_TAG }}
 
   getting-started-with-gcp:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3
@@ -101,7 +101,7 @@ jobs:
           command: push configuration -f cluster/packages/gcp/getting-started-with-gcp.xpkg registry.upbound.io/xp/getting-started-with-gcp:${{ steps.tagger.outputs.VERSION_TAG }}
 
   getting-started-with-azure:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -24,7 +24,7 @@ env:
 
 jobs:
   promote-artifacts:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Checkout

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   stale:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/stale@6f05e4244c9a0b2ed3401882b05d701dd0a7289b # v7
       with:

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   create-tag:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Checkout


### PR DESCRIPTION
### Description of your changes

This PR bumps the Ubuntu version in our GH actions from `20.04` to `22.04`. 
This was primarily triggered by failing actions with `no space left` errors on `release-1.11` branch. There are previous reports on these errors and a lot of [historical context](https://github.com/actions/runner-images/issues/709). 

We have verified that the problem is not related to changes on our side by [reverting the commit](https://github.com/crossplane/crossplane/actions/runs/4260126387/jobs/7412989298), which appears to be the starting point of the failures and getting the same errors. This narrows down the problem to some issues related to GH runners, something like [this](https://github.com/orgs/community/discussions/26488#discussioncomment-3252098). So, we opportunistically tried updating Ubuntu version to `22.04`, which did help, indicating we have enough space to run our CI on that version.

Considering this is a harmless update that we would anyway want to do, I would vote to try this out.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

See https://github.com/crossplane/crossplane/actions/runs/4260183418/jobs/7413102044

[contribution process]: https://git.io/fj2m9
