### PR TITLE
chore(renovate): rebase only on conflicts

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -3,6 +3,9 @@
   "extends": [
     "config:base"
   ],
+// We only want renovate to rebase PRs when they have conflicts,
+// default "auto" mode is not required.
+  "rebaseWhen": "conflicted",
 // The maximum number of PRs to be created in parallel
   "prConcurrentLimit": 5,
 // The branches renovate should target


### PR DESCRIPTION
Signed-off-by: Philippe Scorsolini <p.scorsolini@gmail.com>

### Description of your changes

Renovate's default configuration for "[rebaseWhen](https://docs.renovatebot.com/configuration-options/#rebasewhen)" is "auto", which means that
all PRs are rebased at each new commit on the target branch. This is not
necessary and a waste of runners' time, so we can move to only rebase on
"conflicts" at least, maybe in the future we could consider also "never"
automatically rebasing PRs, and just do it manually.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

N.A.

[contribution process]: https://git.io/fj2m9
