### PR TITLE
Allow supplying additional volumes and volume mounts

### DIFF
--- a/cluster/charts/crossplane/templates/deployment.yaml
+++ b/cluster/charts/crossplane/templates/deployment.yaml
@@ -159,6 +159,9 @@ spec:
           - mountPath: /webhook/tls
             name: webhook-tls-secret
           {{- end }}
+          {{- if .Values.extraVolumeMountsCrossplane }}
+          {{- toYaml .Values.extraVolumeMountsCrossplane | nindent 10 }}
+          {{- end }}
       {{- if .Values.xfn.enabled }}
       - image: {{ .Values.xfn.image.repository }}:{{ .Values.xfn.image.tag }}
         args:
@@ -238,6 +241,9 @@ spec:
           # It's assumed that initializer generates this anyway, so it should be
           # fine.
           secretName: webhook-tls-secret
+      {{- end }}
+      {{- if .Values.extraVolumesCrossplane }}
+      {{- toYaml .Values.extraVolumesCrossplane | nindent 6 }}
       {{- end }}
       {{- if .Values.nodeSelector }}
       nodeSelector: {{ toYaml .Values.nodeSelector | nindent 8 }}

--- a/cluster/charts/crossplane/values.yaml.tmpl
+++ b/cluster/charts/crossplane/values.yaml.tmpl
@@ -95,6 +95,10 @@ podSecurityContextCrossplane: {}
 
 podSecurityContextRBACManager: {}
 
+extraVolumesCrossplane: {}
+
+extraVolumeMountsCrossplane: {}
+
 # The alpha xfn sidecar container that runs Composition Functions. Note you also
 # need to run Crossplane with --enable-composition-functions for it to call xfn.
 xfn:


### PR DESCRIPTION

<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Adds support for supplying additional volumes and volume mounts for Crossplane.

Fixes #3830 

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9

`values.yaml`
```yaml
extraVolumeMountsCrossplane:
- name: extra-volume
  mountPath: "a/very/cool/path"
  readOnly: true

extraVolumesCrossplane:
- name: extra-volume
  some: stuff
- name: cool-volume
  other: stuff
```

Output:
```yaml
# Source: crossplane/templates/deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: crossplane
  namespace: default
  labels:
    app: crossplane
    release: crossplane    
    helm.sh/chart: crossplane-0.0.1
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/component: cloud-infrastructure-controller
    app.kubernetes.io/part-of: crossplane
    app.kubernetes.io/name: crossplane
    app.kubernetes.io/instance: crossplane
    app.kubernetes.io/version: "0.0.1"
spec:
  replicas: 1
  selector:
    matchLabels:
      app: crossplane
      release: crossplane
  strategy:
    type: RollingUpdate
  template:
    metadata:
      labels:
        app: crossplane
        release: crossplane        
        helm.sh/chart: crossplane-0.0.1
        app.kubernetes.io/managed-by: Helm
        app.kubernetes.io/component: cloud-infrastructure-controller
        app.kubernetes.io/part-of: crossplane
        app.kubernetes.io/name: crossplane
        app.kubernetes.io/instance: crossplane
        app.kubernetes.io/version: "0.0.1"
    spec:
      securityContext:
        {}
      serviceAccountName: crossplane
      initContainers:
        - image: crossplane/crossplane:v1.12.0-rc.0.13.gda2e879f.dirty
          args:
          - core
          - init
          imagePullPolicy: IfNotPresent
          name: crossplane-init
          resources:
            limits:
              cpu: 100m
              memory: 512Mi
            requests:
              cpu: 100m
              memory: 256Mi
          securityContext:
            allowPrivilegeEscalation: false
            readOnlyRootFilesystem: true
            runAsGroup: 65532
            runAsUser: 65532
          env:
          - name: GOMAXPROCS
            valueFrom:
              resourceFieldRef:
                containerName: crossplane-init
                resource: limits.cpu
          - name: GOMEMLIMIT
            valueFrom:
              resourceFieldRef:
                containerName: crossplane-init
                resource: limits.memory
          - name: POD_NAMESPACE
            valueFrom:
              fieldRef:
                fieldPath: metadata.namespace
          - name: POD_SERVICE_ACCOUNT
            valueFrom:
              fieldRef:
                fieldPath: spec.serviceAccountName
      containers:
      - image: crossplane/crossplane:v1.12.0-rc.0.13.gda2e879f.dirty
        args:
        - core
        - start
        imagePullPolicy: IfNotPresent
        name: crossplane
        resources:
            limits:
              cpu: 100m
              memory: 512Mi
            requests:
              cpu: 100m
              memory: 256Mi
        securityContext:
            allowPrivilegeEscalation: false
            readOnlyRootFilesystem: true
            runAsGroup: 65532
            runAsUser: 65532
        env:
          - name: GOMAXPROCS
            valueFrom:
              resourceFieldRef:
                containerName: crossplane
                resource: limits.cpu
          - name: GOMEMLIMIT
            valueFrom:
              resourceFieldRef:
                containerName: crossplane
                resource: limits.memory
          - name: POD_NAMESPACE
            valueFrom:
              fieldRef:
                fieldPath: metadata.namespace
          - name: LEADER_ELECTION
            value: "true"
        volumeMounts:
          - mountPath: /cache
            name: package-cache
          - name: extra-volume
            mountPath: "a/very/cool/path"
            readOnly: true
      volumes:
      - name: package-cache
        emptyDir:
          medium: 
          sizeLimit: 5Mi
      - name: extra-volume
        some: stuff
      - name: cool-volume
        other: stuff
```
