### PR TITLE
Update status in composition function

### DIFF
--- a/internal/controller/apiextensions/composite/composition_ptf.go
+++ b/internal/controller/apiextensions/composite/composition_ptf.go
@@ -337,6 +337,9 @@ func (c *PTFComposer) Compose(ctx context.Context, xr resource.Composite, req Co
 	// Subsequent attempts to update that object will therefore fail. This
 	// should be okay; the caller should keep trying until this is a no-op.
 	ao := mergeOptions(filterPatches(allPatches(state.ComposedResources), patchTypesToXR()...))
+	if err := c.client.Status().Update(ctx, state.Composite); err != nil {
+		return CompositionResult{}, errors.Wrap(err, errApplyXR)
+	}
 	if err := c.client.Apply(ctx, state.Composite, ao...); err != nil {
 		return CompositionResult{}, errors.Wrap(err, errApplyXR)
 	}

--- a/internal/controller/apiextensions/composite/composition_ptf_test.go
+++ b/internal/controller/apiextensions/composite/composition_ptf_test.go
@@ -245,7 +245,8 @@ func TestPTFCompose(t *testing.T) {
 			params: params{
 				kube: &test.MockClient{
 					// We test through the ClientApplicator - Get is called by Apply.
-					MockGet: test.NewMockGetFn(errBoom),
+					MockGet:          test.NewMockGetFn(errBoom),
+					MockStatusUpdate: test.NewMockSubResourceUpdateFn(nil),
 				},
 				o: []PTFComposerOption{
 					WithCompositeConnectionDetailsFetcher(ConnectionDetailsFetcherFn(func(ctx context.Context, o resource.ConnectionSecretOwner) (managed.ConnectionDetails, error) {
@@ -287,7 +288,8 @@ func TestPTFCompose(t *testing.T) {
 						return nil
 					}),
 					// The ClientApplicator will call Update for the XR.
-					MockPatch: test.NewMockPatchFn(nil),
+					MockPatch:        test.NewMockPatchFn(nil),
+					MockStatusUpdate: test.NewMockSubResourceUpdateFn(nil),
 				},
 				o: []PTFComposerOption{
 					WithCompositeConnectionDetailsFetcher(ConnectionDetailsFetcherFn(func(ctx context.Context, o resource.ConnectionSecretOwner) (managed.ConnectionDetails, error) {
@@ -341,7 +343,8 @@ func TestPTFCompose(t *testing.T) {
 						return nil
 					}),
 					// The ClientApplicator will call Update for the XR.
-					MockPatch: test.NewMockPatchFn(nil),
+					MockPatch:        test.NewMockPatchFn(nil),
+					MockStatusUpdate: test.NewMockSubResourceUpdateFn(nil),
 				},
 				o: []PTFComposerOption{
 					WithCompositeConnectionDetailsFetcher(ConnectionDetailsFetcherFn(func(ctx context.Context, o resource.ConnectionSecretOwner) (managed.ConnectionDetails, error) {
@@ -382,8 +385,9 @@ func TestPTFCompose(t *testing.T) {
 			params: params{
 				kube: &test.MockClient{
 					// These are both called by Apply.
-					MockGet:   test.NewMockGetFn(nil),
-					MockPatch: test.NewMockPatchFn(nil),
+					MockGet:          test.NewMockGetFn(nil),
+					MockPatch:        test.NewMockPatchFn(nil),
+					MockStatusUpdate: test.NewMockSubResourceUpdateFn(nil),
 				},
 				o: []PTFComposerOption{
 					WithCompositeConnectionDetailsFetcher(ConnectionDetailsFetcherFn(func(ctx context.Context, o resource.ConnectionSecretOwner) (managed.ConnectionDetails, error) {
@@ -418,8 +422,9 @@ func TestPTFCompose(t *testing.T) {
 			params: params{
 				kube: &test.MockClient{
 					// These are both called by Apply.
-					MockGet:   test.NewMockGetFn(nil),
-					MockPatch: test.NewMockPatchFn(nil),
+					MockGet:          test.NewMockGetFn(nil),
+					MockPatch:        test.NewMockPatchFn(nil),
+					MockStatusUpdate: test.NewMockSubResourceUpdateFn(nil),
 				},
 				o: []PTFComposerOption{
 					WithCompositeConnectionDetailsFetcher(ConnectionDetailsFetcherFn(func(ctx context.Context, o resource.ConnectionSecretOwner) (managed.ConnectionDetails, error) {


### PR DESCRIPTION
### Description of your changes
Fixes issue where composition functions do not update the defined status fields in the XR.
Fixes #3812 

I have:

- [X] Read and followed Crossplane's [contribution process].
- [X] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested
Created a function container that just updates values in the definition status fields.
