### PR TITLE
chore: update created property when building packages with crank

### DIFF
--- a/cmd/crank/push.go
+++ b/cmd/crank/push.go
@@ -18,9 +18,12 @@ package main
 
 import (
 	"os"
+	"time"
 
 	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/name"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/mutate"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"github.com/google/go-containerregistry/pkg/v1/tarball"
 	"github.com/spf13/afero"
@@ -75,6 +78,13 @@ func (c *pushCmd) Run(child *pushChild, logger logging.Logger) error {
 		logger.Debug("Failed to create image from package tarball", "error", err)
 		return err
 	}
+	createTime := v1.Time{Time: time.Now()}
+	img, err = mutate.CreatedAt(img, createTime)
+	if err != nil {
+		logger.Debug("Failed to mutate image with current timestamp", "error", err)
+		return err
+	}
+
 	if err := remote.Write(tag, img, remote.WithAuthFromKeychain(authn.DefaultKeychain)); err != nil {
 		logger.Debug("Failed to push created image to remote location", "error", err)
 		return err


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
When publishing packages to our private Gitlab, I noticed the timestamp associated with the image was always `0001-01-01T00:00:00Z` causing Gitlab to display it improperly as seen below.  I presume this would also cause the automatic registry cleanup to not operate as expected since it uses this property.

![image](https://user-images.githubusercontent.com/64557460/225961422-f1eb675d-44e6-42f6-87d1-6344f73f545e.png)

The changes in this MR add the current timestamp when publishing images using the crank bin.  
Be gentle...I really don't know Go.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

I tested this by running a local registry, making a version of the crank bin with my changes, then pushing a package.
The manifest went from the old timestamp:
```
   "history": [
      {
         "v1Compatibility": "{\"architecture\":\"\",\"config\":{},\"created\":\"0001-01-01T00:00:00Z\",\"id\":\"bf1b087d164de1d5c0b6119fbd60801f2aa0cdebac4d14775f4fd330529f39e5\",\"os\":\"\"}"
      }
   ],
```
to the current timestamp:
```
   "history": [
      {
         "v1Compatibility": "{\"architecture\":\"\",\"config\":{},\"created\":\"2023-03-17T12:07:32.280151-04:00\",\"id\":\"75084279a52165c7384a2808c20e83bc7f3a75e9b739f790095111d35c4ddbb9\",\"os\":\"\"}"
      }
   ],
```

I then pushed the package to our private Gitlab and verified the timestamp was correct:
![image](https://user-images.githubusercontent.com/64557460/225965716-acd136b1-6790-416a-9e63-a7690322eef9.png)



After adding the SOURCE_DATE_EPOCH environment variable support I performed the following tests:
Tested SOURCE_DATE_EPOCH unset:
`"created\":\"0001-01-01T00:00:00Z\"`

Tested SOURCE_DATE_EPOCH set to an invalid string:
kubectl crossplane: error: main.pushCmd.Run(): strconv.ParseInt: parsing "derp": invalid syntax

Tested SOURCE_DATE_EPOCH set to `date +%s`:
`"created\":\"2023-03-17T15:46:43-04:00\"`

[contribution process]: https://git.io/fj2m9
