### PR TITLE
make the status of XR and XRC the same

### DIFF
--- a/internal/controller/apiextensions/claim/configurator_test.go
+++ b/internal/controller/apiextensions/claim/configurator_test.go
@@ -668,6 +668,9 @@ func TestClaimConfigure(t *testing.T) {
 							},
 							"status": map[string]any{
 								"previousCoolness": 23,
+								// ubabailableObjects and availableObjects are the same with unavailableReplicas and availaableReplicas
+								// unavailableReplicas changes to availableReplicas when the pods are all ready.
+								"unavailableObjects": 1,
 								"conditions": []map[string]any{
 									{
 										"type": "someCondition",
@@ -690,6 +693,7 @@ func TestClaimConfigure(t *testing.T) {
 							},
 							"status": map[string]any{
 								"previousCoolness": 28,
+								"availableObjects": 1,
 								"conditions": []map[string]any{
 									{
 										"type": "otherCondition",

--- a/internal/controller/apiextensions/claim/configurator_test.go
+++ b/internal/controller/apiextensions/claim/configurator_test.go
@@ -667,9 +667,7 @@ func TestClaimConfigure(t *testing.T) {
 								"writeConnectionSecretToRef": "ref",
 							},
 							"status": map[string]any{
-								"previousCoolness": 23,
-								// unavailableObjects and availableObjects are the same with unavailableReplicas and availaableReplicas
-								// unavailableReplicas changes to availableReplicas when the pods are all ready.
+								"previousCoolness":   23,
 								"unavailableObjects": 1,
 								"conditions": []map[string]any{
 									{

--- a/internal/controller/apiextensions/claim/configurator_test.go
+++ b/internal/controller/apiextensions/claim/configurator_test.go
@@ -668,7 +668,7 @@ func TestClaimConfigure(t *testing.T) {
 							},
 							"status": map[string]any{
 								"previousCoolness": 23,
-								// ubabailableObjects and availableObjects are the same with unavailableReplicas and availaableReplicas
+								// unavailableObjects and availableObjects are the same with unavailableReplicas and availaableReplicas
 								// unavailableReplicas changes to availableReplicas when the pods are all ready.
 								"unavailableObjects": 1,
 								"conditions": []map[string]any{

--- a/internal/controller/apiextensions/claim/configurator_test.go
+++ b/internal/controller/apiextensions/claim/configurator_test.go
@@ -718,6 +718,7 @@ func TestClaimConfigure(t *testing.T) {
 							},
 							"status": map[string]any{
 								"previousCoolness": 28,
+								"availableObjects": 1,
 								"conditions": []map[string]any{
 									{
 										"type": "someCondition",

--- a/internal/controller/apiextensions/composite/composition_patches.go
+++ b/internal/controller/apiextensions/composite/composition_patches.go
@@ -172,7 +172,7 @@ func ApplyFromFieldPathPatch(p v1.Patch, from, to runtime.Object) error {
 
 	in, err := fieldpath.Pave(fromMap).GetValue(*p.FromFieldPath)
 	if IsOptionalFieldPathNotFound(err, p.Policy) {
-		return nil
+		return removeToFieldValueToObject(*p.ToFieldPath, to)
 	}
 	if err != nil {
 		return err

--- a/internal/controller/apiextensions/composite/merge.go
+++ b/internal/controller/apiextensions/composite/merge.go
@@ -99,3 +99,18 @@ func patchFieldValueToObject(fieldPath string, value any, to runtime.Object, mo 
 
 	return runtime.DefaultUnstructuredConverter.FromUnstructured(paved.UnstructuredContent(), to)
 }
+
+// removeToFieldValueToObject removes the given fieldPath to the "to" object
+// returning any errors as they occur.
+func removeToFieldValueToObject(fieldPath string, to runtime.Object) error {
+	paved, err := fieldpath.PaveObject(to)
+	if err != nil {
+		return err
+	}
+
+	if err := paved.DeleteField(fieldPath); err != nil {
+		return err
+	}
+
+	return runtime.DefaultUnstructuredConverter.FromUnstructured(paved.UnstructuredContent(), to)
+}

--- a/internal/xcrd/schemas.go
+++ b/internal/xcrd/schemas.go
@@ -318,6 +318,37 @@ func CompositeResourceClaimSpecProps() map[string]extv1.JSONSchemaProps {
 	}
 }
 
+// CompositeResourceClaimStatusProps is a partial OpenAPIV3Schema for the status
+// fields that Crossplane expects to be present for all defined or published
+// infrastructure resources.
+func CompositeResourceClaimStatusProps() map[string]extv1.JSONSchemaProps {
+	return map[string]extv1.JSONSchemaProps{
+		"conditions": {
+			Description: "Conditions of the resource.",
+			Type:        "array",
+			Items: &extv1.JSONSchemaPropsOrArray{
+				Schema: &extv1.JSONSchemaProps{
+					Type:     "object",
+					Required: []string{"lastTransitionTime", "reason", "status", "type"},
+					Properties: map[string]extv1.JSONSchemaProps{
+						"lastTransitionTime": {Type: "string", Format: "date-time"},
+						"message":            {Type: "string"},
+						"reason":             {Type: "string"},
+						"status":             {Type: "string"},
+						"type":               {Type: "string"},
+					},
+				},
+			},
+		},
+		"connectionDetails": {
+			Type: "object",
+			Properties: map[string]extv1.JSONSchemaProps{
+				"lastPublishedTime": {Type: "string", Format: "date-time"},
+			},
+		},
+	}
+}
+
 // CompositeResourceStatusProps is a partial OpenAPIV3Schema for the status
 // fields that Crossplane expects to be present for all defined or published
 // infrastructure resources.


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #3542 

I accidentally delete the branch so I create a new PR.
I fixed the merge function for XRC to have the same status as XR.

**what Crossplane does currently.**

when the status of XR is like
```
  nginx:
    availableReplicas: 1
```

the status of XRC is like
```
  nginx:
    availableReplicas: 1
    unavailableReplicas: 1
```


**and what I changed.**
when the status of XR is like
```
  nginx:
    availableReplicas: 1
```

the status of XRC is like
```
  nginx:
    availableReplicas: 1
```

I didn't write any docs for these changes. because there is nothing to be changed with policies. 
If I should write about this, please let me know 

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to be tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

I added a test code for this on ConfigureStatus in configurator_test.go

### e2d test scenario I've tested.
I installed this version on my test cluster which is made with bare metal servers with AWS provider.
security groups, load balancers, eip were created by the crossplane on my cluster and have nothing wrong with it.
And I also created a composition with k8s provider and aws provider.
the version of aws provider : v0.38.0
the version of kubernetes provider: v0.7.0

### The Result
when I configured replicas 1, there are availableReplicas on the status.
```
apiVersion: front.aws.io/v1alpha1
kind: Nginx
metadata:
  annotations:
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"front.aws.io/v1alpha1","kind":"Nginx","metadata":{"annotations":{},"name":"front-dev","namespace":"sgs-dev"},"spec":{"compositionRef":{"name":"nginx"},"nginx":{"replicas":1}}}
  creationTimestamp: "2023-03-28T02:58:25Z"
  finalizers:
  - finalizer.apiextensions.crossplane.io
  generation: 3
  name: front-dev
  namespace: sgs-dev
  resourceVersion: "15091943"
  uid: 52f76145-9a41-4ad6-8be0-5032511169d8
spec:
  compositeDeletePolicy: Background
  compositionRef:
    name: nginx
  compositionRevisionRef:
    name: nginx-508f65d
  compositionUpdatePolicy: Automatic
  nginx:
    replicas: 1
  resourceRef:
    apiVersion: front.aws.io/v1alpha1
    kind: XNginx
    name: front-dev-fkjf7
status:
  conditions:
  - lastTransitionTime: "2023-03-28T02:58:25Z"
    reason: ReconcileSuccess
    status: "True"
    type: Synced
  - lastTransitionTime: "2023-03-28T03:00:07Z"
    reason: Available
    status: "True"
    type: Ready
  nginx:
    availableReplicas: 1
    conditions:
    - lastTransitionTime: "2023-03-28T02:58:37Z"
      lastUpdateTime: "2023-03-28T02:58:37Z"
      message: Deployment has minimum availability.
      reason: MinimumReplicasAvailable
      status: "True"
      type: Available
    - lastTransitionTime: "2023-03-28T02:58:26Z"
      lastUpdateTime: "2023-03-28T02:58:37Z"
      message: ReplicaSet "front-dev-f64f7d7d9" has successfully progressed.
      reason: NewReplicaSetAvailable
      status: "True"
      type: Progressing
    observedGeneration: 1
    replicas: 1
    updatedReplicas: 1
```
And then I configured the replicas to 0, and the availableReplicas field on status disappeared either.
```
apiVersion: front.aws.io/v1alpha1
kind: Nginx
metadata:
  annotations:
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"front.aws.io/v1alpha1","kind":"Nginx","metadata":{"annotations":{},"name":"front-dev","namespace":"sgs-dev"},"spec":{"compositionRef":{"name":"nginx"},"nginx":{"replicas":1}}}
  creationTimestamp: "2023-03-28T02:58:25Z"
  finalizers:
  - finalizer.apiextensions.crossplane.io
  generation: 4
  name: front-dev
  namespace: sgs-dev
  resourceVersion: "15093457"
  uid: 52f76145-9a41-4ad6-8be0-5032511169d8
spec:
  compositeDeletePolicy: Background
  compositionRef:
    name: nginx
  compositionRevisionRef:
    name: nginx-508f65d
  compositionUpdatePolicy: Automatic
  nginx:
    replicas: 0
  resourceRef:
    apiVersion: front.aws.io/v1alpha1
    kind: XNginx
    name: front-dev-fkjf7
status:
  conditions:
  - lastTransitionTime: "2023-03-28T02:58:25Z"
    reason: ReconcileSuccess
    status: "True"
    type: Synced
  - lastTransitionTime: "2023-03-28T03:02:07Z"
    reason: Composite resource claim is waiting for composite resource to become Ready
    status: "False"
    type: Ready
  nginx:
    conditions:
    - lastTransitionTime: "2023-03-28T02:58:37Z"
      lastUpdateTime: "2023-03-28T02:58:37Z"
      message: Deployment has minimum availability.
      reason: MinimumReplicasAvailable
      status: "True"
      type: Available
    - lastTransitionTime: "2023-03-28T02:58:26Z"
      lastUpdateTime: "2023-03-28T02:58:37Z"
      message: ReplicaSet "front-dev-f64f7d7d9" has successfully progressed.
      reason: NewReplicaSetAvailable
      status: "True"
      type: Progressing
    observedGeneration: 2
```


### these are my composition, compositeresource, compositeresourcedefinition
#### compositeresource
```
apiVersion: front.aws.io/v1alpha1
kind: Nginx
metadata:
  name: front-dev
spec:
  compositionRef:
    name: nginx
  nginx:
    replicas: 1

```
 
#### composition
```
apiVersion: apiextensions.crossplane.io/v1
kind: Composition
metadata:
  labels:
    crossplane.io/xrd: xnginxs.front.aws.io
  name: nginx
spec:
  compositeTypeRef:
    apiVersion: front.aws.io/v1alpha1
    kind: XNginx
  publishConnectionDetailsWithStoreConfigRef:
    name: default
  resources:
    - name: nginx-deployment
      base:
        apiVersion: kubernetes.crossplane.io/v1alpha1
        kind: Object
        spec:
          forProvider:
            manifest:
              apiVersion: apps/v1
              kind: Deployment
              spec:
                replicas: 1
                selector:
                  matchLabels:
                    app: ""
                template:
                  metadata:
                    labels:
                      app: ""
                  spec:
                    containers:
                      - name: front
                        image: nginx:latest
                        imagePullPolicy: IfNotPresent
                        livenessProbe:
                          failureThreshold: 3
                          periodSeconds: 10
                          successThreshold: 1
                          tcpSocket:
                            port: http
                          timeoutSeconds: 1
                        ports:
                          - containerPort: 80
                            name: http
                            protocol: TCP
                        readinessProbe:
                          failureThreshold: 3
                          tcpSocket:
                            port: http
                          periodSeconds: 10
                          successThreshold: 1
                          timeoutSeconds: 1
                        resources: {}
                        startupProbe:
                          failureThreshold: 3
                          tcpSocket:
                            port: http
                          periodSeconds: 10
                          successThreshold: 1
                          timeoutSeconds: 1
                    imagePullSecrets:
                      - name: regcred
          providerConfigRef:
            name: provider-kubernetes-in-cluster
      patches:
        - fromFieldPath: metadata.labels[crossplane.io/claim-name]
          toFieldPath: metadata.name
          type: FromCompositeFieldPath
        - fromFieldPath: metadata.labels[crossplane.io/claim-namespace]
          toFieldPath: spec.forProvider.manifest.metadata.namespace
          type: FromCompositeFieldPath
        - fromFieldPath: spec.nginx.replicas
          toFieldPath: spec.forProvider.manifest.spec.replicas
          type: FromCompositeFieldPath
        - fromFieldPath: status.atProvider.manifest.status.conditions
          toFieldPath: status.nginx.conditions
          type: ToCompositeFieldPath
        - fromFieldPath: status.atProvider.manifest.status.replicas
          toFieldPath: status.nginx.replicas
          type: ToCompositeFieldPath
        - fromFieldPath: status.atProvider.manifest.status.observedGeneration
          toFieldPath: status.nginx.observedGeneration
          type: ToCompositeFieldPath
        - fromFieldPath: status.atProvider.manifest.status.availableReplicas
          toFieldPath: status.nginx.availableReplicas
          type: ToCompositeFieldPath
        - fromFieldPath: status.atProvider.manifest.status.updatedReplicas
          toFieldPath: status.nginx.updatedReplicas
          type: ToCompositeFieldPath
      readinessChecks:
        - fieldPath: status.atProvider.manifest.status.availableReplicas
          type: NonEmpty
  writeConnectionSecretsToNamespace: crossplane-system
```

#### compositeresource definition
```
apiVersion: apiextensions.crossplane.io/v1
kind: CompositeResourceDefinition
metadata:
  labels:
    app.kubernetes.io/instance: crossplane-nginxcf
  name: xnginxs.front.aws.io
spec:
  claimNames:
    kind: Nginx
    plural: nginxs
  group: front.aws.io
  names:
    kind: XNginx
    plural: xnginxs
  versions:
    - name: v1alpha1
      referenceable: true
      schema:
        openAPIV3Schema:
          properties:
            spec:
              properties:
                nginx:
                  properties:
                    replicas:
                      type: integer
                  required:
                    - replicas
                  type: object
              required:
                - nginx
              type: object
            status:
              properties:
                nginx:
                  properties:
                    availableReplicas:
                      description:
                        Total number of available pods (ready for at least
                        minReadySeconds) targeted by this Prometheus deployment.
                      format: int32
                      type: integer
                    conditions:
                      description: Conditions of the resource.
                      items:
                        description: A Condition that may apply to a resource.
                        properties:
                          lastTransitionTime:
                            format: date-time
                            type: string
                          lastUpdateTime:
                            format: date-time
                            type: string
                          message:
                            type: string
                          reason:
                            type: string
                          status:
                            type: string
                          type:
                            type: string
                        required:
                          - lastTransitionTime
                          - reason
                          - status
                          - type
                        type: object
                      type: array
                    observedGeneration:
                      format: int32
                      type: integer
                    replicas:
                      description:
                        Total number of non-terminated pods targeted by this
                        Prometheus deployment (their labels match the selector).
                      format: int32
                      type: integer
                    unavailableReplicas:
                      description:
                        Total number of unavailable pods targeted by this
                        Prometheus deployment.
                      format: int32
                      type: integer
                    updatedReplicas:
                      description:
                        Total number of non-terminated pods targeted by this
                        Prometheus deployment that have the desired version spec.
                      format: int32
                      type: integer
                  type: object
              type: object
          type: object
      served: true

```

[contribution process]: https://git.io/fj2m9
