### PR TITLE
fix(helm): #3891 - add hostNetwork functionality to crossplane pod

### DIFF
--- a/cluster/charts/crossplane/README.md
+++ b/cluster/charts/crossplane/README.md
@@ -80,6 +80,7 @@ and their default values.
 | `customAnnotations` | Custom annotations to add to the Crossplane deployment and pod | `{}` |
 | `serviceAccount.customAnnotations` | Custom annotations to add to the serviceaccount of Crossplane | `{}` |
 | `priorityClassName` | Priority class name for Crossplane and RBAC Manager (if enabled) pods | `""` |
+| `hostNetwork` | Enable hostNetwork for Crossplane | `false` |
 | `resourcesCrossplane.limits.cpu` | CPU resource limits for Crossplane | `100m` |
 | `resourcesCrossplane.limits.memory` | Memory resource limits for Crossplane | `512Mi` |
 | `resourcesCrossplane.requests.cpu` | CPU resource requests for Crossplane | `100m` |

--- a/cluster/charts/crossplane/README.md
+++ b/cluster/charts/crossplane/README.md
@@ -80,7 +80,7 @@ and their default values.
 | `customAnnotations` | Custom annotations to add to the Crossplane deployment and pod | `{}` |
 | `serviceAccount.customAnnotations` | Custom annotations to add to the serviceaccount of Crossplane | `{}` |
 | `priorityClassName` | Priority class name for Crossplane and RBAC Manager (if enabled) pods | `""` |
-| `hostNetwork` | Enable hostNetwork for Crossplane | `false` |
+| `hostNetwork` | Enable hostNetwork for Crossplane. Caution: setting it to true means Crossplane's Pod will have high privileges. | `false` |
 | `resourcesCrossplane.limits.cpu` | CPU resource limits for Crossplane | `100m` |
 | `resourcesCrossplane.limits.memory` | Memory resource limits for Crossplane | `512Mi` |
 | `resourcesCrossplane.requests.cpu` | CPU resource requests for Crossplane | `100m` |

--- a/cluster/charts/crossplane/templates/deployment.yaml
+++ b/cluster/charts/crossplane/templates/deployment.yaml
@@ -42,6 +42,7 @@ spec:
       priorityClassName: {{ .Values.priorityClassName  | quote }}
       {{- end }}
       serviceAccountName: {{ template "crossplane.name" . }}
+      hostNetwork: {{ .Values.hostNetwork }}
       initContainers:
         - image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
           args:

--- a/cluster/charts/crossplane/values.yaml.tmpl
+++ b/cluster/charts/crossplane/values.yaml.tmpl
@@ -11,6 +11,7 @@ nodeSelector: {}
 tolerations: []
 affinity: {}
 
+# -- Enable hostNetwork for Crossplane. Caution: setting it to true means Crossplane's Pod will have high privileges.
 hostNetwork: false
 
 # -- Custom labels to add into metadata

--- a/cluster/charts/crossplane/values.yaml.tmpl
+++ b/cluster/charts/crossplane/values.yaml.tmpl
@@ -11,6 +11,8 @@ nodeSelector: {}
 tolerations: []
 affinity: {}
 
+hostNetwork: false
+
 # -- Custom labels to add into metadata
 customLabels: {}
 


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

Adds the ability to set `hostNetwork` on the crossplane pod for running in an environment where the Kubernetes control-plane can not access pods directly. For example, when running an EKS cluster with an alternative CNI such as Cilium or Calico. 

Fixes #3891 

