### PR TITLE
fixed crun 1.8.1 support

### DIFF
--- a/internal/oci/spec/spec.go
+++ b/internal/oci/spec/spec.go
@@ -111,10 +111,10 @@ func New(o ...Option) (*runtime.Spec, error) {
 				Options:     []string{"nosuid", "strictatime", "mode=755", "size=65536k"},
 			},
 			{
-				Type:        "sysfs",
+				Type:        "bind",
 				Destination: "/sys",
-				Source:      "sysfs",
-				Options:     []string{"nosuid", "noexec", "nodev", "ro"},
+				Source:      "/sys",
+				Options:     []string{"rprivate", "nosuid", "noexec", "nodev", "ro", "rbind"},
 			},
 
 			{


### PR DESCRIPTION
### Description of your changes
Fixes #3807 

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

Tested it on EKS with manually built crun versions 1.5, 1.6, 1.7, 1.8
