### PR TITLE
Add Audits section to SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -5,6 +5,16 @@ This policy is adapted from the policies of the following CNCF projects:
 * [Rook](https://github.com/rook/rook)
 * [Containerd](https://github.com/containerd/project)
 
+## Audits
+
+The following security related audits have been performed in the Crossplane
+project and are available for download from the [security folder](./security)
+and from the direct links below:
+
+* A fuzzing security audit was completed in March 2023 by [Ada
+  Logics](https://adalogics.com/). The full report is available
+  [here](./security/ADA-fuzzing-audit-22.pdf).
+
 ## Reporting a Vulnerability
 
 To report a vulnerability, either:


### PR DESCRIPTION
### Description of your changes

This PR adds a new brief section to the SECURITY.md file where we can link to security audits performed on the project.  With the Fuzzing audit just completed, and an upcoming full audit soon, this will help with the discoverability of these audit reports.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

I have tested the rendered markdown and all links in my fork: https://github.com/jbw976/crossplane/blob/link-fuzz-audit/SECURITY.md#audits

[contribution process]: https://git.io/fj2m9
