### PR TITLE
feat: In `match` transform, allow fallback to input

### DIFF
--- a/apis/apiextensions/v1/composition_transforms.go
+++ b/apis/apiextensions/v1/composition_transforms.go
@@ -290,6 +290,8 @@ type MatchTransform struct {
 	// The fallback value that should be returned by the transform if now pattern
 	// matches.
 	FallbackValue extv1.JSON `json:"fallbackValue,omitempty"`
+	// If set to true, the input value will be returned if no pattern matches.
+	FallbackToInput bool `json:"fallbackToInput,omitempty"`
 }
 
 // Validate checks this MatchTransform is valid.

--- a/apis/apiextensions/v1/composition_transforms.go
+++ b/apis/apiextensions/v1/composition_transforms.go
@@ -300,6 +300,9 @@ type MatchTransform struct {
 	// matches.
 	FallbackValue extv1.JSON `json:"fallbackValue,omitempty"`
 	// Determines to what value the transform should fallback if no pattern matches.
+	// +optional
+	// +kubebuilder:validation:Enum=Value;Input
+	// +kubebuilder:default=Value
 	FallbackTo MatchFallbackTo `json:"fallbackTo,omitempty"`
 }
 

--- a/apis/apiextensions/v1/composition_transforms.go
+++ b/apis/apiextensions/v1/composition_transforms.go
@@ -279,6 +279,15 @@ func (m *MapTransform) MarshalJSON() ([]byte, error) {
 	return json.Marshal(m.Pairs)
 }
 
+// MatchFallbackTo defines how a match operation will fallback.
+type MatchFallbackTo string
+
+// Valid MatchFallbackTo.
+const (
+	MatchFallbackToTypeValue MatchFallbackTo = "Value"
+	MatchFallbackToTypeInput MatchFallbackTo = "Input"
+)
+
 // MatchTransform is a more complex version of a map transform that matches a
 // list of patterns.
 type MatchTransform struct {
@@ -290,8 +299,8 @@ type MatchTransform struct {
 	// The fallback value that should be returned by the transform if now pattern
 	// matches.
 	FallbackValue extv1.JSON `json:"fallbackValue,omitempty"`
-	// If set to true, the input value will be returned if no pattern matches.
-	FallbackToInput bool `json:"fallbackToInput,omitempty"`
+	// Determines to what value the transform should fallback if no pattern matches.
+	FallbackTo MatchFallbackTo `json:"fallbackTo,omitempty"`
 }
 
 // Validate checks this MatchTransform is valid.

--- a/apis/apiextensions/v1/zz_generated.conversion.go
+++ b/apis/apiextensions/v1/zz_generated.conversion.go
@@ -417,6 +417,7 @@ func (c *GeneratedRevisionSpecConverter) v1MatchTransformToV1beta1MatchTransform
 	}
 	v1beta1MatchTransform.Patterns = v1beta1MatchTransformPatternList
 	v1beta1MatchTransform.FallbackValue = c.v1JSONToV1JSON(source.FallbackValue)
+	v1beta1MatchTransform.FallbackToInput = source.FallbackToInput
 	return v1beta1MatchTransform
 }
 func (c *GeneratedRevisionSpecConverter) v1MathTransformToV1beta1MathTransform(source MathTransform) v1beta1.MathTransform {
@@ -923,6 +924,7 @@ func (c *GeneratedRevisionSpecConverter) v1beta1MatchTransformToV1MatchTransform
 	}
 	v1MatchTransform.Patterns = v1MatchTransformPatternList
 	v1MatchTransform.FallbackValue = c.v1JSONToV1JSON(source.FallbackValue)
+	v1MatchTransform.FallbackToInput = source.FallbackToInput
 	return v1MatchTransform
 }
 func (c *GeneratedRevisionSpecConverter) v1beta1MathTransformToV1MathTransform(source v1beta1.MathTransform) MathTransform {

--- a/apis/apiextensions/v1/zz_generated.conversion.go
+++ b/apis/apiextensions/v1/zz_generated.conversion.go
@@ -417,7 +417,7 @@ func (c *GeneratedRevisionSpecConverter) v1MatchTransformToV1beta1MatchTransform
 	}
 	v1beta1MatchTransform.Patterns = v1beta1MatchTransformPatternList
 	v1beta1MatchTransform.FallbackValue = c.v1JSONToV1JSON(source.FallbackValue)
-	v1beta1MatchTransform.FallbackToInput = source.FallbackToInput
+	v1beta1MatchTransform.FallbackTo = v1beta1.MatchFallbackTo(source.FallbackTo)
 	return v1beta1MatchTransform
 }
 func (c *GeneratedRevisionSpecConverter) v1MathTransformToV1beta1MathTransform(source MathTransform) v1beta1.MathTransform {
@@ -924,7 +924,7 @@ func (c *GeneratedRevisionSpecConverter) v1beta1MatchTransformToV1MatchTransform
 	}
 	v1MatchTransform.Patterns = v1MatchTransformPatternList
 	v1MatchTransform.FallbackValue = c.v1JSONToV1JSON(source.FallbackValue)
-	v1MatchTransform.FallbackToInput = source.FallbackToInput
+	v1MatchTransform.FallbackTo = MatchFallbackTo(source.FallbackTo)
 	return v1MatchTransform
 }
 func (c *GeneratedRevisionSpecConverter) v1beta1MathTransformToV1MathTransform(source v1beta1.MathTransform) MathTransform {

--- a/apis/apiextensions/v1alpha1/zz_generated.revision_types.go
+++ b/apis/apiextensions/v1alpha1/zz_generated.revision_types.go
@@ -581,6 +581,8 @@ type MatchTransform struct {
 	// The fallback value that should be returned by the transform if now pattern
 	// matches.
 	FallbackValue extv1.JSON `json:"fallbackValue,omitempty"`
+	// If set to true, the input value will be returned if no pattern matches.
+	FallbackToInput bool `json:"fallbackToInput,omitempty"`
 }
 
 // MatchTransformPatternType defines the type of a MatchTransformPattern.

--- a/apis/apiextensions/v1alpha1/zz_generated.revision_types.go
+++ b/apis/apiextensions/v1alpha1/zz_generated.revision_types.go
@@ -591,6 +591,9 @@ type MatchTransform struct {
 	// matches.
 	FallbackValue extv1.JSON `json:"fallbackValue,omitempty"`
 	// Determines to what value the transform should fallback if no pattern matches.
+	// +optional
+	// +kubebuilder:validation:Enum=Value;Input
+	// +kubebuilder:default=Value
 	FallbackTo MatchFallbackTo `json:"fallbackTo,omitempty"`
 }
 

--- a/apis/apiextensions/v1alpha1/zz_generated.revision_types.go
+++ b/apis/apiextensions/v1alpha1/zz_generated.revision_types.go
@@ -570,6 +570,15 @@ func (m *MapTransform) Resolve(input any) (any, error) {
 	}
 }
 
+// MatchFallbackTo defines how a match operation will fallback.
+type MatchFallbackTo string
+
+// Valid MatchFallbackTo.
+const (
+	MatchFallbackToTypeValue MatchFallbackTo = "Value"
+	MatchFallbackToTypeInput MatchFallbackTo = "Input"
+)
+
 // MatchTransform is a more complex version of a map transform that matches a
 // list of patterns.
 type MatchTransform struct {
@@ -581,8 +590,8 @@ type MatchTransform struct {
 	// The fallback value that should be returned by the transform if now pattern
 	// matches.
 	FallbackValue extv1.JSON `json:"fallbackValue,omitempty"`
-	// If set to true, the input value will be returned if no pattern matches.
-	FallbackToInput bool `json:"fallbackToInput,omitempty"`
+	// Determines to what value the transform should fallback if no pattern matches.
+	FallbackTo MatchFallbackTo `json:"fallbackTo,omitempty"`
 }
 
 // MatchTransformPatternType defines the type of a MatchTransformPattern.

--- a/apis/apiextensions/v1beta1/revision_types.go
+++ b/apis/apiextensions/v1beta1/revision_types.go
@@ -589,6 +589,9 @@ type MatchTransform struct {
 	// matches.
 	FallbackValue extv1.JSON `json:"fallbackValue,omitempty"`
 	// Determines to what value the transform should fallback if no pattern matches.
+	// +optional
+	// +kubebuilder:validation:Enum=Value;Input
+	// +kubebuilder:default=Value
 	FallbackTo MatchFallbackTo `json:"fallbackTo,omitempty"`
 }
 

--- a/apis/apiextensions/v1beta1/revision_types.go
+++ b/apis/apiextensions/v1beta1/revision_types.go
@@ -579,6 +579,8 @@ type MatchTransform struct {
 	// The fallback value that should be returned by the transform if now pattern
 	// matches.
 	FallbackValue extv1.JSON `json:"fallbackValue,omitempty"`
+	// If set to true, the input value will be returned if no pattern matches.
+	FallbackToInput bool `json:"fallbackToInput,omitempty"`
 }
 
 // MatchTransformPatternType defines the type of a MatchTransformPattern.

--- a/apis/apiextensions/v1beta1/revision_types.go
+++ b/apis/apiextensions/v1beta1/revision_types.go
@@ -568,6 +568,15 @@ func (m *MapTransform) Resolve(input any) (any, error) {
 	}
 }
 
+// MatchFallbackTo defines how a match operation will fallback.
+type MatchFallbackTo string
+
+// Valid MatchFallbackTo.
+const (
+	MatchFallbackToTypeValue MatchFallbackTo = "Value"
+	MatchFallbackToTypeInput MatchFallbackTo = "Input"
+)
+
 // MatchTransform is a more complex version of a map transform that matches a
 // list of patterns.
 type MatchTransform struct {
@@ -579,8 +588,8 @@ type MatchTransform struct {
 	// The fallback value that should be returned by the transform if now pattern
 	// matches.
 	FallbackValue extv1.JSON `json:"fallbackValue,omitempty"`
-	// If set to true, the input value will be returned if no pattern matches.
-	FallbackToInput bool `json:"fallbackToInput,omitempty"`
+	// Determines to what value the transform should fallback if no pattern matches.
+	FallbackTo MatchFallbackTo `json:"fallbackTo,omitempty"`
 }
 
 // MatchTransformPatternType defines the type of a MatchTransformPattern.

--- a/cluster/crds/apiextensions.crossplane.io_compositionrevisions.yaml
+++ b/cluster/crds/apiextensions.crossplane.io_compositionrevisions.yaml
@@ -272,6 +272,10 @@ spec:
                                 description: Match is a more complex version of Map
                                   that matches a list of patterns.
                                 properties:
+                                  fallbackToInput:
+                                    description: If set to true, the input value will
+                                      be returned if no pattern matches.
+                                    type: boolean
                                   fallbackValue:
                                     description: The fallback value that should be
                                       returned by the transform if now pattern matches.
@@ -683,6 +687,10 @@ spec:
                                   description: Match is a more complex version of
                                     Map that matches a list of patterns.
                                   properties:
+                                    fallbackToInput:
+                                      description: If set to true, the input value
+                                        will be returned if no pattern matches.
+                                      type: boolean
                                     fallbackValue:
                                       description: The fallback value that should
                                         be returned by the transform if now pattern
@@ -1069,6 +1077,10 @@ spec:
                                   description: Match is a more complex version of
                                     Map that matches a list of patterns.
                                   properties:
+                                    fallbackToInput:
+                                      description: If set to true, the input value
+                                        will be returned if no pattern matches.
+                                      type: boolean
                                     fallbackValue:
                                       description: The fallback value that should
                                         be returned by the transform if now pattern
@@ -1577,6 +1589,10 @@ spec:
                                 description: Match is a more complex version of Map
                                   that matches a list of patterns.
                                 properties:
+                                  fallbackToInput:
+                                    description: If set to true, the input value will
+                                      be returned if no pattern matches.
+                                    type: boolean
                                   fallbackValue:
                                     description: The fallback value that should be
                                       returned by the transform if now pattern matches.
@@ -1988,6 +2004,10 @@ spec:
                                   description: Match is a more complex version of
                                     Map that matches a list of patterns.
                                   properties:
+                                    fallbackToInput:
+                                      description: If set to true, the input value
+                                        will be returned if no pattern matches.
+                                      type: boolean
                                     fallbackValue:
                                       description: The fallback value that should
                                         be returned by the transform if now pattern
@@ -2374,6 +2394,10 @@ spec:
                                   description: Match is a more complex version of
                                     Map that matches a list of patterns.
                                   properties:
+                                    fallbackToInput:
+                                      description: If set to true, the input value
+                                        will be returned if no pattern matches.
+                                      type: boolean
                                     fallbackValue:
                                       description: The fallback value that should
                                         be returned by the transform if now pattern

--- a/cluster/crds/apiextensions.crossplane.io_compositionrevisions.yaml
+++ b/cluster/crds/apiextensions.crossplane.io_compositionrevisions.yaml
@@ -272,10 +272,10 @@ spec:
                                 description: Match is a more complex version of Map
                                   that matches a list of patterns.
                                 properties:
-                                  fallbackToInput:
-                                    description: If set to true, the input value will
-                                      be returned if no pattern matches.
-                                    type: boolean
+                                  fallbackTo:
+                                    description: Determines to what value the transform
+                                      should fallback if no pattern matches.
+                                    type: string
                                   fallbackValue:
                                     description: The fallback value that should be
                                       returned by the transform if now pattern matches.
@@ -687,10 +687,10 @@ spec:
                                   description: Match is a more complex version of
                                     Map that matches a list of patterns.
                                   properties:
-                                    fallbackToInput:
-                                      description: If set to true, the input value
-                                        will be returned if no pattern matches.
-                                      type: boolean
+                                    fallbackTo:
+                                      description: Determines to what value the transform
+                                        should fallback if no pattern matches.
+                                      type: string
                                     fallbackValue:
                                       description: The fallback value that should
                                         be returned by the transform if now pattern
@@ -1077,10 +1077,10 @@ spec:
                                   description: Match is a more complex version of
                                     Map that matches a list of patterns.
                                   properties:
-                                    fallbackToInput:
-                                      description: If set to true, the input value
-                                        will be returned if no pattern matches.
-                                      type: boolean
+                                    fallbackTo:
+                                      description: Determines to what value the transform
+                                        should fallback if no pattern matches.
+                                      type: string
                                     fallbackValue:
                                       description: The fallback value that should
                                         be returned by the transform if now pattern
@@ -1589,10 +1589,10 @@ spec:
                                 description: Match is a more complex version of Map
                                   that matches a list of patterns.
                                 properties:
-                                  fallbackToInput:
-                                    description: If set to true, the input value will
-                                      be returned if no pattern matches.
-                                    type: boolean
+                                  fallbackTo:
+                                    description: Determines to what value the transform
+                                      should fallback if no pattern matches.
+                                    type: string
                                   fallbackValue:
                                     description: The fallback value that should be
                                       returned by the transform if now pattern matches.
@@ -2004,10 +2004,10 @@ spec:
                                   description: Match is a more complex version of
                                     Map that matches a list of patterns.
                                   properties:
-                                    fallbackToInput:
-                                      description: If set to true, the input value
-                                        will be returned if no pattern matches.
-                                      type: boolean
+                                    fallbackTo:
+                                      description: Determines to what value the transform
+                                        should fallback if no pattern matches.
+                                      type: string
                                     fallbackValue:
                                       description: The fallback value that should
                                         be returned by the transform if now pattern
@@ -2394,10 +2394,10 @@ spec:
                                   description: Match is a more complex version of
                                     Map that matches a list of patterns.
                                   properties:
-                                    fallbackToInput:
-                                      description: If set to true, the input value
-                                        will be returned if no pattern matches.
-                                      type: boolean
+                                    fallbackTo:
+                                      description: Determines to what value the transform
+                                        should fallback if no pattern matches.
+                                      type: string
                                     fallbackValue:
                                       description: The fallback value that should
                                         be returned by the transform if now pattern

--- a/cluster/crds/apiextensions.crossplane.io_compositionrevisions.yaml
+++ b/cluster/crds/apiextensions.crossplane.io_compositionrevisions.yaml
@@ -273,8 +273,12 @@ spec:
                                   that matches a list of patterns.
                                 properties:
                                   fallbackTo:
+                                    default: Value
                                     description: Determines to what value the transform
                                       should fallback if no pattern matches.
+                                    enum:
+                                    - Value
+                                    - Input
                                     type: string
                                   fallbackValue:
                                     description: The fallback value that should be
@@ -688,8 +692,12 @@ spec:
                                     Map that matches a list of patterns.
                                   properties:
                                     fallbackTo:
+                                      default: Value
                                       description: Determines to what value the transform
                                         should fallback if no pattern matches.
+                                      enum:
+                                      - Value
+                                      - Input
                                       type: string
                                     fallbackValue:
                                       description: The fallback value that should
@@ -1078,8 +1086,12 @@ spec:
                                     Map that matches a list of patterns.
                                   properties:
                                     fallbackTo:
+                                      default: Value
                                       description: Determines to what value the transform
                                         should fallback if no pattern matches.
+                                      enum:
+                                      - Value
+                                      - Input
                                       type: string
                                     fallbackValue:
                                       description: The fallback value that should
@@ -1590,8 +1602,12 @@ spec:
                                   that matches a list of patterns.
                                 properties:
                                   fallbackTo:
+                                    default: Value
                                     description: Determines to what value the transform
                                       should fallback if no pattern matches.
+                                    enum:
+                                    - Value
+                                    - Input
                                     type: string
                                   fallbackValue:
                                     description: The fallback value that should be
@@ -2005,8 +2021,12 @@ spec:
                                     Map that matches a list of patterns.
                                   properties:
                                     fallbackTo:
+                                      default: Value
                                       description: Determines to what value the transform
                                         should fallback if no pattern matches.
+                                      enum:
+                                      - Value
+                                      - Input
                                       type: string
                                     fallbackValue:
                                       description: The fallback value that should
@@ -2395,8 +2415,12 @@ spec:
                                     Map that matches a list of patterns.
                                   properties:
                                     fallbackTo:
+                                      default: Value
                                       description: Determines to what value the transform
                                         should fallback if no pattern matches.
+                                      enum:
+                                      - Value
+                                      - Input
                                       type: string
                                     fallbackValue:
                                       description: The fallback value that should

--- a/cluster/crds/apiextensions.crossplane.io_compositions.yaml
+++ b/cluster/crds/apiextensions.crossplane.io_compositions.yaml
@@ -270,10 +270,10 @@ spec:
                                 description: Match is a more complex version of Map
                                   that matches a list of patterns.
                                 properties:
-                                  fallbackToInput:
-                                    description: If set to true, the input value will
-                                      be returned if no pattern matches.
-                                    type: boolean
+                                  fallbackTo:
+                                    description: Determines to what value the transform
+                                      should fallback if no pattern matches.
+                                    type: string
                                   fallbackValue:
                                     description: The fallback value that should be
                                       returned by the transform if now pattern matches.
@@ -691,10 +691,10 @@ spec:
                                   description: Match is a more complex version of
                                     Map that matches a list of patterns.
                                   properties:
-                                    fallbackToInput:
-                                      description: If set to true, the input value
-                                        will be returned if no pattern matches.
-                                      type: boolean
+                                    fallbackTo:
+                                      description: Determines to what value the transform
+                                        should fallback if no pattern matches.
+                                      type: string
                                     fallbackValue:
                                       description: The fallback value that should
                                         be returned by the transform if now pattern
@@ -1087,10 +1087,10 @@ spec:
                                   description: Match is a more complex version of
                                     Map that matches a list of patterns.
                                   properties:
-                                    fallbackToInput:
-                                      description: If set to true, the input value
-                                        will be returned if no pattern matches.
-                                      type: boolean
+                                    fallbackTo:
+                                      description: Determines to what value the transform
+                                        should fallback if no pattern matches.
+                                      type: string
                                     fallbackValue:
                                       description: The fallback value that should
                                         be returned by the transform if now pattern

--- a/cluster/crds/apiextensions.crossplane.io_compositions.yaml
+++ b/cluster/crds/apiextensions.crossplane.io_compositions.yaml
@@ -270,6 +270,10 @@ spec:
                                 description: Match is a more complex version of Map
                                   that matches a list of patterns.
                                 properties:
+                                  fallbackToInput:
+                                    description: If set to true, the input value will
+                                      be returned if no pattern matches.
+                                    type: boolean
                                   fallbackValue:
                                     description: The fallback value that should be
                                       returned by the transform if now pattern matches.
@@ -687,6 +691,10 @@ spec:
                                   description: Match is a more complex version of
                                     Map that matches a list of patterns.
                                   properties:
+                                    fallbackToInput:
+                                      description: If set to true, the input value
+                                        will be returned if no pattern matches.
+                                      type: boolean
                                     fallbackValue:
                                       description: The fallback value that should
                                         be returned by the transform if now pattern
@@ -1079,6 +1087,10 @@ spec:
                                   description: Match is a more complex version of
                                     Map that matches a list of patterns.
                                   properties:
+                                    fallbackToInput:
+                                      description: If set to true, the input value
+                                        will be returned if no pattern matches.
+                                      type: boolean
                                     fallbackValue:
                                       description: The fallback value that should
                                         be returned by the transform if now pattern

--- a/cluster/crds/apiextensions.crossplane.io_compositions.yaml
+++ b/cluster/crds/apiextensions.crossplane.io_compositions.yaml
@@ -271,8 +271,12 @@ spec:
                                   that matches a list of patterns.
                                 properties:
                                   fallbackTo:
+                                    default: Value
                                     description: Determines to what value the transform
                                       should fallback if no pattern matches.
+                                    enum:
+                                    - Value
+                                    - Input
                                     type: string
                                   fallbackValue:
                                     description: The fallback value that should be
@@ -692,8 +696,12 @@ spec:
                                     Map that matches a list of patterns.
                                   properties:
                                     fallbackTo:
+                                      default: Value
                                       description: Determines to what value the transform
                                         should fallback if no pattern matches.
+                                      enum:
+                                      - Value
+                                      - Input
                                       type: string
                                     fallbackValue:
                                       description: The fallback value that should
@@ -1088,8 +1096,12 @@ spec:
                                     Map that matches a list of patterns.
                                   properties:
                                     fallbackTo:
+                                      default: Value
                                       description: Determines to what value the transform
                                         should fallback if no pattern matches.
+                                      enum:
+                                      - Value
+                                      - Input
                                       type: string
                                     fallbackValue:
                                       description: The fallback value that should

--- a/internal/controller/apiextensions/composite/composition_transforms.go
+++ b/internal/controller/apiextensions/composite/composition_transforms.go
@@ -162,7 +162,7 @@ func ResolveMatch(t v1.MatchTransform, input any) (any, error) {
 	}
 
 	// Fallback to input if no pattern matches and fallback to input is set
-	if t.FallbackToInput {
+	if t.FallbackTo == v1.MatchFallbackToTypeInput {
 		if t.FallbackValue.Size() != 0 {
 			return nil, errors.New(errMatchFallbackBoth)
 		}

--- a/internal/controller/apiextensions/composite/composition_transforms.go
+++ b/internal/controller/apiextensions/composite/composition_transforms.go
@@ -54,6 +54,7 @@ const (
 	errFmtMatchPattern            = "cannot match pattern at index %d"
 	errFmtMatchParseResult        = "cannot parse result of pattern at index %d"
 	errMatchParseFallbackValue    = "cannot parse fallback value"
+	errMatchFallbackBoth          = "cannot set both a fallback value and the fallback to input flag"
 	errFmtMatchPatternTypeInvalid = "unsupported pattern type '%s'"
 	errFmtMatchInputTypeInvalid   = "unsupported input type '%s'"
 	errMatchRegexpCompile         = "cannot compile regexp"
@@ -159,6 +160,16 @@ func ResolveMatch(t v1.MatchTransform, input any) (any, error) {
 			return output, nil
 		}
 	}
+
+	// Fallback to input if no pattern matches and fallback to input is set
+	if t.FallbackToInput {
+		if t.FallbackValue.Size() != 0 {
+			return nil, errors.New(errMatchFallbackBoth)
+		}
+
+		return input, nil
+	}
+
 	// Use fallback value if no pattern matches (or if there are no patterns)
 	if err := unmarshalJSON(t.FallbackValue, &output); err != nil {
 		return nil, errors.Wrap(err, errMatchParseFallbackValue)

--- a/internal/controller/apiextensions/composite/composition_transforms_test.go
+++ b/internal/controller/apiextensions/composite/composition_transforms_test.go
@@ -176,6 +176,19 @@ func TestMatchResolve(t *testing.T) {
 				err: errors.Wrapf(errors.Errorf(errFmtMatchInputTypeInvalid, "int"), errFmtMatchPattern, 0),
 			},
 		},
+		"ErrFallbackValueAndToInput": {
+			args: args{
+				t: v1.MatchTransform{
+					Patterns:        []v1.MatchTransformPattern{},
+					FallbackValue:   asJSON("foo"),
+					FallbackToInput: true,
+				},
+				i: "foo",
+			},
+			want: want{
+				err: errors.New(errMatchFallbackBoth),
+			},
+		},
 		"NoPatternsFallback": {
 			args: args{
 				t: v1.MatchTransform{
@@ -197,6 +210,31 @@ func TestMatchResolve(t *testing.T) {
 				i: "foo",
 			},
 			want: want{},
+		},
+		"NoPatternsFallbackToInput": {
+			args: args{
+				t: v1.MatchTransform{
+					Patterns:        []v1.MatchTransformPattern{},
+					FallbackToInput: true,
+				},
+				i: "foo",
+			},
+			want: want{
+				o: "foo",
+			},
+		},
+		"NoPatternsFallbackNilToInput": {
+			args: args{
+				t: v1.MatchTransform{
+					Patterns:        []v1.MatchTransformPattern{},
+					FallbackValue:   asJSON(nil),
+					FallbackToInput: true,
+				},
+				i: "foo",
+			},
+			want: want{
+				o: "foo",
+			},
 		},
 		"MatchLiteral": {
 			args: args{

--- a/internal/controller/apiextensions/composite/composition_transforms_test.go
+++ b/internal/controller/apiextensions/composite/composition_transforms_test.go
@@ -179,9 +179,9 @@ func TestMatchResolve(t *testing.T) {
 		"ErrFallbackValueAndToInput": {
 			args: args{
 				t: v1.MatchTransform{
-					Patterns:        []v1.MatchTransformPattern{},
-					FallbackValue:   asJSON("foo"),
-					FallbackToInput: true,
+					Patterns:      []v1.MatchTransformPattern{},
+					FallbackValue: asJSON("foo"),
+					FallbackTo:    "Input",
 				},
 				i: "foo",
 			},
@@ -194,6 +194,19 @@ func TestMatchResolve(t *testing.T) {
 				t: v1.MatchTransform{
 					Patterns:      []v1.MatchTransformPattern{},
 					FallbackValue: asJSON("bar"),
+				},
+				i: "foo",
+			},
+			want: want{
+				o: "bar",
+			},
+		},
+		"NoPatternsFallbackToValueExplicit": {
+			args: args{
+				t: v1.MatchTransform{
+					Patterns:      []v1.MatchTransformPattern{},
+					FallbackValue: asJSON("bar"),
+					FallbackTo:    "Value", // Explicitly set to Value, unnecessary but valid.
 				},
 				i: "foo",
 			},
@@ -214,8 +227,8 @@ func TestMatchResolve(t *testing.T) {
 		"NoPatternsFallbackToInput": {
 			args: args{
 				t: v1.MatchTransform{
-					Patterns:        []v1.MatchTransformPattern{},
-					FallbackToInput: true,
+					Patterns:   []v1.MatchTransformPattern{},
+					FallbackTo: "Input",
 				},
 				i: "foo",
 			},
@@ -226,9 +239,9 @@ func TestMatchResolve(t *testing.T) {
 		"NoPatternsFallbackNilToInput": {
 			args: args{
 				t: v1.MatchTransform{
-					Patterns:        []v1.MatchTransformPattern{},
-					FallbackValue:   asJSON(nil),
-					FallbackToInput: true,
+					Patterns:      []v1.MatchTransformPattern{},
+					FallbackValue: asJSON(nil),
+					FallbackTo:    "Input",
 				},
 				i: "foo",
 			},


### PR DESCRIPTION
This would be useful to make conditional transformations to an input but, if nothing matches, keep the input unmodified As it is, anything that goes through this transform is squashed

Usecase:

One case this is useful is for the `newer_noncurrent_versions` attribute: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_lifecycle_configuration#newer_noncurrent_versions. It actually takes in a string rather than a number. When the attribute should not be set, it has to be an empty string, not `"0"`, which fails because the value has to be higher than 0

So with this new match feature, I can transform my composition parameter to be replaced by an empty string when it's zero, but keep all other values:
```
                   -  type: FromCompositeFieldPath
                      fromFieldPath: spec.parameters.keepNonCurrentVersions
                      toFieldPath: spec.forProvider.rule[0].noncurrentVersionExpiration[0].newerNoncurrentVersions
                      transforms:
                        - parameters:
                            toType: string
                          type: convert
                        - fallbackTo: Input
                          patterns:
                            - literal: "0"
                              result: ""
                              type: literal
                          type: match
                     
```

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

## How has this code been tested

Unit tests + deployed in my cluster and tested with the case shown above ⏫ 
