### PR TITLE
chore(linter): switching from goimports to gci enforcing imports sorting

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -31,10 +31,15 @@ linters-settings:
     # simplify code: gofmt with `-s` option, true by default
     simplify: true
 
-  goimports:
-    # put imports beginning with prefix after 3rd-party packages;
-    # it's a comma-separated list of prefixes
-    local-prefixes: github.com/crossplane/crossplane
+  gci:
+    custom-order: true
+    sections:
+      - standard
+      - default
+      - prefix(github.com/crossplane/crossplane-runtime)
+      - prefix(github.com/crossplane/crossplane)
+      - blank
+      - dot
 
   gocyclo:
     # minimal code complexity to report, 30 by default (but we recommend 10-20)
@@ -110,7 +115,7 @@ linters:
     - gocyclo
     - gocritic
     - goconst
-    - goimports
+    - gci
     - gofmt  # We enable this as well as goimports for its simplify mode.
     - prealloc
     - revive

--- a/apis/apiextensions/v1/xrd_types.go
+++ b/apis/apiextensions/v1/xrd_types.go
@@ -17,11 +17,10 @@ limitations under the License.
 package v1
 
 import (
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
-
 	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
 )

--- a/cmd/crank/build.go
+++ b/cmd/crank/build.go
@@ -24,7 +24,6 @@ import (
 	"github.com/spf13/afero"
 
 	"github.com/crossplane/crossplane-runtime/pkg/errors"
-
 	"github.com/crossplane/crossplane-runtime/pkg/logging"
 	"github.com/crossplane/crossplane-runtime/pkg/parser"
 

--- a/cmd/crank/build_test.go
+++ b/cmd/crank/build_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/spf13/afero"
 
 	"github.com/crossplane/crossplane-runtime/pkg/errors"
-
 	"github.com/crossplane/crossplane-runtime/pkg/logging"
 	"github.com/crossplane/crossplane-runtime/pkg/parser"
 	"github.com/crossplane/crossplane-runtime/pkg/test"

--- a/cmd/crank/install.go
+++ b/cmd/crank/install.go
@@ -33,8 +33,8 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 
 	"github.com/crossplane/crossplane-runtime/pkg/errors"
-
 	"github.com/crossplane/crossplane-runtime/pkg/logging"
+
 	v1 "github.com/crossplane/crossplane/apis/pkg/v1"
 	typedclient "github.com/crossplane/crossplane/internal/client/clientset/versioned/typed/pkg/v1"
 	"github.com/crossplane/crossplane/internal/version"

--- a/cmd/crank/main.go
+++ b/cmd/crank/main.go
@@ -25,6 +25,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	"github.com/crossplane/crossplane-runtime/pkg/logging"
+
 	"github.com/crossplane/crossplane/internal/version"
 )
 

--- a/cmd/crank/push.go
+++ b/cmd/crank/push.go
@@ -26,8 +26,8 @@ import (
 	"github.com/spf13/afero"
 
 	"github.com/crossplane/crossplane-runtime/pkg/errors"
-
 	"github.com/crossplane/crossplane-runtime/pkg/logging"
+
 	"github.com/crossplane/crossplane/internal/xpkg"
 )
 

--- a/cmd/crank/update.go
+++ b/cmd/crank/update.go
@@ -13,8 +13,8 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 
 	"github.com/crossplane/crossplane-runtime/pkg/errors"
-
 	"github.com/crossplane/crossplane-runtime/pkg/logging"
+
 	v1 "github.com/crossplane/crossplane/apis/pkg/v1"
 	typedclient "github.com/crossplane/crossplane/internal/client/clientset/versioned/typed/pkg/v1"
 

--- a/cmd/crossplane/main.go
+++ b/cmd/crossplane/main.go
@@ -33,6 +33,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	"github.com/crossplane/crossplane-runtime/pkg/logging"
+
 	"github.com/crossplane/crossplane/apis"
 	"github.com/crossplane/crossplane/cmd/crossplane/core"
 	"github.com/crossplane/crossplane/cmd/crossplane/rbac"

--- a/cmd/crossplane/rbac/init.go
+++ b/cmd/crossplane/rbac/init.go
@@ -26,7 +26,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/crossplane/crossplane-runtime/pkg/errors"
-
 	"github.com/crossplane/crossplane-runtime/pkg/logging"
 
 	v1 "github.com/crossplane/crossplane/apis/apiextensions/v1"

--- a/cmd/xfn/main.go
+++ b/cmd/xfn/main.go
@@ -24,6 +24,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	"github.com/crossplane/crossplane-runtime/pkg/logging"
+
 	"github.com/crossplane/crossplane/cmd/xfn/run"
 	"github.com/crossplane/crossplane/cmd/xfn/spark"
 	"github.com/crossplane/crossplane/cmd/xfn/start"

--- a/internal/controller/apiextensions/claim/configurator_test.go
+++ b/internal/controller/apiextensions/claim/configurator_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/resource/unstructured/claim"
 	"github.com/crossplane/crossplane-runtime/pkg/resource/unstructured/composite"
 	"github.com/crossplane/crossplane-runtime/pkg/test"
+
 	"github.com/crossplane/crossplane/internal/xcrd"
 )
 

--- a/internal/controller/apiextensions/claim/connection.go
+++ b/internal/controller/apiextensions/claim/connection.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
-
 	"github.com/crossplane/crossplane-runtime/pkg/reconciler/managed"
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
 )

--- a/internal/controller/apiextensions/composite/composite.go
+++ b/internal/controller/apiextensions/composite/composite.go
@@ -20,6 +20,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/crossplane/crossplane-runtime/pkg/meta"
+
 	v1 "github.com/crossplane/crossplane/apis/apiextensions/v1"
 )
 

--- a/internal/controller/apiextensions/composite/composition_patches_test.go
+++ b/internal/controller/apiextensions/composite/composition_patches_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
 	"github.com/crossplane/crossplane-runtime/pkg/resource/fake"
 	"github.com/crossplane/crossplane-runtime/pkg/test"
+
 	v1 "github.com/crossplane/crossplane/apis/apiextensions/v1"
 )
 

--- a/internal/controller/apiextensions/composite/composition_validate.go
+++ b/internal/controller/apiextensions/composite/composition_validate.go
@@ -18,6 +18,7 @@ package composite
 
 import (
 	"github.com/crossplane/crossplane-runtime/pkg/errors"
+
 	v1 "github.com/crossplane/crossplane/apis/apiextensions/v1"
 )
 

--- a/internal/controller/apiextensions/composite/fuzz_test.go
+++ b/internal/controller/apiextensions/composite/fuzz_test.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 
 	"github.com/crossplane/crossplane-runtime/pkg/resource/fake"
+
 	v1 "github.com/crossplane/crossplane/apis/apiextensions/v1"
 	"github.com/crossplane/crossplane/apis/apiextensions/v1beta1"
 	pkgmetav1 "github.com/crossplane/crossplane/apis/pkg/meta/v1"

--- a/internal/controller/apiextensions/definition/reconciler_test.go
+++ b/internal/controller/apiextensions/definition/reconciler_test.go
@@ -40,6 +40,7 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
 	"github.com/crossplane/crossplane-runtime/pkg/resource/fake"
 	"github.com/crossplane/crossplane-runtime/pkg/test"
+
 	v1 "github.com/crossplane/crossplane/apis/apiextensions/v1"
 )
 

--- a/internal/controller/apiextensions/offered/reconciler_test.go
+++ b/internal/controller/apiextensions/offered/reconciler_test.go
@@ -40,6 +40,7 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
 	"github.com/crossplane/crossplane-runtime/pkg/resource/fake"
 	"github.com/crossplane/crossplane-runtime/pkg/test"
+
 	v1 "github.com/crossplane/crossplane/apis/apiextensions/v1"
 )
 

--- a/internal/controller/apiextensions/offered/watch.go
+++ b/internal/controller/apiextensions/offered/watch.go
@@ -26,6 +26,7 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/meta"
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
 	"github.com/crossplane/crossplane-runtime/pkg/resource/unstructured/composite"
+
 	v1 "github.com/crossplane/crossplane/apis/apiextensions/v1"
 )
 

--- a/internal/controller/apiextensions/offered/watch_test.go
+++ b/internal/controller/apiextensions/offered/watch_test.go
@@ -28,6 +28,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/crossplane/crossplane-runtime/pkg/resource/unstructured/composite"
+
 	v1 "github.com/crossplane/crossplane/apis/apiextensions/v1"
 )
 

--- a/internal/controller/pkg/controller/options.go
+++ b/internal/controller/pkg/controller/options.go
@@ -18,10 +18,10 @@ limitations under the License.
 package controller
 
 import (
-	"github.com/crossplane/crossplane/internal/xpkg"
-
 	"github.com/crossplane/crossplane-runtime/pkg/controller"
 	"github.com/crossplane/crossplane-runtime/pkg/feature"
+
+	"github.com/crossplane/crossplane/internal/xpkg"
 )
 
 // Options specific to pkg controllers.

--- a/internal/controller/pkg/manager/fuzz_test.go
+++ b/internal/controller/pkg/manager/fuzz_test.go
@@ -20,12 +20,13 @@ import (
 	"context"
 	"testing"
 
+	fuzz "github.com/AdaLogics/go-fuzz-headers"
+
 	"github.com/crossplane/crossplane-runtime/pkg/errors"
+
 	v1 "github.com/crossplane/crossplane/apis/pkg/v1"
 	"github.com/crossplane/crossplane/internal/xpkg"
 	"github.com/crossplane/crossplane/internal/xpkg/fake"
-
-	fuzz "github.com/AdaLogics/go-fuzz-headers"
 )
 
 func FuzzPackageRevision(f *testing.F) {

--- a/internal/controller/pkg/manager/reconciler_test.go
+++ b/internal/controller/pkg/manager/reconciler_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/logging"
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
 	"github.com/crossplane/crossplane-runtime/pkg/test"
+
 	v1 "github.com/crossplane/crossplane/apis/pkg/v1"
 )
 

--- a/internal/controller/pkg/manager/revisioner.go
+++ b/internal/controller/pkg/manager/revisioner.go
@@ -23,6 +23,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 
 	"github.com/crossplane/crossplane-runtime/pkg/errors"
+
 	v1 "github.com/crossplane/crossplane/apis/pkg/v1"
 	"github.com/crossplane/crossplane/internal/xpkg"
 )

--- a/internal/controller/pkg/manager/revisioner_test.go
+++ b/internal/controller/pkg/manager/revisioner_test.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/crossplane/crossplane-runtime/pkg/errors"
 	"github.com/crossplane/crossplane-runtime/pkg/test"
+
 	v1 "github.com/crossplane/crossplane/apis/pkg/v1"
 	"github.com/crossplane/crossplane/internal/xpkg"
 	"github.com/crossplane/crossplane/internal/xpkg/fake"

--- a/internal/controller/pkg/revision/dependency.go
+++ b/internal/controller/pkg/revision/dependency.go
@@ -27,6 +27,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/crossplane/crossplane-runtime/pkg/errors"
+
 	pkgmetav1 "github.com/crossplane/crossplane/apis/pkg/meta/v1"
 	v1 "github.com/crossplane/crossplane/apis/pkg/v1"
 	"github.com/crossplane/crossplane/apis/pkg/v1beta1"

--- a/internal/controller/pkg/revision/establisher_test.go
+++ b/internal/controller/pkg/revision/establisher_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/errors"
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
 	"github.com/crossplane/crossplane-runtime/pkg/test"
+
 	v1 "github.com/crossplane/crossplane/apis/pkg/v1"
 )
 

--- a/internal/controller/pkg/revision/imageback_test.go
+++ b/internal/controller/pkg/revision/imageback_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/errors"
 	"github.com/crossplane/crossplane-runtime/pkg/parser"
 	"github.com/crossplane/crossplane-runtime/pkg/test"
+
 	v1 "github.com/crossplane/crossplane/apis/pkg/v1"
 	"github.com/crossplane/crossplane/internal/xpkg"
 	"github.com/crossplane/crossplane/internal/xpkg/fake"

--- a/internal/controller/pkg/revision/watch_test.go
+++ b/internal/controller/pkg/revision/watch_test.go
@@ -19,14 +19,13 @@ package revision
 import (
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
-
-	"github.com/google/go-cmp/cmp"
 
 	"github.com/crossplane/crossplane-runtime/pkg/errors"
 	"github.com/crossplane/crossplane-runtime/pkg/test"

--- a/internal/controller/rbac/definition/reconciler.go
+++ b/internal/controller/rbac/definition/reconciler.go
@@ -35,8 +35,8 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/meta"
 	"github.com/crossplane/crossplane-runtime/pkg/ratelimiter"
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
-	v1 "github.com/crossplane/crossplane/apis/apiextensions/v1"
 
+	v1 "github.com/crossplane/crossplane/apis/apiextensions/v1"
 	"github.com/crossplane/crossplane/internal/controller/rbac/controller"
 )
 

--- a/internal/controller/rbac/definition/reconciler_test.go
+++ b/internal/controller/rbac/definition/reconciler_test.go
@@ -37,6 +37,7 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
 	"github.com/crossplane/crossplane-runtime/pkg/resource/fake"
 	"github.com/crossplane/crossplane-runtime/pkg/test"
+
 	v1 "github.com/crossplane/crossplane/apis/apiextensions/v1"
 )
 

--- a/internal/controller/rbac/definition/roles.go
+++ b/internal/controller/rbac/definition/roles.go
@@ -21,6 +21,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/crossplane/crossplane-runtime/pkg/meta"
+
 	v1 "github.com/crossplane/crossplane/apis/apiextensions/v1"
 )
 

--- a/internal/controller/rbac/provider/binding/reconciler_test.go
+++ b/internal/controller/rbac/provider/binding/reconciler_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
 	"github.com/crossplane/crossplane-runtime/pkg/resource/fake"
 	"github.com/crossplane/crossplane-runtime/pkg/test"
+
 	v1 "github.com/crossplane/crossplane/apis/pkg/v1"
 )
 

--- a/internal/controller/rbac/provider/roles/reconciler_test.go
+++ b/internal/controller/rbac/provider/roles/reconciler_test.go
@@ -38,6 +38,7 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
 	"github.com/crossplane/crossplane-runtime/pkg/resource/fake"
 	"github.com/crossplane/crossplane-runtime/pkg/test"
+
 	v1 "github.com/crossplane/crossplane/apis/pkg/v1"
 )
 

--- a/internal/controller/rbac/provider/roles/roles.go
+++ b/internal/controller/rbac/provider/roles/roles.go
@@ -25,6 +25,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/crossplane/crossplane-runtime/pkg/meta"
+
 	v1 "github.com/crossplane/crossplane/apis/pkg/v1"
 )
 

--- a/internal/controller/rbac/provider/roles/watch_test.go
+++ b/internal/controller/rbac/provider/roles/watch_test.go
@@ -19,6 +19,7 @@ package roles
 import (
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -27,10 +28,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	"github.com/google/go-cmp/cmp"
-
 	"github.com/crossplane/crossplane-runtime/pkg/errors"
 	"github.com/crossplane/crossplane-runtime/pkg/test"
+
 	v1 "github.com/crossplane/crossplane/apis/pkg/v1"
 )
 

--- a/internal/controller/rbac/rbac.go
+++ b/internal/controller/rbac/rbac.go
@@ -20,12 +20,11 @@ package rbac
 import (
 	ctrl "sigs.k8s.io/controller-runtime"
 
+	"github.com/crossplane/crossplane/internal/controller/rbac/controller"
 	"github.com/crossplane/crossplane/internal/controller/rbac/definition"
 	"github.com/crossplane/crossplane/internal/controller/rbac/namespace"
 	"github.com/crossplane/crossplane/internal/controller/rbac/provider/binding"
 	"github.com/crossplane/crossplane/internal/controller/rbac/provider/roles"
-
-	"github.com/crossplane/crossplane/internal/controller/rbac/controller"
 )
 
 // Setup RBAC manager controllers.

--- a/internal/initializer/initializer.go
+++ b/internal/initializer/initializer.go
@@ -21,9 +21,9 @@ import (
 	"context"
 	"reflect"
 
-	"github.com/crossplane/crossplane-runtime/pkg/logging"
-
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/crossplane/crossplane-runtime/pkg/logging"
 )
 
 // New returns a new *Initializer.

--- a/internal/initializer/installer_test.go
+++ b/internal/initializer/installer_test.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/crossplane/crossplane-runtime/pkg/errors"
 	"github.com/crossplane/crossplane-runtime/pkg/test"
+
 	v1 "github.com/crossplane/crossplane/apis/pkg/v1"
 )
 

--- a/internal/initializer/lock.go
+++ b/internal/initializer/lock.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/crossplane/crossplane-runtime/pkg/errors"
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
+
 	"github.com/crossplane/crossplane/apis/pkg/v1beta1"
 )
 

--- a/internal/initializer/webhook_tls.go
+++ b/internal/initializer/webhook_tls.go
@@ -28,13 +28,12 @@ import (
 	"math/big"
 	"time"
 
-	"github.com/crossplane/crossplane-runtime/pkg/logging"
-
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/crossplane/crossplane-runtime/pkg/errors"
+	"github.com/crossplane/crossplane-runtime/pkg/logging"
 )
 
 const (

--- a/internal/oci/store/store.go
+++ b/internal/oci/store/store.go
@@ -34,6 +34,7 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	"github.com/crossplane/crossplane-runtime/pkg/errors"
+
 	"github.com/crossplane/crossplane/internal/oci/spec"
 )
 

--- a/internal/xcrd/crd.go
+++ b/internal/xcrd/crd.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/crossplane/crossplane-runtime/pkg/errors"
 	"github.com/crossplane/crossplane-runtime/pkg/meta"
+
 	v1 "github.com/crossplane/crossplane/apis/apiextensions/v1"
 )
 

--- a/internal/xfn/container.go
+++ b/internal/xfn/container.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/crossplane/crossplane-runtime/pkg/errors"
 	"github.com/crossplane/crossplane-runtime/pkg/logging"
+
 	"github.com/crossplane/crossplane/apis/apiextensions/fn/proto/v1alpha1"
 )
 

--- a/internal/xpkg/fuzz_test.go
+++ b/internal/xpkg/fuzz_test.go
@@ -19,9 +19,8 @@ package xpkg
 import (
 	"testing"
 
-	"github.com/spf13/afero"
-
 	fuzz "github.com/AdaLogics/go-fuzz-headers"
+	"github.com/spf13/afero"
 )
 
 func FuzzFindXpkgInDir(f *testing.F) {

--- a/internal/xpkg/lint.go
+++ b/internal/xpkg/lint.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/crossplane/crossplane-runtime/pkg/errors"
 	"github.com/crossplane/crossplane-runtime/pkg/parser"
+
 	v1 "github.com/crossplane/crossplane/apis/apiextensions/v1"
 	pkgmetav1 "github.com/crossplane/crossplane/apis/pkg/meta/v1"
 	"github.com/crossplane/crossplane/internal/version"

--- a/internal/xpkg/lint_test.go
+++ b/internal/xpkg/lint_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/errors"
 	"github.com/crossplane/crossplane-runtime/pkg/parser"
 	"github.com/crossplane/crossplane-runtime/pkg/test"
+
 	v1 "github.com/crossplane/crossplane/apis/apiextensions/v1"
 	pkgmetav1 "github.com/crossplane/crossplane/apis/pkg/meta/v1"
 	pkgmetav1alpha1 "github.com/crossplane/crossplane/apis/pkg/meta/v1alpha1"


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
As suggested [here](https://github.com/crossplane/crossplane/pull/3921/files/70597edcfc7d2fb9ca299302c22a43aa24ad158b#r1150566626), imports should be sorted as follows:
- standard packages
- external packages
- crossplane-runtime ones
- local packages

This PR switches golangci-lint from goimports to gci as the latter is able to enforce the suggested ordering, and is also fixing all the issues detected (mostly newlines between capture groups), automatically fixed by running `golangci-lint run --fix`.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

N.A. running `make reviewable` is enough.

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
