### PR TITLE
Keep existing finalizers when updating package revision's objects

### DIFF
--- a/internal/controller/pkg/revision/establisher.go
+++ b/internal/controller/pkg/revision/establisher.go
@@ -364,6 +364,7 @@ func (e *APIEstablisher) update(ctx context.Context, current, desired resource.O
 		return err
 	}
 	desired.SetResourceVersion(current.GetResourceVersion())
+	desired.SetFinalizers(current.GetFinalizers())
 	return e.client.Update(ctx, desired, opts...)
 }
 


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Finalizers I set on a CRD belonging to a Crossplane provider are removed whenever the provider's `ProviderRevision` is reconciled. I've also seen that a controller re-applying finalizers as they're removed can provoke "object has been modified" errors during `ProviderRevision` reconciliation, causing the `ProviderRevision` to become unhealthy. Such failed reconciliations can become more likely as a provider installs more CRDs, since the entire set of CRDs is created/updated with each reconciliation. provider-aws is particularly sensitive to this.

This PR modifies the `ProviderRevision` reconciler to keep existing finalizers when updating objects.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

I didn't see a clear opportunity for a regression test, but I'm happy to add one with guidance on where it would belong.

I tested this manually according to the following steps:

1. Deploy the latest Crossplane release and install a provider, such as [provider-terraform](https://github.com/upbound/provider-terraform). Wait for its `ProviderRevision` to become healthy.
2. Add a finalizer to a CRD belonging to the provider, such as `workspaces.tf.upbound.io`.
3. Add any label to the `ProviderRevision` to force a reconciliation.
4. Observe that the finalizer added in step 2 has been removed.
5. Override the Crossplane image with an image built from this PR.
6. Repeat steps 2 and 3, then observe that the finalizer is not removed and the `PackageRevision` is healthy.

[contribution process]: https://git.io/fj2m9