### PR TITLE
Upgrade to Go 1.20

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/crossplane/crossplane
 
-go 1.19
+go 1.20
 
 require (
 	github.com/AdaLogics/go-fuzz-headers v0.0.0-20230106234847-43070de90fa1


### PR DESCRIPTION
### Description of your changes

Upgrade the [go directive](https://go.dev/ref/mod#go-mod-file-go) in `go.mod` to Go 1.20.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

I used Crossplane's [Go 1.19 upgrade](https://github.com/crossplane/crossplane/pull/3306) as a reference. The CI GitHub workflow already builds with `GO_VERSION: '1.20.2'` so I left the workflows untouched.

I ran `make`, `make reviewable`, and confirmed `crossplane` runs. I searched the repo for any remaining mentions of Go 1.19, but didn't find anything:

```text
calvin@mbp crossplane % rg -uu '1\.19'
go.sum
679:go.uber.org/zap v1.19.0/go.mod h1:xg/QME4nWcxGxrpdeYfq7UvYrLh66cuVKdrbD1XF/NI=
1017:google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=

_output/tests/darwin_arm64/coverage.txt
3047:github.com/crossplane/crossplane/internal/xpkg/cache.go:101.2,101.19 1 1

design/assets/design-doc-provider-strategy/dcl/go.sum
453:google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
```