### PR TITLE
Replace deprecated command with environment file

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Find the Go Build Cache
         id: go
-        run: echo "::set-output name=cache::$(make go.cachedir)"
+        run: echo "cache=$(make go.cachedir)" >> $GITHUB_OUTPUT
 
       - name: Cache the Go Build Cache
         uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3
@@ -92,7 +92,7 @@ jobs:
 
       - name: Find the Go Build Cache
         id: go
-        run: echo "::set-output name=cache::$(make go.cachedir)"
+        run: echo "cache=$(make go.cachedir)" >> $GITHUB_OUTPUT
 
       - name: Cache the Go Build Cache
         uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3

--- a/.github/workflows/configurations.yml
+++ b/.github/workflows/configurations.yml
@@ -22,7 +22,7 @@ jobs:
       # The tagger step uses the same logic in the build submodule to generate package tag
       # https://github.com/upbound/build/blob/4f64913157a952dbe77cd9e05457d9abe695a1d4/makelib/common.mk#L193
       - name: Set tag
-        run: echo "::set-output name=VERSION_TAG::$(git describe --dirty --always --tags | sed 's/-/./2' | sed 's/-/./2' )"
+        run: echo "VERSION_TAG=$(git describe --dirty --always --tags | sed 's/-/./2' | sed 's/-/./2' )" >> $GITHUB_OUTPUT
         id: tagger
       - name: Login to Docker
         uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a # v2
@@ -51,7 +51,7 @@ jobs:
           submodules: true
           fetch-depth: 0
       - name: Set tag
-        run: echo "::set-output name=VERSION_TAG::$(git describe --dirty --always --tags | sed 's/-/./2' | sed 's/-/./2' )"
+        run: echo "VERSION_TAG=$(git describe --dirty --always --tags | sed 's/-/./2' | sed 's/-/./2' )" >> $GITHUB_OUTPUT
         id: tagger
       - name: Login to Docker
         uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a # v2
@@ -80,7 +80,7 @@ jobs:
           submodules: true
           fetch-depth: 0
       - name: Set tag
-        run: echo "::set-output name=VERSION_TAG::$(git describe --dirty --always --tags | sed 's/-/./2' | sed 's/-/./2' )"
+        run: echo "VERSION_TAG=$(git describe --dirty --always --tags | sed 's/-/./2' | sed 's/-/./2' )" >> $GITHUB_OUTPUT
         id: tagger
       - name: Login to Docker
         uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a # v2
@@ -109,7 +109,7 @@ jobs:
           submodules: true
           fetch-depth: 0
       - name: Set tag
-        run: echo "::set-output name=VERSION_TAG::$(git describe --dirty --always --tags | sed 's/-/./2' | sed 's/-/./2' )"
+        run: echo "VERSION_TAG=$(git describe --dirty --always --tags | sed 's/-/./2' | sed 's/-/./2' )" >> $GITHUB_OUTPUT
         id: tagger
       - name: Login to Docker
         uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a # v2


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

Fixes  #3934 

Update workflows to use environment file instead of deprecated `set-output` command. 
For more information, see: [https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)

I found the workflow files that use `set-output` command through the following command:

```bash
$ find . -name '*.yml' -o -name '*.yaml' | xargs egrep '\bset-output\b'
```

**AS-IS**

```yml
run: echo "::set-output name=cache::$(make go.cachedir)"
```

```yml
run: echo "::set-output name=VERSION_TAG::$(git describe --dirty --always --tags | sed 's/-/./2' | sed 's/-/./2' )"
```

**TO-BE**

```yml
run: echo "cache=$(make go.cachedir)" >> $GITHUB_OUTPUT
```

```yml
run: echo "VERSION_TAG=$(git describe --dirty --always --tags | sed 's/-/./2' | sed 's/-/./2' )" >> $GITHUB_OUTPUT
```

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

N/A

[contribution process]: https://git.io/fj2m9
