### PR TITLE
ci(fuzz): remove dry-run for fuzz tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -409,7 +409,6 @@ jobs:
         uses: google/oss-fuzz/infra/cifuzz/actions/build_fuzzers@master
         with:
           oss-fuzz-project-name: "crossplane"
-          dry-run: true
           language: go
 
       - name: Run Fuzzers
@@ -417,7 +416,6 @@ jobs:
         with:
           oss-fuzz-project-name: "crossplane"
           fuzz-seconds: 300
-          dry-run: true
           language: go
 
       - name: Upload Crash


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
As suggested by the original [commit](https://github.com/crossplane/crossplane/commit/d7770308487bb25db44dc66ec711e4996d481887), I'm unsetting `dry-run`, this would have allowed us to notice that this [PR](https://github.com/crossplane/crossplane/pull/3930) from being merged and breaking the Fuzzers builds due to the misaligned version between our project (1.20) and `gcr.io/oss-fuzz-base/base-builder-go:latest@sha256:624c6726e2b8178c334d3821b2446b842f87aee9436b4c2eb3756b68791af09f` base image (1.19).

If having this able to fail and required at the same time is an issue we could remove it from the required jobs or move it to a separate workflow directly.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

N.A.

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
