### PR TITLE
feat(chart): enable webhooks by default

### DIFF
--- a/cluster/charts/crossplane/values.yaml.tmpl
+++ b/cluster/charts/crossplane/values.yaml.tmpl
@@ -35,7 +35,7 @@ imagePullSecrets: {}
 registryCaBundleConfig: {}
 
 webhooks:
-  enabled: false
+  enabled: true
 
 rbacManager:
   deploy: true


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Sets `webhooks.enabled` to `true` by default in the Crossplane Helm chart, this will mean that by default both CompositeResourceDefinitions and Compositions Webhooks are going to be validated.

Fixes #3748.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

Locally deploying the chart with the new value.

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
