### PR TITLE
Add EnvironmentConfig support to packages

### DIFF
--- a/internal/xpkg/lint.go
+++ b/internal/xpkg/lint.go
@@ -27,6 +27,7 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/parser"
 
 	v1 "github.com/crossplane/crossplane/apis/apiextensions/v1"
+	v1alpha1 "github.com/crossplane/crossplane/apis/apiextensions/v1alpha1"
 	pkgmetav1 "github.com/crossplane/crossplane/apis/pkg/meta/v1"
 	"github.com/crossplane/crossplane/internal/version"
 )
@@ -41,6 +42,7 @@ const (
 	errNotMutatingWebhookConfiguration   = "object is not a MutatingWebhookConfiguration"
 	errNotValidatingWebhookConfiguration = "object is not an ValidatingWebhookConfiguration"
 	errNotComposition                    = "object is not a Composition"
+	errNotEnvironmentConfig              = "object is not an EnvironmentConfig"
 	errBadConstraints                    = "package version constraints are poorly formatted"
 	errCrossplaneIncompatibleFmt         = "package is not compatible with Crossplane version (%s)"
 )
@@ -53,13 +55,19 @@ func NewProviderLinter() parser.Linter {
 			IsCRD,
 			IsValidatingWebhookConfiguration,
 			IsMutatingWebhookConfiguration,
+			IsEnvironmentConfig,
 		)))
 }
 
 // NewConfigurationLinter is a convenience function for creating a package linter for
 // configurations.
 func NewConfigurationLinter() parser.Linter {
-	return parser.NewPackageLinter(parser.PackageLinterFns(OneMeta), parser.ObjectLinterFns(IsConfiguration, PackageValidSemver), parser.ObjectLinterFns(parser.Or(IsXRD, IsComposition)))
+	return parser.NewPackageLinter(parser.PackageLinterFns(OneMeta), parser.ObjectLinterFns(IsConfiguration, PackageValidSemver),
+		parser.ObjectLinterFns(parser.Or(
+			IsXRD,
+			IsComposition,
+			IsEnvironmentConfig,
+		)))
 }
 
 // OneMeta checks that there is only one meta object in the package.
@@ -165,6 +173,14 @@ func IsXRD(o runtime.Object) error {
 func IsComposition(o runtime.Object) error {
 	if _, ok := o.(*v1.Composition); !ok {
 		return errors.New(errNotComposition)
+	}
+	return nil
+}
+
+// IsEnvironmentConfig checks that an object is a EnvironmentConfig meta type.
+func IsEnvironmentConfig(o runtime.Object) error {
+	if _, ok := o.(*v1alpha1.EnvironmentConfig); !ok {
+		return errors.New(errNotEnvironmentConfig)
 	}
 	return nil
 }

--- a/internal/xpkg/lint_test.go
+++ b/internal/xpkg/lint_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/test"
 
 	v1 "github.com/crossplane/crossplane/apis/apiextensions/v1"
+	v1alpha1 "github.com/crossplane/crossplane/apis/apiextensions/v1alpha1"
 	pkgmetav1 "github.com/crossplane/crossplane/apis/pkg/meta/v1"
 	pkgmetav1alpha1 "github.com/crossplane/crossplane/apis/pkg/meta/v1alpha1"
 	"github.com/crossplane/crossplane/internal/version"
@@ -80,6 +81,11 @@ kind: Composition
 metadata:
   name: test`)
 
+	v1alpha1EnvCfgbytes = []byte(`apiVersion: apiextensions.crossplane.io/v1alpha1
+kind: EnvironmentConfig
+metadata:
+  name: test`)
+
 	v1beta1crd       = &apiextensions.CustomResourceDefinition{}
 	_                = yaml.Unmarshal(v1beta1CRDBytes, v1beta1crd)
 	v1crd            = &apiextensions.CustomResourceDefinition{}
@@ -96,6 +102,8 @@ metadata:
 	_                = yaml.Unmarshal(v1XRDBytes, v1XRD)
 	v1Comp           = &v1.Composition{}
 	_                = yaml.Unmarshal(v1CompBytes, v1Comp)
+	v1alpha1EnvCfg   = &v1alpha1.EnvironmentConfig{}
+	_                = yaml.Unmarshal(v1alpha1EnvCfgbytes, v1alpha1EnvCfg)
 
 	meta, _ = BuildMetaScheme()
 	obj, _  = BuildObjectScheme()
@@ -437,6 +445,34 @@ func TestIsComposition(t *testing.T) {
 
 			if diff := cmp.Diff(tc.err, err, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\nIsComposition(...): -want error, +got error:\n%s", tc.reason, diff)
+			}
+		})
+	}
+}
+
+func TestIsEnvironmentConfig(t *testing.T) {
+	cases := map[string]struct {
+		reason string
+		obj    runtime.Object
+		err    error
+	}{
+		"v1": {
+			reason: "Should not return error if object is EnvironmentConfig.",
+			obj:    v1alpha1EnvCfg,
+		},
+		"ErrNotEnvironmentConfig": {
+			reason: "Should return error if object is not EnvironmentConfig.",
+			obj:    v1beta1crd,
+			err:    errors.New(errNotEnvironmentConfig),
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			err := IsEnvironmentConfig(tc.obj)
+
+			if diff := cmp.Diff(tc.err, err, test.EquateErrors()); diff != "" {
+				t.Errorf("\n%s\nIsEnvironmentConfig(...): -want error, +got error:\n%s", tc.reason, diff)
 			}
 		})
 	}

--- a/internal/xpkg/scheme.go
+++ b/internal/xpkg/scheme.go
@@ -24,6 +24,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/conversion"
 
 	v1 "github.com/crossplane/crossplane/apis/apiextensions/v1"
+	v1alpha1 "github.com/crossplane/crossplane/apis/apiextensions/v1alpha1"
 	pkgmetav1 "github.com/crossplane/crossplane/apis/pkg/meta/v1"
 	pkgmetav1alpha1 "github.com/crossplane/crossplane/apis/pkg/meta/v1alpha1"
 )
@@ -46,6 +47,9 @@ func BuildMetaScheme() (*runtime.Scheme, error) {
 func BuildObjectScheme() (*runtime.Scheme, error) {
 	objScheme := runtime.NewScheme()
 	if err := v1.AddToScheme(objScheme); err != nil {
+		return nil, err
+	}
+	if err := v1alpha1.AddToScheme(objScheme); err != nil {
 		return nil, err
 	}
 	if err := extv1beta1.AddToScheme(objScheme); err != nil {


### PR DESCRIPTION
### Description of your changes
Added support for EnvironmentConfig files in the `kubectl crossplane build` command for Provider and Configuration packages.

Fixes #3865 

I have:

- [X] Read and followed Crossplane's [contribution process].
- [X] Run `make reviewable` to ensure this PR is ready for review.
- [C] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested
Added two EnvironmentConfig yaml files to a Configuration package and verified that the package is generated successfully and contains the two EnvironmentConfig objects.
