### PR TITLE
Add Roadmap section and links

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,19 @@ documentation].
 You can subscribe to the [community calendar] to track all release dates, and
 find the most recent releases on the [releases] page.
 
+## Roadmap
+
+The public roadmap for Crossplane is published as a GitHub project board. Issues
+added to the roadmap have been triaged and identified as valuable to the
+community, and therefore a priority for the project that we expect to invest in.
+
+Milestones assigned to any issues in the roadmap are intended to give a sense of
+overall priority and the expected order of delivery. They should be considered
+approximate estimations and are **not** a strict commitment to a specific
+delivery timeline.
+
+[Crossplane Roadmap]
+
 ## Get Involved
 
 Crossplane is a community driven project; we welcome your contribution. To file
@@ -80,3 +93,4 @@ Crossplane is under the Apache 2.0 license.
 [community calendar]: https://calendar.google.com/calendar/embed?src=c_2cdn0hs9e2m05rrv1233cjoj1k%40group.calendar.google.com
 [releases]: https://github.com/crossplane/crossplane/releases
 [ADOPTERS.md]: ADOPTERS.md
+[Crossplane Roadmap]: https://github.com/orgs/crossplane/projects/20/views/3

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,14 @@
 # Roadmap
 
-Crossplane uses GitHub project boards to track our roadmap. You can find our
-project boards [here][projects].
+The public roadmap for Crossplane is published as a GitHub project board. Issues
+added to the roadmap have been triaged and identified as valuable to the
+community, and therefore a priority for the project that we expect to invest in.
 
-[projects]: https://github.com/orgs/crossplane/projects
+Milestones assigned to any issues in the roadmap are intended to give a sense of
+overall priority and the expected order of delivery. They should be considered
+approximate estimations and are **not** a strict commitment to a specific
+delivery timeline.
+
+[Crossplane Roadmap]
+
+[Crossplane Roadmap]: https://github.com/orgs/crossplane/projects/20/views/3


### PR DESCRIPTION
### Description of your changes

This PR adds a new section to the README for the public roadmap.  This will give the roadmap more discoverability and help members of the community stay more informed of the project direction and expected deliverables.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

I have reviewed the rendered markdown and tested the links within [my fork](https://github.com/jbw976/crossplane/tree/roadmap#roadmap).

[contribution process]: https://git.io/fj2m9
