### PR TITLE
Add defaults for CompositeDelete and CompositionUpdate policies

### DIFF
--- a/apis/apiextensions/v1/xrd_types.go
+++ b/apis/apiextensions/v1/xrd_types.go
@@ -56,6 +56,12 @@ type CompositeResourceDefinitionSpec struct {
 	// +optional
 	ConnectionSecretKeys []string `json:"connectionSecretKeys,omitempty"`
 
+	// DefaultCompositeDeletePolicy is the policy used when deleting the Composite
+	// that is associated with the Claim if no policy has been specified.
+	// +optional
+	// +kubebuilder:default=Background
+	DefaultCompositeDeletePolicy *xpv1.CompositeDeletePolicy `json:"defaultCompositeDeletePolicy,omitempty"`
+
 	// DefaultCompositionRef refers to the Composition resource that will be used
 	// in case no composition selector is given.
 	// +optional
@@ -66,6 +72,12 @@ type CompositeResourceDefinitionSpec struct {
 	// +optional
 	// +immutable
 	EnforcedCompositionRef *CompositionReference `json:"enforcedCompositionRef,omitempty"`
+
+	// DefaultCompositionUpdatePolicy is the policy used when updating composites after a new
+	// Composition Revision has been created if no policy has been specified on the composite.
+	// +optional
+	// +kubebuilder:default=Automatic
+	DefaultCompositionUpdatePolicy *xpv1.UpdatePolicy `json:"defaultCompositionUpdatePolicy,omitempty"`
 
 	// Versions is the list of all API versions of the defined composite
 	// resource. Version names are used to compute the order in which served

--- a/apis/apiextensions/v1/zz_generated.deepcopy.go
+++ b/apis/apiextensions/v1/zz_generated.deepcopy.go
@@ -199,6 +199,11 @@ func (in *CompositeResourceDefinitionSpec) DeepCopyInto(out *CompositeResourceDe
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.DefaultCompositeDeletePolicy != nil {
+		in, out := &in.DefaultCompositeDeletePolicy, &out.DefaultCompositeDeletePolicy
+		*out = new(commonv1.CompositeDeletePolicy)
+		**out = **in
+	}
 	if in.DefaultCompositionRef != nil {
 		in, out := &in.DefaultCompositionRef, &out.DefaultCompositionRef
 		*out = new(CompositionReference)
@@ -207,6 +212,11 @@ func (in *CompositeResourceDefinitionSpec) DeepCopyInto(out *CompositeResourceDe
 	if in.EnforcedCompositionRef != nil {
 		in, out := &in.EnforcedCompositionRef, &out.EnforcedCompositionRef
 		*out = new(CompositionReference)
+		**out = **in
+	}
+	if in.DefaultCompositionUpdatePolicy != nil {
+		in, out := &in.DefaultCompositionUpdatePolicy, &out.DefaultCompositionUpdatePolicy
+		*out = new(commonv1.UpdatePolicy)
 		**out = **in
 	}
 	if in.Versions != nil {

--- a/cluster/crds/apiextensions.crossplane.io_compositeresourcedefinitions.yaml
+++ b/cluster/crds/apiextensions.crossplane.io_compositeresourcedefinitions.yaml
@@ -205,6 +205,15 @@ spec:
                 required:
                 - strategy
                 type: object
+              defaultCompositeDeletePolicy:
+                default: Background
+                description: DefaultCompositeDeletePolicy is the policy used when
+                  deleting the Composite that is associated with the Claim if no policy
+                  has been specified.
+                enum:
+                - Background
+                - Foreground
+                type: string
               defaultCompositionRef:
                 description: DefaultCompositionRef refers to the Composition resource
                   that will be used in case no composition selector is given.
@@ -215,6 +224,15 @@ spec:
                 required:
                 - name
                 type: object
+              defaultCompositionUpdatePolicy:
+                default: Automatic
+                description: DefaultCompositionUpdatePolicy is the policy used when
+                  updating composites after a new Composition Revision has been created
+                  if no policy has been specified on the composite.
+                enum:
+                - Automatic
+                - Manual
+                type: string
               enforcedCompositionRef:
                 description: EnforcedCompositionRef refers to the Composition resource
                   that will be used by all composite instances whose schema is defined

--- a/internal/controller/apiextensions/claim/reconciler_test.go
+++ b/internal/controller/apiextensions/claim/reconciler_test.go
@@ -393,6 +393,29 @@ func TestReconcile(t *testing.T) {
 				r: reconcile.Result{Requeue: true},
 			},
 		},
+		"SelectDefaultsError": {
+			reason: "We should return any error we encounter selecting the claim defaults",
+			args: args{
+				mgr: &fake.Manager{},
+				opts: []ReconcilerOption{
+					WithClaimFinalizer(resource.FinalizerFns{
+						AddFinalizerFn: func(ctx context.Context, obj resource.Object) error { return nil },
+					}),
+					WithDefaultsSelector(DefaultsSelectorFn(func(ctx context.Context, cm resource.CompositeClaim) error { return errBoom })),
+				},
+				claim: withClaim(func(o *claim.Unstructured) {
+					o.SetResourceReference(&corev1.ObjectReference{})
+				}),
+			},
+			want: want{
+				claim: withClaim(func(o *claim.Unstructured) {
+					o.SetResourceReference(&corev1.ObjectReference{})
+					o.SetConditions(xpv1.ReconcileError(errors.Wrap(errBoom, errSelectDefaults)))
+				}),
+				r: reconcile.Result{Requeue: true},
+			},
+		},
+
 		"ConfigureError": {
 			reason: "We should return any error we encounter configuring the composite resource",
 			args: args{
@@ -402,6 +425,7 @@ func TestReconcile(t *testing.T) {
 						AddFinalizerFn: func(ctx context.Context, obj resource.Object) error { return nil },
 					}),
 					WithCompositeConfigurator(ConfiguratorFn(func(ctx context.Context, cm resource.CompositeClaim, cp resource.Composite) error { return errBoom })),
+					WithDefaultsSelector(DefaultsSelectorFn(func(ctx context.Context, cm resource.CompositeClaim) error { return nil })),
 				},
 				claim: withClaim(func(o *claim.Unstructured) {
 					o.SetResourceReference(&corev1.ObjectReference{})
@@ -430,6 +454,7 @@ func TestReconcile(t *testing.T) {
 					}),
 					WithCompositeConfigurator(ConfiguratorFn(func(ctx context.Context, cm resource.CompositeClaim, cp resource.Composite) error { return nil })),
 					WithBinder(BinderFn(func(ctx context.Context, cm resource.CompositeClaim, cp resource.Composite) error { return errBoom })),
+					WithDefaultsSelector(DefaultsSelectorFn(func(ctx context.Context, cm resource.CompositeClaim) error { return nil })),
 				},
 				claim: withClaim(func(o *claim.Unstructured) {
 					o.SetResourceReference(&corev1.ObjectReference{})
@@ -458,6 +483,7 @@ func TestReconcile(t *testing.T) {
 					}),
 					WithCompositeConfigurator(ConfiguratorFn(func(ctx context.Context, cm resource.CompositeClaim, cp resource.Composite) error { return nil })),
 					WithBinder(BinderFn(func(ctx context.Context, cm resource.CompositeClaim, cp resource.Composite) error { return nil })),
+					WithDefaultsSelector(DefaultsSelectorFn(func(ctx context.Context, cm resource.CompositeClaim) error { return nil })),
 				},
 				claim: withClaim(func(o *claim.Unstructured) {
 					o.SetResourceReference(&corev1.ObjectReference{})
@@ -490,6 +516,7 @@ func TestReconcile(t *testing.T) {
 					WithCompositeConfigurator(ConfiguratorFn(func(ctx context.Context, cm resource.CompositeClaim, cp resource.Composite) error { return nil })),
 					WithBinder(BinderFn(func(ctx context.Context, cm resource.CompositeClaim, cp resource.Composite) error { return nil })),
 					WithClaimConfigurator(ConfiguratorFn(func(ctx context.Context, cm resource.CompositeClaim, cp resource.Composite) error { return errBoom })),
+					WithDefaultsSelector(DefaultsSelectorFn(func(ctx context.Context, cm resource.CompositeClaim) error { return nil })),
 				},
 				claim: withClaim(func(o *claim.Unstructured) {
 					o.SetResourceReference(&corev1.ObjectReference{})
@@ -522,6 +549,7 @@ func TestReconcile(t *testing.T) {
 					WithCompositeConfigurator(ConfiguratorFn(func(ctx context.Context, cm resource.CompositeClaim, cp resource.Composite) error { return nil })),
 					WithBinder(BinderFn(func(ctx context.Context, cm resource.CompositeClaim, cp resource.Composite) error { return nil })),
 					WithClaimConfigurator(ConfiguratorFn(func(ctx context.Context, cm resource.CompositeClaim, cp resource.Composite) error { return nil })),
+					WithDefaultsSelector(DefaultsSelectorFn(func(ctx context.Context, cm resource.CompositeClaim) error { return nil })),
 				},
 				claim: withClaim(func(o *claim.Unstructured) {
 					o.SetResourceReference(&corev1.ObjectReference{})
@@ -563,6 +591,7 @@ func TestReconcile(t *testing.T) {
 					WithConnectionPropagator(ConnectionPropagatorFn(func(ctx context.Context, to resource.LocalConnectionSecretOwner, from resource.ConnectionSecretOwner) (propagated bool, err error) {
 						return false, errBoom
 					})),
+					WithDefaultsSelector(DefaultsSelectorFn(func(ctx context.Context, cm resource.CompositeClaim) error { return nil })),
 				},
 				claim: withClaim(func(o *claim.Unstructured) {
 					o.SetResourceReference(&corev1.ObjectReference{})
@@ -604,6 +633,7 @@ func TestReconcile(t *testing.T) {
 					WithConnectionPropagator(ConnectionPropagatorFn(func(ctx context.Context, to resource.LocalConnectionSecretOwner, from resource.ConnectionSecretOwner) (propagated bool, err error) {
 						return true, nil
 					})),
+					WithDefaultsSelector(DefaultsSelectorFn(func(ctx context.Context, cm resource.CompositeClaim) error { return nil })),
 				},
 				claim: withClaim(func(o *claim.Unstructured) {
 					o.SetResourceReference(&corev1.ObjectReference{})
@@ -684,6 +714,7 @@ func TestReconcile(t *testing.T) {
 					WithConnectionPropagator(ConnectionPropagatorFn(func(ctx context.Context, to resource.LocalConnectionSecretOwner, from resource.ConnectionSecretOwner) (propagated bool, err error) {
 						return true, nil
 					})),
+					WithDefaultsSelector(DefaultsSelectorFn(func(ctx context.Context, cm resource.CompositeClaim) error { return nil })),
 				},
 				claim: withClaim(func(o *claim.Unstructured) {
 					o.SetResourceReference(&corev1.ObjectReference{})
@@ -728,6 +759,7 @@ func TestReconcile(t *testing.T) {
 					WithConnectionPropagator(ConnectionPropagatorFn(func(ctx context.Context, to resource.LocalConnectionSecretOwner, from resource.ConnectionSecretOwner) (propagated bool, err error) {
 						return true, nil
 					})),
+					WithDefaultsSelector(DefaultsSelectorFn(func(ctx context.Context, cm resource.CompositeClaim) error { return nil })),
 				},
 				claim: withClaim(func(o *claim.Unstructured) {
 					o.SetResourceReference(&corev1.ObjectReference{})

--- a/internal/controller/apiextensions/composite/api.go
+++ b/internal/controller/apiextensions/composite/api.go
@@ -57,7 +57,8 @@ const (
 
 // Event reasons.
 const (
-	reasonCompositionSelection event.Reason = "CompositionSelection"
+	reasonCompositionSelection    event.Reason = "CompositionSelection"
+	reasonCompositionUpdatePolicy event.Reason = "CompositionUpdatePolicy"
 )
 
 // APIFilteredSecretPublisher publishes ConnectionDetails content after filtering
@@ -429,4 +430,36 @@ func (c *APINamingConfigurator) Configure(ctx context.Context, cp resource.Compo
 	}
 	meta.AddLabels(cp, map[string]string{xcrd.LabelKeyNamePrefixForComposed: cp.GetName()})
 	return errors.Wrap(c.client.Update(ctx, cp), errUpdateComposite)
+}
+
+// NewAPIDefaultCompositionUpdatePolicySelector returns a APIDefaultCompositionUpdatePolicySelector.
+func NewAPIDefaultCompositionUpdatePolicySelector(c client.Client, ref corev1.ObjectReference, r event.Recorder) *APIDefaultCompositionUpdatePolicySelector {
+	return &APIDefaultCompositionUpdatePolicySelector{client: c, defRef: ref, recorder: r}
+}
+
+// APIDefaultCompositionUpdatePolicySelector selects the default composition update policy referenced in
+// the definition of the resource if neither a reference nor selector is given
+// in composite resource.
+type APIDefaultCompositionUpdatePolicySelector struct {
+	client   client.Client
+	defRef   corev1.ObjectReference
+	recorder event.Recorder
+}
+
+// SelectCompositionUpdatePolicy selects the default composition update policy if neither a reference nor
+// selector is given in composite resource.
+func (s *APIDefaultCompositionUpdatePolicySelector) SelectCompositionUpdatePolicy(ctx context.Context, cp resource.Composite) error {
+	if cp.GetCompositionUpdatePolicy() != nil {
+		return nil
+	}
+	def := &v1.CompositeResourceDefinition{}
+	if err := s.client.Get(ctx, meta.NamespacedNameOf(&s.defRef), def); err != nil {
+		return errors.Wrap(err, errGetXRD)
+	}
+	if def.Spec.DefaultCompositionUpdatePolicy == nil {
+		return nil
+	}
+	cp.SetCompositionUpdatePolicy(def.Spec.DefaultCompositionUpdatePolicy)
+	s.recorder.Event(cp, event.Normal(reasonCompositionUpdatePolicy, "Default composition update policy has been selected"))
+	return nil
 }

--- a/internal/controller/apiextensions/composite/api_test.go
+++ b/internal/controller/apiextensions/composite/api_test.go
@@ -1063,3 +1063,98 @@ func TestAPINamingConfigurator(t *testing.T) {
 		})
 	}
 }
+
+func TestAPIDefaultCompositionUpdatePolicySelector(t *testing.T) {
+	errBoom := errors.New("boom")
+	manual := xpv1.UpdateManual
+	auto := xpv1.UpdateAutomatic
+	a, k := schema.EmptyObjectKind.GroupVersionKind().ToAPIVersionAndKind()
+	tref := v1.TypeReference{APIVersion: a, Kind: k}
+	comp := &v1.Composition{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "foo",
+		},
+		Spec: v1.CompositionSpec{
+			CompositeTypeRef: tref,
+		},
+	}
+	type args struct {
+		kube   client.Client
+		defRef corev1.ObjectReference
+		cp     resource.Composite
+	}
+	type want struct {
+		cp  resource.Composite
+		err error
+	}
+	cases := map[string]struct {
+		reason string
+		args
+		want
+	}{
+		"AlreadyResolved": {
+			reason: "Should be no-op if a composition update policy is already specified",
+			args: args{
+				defRef: corev1.ObjectReference{},
+				cp: &fake.Composite{
+					CompositionUpdater: fake.CompositionUpdater{Policy: &manual},
+				},
+			},
+			want: want{
+				cp: &fake.Composite{
+					CompositionUpdater: fake.CompositionUpdater{Policy: &manual},
+				},
+			},
+		},
+		"GetDefinitionFailed": {
+			reason: "Should return error if XRD cannot be retrieved",
+			args: args{
+				kube: &test.MockClient{
+					MockGet: test.NewMockGetFn(errBoom),
+				},
+				cp: &fake.Composite{},
+			},
+			want: want{
+				err: errors.Wrap(errBoom, errGetXRD),
+				cp:  &fake.Composite{},
+			},
+		},
+		"Success": {
+			reason: "Successfully set the default composition update policy",
+			args: args{
+				kube: &test.MockClient{
+					MockGet: func(_ context.Context, _ client.ObjectKey, obj client.Object) error {
+						switch cr := obj.(type) {
+						case *v1.CompositeResourceDefinition:
+							withRef := &v1.CompositeResourceDefinition{Spec: v1.CompositeResourceDefinitionSpec{DefaultCompositionUpdatePolicy: &auto}}
+							withRef.DeepCopyInto(cr)
+							return nil
+						case *v1.Composition:
+							comp.DeepCopyInto(cr)
+							return nil
+						}
+						return nil
+					},
+				},
+				cp: &fake.Composite{},
+			},
+			want: want{
+				cp: &fake.Composite{
+					CompositionUpdater: fake.CompositionUpdater{Policy: &auto},
+				},
+			},
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			c := NewAPIDefaultCompositionUpdatePolicySelector(tc.args.kube, tc.args.defRef, event.NewNopRecorder())
+			err := c.SelectCompositionUpdatePolicy(context.Background(), tc.args.cp)
+			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
+				t.Errorf("\n%s\nSelectCompositionUpdatePolicy(...): -want, +got:\n%s", tc.reason, diff)
+			}
+			if diff := cmp.Diff(tc.want.cp, tc.args.cp); diff != "" {
+				t.Errorf("\n%s\nSelectCompositionUpdatePolicy(...): -want, +got:\n%s", tc.reason, diff)
+			}
+		})
+	}
+}

--- a/internal/controller/apiextensions/composite/reconciler_test.go
+++ b/internal/controller/apiextensions/composite/reconciler_test.go
@@ -202,6 +202,25 @@ func TestReconcile(t *testing.T) {
 				r: reconcile.Result{Requeue: true},
 			},
 		},
+		"SelectCompositionUpdatePolicyError": {
+			reason: "We should return any error encountered while selecting a composition update policy.",
+			args: args{
+				mgr: &fake.Manager{},
+				opts: []ReconcilerOption{
+					WithClient(&test.MockClient{
+						MockGet: test.NewMockGetFn(nil),
+						MockStatusUpdate: WantComposite(t, NewComposite(func(cr resource.Composite) {
+							cr.SetConditions(xpv1.ReconcileError(errors.Wrap(errBoom, errSelectCompUpdatePolicy)))
+						})),
+					}),
+					WithCompositeFinalizer(resource.NewNopFinalizer()),
+					WithCompositionUpdatePolicySelector(CompositionUpdatePolicySelectorFn(func(ctx context.Context, cr resource.Composite) error { return errBoom })),
+				},
+			},
+			want: want{
+				r: reconcile.Result{Requeue: true},
+			},
+		},
 		"SelectCompositionError": {
 			reason: "We should return any error encountered while selecting a composition.",
 			args: args{
@@ -217,6 +236,7 @@ func TestReconcile(t *testing.T) {
 					WithCompositionSelector(CompositionSelectorFn(func(_ context.Context, _ resource.Composite) error {
 						return errBoom
 					})),
+					WithCompositionUpdatePolicySelector(CompositionUpdatePolicySelectorFn(func(ctx context.Context, cr resource.Composite) error { return nil })),
 				},
 			},
 			want: want{
@@ -243,6 +263,7 @@ func TestReconcile(t *testing.T) {
 					WithCompositionFetcher(CompositionFetcherFn(func(_ context.Context, _ resource.Composite) (*v1.Composition, error) {
 						return nil, errBoom
 					})),
+					WithCompositionUpdatePolicySelector(CompositionUpdatePolicySelectorFn(func(ctx context.Context, cr resource.Composite) error { return nil })),
 				},
 			},
 			want: want{
@@ -272,7 +293,7 @@ func TestReconcile(t *testing.T) {
 					WithCompositionValidator(func(_ *v1.Composition) error {
 						return errBoom
 					}),
-				},
+					WithCompositionUpdatePolicySelector(CompositionUpdatePolicySelectorFn(func(ctx context.Context, cr resource.Composite) error { return nil }))},
 			},
 			want: want{
 				r: reconcile.Result{Requeue: true},
@@ -302,6 +323,7 @@ func TestReconcile(t *testing.T) {
 					WithConfigurator(ConfiguratorFn(func(_ context.Context, _ resource.Composite, _ *v1.Composition) error {
 						return errBoom
 					})),
+					WithCompositionUpdatePolicySelector(CompositionUpdatePolicySelectorFn(func(ctx context.Context, cr resource.Composite) error { return nil })),
 				},
 			},
 			want: want{
@@ -330,6 +352,7 @@ func TestReconcile(t *testing.T) {
 					WithEnvironmentSelector(EnvironmentSelectorFn(func(ctx context.Context, cr resource.Composite, cp *v1.Composition) error {
 						return errBoom
 					})),
+					WithCompositionUpdatePolicySelector(CompositionUpdatePolicySelectorFn(func(ctx context.Context, cr resource.Composite) error { return nil })),
 				},
 			},
 			want: want{
@@ -358,6 +381,7 @@ func TestReconcile(t *testing.T) {
 					WithEnvironmentFetcher(EnvironmentFetcherFn(func(ctx context.Context, cr resource.Composite) (*env.Environment, error) {
 						return nil, errBoom
 					})),
+					WithCompositionUpdatePolicySelector(CompositionUpdatePolicySelectorFn(func(ctx context.Context, cr resource.Composite) error { return nil })),
 				},
 			},
 			want: want{
@@ -391,6 +415,7 @@ func TestReconcile(t *testing.T) {
 					WithComposer(ComposerFn(func(ctx context.Context, xr resource.Composite, req CompositionRequest) (CompositionResult, error) {
 						return CompositionResult{}, errBoom
 					})),
+					WithCompositionUpdatePolicySelector(CompositionUpdatePolicySelectorFn(func(ctx context.Context, cr resource.Composite) error { return nil })),
 				},
 			},
 			want: want{
@@ -429,6 +454,7 @@ func TestReconcile(t *testing.T) {
 							return false, errBoom
 						},
 					}),
+					WithCompositionUpdatePolicySelector(CompositionUpdatePolicySelectorFn(func(ctx context.Context, cr resource.Composite) error { return nil })),
 				},
 			},
 			want: want{
@@ -472,6 +498,7 @@ func TestReconcile(t *testing.T) {
 							return false, nil
 						},
 					}),
+					WithCompositionUpdatePolicySelector(CompositionUpdatePolicySelectorFn(func(ctx context.Context, cr resource.Composite) error { return nil })),
 				},
 			},
 			want: want{
@@ -517,6 +544,7 @@ func TestReconcile(t *testing.T) {
 							return false, nil
 						},
 					}),
+					WithCompositionUpdatePolicySelector(CompositionUpdatePolicySelectorFn(func(ctx context.Context, cr resource.Composite) error { return nil })),
 				},
 			},
 			want: want{
@@ -563,6 +591,7 @@ func TestReconcile(t *testing.T) {
 							return true, nil
 						},
 					}),
+					WithCompositionUpdatePolicySelector(CompositionUpdatePolicySelectorFn(func(ctx context.Context, cr resource.Composite) error { return nil })),
 				},
 			},
 			want: want{
@@ -646,6 +675,7 @@ func TestReconcile(t *testing.T) {
 							return true, nil
 						},
 					}),
+					WithCompositionUpdatePolicySelector(CompositionUpdatePolicySelectorFn(func(ctx context.Context, cr resource.Composite) error { return nil })),
 				},
 			},
 			want: want{
@@ -692,6 +722,7 @@ func TestReconcile(t *testing.T) {
 							return true, nil
 						},
 					}),
+					WithCompositionUpdatePolicySelector(CompositionUpdatePolicySelectorFn(func(ctx context.Context, cr resource.Composite) error { return nil })),
 				},
 			},
 			want: want{

--- a/internal/controller/apiextensions/definition/reconciler.go
+++ b/internal/controller/apiextensions/definition/reconciler.go
@@ -434,6 +434,7 @@ func CompositeReconcilerOptions(co controller.Options, d *v1.CompositeResourceDe
 			composite.NewAPIDefaultCompositionSelector(c, *meta.ReferenceTo(d, v1.CompositeResourceDefinitionGroupVersionKind), e),
 			composite.NewAPILabelSelectorResolver(c),
 		)),
+		composite.WithCompositionUpdatePolicySelector(composite.NewAPIDefaultCompositionUpdatePolicySelector(c, *meta.ReferenceTo(d, v1.CompositeResourceDefinitionGroupVersionKind), e)),
 		composite.WithLogger(l.WithValues("controller", composite.ControllerName(d.GetName()))),
 		composite.WithRecorder(e.WithAnnotations("controller", composite.ControllerName(d.GetName()))),
 		composite.WithPollInterval(co.PollInterval),

--- a/internal/controller/apiextensions/offered/reconciler.go
+++ b/internal/controller/apiextensions/offered/reconciler.go
@@ -393,6 +393,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 		claim.WithLogger(log.WithValues("controller", claim.ControllerName(d.GetName()))),
 		claim.WithRecorder(r.record.WithAnnotations("controller", claim.ControllerName(d.GetName()))),
 		claim.WithPollInterval(r.options.PollInterval),
+		claim.WithDefaultsSelector(claim.NewAPIDefaultSelector(r.client, *meta.ReferenceTo(d, v1.CompositeResourceDefinitionGroupVersionKind), r.record.WithAnnotations("controller", claim.ControllerName(d.GetName())))),
 	}
 
 	// We only want to enable ExternalSecretStore support if the relevant

--- a/internal/xcrd/crd_test.go
+++ b/internal/xcrd/crd_test.go
@@ -267,7 +267,6 @@ func TestForCompositeResource(t *testing.T) {
 											{Raw: []byte(`"Automatic"`)},
 											{Raw: []byte(`"Manual"`)},
 										},
-										Default: &extv1.JSON{Raw: []byte(`"Automatic"`)},
 									},
 									"claimRef": {
 										Type:     "object",
@@ -663,8 +662,7 @@ func TestForCompositeResourceClaim(t *testing.T) {
 											},
 										},
 										"compositeDeletePolicy": {
-											Type:    "string",
-											Default: &extv1.JSON{Raw: []byte(`"Background"`)},
+											Type: "string",
 											Enum: []extv1.JSON{{Raw: []byte(`"Background"`)},
 												{Raw: []byte(`"Foreground"`)}},
 										},
@@ -715,7 +713,6 @@ func TestForCompositeResourceClaim(t *testing.T) {
 												{Raw: []byte(`"Automatic"`)},
 												{Raw: []byte(`"Manual"`)},
 											},
-											Default: &extv1.JSON{Raw: []byte(`"Automatic"`)},
 										},
 										"resourceRef": {
 											Type:     "object",

--- a/internal/xcrd/schemas.go
+++ b/internal/xcrd/schemas.go
@@ -112,7 +112,6 @@ func CompositeResourceSpecProps() map[string]extv1.JSONSchemaProps {
 				{Raw: []byte(`"Automatic"`)},
 				{Raw: []byte(`"Manual"`)},
 			},
-			Default: &extv1.JSON{Raw: []byte(`"Automatic"`)},
 		},
 		"claimRef": {
 			Type:     "object",
@@ -252,7 +251,6 @@ func CompositeResourceClaimSpecProps() map[string]extv1.JSONSchemaProps {
 				{Raw: []byte(`"Automatic"`)},
 				{Raw: []byte(`"Manual"`)},
 			},
-			Default: &extv1.JSON{Raw: []byte(`"Automatic"`)},
 		},
 		"compositeDeletePolicy": {
 			Type: "string",
@@ -260,7 +258,7 @@ func CompositeResourceClaimSpecProps() map[string]extv1.JSONSchemaProps {
 				{Raw: []byte(`"Background"`)},
 				{Raw: []byte(`"Foreground"`)},
 			},
-			Default: &extv1.JSON{Raw: []byte(`"Background"`)}},
+		},
 		"resourceRef": {
 			Type:     "object",
 			Required: []string{"apiVersion", "kind", "name"},


### PR DESCRIPTION
### Description of your changes
Added defaultCompositeDeletePolicy and defaultCompositionUpdatePolicy attributes to the XRD to enable the author to specify defaults for how the Composite should be deleted and how Compositions should be updated.

Fixes #3744 #3745 

I have:

- [X] Read and followed Crossplane's [contribution process].
- [X] Run `make reviewable` to ensure this PR is ready for review.
- [X] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested
Created a Composite resource with:

```
spec:
  claimNames:
    kind: TEST
    plural: tests
  defaultCompositeDeletePolicy: Foreground
  defaultCompositionRef:
    name: test
  defaultCompositionUpdatePolicy: Manual
```

and verified that the Claim is modified to include:

```
  spec:
    compositeDeletePolicy: Foreground
    compositionRef:
      name: test
    compositionUpdatePolicy: Manual
```

and the Composite is modified to have:

```
  spec:
    compositionRef:
      name: test
    compositionUpdatePolicy: Manual
```


[contribution process]: https://git.io/fj2m9
