### PR TITLE
fix: validate Composition MathTransform clamp

### DIFF
--- a/apis/apiextensions/v1/composition_transforms.go
+++ b/apis/apiextensions/v1/composition_transforms.go
@@ -261,10 +261,31 @@ type MathTransform struct {
 	ClampMax *int64 `json:"clampMax,omitempty"`
 }
 
+// GetType returns the type of the math transform, returning the default if not specified.
+func (m *MathTransform) GetType() MathTransformType {
+	if m.Type == "" {
+		return MathTransformTypeMultiply
+	}
+	return m.Type
+}
+
 // Validate checks this MathTransform is valid.
 func (m *MathTransform) Validate() *field.Error {
-	if m.Multiply == nil {
-		return field.Required(field.NewPath("multiply"), "at least one operation must be specified if a math transform is specified")
+	switch m.GetType() {
+	case MathTransformTypeMultiply:
+		if m.Multiply == nil {
+			return field.Required(field.NewPath("multiply"), "must specify a value if a multiply math transform is specified")
+		}
+	case MathTransformTypeClampMin:
+		if m.ClampMin == nil {
+			return field.Required(field.NewPath("clampMin"), "must specify a value if a clamp min math transform is specified")
+		}
+	case MathTransformTypeClampMax:
+		if m.ClampMax == nil {
+			return field.Required(field.NewPath("clampMax"), "must specify a value if a clamp max math transform is specified")
+		}
+	default:
+		return field.Invalid(field.NewPath("type"), m.Type, "unknown math transform type")
 	}
 	return nil
 }

--- a/apis/apiextensions/v1/composition_transforms_test.go
+++ b/apis/apiextensions/v1/composition_transforms_test.go
@@ -42,8 +42,20 @@ func TestTransform_Validate(t *testing.T) {
 		args   args
 		want   want
 	}{
-		"ValidMath": {
-			reason: "Math transform with MathTransform set should be valid",
+		"ValidMathMultiply": {
+			reason: "Math transform with MathTransform Multiply set should be valid",
+			args: args{
+				transform: &Transform{
+					Type: TransformTypeMath,
+					Math: &MathTransform{
+						Type:     MathTransformTypeMultiply,
+						Multiply: pointer.Int64(2),
+					},
+				},
+			},
+		},
+		"ValidMathDefaultType": {
+			reason: "Math transform with MathTransform Default set should be valid",
 			args: args{
 				transform: &Transform{
 					Type: TransformTypeMath,
@@ -53,7 +65,37 @@ func TestTransform_Validate(t *testing.T) {
 				},
 			},
 		},
-		"InvalidMath": {
+		"ValidMathClampMin": {
+			reason: "Math transform with valid MathTransform ClampMin set should be valid",
+			args: args{
+				transform: &Transform{
+					Type: TransformTypeMath,
+					Math: &MathTransform{
+						Type:     MathTransformTypeClampMin,
+						ClampMin: pointer.Int64(10),
+					},
+				},
+			},
+		},
+		"InvalidMathWrongSpec": {
+			reason: "Math transform with invalid MathTransform set should be invalid",
+			args: args{
+				transform: &Transform{
+					Type: TransformTypeMath,
+					Math: &MathTransform{
+						Type:     MathTransformTypeMultiply,
+						ClampMin: pointer.Int64(10),
+					},
+				},
+			},
+			want: want{
+				&field.Error{
+					Type:  field.ErrorTypeRequired,
+					Field: "math.multiply",
+				},
+			},
+		},
+		"InvalidMathNotDefinedAtAll": {
 			reason: "Math transform with no MathTransform set should be invalid",
 			args: args{
 				transform: &Transform{

--- a/internal/controller/apiextensions/composite/composition_transforms.go
+++ b/internal/controller/apiextensions/composite/composition_transforms.go
@@ -38,7 +38,6 @@ import (
 
 const (
 	errMathTransformTypeFailed = "type %s is not supported for math transform type"
-	errMathNoInput             = "no input is given"
 	errMathInputNonNumber      = "input is required to be a number for math transformer"
 
 	errFmtRequiredField                 = "%s is required by type %s"
@@ -124,21 +123,15 @@ func ResolveMath(t v1.MathTransform, input any) (any, error) {
 		return nil, errors.New(errMathInputNonNumber)
 	}
 
-	switch t.Type {
+	if err := t.Validate(); err != nil {
+		return nil, err
+	}
+	switch t.GetType() {
 	case v1.MathTransformTypeMultiply:
-		if t.Multiply == nil {
-			return nil, errors.New(errMathNoInput)
-		}
 		return inputInt * *t.Multiply, nil
 	case v1.MathTransformTypeClampMax:
-		if t.ClampMax == nil {
-			return nil, errors.New(errMathNoInput)
-		}
 		return mathClampMax(inputInt, *t.ClampMax), nil
 	case v1.MathTransformTypeClampMin:
-		if t.ClampMin == nil {
-			return nil, errors.New(errMathNoInput)
-		}
 		return mathClampMin(inputInt, *t.ClampMin), nil
 	default:
 		return nil, errors.Errorf(errMathTransformTypeFailed, string(t.Type))

--- a/internal/controller/apiextensions/composite/composition_transforms_test.go
+++ b/internal/controller/apiextensions/composite/composition_transforms_test.go
@@ -481,7 +481,10 @@ func TestMathResolve(t *testing.T) {
 				i:        25,
 			},
 			want: want{
-				err: errors.New("type bad is not supported for math transform type"),
+				err: &field.Error{
+					Type:  field.ErrorTypeInvalid,
+					Field: "type",
+				},
 			},
 		},
 		"NonNumberInput": {
@@ -500,7 +503,10 @@ func TestMathResolve(t *testing.T) {
 				i:        25,
 			},
 			want: want{
-				err: errors.New(errMathNoInput),
+				err: &field.Error{
+					Type:  field.ErrorTypeRequired,
+					Field: "multiply",
+				},
 			},
 		},
 		"MultiplySuccess": {
@@ -559,7 +565,10 @@ func TestMathResolve(t *testing.T) {
 				i:        25,
 			},
 			want: want{
-				err: errors.New(errMathNoInput),
+				err: &field.Error{
+					Type:  field.ErrorTypeRequired,
+					Field: "clampMin",
+				},
 			},
 		},
 		"ClampMaxSuccess": {
@@ -598,7 +607,10 @@ func TestMathResolve(t *testing.T) {
 				i:        25,
 			},
 			want: want{
-				err: errors.New(errMathNoInput),
+				err: &field.Error{
+					Type:  field.ErrorTypeRequired,
+					Field: "clampMax",
+				},
 			},
 		},
 	}
@@ -609,6 +621,11 @@ func TestMathResolve(t *testing.T) {
 
 			if diff := cmp.Diff(tc.want.o, got); diff != "" {
 				t.Errorf("Resolve(b): -want, +got:\n%s", diff)
+			}
+			fieldErr := &field.Error{}
+			if err != nil && errors.As(err, &fieldErr) {
+				fieldErr.Detail = ""
+				fieldErr.BadValue = nil
 			}
 			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
 				t.Errorf("Resolve(b): -want, +got:\n%s", diff)


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Follow up to #3917 adding the missing validation.
Otherwise would have been rejected by the validating webhook and the validation logic.
The switch will ensure any new type added will be caught by the linter and reported as missing in the validate method.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

Unit tests and manually deploying it and applying a Composition with a math transform.

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
