### PR TITLE
Pass ESS cert directory name as env variable

### DIFF
--- a/internal/controller/pkg/revision/deployment.go
+++ b/internal/controller/pkg/revision/deployment.go
@@ -51,8 +51,9 @@ const (
 	webhookPortName         = "webhook"
 	webhookPort             = 9443
 
-	essCertsVolumeName = "ess-client-certs"
-	essCertsDir        = "/ess/tls"
+	essTLSCertDirEnvVar = "ESS_TLS_CERTS_DIR"
+	essCertsVolumeName  = "ess-client-certs"
+	essCertsDir         = "/ess/tls"
 )
 
 //nolint:gocyclo // TODO(negz): Can this be refactored for less complexity (and fewer arguments?)
@@ -200,6 +201,12 @@ func buildProviderDeployment(provider *pkgmetav1.Provider, revision v1.PackageRe
 		}
 		d.Spec.Template.Spec.Containers[0].VolumeMounts =
 			append(d.Spec.Template.Spec.Containers[0].VolumeMounts, vm)
+
+		envs := []corev1.EnvVar{
+			{Name: essTLSCertDirEnvVar, Value: essCertsDir},
+		}
+		d.Spec.Template.Spec.Containers[0].Env =
+			append(d.Spec.Template.Spec.Containers[0].Env, envs...)
 	}
 
 	templateLabels := make(map[string]string)


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

With this PR, we'll start passing ESS certificate path to providers via environment variable. 

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested
Tested with custom provider-gcp package with old Crossplane version and with the version on this branch and validated that new providers with old XP versions are not crashing. 


<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
