### PR TITLE
Add VSHN as a Crossplane adopter

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -46,3 +46,4 @@ This list is sorted in the order that organizations were added to it.
 | [Grafana Labs](https://grafana.com/) | @Duologic | Control plane for an internal developer platform |
 | [Ancestry](https://www.ancestry.com/) | @joshadambell | Control plane and infrastructure management solution in production for AWS EKS |
 | [Syntasso](https://syntasso.io) | @syntassodev |  Used as an optional subcomponent in [Kratix](https://kratix.io), to enable platform teams to manage infrastructure. |
+| [VSHN](https://www.vshn.ch) | @tobru | Crossplane powers the [VSHN Application Catalog (AppCat)](https://products.vshn.ch/appcat/index.html), a Cloud Native marketplace which offers services from Cloud Service Providers like Amazon AWS, Google Cloud, Microsoft Azure, Aiven.io, Exoscale or cloudscale.ch, as well as managed services from VSHN. |


### PR DESCRIPTION
### Description of your changes

VSHN is an early adopter of Crossplane and uses it in production since early 2020. We'd love to be documented as an adopter.
