### PR TITLE
fix: respect logical validation option

### DIFF
--- a/pkg/validation/apiextensions/v1/composition/validator.go
+++ b/pkg/validation/apiextensions/v1/composition/validator.go
@@ -115,9 +115,11 @@ func (v *Validator) Validate(ctx context.Context, obj runtime.Object) (warns []s
 		return nil, append(errs, field.NotSupported(field.NewPath("kind"), obj.GetObjectKind().GroupVersionKind().Kind, []string{v1.CompositionGroupVersionKind.Kind}))
 	}
 
-	// Validate the composition itself, we'll disable it on the Validator below
-	if warns, errs := comp.Validate(); len(errs) != 0 {
-		return warns, errs
+	// Validate the Composition itself
+	if v.logicalValidation != nil {
+		if warns, errs := v.logicalValidation(comp); len(errs) != 0 {
+			return warns, errs
+		}
 	}
 
 	// Validate patches given the above CRDs, skip if any of the required CRDs is not available


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Small follow-up fix for https://github.com/crossplane/crossplane/pull/3937, we forgot to respect the logical validation option provided. This would result in logical validation not being disabled even if asked to do so, running it twice in the validatin webhook if schema-aware validation was enabled with `--enable-composition-webhook-schema-validation`.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

Not really needed, but unit tests are passing and I manually deployed and checked it as described in the original PRs.

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
