### PR TITLE
Bump default package cache size limit to 20Mi

### DIFF
--- a/cluster/charts/crossplane/values.yaml.tmpl
+++ b/cluster/charts/crossplane/values.yaml.tmpl
@@ -66,7 +66,7 @@ securityContextCrossplane:
 
 packageCache:
   medium: ""
-  sizeLimit: 5Mi
+  sizeLimit: 20Mi
   pvc: ""
   configMap: ""
 


### PR DESCRIPTION
### Description of your changes

It turns out that we have been operating on limits with the existing 5Mi package cache size limit, and any further growth or use case including multiple big-sized providers would cause Crossplane pods to be evicted with 

```
  Warning  Evicted              48s   kubelet            Usage of EmptyDir volume "package-cache" exceeds the limit "5Mi".
```

I initially observed this problem while upgrading the latest provider-aws (`xpkg.upbound.io/upbound/provider-aws:v0.32.1`) to a local built from [this PR](https://github.com/upbound/provider-aws/pull/672) where I found out later that package size in the cache increased from `2.2Mb` to `2.8Mb`. Since 1 revision history is kept by default, package cache reached to the limit (`2.2Mb + 2.8Mb = 5Mb`) and XP pod is evicted with the error above.

I want to configure a less conservative value also to allow for future increases and multi-provider scenarios.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

Deploy from this PR and make sure the cache size limit is configured as 20Mi.

[contribution process]: https://git.io/fj2m9
