### PR TITLE
feat: math transform supporting floats

### DIFF
--- a/internal/controller/apiextensions/composite/composition_transforms_test.go
+++ b/internal/controller/apiextensions/composite/composition_transforms_test.go
@@ -495,7 +495,7 @@ func TestMathResolve(t *testing.T) {
 				i:          "ola",
 			},
 			want: want{
-				err: errors.New(errMathInputNonNumber),
+				err: errors.Errorf(errFmtMathInputNonNumber, "ola"),
 			},
 		},
 		"MultiplyNoConfig": {
@@ -540,11 +540,21 @@ func TestMathResolve(t *testing.T) {
 				o: int64(2),
 			},
 		},
-		"ClampMinSuccessNoChange": {
+		"ClampMinSuccessNoChangeInt": {
 			args: args{
 				mathType: v1.MathTransformTypeClampMin,
 				clampMin: &two,
 				i:        3,
+			},
+			want: want{
+				o: 3,
+			},
+		},
+		"ClampMinSuccessNoChangeInt64": {
+			args: args{
+				mathType: v1.MathTransformTypeClampMin,
+				clampMin: &two,
+				i:        int64(3),
 			},
 			want: want{
 				o: int64(3),
@@ -586,7 +596,7 @@ func TestMathResolve(t *testing.T) {
 			args: args{
 				mathType: v1.MathTransformTypeClampMax,
 				clampMax: &two,
-				i:        1,
+				i:        int64(1),
 			},
 			want: want{
 				o: int64(1),


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #3059.

Added float64 support for all current types of math transforms:
- multiply will return float64 if the input is a float64, int64 otherwise
- clampMin/clampMax will return the threshold value as int64 if the input is below/above it, the original input otherwise.

I'd like to highlight that it's suggested not to use floats as outputs, see https://github.com/kubernetes-sigs/controller-tools/issues/245 and https://github.com/crossplane/crossplane/issues/3059#issuecomment-1112744496, but currently there is no transform from float64 to quantities, should we add that too in the context of this PR or should we handle it separately?
Something like the following could be added to https://github.com/crossplane/crossplane/blob/7a55c644a1b50c60d09c2695d56ee6ad61b37424/apis/apiextensions/v1/composition_transforms.go#L182:
```go
	{from: TransformIOTypeFloat64, to: TransformIOTypeString, format: ConvertTransformFormatQuantity}: func(i any) (any, error) { //nolint:unparam // See note above.
		q := resource.NewQuantity(int64(i.(float64)), resource.DecimalSI)
		return q.String(), nil
	},
```

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

Unit tests added.

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
