### PR TITLE
Warn that the --enable-composition-revisions flag will be removed

### DIFF
--- a/cmd/crossplane/core/core.go
+++ b/cmd/crossplane/core/core.go
@@ -92,7 +92,7 @@ type startCommand struct {
 	// You can't turn off a GA feature. We maintain the flags to avoid breaking
 	// folks who are passing them, but they do nothing. The flags are hidden so
 	// they don't show up in the help output.
-	EnableCompositionRevisions bool `hidden:""`
+	EnableCompositionRevisions bool `default:"true" hidden:""`
 }
 
 // Run core Crossplane controllers.
@@ -135,6 +135,9 @@ func (c *startCommand) Run(s *runtime.Scheme, log logging.Logger) error { //noli
 	if c.EnableCompositionWebhookSchemaValidation {
 		feats.Enable(features.EnableAlphaCompositionWebhookSchemaValidation)
 		log.Info("Alpha feature enabled", "flag", features.EnableAlphaCompositionWebhookSchemaValidation)
+	}
+	if !c.EnableCompositionRevisions {
+		log.Info("CompositionRevisions feature is GA and cannot be disabled. The --enable-composition-revisions flag will be removed in a future release.")
 	}
 
 	o := controller.Options{


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
A small follow-up to https://github.com/crossplane/crossplane/pull/3964. If anyone is explicitly disabling the feature today, the flag will continue to work but they'll get a log line telling them its going to be removed in a future version.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9

I've run Crossplane with `--enable-composition-revisions=false` and confirmed I see this log line:

```
2023-04-17T16:42:28-07:00       INFO    crossplane      CompositionRevisions feature is GA and cannot be disabled. The --enable-composition-revisions flag will be removed in a future release.
```