### PR TITLE
fix: schema-aware validation code cleanup and bug fixes

### DIFF
--- a/pkg/validation/apiextensions/v1/composition/patches.go
+++ b/pkg/validation/apiextensions/v1/composition/patches.go
@@ -306,7 +306,7 @@ func validateFieldPath(schema *apiextensions.JSONSchemaProps, fieldPath string) 
 	if len(segments) > 0 && segments[0].Type == fieldpath.SegmentField && segments[0].Field == "metadata" {
 		// if the fieldPath starts with metadata, we need to merge the metadata schema with the schema
 		// to make sure we validate the fieldPath correctly.
-		defaultMetadataSchema(schema)
+		schema = defaultMetadataSchema(schema)
 	}
 	return validateFieldPathSegments(segments, schema, fieldPath)
 }

--- a/pkg/validation/apiextensions/v1/composition/patches.go
+++ b/pkg/validation/apiextensions/v1/composition/patches.go
@@ -159,7 +159,7 @@ func (v *Validator) validatePatchWithSchemaInternal(ctx patchValidationCtx) *fie
 		)
 	case v1.PatchTypePatchSet:
 		// patches in a patch set are validated separately, so we'll just recurse one level deeper
-		for _, ps := range ctx.comp.Spec.PatchSets {
+		for i, ps := range ctx.comp.Spec.PatchSets {
 			if *ctx.patch.PatchSetName == ps.Name {
 				for j, patch := range ps.Patches {
 					if err := v.validatePatchWithSchemaInternal(patchValidationCtx{
@@ -171,7 +171,7 @@ func (v *Validator) validatePatchWithSchemaInternal(ctx patchValidationCtx) *fie
 						resourceGVK:     ctx.resourceGVK,
 					},
 					); err != nil {
-						return verrors.WrapFieldError(err, field.NewPath("inlinedPatchSet").Key(ps.Name).Child("patches").Index(j))
+						return verrors.WrapFieldError(err, field.NewPath("patchSets").Index(i).Child("patches").Index(j))
 					}
 				}
 			}

--- a/pkg/validation/apiextensions/v1/composition/patches.go
+++ b/pkg/validation/apiextensions/v1/composition/patches.go
@@ -98,12 +98,12 @@ func (v *Validator) validatePatchWithSchemas(ctx context.Context, comp *v1.Compo
 		comp.Spec.CompositeTypeRef.Kind,
 	)
 
-	compositeCRD, err := v.crdGetter.Get(ctx, compositeResGVK)
+	compositeCRD, err := v.crdGetter.Get(ctx, compositeResGVK.GroupKind())
 	if err != nil {
 		return field.InternalError(field.NewPath("spec").Child("resources").Index(resourceNumber), errors.Wrapf(err, "cannot find composite type %s: %s", comp.Spec.CompositeTypeRef, err))
 	}
 	resourceGVK := res.GetObjectKind().GroupVersionKind()
-	resourceCRD, err := v.crdGetter.Get(ctx, resourceGVK)
+	resourceCRD, err := v.crdGetter.Get(ctx, resourceGVK.GroupKind())
 	if err != nil {
 		return field.InternalError(field.NewPath("spec").Child("resources").Index(resourceNumber), errors.Errorf("cannot find resource type %s: %s", res.GetObjectKind().GroupVersionKind(), err))
 	}

--- a/pkg/validation/apiextensions/v1/composition/patches.go
+++ b/pkg/validation/apiextensions/v1/composition/patches.go
@@ -292,6 +292,7 @@ func validateTransformsChainIOTypes(transforms []v1.Transform, fromType xpschema
 // It returns the type of the fieldPath and any error.
 // If the returned type is "", but without error, it means the fieldPath is accepted by the schema, but not defined in it.
 func validateFieldPath(schema *apiextensions.JSONSchemaProps, fieldPath string) (fieldType xpschema.KnownJSONType, err error) {
+	// Code inspired by https://github.com/crossplane-contrib/crossplane-lint/commit/d58af636f06467151cce7c89ffd319828c1cd7a2#diff-3b13ed191dd7244f19f4c0870298fc5112153e136250e95095323e6c3c440bdfR230
 	if fieldPath == "" {
 		return "", nil
 	}

--- a/pkg/validation/apiextensions/v1/composition/patches_test.go
+++ b/pkg/validation/apiextensions/v1/composition/patches_test.go
@@ -351,6 +351,18 @@ func TestValidateFieldPath(t *testing.T) {
 									Properties: map[string]apiextensions.JSONSchemaProps{
 										"foo": {Type: "string"}}}}}}}},
 		},
+		"AcceptMetadataLabelsValue": {
+			reason: "Should validate a valid field path",
+			want:   want{err: nil, fieldType: "string"},
+			args: args{
+				fieldPath: "metadata.labels[networks.aws.platformref.upbound.io/network-id]",
+				schema: &apiextensions.JSONSchemaProps{
+					Properties: map[string]apiextensions.JSONSchemaProps{
+						"metadata": *getMetadataSchema(),
+					},
+				},
+			},
+		},
 		"RejectInvalidFieldPath": {
 			reason: "Should return an error for an invalid field path",
 			want:   want{err: xperrors.Errorf(errFmtFieldInvalid, "wrong")},
@@ -422,6 +434,14 @@ func TestValidateFieldPath(t *testing.T) {
 				fieldPath: "spec.forProvider.thumbprintList[0]",
 				// parse the schema from json
 				schema: complexSchemaOpenIDConnectProvidersV1beta1Props,
+			},
+		},
+		"AcceptMetadataUID": {
+			reason: "Should accept metadata.uid",
+			want:   want{err: nil, fieldType: "string"},
+			args: args{
+				fieldPath: "metadata.uid",
+				schema:    &apiextensions.JSONSchemaProps{Properties: map[string]apiextensions.JSONSchemaProps{"metadata": {Type: "object"}}},
 			},
 		},
 	}

--- a/pkg/validation/apiextensions/v1/composition/patches_test.go
+++ b/pkg/validation/apiextensions/v1/composition/patches_test.go
@@ -358,7 +358,7 @@ func TestValidateFieldPath(t *testing.T) {
 				fieldPath: "metadata.labels[networks.aws.platformref.upbound.io/network-id]",
 				schema: &apiextensions.JSONSchemaProps{
 					Properties: map[string]apiextensions.JSONSchemaProps{
-						"metadata": *getMetadataSchema(),
+						"metadata": *getDefaultMetadataSchema(),
 					},
 				},
 			},

--- a/pkg/validation/apiextensions/v1/composition/schema.go
+++ b/pkg/validation/apiextensions/v1/composition/schema.go
@@ -6,10 +6,10 @@ import (
 	"github.com/crossplane/crossplane/pkg/validation/internal/schema"
 )
 
-var (
+func getMetadataSchema() *apiextensions.JSONSchemaProps {
 	// hardcoded metadata schema as CRDs usually don't contain it, but we need the information to be able
 	// to validate patches from `metadata.uid` or similar fields
-	metadataSchema = apiextensions.JSONSchemaProps{
+	return &apiextensions.JSONSchemaProps{
 		Type: string(schema.KnownJSONTypeObject),
 		AdditionalProperties: &apiextensions.JSONSchemaPropsOrBool{
 			Allows: true,
@@ -24,6 +24,7 @@ var (
 			"labels": {
 				Type: string(schema.KnownJSONTypeObject),
 				AdditionalProperties: &apiextensions.JSONSchemaPropsOrBool{
+					Allows: true,
 					Schema: &apiextensions.JSONSchemaProps{
 						Type: string(schema.KnownJSONTypeString),
 					},
@@ -32,6 +33,7 @@ var (
 			"annotations": {
 				Type: string(schema.KnownJSONTypeObject),
 				AdditionalProperties: &apiextensions.JSONSchemaPropsOrBool{
+					Allows: true,
 					Schema: &apiextensions.JSONSchemaProps{
 						Type: string(schema.KnownJSONTypeString),
 					},
@@ -42,4 +44,41 @@ var (
 			},
 		},
 	}
-)
+}
+
+func defaultMetadataSchema(in *apiextensions.JSONSchemaProps) {
+	if in == nil {
+		in = &apiextensions.JSONSchemaProps{}
+	}
+	if in.Type == "" {
+		in.Type = string(schema.KnownJSONTypeObject)
+	}
+	if in.Properties == nil {
+		in.Properties = map[string]apiextensions.JSONSchemaProps{}
+	}
+	if _, exists := in.Properties["metadata"]; !exists {
+		in.Properties["metadata"] = apiextensions.JSONSchemaProps{
+			Type: string(schema.KnownJSONTypeObject),
+		}
+	}
+	metadata := in.Properties["metadata"]
+	if metadata.Properties == nil {
+		metadata.Properties = map[string]apiextensions.JSONSchemaProps{}
+	}
+	for name, prop := range getMetadataSchema().Properties {
+		if _, exists := metadata.Properties[name]; !exists {
+			metadata.Properties[name] = prop
+			continue
+		}
+		t := metadata.Properties[name]
+		if metadata.Properties[name].Type == "" {
+			t.Type = prop.Type
+		}
+		if metadata.Properties[name].AdditionalProperties == nil {
+			t.AdditionalProperties = prop.AdditionalProperties
+		}
+		metadata.Properties[name] = t
+
+	}
+	in.Properties["metadata"] = metadata
+}

--- a/pkg/validation/apiextensions/v1/composition/schema_test.go
+++ b/pkg/validation/apiextensions/v1/composition/schema_test.go
@@ -1,0 +1,146 @@
+package composition
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
+
+	"github.com/crossplane/crossplane/pkg/validation/internal/schema"
+)
+
+func getDefaultMetadataSchema() *apiextensions.JSONSchemaProps {
+	return defaultMetadataOnly(&apiextensions.JSONSchemaProps{})
+}
+
+func getDefaultSchema() *apiextensions.JSONSchemaProps {
+	return defaultMetadataSchema(&apiextensions.JSONSchemaProps{})
+}
+func TestDefaultMetadataSchema(t *testing.T) {
+	type args struct {
+		in *apiextensions.JSONSchemaProps
+	}
+	type want struct {
+		out *apiextensions.JSONSchemaProps
+	}
+	tests := map[string]struct {
+		reason string
+		args   args
+		want   want
+	}{
+		"Nil": {
+			reason: "Nil should output the default metadata schema",
+			args:   args{in: nil},
+			want: want{
+				out: getDefaultSchema(),
+			},
+		},
+		"Empty": {
+			reason: "Empty should output the default metadata schema",
+			args:   args{in: &apiextensions.JSONSchemaProps{}},
+			want: want{
+				out: getDefaultSchema(),
+			},
+		},
+		"Metadata": {
+			reason: "Metadata should output the default metadata schema",
+			args: args{in: &apiextensions.JSONSchemaProps{
+				Type: string(schema.KnownJSONTypeObject),
+				Properties: map[string]apiextensions.JSONSchemaProps{
+					"metadata": *getDefaultMetadataSchema(),
+				},
+			}},
+			want: want{
+				out: &apiextensions.JSONSchemaProps{
+					Type: string(schema.KnownJSONTypeObject),
+					Properties: map[string]apiextensions.JSONSchemaProps{
+						"metadata": *getDefaultMetadataSchema(),
+					},
+				},
+			},
+		},
+		"SpecPreserved": {
+			reason: "Other properties should be preserved",
+			args: args{in: &apiextensions.JSONSchemaProps{
+				Type: string(schema.KnownJSONTypeObject),
+				Properties: map[string]apiextensions.JSONSchemaProps{
+					"spec": {
+						Type: string(schema.KnownJSONTypeObject),
+						AdditionalProperties: &apiextensions.JSONSchemaPropsOrBool{
+							Allows: true,
+						}}}},
+			},
+			want: want{
+				out: &apiextensions.JSONSchemaProps{
+					Type: string(schema.KnownJSONTypeObject),
+					Properties: map[string]apiextensions.JSONSchemaProps{
+						"metadata": *getDefaultMetadataSchema(),
+						"spec": {
+							Type: string(schema.KnownJSONTypeObject),
+							AdditionalProperties: &apiextensions.JSONSchemaPropsOrBool{
+								Allows: true,
+							}}}}},
+		},
+		"MetadataNotOverwrite": {
+			reason: "Other properties should not be overwritten in metadata if specified in the default",
+			args: args{in: &apiextensions.JSONSchemaProps{
+				Type: string(schema.KnownJSONTypeObject),
+				Properties: map[string]apiextensions.JSONSchemaProps{
+					"metadata": {
+						Type: string(schema.KnownJSONTypeObject),
+						Properties: map[string]apiextensions.JSONSchemaProps{
+							"name": {
+								Type: string(schema.KnownJSONTypeBoolean),
+							}}}}}},
+			want: want{
+				out: func() *apiextensions.JSONSchemaProps {
+					s := getDefaultSchema()
+					metadata := s.Properties["metadata"]
+					metadata.Properties["name"] = apiextensions.JSONSchemaProps{
+						Type: string(schema.KnownJSONTypeBoolean),
+					}
+					s.Properties["metadata"] = metadata
+					return s
+				}(),
+			},
+		},
+		"MetadataPreserved": {
+			reason: "Other properties should be preserved in if not specified in the default",
+			args: args{in: &apiextensions.JSONSchemaProps{
+				Type: string(schema.KnownJSONTypeObject),
+				Properties: map[string]apiextensions.JSONSchemaProps{
+					"metadata": {
+						Type: string(schema.KnownJSONTypeObject),
+						Properties: map[string]apiextensions.JSONSchemaProps{
+							"annotations": {
+								Type: string(schema.KnownJSONTypeObject),
+								Properties: map[string]apiextensions.JSONSchemaProps{
+									"foo": {Type: string(schema.KnownJSONTypeString)}}}}}}},
+			},
+			want: want{
+				out: func() *apiextensions.JSONSchemaProps {
+					s := getDefaultSchema()
+					metadata := s.Properties["metadata"]
+					annotations := metadata.Properties["annotations"]
+					if annotations.Properties == nil {
+						annotations.Properties = map[string]apiextensions.JSONSchemaProps{}
+					}
+					annotations.Properties["foo"] = apiextensions.JSONSchemaProps{
+						Type: string(schema.KnownJSONTypeString),
+					}
+					metadata.Properties["annotations"] = annotations
+					s.Properties["metadata"] = metadata
+					return s
+				}(),
+			},
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			out := defaultMetadataSchema(tc.args.in)
+			if diff := cmp.Diff(tc.want.out, out); diff != "" {
+				t.Errorf("\n%s\ndefaultMetadataSchema(...): -want, +got:\n%s", tc.reason, diff)
+			}
+		})
+	}
+}

--- a/pkg/validation/apiextensions/v1/composition/validator.go
+++ b/pkg/validation/apiextensions/v1/composition/validator.go
@@ -38,8 +38,8 @@ type Validator struct {
 
 // CRDGetter is used to get all CRDs the Validator needs, either one by one or all at once.
 type CRDGetter interface {
-	Get(ctx context.Context, gvk schema.GroupVersionKind) (*apiextensions.CustomResourceDefinition, error)
-	GetAll(ctx context.Context) (map[schema.GroupVersionKind]apiextensions.CustomResourceDefinition, error)
+	Get(ctx context.Context, gvk schema.GroupKind) (*apiextensions.CustomResourceDefinition, error)
+	GetAll(ctx context.Context) (map[schema.GroupKind]apiextensions.CustomResourceDefinition, error)
 }
 
 // ValidatorOption is used to configure the Validator.
@@ -77,20 +77,20 @@ func WithCRDGetter(c CRDGetter) ValidatorOption {
 
 // WithCRDGetterFromMap returns a ValidatorOption that configure the Validator to use the given map as a CRDGetter.
 // Will return an error if the CRD is not found on calls to Get.
-func WithCRDGetterFromMap(m map[schema.GroupVersionKind]apiextensions.CustomResourceDefinition) ValidatorOption {
+func WithCRDGetterFromMap(m map[schema.GroupKind]apiextensions.CustomResourceDefinition) ValidatorOption {
 	return WithCRDGetter(crdGetterMap(m))
 }
 
-type crdGetterMap map[schema.GroupVersionKind]apiextensions.CustomResourceDefinition
+type crdGetterMap map[schema.GroupKind]apiextensions.CustomResourceDefinition
 
-func (c crdGetterMap) Get(_ context.Context, gvk schema.GroupVersionKind) (*apiextensions.CustomResourceDefinition, error) {
-	if crd, ok := c[gvk]; ok {
+func (c crdGetterMap) Get(_ context.Context, gk schema.GroupKind) (*apiextensions.CustomResourceDefinition, error) {
+	if crd, ok := c[gk]; ok {
 		return &crd, nil
 	}
-	return nil, apierrors.NewNotFound(schema.GroupResource{Group: gvk.Group, Resource: "CustomResourceDefinition"}, gvk.String())
+	return nil, apierrors.NewNotFound(schema.GroupResource{Group: gk.Group, Resource: "CustomResourceDefinition"}, gk.String())
 }
 
-func (c crdGetterMap) GetAll(_ context.Context) (map[schema.GroupVersionKind]apiextensions.CustomResourceDefinition, error) {
+func (c crdGetterMap) GetAll(_ context.Context) (map[schema.GroupKind]apiextensions.CustomResourceDefinition, error) {
 	return c, nil
 }
 

--- a/pkg/validation/apiextensions/v1/composition/validator_test.go
+++ b/pkg/validation/apiextensions/v1/composition/validator_test.go
@@ -21,8 +21,8 @@ import (
 
 func TestValidatorValidate(t *testing.T) {
 	type args struct {
-		comp      *v1.Composition
-		gvkToCRDs map[schema.GroupVersionKind]apiextensions.CustomResourceDefinition
+		comp     *v1.Composition
+		gkToCRDs map[schema.GroupKind]apiextensions.CustomResourceDefinition
 	}
 	type want struct {
 		errs field.ErrorList
@@ -38,8 +38,8 @@ func TestValidatorValidate(t *testing.T) {
 				errs: nil,
 			},
 			args: args{
-				comp:      buildDefaultComposition(t, v1.CompositionValidationModeStrict, map[string]any{"someOtherField": "test"}),
-				gvkToCRDs: nil,
+				comp:     buildDefaultComposition(t, v1.CompositionValidationModeStrict, map[string]any{"someOtherField": "test"}),
+				gkToCRDs: nil,
 			},
 		},
 		"RejectStrictNoCRDsWithPatches": {
@@ -58,15 +58,15 @@ func TestValidatorValidate(t *testing.T) {
 						FromFieldPath: pointer.String("spec.someField"),
 						ToFieldPath:   pointer.String("spec.someOtherField"),
 					})),
-				gvkToCRDs: nil,
+				gkToCRDs: nil,
 			},
 		},
 		"AcceptStrictAllCRDs": {
 			reason: "Should accept a valid Composition if all CRDs are available",
 			want:   want{errs: nil},
 			args: args{
-				gvkToCRDs: defaultGVKToCRDs(),
-				comp:      buildDefaultComposition(t, v1.CompositionValidationModeStrict, map[string]any{"someOtherField": "test"}),
+				gkToCRDs: defaultGKToCRDs(),
+				comp:     buildDefaultComposition(t, v1.CompositionValidationModeStrict, map[string]any{"someOtherField": "test"}),
 			},
 		},
 		"AcceptStrictInvalid": {
@@ -74,15 +74,15 @@ func TestValidatorValidate(t *testing.T) {
 			// TODO(phisco): this should return an error once we implement rendered validation
 			want: want{errs: nil},
 			args: args{
-				gvkToCRDs: defaultGVKToCRDs(),
-				comp:      buildDefaultComposition(t, v1.CompositionValidationModeStrict, nil),
+				gkToCRDs: defaultGKToCRDs(),
+				comp:     buildDefaultComposition(t, v1.CompositionValidationModeStrict, nil),
 			},
 		},
 		"AcceptStrictRequiredFieldByPatch": {
 			reason: "Should accept a Composition with a required field defined only by a patch if all CRDs are available",
 			want:   want{errs: nil},
 			args: args{
-				gvkToCRDs: defaultGVKToCRDs(),
+				gkToCRDs: defaultGKToCRDs(),
 				comp: buildDefaultComposition(t, v1.CompositionValidationModeStrict, nil, withPatches(0, v1.Patch{
 					Type:          v1.PatchTypeFromCompositeFieldPath,
 					FromFieldPath: pointer.String("spec.someField"),
@@ -101,7 +101,7 @@ func TestValidatorValidate(t *testing.T) {
 				},
 			},
 			args: args{
-				gvkToCRDs: defaultGVKToCRDs(),
+				gkToCRDs: defaultGKToCRDs(),
 				comp: buildDefaultComposition(t, v1.CompositionValidationModeStrict, nil, withPatches(0, v1.Patch{
 					Type:          v1.PatchTypeFromCompositeFieldPath,
 					FromFieldPath: pointer.String("spec.someWrongField"),
@@ -120,7 +120,7 @@ func TestValidatorValidate(t *testing.T) {
 				},
 			},
 			args: args{
-				gvkToCRDs: defaultGVKToCRDs(),
+				gkToCRDs: defaultGKToCRDs(),
 				comp: buildDefaultComposition(t, v1.CompositionValidationModeStrict, map[string]any{"someOtherField": "test"}, withPatches(0, v1.Patch{
 					Type:          v1.PatchTypeFromCompositeFieldPath,
 					FromFieldPath: pointer.String("spec.someField"),
@@ -139,7 +139,7 @@ func TestValidatorValidate(t *testing.T) {
 				},
 			},
 			args: args{
-				gvkToCRDs: buildGvkToCRDs(
+				gkToCRDs: buildGkToCRDs(
 					defaultCompositeCrdBuilder().withOption(func(crd *extv1.CustomResourceDefinition) {
 						crd.Spec.Versions[0].Schema.OpenAPIV3Schema.Properties["spec"].Properties["someField"] = extv1.JSONSchemaProps{
 							Type: "integer",
@@ -165,7 +165,7 @@ func TestValidatorValidate(t *testing.T) {
 				},
 			},
 			args: args{
-				gvkToCRDs: defaultGVKToCRDs(),
+				gkToCRDs: defaultGKToCRDs(),
 				comp: buildDefaultComposition(t, v1.CompositionValidationModeLoose, nil, withPatches(0, v1.Patch{
 					Type:          v1.PatchTypeFromCompositeFieldPath,
 					FromFieldPath: pointer.String("spec.someField"),
@@ -190,7 +190,7 @@ func TestValidatorValidate(t *testing.T) {
 				},
 			},
 			args: args{
-				gvkToCRDs: defaultGVKToCRDs(),
+				gkToCRDs: defaultGKToCRDs(),
 				comp: buildDefaultComposition(t, v1.CompositionValidationModeLoose, nil, withPatches(0, v1.Patch{
 					Type:          v1.PatchTypeFromCompositeFieldPath,
 					FromFieldPath: pointer.String("spec.someField"),
@@ -207,7 +207,7 @@ func TestValidatorValidate(t *testing.T) {
 		"AcceptStrictPatchWithCombinePatch": {
 			reason: "Should accept a Composition with a combine patch, if all CRDs are found",
 			args: args{
-				gvkToCRDs: buildGvkToCRDs(
+				gkToCRDs: buildGkToCRDs(
 					defaultCompositeCrdBuilder().withOption(func(crd *extv1.CustomResourceDefinition) {
 						spec := crd.Spec.Versions[0].Schema.OpenAPIV3Schema.Properties["spec"]
 						spec.Properties["someOtherOtherField"] = extv1.JSONSchemaProps{
@@ -251,7 +251,7 @@ func TestValidatorValidate(t *testing.T) {
 				},
 			},
 			args: args{
-				gvkToCRDs: defaultGVKToCRDs(),
+				gkToCRDs: defaultGKToCRDs(),
 				comp: buildDefaultComposition(t, v1.CompositionValidationModeStrict, nil, withPatches(0, v1.Patch{
 					Type: v1.PatchTypeCombineFromComposite,
 					Combine: &v1.Combine{
@@ -278,7 +278,7 @@ func TestValidatorValidate(t *testing.T) {
 				errs: nil,
 			},
 			args: args{
-				gvkToCRDs: defaultGVKToCRDs(),
+				gkToCRDs: defaultGKToCRDs(),
 				comp: buildDefaultComposition(t, v1.CompositionValidationModeLoose, nil, withPatches(0, v1.Patch{
 					Type:          v1.PatchTypeFromEnvironmentFieldPath,
 					FromFieldPath: pointer.String("spec.someField"),
@@ -292,7 +292,7 @@ func TestValidatorValidate(t *testing.T) {
 				errs: nil,
 			},
 			args: args{
-				gvkToCRDs: buildGvkToCRDs(defaultManagedCrdBuilder().withOption(func(d *extv1.CustomResourceDefinition) {
+				gkToCRDs: buildGkToCRDs(defaultManagedCrdBuilder().withOption(func(d *extv1.CustomResourceDefinition) {
 					d.Spec.Versions = append(d.Spec.Versions, *d.Spec.Versions[0].DeepCopy())
 					d.Spec.Versions[len(d.Spec.Versions)-1].Name = "v2"
 					d.Spec.Versions[len(d.Spec.Versions)-1].Schema.OpenAPIV3Schema.Properties["spec"].Properties["someNewField"] = extv1.JSONSchemaProps{
@@ -309,7 +309,7 @@ func TestValidatorValidate(t *testing.T) {
 	}
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			v, err := NewValidator(WithCRDGetterFromMap(tc.args.gvkToCRDs))
+			v, err := NewValidator(WithCRDGetterFromMap(tc.args.gkToCRDs))
 			if err != nil {
 				t.Errorf("NewValidator(...) = %v", err)
 				return
@@ -376,15 +376,14 @@ func defaultManagedCrdBuilder() *crdBuilder {
 	}))
 }
 
-func defaultGVKToCRDs() map[schema.GroupVersionKind]apiextensions.CustomResourceDefinition {
+func defaultGKToCRDs() map[schema.GroupKind]apiextensions.CustomResourceDefinition {
 	crds := []apiextensions.CustomResourceDefinition{*defaultManagedCrdBuilder().build(), *defaultCompositeCrdBuilder().build()}
-	m := make(map[schema.GroupVersionKind]apiextensions.CustomResourceDefinition, len(crds))
+	m := make(map[schema.GroupKind]apiextensions.CustomResourceDefinition, len(crds))
 	for _, crd := range crds {
 		crd := crd
-		m[schema.GroupVersionKind{
-			Group:   crd.Spec.Group,
-			Version: crd.Spec.Versions[0].Name,
-			Kind:    crd.Spec.Names.Kind,
+		m[schema.GroupKind{
+			Group: crd.Spec.Group,
+			Kind:  crd.Spec.Names.Kind,
 		}] = crd
 	}
 	return m
@@ -526,27 +525,16 @@ func buildDefaultComposition(t *testing.T, validationMode v1.CompositionValidati
 	return c
 }
 
-func buildGvkToCRDs(crds ...*apiextensions.CustomResourceDefinition) map[schema.GroupVersionKind]apiextensions.CustomResourceDefinition {
-	m := map[schema.GroupVersionKind]apiextensions.CustomResourceDefinition{}
+func buildGkToCRDs(crds ...*apiextensions.CustomResourceDefinition) map[schema.GroupKind]apiextensions.CustomResourceDefinition {
+	m := map[schema.GroupKind]apiextensions.CustomResourceDefinition{}
 	for _, crd := range crds {
 		if crd == nil {
 			continue
 		}
-		if len(crd.Spec.Versions) == 0 {
-			m[schema.GroupVersionKind{
-				Group:   crd.Spec.Group,
-				Version: crd.Spec.Version,
-				Kind:    crd.Spec.Names.Kind,
-			}] = *crd
-			continue
-		}
-		for _, version := range crd.Spec.Versions {
-			m[schema.GroupVersionKind{
-				Group:   crd.Spec.Group,
-				Version: version.Name,
-				Kind:    crd.Spec.Names.Kind,
-			}] = *crd
-		}
+		m[schema.GroupKind{
+			Group: crd.Spec.Group,
+			Kind:  crd.Spec.Names.Kind,
+		}] = *crd
 	}
 	return m
 }

--- a/pkg/validation/apiextensions/v1/composition/validator_test.go
+++ b/pkg/validation/apiextensions/v1/composition/validator_test.go
@@ -333,7 +333,7 @@ func TestValidatorValidate(t *testing.T) {
 				errs: field.ErrorList{
 					{
 						Type:  field.ErrorTypeInvalid,
-						Field: "spec.resources[0].patches[0].inlinedPatchSet[some-patch-set].patches[0].combine",
+						Field: "spec.resources[0].patches[0].patchSets[0].patches[0].combine",
 					},
 				},
 			},


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
A few fixes and improvements that came out while integrating the Validator in `crossplane-contrib/crossplane-lint`.
Improvement: Switching CRDGetter interface to deal with groupKind instead of GroupVersionKind as the version was actually ignored and could lead to duplicated CRDs in the store.
Fixes:
- patchsets were always erroring out due to a wrong assumption, leading to false positives.
- the known metadata schema was not properly injected and handled, leading to false positives.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested
Unit tests added and manually tested as follows:
```sh
$ kubectl apply -f - <<EOF
apiVersion: pkg.crossplane.io/v1
kind: Provider
metadata:
  name: provider-aws
spec:
  package: xpkg.upbound.io/crossplane-contrib/provider-aws:v0.38.0
EOF

$ kubectl apply -f - <<EOF
apiVersion: apiextensions.crossplane.io/v1
kind: CompositeResourceDefinition
metadata:
  name: xpostgresqlinstances.database.example.org
spec:
  group: database.example.org
  names:
    kind: XPostgreSQLInstance
    plural: xpostgresqlinstances
  claimNames:
    kind: PostgreSQLInstance
    plural: postgresqlinstances
  connectionSecretKeys:
    - username
    - password
    - endpoint
    - port
  versions:
  - name: v1alpha1
    served: true
    referenceable: true
    schema:
      openAPIV3Schema:
        type: object
        properties:
          spec:
            type: object
            description: "The OpenAPIV3Schema of this Composite Resource Definition."
            properties:
              parameters:
                type: object
                properties:
                  storageGB:
                    type: integer
                    description: "The desired storage capacity of the database, in GB."
                  engine:
                    type: string
                required:
                  - storageGB
                  #- engine     ## <- engine is not required
            required:
              - parameters
EOF

$ kubectl apply -f - <<EOF
apiVersion: apiextensions.crossplane.io/v1
kind: Composition
metadata:
  name: xpostgresqlinstances.aws.database.example.org
  labels:
    provider: aws
    guide: quickstart
    vpc: default
spec:
  writeConnectionSecretsToNamespace: crossplane-system
  compositeTypeRef:
    apiVersion: database.example.org/v1alpha1
    kind: XPostgreSQLInstance
  patchSets:
    - name: some-patch-set
      patches:
        - fromFieldPath: "spec.parameters.engine"
          toFieldPath: "spec.forProvider.wrong"       ## <- missing "wrong" field in RDSInstance
  resources:
    - name: rdsinstance
      base:
        apiVersion: database.aws.crossplane.io/v1beta1
        kind: RDSInstance
        spec:
          forProvider:
            dbInstanceClass: db.t2.small
            masterUsername: masteruser
            engineVersion: "12"
            skipFinalSnapshotBeforeDeletion: true
            publiclyAccessible: true
      patches:
        - type: PatchSet
          patchSetName: some-patch-set
        - fromFieldPath: "metadata.uid"
          toFieldPath: "spec.forProvider.engine"
EOF

The Composition "xpostgresqlinstances.aws.database.example.org" is invalid: spec.resources[0].patches[0].inlinedPatchSet[some-patch-set].patches[0].toFieldPath: Invalid value: "spec.forProvider.wrong": field 'wrong' is not valid according to the schema.
```
without this patch the Composition would have been rejected due to it detecting a patchset type of patch assuming they were all dereferenced at the previous step.

while the metadata related fixes were a little bit more subtle and are hard to reproduce by hand as they depend on the metadata schema already present in the MR itself.
<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
