### PR TITLE
feat: schema-aware readiness check validation

### DIFF
--- a/internal/validation/errors/field.go
+++ b/internal/validation/errors/field.go
@@ -31,3 +31,14 @@ func WrapFieldError(err *field.Error, path *field.Path) *field.Error {
 	err.Field = path.Child(err.Field).String()
 	return err
 }
+
+// WrapFieldErrorList wraps the given field.ErrorList adding the given field.Path as root of the Field.
+func WrapFieldErrorList(errs field.ErrorList, path *field.Path) field.ErrorList {
+	if path == nil {
+		return errs
+	}
+	for i := range errs {
+		errs[i] = WrapFieldError(errs[i], path)
+	}
+	return errs
+}

--- a/pkg/validation/apiextensions/v1/composition/patches.go
+++ b/pkg/validation/apiextensions/v1/composition/patches.go
@@ -291,7 +291,8 @@ func validateTransformsChainIOTypes(transforms []v1.Transform, fromType xpschema
 // It returns the type of the fieldPath and any error.
 // If the returned type is "", but without error, it means the fieldPath is accepted by the schema, but not defined in it.
 func validateFieldPath(schema *apiextensions.JSONSchemaProps, fieldPath string) (fieldType xpschema.KnownJSONType, err error) {
-	// Code inspired by https://github.com/crossplane-contrib/crossplane-lint/commit/d58af636f06467151cce7c89ffd319828c1cd7a2#diff-3b13ed191dd7244f19f4c0870298fc5112153e136250e95095323e6c3c440bdfR230
+	// Code inspired by crossplane-contrib/crossplane-lint implementation:
+	// https://github.com/crossplane-contrib/crossplane-lint/commit/d58af636f06467151cce7c89ffd319828c1cd7a2#diff-3b13ed191dd7244f19f4c0870298fc5112153e136250e95095323e6c3c440bdfR230
 	if fieldPath == "" {
 		return "", nil
 	}

--- a/pkg/validation/apiextensions/v1/composition/readinessChecks.go
+++ b/pkg/validation/apiextensions/v1/composition/readinessChecks.go
@@ -1,0 +1,86 @@
+/*
+Copyright 2023 the Crossplane Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package composition
+
+import (
+	"context"
+	"fmt"
+
+	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+
+	"github.com/crossplane/crossplane-runtime/pkg/errors"
+
+	v1 "github.com/crossplane/crossplane/apis/apiextensions/v1"
+	verrors "github.com/crossplane/crossplane/internal/validation/errors"
+	xpschema "github.com/crossplane/crossplane/pkg/validation/internal/schema"
+)
+
+// validateReadinessChecksWithSchemas validates the readiness check of a composition, given the CRDs of the composed resources.
+// It checks that the readiness check field path is valid and that the fields required for the readiness check type are set and valid.
+func (v *Validator) validateReadinessChecksWithSchemas(ctx context.Context, comp *v1.Composition) (errs field.ErrorList) {
+	for i, resource := range comp.Spec.Resources {
+		if len(resource.ReadinessChecks) == 0 {
+			continue
+		}
+		gvk, err := GetBaseObjectGVK(&comp.Spec.Resources[i])
+		if err != nil {
+			return append(errs, field.InternalError(field.NewPath("spec", "resources").Index(i), errors.Wrap(err, "cannot get object gvk")))
+		}
+		crd, err := v.crdGetter.Get(ctx, gvk.GroupKind())
+		if err != nil {
+			return append(errs, field.InternalError(
+				field.NewPath("spec", "resources").Index(i),
+				err,
+			))
+		}
+		errs = append(errs, verrors.WrapFieldErrorList(validateReadinessChecks(resource, crd), field.NewPath("spec", "resources").Index(i))...)
+	}
+
+	if len(errs) > 0 {
+		return errs
+	}
+
+	return nil
+}
+
+func validateReadinessChecks(resource v1.ComposedTemplate, crd *apiextensions.CustomResourceDefinition) (errs field.ErrorList) {
+	for j, r := range resource.ReadinessChecks {
+		if r.FieldPath == "" {
+			continue
+		}
+		fieldType, err := validateFieldPath(crd.Spec.Validation.OpenAPIV3Schema, r.FieldPath)
+		if err != nil {
+			errs = append(errs, field.Invalid(field.NewPath("readinessCheck").Index(j).Child("fieldPath"), r.FieldPath, err.Error()))
+			continue
+		}
+		if matchType := getReadinessCheckExpectedType(r); matchType != "" && matchType != fieldType {
+			errs = append(errs, field.Invalid(field.NewPath("readinessCheck").Index(j).Child("fieldPath"), r.FieldPath, fmt.Sprintf("expected field path to be of type %s", matchType)))
+			continue
+		}
+	}
+	return errs
+}
+
+func getReadinessCheckExpectedType(r v1.ReadinessCheck) xpschema.KnownJSONType {
+	var matchType xpschema.KnownJSONType
+	switch r.Type {
+	case v1.ReadinessCheckTypeMatchString:
+		matchType = xpschema.KnownJSONTypeString
+	case v1.ReadinessCheckTypeMatchInteger:
+		matchType = xpschema.KnownJSONTypeInteger
+	case v1.ReadinessCheckTypeNone, v1.ReadinessCheckTypeNonEmpty:
+	}
+	return matchType
+}

--- a/pkg/validation/apiextensions/v1/composition/readinessChecks_test.go
+++ b/pkg/validation/apiextensions/v1/composition/readinessChecks_test.go
@@ -1,0 +1,198 @@
+/*
+Copyright 2023 The Crossplane Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package composition
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
+	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+
+	v1 "github.com/crossplane/crossplane/apis/apiextensions/v1"
+)
+
+func withReadinessChecks(index int, rcs ...v1.ReadinessCheck) compositionBuilderOption {
+	return func(c *v1.Composition) {
+		c.Spec.Resources[index].ReadinessChecks = rcs
+	}
+}
+
+func TestValidateReadinessCheck(t *testing.T) {
+	type args struct {
+		comp    *v1.Composition
+		gkToCRD map[schema.GroupKind]apiextensions.CustomResourceDefinition
+	}
+	type want struct {
+		errs field.ErrorList
+	}
+	tests := []struct {
+		name string
+		args args
+		want want
+	}{
+		{
+			name: "should accept empty readiness check",
+			args: args{
+				comp:    buildDefaultComposition(t, v1.CompositionValidationModeLoose, nil),
+				gkToCRD: defaultGKToCRDs(),
+			},
+			want: want{
+				errs: nil,
+			},
+		},
+		{
+			name: "should accept valid readiness check - none type",
+			args: args{
+				comp: buildDefaultComposition(t, v1.CompositionValidationModeLoose, nil, withReadinessChecks(
+					0,
+					v1.ReadinessCheck{
+						Type: v1.ReadinessCheckTypeNone,
+					},
+				)),
+				gkToCRD: defaultGKToCRDs(),
+			},
+			want: want{
+				errs: nil,
+			},
+		},
+		{
+			name: "should accept valid readiness check - nonEmpty type",
+			args: args{
+				comp: buildDefaultComposition(t, v1.CompositionValidationModeLoose, nil, withReadinessChecks(
+					0,
+					v1.ReadinessCheck{
+						Type:      v1.ReadinessCheckTypeNonEmpty,
+						FieldPath: "spec.someOtherField",
+					},
+				)),
+				gkToCRD: defaultGKToCRDs(),
+			},
+			want: want{
+				errs: nil,
+			},
+		},
+		{
+			name: "should accept valid readiness check - matchString type",
+			args: args{
+				comp: buildDefaultComposition(t, v1.CompositionValidationModeLoose, nil, withReadinessChecks(
+					0,
+					v1.ReadinessCheck{
+						Type:        v1.ReadinessCheckTypeMatchString,
+						MatchString: "bob",
+						FieldPath:   "spec.someOtherField",
+					},
+				)),
+				gkToCRD: defaultGKToCRDs(),
+			},
+			want: want{
+				errs: nil,
+			},
+		},
+		{
+			name: "should reject invalid readiness check - matchInteger type",
+			args: args{
+				comp: buildDefaultComposition(t, v1.CompositionValidationModeLoose, nil, withReadinessChecks(
+					0,
+					v1.ReadinessCheck{
+						Type:         v1.ReadinessCheckTypeMatchInteger,
+						MatchInteger: 0,
+						FieldPath:    "spec.someField",
+					},
+				)),
+				gkToCRD: buildGkToCRDs(
+					defaultManagedCrdBuilder().withOption(func(crd *extv1.CustomResourceDefinition) {
+						crd.Spec.Versions[0].Schema.OpenAPIV3Schema.Properties["spec"].Properties["someField"] = extv1.JSONSchemaProps{
+							Type: "string",
+						}
+					}).build()),
+			},
+			want: want{
+				errs: field.ErrorList{
+					{
+						Type:     field.ErrorTypeInvalid,
+						Field:    "spec.resources[0].readinessCheck[0].fieldPath",
+						BadValue: "spec.someField",
+					},
+				},
+			},
+		},
+		{
+			name: "should accept valid readiness check - matchInteger type",
+			args: args{
+				comp: buildDefaultComposition(t, v1.CompositionValidationModeLoose, nil, withReadinessChecks(
+					0,
+					v1.ReadinessCheck{
+						Type:         v1.ReadinessCheckTypeMatchInteger,
+						MatchInteger: 15,
+						FieldPath:    "spec.someField",
+					},
+				)),
+				gkToCRD: buildGkToCRDs(
+					defaultManagedCrdBuilder().withOption(func(crd *extv1.CustomResourceDefinition) {
+						crd.Spec.Versions[0].Schema.OpenAPIV3Schema.Properties["spec"].Properties["someField"] = extv1.JSONSchemaProps{
+							Type: "integer",
+						}
+					}).build()),
+			},
+			want: want{
+				errs: nil,
+			},
+		},
+		{
+			name: "should reject invalid readiness check - matchInteger type - type mismatch",
+			args: args{
+				comp: buildDefaultComposition(t, v1.CompositionValidationModeLoose, nil, withReadinessChecks(
+					0,
+					v1.ReadinessCheck{
+						Type:         v1.ReadinessCheckTypeMatchInteger,
+						MatchInteger: 10,
+						FieldPath:    "spec.someField",
+					},
+				)),
+				gkToCRD: buildGkToCRDs(
+					defaultManagedCrdBuilder().withOption(func(crd *extv1.CustomResourceDefinition) {
+						crd.Spec.Versions[0].Schema.OpenAPIV3Schema.Properties["spec"].Properties["someField"] = extv1.JSONSchemaProps{
+							Type: "string",
+						}
+					}).build()),
+			},
+			want: want{
+				errs: field.ErrorList{
+					{
+						Type:     field.ErrorTypeInvalid,
+						Field:    "spec.resources[0].readinessCheck[0].fieldPath",
+						BadValue: "spec.someField",
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			v, err := NewValidator(WithCRDGetterFromMap(tt.args.gkToCRD))
+			if err != nil {
+				t.Fatalf("NewValidator() error = %v", err)
+			}
+			got := v.validateReadinessChecksWithSchemas(context.TODO(), tt.args.comp)
+			if diff := cmp.Diff(got, tt.want.errs, sortFieldErrors(), cmpopts.IgnoreFields(field.Error{}, "Detail")); diff != "" {
+				t.Errorf("Validate(...) = -want, +got\n%s\n", diff)
+			}
+		})
+	}
+}

--- a/pkg/validation/apiextensions/v1/composition/validator.go
+++ b/pkg/validation/apiextensions/v1/composition/validator.go
@@ -131,8 +131,8 @@ func (v *Validator) Validate(ctx context.Context, obj runtime.Object) (warns []s
 	// Validate patches given the above CRDs, skip if any of the required CRDs is not available
 	for _, f := range []func(context.Context, *v1.Composition) field.ErrorList{
 		v.validatePatchesWithSchemas,
+		v.validateReadinessChecksWithSchemas,
 		// v.validateConnectionDetailsWithSchemas,
-		// v.validateReadinessCheckWithSchemas,
 		// TODO(phisco): add more phase 2 validation here
 	} {
 		errs = append(errs, f(ctx, comp)...)


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Implements Readiness checks schema-aware validation as described in #3756, following up on #3937.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

Unit tests added and manually:
```sh
$ make
...
$ HELM3_FLAGS="--set args={--enable-composition-webhook-schema-validation}" ./cluster/local/kind.sh helm-upgrade
...
$ kubectl apply -f - <<EOF
---
apiVersion: pkg.crossplane.io/v1
kind: Provider
metadata:
  name: provider-aws
spec:
  package: xpkg.upbound.io/crossplane-contrib/provider-aws:v0.38.0
EOF

$ kubectl apply -f - <<EOF
---
apiVersion: apiextensions.crossplane.io/v1
kind: CompositeResourceDefinition
metadata:
  name: xpostgresqlinstances.database.example.org
spec:
  group: database.example.org
  names:
    kind: XPostgreSQLInstance
    plural: xpostgresqlinstances
  claimNames:
    kind: PostgreSQLInstance
    plural: postgresqlinstances
  connectionSecretKeys:
    - username
    - password
    - endpoint
    - port
  versions:
  - name: v1alpha1
    served: true
    referenceable: true
    schema:
      openAPIV3Schema:
        type: object
        properties:
          spec:
            type: object
            description: "The OpenAPIV3Schema of this Composite Resource Definition."
            properties:
              parameters:
                type: object
                properties:
                  storageGB:
                    type: integer
                    description: "The desired storage capacity of the database, in GB."
                  engine:
                    type: string
                required:
                  - storageGB
                  #- engine     ## <- engine is not required
            required:
              - parameters

EOF

$ kubectl apply -f - <<EOF                                                                                                                                                                                             
---
apiVersion: apiextensions.crossplane.io/v1
kind: Composition
metadata:
  name: xpostgresqlinstances.aws.database.example.org
  labels:
    provider: aws
    guide: quickstart
    vpc: default
spec:
  writeConnectionSecretsToNamespace: crossplane-system
  compositeTypeRef:
    apiVersion: database.example.org/v1alpha1
    kind: XPostgreSQLInstance
  resources:
    - name: rdsinstance
      base:
        apiVersion: database.aws.crossplane.io/v1beta1
        kind: RDSInstance
        spec:
          forProvider:
            dbInstanceClass: db.t2.small
            masterUsername: masteruser
            engineVersion: "12"
            skipFinalSnapshotBeforeDeletion: true
            publiclyAccessible: true
      patches:
        - fromFieldPath: "spec.parameters.engine"
          toFieldPath: "spec.forProvider.engine"
        - fromFieldPath: "spec.parameters.engine"
          toFieldPath: "spec.forProvider.wrong"       ## <- missing "wrong" field in RDSInstance
        - fromFieldPath: "spec.parameters.region"     ## <- missing "region" field in XRD
          toFieldPath: "spec.forProvider.region"
        - fromFieldPath: "metadata.uid"               ## <- source field is a string for the XRD, target is an integer
          toFieldPath: "spec.forProvider.allocatedStorage"
        - fromFieldPath: "spec.parameters.storageGB"
          toFieldPath: "spec.forProvider.allocatedStorage"
      readinessChecks:
        - type: MatchInteger
          fieldPath: status.atProvider.endpoint.address ## <- a string according to the RDSInstance schema
          matchInteger: 1
      connectionDetails:
        - fromConnectionSecretKey: username
        - fromConnectionSecretKey: password
        - fromConnectionSecretKey: endpoint
        - fromConnectionSecretKey: port
EOF
```
Should result in the following error:
```
The Composition "xpostgresqlinstances.aws.database.example.org" is invalid:
* spec.resources[0].patches[1].toFieldPath: Invalid value: "spec.forProvider.wrong": field 'wrong' is not valid according to the schema
* spec.resources[0].patches[2].fromFieldPath: Invalid value: "spec.parameters.region": field 'region' is not valid according to the schema
* spec.resources[0].patches[3].transforms: Required value: the fromFieldPath does not have a type compatible with the toFieldPath according to their schemas and no transforms were provided: string != integer
* spec.resources[0].readinessCheck[0].fieldPath: Invalid value: "status.atProvider.endpoint.address": expected field path to be of type integer
```

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
