### PR TITLE
ci: avoid running scheduled trivy scan on forks

### DIFF
--- a/.github/workflows/scan.yaml
+++ b/.github/workflows/scan.yaml
@@ -11,6 +11,7 @@ env:
 jobs:
   generate-matrix:
     runs-on: ubuntu-latest
+    if: github.repository == 'crossplane/crossplane'
     outputs:
       versions: ${{ steps.get-releases.outputs.versions}}
       supported_releases: ${{ steps.get-releases.outputs.supported_releases }}


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

This will avoid that the scheduled nightly trivy scan is run on forks, as it was unnecessary and could lead to failures if tags or release branches were not part of the fork.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

N.A.

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
