### PR TITLE
Start v1.13 release cycle

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -10,7 +10,7 @@
   "prConcurrentLimit": 5,
 // The branches renovate should target
 // PLEASE UPDATE THIS WHEN RELEASING.
-  "baseBranches": ["master","release-1.9","release-1.10","release-1.11"],
+  "baseBranches": ["master","release-1.10","release-1.11","release-1.12"],
   "ignorePaths": ["design/**"],
   "postUpdateOptions": ["gomodTidy"],
 // By default renovate will auto detect whether semantic commits have been used

--- a/README.md
+++ b/README.md
@@ -17,12 +17,12 @@ Currently maintained releases, as well as the next upcoming release are listed
 below. For more information take a look at the Crossplane [release cycle
 documentation].
 
-| Release | Release Date |      EOL      |
-|:-------:|:------------:|:-------------:|
-|   v1.9  | Jul 14, 2022 |    Apr 2023   |
-|   v1.10 | Oct 18, 2022 |    Jul 2023   |
-|   v1.11 | Jan 31, 2023 |    Oct 2023   |
-|   v1.12 | Apr 25, 2023 |    Jan 2024   |
+| Release | Release Date |   EOL    |
+|:-------:|:------------:|:--------:|
+|  v1.10  | Oct 18, 2022 | Jul 2023 |
+|  v1.11  | Jan 31, 2023 | Oct 2023 |
+|  v1.12  | Apr 25, 2023 | Jan 2024 |
+|  v1.13  | Jul 25, 2023 | Apr 2024 |
 
 You can subscribe to the [community calendar] to track all release dates, and
 find the most recent releases on the [releases] page.


### PR DESCRIPTION
Signed-off-by: Predrag Knezevic <predrag.knezevic@upbound.io>

### Description of your changes

- Added `release-1.12`, removed `release-1.9` branch from renovate configuration
- Updated release table in `README`, removed 1.9 and added 1.13

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

This will be verified by the subsequent CI runs.