### PR TITLE
Increase delay before closing stale issues to 14 days

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -28,7 +28,7 @@ jobs:
         # https://docs.github.com/en/rest/overview/resources-in-the-rest-api#requests-from-github-actions
         operations-per-run: 100
         days-before-stale: 90
-        days-before-close: 7
+        days-before-close: 40
         stale-issue-label: stale
         exempt-issue-labels: exempt-from-stale
         stale-issue-message: >

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -28,7 +28,7 @@ jobs:
         # https://docs.github.com/en/rest/overview/resources-in-the-rest-api#requests-from-github-actions
         operations-per-run: 100
         days-before-stale: 90
-        days-before-close: 40
+        days-before-close: 14
         stale-issue-label: stale
         exempt-issue-labels: exempt-from-stale
         stale-issue-message: >

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -35,7 +35,7 @@ jobs:
           Crossplane does not currently have enough maintainers to address every
           issue and pull request. This issue has been automatically marked as
           `stale` because it has had no activity in the last 90 days. It will be
-          closed in 7 days if no further activity occurs. Leaving a comment
+          closed in 14 days if no further activity occurs. Leaving a comment
           **starting with** `/fresh` will mark this issue as not stale.
         stale-pr-label: stale
         exempt-pr-labels: exempt-from-stale
@@ -43,6 +43,5 @@ jobs:
           Crossplane does not currently have enough maintainers to address every
           issue and pull request. This pull request has been automatically
           marked as `stale` because it has had no activity in the last 90 days.
-          It will be closed in 7 days if no further activity occurs.
-          closed in 7 days if no further activity occurs. Adding a comment
-          **starting with** `/fresh` will mark this PR as not stale.
+          It will be closed in 14 days if no further activity occurs.
+          Adding a comment **starting with** `/fresh` will mark this PR as not stale.


### PR DESCRIPTION
The 7 days current limit is preventing people away from keyboard to comment the issue and there is supported bot action to reopen them afterwards

See related side effect of misconfigured stale bot at https://github.com/actions/stale/issues/719

<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #

I have:

- [x] Read and followed Crossplane's [contribution process].
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
