### PR TITLE
set xfn image tag in kind.sh

### DIFF
--- a/cluster/local/kind.sh
+++ b/cluster/local/kind.sh
@@ -73,7 +73,7 @@ case "${1:-}" in
 
     [ "$2" ] && ns=$2 || ns="${DEFAULT_NAMESPACE}"
     echo "installing helm package into \"$ns\" namespace"
-    ${HELM3} install ${PROJECT_NAME} --namespace ${ns} --create-namespace ${projectdir}/cluster/charts/${PROJECT_NAME} --set image.pullPolicy=Never,imagePullSecrets='',image.tag="${helm_tag}" ${HELM3_FLAGS}
+    ${HELM3} install ${PROJECT_NAME} --namespace ${ns} --create-namespace ${projectdir}/cluster/charts/${PROJECT_NAME} --set image.pullPolicy=Never,imagePullSecrets='',image.tag="${helm_tag}",xfn.image.tag="${helm_tag}" ${HELM3_FLAGS}
     ;;
   helm-upgrade)
     echo "copying image for helm"
@@ -83,7 +83,7 @@ case "${1:-}" in
 
     [ "$2" ] && ns=$2 || ns="${DEFAULT_NAMESPACE}"
     echo "upgrading helm package in \"$ns\" namespace"
-    ${HELM3} upgrade --install --namespace ${ns} --create-namespace ${PROJECT_NAME} ${projectdir}/cluster/charts/${PROJECT_NAME} ${HELM3_FLAGS} --set image.pullPolicy=Never,imagePullSecrets='',image.tag="${helm_tag}"
+    ${HELM3} upgrade --install --namespace ${ns} --create-namespace ${PROJECT_NAME} ${projectdir}/cluster/charts/${PROJECT_NAME} ${HELM3_FLAGS} --set image.pullPolicy=Never,imagePullSecrets='',image.tag="${helm_tag}",xfn.image.tag="${helm_tag}"
     ;;
   helm-delete)
     [ "$2" ] && ns=$2 || ns="${DEFAULT_NAMESPACE}"


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes
Sets the xfn sidecar image tag that was missing in `kind.sh` install/upgrade scripts.

Noticed this with @pedjak while running some tests using the `kind.sh` script to set up the local environment with Composition functions enabled. Its missing a set for the xfn image [here](https://github.com/crossplane/crossplane/blob/9e41a7395bfafd84fab1b3223432a8fe4520fbc6/cluster/local/kind.sh). 

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

Ran the `kind.sh` helm-install/helm-upgrade and checked if the proper image is set.

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
