### PR TITLE
Add shortNames for resources

### DIFF
--- a/apis/apiextensions/v1/composition_revision_types.go
+++ b/apis/apiextensions/v1/composition_revision_types.go
@@ -104,7 +104,7 @@ type CompositionRevisionStatus struct {
 // +kubebuilder:printcolumn:name="XR-KIND",type="string",JSONPath=".spec.compositeTypeRef.kind"
 // +kubebuilder:printcolumn:name="XR-APIVERSION",type="string",JSONPath=".spec.compositeTypeRef.apiVersion"
 // +kubebuilder:printcolumn:name="AGE",type="date",JSONPath=".metadata.creationTimestamp"
-// +kubebuilder:resource:scope=Cluster,categories=crossplane
+// +kubebuilder:resource:scope=Cluster,categories=crossplane,shortName=comprev
 // +kubebuilder:subresource:status
 type CompositionRevision struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/apis/apiextensions/v1/composition_types.go
+++ b/apis/apiextensions/v1/composition_types.go
@@ -92,7 +92,7 @@ type CompositionSpec struct {
 // +kubebuilder:printcolumn:name="XR-KIND",type="string",JSONPath=".spec.compositeTypeRef.kind"
 // +kubebuilder:printcolumn:name="XR-APIVERSION",type="string",JSONPath=".spec.compositeTypeRef.apiVersion"
 // +kubebuilder:printcolumn:name="AGE",type="date",JSONPath=".metadata.creationTimestamp"
-// +kubebuilder:resource:scope=Cluster,categories=crossplane
+// +kubebuilder:resource:scope=Cluster,categories=crossplane,shortName=comp
 type Composition struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/apis/apiextensions/v1alpha1/environment_config_types.go
+++ b/apis/apiextensions/v1alpha1/environment_config_types.go
@@ -28,7 +28,7 @@ import (
 
 // A EnvironmentConfig contains a set of arbitrary, unstructured values.
 // +kubebuilder:printcolumn:name="AGE",type="date",JSONPath=".metadata.creationTimestamp"
-// +kubebuilder:resource:scope=Cluster,categories=crossplane
+// +kubebuilder:resource:scope=Cluster,categories=crossplane,shortName=envcfg
 type EnvironmentConfig struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/apis/apiextensions/v1alpha1/zz_generated.revision_types.go
+++ b/apis/apiextensions/v1alpha1/zz_generated.revision_types.go
@@ -963,7 +963,7 @@ type CompositionRevisionStatus struct {
 // +kubebuilder:printcolumn:name="XR-KIND",type="string",JSONPath=".spec.compositeTypeRef.kind"
 // +kubebuilder:printcolumn:name="XR-APIVERSION",type="string",JSONPath=".spec.compositeTypeRef.apiVersion"
 // +kubebuilder:printcolumn:name="AGE",type="date",JSONPath=".metadata.creationTimestamp"
-// +kubebuilder:resource:scope=Cluster,categories=crossplane
+// +kubebuilder:resource:scope=Cluster,categories=crossplane,shortName=comprev
 // +kubebuilder:subresource:status
 type CompositionRevision struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/apis/apiextensions/v1beta1/zz_generated.composition_revision_types.go
+++ b/apis/apiextensions/v1beta1/zz_generated.composition_revision_types.go
@@ -105,7 +105,7 @@ type CompositionRevisionStatus struct {
 // +kubebuilder:printcolumn:name="XR-KIND",type="string",JSONPath=".spec.compositeTypeRef.kind"
 // +kubebuilder:printcolumn:name="XR-APIVERSION",type="string",JSONPath=".spec.compositeTypeRef.apiVersion"
 // +kubebuilder:printcolumn:name="AGE",type="date",JSONPath=".metadata.creationTimestamp"
-// +kubebuilder:resource:scope=Cluster,categories=crossplane
+// +kubebuilder:resource:scope=Cluster,categories=crossplane,shortName=comprev
 // +kubebuilder:subresource:status
 type CompositionRevision struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/cluster/crds/apiextensions.crossplane.io_compositionrevisions.yaml
+++ b/cluster/crds/apiextensions.crossplane.io_compositionrevisions.yaml
@@ -13,6 +13,8 @@ spec:
     kind: CompositionRevision
     listKind: CompositionRevisionList
     plural: compositionrevisions
+    shortNames:
+    - comprev
     singular: compositionrevision
   scope: Cluster
   versions:

--- a/cluster/crds/apiextensions.crossplane.io_compositions.yaml
+++ b/cluster/crds/apiextensions.crossplane.io_compositions.yaml
@@ -13,6 +13,8 @@ spec:
     kind: Composition
     listKind: CompositionList
     plural: compositions
+    shortNames:
+    - comp
     singular: composition
   scope: Cluster
   versions:

--- a/cluster/crds/apiextensions.crossplane.io_environmentconfigs.yaml
+++ b/cluster/crds/apiextensions.crossplane.io_environmentconfigs.yaml
@@ -13,6 +13,8 @@ spec:
     kind: EnvironmentConfig
     listKind: EnvironmentConfigList
     plural: environmentconfigs
+    shortNames:
+    - envcfg
     singular: environmentconfig
   scope: Cluster
   versions:


### PR DESCRIPTION
### Description of your changes
Add shortNames to Composition (comp), CompositionRevisions (comprev) and EnvironmentConfig (envcfg) resources to reduce the amount of typing required.

Fixes #3990 

I have:

- [X] Read and followed Crossplane's [contribution process].
- [X] Run `make reviewable` to ensure this PR is ready for review.
- [X] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested
Applied the changes to a running cluster and verified that the following commands all work as expected:
```
kubectl get comp
kubectl get comprev
kubectl get envcfg
```

[contribution process]: https://git.io/fj2m9
