### PR TITLE
Prevent configuration jobs from running on forks

### DIFF
--- a/.github/workflows/configurations.yml
+++ b/.github/workflows/configurations.yml
@@ -13,6 +13,7 @@ env:
 jobs:
   getting-started-with-aws:
     runs-on: ubuntu-22.04
+    if: github.repository == 'crossplane/crossplane'
     steps:
       - name: Checkout
         uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3
@@ -44,6 +45,7 @@ jobs:
 
   getting-started-with-aws-with-vpc:
     runs-on: ubuntu-22.04
+    if: github.repository == 'crossplane/crossplane'
     steps:
       - name: Checkout
         uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3
@@ -73,6 +75,7 @@ jobs:
 
   getting-started-with-gcp:
     runs-on: ubuntu-22.04
+    if: github.repository == 'crossplane/crossplane'
     steps:
       - name: Checkout
         uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3
@@ -102,6 +105,7 @@ jobs:
 
   getting-started-with-azure:
     runs-on: ubuntu-22.04
+    if: github.repository == 'crossplane/crossplane'
     steps:
       - name: Checkout
         uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3


### PR DESCRIPTION
### Description of your changes
Prevent configuration jobs from running on forks.  The job runs every time the fork is synced with upstream master and generates errors.

I have:

- [X] Read and followed Crossplane's [contribution process].
- [X] Run `make reviewable` to ensure this PR is ready for review.
- [X] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested
N/A


[contribution process]: https://git.io/fj2m9
