### PR TITLE
Avoid listing CRDs in the RBAC manager

### DIFF
--- a/cmd/crossplane/core/core.go
+++ b/cmd/crossplane/core/core.go
@@ -18,6 +18,8 @@ limitations under the License.
 package core
 
 import (
+	"net/http"
+	"net/http/pprof"
 	"path/filepath"
 	"time"
 
@@ -46,6 +48,8 @@ import (
 	"github.com/crossplane/crossplane/internal/xpkg"
 )
 
+const pprofPath = "/debug/pprof/"
+
 // Command runs the core crossplane controllers
 type Command struct {
 	Start startCommand `cmd:"" help:"Start Crossplane controllers."`
@@ -67,6 +71,8 @@ func (c *Command) Run() error {
 }
 
 type startCommand struct {
+	Profile string `placeholder:"host:port" help:"Serve runtime profiling data via HTTP at /debug/pprof."`
+
 	Namespace            string `short:"n" help:"Namespace used to unpack and run packages." default:"crossplane-system" env:"POD_NAMESPACE"`
 	ServiceAccount       string `help:"Name of the Crossplane Service Account." default:"crossplane" env:"POD_SERVICE_ACCOUNT"`
 	CacheDir             string `short:"c" help:"Directory used for caching package images." default:"/cache" env:"CACHE_DIR"`
@@ -96,7 +102,34 @@ type startCommand struct {
 }
 
 // Run core Crossplane controllers.
-func (c *startCommand) Run(s *runtime.Scheme, log logging.Logger) error { //nolint:gocyclo // Only slightly over (11).
+func (c *startCommand) Run(s *runtime.Scheme, log logging.Logger) error { //nolint:gocyclo // Only slightly over.
+	if c.Profile != "" {
+		// NOTE(negz): These log messages attempt to match those emitted by
+		// controller-runtime's metrics HTTP server when it starts.
+		log.Debug("Profiling server is starting to listen", "addr", c.Profile)
+		go func() {
+
+			// Registering these explicitly ensures they're only served by the
+			// HTTP server we start explicitly for profiling.
+			mux := http.NewServeMux()
+			mux.HandleFunc(pprofPath, pprof.Index)
+			mux.HandleFunc(filepath.Join(pprofPath, "cmdline"), pprof.Cmdline)
+			mux.HandleFunc(filepath.Join(pprofPath, "profile"), pprof.Profile)
+			mux.HandleFunc(filepath.Join(pprofPath, "symbol"), pprof.Symbol)
+			mux.HandleFunc(filepath.Join(pprofPath, "trace"), pprof.Trace)
+
+			s := &http.Server{
+				Addr:         c.Profile,
+				ReadTimeout:  2 * time.Minute,
+				WriteTimeout: 2 * time.Minute,
+				Handler:      mux,
+			}
+			log.Debug("Starting server", "type", "pprof", "path", pprofPath, "addr", s.Addr)
+			err := s.ListenAndServe()
+			log.Debug("Profiling server has stopped listening", "error", err)
+		}()
+	}
+
 	cfg, err := ctrl.GetConfig()
 	if err != nil {
 		return errors.Wrap(err, "Cannot get config")


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #4016

We found in https://github.com/crossplane/crossplane/issues/4016 that working with CRDs was quite expensive. It turns out we don't need to. In order to create RBAC roles we only need the plural and group of the types defined by a ProviderRevision (i.e. the types defined by CRDs installed by a ProviderRevision). We can derive this from the status of the ProviderRevision, which has references to all CRDs it creates.

My testing shows that this significantly reduces CPU and memory consumed by the RBAC manager when installing many (~70) providers from the same family at once.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9

I've confirmed that Crossplane creates RBAC cluster roles just like it did before this change, and that it does so while using much less CPU and memory. Previously installing ~70 providers from the same family all at once would cause the RBAC manager to hit its CPU and memory limits. Now I see it using ~50m CPU and 50Mi to 100Mi of memory even in the "worst case scenario" where provider package and controller images are pre-loaded, allowing ~70 providers to be created and ready in under 2 minutes.

<img width="1573" alt="Screenshot 2023-04-27 at 11 55 29 PM" src="https://user-images.githubusercontent.com/1049349/235076443-3678bda2-ec5e-4b50-bb52-6bfbd8b35f5f.png">

<img width="1577" alt="Screenshot 2023-04-27 at 11 55 40 PM" src="https://user-images.githubusercontent.com/1049349/235076468-a44c8c66-36e8-409f-a8bd-c03beee13949.png">

Note that in the above screenshot the CPU limit is 100m (1/10th of a core) and the memory limit is 512Mi.