### PR TITLE
[release-1.12] Backport #4010

### DIFF
--- a/apis/pkg/v1/interfaces.go
+++ b/apis/pkg/v1/interfaces.go
@@ -28,6 +28,19 @@ const (
 	// LabelParentPackage is used as key for the owner package label we add to the
 	// revisions. Its corresponding value should be the name of the owner package.
 	LabelParentPackage = "pkg.crossplane.io/package"
+
+	// TODO(negz): Should we propagate the family label up from revision to
+	// provider? It could potentially change over time, for example if the
+	// active revision's label changed for some reason. There's no technical
+	// reason to need it, but being able to list provider.pkg by family seems
+	// convenient.
+
+	// LabelProviderFamily is used as key for the provider family label. This
+	// label is added to any provider that rolls up to a larger 'family', such
+	// as 'family-aws'. It is propagated from provider metadata to provider
+	// revisions, and can be used to select all provider revisions that belong
+	// to a particular family. It is not added to providers, only revisions.
+	LabelProviderFamily = "pkg.crossplane.io/provider-family"
 )
 
 // RevisionActivationPolicy indicates how a package should activate its

--- a/internal/controller/pkg/revision/reconciler.go
+++ b/internal/controller/pkg/revision/reconciler.go
@@ -82,7 +82,7 @@ const (
 
 	errEstablishControl = "cannot establish control of object"
 
-	errUpdateAnnotations = "cannot update annotations for package revision"
+	errUpdateMeta = "cannot update package revision object metadata"
 
 	errRemoveLock  = "cannot remove package revision from Lock"
 	errResolveDeps = "cannot resolve package dependencies"
@@ -525,13 +525,15 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 
 	pkgMeta, _ := xpkg.TryConvert(pkg.GetMeta()[0], &pkgmetav1.Provider{}, &pkgmetav1.Configuration{})
 
-	pr.SetAnnotations(pkgMeta.(metav1.ObjectMetaAccessor).GetObjectMeta().GetAnnotations())
+	pmo := pkgMeta.(metav1.Object)
+	pr.SetLabels(pmo.GetLabels())
+	pr.SetAnnotations(pmo.GetAnnotations())
 	if err := r.client.Update(ctx, pr); err != nil {
 		pr.SetConditions(v1.Unhealthy())
 		_ = r.client.Status().Update(ctx, pr)
 
-		log.Debug(errUpdateAnnotations, "error", err)
-		err = errors.Wrap(err, errUpdateAnnotations)
+		log.Debug(errUpdateMeta, "error", err)
+		err = errors.Wrap(err, errUpdateMeta)
 		r.record.Event(pr, event.Warning(reasonSync, err))
 		return reconcile.Result{}, err
 	}

--- a/internal/controller/pkg/revision/reconciler.go
+++ b/internal/controller/pkg/revision/reconciler.go
@@ -526,8 +526,8 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 	pkgMeta, _ := xpkg.TryConvert(pkg.GetMeta()[0], &pkgmetav1.Provider{}, &pkgmetav1.Configuration{})
 
 	pmo := pkgMeta.(metav1.Object)
-	pr.SetLabels(pmo.GetLabels())
-	pr.SetAnnotations(pmo.GetAnnotations())
+	meta.AddLabels(pr, pmo.GetLabels())
+	meta.AddAnnotations(pr, pmo.GetAnnotations())
 	if err := r.client.Update(ctx, pr); err != nil {
 		pr.SetConditions(v1.Unhealthy())
 		_ = r.client.Status().Update(ctx, pr)

--- a/internal/controller/pkg/revision/reconciler_test.go
+++ b/internal/controller/pkg/revision/reconciler_test.go
@@ -895,7 +895,7 @@ func TestReconcile(t *testing.T) {
 				},
 			},
 			want: want{
-				err: errors.Wrap(errBoom, errUpdateAnnotations),
+				err: errors.Wrap(errBoom, errUpdateMeta),
 			},
 		},
 		"ErrResolveDependencies": {

--- a/internal/controller/rbac/controller/options.go
+++ b/internal/controller/rbac/controller/options.go
@@ -48,4 +48,10 @@ type Options struct {
 	// permissions may be granted to Providers that request them. The
 	// provider may request any permission that appears in the named role.
 	AllowClusterRole string
+
+	// DefaultRegistry used by the package manager to pull packages. Must match
+	// the package manager's DefaultRegistry in order for the RBAC manager to be
+	// able to determine whether two packages are part of the same registry and
+	// org.
+	DefaultRegistry string
 }

--- a/internal/controller/rbac/provider/roles/watch.go
+++ b/internal/controller/rbac/provider/roles/watch.go
@@ -137,7 +137,12 @@ func (e *EnqueueRequestForAllRevisionsInFamily) add(obj runtime.Object, queue ad
 		return
 	}
 
-	for _, pr := range l.Items {
-		queue.Add(reconcile.Request{NamespacedName: types.NamespacedName{Name: pr.GetName()}})
+	for _, member := range l.Items {
+		if member.GetUID() == pr.GetUID() {
+			// No need to enqueue a request for the ProviderRevision that
+			// triggered this enqueue.
+			continue
+		}
+		queue.Add(reconcile.Request{NamespacedName: types.NamespacedName{Name: member.GetName()}})
 	}
 }

--- a/internal/controller/rbac/provider/roles/watch.go
+++ b/internal/controller/rbac/provider/roles/watch.go
@@ -92,3 +92,52 @@ func (e *EnqueueRequestForAllRevisionsWithRequests) add(obj runtime.Object, queu
 		queue.Add(reconcile.Request{NamespacedName: types.NamespacedName{Name: pr.GetName()}})
 	}
 }
+
+// EnqueueRequestForAllRevisionsInFamily enqueues a request for all
+// provider revisions with the same family as one that changed.
+type EnqueueRequestForAllRevisionsInFamily struct {
+	client client.Client
+}
+
+// Create enqueues a request for all provider revisions within the same family.
+func (e *EnqueueRequestForAllRevisionsInFamily) Create(evt event.CreateEvent, q workqueue.RateLimitingInterface) {
+	e.add(evt.Object, q)
+}
+
+// Update enqueues a request for all provider revisions within the same family.
+func (e *EnqueueRequestForAllRevisionsInFamily) Update(evt event.UpdateEvent, q workqueue.RateLimitingInterface) {
+	e.add(evt.ObjectOld, q)
+	e.add(evt.ObjectNew, q)
+}
+
+// Delete enqueues a request for all provider revisions within the same family.
+func (e *EnqueueRequestForAllRevisionsInFamily) Delete(evt event.DeleteEvent, q workqueue.RateLimitingInterface) {
+	e.add(evt.Object, q)
+}
+
+// Generic enqueues a request for all provider revisions within the same family.
+func (e *EnqueueRequestForAllRevisionsInFamily) Generic(evt event.GenericEvent, q workqueue.RateLimitingInterface) {
+	e.add(evt.Object, q)
+}
+
+func (e *EnqueueRequestForAllRevisionsInFamily) add(obj runtime.Object, queue adder) {
+	pr, ok := obj.(*v1.ProviderRevision)
+	if !ok {
+		return
+	}
+	family := pr.GetLabels()[v1.LabelProviderFamily]
+	if family == "" {
+		// This revision is not part of a family.
+		return
+	}
+
+	l := &v1.ProviderRevisionList{}
+	if err := e.client.List(context.TODO(), l, client.MatchingLabels{v1.LabelProviderFamily: family}); err != nil {
+		// TODO(negz): Handle this error?
+		return
+	}
+
+	for _, pr := range l.Items {
+		queue.Add(reconcile.Request{NamespacedName: types.NamespacedName{Name: pr.GetName()}})
+	}
+}


### PR DESCRIPTION
### Description of your changes

This PR backports #4010 to the release-1.12 branch.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

N/A

[contribution process]: https://git.io/fj2m9
