### PR TITLE
tests: parse timestamps before comparing them

### DIFF
--- a/internal/controller/apiextensions/claim/reconciler_test.go
+++ b/internal/controller/apiextensions/claim/reconciler_test.go
@@ -831,7 +831,7 @@ func TestReconcile(t *testing.T) {
 					return s
 				}
 				return ts
-			}), cmpopts.EquateApproxTime(30*time.Second)); diff != "" {
+			}), cmpopts.EquateApproxTime(3*time.Second)); diff != "" {
 				t.Errorf("\n%s\nr.Reconcile(...): -want, +got:\n%s", tc.reason, diff)
 			}
 			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {

--- a/internal/controller/apiextensions/claim/reconciler_test.go
+++ b/internal/controller/apiextensions/claim/reconciler_test.go
@@ -825,7 +825,13 @@ func TestReconcile(t *testing.T) {
 
 			got, err := r.Reconcile(context.Background(), reconcile.Request{})
 
-			if diff := cmp.Diff(tc.want.claim, tc.args.claim, cmpopts.EquateApproxTime(30*time.Second)); diff != "" {
+			if diff := cmp.Diff(tc.want.claim, tc.args.claim, cmpopts.AcyclicTransformer("StringToTime", func(s string) any {
+				ts, err := time.Parse(time.RFC3339, s)
+				if err != nil {
+					return s
+				}
+				return ts
+			}), cmpopts.EquateApproxTime(30*time.Second)); diff != "" {
 				t.Errorf("\n%s\nr.Reconcile(...): -want, +got:\n%s", tc.reason, diff)
 			}
 			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {

--- a/internal/controller/apiextensions/composite/reconciler_test.go
+++ b/internal/controller/apiextensions/composite/reconciler_test.go
@@ -775,7 +775,13 @@ func WantComposite(t *testing.T, want resource.Composite) func(ctx context.Conte
 		// Normally we use a custom Equal method on conditions to ignore the
 		// lastTransitionTime, but we may be using unstructured types here where
 		// the conditions are just a map[string]any.
-		diff := cmp.Diff(want, got, cmpopts.EquateApproxTime(3*time.Second))
+		diff := cmp.Diff(want, got, cmpopts.AcyclicTransformer("StringToTime", func(s string) any {
+			ts, err := time.Parse(time.RFC3339, s)
+			if err != nil {
+				return s
+			}
+			return ts
+		}), cmpopts.EquateApproxTime(3*time.Second))
 		if diff != "" {
 			t.Errorf("WantComposite(...): -want, +got: %s", diff)
 		}


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #4003.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

Unit tests are passing and checked with the debugger that EquateApproxTime is actually executed now, which was not the case before.

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
