### PR TITLE
feat: schema-aware validation of Environment Patches

### DIFF
--- a/pkg/validation/apiextensions/v1/composition/patches.go
+++ b/pkg/validation/apiextensions/v1/composition/patches.go
@@ -176,11 +176,30 @@ func (v *Validator) validatePatchWithSchemaInternal(ctx patchValidationCtx) *fie
 				}
 			}
 		}
-	case v1.PatchTypeFromEnvironmentFieldPath,
-		v1.PatchTypeCombineFromEnvironment, v1.PatchTypeToEnvironmentFieldPath,
-		v1.PatchTypeCombineToEnvironment:
-		// TODO(phisco): implement validation for environment related patches
-		return nil
+	case v1.PatchTypeFromEnvironmentFieldPath:
+		fromType, toType, validationErr = validateFromCompositeFieldPathPatch(
+			ctx.patch,
+			nil,
+			getSchemaForVersion(ctx.resourceCRD, ctx.resourceGVK.Version),
+		)
+	case v1.PatchTypeToEnvironmentFieldPath:
+		fromType, toType, validationErr = validateFromCompositeFieldPathPatch(
+			ctx.patch,
+			getSchemaForVersion(ctx.resourceCRD, ctx.resourceGVK.Version),
+			nil,
+		)
+	case v1.PatchTypeCombineFromEnvironment:
+		fromType, toType, validationErr = validateCombineFromCompositePathPatch(
+			ctx.patch,
+			nil,
+			getSchemaForVersion(ctx.resourceCRD, ctx.resourceGVK.Version),
+		)
+	case v1.PatchTypeCombineToEnvironment:
+		fromType, toType, validationErr = validateCombineFromCompositePathPatch(
+			ctx.patch,
+			getSchemaForVersion(ctx.resourceCRD, ctx.resourceGVK.Version),
+			nil,
+		)
 	}
 	if validationErr != nil {
 		return validationErr

--- a/pkg/validation/apiextensions/v1/composition/validator_test.go
+++ b/pkg/validation/apiextensions/v1/composition/validator_test.go
@@ -367,6 +367,190 @@ func TestValidatorValidate(t *testing.T) {
 					})),
 			},
 		},
+		"FromEnvironmentFieldPathHandledProperly": {
+			reason: "Should accept a Composition with a FromEnvironmentFieldPath patch, if all CRDs are found",
+			want: want{
+				errs: nil,
+			},
+			args: args{
+				gkToCRDs: defaultGKToCRDs(),
+				comp: buildDefaultComposition(t, v1.CompositionValidationModeStrict, nil, withPatches(0, v1.Patch{
+					Type:          v1.PatchTypeFromEnvironmentFieldPath,
+					FromFieldPath: pointer.String("tier.name"),
+					ToFieldPath:   pointer.String("spec.someOtherField"),
+				})),
+			},
+		},
+		"FromEnvironmentFieldPathCatchErrorInToFieldPath": {
+			reason: "Should reject a Composition with a FromEnvironmentFieldPath patch, if all CRDs are found",
+			want: want{
+				errs: field.ErrorList{
+					{
+						Type:  field.ErrorTypeInvalid,
+						Field: "spec.resources[0].patches[0].toFieldPath",
+					},
+				},
+			},
+			args: args{
+				gkToCRDs: defaultGKToCRDs(),
+				comp: buildDefaultComposition(t, v1.CompositionValidationModeStrict, nil, withPatches(0, v1.Patch{
+					Type:          v1.PatchTypeFromEnvironmentFieldPath,
+					FromFieldPath: pointer.String("tier.name"),
+					ToFieldPath:   pointer.String("spec.someOtherWrongField"),
+				})),
+			},
+		},
+		"ToEnvironmentFieldPathHandledProperly": {
+			reason: "Should accept a Composition with a FromEnvironmentFieldPath patch, if all CRDs are found",
+			want: want{
+				errs: nil,
+			},
+			args: args{
+				gkToCRDs: defaultGKToCRDs(),
+				comp: buildDefaultComposition(t, v1.CompositionValidationModeStrict, nil, withPatches(0, v1.Patch{
+					Type:          v1.PatchTypeToEnvironmentFieldPath,
+					FromFieldPath: pointer.String("spec.someOtherField"),
+					ToFieldPath:   pointer.String("tier.name"),
+				})),
+			},
+		},
+		"ToEnvironmentFieldPathCatchErrorInFromFieldPath": {
+			reason: "Should reject a Composition with a FromEnvironmentFieldPath patch, if all CRDs are found",
+			want: want{
+				errs: field.ErrorList{
+					{
+						Type:  field.ErrorTypeInvalid,
+						Field: "spec.resources[0].patches[0].fromFieldPath",
+					},
+				},
+			},
+			args: args{
+				gkToCRDs: defaultGKToCRDs(),
+				comp: buildDefaultComposition(t, v1.CompositionValidationModeStrict, nil, withPatches(0, v1.Patch{
+					Type:          v1.PatchTypeToEnvironmentFieldPath,
+					FromFieldPath: pointer.String("spec.someOtherWrongField"),
+					ToFieldPath:   pointer.String("tier.name"),
+				})),
+			},
+		},
+		"CombineToEnvironmentHandledProperly": {
+			reason: "Should accept a Composition with a CombineToEnvironment patch, if all CRDs are found",
+			want: want{
+				errs: nil,
+			},
+			args: args{
+				gkToCRDs: defaultGKToCRDs(),
+				comp: buildDefaultComposition(t, v1.CompositionValidationModeStrict, nil, withPatches(0, v1.Patch{
+					Type: v1.PatchTypeCombineToEnvironment,
+					Combine: &v1.Combine{
+						Variables: []v1.CombineVariable{
+							{
+								FromFieldPath: "spec.someNonRequiredField",
+							},
+							{
+								FromFieldPath: "spec.someOtherField",
+							},
+						},
+						Strategy: v1.CombineStrategyString,
+						String: &v1.StringCombine{
+							Format: "%s-%s",
+						},
+					},
+					ToFieldPath: pointer.String("tier.name"),
+				})),
+			},
+		},
+		"CombineFromEnvironmentHandledProperly": {
+			reason: "Should accept a Composition with a CombineFromEnvironment patch, if all CRDs are found",
+			want: want{
+				errs: nil,
+			},
+			args: args{
+				gkToCRDs: defaultGKToCRDs(),
+				comp: buildDefaultComposition(t, v1.CompositionValidationModeStrict, nil, withPatches(0, v1.Patch{
+					Type: v1.PatchTypeCombineFromEnvironment,
+					Combine: &v1.Combine{
+						Variables: []v1.CombineVariable{
+							{
+								FromFieldPath: "tier.name",
+							},
+							{
+								FromFieldPath: "tier.someOtherName",
+							},
+						},
+						Strategy: v1.CombineStrategyString,
+						String: &v1.StringCombine{
+							Format: "%s-%s",
+						},
+					},
+					ToFieldPath: pointer.String("spec.someOtherField"),
+				})),
+			},
+		},
+		"CombineFromEnvironmentCatchErrorInToFieldPath": {
+			reason: "Should reject a Composition with a CombineFromEnvironment patch, if all CRDs are found",
+			want: want{
+				errs: field.ErrorList{
+					{
+						Type:  field.ErrorTypeInvalid,
+						Field: "spec.resources[0].patches[0].toFieldPath",
+					},
+				},
+			},
+			args: args{
+				gkToCRDs: defaultGKToCRDs(),
+				comp: buildDefaultComposition(t, v1.CompositionValidationModeStrict, nil, withPatches(0, v1.Patch{
+					Type: v1.PatchTypeCombineFromEnvironment,
+					Combine: &v1.Combine{
+						Variables: []v1.CombineVariable{
+							{
+								FromFieldPath: "tier.name",
+							},
+							{
+								FromFieldPath: "tier.someOtherName",
+							},
+						},
+						Strategy: v1.CombineStrategyString,
+						String: &v1.StringCombine{
+							Format: "%s-%s",
+						},
+					},
+					ToFieldPath: pointer.String("spec.someOtherWrongField"),
+				})),
+			},
+		},
+		"CombineToEnvironmentCatchErrorInFromFieldPath": {
+			reason: "Should reject a Composition with a CombineToEnvironment patch, if all CRDs are found",
+			want: want{
+				errs: field.ErrorList{
+					{
+						Type:  field.ErrorTypeInvalid,
+						Field: "spec.resources[0].patches[0].combine",
+					},
+				},
+			},
+			args: args{
+				gkToCRDs: defaultGKToCRDs(),
+				comp: buildDefaultComposition(t, v1.CompositionValidationModeStrict, nil, withPatches(0, v1.Patch{
+					Type: v1.PatchTypeCombineToEnvironment,
+					Combine: &v1.Combine{
+						Variables: []v1.CombineVariable{
+							{
+								FromFieldPath: "spec.someNonRequiredField",
+							},
+							{
+								FromFieldPath: "spec.someOtherWrongField",
+							},
+						},
+						Strategy: v1.CombineStrategyString,
+						String: &v1.StringCombine{
+							Format: "%s-%s",
+						},
+					},
+					ToFieldPath: pointer.String("tier.name"),
+				})),
+			},
+		},
 	}
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
@@ -431,6 +615,9 @@ func defaultManagedCrdBuilder() *crdBuilder {
 		},
 		Properties: map[string]extv1.JSONSchemaProps{
 			"someOtherField": {
+				Type: "string",
+			},
+			"someNonRequiredField": {
 				Type: "string",
 			},
 		},


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Implements Environment Config schema-aware validation as described in https://github.com/crossplane/crossplane/pull/3756, following up on https://github.com/crossplane/crossplane/pull/3937.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested
Unit tests added and manually tested:
```bash
$ make
...
$ HELM3_FLAGS="--set args={--enable-composition-webhook-schema-validation}" ./cluster/local/kind.sh helm-upgrade
...

$ kubectl apply -f <<EOF
apiVersion: pkg.crossplane.io/v1
kind: Provider
metadata:
  name: provider-aws
spec:
  package: xpkg.upbound.io/crossplane-contrib/provider-aws:v0.38.0
EOF
...
$ kubectl apply -f - <<EOF
apiVersion: apiextensions.crossplane.io/v1
kind: CompositeResourceDefinition
metadata:
  name: xpostgresqlinstances.database.example.org
spec:
  group: database.example.org
  names:
    kind: XPostgreSQLInstance
    plural: xpostgresqlinstances
  claimNames:
    kind: PostgreSQLInstance
    plural: postgresqlinstances
  connectionSecretKeys:
    - username
    - password
    - endpoint
    - port
  versions:
  - name: v1alpha1
    served: true
    referenceable: true
    schema:
      openAPIV3Schema:
        type: object
        properties:
          spec:
            type: object
            description: "The OpenAPIV3Schema of this Composite Resource Definition."
            properties:
              parameters:
                type: object
                properties:
                  storageGB:
                    type: integer
                    description: "The desired storage capacity of the database, in GB."
                  engine:
                    type: string
                required:
                  - storageGB
                  #- engine     ## <- engine is not required
            required:
              - parameters
EOF
...
$ kubectl apply -f - <<EOF
---
apiVersion: apiextensions.crossplane.io/v1
kind: Composition
metadata:
  name: xpostgresqlinstances.aws.database.example.org
  labels:
    provider: aws
    guide: quickstart
    vpc: default
spec:
  writeConnectionSecretsToNamespace: crossplane-system
  compositeTypeRef:
    apiVersion: database.example.org/v1alpha1
    kind: XPostgreSQLInstance
  resources:
    - name: rdsinstance
      base:
        apiVersion: database.aws.crossplane.io/v1beta1
        kind: RDSInstance
        spec:
          forProvider:
            dbInstanceClass: db.t2.small
            masterUsername: masteruser
            engineVersion: "12"
            skipFinalSnapshotBeforeDeletion: true
            publiclyAccessible: true
      patches:
        - type: FromEnvironmentFieldPath
          fromFieldPath: "spec.someEnvParameter"
          toFieldPath: "spec.forProvider.wrong"       ## <- missing "wrong" field in RDSInstance
      connectionDetails:
        - fromConnectionSecretKey: username
        - fromConnectionSecretKey: password
        - fromConnectionSecretKey: endpoint
        - fromConnectionSecretKey: port
EOF
```
Should return the following errors:
```
The Composition "xpostgresqlinstances.aws.database.example.org" is invalid: spec.resources[0].patches[0].toFieldPath: Invalid value: "spec.forProvider.wrong": field 'wrong' is not valid according to the schema
```
<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
