### PR TITLE
feat(alpha): connection details schema-aware validation

### DIFF
--- a/pkg/validation/apiextensions/v1/composition/connectionDetails.go
+++ b/pkg/validation/apiextensions/v1/composition/connectionDetails.go
@@ -1,0 +1,68 @@
+/*
+Copyright 2023 the Crossplane Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package composition
+
+import (
+	"context"
+
+	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+
+	"github.com/crossplane/crossplane-runtime/pkg/errors"
+
+	v1 "github.com/crossplane/crossplane/apis/apiextensions/v1"
+	verrors "github.com/crossplane/crossplane/internal/validation/errors"
+)
+
+// validateConnectionDetailsWithSchemas validates the connection details of a composition. It only checks the
+// FromFieldPath as that is the only one we are able to validate with certainty.
+func (v *Validator) validateConnectionDetailsWithSchemas(ctx context.Context, comp *v1.Composition) (errs field.ErrorList) {
+	for i, resource := range comp.Spec.Resources {
+		if len(resource.ConnectionDetails) == 0 {
+			continue
+		}
+		gvk, err := GetBaseObjectGVK(&comp.Spec.Resources[i])
+		if err != nil {
+			return append(errs, field.InternalError(field.NewPath("spec", "resources").Index(i), errors.Wrap(err, "cannot get object gvk")))
+		}
+		crd, err := v.crdGetter.Get(ctx, gvk.GroupKind())
+		if err != nil {
+			return append(errs, field.InternalError(
+				field.NewPath("spec", "resources").Index(i),
+				err,
+			))
+		}
+		for j, con := range resource.ConnectionDetails {
+			if err := validateConnectionDetail(con, getSchemaForVersion(crd, gvk.Version)); err != nil {
+				errs = append(errs, verrors.WrapFieldError(err, field.NewPath("spec", "resources").Index(i).Child("connectionDetails").Index(j)))
+			}
+		}
+	}
+
+	return errs
+}
+
+func validateConnectionDetail(con v1.ConnectionDetail, schema *apiextensions.JSONSchemaProps) *field.Error {
+	if schema == nil {
+		return nil
+	}
+	// If defined we validate it, logical validation should enforce consistency if needed.
+	if con.FromFieldPath != nil {
+		if _, err := validateFieldPath(schema, *con.FromFieldPath); err != nil {
+			return field.Invalid(field.NewPath("fromFieldPath"), *con.FromFieldPath, err.Error())
+		}
+	}
+	// We don't validate other fields now as they do not have a schema to validate against.
+	return nil
+}

--- a/pkg/validation/apiextensions/v1/composition/connectionDetails_test.go
+++ b/pkg/validation/apiextensions/v1/composition/connectionDetails_test.go
@@ -1,0 +1,132 @@
+/*
+Copyright 2023 The Crossplane Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package composition
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
+	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/utils/pointer"
+
+	v1 "github.com/crossplane/crossplane/apis/apiextensions/v1"
+)
+
+func withConnectionDetails(index int, cds ...v1.ConnectionDetail) compositionBuilderOption {
+	return func(c *v1.Composition) {
+		c.Spec.Resources[index].ConnectionDetails = cds
+	}
+}
+
+func TestValidateConnectionDetails(t *testing.T) {
+	type args struct {
+		comp    *v1.Composition
+		gkToCRD map[schema.GroupKind]apiextensions.CustomResourceDefinition
+	}
+	type want struct {
+		errs field.ErrorList
+	}
+	tests := []struct {
+		name string
+		args args
+		want want
+	}{
+		{
+			name: "should accept empty connection details",
+			args: args{
+				comp:    buildDefaultComposition(t, v1.CompositionValidationModeLoose, nil),
+				gkToCRD: defaultGKToCRDs(),
+			},
+			want: want{
+				errs: nil,
+			},
+		},
+		{
+			name: "should accept valid connection details, unknown type",
+			args: args{
+				comp: buildDefaultComposition(t, v1.CompositionValidationModeLoose, nil, withConnectionDetails(
+					0,
+					v1.ConnectionDetail{
+						Type: &[]v1.ConnectionDetailType{v1.ConnectionDetailTypeUnknown}[0],
+					},
+				)),
+				gkToCRD: defaultGKToCRDs(),
+			},
+			want: want{
+				errs: nil,
+			},
+		},
+		{
+			name: "should accept valid connection detail specifying a valid fromFieldPath",
+			args: args{
+				comp: buildDefaultComposition(t, v1.CompositionValidationModeLoose, nil, withConnectionDetails(
+					0,
+					v1.ConnectionDetail{
+						FromFieldPath: pointer.String("spec.someOtherField"),
+					},
+				)),
+				gkToCRD: defaultGKToCRDs(),
+			},
+			want: want{
+				errs: nil,
+			},
+		},
+		{
+			name: "should reject invalid connection detail specifying an invalid fromFieldPath",
+			args: args{
+				comp: buildDefaultComposition(t, v1.CompositionValidationModeLoose, nil, withConnectionDetails(
+					0,
+					v1.ConnectionDetail{
+						FromFieldPath: pointer.String("spec.someWrongField"),
+					},
+					v1.ConnectionDetail{
+						FromFieldPath: pointer.String("spec.someField"),
+					},
+				)),
+				gkToCRD: buildGkToCRDs(
+					defaultManagedCrdBuilder().withOption(func(crd *extv1.CustomResourceDefinition) {
+						crd.Spec.Versions[0].Schema.OpenAPIV3Schema.Properties["spec"].Properties["someField"] = extv1.JSONSchemaProps{
+							Type: "string",
+						}
+					}).build()),
+			},
+			want: want{
+				errs: field.ErrorList{
+					{
+						Type:     field.ErrorTypeInvalid,
+						Field:    "spec.resources[0].connectionDetails[0].fromFieldPath",
+						BadValue: "spec.someWrongField",
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			v, err := NewValidator(WithCRDGetterFromMap(tt.args.gkToCRD))
+			if err != nil {
+				t.Fatalf("NewValidator() error = %v", err)
+			}
+			got := v.validateConnectionDetailsWithSchemas(context.TODO(), tt.args.comp)
+			if diff := cmp.Diff(got, tt.want.errs, sortFieldErrors(), cmpopts.IgnoreFields(field.Error{}, "Detail")); diff != "" {
+				t.Errorf("validateConnectionDetailsWithSchemas(...) = -want, +got\n%s\n", diff)
+			}
+		})
+	}
+}

--- a/pkg/validation/apiextensions/v1/composition/validator.go
+++ b/pkg/validation/apiextensions/v1/composition/validator.go
@@ -132,7 +132,7 @@ func (v *Validator) Validate(ctx context.Context, obj runtime.Object) (warns []s
 	for _, f := range []func(context.Context, *v1.Composition) field.ErrorList{
 		v.validatePatchesWithSchemas,
 		v.validateReadinessChecksWithSchemas,
-		// v.validateConnectionDetailsWithSchemas,
+		v.validateConnectionDetailsWithSchemas,
 		// TODO(phisco): add more phase 2 validation here
 	} {
 		errs = append(errs, f(ctx, comp)...)


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Implements ConnectionDetails schema-aware validation as described in https://github.com/crossplane/crossplane/pull/3756, following up on https://github.com/crossplane/crossplane/pull/3937.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested
Unit tests added and manually tested:
```bash
$ make
...
$ HELM3_FLAGS="--set args={--enable-composition-webhook-schema-validation}" ./cluster/local/kind.sh helm-upgrade
...

$ kubectl apply -f - <<EOF
apiVersion: pkg.crossplane.io/v1
kind: Provider
metadata:
  name: provider-aws
spec:
  package: xpkg.upbound.io/crossplane-contrib/provider-aws:v0.38.0
EOF
...
$ kubectl apply -f - <<EOF
apiVersion: apiextensions.crossplane.io/v1
kind: CompositeResourceDefinition
metadata:
  name: xpostgresqlinstances.database.example.org
spec:
  group: database.example.org
  names:
    kind: XPostgreSQLInstance
    plural: xpostgresqlinstances
  claimNames:
    kind: PostgreSQLInstance
    plural: postgresqlinstances
  connectionSecretKeys:
    - username
    - password
    - endpoint
    - port
  versions:
  - name: v1alpha1
    served: true
    referenceable: true
    schema:
      openAPIV3Schema:
        type: object
        properties:
          spec:
            type: object
            description: "The OpenAPIV3Schema of this Composite Resource Definition."
            properties:
              parameters:
                type: object
                properties:
                  storageGB:
                    type: integer
                    description: "The desired storage capacity of the database, in GB."
                  engine:
                    type: string
                required:
                  - storageGB
                  #- engine     ## <- engine is not required
            required:
              - parameters
EOF
...
$ kubectl apply -f - <<EOF
---
apiVersion: apiextensions.crossplane.io/v1
kind: Composition
metadata:
  name: xpostgresqlinstances.aws.database.example.org
  labels:
    provider: aws
    guide: quickstart
    vpc: default
spec:
  writeConnectionSecretsToNamespace: crossplane-system
  compositeTypeRef:
    apiVersion: database.example.org/v1alpha1
    kind: XPostgreSQLInstance
  resources:
    - name: rdsinstance
      base:
        apiVersion: database.aws.crossplane.io/v1beta1
        kind: RDSInstance
        spec:
          forProvider:
            dbInstanceClass: db.t2.small
            masterUsername: masteruser
            engineVersion: "12"
            skipFinalSnapshotBeforeDeletion: true
            publiclyAccessible: true
      patches:
      connectionDetails:
        - fromFieldPath: "spec.forProvider.wrong"      # <- Not accepted according to the RDSInstance schema
        - fromConnectionSecretKey: username
        - fromConnectionSecretKey: password
        - fromConnectionSecretKey: endpoint
        - fromConnectionSecretKey: port
EOF
```
Should return the following errors:
```
he Composition "xpostgresqlinstances.aws.database.example.org" is invalid: spec.resources[0].connectionDetails[0].fromFieldPath: Invalid value: "spec.forProvider.wrong": field 'wrong' is not valid according to the schema
```
<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9