### PR TITLE
Refactor in-cluster auth into a `ContainerFunctionRunnerOption`

### DIFF
--- a/apis/apiextensions/v1/composition_common.go
+++ b/apis/apiextensions/v1/composition_common.go
@@ -286,14 +286,14 @@ type ContainerFunction struct {
 	// +kubebuilder:validation:Enum="IfNotPresent";"Always";"Never"
 	ImagePullPolicy *corev1.PullPolicy `json:"imagePullPolicy,omitempty"`
 
+	// ImagePullSecrets are used to pull images from private OCI registries.
+	// +optional
+	ImagePullSecrets []corev1.LocalObjectReference `json:"imagePullSecrets,omitempty"`
+
 	// Timeout after which the Composition Function will be killed.
 	// +optional
 	// +kubebuilder:default="20s"
 	Timeout *metav1.Duration `json:"timeout,omitempty"`
-
-	// Secrets for pulling function images.
-	// +optional
-	ImagePullSecrets []corev1.LocalObjectReference `json:"imagePullSecrets,omitempty"`
 
 	// Network configuration for the Composition Function.
 	// +optional

--- a/apis/apiextensions/v1/zz_generated.conversion.go
+++ b/apis/apiextensions/v1/zz_generated.conversion.go
@@ -215,17 +215,17 @@ func (c *GeneratedRevisionSpecConverter) v1ContainerFunctionToV1ContainerFunctio
 		pV1PullPolicy = &v1PullPolicy
 	}
 	v1ContainerFunction.ImagePullPolicy = pV1PullPolicy
+	v1LocalObjectReferenceList := make([]v1.LocalObjectReference, len(source.ImagePullSecrets))
+	for i := 0; i < len(source.ImagePullSecrets); i++ {
+		v1LocalObjectReferenceList[i] = c.v1LocalObjectReferenceToV1LocalObjectReference(source.ImagePullSecrets[i])
+	}
+	v1ContainerFunction.ImagePullSecrets = v1LocalObjectReferenceList
 	var pV1Duration *v11.Duration
 	if source.Timeout != nil {
 		v1Duration := c.v1DurationToV1Duration(*source.Timeout)
 		pV1Duration = &v1Duration
 	}
 	v1ContainerFunction.Timeout = pV1Duration
-	v1LocalObjectReferenceList := make([]v1.LocalObjectReference, len(source.ImagePullSecrets))
-	for i := 0; i < len(source.ImagePullSecrets); i++ {
-		v1LocalObjectReferenceList[i] = c.v1LocalObjectReferenceToV1LocalObjectReference(source.ImagePullSecrets[i])
-	}
-	v1ContainerFunction.ImagePullSecrets = v1LocalObjectReferenceList
 	var pV1ContainerFunctionNetwork *ContainerFunctionNetwork
 	if source.Network != nil {
 		v1ContainerFunctionNetwork := c.v1ContainerFunctionNetworkToV1ContainerFunctionNetwork(*source.Network)

--- a/apis/apiextensions/v1/zz_generated.deepcopy.go
+++ b/apis/apiextensions/v1/zz_generated.deepcopy.go
@@ -611,15 +611,15 @@ func (in *ContainerFunction) DeepCopyInto(out *ContainerFunction) {
 		*out = new(corev1.PullPolicy)
 		**out = **in
 	}
-	if in.Timeout != nil {
-		in, out := &in.Timeout, &out.Timeout
-		*out = new(metav1.Duration)
-		**out = **in
-	}
 	if in.ImagePullSecrets != nil {
 		in, out := &in.ImagePullSecrets, &out.ImagePullSecrets
 		*out = make([]corev1.LocalObjectReference, len(*in))
 		copy(*out, *in)
+	}
+	if in.Timeout != nil {
+		in, out := &in.Timeout, &out.Timeout
+		*out = new(metav1.Duration)
+		**out = **in
 	}
 	if in.Network != nil {
 		in, out := &in.Network, &out.Network

--- a/apis/apiextensions/v1beta1/zz_generated.composition_common.go
+++ b/apis/apiextensions/v1beta1/zz_generated.composition_common.go
@@ -288,14 +288,14 @@ type ContainerFunction struct {
 	// +kubebuilder:validation:Enum="IfNotPresent";"Always";"Never"
 	ImagePullPolicy *corev1.PullPolicy `json:"imagePullPolicy,omitempty"`
 
+	// ImagePullSecrets are used to pull images from private OCI registries.
+	// +optional
+	ImagePullSecrets []corev1.LocalObjectReference `json:"imagePullSecrets,omitempty"`
+
 	// Timeout after which the Composition Function will be killed.
 	// +optional
 	// +kubebuilder:default="20s"
 	Timeout *metav1.Duration `json:"timeout,omitempty"`
-
-	// Secrets for pulling function images.
-	// +optional
-	ImagePullSecrets []corev1.LocalObjectReference `json:"imagePullSecrets,omitempty"`
 
 	// Network configuration for the Composition Function.
 	// +optional

--- a/apis/apiextensions/v1beta1/zz_generated.deepcopy.go
+++ b/apis/apiextensions/v1beta1/zz_generated.deepcopy.go
@@ -284,15 +284,15 @@ func (in *ContainerFunction) DeepCopyInto(out *ContainerFunction) {
 		*out = new(v1.PullPolicy)
 		**out = **in
 	}
-	if in.Timeout != nil {
-		in, out := &in.Timeout, &out.Timeout
-		*out = new(metav1.Duration)
-		**out = **in
-	}
 	if in.ImagePullSecrets != nil {
 		in, out := &in.ImagePullSecrets, &out.ImagePullSecrets
 		*out = make([]v1.LocalObjectReference, len(*in))
 		copy(*out, *in)
+	}
+	if in.Timeout != nil {
+		in, out := &in.Timeout, &out.Timeout
+		*out = new(metav1.Duration)
+		**out = **in
 	}
 	if in.Network != nil {
 		in, out := &in.Network, &out.Network

--- a/cluster/crds/apiextensions.crossplane.io_compositionrevisions.yaml
+++ b/cluster/crds/apiextensions.crossplane.io_compositionrevisions.yaml
@@ -486,7 +486,8 @@ spec:
                           - Never
                           type: string
                         imagePullSecrets:
-                          description: Secrets for pulling function images.
+                          description: ImagePullSecrets are used to pull images from
+                            private OCI registries.
                           items:
                             description: LocalObjectReference contains enough information
                               to let you locate the referenced object inside the same
@@ -3280,7 +3281,8 @@ spec:
                           - Never
                           type: string
                         imagePullSecrets:
-                          description: Secrets for pulling function images.
+                          description: ImagePullSecrets are used to pull images from
+                            private OCI registries.
                           items:
                             description: LocalObjectReference contains enough information
                               to let you locate the referenced object inside the same

--- a/cluster/crds/apiextensions.crossplane.io_compositions.yaml
+++ b/cluster/crds/apiextensions.crossplane.io_compositions.yaml
@@ -486,7 +486,8 @@ spec:
                           - Never
                           type: string
                         imagePullSecrets:
-                          description: Secrets for pulling function images.
+                          description: ImagePullSecrets are used to pull images from
+                            private OCI registries.
                           items:
                             description: LocalObjectReference contains enough information
                               to let you locate the referenced object inside the same

--- a/cmd/xfn/run/run.go
+++ b/cmd/xfn/run/run.go
@@ -37,9 +37,9 @@ import (
 const (
 	errWriteFIO        = "cannot write FunctionIO YAML to stdout"
 	errRunFunction     = "cannot run function"
-	errParseImage      = "cannot parse image"
-	errResolveKeychain = "cannot resolve keychain"
-	errAuthCfg         = "cannot get xfn registry auth configuration"
+	errParseImage      = "cannot parse image reference"
+	errResolveKeychain = "cannot resolve default registry authentication keychain"
+	errAuthCfg         = "cannot get default registry authentication credentials"
 )
 
 // Command runs a Composition function.
@@ -75,9 +75,12 @@ func (c *Command) Run() error {
 		return errors.Wrap(err, errParseImage)
 	}
 
-	// DefaultKeychain uses credentials from ~/.docker/config.json to pull Composite Function private image.
-	keychain := authn.DefaultKeychain
-	auth, err := keychain.Resolve(ref.Context())
+	// We want to resolve authentication credentials here, using the caller's
+	// environment rather than inside the user namespace that spark will create.
+	// DefaultKeychain uses credentials from ~/.docker/config.json to pull
+	// private images. Despite being 'the default' it must be explicitly
+	// provided, or go-containerregistry will use anonymous authentication.
+	auth, err := authn.DefaultKeychain.Resolve(ref.Context())
 	if err != nil {
 		return errors.Wrap(err, errResolveKeychain)
 	}

--- a/internal/controller/apiextensions/composite/composition_ptf_test.go
+++ b/internal/controller/apiextensions/composite/composition_ptf_test.go
@@ -54,7 +54,6 @@ import (
 
 	iov1alpha1 "github.com/crossplane/crossplane/apis/apiextensions/fn/io/v1alpha1"
 	fnpbv1alpha1 "github.com/crossplane/crossplane/apis/apiextensions/fn/proto/v1alpha1"
-	fnv1alpha1 "github.com/crossplane/crossplane/apis/apiextensions/fn/proto/v1alpha1"
 	v1 "github.com/crossplane/crossplane/apis/apiextensions/v1"
 	env "github.com/crossplane/crossplane/internal/controller/apiextensions/composite/environment"
 	"github.com/crossplane/crossplane/internal/xcrd"
@@ -1122,10 +1121,10 @@ func TestWithKubernetesAuthentication(t *testing.T) {
 	type args struct {
 		ctx context.Context
 		fn  *v1.ContainerFunction
-		r   *fnv1alpha1.RunFunctionRequest
+		r   *fnpbv1alpha1.RunFunctionRequest
 	}
 	type want struct {
-		r   *fnv1alpha1.RunFunctionRequest
+		r   *fnpbv1alpha1.RunFunctionRequest
 		err error
 	}
 
@@ -1189,12 +1188,12 @@ func TestWithKubernetesAuthentication(t *testing.T) {
 					Image:            "xpkg.example.org/cool-image:v1.0.0",
 					ImagePullSecrets: []corev1.LocalObjectReference{{Name: "cool-secret"}},
 				},
-				r: &fnv1alpha1.RunFunctionRequest{},
+				r: &fnpbv1alpha1.RunFunctionRequest{},
 			},
 			want: want{
-				r: &fnv1alpha1.RunFunctionRequest{
-					ImagePullConfig: &fnv1alpha1.ImagePullConfig{
-						Auth: &fnv1alpha1.ImagePullAuth{
+				r: &fnpbv1alpha1.RunFunctionRequest{
+					ImagePullConfig: &fnpbv1alpha1.ImagePullConfig{
+						Auth: &fnpbv1alpha1.ImagePullAuth{
 							Username: "cool-user",
 							Password: "cool-pass",
 						},

--- a/internal/controller/apiextensions/controller/options.go
+++ b/internal/controller/apiextensions/controller/options.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package controller contains options specific to apiextension controllers.
+// Package controller contains options specific to apiextensions controllers.
 package controller
 
 import (
@@ -25,9 +25,11 @@ import (
 type Options struct {
 	controller.Options
 
-	// Namespace used for XFN private registries authentication.
+	// Namespace in which we'll look for image pull secrets for in-cluster
+	// private registry authentication when pulling Composition Functions.
 	Namespace string
 
-	// ServiceAccount is the core Crossplane ServiceAccount name.
+	// ServiceAccount for which we'll find image pull secrets for in-cluster
+	// private registry authentication when pulling Composition Functions.
 	ServiceAccount string
 }

--- a/internal/controller/apiextensions/definition/reconciler.go
+++ b/internal/controller/apiextensions/definition/reconciler.go
@@ -505,7 +505,7 @@ func CompositeReconcilerOptions(co apiextensionscontroller.Options, d *v1.Compos
 				composite.WithCompositeConnectionDetailsFetcher(fetcher),
 				composite.WithFunctionPipelineRunner(composite.NewFunctionPipeline(
 					composite.ContainerFunctionRunnerFn(composite.RunFunction),
-					composite.WithInClusterAuth(co.Namespace, co.ServiceAccount),
+					composite.WithKubernetesAuthentication(c, co.Namespace, co.ServiceAccount),
 				)),
 			),
 			composite.NewPTComposer(c, composite.WithComposedConnectionDetailsFetcher(fetcher)),

--- a/internal/controller/apiextensions/definition/reconciler.go
+++ b/internal/controller/apiextensions/definition/reconciler.go
@@ -499,16 +499,13 @@ func CompositeReconcilerOptions(co apiextensionscontroller.Options, d *v1.Compos
 	// Composition validation ensures that a Composition that uses functions
 	// must have named resources templates.
 	if co.Features.Enabled(features.EnableAlphaCompositionFunctions) {
-		xfnRunner := &composite.DefaultCompositeFunctionRunner{
-			Namespace:      co.Namespace,
-			ServiceAccount: co.ServiceAccount,
-		}
 		fb := composite.NewFallBackComposer(
 			composite.NewPTFComposer(c,
 				composite.WithComposedResourceGetter(composite.NewExistingComposedResourceGetter(c, fetcher)),
 				composite.WithCompositeConnectionDetailsFetcher(fetcher),
 				composite.WithFunctionPipelineRunner(composite.NewFunctionPipeline(
-					composite.ContainerFunctionRunnerFn(xfnRunner.RunFunction),
+					composite.ContainerFunctionRunnerFn(composite.RunFunction),
+					composite.WithInClusterAuth(co.Namespace, co.ServiceAccount),
 				)),
 			),
 			composite.NewPTComposer(c, composite.WithComposedConnectionDetailsFetcher(fetcher)),


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
This reduces the complexity of RunFunction a little. This PR also has a few small cleanups following on to https://github.com/crossplane/crossplane/pull/3869.


I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9


https://github.com/crossplane-contrib/contribfest/blob/63c50e/lab-composition-functions/02-xfn-noop.md

I used a variant of the above lab, modified to use a private function (`index.docker.io/negz/private-fn:v0.0.1`). I confirmed that:

* When I specify a valid `imagePullSecret` everything works as expected.
* When I specify a non-existent `imagePullSecret` I get an error (see below).
* When I don't specify an `imagePullSecret` I get another error (see below).

```
  Warning  ComposeResources         23s (x6 over 53s)      defined/compositeresourcedefinition.apiextensions.crossplane.io  cannot compose resources: cannot run Composition Function pipeline: cannot run function "my-noop-function": cannot run container: rpc error: code = Unknown desc = exit status 1: xfn: error: spark.Command.Run(): cannot pull OCI image: cannot pull image from remote: GET https://index.docker.io/v2/negz/private-fn/manifests/v0.0.1: UNAUTHORIZED: authentication required; [map[Action:pull Class: Name:negz/private-fn Type:repository]]
```

```
  Warning  ComposeResources         0s (x2 over 0s)     defined/compositeresourcedefinition.apiextensions.crossplane.io  cannot compose resources: cannot run Composition Function pipeline: cannot run function "my-noop-function": cannot apply run function option: cannot get image pull secret: Secret "does-not-exist" not found
```