### PR TITLE
chore: add helm and kind to renovate config

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -40,6 +40,26 @@
       "datasourceTemplate": "github-tags",
       "depNameTemplate": "golangci/golangci-lint",
       "extractVersionTemplate": "^v(?<version>.*)$"
+    }, {
+// We want a PR to bump the helm version used through env variables in
+// any Github Actions or Makefile, taking it from the official Github
+// repository tags.
+      "fileMatch": ["^Makefile$"],
+      "matchStrings": [
+        "HELM3_VERSION = (?<currentValue>.*?)\\n"
+      ],
+      "datasourceTemplate": "github-tags",
+      "depNameTemplate": "helm/helm",
+    }, {
+// We want a PR to bump the kind version used through env variables in
+// any Github Actions or Makefile, taking it from the official Github
+// repository tags.
+      "fileMatch": ["^Makefile$"],
+      "matchStrings": [
+        "KIND_VERSION = (?<currentValue>.*?)\\n"
+      ],
+      "datasourceTemplate": "github-tags",
+      "depNameTemplate": "kubernetes-sigs/kind",
     }
   ],
 // PackageRules disabled below should be enabled in case of vulnerabilities

--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,7 @@ GOLANGCILINT_VERSION = 1.52.2
 
 USE_HELM3 = true
 HELM3_VERSION = v3.6.3
+KIND_VERSION = v0.16.0
 -include build/makelib/k8s_tools.mk
 
 # ====================================================================================


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Configure Renovate to also open PRs to keep Helm and Kind versions used updated.
Explicitly setting kind's version to the same one currently set in the build submodule.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

Configured on my fork, results in the following PRs:
- https://github.com/phisco/crossplane/pull/176
- https://github.com/phisco/crossplane/pull/177

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
