### PR TITLE
Improve package dependency conflict error message

### DIFF
--- a/internal/controller/pkg/revision/dependency.go
+++ b/internal/controller/pkg/revision/dependency.go
@@ -40,6 +40,7 @@ const (
 
 	errNotMeta                   = "meta type is not a valid package"
 	errGetOrCreateLock           = "cannot get or create lock"
+	errInitDAG                   = "cannot initialize dependency graph from the packages in the lock"
 	errIncompatibleDependencyFmt = "incompatible dependencies: %+v"
 	errMissingDependenciesFmt    = "missing dependencies: %+v"
 	errDependencyNotInGraph      = "dependency is not present in graph"
@@ -116,7 +117,7 @@ func (m *PackageDependencyManager) Resolve(ctx context.Context, pkg runtime.Obje
 	d := m.newDag()
 	implied, err := d.Init(v1beta1.ToNodes(lock.Packages...))
 	if err != nil {
-		return found, installed, invalid, err
+		return found, installed, invalid, errors.Wrap(err, errInitDAG)
 	}
 
 	lockRef := xpkg.ParsePackageSourceFromReference(prRef)

--- a/internal/controller/pkg/revision/dependency_test.go
+++ b/internal/controller/pkg/revision/dependency_test.go
@@ -259,7 +259,7 @@ func TestResolve(t *testing.T) {
 				},
 			},
 			want: want{
-				err: errBoom,
+				err: errors.Wrap(errBoom, errInitDAG),
 			},
 		},
 		"SuccessfulSelfExistNoDependencies": {

--- a/internal/dag/dag.go
+++ b/internal/dag/dag.go
@@ -97,7 +97,7 @@ func (d *MapDag) AddNodes(nodes ...Node) error {
 // AddNode adds a node to the graph.
 func (d *MapDag) AddNode(node Node) error {
 	if _, ok := d.nodes[node.Identifier()]; ok {
-		return errors.New("node already exists")
+		return errors.Errorf("node %s already exists", node.Identifier())
 	}
 	d.nodes[node.Identifier()] = node
 	return nil
@@ -120,7 +120,7 @@ func (d *MapDag) NodeExists(identifier string) bool {
 // NodeNeighbors returns a node's neighbors.
 func (d *MapDag) NodeNeighbors(identifier string) ([]Node, error) {
 	if _, ok := d.nodes[identifier]; !ok {
-		return nil, errors.New("node does not exist")
+		return nil, errors.Errorf("node %s does not exist", identifier)
 	}
 	return d.nodes[identifier].Neighbors(), nil
 }


### PR DESCRIPTION
### Description of your changes

Under [certain circumstances](https://github.com/crossplane/crossplane/issues/3742#issuecomment-1543843655), the Crossplane package manager may end up in a situation where the lock file contains duplicate entries resulting in failures in dependency resolution. 

This PR improves the error message we are getting in that case by:

- Adding more context indicating that it is an issue related to initializing dependency graph using the lock.
- Including the identifier of the node to point the failing package.

For example, it changes from

```
cannot resolve package dependencies: node already exists
```

to

```
cannot resolve package dependencies: cannot initialize dependency graph from the packages in the lock: node xpkg.upbound.io/hasan/provider-helm already exists
```


Fixes #4022

I have:

- [ ] Read and followed Crossplane's [contribution process].
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

By reproducing inconsistent state by following step here: https://github.com/crossplane/crossplane/issues/3742#issuecomment-1543800668

[contribution process]: https://git.io/fj2m9
