### PR TITLE
Deactivate inactive revisions without pulling/parsing the package contents

### DIFF
--- a/internal/controller/pkg/revision/dependency.go
+++ b/internal/controller/pkg/revision/dependency.go
@@ -71,9 +71,9 @@ func NewPackageDependencyManager(c client.Client, nd dag.NewDAGFn, t v1beta1.Pac
 
 // Resolve resolves package dependencies.
 func (m *PackageDependencyManager) Resolve(ctx context.Context, pkg runtime.Object, pr v1.PackageRevision) (found, installed, invalid int, err error) { //nolint:gocyclo // TODO(negz): Can this be refactored for less complexity?
-	// If we are inactive, all we want to do is remove self.
+	// If we are inactive, we don't need to resolve dependencies.
 	if pr.GetDesiredState() == v1.PackageRevisionInactive {
-		return found, installed, invalid, m.RemoveSelf(ctx, pr)
+		return 0, 0, 0, nil
 	}
 
 	pack, ok := xpkg.TryConvertToPkg(pkg, &pkgmetav1.Provider{}, &pkgmetav1.Configuration{})

--- a/internal/controller/pkg/revision/dependency_test.go
+++ b/internal/controller/pkg/revision/dependency_test.go
@@ -61,8 +61,8 @@ func TestResolve(t *testing.T) {
 		args   args
 		want   want
 	}{
-		"ErrorResolveInactive": {
-			reason: "Should return error if we resolve is called for an inactive revision.",
+		"SuccessfulInactiveNothingToDo": {
+			reason: "Should return no error if resolve is called for an inactive revision.",
 			args: args{
 				meta: &pkgmetav1.Configuration{},
 				pr: &v1.ConfigurationRevision{
@@ -72,9 +72,7 @@ func TestResolve(t *testing.T) {
 					},
 				},
 			},
-			want: want{
-				err: errors.New(errNoResolveForInactiveRevisions),
-			},
+			want: want{},
 		},
 		"ErrNotMeta": {
 			reason: "Should return error if not a valid package meta type.",

--- a/internal/controller/pkg/revision/establisher.go
+++ b/internal/controller/pkg/revision/establisher.go
@@ -62,7 +62,7 @@ const (
 // resources and then establishing it.
 type Establisher interface {
 	Establish(ctx context.Context, objects []runtime.Object, parent v1.PackageRevision, control bool) ([]xpv1.TypedReference, error)
-	Relinquish(ctx context.Context, parent v1.PackageRevision) error
+	ReleaseObjects(ctx context.Context, parent v1.PackageRevision) error
 }
 
 // NewNopEstablisher returns a new NopEstablisher.
@@ -78,8 +78,8 @@ func (*NopEstablisher) Establish(_ context.Context, _ []runtime.Object, _ v1.Pac
 	return nil, nil
 }
 
-// Relinquish does nothing.
-func (*NopEstablisher) Relinquish(_ context.Context, _ v1.PackageRevision) error {
+// ReleaseObjects does nothing.
+func (*NopEstablisher) ReleaseObjects(_ context.Context, _ v1.PackageRevision) error {
 	return nil
 }
 
@@ -126,9 +126,9 @@ func (e *APIEstablisher) Establish(ctx context.Context, objs []runtime.Object, p
 	return resourceRefs, nil
 }
 
-// Relinquish removes control of owned resources in the API server for a package
-// revision.
-func (e *APIEstablisher) Relinquish(ctx context.Context, parent v1.PackageRevision) error {
+// ReleaseObjects removes control of owned resources in the API server for a
+// package revision.
+func (e *APIEstablisher) ReleaseObjects(ctx context.Context, parent v1.PackageRevision) error {
 	// Note(turkenh): We rely on status.objectRefs to get the list of objects
 	// that are controlled by the package revision. Relying on the status is
 	// not ideal as it might get lost (e.g. if the status subresource is

--- a/internal/controller/pkg/revision/establisher_test.go
+++ b/internal/controller/pkg/revision/establisher_test.go
@@ -565,7 +565,7 @@ func TestAPIEstablisherRelinquish(t *testing.T) {
 			},
 		},
 		"SuccessfulRelinquish": {
-			reason: "Relinquish should be successful if we can relinquish control of existing objects",
+			reason: "ReleaseObjects should be successful if we can relinquish control of existing objects",
 			args: args{
 				est: &APIEstablisher{
 					client: &test.MockClient{
@@ -626,7 +626,7 @@ func TestAPIEstablisherRelinquish(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			err := tc.args.est.Relinquish(context.TODO(), tc.args.parent)
+			err := tc.args.est.ReleaseObjects(context.TODO(), tc.args.parent)
 
 			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\ne.Check(...): -want error, +got error:\n%s", tc.reason, diff)

--- a/internal/controller/pkg/revision/establisher_test.go
+++ b/internal/controller/pkg/revision/establisher_test.go
@@ -27,6 +27,7 @@ import (
 	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
@@ -409,6 +410,226 @@ func TestAPIEstablisherEstablish(t *testing.T) {
 			})
 			if diff := cmp.Diff(tc.want.refs, refs, test.EquateErrors(), sort); diff != "" {
 				t.Errorf("\n%s\ne.Check(...): -want, +got:\n%s", tc.reason, diff)
+			}
+		})
+	}
+}
+
+func TestAPIEstablisherRelinquish(t *testing.T) {
+	errBoom := errors.New("boom")
+	controls := true
+	noControl := false
+
+	type args struct {
+		est    *APIEstablisher
+		parent v1.PackageRevision
+	}
+
+	type want struct {
+		err error
+	}
+
+	cases := map[string]struct {
+		reason string
+		args   args
+		want   want
+	}{
+		"CannotGetObject": {
+			reason: "Should return an error if we cannot get the owned object.",
+			args: args{
+				est: &APIEstablisher{
+					client: &test.MockClient{
+						MockGet: func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
+							return errBoom
+						},
+					},
+				},
+				parent: &v1.ProviderRevision{
+					ObjectMeta: metav1.ObjectMeta{
+						UID: "some-unique-uid-2312",
+					},
+					Status: v1.PackageRevisionStatus{
+						ObjectRefs: []xpv1.TypedReference{
+							{
+								APIVersion: "apiextensions.k8s.io/v1",
+								Kind:       "CustomResourceDefinition",
+								Name:       "releases.helm.crossplane.io",
+							},
+						},
+					},
+				},
+			},
+			want: want{
+				err: errors.Wrapf(errBoom, errFmtGetOwnedObject, "CustomResourceDefinition", "releases.helm.crossplane.io"),
+			},
+		},
+		"IgnoreOwnedObjectNotFound": {
+			reason: "Should ignore if we the owned object does not exist.",
+			args: args{
+				est: &APIEstablisher{
+					client: &test.MockClient{
+						MockGet: func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
+							return kerrors.NewNotFound(schema.GroupResource{}, "")
+						},
+					},
+				},
+				parent: &v1.ProviderRevision{
+					ObjectMeta: metav1.ObjectMeta{
+						UID: "some-unique-uid-2312",
+					},
+					Status: v1.PackageRevisionStatus{
+						ObjectRefs: []xpv1.TypedReference{
+							{
+								APIVersion: "apiextensions.k8s.io/v1",
+								Kind:       "CustomResourceDefinition",
+								Name:       "releases.helm.crossplane.io",
+							},
+						},
+					},
+				},
+			},
+			want: want{
+				err: nil,
+			},
+		},
+		"CannotGetUpdate": {
+			reason: "Should return an error if we cannot update the owned object.",
+			args: args{
+				est: &APIEstablisher{
+					client: &test.MockClient{
+						MockGet: func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
+							o := obj.(*unstructured.Unstructured)
+							o.SetOwnerReferences([]metav1.OwnerReference{
+								{
+									APIVersion: "pkg.crossplane.io/v1",
+									Kind:       "Provider",
+									Name:       "provider-helm",
+									UID:        "some-other-uid-1234",
+									Controller: &noControl,
+								},
+								{
+									APIVersion: "pkg.crossplane.io/v1",
+									Kind:       "ProviderRevision",
+									Name:       "provider-helm-ce18dd03e6e4",
+									UID:        "some-unique-uid-2312",
+									Controller: &controls,
+								},
+							})
+							return nil
+						},
+						MockUpdate: func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
+							return errBoom
+						},
+					},
+				},
+				parent: &v1.ProviderRevision{
+					ObjectMeta: metav1.ObjectMeta{
+						UID: "some-unique-uid-2312",
+					},
+					Status: v1.PackageRevisionStatus{
+						ObjectRefs: []xpv1.TypedReference{
+							{
+								APIVersion: "apiextensions.k8s.io/v1",
+								Kind:       "CustomResourceDefinition",
+								Name:       "releases.helm.crossplane.io",
+							},
+						},
+					},
+				},
+			},
+			want: want{
+				err: errors.Wrapf(errBoom, errFmtUpdateOwnedObject, "CustomResourceDefinition", "releases.helm.crossplane.io"),
+			},
+		},
+		"NoObjectsInStatus": {
+			reason: "Should not return an error if there are no objects in the status.",
+			args: args{
+				est: &APIEstablisher{
+					client: &test.MockClient{
+						MockGet: func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
+							return nil
+						},
+						MockUpdate: func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
+							return nil
+						},
+					},
+				},
+				parent: &v1.ProviderRevision{
+					ObjectMeta: metav1.ObjectMeta{
+						UID: "some-unique-uid-2312",
+					},
+				},
+			},
+			want: want{
+				err: nil,
+			},
+		},
+		"SuccessfulRelinquish": {
+			reason: "Relinquish should be successful if we can relinquish control of existing objects",
+			args: args{
+				est: &APIEstablisher{
+					client: &test.MockClient{
+						MockGet: func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
+							o := obj.(*unstructured.Unstructured)
+							o.SetOwnerReferences([]metav1.OwnerReference{
+								{
+									APIVersion: "pkg.crossplane.io/v1",
+									Kind:       "Provider",
+									Name:       "provider-helm",
+									UID:        "some-other-uid-1234",
+									Controller: &noControl,
+								},
+								{
+									APIVersion: "pkg.crossplane.io/v1",
+									Kind:       "ProviderRevision",
+									Name:       "provider-helm-ce18dd03e6e4",
+									UID:        "some-unique-uid-2312",
+									Controller: &controls,
+								},
+							})
+							return nil
+						},
+						MockUpdate: func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
+							o := obj.(*unstructured.Unstructured)
+							if len(o.GetOwnerReferences()) != 2 {
+								t.Errorf("expected 2 owner references, got %d", len(o.GetOwnerReferences()))
+							}
+							for _, ref := range o.GetOwnerReferences() {
+								if ref.UID == "some-unique-uid-2312" && *ref.Controller {
+									t.Errorf("expected controller to be false, got %t", *ref.Controller)
+								}
+							}
+							return nil
+						},
+					},
+				},
+				parent: &v1.ProviderRevision{
+					ObjectMeta: metav1.ObjectMeta{
+						UID: "some-unique-uid-2312",
+					},
+					Status: v1.PackageRevisionStatus{
+						ObjectRefs: []xpv1.TypedReference{
+							{
+								APIVersion: "apiextensions.k8s.io/v1",
+								Kind:       "CustomResourceDefinition",
+								Name:       "releases.helm.crossplane.io",
+							},
+						},
+					},
+				},
+			},
+			want: want{
+				err: nil,
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			err := tc.args.est.Relinquish(context.TODO(), tc.args.parent)
+
+			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
+				t.Errorf("\n%s\ne.Check(...): -want error, +got error:\n%s", tc.reason, diff)
 			}
 		})
 	}

--- a/internal/controller/pkg/revision/hook.go
+++ b/internal/controller/pkg/revision/hook.go
@@ -74,7 +74,7 @@ type Hooks interface {
 	// Post performs operations meant to happen after establishing objects.
 	Post(context.Context, runtime.Object, v1.PackageRevision) error
 
-	// Deactivate performs operations meant to happen for deactivating a revision.
+	// Deactivate performs operations meant to happen before deactivating a revision.
 	Deactivate(context.Context, v1.PackageRevision) error
 }
 
@@ -172,7 +172,7 @@ func (h *ProviderHooks) Post(ctx context.Context, pkg runtime.Object, pr v1.Pack
 	return errors.New(errNoAvailableConditionProviderDeployment)
 }
 
-// Deactivate performs operations meant to happen for deactivating a provider revision.
+// Deactivate performs operations meant to happen before deactivating a provider revision.
 func (h *ProviderHooks) Deactivate(ctx context.Context, pr v1.PackageRevision) error {
 	// Delete the deployment if it exists.
 	if err := h.client.Delete(ctx, &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: pr.GetName(), Namespace: h.namespace}}); resource.IgnoreNotFound(err) != nil {

--- a/internal/controller/pkg/revision/hook.go
+++ b/internal/controller/pkg/revision/hook.go
@@ -73,6 +73,9 @@ type Hooks interface {
 
 	// Post performs operations meant to happen after establishing objects.
 	Post(context.Context, runtime.Object, v1.PackageRevision) error
+
+	// Deactivate performs operations meant to happen for deactivating a revision.
+	Deactivate(context.Context, v1.PackageRevision) error
 }
 
 // ProviderHooks performs operations for a provider package that requires a
@@ -92,9 +95,38 @@ func NewProviderHooks(client resource.ClientApplicator, namespace, serviceAccoun
 	}
 }
 
-// Pre cleans up a packaged controller and service account if the revision is
-// inactive.
-func (h *ProviderHooks) Pre(ctx context.Context, pkg runtime.Object, pr v1.PackageRevision) error {
+// Deactivate performs operations meant to happen for deactivating a provider revision.
+func (h *ProviderHooks) Deactivate(ctx context.Context, pr v1.PackageRevision) error {
+	// Delete the deployment if it exists.
+	if err := h.client.Delete(ctx, &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: pr.GetName(), Namespace: h.namespace}}); resource.IgnoreNotFound(err) != nil {
+		return errors.Wrap(err, errDeleteProviderDeployment)
+	}
+	// Delete the service account if it exists.
+	if err := h.client.Delete(ctx, &corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: pr.GetName(), Namespace: h.namespace}}); resource.IgnoreNotFound(err) != nil {
+		return errors.Wrap(err, errDeleteProviderSA)
+	}
+	// Delete the service if it exists.
+	if err := h.client.Delete(ctx, &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: pr.GetName(), Namespace: h.namespace}}); resource.IgnoreNotFound(err) != nil {
+		return errors.Wrap(err, errDeleteProviderService)
+	}
+	// Delete the TLS Server Secret if it exists.
+	if pr.GetTLSServerSecretName() != nil {
+		if err := h.client.Delete(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: *pr.GetTLSServerSecretName(), Namespace: h.namespace}}); resource.IgnoreNotFound(err) != nil {
+			return errors.Wrap(err, errDeleteProviderSecret)
+		}
+	}
+	// Delete the TLS Client Secret if it exists.
+	if pr.GetTLSClientSecretName() != nil {
+		if err := h.client.Delete(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: *pr.GetTLSClientSecretName(), Namespace: h.namespace}}); resource.IgnoreNotFound(err) != nil {
+			return errors.Wrap(err, errDeleteProviderSecret)
+		}
+	}
+
+	return nil
+}
+
+// Pre fills permission requests from the provider package to the revision.
+func (h *ProviderHooks) Pre(_ context.Context, pkg runtime.Object, pr v1.PackageRevision) error {
 	po, _ := xpkg.TryConvert(pkg, &pkgmetav1.Provider{})
 	pkgProvider, ok := po.(*pkgmetav1.Provider)
 	if !ok {
@@ -110,29 +142,6 @@ func (h *ProviderHooks) Pre(ctx context.Context, pkg runtime.Object, pr v1.Packa
 
 	// TODO(hasheddan): update any status fields relevant to package revisions.
 
-	// Do not clean up SA and controller if revision is not inactive.
-	if pr.GetDesiredState() != v1.PackageRevisionInactive {
-		return nil
-	}
-
-	// NOTE(hasheddan): we avoid fetching pull secrets and controller config as
-	// they aren't needed to delete Deployment, ServiceAccount, and Service.
-	s, d, svc, secSer, secCli := buildProviderDeployment(pkgProvider, pr, nil, h.namespace, []corev1.LocalObjectReference{})
-	if err := h.client.Delete(ctx, d); resource.IgnoreNotFound(err) != nil {
-		return errors.Wrap(err, errDeleteProviderDeployment)
-	}
-	if err := h.client.Delete(ctx, s); resource.IgnoreNotFound(err) != nil {
-		return errors.Wrap(err, errDeleteProviderSA)
-	}
-	if err := h.client.Delete(ctx, svc); resource.IgnoreNotFound(err) != nil {
-		return errors.Wrap(err, errDeleteProviderService)
-	}
-	if err := h.client.Delete(ctx, secSer); resource.IgnoreNotFound(err) != nil {
-		return errors.Wrap(err, errDeleteProviderSecret)
-	}
-	if err := h.client.Delete(ctx, secCli); resource.IgnoreNotFound(err) != nil {
-		return errors.Wrap(err, errDeleteProviderSecret)
-	}
 	return nil
 }
 
@@ -232,6 +241,11 @@ func (h *ConfigurationHooks) Post(context.Context, runtime.Object, v1.PackageRev
 	return nil
 }
 
+// Deactivate is a no op for configuration packages.
+func (h *ConfigurationHooks) Deactivate(_ context.Context, _ v1.PackageRevision) error {
+	return nil
+}
+
 // FunctionHooks performs operations for a function package that requires a
 // controller before and after the revision establishes objects.
 type FunctionHooks struct {
@@ -249,34 +263,26 @@ func NewFunctionHooks(client resource.ClientApplicator, namespace, serviceAccoun
 	}
 }
 
-// Pre cleans up a packaged controller and service account if the revision is
-// inactive.
-func (h *FunctionHooks) Pre(ctx context.Context, pkg runtime.Object, pr v1.PackageRevision) error {
-	fo, _ := xpkg.TryConvert(pkg, &pkgmetav1beta1.Function{})
-	pkgFunction, ok := fo.(*pkgmetav1beta1.Function)
-	if !ok {
-		return errors.New(errNotFunction)
-	}
-
-	// TODO(ezgidemirel): update any status fields relevant to package revisions.
-
-	// Do not clean up SA and controller if revision is not inactive.
-	if pr.GetDesiredState() != v1.PackageRevisionInactive {
-		return nil
-	}
-
-	// NOTE(hasheddan): we avoid fetching pull secrets and controller config as
-	// they aren't needed to delete Deployment and service account.
-	// NOTE(ezgidemirel): Service and secret are created per package. Therefore,
-	// we're not deleting them here.
-	s, d, _, _ := buildFunctionDeployment(pkgFunction, pr, nil, h.namespace, []corev1.LocalObjectReference{})
-	if err := h.client.Delete(ctx, d); resource.IgnoreNotFound(err) != nil {
+// Deactivate performs operations meant to happen for deactivating a function revision.
+func (h *FunctionHooks) Deactivate(ctx context.Context, pr v1.PackageRevision) error {
+	// Delete the deployment if it exists.
+	if err := h.client.Delete(ctx, &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: pr.GetName(), Namespace: h.namespace}}); resource.IgnoreNotFound(err) != nil {
 		return errors.Wrap(err, errDeleteFunctionDeployment)
 	}
-	if err := h.client.Delete(ctx, s); resource.IgnoreNotFound(err) != nil {
+	// Delete the service account if it exists.
+	if err := h.client.Delete(ctx, &corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: pr.GetName(), Namespace: h.namespace}}); resource.IgnoreNotFound(err) != nil {
 		return errors.Wrap(err, errDeleteFunctionSA)
 	}
 
+	// NOTE(ezgidemirel): Service and secret are created per package. Therefore,
+	// we're not deleting them here.
+	return nil
+}
+
+// Pre cleans up a packaged controller and service account if the revision is
+// inactive.
+func (h *FunctionHooks) Pre(_ context.Context, _ runtime.Object, _ v1.PackageRevision) error {
+	// TODO(ezgidemirel): update any status fields relevant to package revisions.
 	return nil
 }
 
@@ -370,5 +376,10 @@ func (h *NopHooks) Pre(context.Context, runtime.Object, v1.PackageRevision) erro
 
 // Post does nothing and returns nil.
 func (h *NopHooks) Post(context.Context, runtime.Object, v1.PackageRevision) error {
+	return nil
+}
+
+// Deactivate does nothing and returns nil.
+func (h *NopHooks) Deactivate(context.Context, v1.PackageRevision) error {
 	return nil
 }

--- a/internal/controller/pkg/revision/reconciler.go
+++ b/internal/controller/pkg/revision/reconciler.go
@@ -73,7 +73,7 @@ const (
 	errAddFinalizer    = "cannot add package revision finalizer"
 	errRemoveFinalizer = "cannot remove package revision finalizer"
 
-	errDeactivateRevision = "cannot deactivate revision"
+	errDeactivateRevision = "cannot deactivate package revision"
 
 	errInitParserBackend = "cannot initialize parser backend"
 	errParsePackage      = "cannot parse package contents"
@@ -83,10 +83,10 @@ const (
 
 	errPreHook          = "cannot run pre establish hook for package"
 	errPostHook         = "cannot run post establish hook for package"
-	errDeactivationHook = "cannot run deactivation hook"
+	errDeactivationHook = "cannot run deactivation hook for package"
 
-	errEstablishControl  = "cannot establish control of object"
-	errRelinquishObjects = "cannot relinquish objects"
+	errEstablishControl = "cannot establish control of object"
+	errReleaseObjects   = "cannot release objects"
 
 	errUpdateMeta = "cannot update package revision object metadata"
 
@@ -762,9 +762,9 @@ func (r *Reconciler) deactivateRevision(ctx context.Context, pr v1.PackageRevisi
 		return errors.Wrap(err, errRemoveLock)
 	}
 
-	// Relinquish control of objects.
-	if err := r.objects.Relinquish(ctx, pr); err != nil {
-		return errors.Wrap(err, errRelinquishObjects)
+	// ReleaseObjects control of objects.
+	if err := r.objects.ReleaseObjects(ctx, pr); err != nil {
+		return errors.Wrap(err, errReleaseObjects)
 	}
 
 	// Call deactivation hook.

--- a/internal/controller/pkg/revision/reconciler_test.go
+++ b/internal/controller/pkg/revision/reconciler_test.go
@@ -83,7 +83,7 @@ func (e *MockEstablisher) Establish(context.Context, []runtime.Object, v1.Packag
 	return e.MockEstablish()
 }
 
-func (e *MockEstablisher) Relinquish(context.Context, v1.PackageRevision) error {
+func (e *MockEstablisher) ReleaseObjects(context.Context, v1.PackageRevision) error {
 	return e.MockRelinquish()
 }
 
@@ -1347,7 +1347,7 @@ func TestReconcile(t *testing.T) {
 				},
 			},
 			want: want{
-				err: errors.Wrap(errors.Wrap(errBoom, errRelinquishObjects), errDeactivateRevision),
+				err: errors.Wrap(errors.Wrap(errBoom, errReleaseObjects), errDeactivateRevision),
 			},
 		},
 		"SuccessfulInactiveRevisionWithoutObjectRefs": {

--- a/internal/controller/pkg/revision/reconciler_test.go
+++ b/internal/controller/pkg/revision/reconciler_test.go
@@ -1282,13 +1282,84 @@ func TestReconcile(t *testing.T) {
 				err: errors.Wrap(errBoom, errEstablishControl),
 			},
 		},
-		"SuccessfulInactiveRevision": {
-			reason: "An inactive revision should establish ownership of all of its resources.",
+		"ErrEstablishInactiveRevision": {
+			reason: "An inactive revision that fails to establish ownership should return an error.",
+			args: args{
+				mgr: &fake.Manager{},
+				req: reconcile.Request{NamespacedName: types.NamespacedName{Name: "test"}},
+				rec: []ReconcilerOption{
+					WithNewPackageRevisionFn(func() v1.PackageRevision {
+						return &v1.ConfigurationRevision{
+							Status: v1.PackageRevisionStatus{
+								ObjectRefs: []xpv1.TypedReference{
+									{
+										APIVersion: "apiextensions.k8s.io/v1",
+										Kind:       "CustomResourceDefinition",
+										Name:       "releases.helm.crossplane.io",
+									},
+								},
+							},
+						}
+					}),
+					WithDependencyManager(&MockDependencyManager{
+						MockRemoveSelf: NewMockRemoveSelfFn(nil),
+					}),
+					WithClientApplicator(resource.ClientApplicator{
+						Client: &test.MockClient{
+							MockGet: test.NewMockGetFn(nil, func(o client.Object) error {
+								pr := o.(*v1.ConfigurationRevision)
+								pr.SetGroupVersionKind(v1.ConfigurationRevisionGroupVersionKind)
+								pr.SetDesiredState(v1.PackageRevisionInactive)
+								return nil
+							}),
+							MockStatusUpdate: test.NewMockSubResourceUpdateFn(nil, func(o client.Object) error {
+								want := &v1.ConfigurationRevision{
+									Status: v1.PackageRevisionStatus{
+										ObjectRefs: []xpv1.TypedReference{
+											{
+												APIVersion: "apiextensions.k8s.io/v1",
+												Kind:       "CustomResourceDefinition",
+												Name:       "releases.helm.crossplane.io",
+											},
+										},
+									},
+								}
+								want.SetGroupVersionKind(v1.ConfigurationRevisionGroupVersionKind)
+								want.SetDesiredState(v1.PackageRevisionInactive)
+								want.SetConditions(v1.Healthy())
+
+								if diff := cmp.Diff(want, o); diff != "" {
+									t.Errorf("-want, +got:\n%s", diff)
+								}
+								return nil
+							}),
+						},
+					}),
+					WithFinalizer(resource.FinalizerFns{AddFinalizerFn: func(_ context.Context, _ resource.Object) error {
+						return nil
+					}}),
+					WithHooks(NewNopHooks()),
+					WithEstablisher(&MockEstablisher{
+						MockRelinquish: func() error {
+							return errBoom
+						},
+					}),
+				},
+			},
+			want: want{
+				err: errors.Wrap(errors.Wrap(errBoom, errRelinquishObjects), errDeactivateRevision),
+			},
+		},
+		"SuccessfulInactiveRevisionWithoutObjectRefs": {
+			reason: "An inactive revision without ObjectRefs should be deactivated successfully by pulling/parsing the package again.",
 			args: args{
 				mgr: &fake.Manager{},
 				req: reconcile.Request{NamespacedName: types.NamespacedName{Name: "test"}},
 				rec: []ReconcilerOption{
 					WithNewPackageRevisionFn(func() v1.PackageRevision { return &v1.ConfigurationRevision{} }),
+					WithDependencyManager(&MockDependencyManager{
+						MockRemoveSelf: NewMockRemoveSelfFn(nil),
+					}),
 					WithClientApplicator(resource.ClientApplicator{
 						Client: &test.MockClient{
 							MockGet: test.NewMockGetFn(nil, func(o client.Object) error {
@@ -1345,13 +1416,28 @@ func TestReconcile(t *testing.T) {
 				r: reconcile.Result{Requeue: false},
 			},
 		},
-		"ErrEstablishInactiveRevision": {
-			reason: "An inactive revision that fails to establish ownership should return an error.",
+		"SuccessfulInactiveRevisionWithObjectRefs": {
+			reason: "An inactive revision with ObjectRefs should be deactivated successfully without pulling/parsing the package again.",
 			args: args{
 				mgr: &fake.Manager{},
 				req: reconcile.Request{NamespacedName: types.NamespacedName{Name: "test"}},
 				rec: []ReconcilerOption{
-					WithNewPackageRevisionFn(func() v1.PackageRevision { return &v1.ConfigurationRevision{} }),
+					WithNewPackageRevisionFn(func() v1.PackageRevision {
+						return &v1.ConfigurationRevision{
+							Status: v1.PackageRevisionStatus{
+								ObjectRefs: []xpv1.TypedReference{
+									{
+										APIVersion: "apiextensions.k8s.io/v1",
+										Kind:       "CustomResourceDefinition",
+										Name:       "releases.helm.crossplane.io",
+									},
+								},
+							},
+						}
+					}),
+					WithDependencyManager(&MockDependencyManager{
+						MockRemoveSelf: NewMockRemoveSelfFn(nil),
+					}),
 					WithClientApplicator(resource.ClientApplicator{
 						Client: &test.MockClient{
 							MockGet: test.NewMockGetFn(nil, func(o client.Object) error {
@@ -1361,23 +1447,21 @@ func TestReconcile(t *testing.T) {
 								return nil
 							}),
 							MockStatusUpdate: test.NewMockSubResourceUpdateFn(nil, func(o client.Object) error {
-								want := &v1.ConfigurationRevision{}
-								want.SetGroupVersionKind(v1.ConfigurationRevisionGroupVersionKind)
-								want.SetDesiredState(v1.PackageRevisionInactive)
-								want.SetAnnotations(map[string]string{"author": "crossplane"})
-								want.SetConditions(v1.Unhealthy().WithMessage("cannot establish control of object: boom"))
-
-								if diff := cmp.Diff(want, o); diff != "" {
-									t.Errorf("-want, +got:\n%s", diff)
+								want := &v1.ConfigurationRevision{
+									Status: v1.PackageRevisionStatus{
+										ObjectRefs: []xpv1.TypedReference{
+											{
+												APIVersion: "apiextensions.k8s.io/v1",
+												Kind:       "CustomResourceDefinition",
+												Name:       "releases.helm.crossplane.io",
+											},
+										},
+									},
 								}
-								return nil
-							}),
-							MockDelete: test.NewMockDeleteFn(nil),
-							MockUpdate: test.NewMockUpdateFn(nil, func(o client.Object) error {
-								want := &v1.ConfigurationRevision{}
 								want.SetGroupVersionKind(v1.ConfigurationRevisionGroupVersionKind)
 								want.SetDesiredState(v1.PackageRevisionInactive)
-								want.SetAnnotations(map[string]string{"author": "crossplane"})
+								want.SetConditions(v1.Healthy())
+
 								if diff := cmp.Diff(want, o); diff != "" {
 									t.Errorf("-want, +got:\n%s", diff)
 								}
@@ -1389,24 +1473,11 @@ func TestReconcile(t *testing.T) {
 						return nil
 					}}),
 					WithHooks(NewNopHooks()),
-					WithEstablisher(&MockEstablisher{
-						MockEstablish: NewMockEstablishFn(nil, errBoom),
-					}),
-					WithParser(parser.New(metaScheme, objScheme)),
-					WithParserBackend(parser.NewEchoBackend(string(providerBytes))),
-					WithCache(&xpkgfake.MockCache{
-						MockHas: xpkgfake.NewMockCacheHasFn(false),
-						MockStore: func(s string, rc io.ReadCloser) error {
-							_, err := io.ReadAll(rc)
-							return err
-						},
-					}),
-					WithLinter(&MockLinter{MockLint: NewMockLintFn(nil)}),
-					WithVersioner(&verfake.MockVersioner{MockInConstraints: verfake.NewMockInConstraintsFn(true, nil)}),
+					WithEstablisher(NewMockEstablisher()),
 				},
 			},
 			want: want{
-				err: errors.Wrap(errBoom, errEstablishControl),
+				r: reconcile.Result{Requeue: false},
 			},
 		},
 	}


### PR DESCRIPTION
### Description of your changes

This PR updates the package revision reconciler not to rely on package content (and all other steps including dependency resolution) during deactivation of revisions to improve the reliability against edge cases where it is no longer possible to successfully reconcile a previously installed revision. 

We do this by relying the fact that package revisions persist a list of owned resources in their status and we don't actually need the contents of the package once we leverage that. We still fallback to parsing the package contents as it is not ideal to rely on existence of the status sub-resource (e.g. status may got lost after a backup/restore operation), even though we expect this to be fairly infrequent.

Fixes #3742
Fixes #3942

This PR changing the Package Revision Reconciler as below:

![Package Revision Reconciler (2)](https://github.com/crossplane/crossplane/assets/9900707/21951609-8439-404e-b689-7bebba91ffd5)

Also [link to the recording](https://www.youtube.com/watch?v=EsJRj5ZRnGY&list=PL510POnNVaaYYYDSICFSNWFqNbx1EMr-M&t=828s) from the community meeting where I talked about this PR.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Added or updated unit **and** E2E tests for my change.
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR, if necessary.~
- [ ] ~Opened a PR updating the [docs], if necessary.~

[contribution process]: https://git.io/fj2m9
[docs]: https://docs.crossplane.io/contribute/contribute
