### PR TITLE
feat: composition's environment logical validation

### DIFF
--- a/apis/apiextensions/v1/composition_environment.go
+++ b/apis/apiextensions/v1/composition_environment.go
@@ -16,6 +16,12 @@ limitations under the License.
 
 package v1
 
+import (
+	"k8s.io/apimachinery/pkg/util/validation/field"
+
+	"github.com/crossplane/crossplane/internal/validation/errors"
+)
+
 // An EnvironmentConfiguration specifies the environment for rendering composed
 // resources.
 type EnvironmentConfiguration struct {
@@ -36,6 +42,25 @@ type EnvironmentConfiguration struct {
 	// Patches is a list of environment patches that are executed before a
 	// composition's resources are composed.
 	Patches []EnvironmentPatch `json:"patches,omitempty"`
+}
+
+// Validate the EnvironmentConfiguration.
+func (e *EnvironmentConfiguration) Validate() field.ErrorList {
+	errs := field.ErrorList{}
+
+	for i, p := range e.Patches {
+		if err := errors.WrapFieldError(p.Validate(), field.NewPath("patches").Index(i)); err != nil {
+			errs = append(errs, err)
+		}
+	}
+
+	for i, ec := range e.EnvironmentConfigs {
+		if err := errors.WrapFieldError(ec.Validate(), field.NewPath("environmentConfigs").Index(i)); err != nil {
+			errs = append(errs, err)
+		}
+	}
+
+	return errs
 }
 
 // EnvironmentSourceType specifies the way the EnvironmentConfig is selected.
@@ -67,10 +92,47 @@ type EnvironmentSource struct {
 	Selector *EnvironmentSourceSelector `json:"selector,omitempty"`
 }
 
+// Validate the EnvironmentSource.
+func (e *EnvironmentSource) Validate() *field.Error {
+	switch e.Type {
+	case EnvironmentSourceTypeReference:
+		if e.Ref == nil {
+			return field.Required(field.NewPath("ref"), "ref is required")
+		}
+		if err := e.Ref.Validate(); err != nil {
+			return errors.WrapFieldError(err, field.NewPath("ref"))
+		}
+
+	case EnvironmentSourceTypeSelector:
+		if e.Selector == nil {
+			return field.Required(field.NewPath("selector"), "selector is required")
+		}
+		if len(e.Selector.MatchLabels) == 0 {
+			return field.Required(field.NewPath("selector", "matchLabels"), "selector must have at least one match label")
+		}
+		for i, m := range e.Selector.MatchLabels {
+			if err := m.Validate(); err != nil {
+				return errors.WrapFieldError(err, field.NewPath("selector", "matchLabels").Index(i))
+			}
+		}
+	default:
+		return field.Invalid(field.NewPath("type"), e.Type, "invalid type")
+	}
+	return nil
+}
+
 // An EnvironmentSourceReference references an EnvironmentConfig by it's name.
 type EnvironmentSourceReference struct {
 	// The name of the object.
 	Name string `json:"name"`
+}
+
+// Validate the EnvironmentSourceReference.
+func (e *EnvironmentSourceReference) Validate() *field.Error {
+	if e.Name == "" {
+		return field.Required(field.NewPath("name"), "name is required")
+	}
+	return nil
 }
 
 // An EnvironmentSourceSelector selects an EnvironmentConfig via labels.
@@ -111,6 +173,40 @@ type EnvironmentSourceSelectorLabelMatcher struct {
 	Value *string `json:"value,omitempty"`
 }
 
+// GetType returns the type of the label matcher, returning the default if not set.
+func (e *EnvironmentSourceSelectorLabelMatcher) GetType() EnvironmentSourceSelectorLabelMatcherType {
+	if e == nil {
+		return EnvironmentSourceSelectorLabelMatcherTypeFromCompositeFieldPath
+	}
+	return e.Type
+}
+
+// Validate logically validate the EnvironmentSourceSelectorLabelMatcher.
+func (e *EnvironmentSourceSelectorLabelMatcher) Validate() *field.Error {
+	if e.Key == "" {
+		return field.Required(field.NewPath("key"), "key is required")
+	}
+	switch e.GetType() {
+	case EnvironmentSourceSelectorLabelMatcherTypeFromCompositeFieldPath:
+		if e.ValueFromFieldPath == nil {
+			return field.Required(field.NewPath("valueFromFieldPath"), "valueFromFieldPath is required")
+		}
+		if *e.ValueFromFieldPath == "" {
+			return field.Required(field.NewPath("valueFromFieldPath"), "valueFromFieldPath must not be empty")
+		}
+	case EnvironmentSourceSelectorLabelMatcherTypeValue:
+		if e.Value == nil {
+			return field.Required(field.NewPath("value"), "value is required")
+		}
+		if *e.Value == "" {
+			return field.Required(field.NewPath("value"), "value must not be empty")
+		}
+	default:
+		return field.Invalid(field.NewPath("type"), e.Type, "invalid type")
+	}
+	return nil
+}
+
 // EnvironmentPatch is a patch for a Composition environment.
 type EnvironmentPatch struct {
 	// Type sets the patching behaviour to be used. Each patch type may require
@@ -145,4 +241,28 @@ type EnvironmentPatch struct {
 	// Policy configures the specifics of patching behaviour.
 	// +optional
 	Policy *PatchPolicy `json:"policy,omitempty"`
+}
+
+// ToPatch converts the EnvironmentPatch to a Patch.
+func (e *EnvironmentPatch) ToPatch() *Patch {
+	if e == nil {
+		return nil
+	}
+	return &Patch{
+		Type:          e.Type,
+		FromFieldPath: e.FromFieldPath,
+		Combine:       e.Combine,
+		ToFieldPath:   e.ToFieldPath,
+		Transforms:    e.Transforms,
+		Policy:        e.Policy,
+	}
+}
+
+// Validate validates the EnvironmentPatch.
+func (e *EnvironmentPatch) Validate() *field.Error {
+	p := e.ToPatch()
+	if p == nil {
+		return nil
+	}
+	return p.Validate()
 }

--- a/apis/apiextensions/v1/composition_environment_test.go
+++ b/apis/apiextensions/v1/composition_environment_test.go
@@ -1,0 +1,77 @@
+package v1
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/utils/pointer"
+)
+
+func TestEnvironmentPatchValidate(t *testing.T) {
+	type args struct {
+		envPatch *EnvironmentPatch
+	}
+	type want struct {
+		output *field.Error
+	}
+
+	cases := map[string]struct {
+		reason string
+		args   args
+		want   want
+	}{
+		"ValidPatch": {
+			reason: "Should accept a valid patch",
+			args: args{
+				envPatch: &EnvironmentPatch{
+					Type:          PatchTypeFromCompositeFieldPath,
+					FromFieldPath: pointer.String("spec.foo"),
+					ToFieldPath:   pointer.String("metadata.annotations[\"foo\"]"),
+				},
+			},
+			want: want{output: nil},
+		},
+		"InvalidPatchMissingFromFieldPath": {
+			reason: "Should reject a patch missing fromFieldPath",
+			args: args{
+				envPatch: &EnvironmentPatch{
+					Type:        PatchTypeFromCompositeFieldPath,
+					ToFieldPath: pointer.String("metadata.annotations[\"foo\"]"),
+				},
+			},
+			want: want{
+				output: &field.Error{
+					Type:  field.ErrorTypeRequired,
+					Field: "fromFieldPath",
+				},
+			},
+		},
+		"InvalidPatchMissingToFieldPath": {
+			reason: "Should reject a patch missing toFieldPath",
+			args: args{
+				envPatch: &EnvironmentPatch{
+					Type:          PatchTypeCombineToComposite,
+					FromFieldPath: pointer.String("spec.foo"),
+					Combine:       nil, // required
+				},
+			},
+			want: want{
+				output: &field.Error{
+					Type:  field.ErrorTypeRequired,
+					Field: "combine",
+				},
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got := tc.args.envPatch.Validate()
+			if diff := cmp.Diff(tc.want.output, got, cmpopts.IgnoreFields(field.Error{}, "Detail", "BadValue")); diff != "" {
+				t.Errorf("%s\nValidate(...): -want, +got:\n%s", tc.reason, diff)
+			}
+		})
+	}
+}

--- a/apis/apiextensions/v1/composition_validation.go
+++ b/apis/apiextensions/v1/composition_validation.go
@@ -31,6 +31,7 @@ func (c *Composition) Validate() (warns []string, errs field.ErrorList) {
 		c.validatePatchSets,
 		c.validateResources,
 		c.validateFunctions,
+		c.validateEnvironment,
 	}
 	for _, f := range validations {
 		errs = append(errs, f()...)
@@ -130,4 +131,15 @@ func (c *Composition) validateResourceNames() (errs field.ErrorList) {
 		seen[name] = true
 	}
 	return errs
+}
+
+// validateEnvironment checks that the environment is logically valid.
+func (c *Composition) validateEnvironment() field.ErrorList {
+	if c.Spec.Environment == nil {
+		return nil
+	}
+	if errs := verrors.WrapFieldErrorList(c.Spec.Environment.Validate(), field.NewPath("spec", "environment")); len(errs) > 0 {
+		return errs
+	}
+	return nil
 }

--- a/internal/controller/apiextensions/composite/composition_patches.go
+++ b/internal/controller/apiextensions/composite/composition_patches.go
@@ -47,18 +47,15 @@ func ApplyEnvironmentPatch(p v1.EnvironmentPatch, cp, env runtime.Object) error 
 	// TODO(negz): Should this take composite.Resource and *env.Environment as
 	// arguments rather than generic runtime.Objects?
 
+	regularPatch := p.ToPatch()
+	if regularPatch == nil {
+		// Should never happen, but just in case, nothing to do.
+		return nil
+	}
 	// To make thing easy, we are going to reuse the logic of a regular
 	// composition patch.
-	regularPatch := v1.Patch{
-		Type:          p.Type,
-		FromFieldPath: p.FromFieldPath,
-		Combine:       p.Combine,
-		ToFieldPath:   p.ToFieldPath,
-		Transforms:    p.Transforms,
-		Policy:        p.Policy,
-	}
 	return ApplyToObjects(
-		regularPatch,
+		*regularPatch,
 		cp,
 		env,
 		v1.PatchTypeFromCompositeFieldPath,


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Add `spec.environment` logical validation, as part of #3756 and I feel should be considered part of #3770.

Minor refactor of the logic converting an EnvironmentPatch to a Patch to a separate EnvironmentPatch.ToPatch function, to allow reusing Patch validation logic instead of duplicating it.

Also added a missing sorting of field.ErrorList that made the tests a little bit too brittle, as we don't care about the errors ordering, we sort them before comparing, already used by the Validator's tests: https://github.com/crossplane/crossplane/blob/master/pkg/validation/apiextensions/v1/composition/validator_test.go#L571.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested
Unit tests added and manually deploying Compositions:
```sh
kubectl apply -f - <<EOF
---
apiVersion: apiextensions.crossplane.io/v1
kind: Composition
metadata:
  name: nop.sqlinstances.example.org
spec:
  writeConnectionSecretsToNamespace: crossplane-system
  compositeTypeRef:
    apiVersion: example.org/v1alpha1
    kind: XSQLInstance
  environment:
    patches:
    - # fromFieldPath: spec.parameters.engineVersion    <- required for patches of type FromCompositeFieldPath
      toFieldPath: complex.c.f
    environmentConfigs:
    - type: Reference
      ref:
        #name: example-environment                                    <- required for type Reference
    - type: Selector
      selector:
        matchLabels:
        - type: FromCompositeFieldPath
          key: stage
          #valueFromFieldPath: metadata.labels[stage]        <- required for FromCompositeFieldPath selector
EOF

The Composition "nop.sqlinstances.example.org" is invalid:
* spec.environment.patches[0].fromFieldPath: Required value: fromFieldPath must be set for patch type FromCompositeFieldPath
* spec.environment.environmentConfigs[0].type: Required value: ref is required
* spec.environment.environmentConfigs[1].selector.matchLabels[0].valueFromFieldPath: Required value: valueFromFieldPath is required
```
While it would have been accepted and resulted in an error at runtime before.
<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
