### PR TITLE
Composition's environment patches schema-aware validation

### DIFF
--- a/pkg/validation/apiextensions/v1/composition/validator.go
+++ b/pkg/validation/apiextensions/v1/composition/validator.go
@@ -133,6 +133,7 @@ func (v *Validator) Validate(ctx context.Context, obj runtime.Object) (warns []s
 		v.validatePatchesWithSchemas,
 		v.validateReadinessChecksWithSchemas,
 		v.validateConnectionDetailsWithSchemas,
+		v.validateEnvironmentPatchesWithSchemas,
 		// TODO(phisco): add more phase 2 validation here
 	} {
 		errs = append(errs, f(ctx, comp)...)


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Based on #4076 because it needed the `ToPatch` method introduced there.
Part of #3991.

Adds schema-aware validation of patches defined at `spec.environment.patches`.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested
Unit tests added.

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
