### PR TITLE
Remove crun v1.5 distinction

### DIFF
--- a/cluster/images/xfn/Dockerfile
+++ b/cluster/images/xfn/Dockerfile
@@ -1,4 +1,4 @@
-# This is debian:bookworm-slim (i.e. Debian 12, testing), which has crun v1.5.
+# This is debian:bookworm-slim (i.e. Debian 12, testing)
 FROM debian:bookworm-slim@sha256:2fd76b2b011a8b171f9ee0540fb74e9be0dc55fafc8f7f2858a482c0e7776ebc
 
 ARG TARGETOS


### PR DESCRIPTION


<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Unfortunately every build of the xfn image is using whatever the latest version of crun is available at that time, which results in non-reproducible build steps. This removes the comment specifying that we are using crun v1.5 to eliminate confusion until we have a better strategy.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

n/a -- just cleaning up a comment

[contribution process]: https://git.io/fj2m9
