### PR TITLE
Run RBAC manager in `Basic` mode by default

### DIFF
--- a/cluster/charts/crossplane/README.md
+++ b/cluster/charts/crossplane/README.md
@@ -95,7 +95,7 @@ and their default values.
 | `rbacManager.args` | A list of additional args to be pased to the RBAC manager's container. | `[]` |
 | `rbacManager.deploy` | Deploy RBAC Manager and its required roles. | `true` |
 | `rbacManager.leaderElection` | Enable leader election for RBAC Managers pod. | `true` |
-| `rbacManager.managementPolicy` | The extent to which the RBAC manager will manage permissions:. - `All` indicates to manage all Crossplane controller and user roles. - `Basic` indicates to only manage Crossplane controller roles and the `crossplane-admin`, `crossplane-edit`, and `crossplane-view` user roles. | `"All"` |
+| `rbacManager.managementPolicy` | The extent to which the RBAC manager will manage permissions:. - `All` indicates to manage all Crossplane controller and user roles. - `Basic` indicates to only manage Crossplane controller roles and the `crossplane-admin`, `crossplane-edit`, and `crossplane-view` user roles. | `"Basic"` |
 | `rbacManager.nodeSelector` | Enable nodeSelector for RBAC Managers pod. | `{}` |
 | `rbacManager.replicas` | The number of replicas to run for the RBAC Manager pods. | `1` |
 | `rbacManager.skipAggregatedClusterRoles` | Opt out of deploying aggregated ClusterRoles. | `false` |

--- a/cluster/charts/crossplane/values.yaml
+++ b/cluster/charts/crossplane/values.yaml
@@ -68,7 +68,7 @@ rbacManager:
   # -- The extent to which the RBAC manager will manage permissions:.
   # - `All` indicates to manage all Crossplane controller and user roles.
   # - `Basic` indicates to only manage Crossplane controller roles and the `crossplane-admin`, `crossplane-edit`, and `crossplane-view` user roles.
-  managementPolicy: All
+  managementPolicy: Basic
   # -- Enable leader election for RBAC Managers pod.
   leaderElection: true
   # -- A list of additional args to be pased to the RBAC manager's container.

--- a/cmd/crossplane/rbac/rbac.go
+++ b/cmd/crossplane/rbac/rbac.go
@@ -50,7 +50,7 @@ const pprofPath = "/debug/pprof/"
 // KongVars represent the kong variables associated with the CLI parser
 // required for the RBAC enum interpolation.
 var KongVars = kong.Vars{
-	"rbac_manage_default_var": ManagementPolicyAll,
+	"rbac_manage_default_var": ManagementPolicyBasic,
 	"rbac_manage_enum_var": strings.Join(
 		[]string{
 			ManagementPolicyAll,
@@ -77,8 +77,8 @@ type startCommand struct {
 	Profile string `placeholder:"host:port" help:"Serve runtime profiling data via HTTP at /debug/pprof."`
 
 	ProviderClusterRole string `name:"provider-clusterrole" help:"A ClusterRole enumerating the permissions provider packages may request."`
-	LeaderElection      bool   `name:"leader-election" short:"l" help:"Use leader election for the conroller manager." env:"LEADER_ELECTION"`
-	ManagementPolicy    string `name:"manage" short:"m" help:"RBAC management policy." default:"${rbac_manage_default_var}" enum:"${rbac_manage_enum_var}"`
+	LeaderElection      bool   `name:"leader-election" short:"l" help:"Use leader election for the controller manager." env:"LEADER_ELECTION"`
+	ManagementPolicy    string `name:"manage" short:"m" help:"RBAC management policy - Basic or All." default:"${rbac_manage_default_var}" enum:"${rbac_manage_enum_var}"`
 	Registry            string `short:"r" help:"Default registry used to fetch packages when not specified in tag." default:"${default_registry}" env:"REGISTRY"`
 
 	SyncInterval     time.Duration `short:"s" help:"How often all resources will be double-checked for drift from the desired state." default:"1h"`

--- a/go.mod
+++ b/go.mod
@@ -80,7 +80,7 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dimchansky/utfbom v1.1.1 // indirect
 	github.com/docker/cli v23.0.1+incompatible // indirect
-	github.com/docker/distribution v2.8.1+incompatible // indirect
+	github.com/docker/distribution v2.8.2+incompatible // indirect
 	github.com/docker/docker v23.0.3+incompatible // indirect
 	github.com/docker/docker-credential-helpers v0.7.0 // indirect
 	github.com/docker/go-connections v0.4.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -196,8 +196,8 @@ github.com/dimchansky/utfbom v1.1.1 h1:vV6w1AhK4VMnhBno/TPVCoK9U/LP0PkLCS9tbxHdi
 github.com/dimchansky/utfbom v1.1.1/go.mod h1:SxdoEBH5qIqFocHMyGOXVAybYJdr71b1Q/j0mACtrfE=
 github.com/docker/cli v23.0.1+incompatible h1:LRyWITpGzl2C9e9uGxzisptnxAn1zfZKXy13Ul2Q5oM=
 github.com/docker/cli v23.0.1+incompatible/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
-github.com/docker/distribution v2.8.1+incompatible h1:Q50tZOPR6T/hjNsyc9g8/syEs6bk8XXApsHjKukMl68=
-github.com/docker/distribution v2.8.1+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
+github.com/docker/distribution v2.8.2+incompatible h1:T3de5rq0dB1j30rp0sA2rER+m322EBzniBPB6ZIzuh8=
+github.com/docker/distribution v2.8.2+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
 github.com/docker/docker v23.0.3+incompatible h1:9GhVsShNWz1hO//9BNg/dpMnZW25KydO4wtVxWAIbho=
 github.com/docker/docker v23.0.3+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/docker-credential-helpers v0.6.3/go.mod h1:WRaJzqw3CTB9bk10avuGsjVBZsD05qeibJ1/TYlvc0Y=


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes https://github.com/crossplane/crossplane/issues/4043

See that issue for context. In short, I suspect very few people make use of (or are even aware of) the functionality enabled by `All` mode. I asked for community feedback on the aforementioned issue and no one seems to feel strongly, let's not create and manage a bunch of RBAC roles (per namespace) that few people are using.

This is a breaking behaviour change, so we'll need to make sure it's very obvious in the release notes.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9

I built and ran Crossplane, then confirmed I see:

```console
$ k -n upbound-system logs crossplane-rbac-manager-7c6db6c779-dfffs
Defaulted container "crossplane" out of: crossplane, crossplane-init (init)
2023-05-25T23:21:45Z    DEBUG   crossplane      Starting        {"policy": "Basic"}
```

I also created a namespace and verified that Crossplane didn't add any RBAC roles to it:

```console
$ k create namespace will-it-have-roles
namespace/will-it-have-roles created
$ k -n will-it-have-roles get roles.rbac.authorization.k8s.io
No resources found in will-it-have-roles namespace.
```