### PR TITLE
chore: configure single group for all kubernetes related prs

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -96,7 +96,7 @@
       "matchDatasources": [
         "go"
       ],
-      "groupName": "kubernetes patches",
+      "groupName": "kubernetes deps",
       "matchUpdateTypes": [
         "digest",
       ],
@@ -106,28 +106,16 @@
         "sigs.k8s.io"
       ]
     }, {
-// We want a single PR for all the patches bumps of kubernetes related
+// We want a single PR for all the bumps of kubernetes related
 // dependencies, as most of the times these are all strictly related.
       "matchDatasources": [
         "go"
       ],
-      "groupName": "kubernetes patches",
-      "matchUpdateTypes": [
-        "patch",
-      ],
-      "matchPackagePrefixes": [
-        "k8s.io",
-        "sigs.k8s.io"
-      ]
-    }, {
-// We want dedicated PRs for each minor and major bumps to kubernetes related
-// dependencies.
-      "matchDatasources": [
-        "go"
-      ],
+      "groupName": "kubernetes deps",
       "matchUpdateTypes": [
         "major",
-        "minor"
+        "minor",
+        "patch"
       ],
       "matchPackagePrefixes": [
         "k8s.io",


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Configures a single renovate group for kubernetes-related patches, as it doesn't make sense to  keep https://github.com/crossplane/crossplane/pull/4097, https://github.com/crossplane/crossplane/pull/4040 and https://github.com/crossplane/crossplane/pull/3971 separate

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested
Validated config using `renovate-config-validator`
<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
