### PR TITLE
chore(renovate): disable non-security related k8s deps

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -89,53 +89,11 @@
       "matchDepNames": [
         "k8s.io/client-go"
       ],
-      "allowedVersions": "<1.0"
+      "allowedVersions": "<1.0",
     }, {
-// We don't want digest updates for kubernetes dependencies, as they are too
-// noisy
-      "matchDatasources": [
-        "go"
-      ],
-      "groupName": "kubernetes patches",
-      "matchUpdateTypes": [
-        "digest",
-      ],
-      "extends": ['schedule:monthly'],
-      "matchPackagePrefixes": [
-        "k8s.io",
-        "sigs.k8s.io"
-      ]
-    }, {
-// We want a single PR for all the patches bumps of kubernetes related
-// dependencies, as most of the times these are all strictly related.
-      "matchDatasources": [
-        "go"
-      ],
-      "groupName": "kubernetes patches",
-      "matchUpdateTypes": [
-        "patch",
-      ],
-      "matchPackagePrefixes": [
-        "k8s.io",
-        "sigs.k8s.io"
-      ]
-    }, {
-// We want dedicated PRs for each minor and major bumps to kubernetes related
-// dependencies.
-      "matchDatasources": [
-        "go"
-      ],
-      "matchUpdateTypes": [
-        "major",
-        "minor"
-      ],
-      "matchPackagePrefixes": [
-        "k8s.io",
-        "sigs.k8s.io"
-      ]
-    }, {
-// We want dedicated PRs for each bump to non-kubernetes Go dependencies, but
-// only if there are known vulnerabilities in the current version.
+// We want a single PR for all bumps to Go dependencies, but only if there are
+// known vulnerabilities in the current version. We need to ignore k8s related
+// dependencies too as they should be first updated on crossplane-runtime.
       "matchDatasources": [
         "go"
       ],
@@ -143,34 +101,13 @@
         "*"
       ],
       "enabled": false,
-      "excludePackagePrefixes": [
-        "k8s.io",
-        "sigs.k8s.io"
-      ],
       "matchUpdateTypes": [
         "major",
-      ],
-    }, {
-// We want a single PR for all minor and patch bumps to non-kubernetes Go
-// dependencies, but only if there are known vulnerabilities in the current
-// version.
-      "matchDatasources": [
-        "go"
-      ],
-      "matchPackagePatterns": [
-        "*"
-      ],
-      "enabled": false,
-      "excludePackagePrefixes": [
-        "k8s.io",
-        "sigs.k8s.io"
-      ],
-      "matchUpdateTypes": [
         "minor",
         "patch",
         "digest"
       ],
-      "groupName": "all non-major go dependencies"
+      "groupName": "all go dependencies"
     }, {
 // We want a single PR for all non-major bumps of Github Actions
       "matchDepTypes": [


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Address https://github.com/crossplane/crossplane/pull/4113#issuecomment-1564554033 and just keep security-related updates, removing the exception for kubernetes dependencies, as those should go first through crossplane-runtime.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

Configured on my fork.

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
