### PR TITLE
Fix typos and broken links in documentation

### DIFF
--- a/design/one-pager-cross-resource-referencing.md
+++ b/design/one-pager-cross-resource-referencing.md
@@ -290,6 +290,6 @@ dependent objects are deleted first.
 (https://github.com/crossplane/provider-gcp/blob/master/apis/compute/v1alpha2/subnetwork_types.go#L144)
 
 [Managed Reconciler]:
-https://github.com/crossplane/crossplane-runtime/blob/master/pkg/resource/managed_reconciler.go
+https://github.com/crossplane/crossplane-runtime/blob/master/pkg/reconciler/managed/reconciler.go
 [Foreground cascading deletion]:
 (https://kubernetes.io/docs/concepts/workloads/controllers/garbage-collection/#foreground-cascading-deletion)

--- a/design/proposal-controller-code-generation.md
+++ b/design/proposal-controller-code-generation.md
@@ -158,7 +158,7 @@ designed to be used and read by developers (vs Terraform where provider code is
 “internal”, and where additional complexity exists to support Terraform internal
 requirements). This is probably high effort because we would need to do it over
 again for each Provider, however it could be easier for developers to fill in
-COUD controller methods using well-documented and Provider-supported SDK code.
+CRUD controller methods using well-documented and Provider-supported SDK code.
 
 **Provider-specific Infrastructure DSL**: rather than trying to represent the
 direct resource-level APIs, we could build on top of cloud provider "stack


### PR DESCRIPTION
### Description of your changes
This PR fixes a broken link in the `one-pager-cross-resource-referencing.md` and a typo in `proposal-controller-code-generation-md`.

I have:

- [X] Read and followed Crossplane's [contribution process].
- [X] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested
Since I just updated the documentation, no further testing is necessary.

[contribution process]: https://git.io/fj2m9
