### PR TITLE
Refactor composed resource Renderer into a pipeline of Renderers

### DIFF
--- a/internal/controller/apiextensions/composite/composition_pt.go
+++ b/internal/controller/apiextensions/composite/composition_pt.go
@@ -471,14 +471,6 @@ type Observation struct {
 	Ready             bool
 }
 
-// A RenderFn renders the supplied composed resource.
-type RenderFn func(cp resource.Composite, cd resource.Composed, t v1.ComposedTemplate) error
-
-// Render calls RenderFn.
-func (c RenderFn) Render(cp resource.Composite, cd resource.Composed, t v1.ComposedTemplate) error {
-	return c(cp, cd, t)
-}
-
 // An APIDryRunRenderer renders composed resources. It may perform a dry-run
 // create against an API server in order to name and validate the rendered
 // resource.

--- a/internal/controller/apiextensions/composite/composition_pt.go
+++ b/internal/controller/apiextensions/composite/composition_pt.go
@@ -24,7 +24,6 @@ import (
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/json"
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -37,8 +36,6 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/resource/unstructured/composed"
 
 	v1 "github.com/crossplane/crossplane/apis/apiextensions/v1"
-	env "github.com/crossplane/crossplane/internal/controller/apiextensions/composite/environment"
-	"github.com/crossplane/crossplane/internal/xcrd"
 )
 
 // Error strings
@@ -150,7 +147,7 @@ func NewPTComposer(kube client.Client, o ...PTComposerOption) *PTComposer {
 		// means we will be able to delete the GarbageCollectingAssociator and
 		// just use AssociateByOrder. Compositions with named templates will be
 		// handled by the PTFComposer.
-		composite:   RendererFn(RenderComposite),
+		composite:   RenderFn(RenderComposite),
 		composition: NewGarbageCollectingAssociator(kube),
 		composed: composedResource{
 			Renderer:                   NewAPIDryRunRenderer(kube),
@@ -469,107 +466,4 @@ type Observation struct {
 	Ref               corev1.ObjectReference
 	ConnectionDetails managed.ConnectionDetails
 	Ready             bool
-}
-
-// An APIDryRunRenderer renders composed resources. It may perform a dry-run
-// create against an API server in order to name and validate the rendered
-// resource.
-type APIDryRunRenderer struct {
-	client client.Client
-}
-
-// NewAPIDryRunRenderer returns a Renderer of composed resources that may
-// perform a dry-run create against an API server in order to name and validate
-// it.
-func NewAPIDryRunRenderer(c client.Client) *APIDryRunRenderer {
-	return &APIDryRunRenderer{client: c}
-}
-
-// Render the supplied composed resource using the supplied composite resource
-// and template. The rendered resource may be submitted to an API server via a
-// dry run create in order to name and validate it.
-func (r *APIDryRunRenderer) Render(ctx context.Context, cp resource.Composite, cd resource.Composed, t v1.ComposedTemplate, env *env.Environment) error { //nolint:gocyclo // Only slightly over (11).
-	kind := cd.GetObjectKind().GroupVersionKind().Kind
-	name := cd.GetName()
-	namespace := cd.GetNamespace()
-
-	if err := json.Unmarshal(t.Base.Raw, cd); err != nil {
-		return errors.Wrap(err, errUnmarshal)
-	}
-
-	// We think this composed resource exists, but when we rendered its template
-	// its kind changed. This shouldn't happen. Either someone changed the kind
-	// in the template or we're trying to use the wrong template (e.g. because
-	// the order of an array of anonymous templates changed).
-	if kind != "" && cd.GetObjectKind().GroupVersionKind().Kind != kind {
-		return errors.New(errKindChanged)
-	}
-
-	if cp.GetLabels()[xcrd.LabelKeyNamePrefixForComposed] == "" {
-		return errors.New(errNamePrefix)
-	}
-
-	// Unmarshalling the template will overwrite any existing fields, so we must
-	// restore the existing name, if any. We also set generate name in case we
-	// haven't yet named this composed resource.
-	cd.SetGenerateName(cp.GetLabels()[xcrd.LabelKeyNamePrefixForComposed] + "-")
-	cd.SetName(name)
-	cd.SetNamespace(namespace)
-
-	for i := range t.Patches {
-		if err := Apply(t.Patches[i], cp, cd, patchTypesFromXR()...); err != nil {
-			return errors.Wrapf(err, errFmtPatch, i)
-		}
-		if env != nil {
-			if err := ApplyToObjects(t.Patches[i], env, cd, patchTypesFromToEnvironment()...); err != nil {
-				return errors.Wrapf(err, errFmtPatch, i)
-			}
-		}
-	}
-
-	// Composed labels and annotations should be rendered after patches are applied
-	meta.AddLabels(cd, map[string]string{
-		xcrd.LabelKeyNamePrefixForComposed: cp.GetLabels()[xcrd.LabelKeyNamePrefixForComposed],
-		xcrd.LabelKeyClaimName:             cp.GetLabels()[xcrd.LabelKeyClaimName],
-		xcrd.LabelKeyClaimNamespace:        cp.GetLabels()[xcrd.LabelKeyClaimNamespace],
-	})
-
-	if t.Name != nil {
-		SetCompositionResourceName(cd, *t.Name)
-	}
-
-	// We do this last to ensure that a Composition cannot influence controller references.
-	or := meta.AsController(meta.TypedReferenceTo(cp, cp.GetObjectKind().GroupVersionKind()))
-	if err := meta.AddControllerReference(cd, or); err != nil {
-		return errors.Wrap(err, errSetControllerRef)
-	}
-
-	// We don't want to dry-run create a resource that can't be named by the API
-	// server due to a missing generate name. We also don't want to create one
-	// that is already named, because doing so will result in an error. The API
-	// server seems to respond with a 500 ServerTimeout error for all dry-run
-	// failures, so we can't just perform a dry-run and ignore 409 Conflicts for
-	// resources that are already named.
-	if cd.GetName() != "" || cd.GetGenerateName() == "" {
-		return nil
-	}
-
-	// The API server returns an available name derived from generateName when
-	// we perform a dry-run create. This name is likely (but not guaranteed) to
-	// be available when we create the composed resource. If the API server
-	// generates a name that is unavailable it will return a 500 ServerTimeout
-	// error.
-	return errors.Wrap(r.client.Create(ctx, cd, client.DryRunAll), errName)
-}
-
-// RenderComposite renders the supplied composite resource using the supplied composed
-// resource and template.
-func RenderComposite(_ context.Context, cp resource.Composite, cd resource.Composed, t v1.ComposedTemplate, _ *env.Environment) error {
-	for i, p := range t.Patches {
-		if err := Apply(p, cp, cd, patchTypesToXR()...); err != nil {
-			return errors.Wrapf(err, errFmtPatch, i)
-		}
-	}
-
-	return nil
 }

--- a/internal/controller/apiextensions/composite/composition_pt_test.go
+++ b/internal/controller/apiextensions/composite/composition_pt_test.go
@@ -28,7 +28,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/json"
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -41,7 +40,6 @@ import (
 
 	v1 "github.com/crossplane/crossplane/apis/apiextensions/v1"
 	env "github.com/crossplane/crossplane/internal/controller/apiextensions/composite/environment"
-	"github.com/crossplane/crossplane/internal/xcrd"
 )
 
 func TestPTCompose(t *testing.T) {
@@ -128,10 +126,10 @@ func TestPTCompose(t *testing.T) {
 						}}
 						return tas, nil
 					})),
-					WithComposedRenderer(RendererFn(func(ctx context.Context, cp resource.Composite, cd resource.Composed, t v1.ComposedTemplate, env *env.Environment) error {
+					WithComposedRenderer(RenderFn(func(ctx context.Context, cp resource.Composite, cd resource.Composed, t v1.ComposedTemplate, env *env.Environment) error {
 						return errBoom
 					})),
-					WithCompositeRenderer(RendererFn(func(ctx context.Context, cp resource.Composite, cd resource.Composed, t v1.ComposedTemplate, env *env.Environment) error {
+					WithCompositeRenderer(RenderFn(func(ctx context.Context, cp resource.Composite, cd resource.Composed, t v1.ComposedTemplate, env *env.Environment) error {
 						return nil
 					})),
 					WithComposedConnectionDetailsExtractor(ConnectionDetailsExtractorFn(func(cd resource.Composed, conn managed.ConnectionDetails, cfg ...ConnectionDetailExtractConfig) (managed.ConnectionDetails, error) {
@@ -172,7 +170,7 @@ func TestPTCompose(t *testing.T) {
 						}}
 						return tas, nil
 					})),
-					WithComposedRenderer(RendererFn(func(ctx context.Context, cp resource.Composite, cd resource.Composed, t v1.ComposedTemplate, env *env.Environment) error {
+					WithComposedRenderer(RenderFn(func(ctx context.Context, cp resource.Composite, cd resource.Composed, t v1.ComposedTemplate, env *env.Environment) error {
 						return nil
 					})),
 				},
@@ -205,7 +203,7 @@ func TestPTCompose(t *testing.T) {
 						}}
 						return tas, nil
 					})),
-					WithComposedRenderer(RendererFn(func(ctx context.Context, cp resource.Composite, cd resource.Composed, t v1.ComposedTemplate, env *env.Environment) error {
+					WithComposedRenderer(RenderFn(func(ctx context.Context, cp resource.Composite, cd resource.Composed, t v1.ComposedTemplate, env *env.Environment) error {
 						return nil
 					})),
 				},
@@ -239,10 +237,10 @@ func TestPTCompose(t *testing.T) {
 						}}
 						return tas, nil
 					})),
-					WithComposedRenderer(RendererFn(func(ctx context.Context, cp resource.Composite, cd resource.Composed, t v1.ComposedTemplate, env *env.Environment) error {
+					WithComposedRenderer(RenderFn(func(ctx context.Context, cp resource.Composite, cd resource.Composed, t v1.ComposedTemplate, env *env.Environment) error {
 						return nil
 					})),
-					WithCompositeRenderer(RendererFn(func(ctx context.Context, cp resource.Composite, cd resource.Composed, t v1.ComposedTemplate, env *env.Environment) error {
+					WithCompositeRenderer(RenderFn(func(ctx context.Context, cp resource.Composite, cd resource.Composed, t v1.ComposedTemplate, env *env.Environment) error {
 						return errBoom
 					})),
 				},
@@ -276,10 +274,10 @@ func TestPTCompose(t *testing.T) {
 						}}
 						return tas, nil
 					})),
-					WithComposedRenderer(RendererFn(func(ctx context.Context, cp resource.Composite, cd resource.Composed, t v1.ComposedTemplate, env *env.Environment) error {
+					WithComposedRenderer(RenderFn(func(ctx context.Context, cp resource.Composite, cd resource.Composed, t v1.ComposedTemplate, env *env.Environment) error {
 						return nil
 					})),
-					WithCompositeRenderer(RendererFn(func(ctx context.Context, cp resource.Composite, cd resource.Composed, t v1.ComposedTemplate, env *env.Environment) error {
+					WithCompositeRenderer(RenderFn(func(ctx context.Context, cp resource.Composite, cd resource.Composed, t v1.ComposedTemplate, env *env.Environment) error {
 						return nil
 					})),
 					WithComposedConnectionDetailsFetcher(ConnectionDetailsFetcherFn(func(ctx context.Context, o resource.ConnectionSecretOwner) (managed.ConnectionDetails, error) {
@@ -316,10 +314,10 @@ func TestPTCompose(t *testing.T) {
 						}}
 						return tas, nil
 					})),
-					WithComposedRenderer(RendererFn(func(ctx context.Context, cp resource.Composite, cd resource.Composed, t v1.ComposedTemplate, env *env.Environment) error {
+					WithComposedRenderer(RenderFn(func(ctx context.Context, cp resource.Composite, cd resource.Composed, t v1.ComposedTemplate, env *env.Environment) error {
 						return nil
 					})),
-					WithCompositeRenderer(RendererFn(func(ctx context.Context, cp resource.Composite, cd resource.Composed, t v1.ComposedTemplate, env *env.Environment) error {
+					WithCompositeRenderer(RenderFn(func(ctx context.Context, cp resource.Composite, cd resource.Composed, t v1.ComposedTemplate, env *env.Environment) error {
 						return nil
 					})),
 					WithComposedConnectionDetailsFetcher(ConnectionDetailsFetcherFn(func(ctx context.Context, o resource.ConnectionSecretOwner) (managed.ConnectionDetails, error) {
@@ -359,10 +357,10 @@ func TestPTCompose(t *testing.T) {
 						}}
 						return tas, nil
 					})),
-					WithComposedRenderer(RendererFn(func(ctx context.Context, cp resource.Composite, cd resource.Composed, t v1.ComposedTemplate, env *env.Environment) error {
+					WithComposedRenderer(RenderFn(func(ctx context.Context, cp resource.Composite, cd resource.Composed, t v1.ComposedTemplate, env *env.Environment) error {
 						return nil
 					})),
-					WithCompositeRenderer(RendererFn(func(ctx context.Context, cp resource.Composite, cd resource.Composed, t v1.ComposedTemplate, env *env.Environment) error {
+					WithCompositeRenderer(RenderFn(func(ctx context.Context, cp resource.Composite, cd resource.Composed, t v1.ComposedTemplate, env *env.Environment) error {
 						return nil
 					})),
 					WithComposedConnectionDetailsFetcher(ConnectionDetailsFetcherFn(func(ctx context.Context, o resource.ConnectionSecretOwner) (managed.ConnectionDetails, error) {
@@ -402,7 +400,7 @@ func TestPTCompose(t *testing.T) {
 					WithTemplateAssociator(CompositionTemplateAssociatorFn(func(ctx context.Context, c resource.Composite, ct []v1.ComposedTemplate) ([]TemplateAssociation, error) {
 						return nil, nil
 					})),
-					WithCompositeRenderer(RendererFn(func(ctx context.Context, cp resource.Composite, cd resource.Composed, t v1.ComposedTemplate, env *env.Environment) error {
+					WithCompositeRenderer(RenderFn(func(ctx context.Context, cp resource.Composite, cd resource.Composed, t v1.ComposedTemplate, env *env.Environment) error {
 						return nil
 					})),
 				},
@@ -436,10 +434,10 @@ func TestPTCompose(t *testing.T) {
 						}}
 						return tas, nil
 					})),
-					WithComposedRenderer(RendererFn(func(ctx context.Context, cp resource.Composite, cd resource.Composed, t v1.ComposedTemplate, env *env.Environment) error {
+					WithComposedRenderer(RenderFn(func(ctx context.Context, cp resource.Composite, cd resource.Composed, t v1.ComposedTemplate, env *env.Environment) error {
 						return nil
 					})),
-					WithCompositeRenderer(RendererFn(func(ctx context.Context, cp resource.Composite, cd resource.Composed, t v1.ComposedTemplate, env *env.Environment) error {
+					WithCompositeRenderer(RenderFn(func(ctx context.Context, cp resource.Composite, cd resource.Composed, t v1.ComposedTemplate, env *env.Environment) error {
 						return nil
 					})),
 					WithComposedConnectionDetailsFetcher(ConnectionDetailsFetcherFn(func(ctx context.Context, o resource.ConnectionSecretOwner) (managed.ConnectionDetails, error) {
@@ -483,144 +481,6 @@ func TestPTCompose(t *testing.T) {
 
 			if diff := cmp.Diff(tc.want.res, res, cmpopts.EquateEmpty()); diff != "" {
 				t.Errorf("\n%s\nCompose(...): -want, +got:\n%s", tc.reason, diff)
-			}
-		})
-	}
-}
-
-func TestRender(t *testing.T) {
-	ctrl := true
-	tmpl, _ := json.Marshal(&fake.Managed{})
-	errBoom := errors.New("boom")
-
-	type args struct {
-		ctx context.Context
-		cp  resource.Composite
-		cd  resource.Composed
-		t   v1.ComposedTemplate
-	}
-	type want struct {
-		cd  resource.Composed
-		err error
-	}
-	cases := map[string]struct {
-		reason string
-		client client.Client
-		args
-		want
-	}{
-		"InvalidTemplate": {
-			reason: "Invalid template should not be accepted",
-			args: args{
-				cd: &fake.Composed{},
-				t:  v1.ComposedTemplate{Base: runtime.RawExtension{Raw: []byte("olala")}},
-			},
-			want: want{
-				cd:  &fake.Composed{},
-				err: errors.Wrap(errors.New("invalid character 'o' looking for beginning of value"), errUnmarshal),
-			},
-		},
-		"NoLabel": {
-			reason: "The name prefix label has to be set",
-			args: args{
-				cp: &fake.Composite{},
-				cd: &fake.Composed{ObjectMeta: metav1.ObjectMeta{Name: "cd"}},
-				t:  v1.ComposedTemplate{Base: runtime.RawExtension{Raw: tmpl}},
-			},
-			want: want{
-				cd:  &fake.Composed{ObjectMeta: metav1.ObjectMeta{Name: "cd"}},
-				err: errors.New(errNamePrefix),
-			},
-		},
-		"DryRunError": {
-			reason: "Errors dry-run creating the rendered resource to name it should be returned",
-			client: &test.MockClient{MockCreate: test.NewMockCreateFn(errBoom)},
-			args: args{
-				cp: &fake.Composite{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{
-					xcrd.LabelKeyNamePrefixForComposed: "ola",
-					xcrd.LabelKeyClaimName:             "rola",
-					xcrd.LabelKeyClaimNamespace:        "rolans",
-				}}},
-				cd: &fake.Composed{ObjectMeta: metav1.ObjectMeta{}},
-				t:  v1.ComposedTemplate{Base: runtime.RawExtension{Raw: tmpl}},
-			},
-			want: want{
-				cd: &fake.Composed{ObjectMeta: metav1.ObjectMeta{
-					GenerateName: "ola-",
-					Labels: map[string]string{
-						xcrd.LabelKeyNamePrefixForComposed: "ola",
-						xcrd.LabelKeyClaimName:             "rola",
-						xcrd.LabelKeyClaimNamespace:        "rolans",
-					},
-					OwnerReferences: []metav1.OwnerReference{{Controller: &ctrl, BlockOwnerDeletion: &ctrl}},
-				}},
-				err: errors.Wrap(errBoom, errName),
-			},
-		},
-		"ControllerError": {
-			reason: "External controller owner references should cause an exception",
-			client: &test.MockClient{MockCreate: test.NewMockCreateFn(nil)},
-			args: args{
-				cp: &fake.Composite{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{
-					xcrd.LabelKeyNamePrefixForComposed: "ola",
-					xcrd.LabelKeyClaimName:             "rola",
-					xcrd.LabelKeyClaimNamespace:        "rolans",
-				}}},
-				cd: &fake.Composed{ObjectMeta: metav1.ObjectMeta{Name: "cd",
-					OwnerReferences: []metav1.OwnerReference{{Controller: &ctrl, BlockOwnerDeletion: &ctrl,
-						UID: "random_uid"}}}},
-				t: v1.ComposedTemplate{Base: runtime.RawExtension{Raw: tmpl}},
-			},
-			want: want{
-				cd: &fake.Composed{ObjectMeta: metav1.ObjectMeta{
-					Name:         "cd",
-					GenerateName: "ola-",
-					Labels: map[string]string{
-						xcrd.LabelKeyNamePrefixForComposed: "ola",
-						xcrd.LabelKeyClaimName:             "rola",
-						xcrd.LabelKeyClaimNamespace:        "rolans",
-					},
-					OwnerReferences: []metav1.OwnerReference{{Controller: &ctrl, BlockOwnerDeletion: &ctrl,
-						UID: "random_uid"}},
-				}},
-				err: errors.Wrap(errors.Errorf("cd is already controlled by   (UID random_uid)"), errSetControllerRef),
-			},
-		},
-		"Success": {
-			reason: "Configuration should result in the right object with correct generateName",
-			client: &test.MockClient{MockCreate: test.NewMockCreateFn(nil)},
-			args: args{
-				cp: &fake.Composite{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{
-					xcrd.LabelKeyNamePrefixForComposed: "ola",
-					xcrd.LabelKeyClaimName:             "rola",
-					xcrd.LabelKeyClaimNamespace:        "rolans",
-				}}},
-				cd: &fake.Composed{ObjectMeta: metav1.ObjectMeta{Name: "cd"}},
-				t:  v1.ComposedTemplate{Base: runtime.RawExtension{Raw: tmpl}},
-			},
-			want: want{
-				cd: &fake.Composed{ObjectMeta: metav1.ObjectMeta{
-					Name:         "cd",
-					GenerateName: "ola-",
-					Labels: map[string]string{
-						xcrd.LabelKeyNamePrefixForComposed: "ola",
-						xcrd.LabelKeyClaimName:             "rola",
-						xcrd.LabelKeyClaimNamespace:        "rolans",
-					},
-					OwnerReferences: []metav1.OwnerReference{{Controller: &ctrl, BlockOwnerDeletion: &ctrl}},
-				}},
-			},
-		},
-	}
-	for name, tc := range cases {
-		t.Run(name, func(t *testing.T) {
-			r := NewAPIDryRunRenderer(tc.client)
-			err := r.Render(tc.args.ctx, tc.args.cp, tc.args.cd, tc.args.t, nil)
-			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
-				t.Errorf("\n%s\nRender(...): -want, +got:\n%s", tc.reason, diff)
-			}
-			if diff := cmp.Diff(tc.want.cd, tc.args.cd); diff != "" {
-				t.Errorf("\n%s\nRender(...): -want, +got:\n%s", tc.reason, diff)
 			}
 		})
 	}

--- a/internal/controller/apiextensions/composite/composition_ptf.go
+++ b/internal/controller/apiextensions/composite/composition_ptf.go
@@ -260,7 +260,7 @@ func NewPTFComposer(kube client.Client, o ...PTFComposerOption) *PTFComposer {
 			},
 		},
 		composition: ptfComposition{
-			PatchAndTransformer:    NewXRCDPatchAndTransformer(RendererFn(RenderComposite), NewAPIDryRunRenderer(kube)),
+			PatchAndTransformer:    NewXRCDPatchAndTransformer(RenderFn(RenderComposite), NewAPIDryRunRenderer(kube)),
 			FunctionPipelineRunner: NewFunctionPipeline(ContainerFunctionRunnerFn(RunFunction)),
 		},
 	}

--- a/internal/controller/apiextensions/composite/composition_ptf.go
+++ b/internal/controller/apiextensions/composite/composition_ptf.go
@@ -247,6 +247,14 @@ func NewPTFComposer(kube client.Client, o ...PTFComposerOption) *PTFComposer {
 
 	f := NewSecretConnectionDetailsFetcher(kube)
 
+	rp := RenderPipeline{
+		RenderFn(RenderComposedResourceBase),
+		RenderFn(RenderFromCompositePatches),
+		RenderFn(RenderFromEnvironmentPatches),
+		RenderFn(RenderComposedResourceMetadata),
+		NewAPIDryRunRenderer(kube),
+	}
+
 	c := &PTFComposer{
 		client: resource.ClientApplicator{Client: kube, Applicator: resource.NewAPIPatchingApplicator(kube)},
 
@@ -260,7 +268,7 @@ func NewPTFComposer(kube client.Client, o ...PTFComposerOption) *PTFComposer {
 			},
 		},
 		composition: ptfComposition{
-			PatchAndTransformer:    NewXRCDPatchAndTransformer(RenderFn(RenderComposite), NewAPIDryRunRenderer(kube)),
+			PatchAndTransformer:    NewXRCDPatchAndTransformer(RenderFn(RenderToCompositePatches), rp),
 			FunctionPipelineRunner: NewFunctionPipeline(ContainerFunctionRunnerFn(RunFunction)),
 		},
 	}

--- a/internal/controller/apiextensions/composite/composition_ptf_test.go
+++ b/internal/controller/apiextensions/composite/composition_ptf_test.go
@@ -870,7 +870,7 @@ func TestPatchAndTransform(t *testing.T) {
 		"CompositeRenderError": {
 			reason: "We should return any error encountered while rendering an XR.",
 			params: params{
-				composite: RendererFn(func(ctx context.Context, cp resource.Composite, cd resource.Composed, t v1.ComposedTemplate, env *env.Environment) error {
+				composite: RenderFn(func(ctx context.Context, cp resource.Composite, cd resource.Composed, t v1.ComposedTemplate, env *env.Environment) error {
 					return errBoom
 				}),
 			},
@@ -922,10 +922,10 @@ func TestPatchAndTransform(t *testing.T) {
 		"ComposedRenderError": {
 			reason: "We should include any error encountered while rendering a composed resource in our state.",
 			params: params{
-				composite: RendererFn(func(ctx context.Context, cp resource.Composite, cd resource.Composed, t v1.ComposedTemplate, env *env.Environment) error {
+				composite: RenderFn(func(ctx context.Context, cp resource.Composite, cd resource.Composed, t v1.ComposedTemplate, env *env.Environment) error {
 					return nil
 				}),
-				composed: RendererFn(func(ctx context.Context, cp resource.Composite, cd resource.Composed, t v1.ComposedTemplate, env *env.Environment) error {
+				composed: RenderFn(func(ctx context.Context, cp resource.Composite, cd resource.Composed, t v1.ComposedTemplate, env *env.Environment) error {
 					return errBoom
 				}),
 			},

--- a/internal/controller/apiextensions/composite/composition_render.go
+++ b/internal/controller/apiextensions/composite/composition_render.go
@@ -1,0 +1,134 @@
+/*
+Copyright 2022 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+this file except in compliance with the License. You may obtain a copy of the
+License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed
+under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+*/
+
+package composite
+
+import (
+	"context"
+
+	"k8s.io/apimachinery/pkg/util/json"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/crossplane/crossplane-runtime/pkg/errors"
+	"github.com/crossplane/crossplane-runtime/pkg/meta"
+	"github.com/crossplane/crossplane-runtime/pkg/resource"
+
+	v1 "github.com/crossplane/crossplane/apis/apiextensions/v1"
+	env "github.com/crossplane/crossplane/internal/controller/apiextensions/composite/environment"
+	"github.com/crossplane/crossplane/internal/xcrd"
+)
+
+// An APIDryRunRenderer renders composed resources. It may perform a dry-run
+// create against an API server in order to name and validate the rendered
+// resource.
+type APIDryRunRenderer struct {
+	client client.Client
+}
+
+// NewAPIDryRunRenderer returns a Renderer of composed resources that may
+// perform a dry-run create against an API server in order to name and validate
+// it.
+func NewAPIDryRunRenderer(c client.Client) *APIDryRunRenderer {
+	return &APIDryRunRenderer{client: c}
+}
+
+// Render the supplied composed resource using the supplied composite resource
+// and template. The rendered resource may be submitted to an API server via a
+// dry run create in order to name and validate it.
+func (r *APIDryRunRenderer) Render(ctx context.Context, cp resource.Composite, cd resource.Composed, t v1.ComposedTemplate, env *env.Environment) error { //nolint:gocyclo // Only slightly over (11).
+	kind := cd.GetObjectKind().GroupVersionKind().Kind
+	name := cd.GetName()
+	namespace := cd.GetNamespace()
+
+	if err := json.Unmarshal(t.Base.Raw, cd); err != nil {
+		return errors.Wrap(err, errUnmarshal)
+	}
+
+	// We think this composed resource exists, but when we rendered its template
+	// its kind changed. This shouldn't happen. Either someone changed the kind
+	// in the template or we're trying to use the wrong template (e.g. because
+	// the order of an array of anonymous templates changed).
+	if kind != "" && cd.GetObjectKind().GroupVersionKind().Kind != kind {
+		return errors.New(errKindChanged)
+	}
+
+	if cp.GetLabels()[xcrd.LabelKeyNamePrefixForComposed] == "" {
+		return errors.New(errNamePrefix)
+	}
+
+	// Unmarshalling the template will overwrite any existing fields, so we must
+	// restore the existing name, if any. We also set generate name in case we
+	// haven't yet named this composed resource.
+	cd.SetGenerateName(cp.GetLabels()[xcrd.LabelKeyNamePrefixForComposed] + "-")
+	cd.SetName(name)
+	cd.SetNamespace(namespace)
+
+	for i := range t.Patches {
+		if err := Apply(t.Patches[i], cp, cd, patchTypesFromXR()...); err != nil {
+			return errors.Wrapf(err, errFmtPatch, i)
+		}
+		if env != nil {
+			if err := ApplyToObjects(t.Patches[i], env, cd, patchTypesFromToEnvironment()...); err != nil {
+				return errors.Wrapf(err, errFmtPatch, i)
+			}
+		}
+	}
+
+	// Composed labels and annotations should be rendered after patches are applied
+	meta.AddLabels(cd, map[string]string{
+		xcrd.LabelKeyNamePrefixForComposed: cp.GetLabels()[xcrd.LabelKeyNamePrefixForComposed],
+		xcrd.LabelKeyClaimName:             cp.GetLabels()[xcrd.LabelKeyClaimName],
+		xcrd.LabelKeyClaimNamespace:        cp.GetLabels()[xcrd.LabelKeyClaimNamespace],
+	})
+
+	if t.Name != nil {
+		SetCompositionResourceName(cd, *t.Name)
+	}
+
+	// We do this last to ensure that a Composition cannot influence controller references.
+	or := meta.AsController(meta.TypedReferenceTo(cp, cp.GetObjectKind().GroupVersionKind()))
+	if err := meta.AddControllerReference(cd, or); err != nil {
+		return errors.Wrap(err, errSetControllerRef)
+	}
+
+	// We don't want to dry-run create a resource that can't be named by the API
+	// server due to a missing generate name. We also don't want to create one
+	// that is already named, because doing so will result in an error. The API
+	// server seems to respond with a 500 ServerTimeout error for all dry-run
+	// failures, so we can't just perform a dry-run and ignore 409 Conflicts for
+	// resources that are already named.
+	if cd.GetName() != "" || cd.GetGenerateName() == "" {
+		return nil
+	}
+
+	// The API server returns an available name derived from generateName when
+	// we perform a dry-run create. This name is likely (but not guaranteed) to
+	// be available when we create the composed resource. If the API server
+	// generates a name that is unavailable it will return a 500 ServerTimeout
+	// error.
+	return errors.Wrap(r.client.Create(ctx, cd, client.DryRunAll), errName)
+}
+
+// RenderComposite renders the supplied composite resource using the supplied composed
+// resource and template.
+func RenderComposite(_ context.Context, cp resource.Composite, cd resource.Composed, t v1.ComposedTemplate, _ *env.Environment) error {
+	for i, p := range t.Patches {
+		if err := Apply(p, cp, cd, patchTypesToXR()...); err != nil {
+			return errors.Wrapf(err, errFmtPatch, i)
+		}
+	}
+
+	return nil
+}

--- a/internal/controller/apiextensions/composite/composition_render_test.go
+++ b/internal/controller/apiextensions/composite/composition_render_test.go
@@ -21,22 +21,322 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/crossplane/crossplane-runtime/pkg/errors"
+	"github.com/crossplane/crossplane-runtime/pkg/meta"
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
 	"github.com/crossplane/crossplane-runtime/pkg/resource/fake"
+	"github.com/crossplane/crossplane-runtime/pkg/resource/unstructured/composed"
 	"github.com/crossplane/crossplane-runtime/pkg/test"
 
 	v1 "github.com/crossplane/crossplane/apis/apiextensions/v1"
+	env "github.com/crossplane/crossplane/internal/controller/apiextensions/composite/environment"
 	"github.com/crossplane/crossplane/internal/xcrd"
 )
 
-func TestRender(t *testing.T) {
-	ctrl := true
-	tmpl, _ := json.Marshal(&fake.Managed{})
+func TestRenderComposedResourceBase(t *testing.T) {
+	base := runtime.RawExtension{Raw: []byte(`{"apiVersion": "example.org/v1", "kind": "Potato", "spec": {"cool": true}}`)}
+	errInvalidChar := json.Unmarshal([]byte("olala"), &fake.Composed{})
+
+	type args struct {
+		ctx context.Context
+		xr  resource.Composite
+		cd  resource.Composed
+		t   v1.ComposedTemplate
+		env *env.Environment
+	}
+	type want struct {
+		cd  resource.Composed
+		err error
+	}
+	cases := map[string]struct {
+		reason string
+		args
+		want
+	}{
+		"NoNamePrefixLabel": {
+			reason: "We should return an error if the XR is missing the name prefix label",
+			args: args{
+				xr: &fake.Composite{},
+				cd: &fake.Composed{},
+				t:  v1.ComposedTemplate{Base: base},
+			},
+			want: want{
+				cd:  &fake.Composed{},
+				err: errors.New(errNamePrefix),
+			},
+		},
+		"InvalidBaseTemplate": {
+			reason: "We should return an error if the base template can't be unmarshalled",
+			args: args{
+				xr: &fake.Composite{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{
+							xcrd.LabelKeyNamePrefixForComposed: "ola",
+						},
+					},
+				},
+				cd: &fake.Composed{},
+				t:  v1.ComposedTemplate{Base: runtime.RawExtension{Raw: []byte("olala")}},
+			},
+			want: want{
+				cd:  &fake.Composed{},
+				err: errors.Wrap(errInvalidChar, errUnmarshal),
+			},
+		},
+		"ExistingComposedResourceGVKChanged": {
+			reason: "We should return an error if unmarshalling the base template changed the composed resource's group, version, or kind",
+			args: args{
+				xr: &fake.Composite{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{
+							xcrd.LabelKeyNamePrefixForComposed: "ola",
+						},
+					},
+				},
+				cd: composed.New(composed.FromReference(corev1.ObjectReference{
+					APIVersion: "example.org/v1",
+					Kind:       "Potato",
+				})),
+				t: v1.ComposedTemplate{Base: runtime.RawExtension{Raw: []byte(`{"apiVersion": "example.org/v1", "kind": "Different"}`)}},
+			},
+			want: want{
+				cd: composed.New(composed.FromReference(corev1.ObjectReference{
+					APIVersion: "example.org/v1",
+					Kind:       "Different",
+				})),
+				err: errors.New(errKindChanged),
+			},
+		},
+		"NewComposedResource": {
+			reason: "A valid base template should apply successfully to a new (empty) composed resource",
+			args: args{
+				xr: &fake.Composite{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{
+							xcrd.LabelKeyNamePrefixForComposed: "ola",
+						},
+					},
+				},
+				cd: &fake.Composed{},
+				t:  v1.ComposedTemplate{Base: base},
+			},
+			want: want{
+				cd: &fake.Composed{
+					ObjectMeta: metav1.ObjectMeta{
+						GenerateName: "ola-",
+					},
+				},
+			},
+		},
+		"ExistingComposedResource": {
+			reason: "A valid base template should apply successfully to a new (empty) composed resource",
+			args: args{
+				xr: &fake.Composite{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{
+							xcrd.LabelKeyNamePrefixForComposed: "ola",
+						},
+					},
+				},
+				cd: composed.New(composed.FromReference(corev1.ObjectReference{
+					APIVersion: "example.org/v1",
+					Kind:       "Potato",
+					Name:       "ola-superrandom",
+				})),
+				t: v1.ComposedTemplate{Base: base},
+			},
+			want: want{
+				cd: &composed.Unstructured{Unstructured: unstructured.Unstructured{
+					Object: map[string]any{
+						"apiVersion": "example.org/v1",
+						"kind":       "Potato",
+						"metadata": map[string]any{
+							"generateName": "ola-",
+							"name":         "ola-superrandom",
+						},
+						"spec": map[string]any{
+							"cool": true,
+						},
+					},
+				}},
+			},
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			err := RenderComposedResourceBase(tc.args.ctx, tc.args.xr, tc.args.cd, tc.args.t, tc.args.env)
+			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
+				t.Errorf("\n%s\nRenderComposedResourceBase(...): -want error, +got error:\n%s", tc.reason, diff)
+			}
+			if diff := cmp.Diff(tc.want.cd, tc.args.cd); diff != "" {
+				t.Errorf("\n%s\nRenderComposedResourceBase(...): -want, +got:\n%s", tc.reason, diff)
+			}
+		})
+	}
+}
+
+func TestRenderComposedResourceMetadata(t *testing.T) {
+	controlled := &fake.Composed{
+		ObjectMeta: metav1.ObjectMeta{
+			OwnerReferences: []metav1.OwnerReference{{
+				Controller: pointer.Bool(true),
+				UID:        "very-random",
+			}},
+		},
+	}
+	errRef := meta.AddControllerReference(controlled, metav1.OwnerReference{UID: "not-very-random"})
+
+	type args struct {
+		ctx context.Context
+		xr  resource.Composite
+		cd  resource.Composed
+		t   v1.ComposedTemplate
+		env *env.Environment
+	}
+	type want struct {
+		cd  resource.Composed
+		err error
+	}
+	cases := map[string]struct {
+		reason string
+		args
+		want
+	}{
+		"ConflictingControllerReference": {
+			reason: "We should return an error if the composed resource has an existing (and different) controller reference",
+			args: args{
+				xr: &fake.Composite{
+					ObjectMeta: metav1.ObjectMeta{
+						UID: "somewhat-random",
+						Labels: map[string]string{
+							xcrd.LabelKeyNamePrefixForComposed: "prefix",
+							xcrd.LabelKeyClaimName:             "name",
+							xcrd.LabelKeyClaimNamespace:        "namespace",
+						},
+					},
+				},
+				cd: &fake.Composed{
+					ObjectMeta: metav1.ObjectMeta{
+						OwnerReferences: []metav1.OwnerReference{{
+							Controller: pointer.Bool(true),
+							UID:        "very-random",
+						}},
+					},
+				},
+				t: v1.ComposedTemplate{},
+			},
+			want: want{
+				cd: &fake.Composed{
+					ObjectMeta: metav1.ObjectMeta{
+						OwnerReferences: []metav1.OwnerReference{{
+							Controller: pointer.Bool(true),
+							UID:        "very-random",
+						}},
+						Labels: map[string]string{
+							xcrd.LabelKeyNamePrefixForComposed: "prefix",
+							xcrd.LabelKeyClaimName:             "name",
+							xcrd.LabelKeyClaimNamespace:        "namespace",
+						},
+					},
+				},
+				err: errors.Wrap(errRef, errSetControllerRef),
+			},
+		},
+		"CompatibleControllerReference": {
+			reason: "We should not return an error if the composed resource has an existing (and matching) controller reference",
+			args: args{
+				xr: &fake.Composite{
+					ObjectMeta: metav1.ObjectMeta{
+						UID: "somewhat-random",
+						Labels: map[string]string{
+							xcrd.LabelKeyNamePrefixForComposed: "prefix",
+							xcrd.LabelKeyClaimName:             "name",
+							xcrd.LabelKeyClaimNamespace:        "namespace",
+						},
+					},
+				},
+				cd: &fake.Composed{
+					ObjectMeta: metav1.ObjectMeta{
+						OwnerReferences: []metav1.OwnerReference{{
+							Controller: pointer.Bool(true),
+							UID:        "somewhat-random",
+						}},
+					},
+				},
+				t: v1.ComposedTemplate{},
+			},
+			want: want{
+				cd: &fake.Composed{
+					ObjectMeta: metav1.ObjectMeta{
+						OwnerReferences: []metav1.OwnerReference{{
+							Controller:         pointer.Bool(true),
+							BlockOwnerDeletion: pointer.Bool(true),
+							UID:                "somewhat-random",
+						}},
+						Labels: map[string]string{
+							xcrd.LabelKeyNamePrefixForComposed: "prefix",
+							xcrd.LabelKeyClaimName:             "name",
+							xcrd.LabelKeyClaimNamespace:        "namespace",
+						},
+					},
+				},
+			},
+		},
+		"NoControllerReference": {
+			reason: "We should not return an error if the composed resource has no controller reference",
+			args: args{
+				xr: &fake.Composite{
+					ObjectMeta: metav1.ObjectMeta{
+						UID: "somewhat-random",
+						Labels: map[string]string{
+							xcrd.LabelKeyNamePrefixForComposed: "prefix",
+							xcrd.LabelKeyClaimName:             "name",
+							xcrd.LabelKeyClaimNamespace:        "namespace",
+						},
+					},
+				},
+				cd: &fake.Composed{},
+				t:  v1.ComposedTemplate{},
+			},
+			want: want{
+				cd: &fake.Composed{
+					ObjectMeta: metav1.ObjectMeta{
+						OwnerReferences: []metav1.OwnerReference{{
+							Controller:         pointer.Bool(true),
+							BlockOwnerDeletion: pointer.Bool(true),
+							UID:                "somewhat-random",
+						}},
+						Labels: map[string]string{
+							xcrd.LabelKeyNamePrefixForComposed: "prefix",
+							xcrd.LabelKeyClaimName:             "name",
+							xcrd.LabelKeyClaimNamespace:        "namespace",
+						},
+					},
+				},
+			},
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			err := RenderComposedResourceMetadata(tc.args.ctx, tc.args.xr, tc.args.cd, tc.args.t, tc.args.env)
+			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
+				t.Errorf("\n%s\nRenderComposedResourceMetadata(...): -want error, +got error:\n%s", tc.reason, diff)
+			}
+			if diff := cmp.Diff(tc.want.cd, tc.args.cd); diff != "" {
+				t.Errorf("\n%s\nRenderComposedResourceMetadata(...): -want, +got:\n%s", tc.reason, diff)
+			}
+		})
+	}
+}
+
+func TestAPIDryRunRender(t *testing.T) {
 	errBoom := errors.New("boom")
 
 	type args struct {
@@ -55,105 +355,71 @@ func TestRender(t *testing.T) {
 		args
 		want
 	}{
-		"InvalidTemplate": {
-			reason: "Invalid template should not be accepted",
-			args: args{
-				cd: &fake.Composed{},
-				t:  v1.ComposedTemplate{Base: runtime.RawExtension{Raw: []byte("olala")}},
-			},
-			want: want{
-				cd:  &fake.Composed{},
-				err: errors.Wrap(errors.New("invalid character 'o' looking for beginning of value"), errUnmarshal),
-			},
-		},
-		"NoLabel": {
-			reason: "The name prefix label has to be set",
-			args: args{
-				cp: &fake.Composite{},
-				cd: &fake.Composed{ObjectMeta: metav1.ObjectMeta{Name: "cd"}},
-				t:  v1.ComposedTemplate{Base: runtime.RawExtension{Raw: tmpl}},
-			},
-			want: want{
-				cd:  &fake.Composed{ObjectMeta: metav1.ObjectMeta{Name: "cd"}},
-				err: errors.New(errNamePrefix),
-			},
-		},
-		"DryRunError": {
-			reason: "Errors dry-run creating the rendered resource to name it should be returned",
+		"SkipDryRunForNamedResources": {
+			reason: "We should not try to dry-run create resources that already have a name",
+			// We must be returning early, or else we'd hit this error.
 			client: &test.MockClient{MockCreate: test.NewMockCreateFn(errBoom)},
 			args: args{
-				cp: &fake.Composite{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{
-					xcrd.LabelKeyNamePrefixForComposed: "ola",
-					xcrd.LabelKeyClaimName:             "rola",
-					xcrd.LabelKeyClaimNamespace:        "rolans",
-				}}},
-				cd: &fake.Composed{ObjectMeta: metav1.ObjectMeta{}},
-				t:  v1.ComposedTemplate{Base: runtime.RawExtension{Raw: tmpl}},
+				cp: &fake.Composite{},
+				cd: &fake.Composed{ObjectMeta: metav1.ObjectMeta{
+					Name: "already-has-a-cool-name",
+				}},
+				t: v1.ComposedTemplate{},
 			},
 			want: want{
 				cd: &fake.Composed{ObjectMeta: metav1.ObjectMeta{
-					GenerateName: "ola-",
-					Labels: map[string]string{
-						xcrd.LabelKeyNamePrefixForComposed: "ola",
-						xcrd.LabelKeyClaimName:             "rola",
-						xcrd.LabelKeyClaimNamespace:        "rolans",
-					},
-					OwnerReferences: []metav1.OwnerReference{{Controller: &ctrl, BlockOwnerDeletion: &ctrl}},
+					Name: "already-has-a-cool-name",
+				}},
+				err: nil,
+			},
+		},
+		"SkipDryRunForResourcesWithoutGenerateName": {
+			reason: "We should not try to dry-run create resources that don't have a generate name (though that should never happen)",
+			// We must be returning early, or else we'd hit this error.
+			client: &test.MockClient{MockCreate: test.NewMockCreateFn(errBoom)},
+			args: args{
+				cp: &fake.Composite{},
+				cd: &fake.Composed{}, // Conspicously missing a generate name.
+				t:  v1.ComposedTemplate{},
+			},
+			want: want{
+				cd:  &fake.Composed{},
+				err: nil,
+			},
+		},
+		"DryRunError": {
+			reason: "Errors dry-run creating the rendered composed resource to name it should be returned",
+			client: &test.MockClient{MockCreate: test.NewMockCreateFn(errBoom)},
+			args: args{
+				cp: &fake.Composite{},
+				cd: &fake.Composed{ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "cool-resource-",
+				}},
+				t: v1.ComposedTemplate{},
+			},
+			want: want{
+				cd: &fake.Composed{ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "cool-resource-",
 				}},
 				err: errors.Wrap(errBoom, errName),
 			},
 		},
-		"ControllerError": {
-			reason: "External controller owner references should cause an exception",
-			client: &test.MockClient{MockCreate: test.NewMockCreateFn(nil)},
-			args: args{
-				cp: &fake.Composite{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{
-					xcrd.LabelKeyNamePrefixForComposed: "ola",
-					xcrd.LabelKeyClaimName:             "rola",
-					xcrd.LabelKeyClaimNamespace:        "rolans",
-				}}},
-				cd: &fake.Composed{ObjectMeta: metav1.ObjectMeta{Name: "cd",
-					OwnerReferences: []metav1.OwnerReference{{Controller: &ctrl, BlockOwnerDeletion: &ctrl,
-						UID: "random_uid"}}}},
-				t: v1.ComposedTemplate{Base: runtime.RawExtension{Raw: tmpl}},
-			},
-			want: want{
-				cd: &fake.Composed{ObjectMeta: metav1.ObjectMeta{
-					Name:         "cd",
-					GenerateName: "ola-",
-					Labels: map[string]string{
-						xcrd.LabelKeyNamePrefixForComposed: "ola",
-						xcrd.LabelKeyClaimName:             "rola",
-						xcrd.LabelKeyClaimNamespace:        "rolans",
-					},
-					OwnerReferences: []metav1.OwnerReference{{Controller: &ctrl, BlockOwnerDeletion: &ctrl,
-						UID: "random_uid"}},
-				}},
-				err: errors.Wrap(errors.Errorf("cd is already controlled by   (UID random_uid)"), errSetControllerRef),
-			},
-		},
 		"Success": {
-			reason: "Configuration should result in the right object with correct generateName",
-			client: &test.MockClient{MockCreate: test.NewMockCreateFn(nil)},
+			reason: "Updates returned by dry-run creating the composed resource should be rendered",
+			client: &test.MockClient{MockCreate: test.NewMockCreateFn(nil, func(obj client.Object) error {
+				obj.SetName("cool-resource-42")
+				return nil
+			})},
 			args: args{
-				cp: &fake.Composite{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{
-					xcrd.LabelKeyNamePrefixForComposed: "ola",
-					xcrd.LabelKeyClaimName:             "rola",
-					xcrd.LabelKeyClaimNamespace:        "rolans",
-				}}},
-				cd: &fake.Composed{ObjectMeta: metav1.ObjectMeta{Name: "cd"}},
-				t:  v1.ComposedTemplate{Base: runtime.RawExtension{Raw: tmpl}},
+				cp: &fake.Composite{},
+				cd: &fake.Composed{ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "cool-resource-",
+				}},
 			},
 			want: want{
 				cd: &fake.Composed{ObjectMeta: metav1.ObjectMeta{
-					Name:         "cd",
-					GenerateName: "ola-",
-					Labels: map[string]string{
-						xcrd.LabelKeyNamePrefixForComposed: "ola",
-						xcrd.LabelKeyClaimName:             "rola",
-						xcrd.LabelKeyClaimNamespace:        "rolans",
-					},
-					OwnerReferences: []metav1.OwnerReference{{Controller: &ctrl, BlockOwnerDeletion: &ctrl}},
+					GenerateName: "cool-resource-",
+					Name:         "cool-resource-42",
 				}},
 			},
 		},

--- a/internal/controller/apiextensions/composite/composition_render_test.go
+++ b/internal/controller/apiextensions/composite/composition_render_test.go
@@ -1,0 +1,173 @@
+/*
+Copyright 2022 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+this file except in compliance with the License. You may obtain a copy of the
+License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed
+under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+*/
+
+package composite
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/crossplane/crossplane-runtime/pkg/errors"
+	"github.com/crossplane/crossplane-runtime/pkg/resource"
+	"github.com/crossplane/crossplane-runtime/pkg/resource/fake"
+	"github.com/crossplane/crossplane-runtime/pkg/test"
+
+	v1 "github.com/crossplane/crossplane/apis/apiextensions/v1"
+	"github.com/crossplane/crossplane/internal/xcrd"
+)
+
+func TestRender(t *testing.T) {
+	ctrl := true
+	tmpl, _ := json.Marshal(&fake.Managed{})
+	errBoom := errors.New("boom")
+
+	type args struct {
+		ctx context.Context
+		cp  resource.Composite
+		cd  resource.Composed
+		t   v1.ComposedTemplate
+	}
+	type want struct {
+		cd  resource.Composed
+		err error
+	}
+	cases := map[string]struct {
+		reason string
+		client client.Client
+		args
+		want
+	}{
+		"InvalidTemplate": {
+			reason: "Invalid template should not be accepted",
+			args: args{
+				cd: &fake.Composed{},
+				t:  v1.ComposedTemplate{Base: runtime.RawExtension{Raw: []byte("olala")}},
+			},
+			want: want{
+				cd:  &fake.Composed{},
+				err: errors.Wrap(errors.New("invalid character 'o' looking for beginning of value"), errUnmarshal),
+			},
+		},
+		"NoLabel": {
+			reason: "The name prefix label has to be set",
+			args: args{
+				cp: &fake.Composite{},
+				cd: &fake.Composed{ObjectMeta: metav1.ObjectMeta{Name: "cd"}},
+				t:  v1.ComposedTemplate{Base: runtime.RawExtension{Raw: tmpl}},
+			},
+			want: want{
+				cd:  &fake.Composed{ObjectMeta: metav1.ObjectMeta{Name: "cd"}},
+				err: errors.New(errNamePrefix),
+			},
+		},
+		"DryRunError": {
+			reason: "Errors dry-run creating the rendered resource to name it should be returned",
+			client: &test.MockClient{MockCreate: test.NewMockCreateFn(errBoom)},
+			args: args{
+				cp: &fake.Composite{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{
+					xcrd.LabelKeyNamePrefixForComposed: "ola",
+					xcrd.LabelKeyClaimName:             "rola",
+					xcrd.LabelKeyClaimNamespace:        "rolans",
+				}}},
+				cd: &fake.Composed{ObjectMeta: metav1.ObjectMeta{}},
+				t:  v1.ComposedTemplate{Base: runtime.RawExtension{Raw: tmpl}},
+			},
+			want: want{
+				cd: &fake.Composed{ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "ola-",
+					Labels: map[string]string{
+						xcrd.LabelKeyNamePrefixForComposed: "ola",
+						xcrd.LabelKeyClaimName:             "rola",
+						xcrd.LabelKeyClaimNamespace:        "rolans",
+					},
+					OwnerReferences: []metav1.OwnerReference{{Controller: &ctrl, BlockOwnerDeletion: &ctrl}},
+				}},
+				err: errors.Wrap(errBoom, errName),
+			},
+		},
+		"ControllerError": {
+			reason: "External controller owner references should cause an exception",
+			client: &test.MockClient{MockCreate: test.NewMockCreateFn(nil)},
+			args: args{
+				cp: &fake.Composite{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{
+					xcrd.LabelKeyNamePrefixForComposed: "ola",
+					xcrd.LabelKeyClaimName:             "rola",
+					xcrd.LabelKeyClaimNamespace:        "rolans",
+				}}},
+				cd: &fake.Composed{ObjectMeta: metav1.ObjectMeta{Name: "cd",
+					OwnerReferences: []metav1.OwnerReference{{Controller: &ctrl, BlockOwnerDeletion: &ctrl,
+						UID: "random_uid"}}}},
+				t: v1.ComposedTemplate{Base: runtime.RawExtension{Raw: tmpl}},
+			},
+			want: want{
+				cd: &fake.Composed{ObjectMeta: metav1.ObjectMeta{
+					Name:         "cd",
+					GenerateName: "ola-",
+					Labels: map[string]string{
+						xcrd.LabelKeyNamePrefixForComposed: "ola",
+						xcrd.LabelKeyClaimName:             "rola",
+						xcrd.LabelKeyClaimNamespace:        "rolans",
+					},
+					OwnerReferences: []metav1.OwnerReference{{Controller: &ctrl, BlockOwnerDeletion: &ctrl,
+						UID: "random_uid"}},
+				}},
+				err: errors.Wrap(errors.Errorf("cd is already controlled by   (UID random_uid)"), errSetControllerRef),
+			},
+		},
+		"Success": {
+			reason: "Configuration should result in the right object with correct generateName",
+			client: &test.MockClient{MockCreate: test.NewMockCreateFn(nil)},
+			args: args{
+				cp: &fake.Composite{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{
+					xcrd.LabelKeyNamePrefixForComposed: "ola",
+					xcrd.LabelKeyClaimName:             "rola",
+					xcrd.LabelKeyClaimNamespace:        "rolans",
+				}}},
+				cd: &fake.Composed{ObjectMeta: metav1.ObjectMeta{Name: "cd"}},
+				t:  v1.ComposedTemplate{Base: runtime.RawExtension{Raw: tmpl}},
+			},
+			want: want{
+				cd: &fake.Composed{ObjectMeta: metav1.ObjectMeta{
+					Name:         "cd",
+					GenerateName: "ola-",
+					Labels: map[string]string{
+						xcrd.LabelKeyNamePrefixForComposed: "ola",
+						xcrd.LabelKeyClaimName:             "rola",
+						xcrd.LabelKeyClaimNamespace:        "rolans",
+					},
+					OwnerReferences: []metav1.OwnerReference{{Controller: &ctrl, BlockOwnerDeletion: &ctrl}},
+				}},
+			},
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			r := NewAPIDryRunRenderer(tc.client)
+			err := r.Render(tc.args.ctx, tc.args.cp, tc.args.cd, tc.args.t, nil)
+			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
+				t.Errorf("\n%s\nRender(...): -want, +got:\n%s", tc.reason, diff)
+			}
+			if diff := cmp.Diff(tc.want.cd, tc.args.cd); diff != "" {
+				t.Errorf("\n%s\nRender(...): -want, +got:\n%s", tc.reason, diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes https://github.com/crossplane/crossplane/issues/3896

I'd like to be able to:

* Share this render logic between the PTComposer and PTFComposer
* In the PTFComposer, run some before Functions, and some after

To that end I've refactored the single "render a composed resource" function into a pipeline of smaller functions that when combined will render the composed resource. I also added tests for a few cases that were not previously covered.

I have:

- [ ] Read and followed Crossplane's [contribution process].
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9

It hasn't yet.