### PR TITLE
chore(renovate): enable PRs for all non-kubernetes dependencies

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -21,7 +21,7 @@
   "labels": ["automated"],
   "regexManagers": [
     {
-      "description": "Bump Go version ued in workflows",
+      "description": "Bump Go version used in workflows",
       "fileMatch": ["^\\.github\\/workflows\\/[^/]+\\.ya?ml$"],
       "matchStrings": [
         "GO_VERSION: '(?<currentValue>.*?)'\\n"
@@ -69,12 +69,12 @@
       matchBaseBranches: [ "/^release-.*/"],
       enabled: false,
     }, {
-      "description": "Still update docker images on release branches though",
+      "description": "Still update Docker images on release branches though",
       "matchDatasources": ["docker"],
       matchBaseBranches: [ "/^release-.*/"],
       enabled: true,
     }, {
-      "description": "Only get docker image updates every 2 weeks to reduce noise",
+      "description": "Only get Docker image updates every 2 weeks to reduce noise",
       "matchDatasources": ["docker"],
       "schedule": ["every 2 week on monday"],
       enabled: true,

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,7 +1,8 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:base"
+    "config:base",
+    "helpers:pinGitHubActionDigests"
   ],
 // We only want renovate to rebase PRs when they have conflicts,
 // default "auto" mode is not required.
@@ -20,8 +21,7 @@
   "labels": ["automated"],
   "regexManagers": [
     {
-// We want a PR to bump Go versions used through env variables in any Github
-// Actions, taking it from the official Github repository.
+      "description": "Bump Go version ued in workflows",
       "fileMatch": ["^\\.github\\/workflows\\/[^/]+\\.ya?ml$"],
       "matchStrings": [
         "GO_VERSION: '(?<currentValue>.*?)'\\n"
@@ -29,9 +29,7 @@
       "datasourceTemplate": "golang-version",
       "depNameTemplate": "golang"
     }, {
-// We want a PR to bump golangci-lint versions used through env variables in
-// any Github Actions or Makefile, taking it from the official Github
-// repository tags.
+      "description": "Bump golangci-lint version in workflows and the Makefile",
       "fileMatch": ["^\\.github\\/workflows\\/[^/]+\\.ya?ml$","^Makefile$"],
       "matchStrings": [
         "GOLANGCI_VERSION: 'v(?<currentValue>.*?)'\\n",
@@ -41,9 +39,7 @@
       "depNameTemplate": "golangci/golangci-lint",
       "extractVersionTemplate": "^v(?<version>.*)$"
     }, {
-// We want a PR to bump the helm version used through env variables in
-// any Github Actions or Makefile, taking it from the official Github
-// repository tags.
+      "description": "Bump helm version in the Makefile",
       "fileMatch": ["^Makefile$"],
       "matchStrings": [
         "HELM3_VERSION = (?<currentValue>.*?)\\n"
@@ -51,9 +47,7 @@
       "datasourceTemplate": "github-tags",
       "depNameTemplate": "helm/helm",
     }, {
-// We want a PR to bump the kind version used through env variables in
-// any Github Actions or Makefile, taking it from the official Github
-// repository tags.
+      "description": "Bump kind version in the Makefile",
       "fileMatch": ["^Makefile$"],
       "matchStrings": [
         "KIND_VERSION = (?<currentValue>.*?)\\n"
@@ -66,23 +60,26 @@
   "vulnerabilityAlerts": {
     "enabled": true
   },
+  "osvVulnerabilityAlerts": true,
+// Renovate evaluates all packageRules in order, so low priority rules should
+// be at the beginning, high priority at the end
   "packageRules": [
-// We don't want dependency updates which are not security related for
-// release branches, except for docker images
     {
+      "description": "Ignore non-security related updates to release branches",
       matchBaseBranches: [ "/^release-.*/"],
       enabled: false,
     }, {
+      "description": "Still update docker images on release branches though",
       "matchDatasources": ["docker"],
       matchBaseBranches: [ "/^release-.*/"],
       enabled: true,
     }, {
+      "description": "Only get docker image updates every 2 weeks to reduce noise",
       "matchDatasources": ["docker"],
       "schedule": ["every 2 week on monday"],
       enabled: true,
     }, {
-// We need to ignore k8s.io/client-go older versions as they switched to
-// semantic version and old tags are still available in the repo.
+      "description": "Ignore k8s.io/client-go older versions, they switched to semantic version and old tags are still available in the repo",
       "matchDatasources": [
         "go"
       ],
@@ -91,44 +88,26 @@
       ],
       "allowedVersions": "<1.0",
     }, {
-// We want a single PR for all bumps to Go dependencies, but only if there are
-// known vulnerabilities in the current version. We need to ignore k8s related
-// dependencies too as they should be first updated on crossplane-runtime.
+      "description": "Ignore k8s dependencies, should be updated on crossplane-runtime",
       "matchDatasources": [
         "go"
       ],
-      "matchPackagePatterns": [
-        "*"
+      "matchPackagePrefixes": [
+        "k8s.io",
+        "sigs.k8s.io"
       ],
       "enabled": false,
-      "matchUpdateTypes": [
-        "major",
-        "minor",
-        "patch",
-        "digest"
+    },{
+      "description": "Only get dependency digest updates every month to reduce noise",
+      "matchDatasources": [
+        "go"
       ],
-      "groupName": "all go dependencies"
+      "matchUpdateTypes": [
+        "digest",
+      ],
+      "extends": ["schedule:monthly"],
     }, {
-// We want a single PR for all non-major bumps of Github Actions
-      "matchDepTypes": [
-        "action"
-      ],
-      "matchUpdateTypes": [
-        "minor",
-        "patch",
-        "digest"
-      ],
-      "groupName": "all non-major github action",
-      "pinDigests": true
-    },{
-// We want dedicated PRs for each major bump to Github Actions
-      "matchDepTypes": [
-        "action"
-      ],
-      "pinDigests": true
-    },{
-// We disable updates actions for oss-fuzz, as it's not using tags, we'll just
-// point to master branch
+      "description": "Ignore oss-fuzz, it's not using tags, we'll stick to master",
       "matchDepTypes": [
         "action"
       ],


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Simplified config to address #4127.

We initially decided to only have security-related updates to dependencies, see https://github.com/crossplane/crossplane/pull/3575#discussion_r1072854569, but that complicates a lot dealing with indirect dependencies (see #4127), I feel like we now have been using renovate enough to switch back to opening PRs for all updates only on master, we can always close the PRs if we don't think we need them, but at least we'll know about the updates and we can always reopen them if needed. We'd still keep the recently introduced rule to disable kubernetes related updates, as those should come in as part of `crossplane-runtime` version bumps first.

We shouldn't fear regressions being introduced, we have a strong suite of unit tests and work is being done to improve also on the E2Es, #4101.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

Deployed in my fork, see https://github.com/phisco/crossplane/issues/137 for the PRs that would be created at the moment.
<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
