### PR TITLE
chore(Dockerfile): use COPY instead of ADD

### DIFF
--- a/cluster/images/crossplane/Dockerfile
+++ b/cluster/images/crossplane/Dockerfile
@@ -3,9 +3,9 @@ FROM gcr.io/distroless/static@sha256:7198a357ff3a8ef750b041324873960cf2153c11cc5
 ARG TARGETOS
 ARG TARGETARCH
 
-ADD bin/$TARGETOS\_$TARGETARCH/crossplane /usr/local/bin/
-ADD crds /crds
-ADD webhookconfigurations /webhookconfigurations
+COPY bin/$TARGETOS\_$TARGETARCH/crossplane /usr/local/bin/
+COPY crds /crds
+COPY webhookconfigurations /webhookconfigurations
 EXPOSE 8080
 USER 65532
 ENTRYPOINT ["crossplane"]

--- a/cluster/images/xfn/Dockerfile
+++ b/cluster/images/xfn/Dockerfile
@@ -11,7 +11,7 @@ ARG TARGETARCH
 # time.
 RUN apt-get update && apt-get install -y ca-certificates crun && rm -rf /var/lib/apt/lists/*
 
-ADD bin/${TARGETOS}\_${TARGETARCH}/xfn /usr/local/bin/
+COPY bin/${TARGETOS}\_${TARGETARCH}/xfn /usr/local/bin/
 
 # We run xfn as root in order to grant it CAP_SETUID and CAP_SETGID, which are
 # required in order to create a user namespace with more than one available UID


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
It's considered to be a best practice to use `COPY` instead of `ADD` by Docker's [docs](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#add-or-copy).
It's also reported by hadolint:
```sh
$ docker run --rm -i hadolint/hadolint < cluster/images/crossplane/Dockerfile
...
Status: Downloaded newer image for hadolint/hadolint:latest
-:6 DL3020 error: Use COPY instead of ADD for files and folders
-:7 DL3020 error: Use COPY instead of ADD for files and folders
-:8 DL3020 error: Use COPY instead of ADD for files and folders

$ docker run --rm -i hadolint/hadolint < cluster/images/xfn/Dockerfile
...
-:14 DL3020 error: Use COPY instead of ADD for files and folders
```

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

Backport will fail for 1.10, because of the missing xfn Dockerfile, we'll do that by hand later.

### How has this code been tested

Locally built and deployed Crossplane successfully.
<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
