### PR TITLE
fix(xfn): close grpc connection with errors on options

### DIFF
--- a/internal/controller/apiextensions/composite/composition_ptf.go
+++ b/internal/controller/apiextensions/composite/composition_ptf.go
@@ -805,6 +805,8 @@ func RunFunction(ctx context.Context, fnio *iov1alpha1.FunctionIO, fn *v1.Contai
 	if err != nil {
 		return nil, errors.Wrap(err, errDialRunner)
 	}
+	// Remember to close the connection, we are not deferring it to be able to properly handle errors,
+	// without having to use a named return.
 
 	req := &fnv1alpha1.RunFunctionRequest{
 		Image:             fn.Image,
@@ -815,6 +817,7 @@ func RunFunction(ctx context.Context, fnio *iov1alpha1.FunctionIO, fn *v1.Contai
 
 	for _, opt := range o {
 		if err := opt(ctx, fn, req); err != nil {
+			_ = conn.Close()
 			return nil, errors.Wrap(err, errApplyRunFunctionOption)
 		}
 	}


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Closing the gRPC connection to the function runner in case of errors while applying options, to avoid leakages.

I didn't move it to a `defer` as it looks there is only one case in which we care about it, and handling that properly would have been not so straightforward, but I'm open to discussing it.

Added comment to avoid forgetting about it in the future.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

Locally deployed.

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
