### PR TITLE
Update roadmap links to include info panel

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,9 +88,9 @@ Crossplane is under the Apache 2.0 license.
 [community meeting time]: https://www.thetimezoneconverter.com/?t=10:00&tz=PT%20%28Pacific%20Time%29
 [Current agenda and past meeting notes]: https://docs.google.com/document/d/1q_sp2jLQsDEOX7Yug6TPOv7Fwrys6EwcF5Itxjkno7Y/edit?usp=sharing
 [Past meeting recordings]: https://www.youtube.com/playlist?list=PL510POnNVaaYYYDSICFSNWFqNbx1EMr-M
-[roadmap and releases board]: https://github.com/orgs/crossplane/projects/20
+[roadmap and releases board]: https://github.com/orgs/crossplane/projects/20/views/3?pane=info
 [cncf]: https://www.cncf.io/
 [community calendar]: https://calendar.google.com/calendar/embed?src=c_2cdn0hs9e2m05rrv1233cjoj1k%40group.calendar.google.com
 [releases]: https://github.com/crossplane/crossplane/releases
 [ADOPTERS.md]: ADOPTERS.md
-[Crossplane Roadmap]: https://github.com/orgs/crossplane/projects/20/views/3
+[Crossplane Roadmap]: https://github.com/orgs/crossplane/projects/20/views/3?pane=info

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -11,4 +11,4 @@ delivery timeline.
 
 [Crossplane Roadmap]
 
-[Crossplane Roadmap]: https://github.com/orgs/crossplane/projects/20/views/3
+[Crossplane Roadmap]: https://github.com/orgs/crossplane/projects/20/views/3?pane=info


### PR DESCRIPTION
### Description of your changes

This PR updates all links in the crossplane repo to the public roadmap so that the info panel is also shown upon landing on the roadmap.  All the important expectation setting details are included in that info panel, which GitHub does not display by default, so we would like to increase the chances that users will see it.

Compare:

* with info panel: https://github.com/orgs/crossplane/projects/20/views/3?pane=info
* without info panel: https://github.com/orgs/crossplane/projects/20/views/3

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

I have tested this by navigating to my fork/branch, verifying the rendered markdown, and clicking on the links

e.g., https://github.com/jbw976/crossplane/tree/roadmap-info#roadmap