### PR TITLE
Return nil error when we successfully run a MatchCondition check

### DIFF
--- a/apis/apiextensions/fn/io/v1alpha1/functionio_types.go
+++ b/apis/apiextensions/fn/io/v1alpha1/functionio_types.go
@@ -17,8 +17,11 @@ limitations under the License.
 package v1alpha1
 
 import (
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+
+	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
 )
 
 // +kubebuilder:object:root=true
@@ -239,11 +242,11 @@ type DesiredReadinessCheck struct {
 type MatchConditionReadinessCheck struct {
 	// Type indicates the type of condition you'd like to use.
 	// +kubebuilder:default="Ready"
-	Type string `json:"type"`
+	Type xpv1.ConditionType `json:"type"`
 
 	// Status is the status of the condition you'd like to match.
 	// +kubebuilder:default="True"
-	Status string `json:"status"`
+	Status corev1.ConditionStatus `json:"status"`
 }
 
 // Result is an optional list that can be used by function to emit results for

--- a/apis/apiextensions/v1/composition_common.go
+++ b/apis/apiextensions/v1/composition_common.go
@@ -24,6 +24,8 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
+	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
+
 	"github.com/crossplane/crossplane/internal/validation/errors"
 )
 
@@ -157,11 +159,11 @@ type ReadinessCheck struct {
 type MatchConditionReadinessCheck struct {
 	// Type indicates the type of condition you'd like to use.
 	// +kubebuilder:default="Ready"
-	Type string `json:"type"`
+	Type xpv1.ConditionType `json:"type"`
 
 	// Status is the status of the condition you'd like to match.
 	// +kubebuilder:default="True"
-	Status string `json:"status"`
+	Status corev1.ConditionStatus `json:"status"`
 }
 
 // Validate checks if the match condition is logically valid.

--- a/apis/apiextensions/v1/zz_generated.conversion.go
+++ b/apis/apiextensions/v1/zz_generated.conversion.go
@@ -402,8 +402,8 @@ func (c *GeneratedRevisionSpecConverter) v1MapTransformToV1MapTransform(source M
 }
 func (c *GeneratedRevisionSpecConverter) v1MatchConditionReadinessCheckToV1MatchConditionReadinessCheck(source MatchConditionReadinessCheck) MatchConditionReadinessCheck {
 	var v1MatchConditionReadinessCheck MatchConditionReadinessCheck
-	v1MatchConditionReadinessCheck.Type = source.Type
-	v1MatchConditionReadinessCheck.Status = source.Status
+	v1MatchConditionReadinessCheck.Type = v13.ConditionType(source.Type)
+	v1MatchConditionReadinessCheck.Status = v1.ConditionStatus(source.Status)
 	return v1MatchConditionReadinessCheck
 }
 func (c *GeneratedRevisionSpecConverter) v1MatchTransformPatternToV1MatchTransformPattern(source MatchTransformPattern) MatchTransformPattern {

--- a/apis/apiextensions/v1beta1/zz_generated.composition_common.go
+++ b/apis/apiextensions/v1beta1/zz_generated.composition_common.go
@@ -26,6 +26,8 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
+	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
+
 	"github.com/crossplane/crossplane/internal/validation/errors"
 )
 
@@ -159,11 +161,11 @@ type ReadinessCheck struct {
 type MatchConditionReadinessCheck struct {
 	// Type indicates the type of condition you'd like to use.
 	// +kubebuilder:default="Ready"
-	Type string `json:"type"`
+	Type xpv1.ConditionType `json:"type"`
 
 	// Status is the status of the condition you'd like to match.
 	// +kubebuilder:default="True"
-	Status string `json:"status"`
+	Status corev1.ConditionStatus `json:"status"`
 }
 
 // Validate checks if the match condition is logically valid.

--- a/internal/controller/apiextensions/composite/ready.go
+++ b/internal/controller/apiextensions/composite/ready.go
@@ -227,7 +227,7 @@ func (c ReadinessCheck) IsReady(p *fieldpath.Paved, o ConditionedObject) (bool, 
 	case ReadinessCheckTypeMatchCondition:
 		// we should have checked this outside of this function
 		val := o.GetCondition(xpv1.ConditionType(c.MatchCondition.Type))
-		return string(val.Status) == c.MatchCondition.Status, errors.New(errInvalidCheck)
+		return string(val.Status) == c.MatchCondition.Status, nil
 	}
 
 	return false, nil

--- a/internal/controller/apiextensions/composite/ready.go
+++ b/internal/controller/apiextensions/composite/ready.go
@@ -19,6 +19,7 @@ package composite
 import (
 	"context"
 
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/utils/pointer"
 
 	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
@@ -71,20 +72,17 @@ type ReadinessCheck struct {
 	MatchInteger *int64
 
 	// MatchCondition is the condition you'd like to match if you're using "MatchCondition" type.
-	// +optional
-	MatchCondition *MatchConditionReadinessCheck `json:"matchCondition,omitempty"`
+	MatchCondition *MatchConditionReadinessCheck
 }
 
 // MatchConditionReadinessCheck is used to indicate how to tell whether a resource is ready
 // for consumption
 type MatchConditionReadinessCheck struct {
 	// Type indicates the type of condition you'd like to use.
-	// +kubebuilder:default="Ready"
-	Type string `json:"type,omitempty"`
+	Type xpv1.ConditionType
 
 	// Status is the status of the condition you'd like to match.
-	// +kubebuilder:default="True"
-	Status string `json:"status,omitempty"`
+	Status corev1.ConditionStatus
 }
 
 // ReadinessCheckFromV1 derives a ReadinessCheck from the supplied v1.ReadinessCheck.
@@ -226,8 +224,8 @@ func (c ReadinessCheck) IsReady(p *fieldpath.Paved, o ConditionedObject) (bool, 
 		return val == *c.MatchInteger, nil
 	case ReadinessCheckTypeMatchCondition:
 		// we should have checked this outside of this function
-		val := o.GetCondition(xpv1.ConditionType(c.MatchCondition.Type))
-		return string(val.Status) == c.MatchCondition.Status, nil
+		val := o.GetCondition(c.MatchCondition.Type)
+		return val.Status == c.MatchCondition.Status, nil
 	}
 
 	return false, nil

--- a/internal/controller/apiextensions/composite/ready.go
+++ b/internal/controller/apiextensions/composite/ready.go
@@ -223,7 +223,6 @@ func (c ReadinessCheck) IsReady(p *fieldpath.Paved, o ConditionedObject) (bool, 
 		}
 		return val == *c.MatchInteger, nil
 	case ReadinessCheckTypeMatchCondition:
-		// we should have checked this outside of this function
 		val := o.GetCondition(c.MatchCondition.Type)
 		return val.Status == c.MatchCondition.Status, nil
 	}

--- a/internal/controller/apiextensions/composite/ready_test.go
+++ b/internal/controller/apiextensions/composite/ready_test.go
@@ -73,7 +73,6 @@ func TestIsReady(t *testing.T) {
 				rc: []ReadinessCheck{{
 					Type: ReadinessCheckTypeMatchCondition,
 					MatchCondition: &MatchConditionReadinessCheck{
-						// TODO(negz): These should not be plain strings.
 						Type:   xpv1.TypeReady,
 						Status: corev1.ConditionTrue,
 					},
@@ -90,7 +89,6 @@ func TestIsReady(t *testing.T) {
 				rc: []ReadinessCheck{{
 					Type: ReadinessCheckTypeMatchCondition,
 					MatchCondition: &MatchConditionReadinessCheck{
-						// TODO(negz): These should not be plain strings.
 						Type:   xpv1.TypeReady,
 						Status: corev1.ConditionTrue,
 					},

--- a/internal/controller/apiextensions/composite/ready_test.go
+++ b/internal/controller/apiextensions/composite/ready_test.go
@@ -74,8 +74,8 @@ func TestIsReady(t *testing.T) {
 					Type: ReadinessCheckTypeMatchCondition,
 					MatchCondition: &MatchConditionReadinessCheck{
 						// TODO(negz): These should not be plain strings.
-						Type:   string(xpv1.TypeReady),
-						Status: string(corev1.ConditionTrue),
+						Type:   xpv1.TypeReady,
+						Status: corev1.ConditionTrue,
 					},
 				}},
 			},
@@ -91,8 +91,8 @@ func TestIsReady(t *testing.T) {
 					Type: ReadinessCheckTypeMatchCondition,
 					MatchCondition: &MatchConditionReadinessCheck{
 						// TODO(negz): These should not be plain strings.
-						Type:   string(xpv1.TypeReady),
-						Status: string(corev1.ConditionTrue),
+						Type:   xpv1.TypeReady,
+						Status: corev1.ConditionTrue,
 					},
 				}},
 			},

--- a/internal/controller/apiextensions/composite/ready_test.go
+++ b/internal/controller/apiextensions/composite/ready_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/utils/pointer"
 
 	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
@@ -60,6 +61,40 @@ func TestIsReady(t *testing.T) {
 			reason: "If no custom check is given, Ready condition should be used",
 			args: args{
 				o: composed.New(composed.WithConditions(xpv1.Unavailable())),
+			},
+			want: want{
+				ready: false,
+			},
+		},
+		"MatchConditionReady": {
+			reason: "If no custom check is given, Ready condition should be used",
+			args: args{
+				o: composed.New(composed.WithConditions(xpv1.Available())),
+				rc: []ReadinessCheck{{
+					Type: ReadinessCheckTypeMatchCondition,
+					MatchCondition: &MatchConditionReadinessCheck{
+						// TODO(negz): These should not be plain strings.
+						Type:   string(xpv1.TypeReady),
+						Status: string(corev1.ConditionTrue),
+					},
+				}},
+			},
+			want: want{
+				ready: true,
+			},
+		},
+		"MatchConditionNotReady": {
+			reason: "If no custom check is given, Ready condition should be used",
+			args: args{
+				o: composed.New(composed.WithConditions(xpv1.Unavailable())),
+				rc: []ReadinessCheck{{
+					Type: ReadinessCheckTypeMatchCondition,
+					MatchCondition: &MatchConditionReadinessCheck{
+						// TODO(negz): These should not be plain strings.
+						Type:   string(xpv1.TypeReady),
+						Status: string(corev1.ConditionTrue),
+					},
+				}},
 			},
 			want: want{
 				ready: false,

--- a/internal/controller/apiextensions/composite/ready_test.go
+++ b/internal/controller/apiextensions/composite/ready_test.go
@@ -67,7 +67,7 @@ func TestIsReady(t *testing.T) {
 			},
 		},
 		"MatchConditionReady": {
-			reason: "If no custom check is given, Ready condition should be used",
+			reason: "If a match condition is explicitly specified it should be used",
 			args: args{
 				o: composed.New(composed.WithConditions(xpv1.Available())),
 				rc: []ReadinessCheck{{
@@ -83,7 +83,7 @@ func TestIsReady(t *testing.T) {
 			},
 		},
 		"MatchConditionNotReady": {
-			reason: "If no custom check is given, Ready condition should be used",
+			reason: "If a match condition is explicitly specified it should be used",
 			args: args{
 				o: composed.New(composed.WithConditions(xpv1.Unavailable())),
 				rc: []ReadinessCheck{{


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
I discovered this bug (which only exists in master) while adding E2E tests in https://github.com/crossplane/crossplane/pull/4187. 🙂 

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9

I found that the Composition E2E tests I implemented in https://github.com/crossplane/crossplane/pull/4187 failed without this change, but passed after it. I also added some unit tests to cover this case.