### PR TITLE
composite: add fuzzer

### DIFF
--- a/internal/controller/apiextensions/composite/fuzz_test.go
+++ b/internal/controller/apiextensions/composite/fuzz_test.go
@@ -21,9 +21,13 @@ import (
 	"testing"
 
 	fuzz "github.com/AdaLogics/go-fuzz-headers"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/yaml"
 
+	"github.com/crossplane/crossplane-runtime/pkg/reconciler/managed"
 	"github.com/crossplane/crossplane-runtime/pkg/resource/fake"
+	"github.com/crossplane/crossplane-runtime/pkg/resource/unstructured/composite"
 
 	v1 "github.com/crossplane/crossplane/apis/apiextensions/v1"
 	pkgmetav1 "github.com/crossplane/crossplane/apis/pkg/meta/v1"
@@ -143,5 +147,42 @@ func FuzzTransform(f *testing.F) {
 		}
 
 		_, _ = Resolve(*t, i)
+	})
+}
+
+func YamlToUnstructured(yamlStr string) (*unstructured.Unstructured, error) {
+	obj := make(map[string]interface{})
+	err := yaml.Unmarshal([]byte(yamlStr), &obj)
+	if err != nil {
+		return nil, err
+	}
+	return &unstructured.Unstructured{Object: obj}, nil
+}
+
+func FuzzPTFComposer(f *testing.F) {
+	f.Fuzz(func(t *testing.T, data []byte, yamlData string) {
+		ff := fuzz.NewConsumer(data)
+		state := &PTFCompositionState{}
+		unstr, err := YamlToUnstructured(yamlData)
+		if err != nil {
+			return
+		}
+		if unstr.Object == nil {
+			return
+		}
+		state.Composite = &composite.Unstructured{Unstructured: *unstr}
+		cd := &managed.ConnectionDetails{}
+		ff.GenerateStruct(cd)
+		state.ConnectionDetails = *cd
+		_, err = FunctionIOObserved(state)
+		if err != nil {
+			return
+		}
+
+		_, err = FunctionIODesired(state)
+		if err != nil {
+			return
+		}
+		UpdateResourceRefs(state)
 	})
 }


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Adds a fuzzer for the composite controller. It calls `FunctionIOObserved`, `FunctionIODesired`, `UpdateResourceRefs `in the same order as the controller does to mimic real-world data flow.

I have:

- [ ] Read and followed Crossplane's [contribution process].
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

`go test -fuzz=FuzzPTFComposer`
<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
