### PR TITLE
fix(xfn): set max layers number limit for images

### DIFF
--- a/internal/oci/store/overlay/store_overlay.go
+++ b/internal/oci/store/overlay/store_overlay.go
@@ -173,8 +173,11 @@ func (c *CachingBundler) Bundle(ctx context.Context, i ociv1.Image, id string, o
 	if err != nil {
 		return nil, errors.Wrap(err, errGetLayers)
 	}
-
-	lowerPaths := make([]string, len(layers))
+	nLayers := len(layers)
+	if nLayers > store.MaxLayers {
+		return nil, errors.Errorf(store.ErrFmtTooManyLayers, nLayers, store.MaxLayers)
+	}
+	lowerPaths := make([]string, nLayers)
 	for i := range layers {
 		p, err := c.layer.Resolve(ctx, layers[i], layers[:i]...)
 		if err != nil {

--- a/internal/oci/store/overlay/store_overlay.go
+++ b/internal/oci/store/overlay/store_overlay.go
@@ -169,15 +169,16 @@ func (c *CachingBundler) Bundle(ctx context.Context, i ociv1.Image, id string, o
 		return nil, errors.Wrap(err, errReadConfigFile)
 	}
 
+	if err := store.Validate(i); err != nil {
+		return nil, err
+	}
+
 	layers, err := i.Layers()
 	if err != nil {
 		return nil, errors.Wrap(err, errGetLayers)
 	}
-	nLayers := len(layers)
-	if nLayers > store.MaxLayers {
-		return nil, errors.Errorf(store.ErrFmtTooManyLayers, nLayers, store.MaxLayers)
-	}
-	lowerPaths := make([]string, nLayers)
+
+	lowerPaths := make([]string, len(layers))
 	for i := range layers {
 		p, err := c.layer.Resolve(ctx, layers[i], layers[:i]...)
 		if err != nil {

--- a/internal/oci/store/store.go
+++ b/internal/oci/store/store.go
@@ -78,6 +78,12 @@ const (
 	errOpenLayer        = "cannot open layer"
 	errStatLayer        = "cannot stat layer"
 	errCheckExistence   = "cannot determine whether layer exists"
+	ErrFmtTooManyLayers = "image has too many layers: %d (max %d)"
+)
+
+var (
+	// MaxLayers is the maximum number of layers an image can have.
+	MaxLayers = 256
 )
 
 // A Bundler prepares OCI runtime bundles for use by an OCI runtime.
@@ -159,7 +165,7 @@ func (i *Image) Image(h ociv1.Hash) (ociv1.Image, error) {
 }
 
 // WriteImage writes the supplied image to the store.
-func (i *Image) WriteImage(img ociv1.Image) error {
+func (i *Image) WriteImage(img ociv1.Image) error { //nolint:gocyclo // TODO(phisco): Refactor to reduce complexity.
 	d, err := img.Digest()
 	if err != nil {
 		return errors.Wrap(err, errGetDigest)
@@ -202,6 +208,10 @@ func (i *Image) WriteImage(img ociv1.Image) error {
 	layers, err := img.Layers()
 	if err != nil {
 		return errors.Wrap(err, errGetLayers)
+	}
+
+	if nLayers := len(layers); nLayers > MaxLayers {
+		return errors.Errorf(ErrFmtTooManyLayers, nLayers, MaxLayers)
 	}
 
 	g := &errgroup.Group{}

--- a/internal/oci/store/uncompressed/store_uncompressed.go
+++ b/internal/oci/store/uncompressed/store_uncompressed.go
@@ -104,8 +104,8 @@ func (c *Bundler) Bundle(ctx context.Context, i ociv1.Image, id string, o ...spe
 	}
 	b := Bundle{path: path}
 
-	if nLayers := len(layers); nLayers > store.MaxLayers {
-		return nil, errors.Errorf(store.ErrFmtTooManyLayers, nLayers, store.MaxLayers)
+	if err := store.Validate(i); err != nil {
+		return nil, err
 	}
 
 	for _, l := range layers {

--- a/internal/oci/store/uncompressed/store_uncompressed.go
+++ b/internal/oci/store/uncompressed/store_uncompressed.go
@@ -104,6 +104,10 @@ func (c *Bundler) Bundle(ctx context.Context, i ociv1.Image, id string, o ...spe
 	}
 	b := Bundle{path: path}
 
+	if nLayers := len(layers); nLayers > store.MaxLayers {
+		return nil, errors.Errorf(store.ErrFmtTooManyLayers, nLayers, store.MaxLayers)
+	}
+
 	for _, l := range layers {
 		tb, err := l.Uncompressed()
 		if err != nil {


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Enforce maximum number of layers for images, setting it to 256 by default as a symbolic upper limit which we should never  hit except if something shady is going on.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

Manually deploying crossplane with xfn enabled.

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
