### PR TITLE
Set provider condition on package fetch error

### DIFF
--- a/internal/controller/pkg/manager/reconciler.go
+++ b/internal/controller/pkg/manager/reconciler.go
@@ -286,7 +286,13 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 	if err != nil {
 		log.Debug(errUnpack, "error", err)
 		err = errors.Wrap(err, errUnpack)
+		p.SetConditions(v1.Unpacking().WithMessage(err.Error()))
 		r.record.Event(p, event.Warning(reasonUnpack, err))
+
+		if updateErr := r.client.Status().Update(ctx, p); updateErr != nil {
+			return reconcile.Result{}, errors.Wrap(updateErr, errUpdateStatus)
+		}
+
 		return reconcile.Result{}, err
 	}
 


### PR DESCRIPTION
### Description of your changes

Fixes https://github.com/crossplane/crossplane/issues/4196

Before this, the only way to notice a 404 when fetching a revision was the following event:

```
37s   Warning   UnpackPackage   provider/provider-gcp   cannot unpack package: failed to fetch package digest from remote: failed to fetch package descriptor with a GET request after a previous HEAD request failure: HEAD https://xpkg.upbound.io/v2/upbound/provider-gcp/manifests/latest: unexpected status code 404 Not Found (HEAD responses have no body, use GET for details): GET https://xpkg.upbound.io/v2/upbound/provider-gcp/manifests/latest: MANIFEST_UNKNOWN: manifest unknown; map[Tag:latest]
```

The conditions of the provider object were never set, making diagnoses hard, especially as this happens to first-time users of Crossplane when installing the first provider.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

Added a unit test.

[contribution process]: https://git.io/fj2m9