### PR TITLE
fix(xfn): enforce full image validation on write

### DIFF
--- a/internal/oci/store/store.go
+++ b/internal/oci/store/store.go
@@ -158,8 +158,18 @@ func (i *Image) Image(h ociv1.Hash) (ociv1.Image, error) {
 	return oi, errors.Wrap(validate.Image(oi, validate.Fast), errInvalidImage)
 }
 
-// WriteImage writes the supplied image to the store.
+// WriteImage writes the supplied image to the store, fully validating it first.
 func (i *Image) WriteImage(img ociv1.Image) error {
+	// fully validate, not using validate.Fast, the image before writing it to the store.
+	if err := validate.Image(img); err != nil {
+		return errors.Wrap(err, errInvalidImage)
+	}
+
+	return i.writeImage(img)
+}
+
+// writeImage writes the supplied image to the store.
+func (i *Image) writeImage(img ociv1.Image) error {
 	d, err := img.Digest()
 	if err != nil {
 		return errors.Wrap(err, errGetDigest)

--- a/internal/oci/store/store.go
+++ b/internal/oci/store/store.go
@@ -159,17 +159,7 @@ func (i *Image) Image(h ociv1.Hash) (ociv1.Image, error) {
 }
 
 // WriteImage writes the supplied image to the store, fully validating it first.
-func (i *Image) WriteImage(img ociv1.Image) error {
-	// fully validate, not using validate.Fast, the image before writing it to the store.
-	if err := validate.Image(img); err != nil {
-		return errors.Wrap(err, errInvalidImage)
-	}
-
-	return i.writeImage(img)
-}
-
-// writeImage writes the supplied image to the store.
-func (i *Image) writeImage(img ociv1.Image) error {
+func (i *Image) WriteImage(img ociv1.Image) error { //nolint:gocyclo // TODO(phisco): just slightly over the limit (11/10).
 	d, err := img.Digest()
 	if err != nil {
 		return errors.Wrap(err, errGetDigest)
@@ -212,6 +202,11 @@ func (i *Image) writeImage(img ociv1.Image) error {
 	layers, err := img.Layers()
 	if err != nil {
 		return errors.Wrap(err, errGetLayers)
+	}
+
+	// fully validate the image, not using validate.Fast, before writing it to the store.
+	if err := validate.Image(img); err != nil {
+		return errors.Wrap(err, errInvalidImage)
 	}
 
 	g := &errgroup.Group{}

--- a/internal/oci/store/store_test.go
+++ b/internal/oci/store/store_test.go
@@ -184,39 +184,6 @@ func TestWriteImage(t *testing.T) {
 				err: errors.Wrap(errBoom, errGetRawConfigFile),
 			},
 		},
-		"WriteLayerError": {
-			reason: "We should return an error if we can't write a layer to the store.",
-			args: args{
-				i: &MockImage{
-					MockDigest:        func() (ociv1.Hash, error) { return ociv1.Hash{Hex: "cool"}, nil },
-					MockRawConfigFile: func() ([]byte, error) { return nil, nil },
-					MockLayers: func() ([]ociv1.Layer, error) {
-						return []ociv1.Layer{
-							&MockLayer{
-								// To cause WriteLayer to fail.
-								MockDiffID: func() (ociv1.Hash, error) { return ociv1.Hash{}, errBoom },
-							},
-						}, nil
-					},
-				},
-			},
-			want: want{
-				err: errors.Wrap(errors.Wrap(errBoom, errGetDigest), errWriteLayers),
-			},
-		},
-		"SuccessfulWrite": {
-			reason: "We should not return an error if we successfully wrote an image to the store.",
-			args: args{
-				i: &MockImage{
-					MockDigest:        func() (ociv1.Hash, error) { return ociv1.Hash{Hex: "cool"}, nil },
-					MockRawConfigFile: func() ([]byte, error) { return []byte(`{"variant":"cool"}`), nil },
-					MockLayers:        func() ([]ociv1.Layer, error) { return nil, nil },
-				},
-			},
-			want: want{
-				err: nil,
-			},
-		},
 		"SuccessfulNoOp": {
 			reason: "We should return early if the supplied image is already stored.",
 			files: map[string][]byte{
@@ -251,7 +218,7 @@ func TestWriteImage(t *testing.T) {
 			}
 
 			c := NewImage(tmp)
-			err = c.writeImage(tc.args.i)
+			err = c.WriteImage(tc.args.i)
 			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\nWriteImage(...): -want error, +got error:\n%s", tc.reason, diff)
 			}

--- a/internal/oci/store/store_test.go
+++ b/internal/oci/store/store_test.go
@@ -251,7 +251,7 @@ func TestWriteImage(t *testing.T) {
 			}
 
 			c := NewImage(tmp)
-			err = c.WriteImage(tc.args.i)
+			err = c.writeImage(tc.args.i)
 			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\nWriteImage(...): -want error, +got error:\n%s", tc.reason, diff)
 			}


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Enforce Full validation before writing images to disk.
I tried different approaches, but this was the less invasive one. With other approaches unit tests were failing and were really hard to fix as that would have required to mock most methods on the ocv1.Image, or add options to allow bypassing validation only for tests.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested
Same as #4217.
Tested it manually by building and deploying crossplane and an [example](https://github.com/upbound/sa-up/tree/main/examples/functions/crossplane-doc/configuration) (thanks @ytsarev locally as follows:
```sh
# building xp and xfn images
$ make
...
# spinning up kind cluster
$ ./cluster/local/kind.sh up
...
#  deploying xp with xfn enabled
$ HELM3_FLAGS="--set "args={--debug,--enable-composition-functions}" --set "xfn.enabled=true" --set "xfn.ars={--debug}"" ./cluster/local/kind.sh helm-upgrade
...
# deploying the needed provider by the example
$ kubectl apply -f - <<EOF
apiVersion: pkg.crossplane.io/v1
kind: Provider
metadata:
  name: provider-aws-rds
spec:
  package: xpkg.upbound.io/upbound/provider-aws-rds:v0.36.0
EOF
... 
# deploying the example
$ kubectl apply -f - <<EOF
apiVersion: apiextensions.crossplane.io/v1
kind: CompositeResourceDefinition
metadata:
  name: xpostgresqlinstances.database.example.org
spec:
  group: database.example.org
  names:
    kind: XPostgreSQLInstance
    plural: xpostgresqlinstances
  claimNames:
    kind: PostgreSQLInstance
    plural: postgresqlinstances
  versions:
  - name: v1alpha1
    served: true
    referenceable: true
    schema:
      openAPIV3Schema:
        type: object
        properties:
          spec:
            type: object
            properties:
              parameters:
                type: object
                properties:
                  storageGB:
                    type: integer
                required:
                - storageGB
            required:
            - parameters

EOF
...
$  kubectl apply -f - <<EOF
apiVersion: apiextensions.crossplane.io/v1
kind: Composition
metadata:
  name: example
spec:
  compositeTypeRef:
    apiVersion: database.example.org/v1alpha1
    kind: XPostgreSQLInstance
  resources:
    - name: rds-instance
      base:
        apiVersion: rds.aws.upbound.io/v1beta1
        kind: Instance
        spec:
          forProvider:
            dbName: example
            instanceClass: db.t3.micro
            region: us-west-2
            skipFinalSnapshot: true
            username: exampleuser
            engine: postgres
            engineVersion: "12"
      patches:
        - fromFieldPath: spec.parameters.storageGB
          toFieldPath: spec.forProvider.allocatedStorage
      connectionDetails:
        - type: FromFieldPath
          name: username
          fromFieldPath: spec.forProvider.username
        - type: FromConnectionSecretKey
          name: password
          fromConnectionSecretKey: attribute.password
  functions:
  - name: quotable
    type: Container
    container:
      image: ytsarev/xfn-quotable-simple:v0.1.0
      network:
        policy: Runner
EOF
...
$ kubectl apply -f - <<EOF
apiVersion: database.example.org/v1alpha1
kind: PostgreSQLInstance
metadata:
  namespace: default
  name: my-db
spec:
  parameters:
    storageGB: 20
  writeConnectionSecretToRef:
    name: my-db-connection-details
EOF
...
```
Then checking that the created rds instance has a nice memorable quote set as expected by the `ytsarev/xfn-quotable-simple:v0.1.0` function.
```sh
$  k get instances.rds.aws.upbound.io -o yaml
apiVersion: v1
items:
- apiVersion: rds.aws.upbound.io/v1beta1
  kind: Instance
  metadata:
    annotations:
      crossplane.io/composition-resource-name: rds-instance
      crossplane.io/external-name: my-db-59wxt-9j7cp
      quotable.io/author: What wisdom can you find that is greater than kindness?                  # <=== 🎉 here they are!! although there is a small bug in the function and author and quote are switched....
      quotable.io/quote: Jean-Jacques Rousseau
    creationTimestamp: "2023-06-21T11:37:47Z"
    generateName: my-db-59wxt-
    generation: 2
    labels:
      crossplane.io/claim-name: my-db
      crossplane.io/claim-namespace: default
      crossplane.io/composite: my-db-59wxt
    name: my-db-59wxt-9j7cp
    ownerReferences:
    - apiVersion: database.example.org/v1alpha1
      blockOwnerDeletion: true
      controller: true
      kind: XPostgreSQLInstance
      name: my-db-59wxt
      uid: 1b667eb4-ec6a-467f-a20d-3f60958d9350
    resourceVersion: "7453"
    uid: 8f22d126-63a2-46b7-bd3d-85556343f9ff
  spec:
    deletionPolicy: Delete
    forProvider:
      allocatedStorage: 20
      dbName: example
      engine: postgres
      engineVersion: "12"
      instanceClass: db.t3.micro
      region: us-west-2
      skipFinalSnapshot: true
      tags:
        crossplane-kind: instance.rds.aws.upbound.io
        crossplane-name: my-db-59wxt-9j7cp
        crossplane-providerconfig: default
      username: exampleuser
    managementPolicy: FullControl
    providerConfigRef:
      name: default
  status:
    atProvider: {}
    conditions:
    - lastTransitionTime: "2023-06-21T11:37:47Z"
      message: 'connect failed: cannot get terraform setup: cannot get referenced
        Provider: default: ProviderConfig.aws.upbound.io "default" not found'
      reason: ReconcileError
      status: "False"
      type: Synced
kind: List
metadata:
  resourceVersion: ""
```
Note: I didn't setup credentials for the provider, so the Instance is not expected to become ready, but that's not relevant for this patch.
<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
