### PR TITLE
fix: limit xfn stdout and stderr

### DIFF
--- a/internal/xfn/container_linux.go
+++ b/internal/xfn/container_linux.go
@@ -58,6 +58,7 @@ const (
 const (
 	UserNamespaceUIDs = 65536
 	UserNamespaceGIDs = 65536
+	MaxStdioBytes     = 100 << 20 // 100 MB
 )
 
 // The subcommand of xfn to invoke - i.e. "xfn spark <source> <bundle>"
@@ -160,12 +161,14 @@ func (r *ContainerRunner) RunFunction(ctx context.Context, req *v1alpha1.RunFunc
 
 	// We must read all of stdout and stderr before calling cmd.Wait, which
 	// closes the underlying pipes.
-	stdout, err := io.ReadAll(stdio.Stdout)
+	// Limited to MaxStdioBytes to avoid OOMing if the function writes a lot of
+	// data to stdout or stderr.
+	stdout, err := io.ReadAll(io.LimitReader(stdio.Stdout, MaxStdioBytes))
 	if err != nil {
 		return nil, errors.Wrap(err, errReadStdout)
 	}
 
-	stderr, err := io.ReadAll(stdio.Stderr)
+	stderr, err := io.ReadAll(io.LimitReader(stdio.Stderr, MaxStdioBytes))
 	if err != nil {
 		return nil, errors.Wrap(err, errReadStderr)
 	}

--- a/internal/xfn/container_linux.go
+++ b/internal/xfn/container_linux.go
@@ -21,6 +21,7 @@ package xfn
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"io"
 	"os"
 	"os/exec"
@@ -97,7 +98,7 @@ func (r *ContainerRunner) RunFunction(ctx context.Context, req *v1alpha1.RunFunc
 		bundle, then then executes an OCI runtime in order to actually execute
 		the function.
 	*/
-	cmd := exec.CommandContext(ctx, os.Args[0], spark, "--cache-dir="+r.cache) //nolint:gosec // We're intentionally executing with variable input.
+	cmd := exec.CommandContext(ctx, os.Args[0], spark, "--cache-dir="+r.cache, fmt.Sprintf("--max-stdio-bytes=%d", MaxStdioBytes)) //nolint:gosec // We're intentionally executing with variable input.
 	cmd.SysProcAttr = &syscall.SysProcAttr{
 		Cloneflags:  syscall.CLONE_NEWUSER | syscall.CLONE_NEWNS,
 		UidMappings: []syscall.SysProcIDMap{{ContainerID: 0, HostID: r.rootUID, Size: 1}},


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Limit the size of Composition functions outputs to 100 MB.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested
Tested it manually by building and deploying crossplane and an [example](https://github.com/upbound/sa-up/tree/main/examples/functions/crossplane-doc/configuration) (thanks @ytsarev locally as follows:
```sh
# building xp and xfn images
$ make
...
# spinning up kind cluster
$ ./cluster/local/kind.sh up
...
#  deploying xp with xfn enabled
$ HELM3_FLAGS="--set "args={--debug,--enable-composition-functions}" --set "xfn.enabled=true" --set "xfn.ars={--debug}"" ./cluster/local/kind.sh helm-upgrade
...
# deploying the needed provider by the example
$ kubectl apply -f - <<EOF
apiVersion: pkg.crossplane.io/v1
kind: Provider
metadata:
  name: provider-aws-rds
spec:
  package: xpkg.upbound.io/upbound/provider-aws-rds:v0.36.0
EOF
... 
# deploying the example
$ kubectl apply -f - <<EOF
apiVersion: apiextensions.crossplane.io/v1
kind: CompositeResourceDefinition
metadata:
  name: xpostgresqlinstances.database.example.org
spec:
  group: database.example.org
  names:
    kind: XPostgreSQLInstance
    plural: xpostgresqlinstances
  claimNames:
    kind: PostgreSQLInstance
    plural: postgresqlinstances
  versions:
  - name: v1alpha1
    served: true
    referenceable: true
    schema:
      openAPIV3Schema:
        type: object
        properties:
          spec:
            type: object
            properties:
              parameters:
                type: object
                properties:
                  storageGB:
                    type: integer
                required:
                - storageGB
            required:
            - parameters

EOF
...
$  kubectl apply -f - <<EOF
apiVersion: apiextensions.crossplane.io/v1
kind: Composition
metadata:
  name: example
spec:
  compositeTypeRef:
    apiVersion: database.example.org/v1alpha1
    kind: XPostgreSQLInstance
  resources:
    - name: rds-instance
      base:
        apiVersion: rds.aws.upbound.io/v1beta1
        kind: Instance
        spec:
          forProvider:
            dbName: example
            instanceClass: db.t3.micro
            region: us-west-2
            skipFinalSnapshot: true
            username: exampleuser
            engine: postgres
            engineVersion: "12"
      patches:
        - fromFieldPath: spec.parameters.storageGB
          toFieldPath: spec.forProvider.allocatedStorage
      connectionDetails:
        - type: FromFieldPath
          name: username
          fromFieldPath: spec.forProvider.username
        - type: FromConnectionSecretKey
          name: password
          fromConnectionSecretKey: attribute.password
  functions:
  - name: quotable
    type: Container
    container:
      image: ytsarev/xfn-quotable-simple:v0.1.0
      network:
        policy: Runner
EOF
...
$ kubectl apply -f - <<EOF
apiVersion: database.example.org/v1alpha1
kind: PostgreSQLInstance
metadata:
  namespace: default
  name: my-db
spec:
  parameters:
    storageGB: 20
  writeConnectionSecretToRef:
    name: my-db-connection-details
EOF
...
```
Then checking that the created rds instance has a nice memorable quote set as expected by the `ytsarev/xfn-quotable-simple:v0.1.0` function.
```sh
$  k get instances.rds.aws.upbound.io -o yaml
apiVersion: v1
items:
- apiVersion: rds.aws.upbound.io/v1beta1
  kind: Instance
  metadata:
    annotations:
      crossplane.io/composition-resource-name: rds-instance
      crossplane.io/external-name: my-db-59wxt-9j7cp
      quotable.io/author: What wisdom can you find that is greater than kindness?                  # <=== 🎉 here they are!! although there is a small bug in the function and author and quote are switched....
      quotable.io/quote: Jean-Jacques Rousseau
    creationTimestamp: "2023-06-21T11:37:47Z"
    generateName: my-db-59wxt-
    generation: 2
    labels:
      crossplane.io/claim-name: my-db
      crossplane.io/claim-namespace: default
      crossplane.io/composite: my-db-59wxt
    name: my-db-59wxt-9j7cp
    ownerReferences:
    - apiVersion: database.example.org/v1alpha1
      blockOwnerDeletion: true
      controller: true
      kind: XPostgreSQLInstance
      name: my-db-59wxt
      uid: 1b667eb4-ec6a-467f-a20d-3f60958d9350
    resourceVersion: "7453"
    uid: 8f22d126-63a2-46b7-bd3d-85556343f9ff
  spec:
    deletionPolicy: Delete
    forProvider:
      allocatedStorage: 20
      dbName: example
      engine: postgres
      engineVersion: "12"
      instanceClass: db.t3.micro
      region: us-west-2
      skipFinalSnapshot: true
      tags:
        crossplane-kind: instance.rds.aws.upbound.io
        crossplane-name: my-db-59wxt-9j7cp
        crossplane-providerconfig: default
      username: exampleuser
    managementPolicy: FullControl
    providerConfigRef:
      name: default
  status:
    atProvider: {}
    conditions:
    - lastTransitionTime: "2023-06-21T11:37:47Z"
      message: 'connect failed: cannot get terraform setup: cannot get referenced
        Provider: default: ProviderConfig.aws.upbound.io "default" not found'
      reason: ReconcileError
      status: "False"
      type: Synced
kind: List
metadata:
  resourceVersion: ""
```
Note: I didn't setup credentials for the provider, so the Instance is not expected to become ready, but that's not relevant for this patch.

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
