### PR TITLE
Run xfn with unconfined AppArmor profile

### DIFF
--- a/cluster/charts/crossplane/templates/deployment.yaml
+++ b/cluster/charts/crossplane/templates/deployment.yaml
@@ -21,13 +21,16 @@ spec:
     type: {{ .Values.deploymentStrategy }}
   template:
     metadata:
-      {{- if or .Values.metrics.enabled .Values.customAnnotations }}
+      {{- if or .Values.metrics.enabled .Values.xfn.enabled .Values.customAnnotations }}
       annotations:
       {{- end }}
       {{- if .Values.metrics.enabled }}
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"
+      {{- end }}
+      {{- if .Values.xfn.enabled }}
+        container.apparmor.security.beta.kubernetes.io/{{ .Chart.Name }}-xfn: unconfined
       {{- end }}
       {{- with .Values.customAnnotations }}
         {{- toYaml . | nindent 8 }}


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes https://github.com/crossplane/crossplane/issues/4228

https://kubernetes.io/docs/tutorials/security/apparmor/#securing-a-pod

The xfn container needs the unshare syscall in order to run rootless containers (i.e. create user namespaces). Most default apparmor and seccomp profiles don't allow this. We already run the container unconfined by seccomp, but must also run it unconfined by apparmor.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9

Deployed to a `kind` cluster and validated that the annotation appears:

```shell
$ k -n upbound-system get po crossplane-674556f578-n9rlc -o json|jq ".spec.containers[1].name"
"crossplane-xfn"

$ k -n upbound-system get po crossplane-674556f578-n9rlc -o json|jq ".metadata.annotations"
{
  "container.apparmor.security.beta.kubernetes.io/crossplane-xfn": "unconfined"
}
```