### PR TITLE
Allow Scaling of Controllerconfig

### DIFF
--- a/cluster/crds/pkg.crossplane.io_controllerconfigs.yaml
+++ b/cluster/crds/pkg.crossplane.io_controllerconfigs.yaml
@@ -3163,4 +3163,14 @@ spec:
         type: object
     served: true
     storage: true
-    subresources: {}
+    subresources:
+      # status enables the status subresource.
+      status: {}
+      # scale enables the scale subresource.
+      scale:
+        # specReplicasPath defines the JSONPath inside of a custom resource that corresponds to Scale.Spec.Replicas.
+        specReplicasPath: .spec.replicas
+        # statusReplicasPath defines the JSONPath inside of a custom resource that corresponds to Scale.Status.Replicas.
+        statusReplicasPath: .status.replicas
+        # labelSelectorPath defines the JSONPath inside of a custom resource that corresponds to Scale.Status.Selector.
+        labelSelectorPath: .status.labelSelector


### PR DESCRIPTION
### Description of your changes

Allows scaling of  `ControllerConfig` kind  wrt https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#scale-subresource 

This change enables automatic scaling of providers, e.g. by using KEDA

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

Tested in a kubernetes cluster with crossplane installed.
