### PR TITLE
Don't require renovate to complete its checklist

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   checklist-completed:
+    if: github.actor != 'renovate[bot]'
     runs-on: ubuntu-22.04
     steps:
       - uses: mheap/require-checklist-action@61408353f11a0a1b1d16972193791960a4f2dc29 # v2


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does, and how it is covered by tests.
Be proactive - direct your reviewers' attention to anything that needs special
consideration.

You MUST either [x] check or ~strikethrough~ every item in the checklist below.

We love pull requests that fix an open issue. If yours does, use the below line
to indicate which issue it fixes, for example "Fixes #500".
-->

Renovate PRs contain a 'checklist' that you can click to trigger a rebase. We don't want to fail a PR just because that checklist isn't clicked. :)

Note that the `PR / checklist-created` workflow isn't actually required so Renovate isn't blocked right now. It just gets an ugly red x on its PRs.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [ ] ~Added or updated unit **and** E2E tests for my change.~
- [ ] ~Run `make reviewable` to ensure this PR is ready for review.~
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR if necessary.~

[contribution process]: https://git.io/fj2m9