### PR TITLE
Support `-create-kind-cluster=false` in E2E tests

### DIFF
--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -42,6 +42,10 @@ E2E_TEST_FLAGS="-feature=Install" make e2e
 
 # Stop immediately on first test failure, and leave the kind cluster to debug.
 E2E_TEST_FLAGS="-test.v -test.failfast -destroy-kind-cluster=false"
+
+# Use an existing Kubernetes cluster. Note that the E2E tests can't deploy your
+# local build of Crossplane in this scenario, so you'll have to do it yourself.
+E2E_TEST_FLAGS="-create-kind-cluster=false -destroy-kind-cluster=false -kubeconfig=$HOME/.kube/config"
 ```
 
 ## Test Parallelism


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does, and how it is covered by tests.
Be proactive - direct your reviewers' attention to anything that needs special
consideration.

You MUST either [x] check or ~strikethrough~ every item in the checklist below.

We love pull requests that fix an open issue. If yours does, use the below line
to indicate which issue it fixes, for example "Fixes #500".
-->

This allows you to run E2E tests against an existing Kubernetes cluster. Note that we can't load our local build of Crossplane into an existing Kubernetes cluster, so if you pass this flag you'll also need to make sure Crossplane is installed on the cluster where you'll run the tests.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Added or updated unit **and** E2E tests for my change.
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR if necessary.~

[contribution process]: https://git.io/fj2m9