### PR TITLE
Helm Chart: add locks to the RBAC for pkg.crossplane.io

### DIFF
--- a/cluster/charts/crossplane/templates/rbac-manager-managed-clusterroles.yaml
+++ b/cluster/charts/crossplane/templates/rbac-manager-managed-clusterroles.yaml
@@ -101,7 +101,7 @@ rules:
   verbs: ["*"]
 - apiGroups:
   - pkg.crossplane.io
-  resources: [providers, configurations, providerrevisions, configurationrevisions]
+  resources: [locks, providers, configurations, providerrevisions, configurationrevisions]
   verbs: ["*"]
 # Crossplane administrators have access to view CRDs in order to debug XRDs.
 - apiGroups: [apiextensions.k8s.io]
@@ -137,7 +137,7 @@ rules:
   verbs: ["*"]
 - apiGroups:
   - pkg.crossplane.io
-  resources: [providers, configurations, providerrevisions, configurationrevisions]
+  resources: [locks, providers, configurations, providerrevisions, configurationrevisions]
   verbs: ["*"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -164,7 +164,7 @@ rules:
   verbs: [get, list, watch]
 - apiGroups:
   - pkg.crossplane.io
-  resources: [providers, configurations, providerrevisions, configurationrevisions]
+  resources: [locks, providers, configurations, providerrevisions, configurationrevisions]
   verbs: [get, list, watch]
 ---
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
### Description of your changes

In the Upbound managed environment, users are not able to upgrade from the monolithic providers to SSOPs following [1] due to missing permissions to the lock. This changes add `locks.pkg.crossplane.io` to the RBACs for admin, view and edit.

[1] https://docs.upbound.io/knowledge-base/migrate-to-provider-families

I have:

- [X] Read and followed Crossplane's [contribution process].
- [x] ~Added or updated unit **and** E2E tests for my change.~
- [X] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.
