### PR TITLE
Add registry option for xfn

### DIFF
--- a/cmd/crossplane/core/core.go
+++ b/cmd/crossplane/core/core.go
@@ -214,6 +214,7 @@ func (c *startCommand) Run(s *runtime.Scheme, log logging.Logger) error { //noli
 		Options:        o,
 		Namespace:      c.Namespace,
 		ServiceAccount: c.ServiceAccount,
+		Registry:       c.Registry,
 	}
 
 	if err := apiextensions.Setup(mgr, ao); err != nil {

--- a/cmd/xfn/spark/spark.go
+++ b/cmd/xfn/spark/spark.go
@@ -35,6 +35,7 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/errors"
 
 	"github.com/crossplane/crossplane/apis/apiextensions/fn/proto/v1alpha1"
+	"github.com/crossplane/crossplane/cmd/xfn/start"
 	"github.com/crossplane/crossplane/internal/oci"
 	"github.com/crossplane/crossplane/internal/oci/spec"
 	"github.com/crossplane/crossplane/internal/oci/store"
@@ -79,7 +80,7 @@ type Command struct {
 // Run a Composition Function inside an unprivileged user namespace. Reads a
 // protocol buffer serialized RunFunctionRequest from stdin, and writes a
 // protocol buffer serialized RunFunctionResponse to stdout.
-func (c *Command) Run() error { //nolint:gocyclo // TODO(negz): Refactor some of this out into functions, add tests.
+func (c *Command) Run(args *start.Args) error { //nolint:gocyclo // TODO(negz): Refactor some of this out into functions, add tests.
 	pb, err := io.ReadAll(os.Stdin)
 	if err != nil {
 		return errors.Wrap(err, errReadRequest)
@@ -121,7 +122,7 @@ func (c *Command) Run() error { //nolint:gocyclo // TODO(negz): Refactor some of
 		return errors.Wrap(err, errNewDigestStore)
 	}
 
-	r, err := name.ParseReference(req.GetImage())
+	r, err := name.ParseReference(req.GetImage(), name.WithDefaultRegistry(args.Registry))
 	if err != nil {
 		return errors.Wrap(err, errParseRef)
 	}

--- a/cmd/xfn/start/start.go
+++ b/cmd/xfn/start/start.go
@@ -33,6 +33,11 @@ const (
 	errListenAndServe = "cannot listen for and serve gRPC API"
 )
 
+// Args contains the default registry used to pull XFN containers.
+type Args struct {
+	Registry string
+}
+
 // Command starts a gRPC API to run Composition Functions.
 type Command struct {
 	CacheDir   string `short:"c" help:"Directory used for caching function images and containers." default:"/xfn"`
@@ -43,7 +48,7 @@ type Command struct {
 }
 
 // Run a Composition Function gRPC API.
-func (c *Command) Run(log logging.Logger) error {
+func (c *Command) Run(args *Args, log logging.Logger) error {
 	// If we don't have CAP_SETUID or CAP_SETGID, we'll only be able to map our
 	// own UID and GID to root inside the user namespace.
 	rootUID := os.Getuid()
@@ -59,6 +64,7 @@ func (c *Command) Run(log logging.Logger) error {
 		xfn.SetUID(setuid),
 		xfn.MapToRoot(rootUID, rootGID),
 		xfn.WithCacheDir(filepath.Clean(c.CacheDir)),
-		xfn.WithLogger(log))
+		xfn.WithLogger(log),
+		xfn.WithRegistry(args.Registry))
 	return errors.Wrap(f.ListenAndServe(c.Network, c.Address), errListenAndServe)
 }

--- a/internal/controller/apiextensions/composite/composition_ptf.go
+++ b/internal/controller/apiextensions/composite/composition_ptf.go
@@ -649,7 +649,7 @@ type ContainerFunctionRunnerOption func(ctx context.Context, fn *v1.ContainerFun
 // 2. Loads credentials from the supplied service account's image pull secrets.
 // 3. Loads credentials from the function's image pull secrets.
 // 4. Loads credentials using the GKE, EKS, or AKS credentials helper.
-func WithKubernetesAuthentication(c client.Reader, namespace, serviceAccount string, registry string) ContainerFunctionRunnerOption {
+func WithKubernetesAuthentication(c client.Reader, namespace, serviceAccount, registry string) ContainerFunctionRunnerOption {
 	return func(ctx context.Context, fn *v1.ContainerFunction, r *fnv1alpha1.RunFunctionRequest) error {
 
 		sa := &corev1.ServiceAccount{}

--- a/internal/controller/apiextensions/composite/composition_ptf.go
+++ b/internal/controller/apiextensions/composite/composition_ptf.go
@@ -649,7 +649,7 @@ type ContainerFunctionRunnerOption func(ctx context.Context, fn *v1.ContainerFun
 // 2. Loads credentials from the supplied service account's image pull secrets.
 // 3. Loads credentials from the function's image pull secrets.
 // 4. Loads credentials using the GKE, EKS, or AKS credentials helper.
-func WithKubernetesAuthentication(c client.Reader, namespace, serviceAccount string) ContainerFunctionRunnerOption {
+func WithKubernetesAuthentication(c client.Reader, namespace, serviceAccount string, registry string) ContainerFunctionRunnerOption {
 	return func(ctx context.Context, fn *v1.ContainerFunction, r *fnv1alpha1.RunFunctionRequest) error {
 
 		sa := &corev1.ServiceAccount{}
@@ -677,7 +677,7 @@ func WithKubernetesAuthentication(c client.Reader, namespace, serviceAccount str
 			return errors.Wrap(err, errNewKeychain)
 		}
 
-		ref, err := name.ParseReference(fn.Image)
+		ref, err := name.ParseReference(fn.Image, name.WithDefaultRegistry(registry))
 		if err != nil {
 			return errors.Wrap(err, errParseImage)
 		}

--- a/internal/controller/apiextensions/composite/composition_ptf_test.go
+++ b/internal/controller/apiextensions/composite/composition_ptf_test.go
@@ -1117,6 +1117,7 @@ func TestWithKubernetesAuthentication(t *testing.T) {
 		c              client.Reader
 		namespace      string
 		serviceAccount string
+		registry       string
 	}
 	type args struct {
 		ctx context.Context
@@ -1188,6 +1189,7 @@ func TestWithKubernetesAuthentication(t *testing.T) {
 						return nil
 					},
 				},
+				registry: "index.docker.io",
 			},
 			args: args{
 				fn: &v1.ContainerFunction{
@@ -1211,7 +1213,7 @@ func TestWithKubernetesAuthentication(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			err := WithKubernetesAuthentication(tc.params.c, tc.params.namespace, tc.params.serviceAccount)(tc.args.ctx, tc.args.fn, tc.args.r)
+			err := WithKubernetesAuthentication(tc.params.c, tc.params.namespace, tc.params.serviceAccount, tc.params.registry)(tc.args.ctx, tc.args.fn, tc.args.r)
 
 			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\nWithKubernetesAuthentication(...): -want error, +got error:\n%s", tc.reason, diff)

--- a/internal/controller/apiextensions/controller/options.go
+++ b/internal/controller/apiextensions/controller/options.go
@@ -32,4 +32,8 @@ type Options struct {
 	// ServiceAccount for which we'll find image pull secrets for in-cluster
 	// private registry authentication when pulling Composition Functions.
 	ServiceAccount string
+
+	// Registry is the default registry to use when pulling containers for
+	// Composition Functions
+	Registry string
 }

--- a/internal/controller/apiextensions/definition/reconciler.go
+++ b/internal/controller/apiextensions/definition/reconciler.go
@@ -505,7 +505,7 @@ func CompositeReconcilerOptions(co apiextensionscontroller.Options, d *v1.Compos
 				composite.WithCompositeConnectionDetailsFetcher(fetcher),
 				composite.WithFunctionPipelineRunner(composite.NewFunctionPipeline(
 					composite.ContainerFunctionRunnerFn(composite.RunFunction),
-					composite.WithKubernetesAuthentication(c, co.Namespace, co.ServiceAccount),
+					composite.WithKubernetesAuthentication(c, co.Namespace, co.ServiceAccount, co.Registry),
 				)),
 			),
 			composite.NewPTComposer(c, composite.WithComposedConnectionDetailsFetcher(fetcher)),

--- a/internal/xfn/container.go
+++ b/internal/xfn/container.go
@@ -43,10 +43,11 @@ type ContainerRunner struct {
 
 	log logging.Logger
 
-	rootUID int
-	rootGID int
-	setuid  bool // Specifically, CAP_SETUID and CAP_SETGID.
-	cache   string
+	rootUID  int
+	rootGID  int
+	setuid   bool // Specifically, CAP_SETUID and CAP_SETGID.
+	cache    string
+	registry string
 }
 
 // A ContainerRunnerOption configures a new ContainerRunner.
@@ -75,6 +76,14 @@ func SetUID(s bool) ContainerRunnerOption {
 func WithCacheDir(d string) ContainerRunnerOption {
 	return func(r *ContainerRunner) {
 		r.cache = d
+	}
+}
+
+// WithRegistry specifies the default registry used to retrieve function images and
+// containers.
+func WithRegistry(dr string) ContainerRunnerOption {
+	return func(r *ContainerRunner) {
+		r.registry = dr
 	}
 }
 

--- a/internal/xfn/container_linux.go
+++ b/internal/xfn/container_linux.go
@@ -95,10 +95,10 @@ func (r *ContainerRunner) RunFunction(ctx context.Context, req *v1alpha1.RunFunc
 
 		Therefore we execute a shim - xfn spark - in a new user and mount
 		namespace. spark fetches and caches the image, creates an OCI runtime
-		bundle, then then executes an OCI runtime in order to actually execute
+		bundle, then executes an OCI runtime in order to actually execute
 		the function.
 	*/
-	cmd := exec.CommandContext(ctx, os.Args[0], spark, "--cache-dir="+r.cache, fmt.Sprintf("--max-stdio-bytes=%d", MaxStdioBytes)) //nolint:gosec // We're intentionally executing with variable input.
+	cmd := exec.CommandContext(ctx, os.Args[0], spark, "--cache-dir="+r.cache, "--registry="+r.registry, fmt.Sprintf("--max-stdio-bytes=%d", MaxStdioBytes)) //nolint:gosec // We're intentionally executing with variable input.
 	cmd.SysProcAttr = &syscall.SysProcAttr{
 		Cloneflags:  syscall.CLONE_NEWUSER | syscall.CLONE_NEWNS,
 		UidMappings: []syscall.SysProcIDMap{{ContainerID: 0, HostID: r.rootUID, Size: 1}},

--- a/internal/xfn/container_linux.go
+++ b/internal/xfn/container_linux.go
@@ -98,7 +98,8 @@ func (r *ContainerRunner) RunFunction(ctx context.Context, req *v1alpha1.RunFunc
 		bundle, then executes an OCI runtime in order to actually execute
 		the function.
 	*/
-	cmd := exec.CommandContext(ctx, os.Args[0], spark, "--cache-dir="+r.cache, "--registry="+r.registry, fmt.Sprintf("--max-stdio-bytes=%d", MaxStdioBytes)) //nolint:gosec // We're intentionally executing with variable input.
+	cmd := exec.CommandContext(ctx, os.Args[0], spark, "--cache-dir="+r.cache, "--registry="+r.registry, //nolint:gosec // We're intentionally executing with variable input.
+		fmt.Sprintf("--max-stdio-bytes=%d", MaxStdioBytes))
 	cmd.SysProcAttr = &syscall.SysProcAttr{
 		Cloneflags:  syscall.CLONE_NEWUSER | syscall.CLONE_NEWNS,
 		UidMappings: []syscall.SysProcIDMap{{ContainerID: 0, HostID: r.rootUID, Size: 1}},


### PR DESCRIPTION
### Description of your changes
Added the `--registry` option to the `xfn` commands to allow a default registry to be specified for pulling containers in Composition Function processing.
 
This capability is enabled by adding the `--registry=myregistry.mydomain.com` argument to the `xfn.args` array in the helm chart.  That causes the `crossplane-xfn` container to run `xfn start` with the `--registry` argument, which starts a container runner with the default registry.

The container runner then calls `xfn spark` with the `--registry` option.

The user's specified container is checked to see if it has a valid registry component in the name, and if it does not the default registry is used.  The default registry is `index.docker.io`.

Fixes #4116 

I have:

- [X] Read and followed Crossplane's [contribution process].
~- [ ] Added or updated unit **and** E2E tests for my change.~
- [X] Run `make reviewable` to ensure this PR is ready for review.
- [X] Added `backport release-x.y` labels to auto-backport this PR if necessary.

[contribution process]: https://git.io/fj2m9