### PR TITLE
cmd/crank: make commands reusable

### DIFF
--- a/cmd/crank/commands/build_test.go
+++ b/cmd/crank/commands/build_test.go
@@ -14,7 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
+// Package commands implements Crossplane CLI commands.
+package commands
 
 import (
 	"os"
@@ -33,7 +34,7 @@ import (
 
 func TestBuild(t *testing.T) {
 	type args struct {
-		child  *buildChild
+		child  *BuildChild
 		root   string
 		ignore []string
 	}
@@ -46,10 +47,10 @@ func TestBuild(t *testing.T) {
 		"SuccessfulWithName": {
 			reason: "",
 			args: args{
-				child: &buildChild{
-					name:   "test",
-					linter: parser.NewPackageLinter(nil, nil, nil),
-					fs:     afero.NewMemMapFs(),
+				child: &BuildChild{
+					Name:   "test",
+					Linter: parser.NewPackageLinter(nil, nil, nil),
+					FS:     afero.NewMemMapFs(),
 				},
 				root: "/",
 			},
@@ -57,9 +58,9 @@ func TestBuild(t *testing.T) {
 		"ErrNoNameNoMeta": {
 			reason: "",
 			args: args{
-				child: &buildChild{
-					linter: parser.NewPackageLinter(nil, nil, nil),
-					fs:     afero.NewMemMapFs(),
+				child: &BuildChild{
+					Linter: parser.NewPackageLinter(nil, nil, nil),
+					FS:     afero.NewMemMapFs(),
 				},
 				root: "/",
 			},
@@ -69,7 +70,7 @@ func TestBuild(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			b := buildCmd{
+			b := BuildCmd{
 				PackageRoot: tc.args.root,
 				Ignore:      tc.args.ignore,
 			}
@@ -80,7 +81,7 @@ func TestBuild(t *testing.T) {
 			}
 			// If we didn't encounter an error there should be a package in root.
 			if tc.want == nil {
-				if _, err := xpkg.FindXpkgInDir(tc.args.child.fs, tc.args.root); err != nil {
+				if _, err := xpkg.FindXpkgInDir(tc.args.child.FS, tc.args.root); err != nil {
 					t.Error(err)
 				}
 			}

--- a/cmd/crank/commands/install.go
+++ b/cmd/crank/commands/install.go
@@ -14,7 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
+// Package commands implements Crossplane CLI commands.
+package commands
 
 import (
 	"context"
@@ -63,19 +64,19 @@ const (
 	msgProviderWaiting  = "Waiting for the Provider to be ready"
 )
 
-// installCmd installs a package.
-type installCmd struct {
-	Configuration installConfigCmd   `cmd:"" help:"Install a Configuration package."`
-	Provider      installProviderCmd `cmd:"" help:"Install a Provider package."`
+// InstallCmd installs a package.
+type InstallCmd struct {
+	Configuration InstallConfigCmd   `cmd:"" help:"Install a Configuration package."`
+	Provider      InstallProviderCmd `cmd:"" help:"Install a Provider package."`
 }
 
 // Run runs the install cmd.
-func (c *installCmd) Run(_ *buildChild) error {
+func (c *InstallCmd) Run(_ *BuildChild) error {
 	return nil
 }
 
-// installConfigCmd installs a Configuration.
-type installConfigCmd struct {
+// InstallConfigCmd installs a Configuration.
+type InstallConfigCmd struct {
 	Package string `arg:"" help:"Image containing Configuration package."`
 
 	Name                 string        `arg:"" optional:"" help:"Name of Configuration."`
@@ -86,7 +87,7 @@ type installConfigCmd struct {
 }
 
 // Run runs the Configuration install cmd.
-func (c *installConfigCmd) Run(k *kong.Context, logger logging.Logger) error { //nolint:gocyclo // TODO(negz): Can anything be broken out here?
+func (c *InstallConfigCmd) Run(k *kong.Context, logger logging.Logger) error { //nolint:gocyclo // TODO(negz): Can anything be broken out here?
 	rap := v1.AutomaticActivation
 	if c.ManualActivation {
 		rap = v1.ManualActivation
@@ -166,8 +167,8 @@ func (c *installConfigCmd) Run(k *kong.Context, logger logging.Logger) error { /
 	return err
 }
 
-// installProviderCmd install a Provider.
-type installProviderCmd struct {
+// InstallProviderCmd install a Provider.
+type InstallProviderCmd struct {
 	Package string `arg:"" help:"Image containing Provider package."`
 
 	Name                 string        `arg:"" optional:"" help:"Name of Provider."`
@@ -179,7 +180,7 @@ type installProviderCmd struct {
 }
 
 // Run runs the Provider install cmd.
-func (c *installProviderCmd) Run(k *kong.Context, logger logging.Logger) error { //nolint:gocyclo // TODO(negz): Can anything be broken out here?
+func (c *InstallProviderCmd) Run(k *kong.Context, logger logging.Logger) error { //nolint:gocyclo // TODO(negz): Can anything be broken out here?
 	rap := v1.AutomaticActivation
 	if c.ManualActivation {
 		rap = v1.ManualActivation

--- a/cmd/crank/commands/push.go
+++ b/cmd/crank/commands/push.go
@@ -14,7 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
+// Package commands implements Crossplane CLI commands.
+package commands
 
 import (
 	"os"
@@ -36,18 +37,18 @@ const (
 	errFindPackageinWd = "failed to find a package in current working directory"
 )
 
-// pushCmd pushes a package.
-type pushCmd struct {
-	Configuration pushConfigCmd   `cmd:"" help:"Push a Configuration package."`
-	Provider      pushProviderCmd `cmd:"" help:"Push a Provider package."`
+// PushCmd pushes a package.
+type PushCmd struct {
+	Configuration PushConfigCmd   `cmd:"" help:"Push a Configuration package."`
+	Provider      PushProviderCmd `cmd:"" help:"Push a Provider package."`
 
 	Package string `short:"f" help:"Path to package. If not specified and only one package exists in current directory it will be used."`
 }
 
 // Run runs the push cmd.
-func (c *pushCmd) Run(child *pushChild, logger logging.Logger) error {
-	logger = logger.WithValues("tag", child.tag)
-	tag, err := name.NewTag(child.tag)
+func (c *PushCmd) Run(child *PushChild, logger logging.Logger) error {
+	logger = logger.WithValues("tag", child.Tag)
+	tag, err := name.NewTag(child.Tag)
 	if err != nil {
 		logger.Debug("Failed to create tag for package", "error", err)
 		return err
@@ -62,7 +63,7 @@ func (c *pushCmd) Run(child *pushChild, logger logging.Logger) error {
 			logger.Debug("Failed to find package in directory", "error", errors.Wrap(err, errGetwd))
 			return errors.Wrap(err, errGetwd)
 		}
-		path, err := xpkg.FindXpkgInDir(child.fs, wd)
+		path, err := xpkg.FindXpkgInDir(child.FS, wd)
 		if err != nil {
 			logger.Debug("Failed to find package in directory", "error", errors.Wrap(err, errFindPackageinWd))
 			return errors.Wrap(err, errFindPackageinWd)
@@ -82,29 +83,30 @@ func (c *pushCmd) Run(child *pushChild, logger logging.Logger) error {
 	return nil
 }
 
-type pushChild struct {
-	tag string
-	fs  afero.Fs
+// PushChild provides context to the Push commands' hooks.
+type PushChild struct {
+	Tag string
+	FS  afero.Fs
 }
 
-// pushConfigCmd pushes a Configuration.
-type pushConfigCmd struct {
+// PushConfigCmd pushes a Configuration.
+type PushConfigCmd struct {
 	Tag string `arg:"" help:"Tag of the package to be pushed. Must be a valid OCI image tag."`
 }
 
 // AfterApply sets the tag for the parent push command.
-func (c pushConfigCmd) AfterApply(p *pushChild) error { //nolint:unparam // AfterApply requires this signature.
-	p.tag = c.Tag
+func (c PushConfigCmd) AfterApply(p *PushChild) error {
+	p.Tag = c.Tag
 	return nil
 }
 
-// pushProviderCmd pushes a Provider.
-type pushProviderCmd struct {
+// PushProviderCmd pushes a Provider.
+type PushProviderCmd struct {
 	Tag string `arg:"" help:"Tag of the package to be pushed. Must be a valid OCI image tag."`
 }
 
 // AfterApply sets the tag for the parent push command.
-func (c pushProviderCmd) AfterApply(p *pushChild) error { //nolint:unparam // AfterApply requires this signature.
-	p.tag = c.Tag
+func (c PushProviderCmd) AfterApply(p *PushChild) error {
+	p.Tag = c.Tag
 	return nil
 }

--- a/cmd/crank/commands/update.go
+++ b/cmd/crank/commands/update.go
@@ -1,4 +1,21 @@
-package main
+/*
+Copyright 2023 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package commands implements Crossplane CLI commands.
+package commands
 
 import (
 	"context"
@@ -22,25 +39,25 @@ import (
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 )
 
-// updateCmd updates a package.
-type updateCmd struct {
-	Configuration updateConfigCmd   `cmd:"" help:"Update a Configuration package."`
-	Provider      updateProviderCmd `cmd:"" help:"Update a Provider package."`
+// UpdateCmd updates a package.
+type UpdateCmd struct {
+	Configuration UpdateConfigCmd   `cmd:"" help:"Update a Configuration package."`
+	Provider      UpdateProviderCmd `cmd:"" help:"Update a Provider package."`
 }
 
 // Run runs the update cmd.
-func (c *updateCmd) Run(_ *buildChild) error {
+func (c *UpdateCmd) Run(_ *BuildChild) error {
 	return nil
 }
 
-// updateConfigCmd updates a Configuration.
-type updateConfigCmd struct {
+// UpdateConfigCmd updates a Configuration.
+type UpdateConfigCmd struct {
 	Name string `arg:"" help:"Name of Configuration."`
 	Tag  string `arg:"" help:"Updated tag for Configuration package."`
 }
 
 // Run runs the Configuration update cmd.
-func (c *updateConfigCmd) Run(k *kong.Context, logger logging.Logger) error {
+func (c *UpdateConfigCmd) Run(k *kong.Context, logger logging.Logger) error {
 	logger = logger.WithValues("Name", c.Name)
 	kubeConfig, err := ctrl.GetConfig()
 	if err != nil {
@@ -91,14 +108,14 @@ func (c *updateConfigCmd) Run(k *kong.Context, logger logging.Logger) error {
 	return err
 }
 
-// updateProviderCmd update a Provider.
-type updateProviderCmd struct {
+// UpdateProviderCmd update a Provider.
+type UpdateProviderCmd struct {
 	Name string `arg:"" help:"Name of Provider."`
 	Tag  string `arg:"" help:"Updated tag for Provider package."`
 }
 
 // Run runs the Provider update cmd.
-func (c *updateProviderCmd) Run(k *kong.Context, logger logging.Logger) error {
+func (c *UpdateProviderCmd) Run(k *kong.Context, logger logging.Logger) error {
 	kubeConfig, err := ctrl.GetConfig()
 	if err != nil {
 		logger.Debug(errKubeConfig, "error", err)

--- a/cmd/crank/main.go
+++ b/cmd/crank/main.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/crossplane/crossplane-runtime/pkg/logging"
 
+	"github.com/crossplane/crossplane/cmd/crank/commands"
 	"github.com/crossplane/crossplane/internal/version"
 )
 
@@ -58,18 +59,18 @@ var cli struct {
 	Version versionFlag `short:"v" name:"version" help:"Print version and quit."`
 	Verbose verboseFlag `name:"verbose" help:"Print verbose logging statements."`
 
-	Build   buildCmd   `cmd:"" help:"Build Crossplane packages."`
-	Install installCmd `cmd:"" help:"Install Crossplane packages."`
-	Update  updateCmd  `cmd:"" help:"Update Crossplane packages."`
-	Push    pushCmd    `cmd:"" help:"Push Crossplane packages."`
+	Build   commands.BuildCmd   `cmd:"" help:"Build Crossplane packages."`
+	Install commands.InstallCmd `cmd:"" help:"Install Crossplane packages."`
+	Update  commands.UpdateCmd  `cmd:"" help:"Update Crossplane packages."`
+	Push    commands.PushCmd    `cmd:"" help:"Push Crossplane packages."`
 }
 
 func main() {
-	buildChild := &buildChild{
-		fs: afero.NewOsFs(),
+	buildChild := &commands.BuildChild{
+		FS: afero.NewOsFs(),
 	}
-	pushChild := &pushChild{
-		fs: afero.NewOsFs(),
+	pushChild := &commands.PushChild{
+		FS: afero.NewOsFs(),
 	}
 	logger := logging.NewNopLogger()
 	ctx := kong.Parse(&cli,


### PR DESCRIPTION
### Description of your changes

The konq commands of the CLI were not public, making it impossible to add them to another tool. This PR moves the command into a `commands` package and make everything necessary public.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [ ] Added or updated unit **and** E2E tests for my change.
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

[contribution process]: https://git.io/fj2m9