### PR TITLE
guide-observability.md: don't record events on noops

### DIFF
--- a/contributing/guide-observability.md
+++ b/contributing/guide-observability.md
@@ -50,6 +50,9 @@ Events should be recorded in the following cases:
 * The state of a resource is changed
 * An error occurs
 
+Events should *not* be recorded if nothing happens or changes, with the exception
+of repeated errors.
+
 The events recorded in these cases can be thought of as forming an event log of
 things that happen for the resources that Crossplane manages. Each event should
 refer back to the relevant controller and resource, and use other fields of the


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

Add a sentence to the event guidelines to not create events when nothing changes, with the exception of repeated errors.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [ ] ~~Added or updated unit **and** E2E tests for my change.~~
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] ~~Added `backport release-x.y` labels to auto-backport this PR if necessary.~~

[contribution process]: https://git.io/fj2m9