### PR TITLE
chore: rename error constants according to our standard

### DIFF
--- a/internal/controller/pkg/resolver/reconciler.go
+++ b/internal/controller/pkg/resolver/reconciler.go
@@ -58,12 +58,12 @@ const (
 	errRemoveFinalizer      = "cannot remove lock finalizer"
 	errBuildDAG             = "cannot build DAG"
 	errSortDAG              = "cannot sort DAG"
-	errMissingDependencyFmt = "missing package (%s) is not a dependency"
+	errFmtMissingDependency = "missing package (%s) is not a dependency"
 	errInvalidConstraint    = "version constraint on dependency is invalid"
 	errInvalidDependency    = "dependency package is not valid"
 	errFetchTags            = "cannot fetch dependency package tags"
 	errNoValidVersion       = "cannot find a valid version for package constraints"
-	errNoValidVersionFmt    = "dependency (%s) does not have version in constraints (%s)"
+	errFmtNoValidVersion    = "dependency (%s) does not have version in constraints (%s)"
 	errInvalidPackageType   = "cannot create invalid package dependency type"
 	errCreateDependency     = "cannot create dependency package"
 )
@@ -216,7 +216,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 	// check for missing nodes again.
 	dep, ok := implied[0].(*v1beta1.Dependency)
 	if !ok {
-		log.Debug(errInvalidDependency, "error", errors.Errorf(errMissingDependencyFmt, dep.Identifier()))
+		log.Debug(errInvalidDependency, "error", errors.Errorf(errFmtMissingDependency, dep.Identifier()))
 		return reconcile.Result{Requeue: false}, nil
 	}
 	c, err := semver.NewConstraint(dep.Constraints)
@@ -260,7 +260,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 	// NOTE(hasheddan): consider creating event on package revision
 	// dictating constraints.
 	if addVer == "" {
-		log.Debug(errNoValidVersion, "error", errors.Errorf(errNoValidVersionFmt, dep.Identifier(), dep.Constraints))
+		log.Debug(errNoValidVersion, "error", errors.Errorf(errFmtNoValidVersion, dep.Identifier(), dep.Constraints))
 		return reconcile.Result{Requeue: false}, nil
 	}
 

--- a/internal/controller/pkg/revision/dependency.go
+++ b/internal/controller/pkg/revision/dependency.go
@@ -41,8 +41,8 @@ const (
 	errNotMeta                   = "meta type is not a valid package"
 	errGetOrCreateLock           = "cannot get or create lock"
 	errInitDAG                   = "cannot initialize dependency graph from the packages in the lock"
-	errIncompatibleDependencyFmt = "incompatible dependencies: %+v"
-	errMissingDependenciesFmt    = "missing dependencies: %+v"
+	errFmtIncompatibleDependency = "incompatible dependencies: %+v"
+	errFmtMissingDependencies    = "missing dependencies: %+v"
 	errDependencyNotInGraph      = "dependency is not present in graph"
 	errDependencyNotLockPackage  = "dependency in graph is not a lock package"
 )
@@ -160,7 +160,7 @@ func (m *PackageDependencyManager) Resolve(ctx context.Context, pkg runtime.Obje
 			missing = append(missing, dep.Identifier())
 		}
 		if installed != found {
-			return found, installed, invalid, errors.Errorf(errMissingDependenciesFmt, missing)
+			return found, installed, invalid, errors.Errorf(errFmtMissingDependencies, missing)
 		}
 	}
 
@@ -179,7 +179,7 @@ func (m *PackageDependencyManager) Resolve(ctx context.Context, pkg runtime.Obje
 		}
 	}
 	if len(missing) != 0 {
-		return found, installed, invalid, errors.Errorf(errMissingDependenciesFmt, missing)
+		return found, installed, invalid, errors.Errorf(errFmtMissingDependencies, missing)
 	}
 
 	// All of our dependencies and transitive dependencies must exist. Check
@@ -208,7 +208,7 @@ func (m *PackageDependencyManager) Resolve(ctx context.Context, pkg runtime.Obje
 	}
 	invalid = len(invalidDeps)
 	if invalid > 0 {
-		return found, installed, invalid, errors.Errorf(errIncompatibleDependencyFmt, invalidDeps)
+		return found, installed, invalid, errors.Errorf(errFmtIncompatibleDependency, invalidDeps)
 	}
 	return found, installed, invalid, nil
 }

--- a/internal/controller/pkg/revision/dependency_test.go
+++ b/internal/controller/pkg/revision/dependency_test.go
@@ -353,7 +353,7 @@ func TestResolve(t *testing.T) {
 			},
 			want: want{
 				total: 2,
-				err:   errors.Errorf(errMissingDependenciesFmt, []string{"not-here-1", "not-here-2"}),
+				err:   errors.Errorf(errFmtMissingDependencies, []string{"not-here-1", "not-here-2"}),
 			},
 		},
 		"ErrorSelfExistMissingDependencies": {
@@ -441,7 +441,7 @@ func TestResolve(t *testing.T) {
 			want: want{
 				total:     3,
 				installed: 1,
-				err:       errors.Errorf(errMissingDependenciesFmt, []string{"not-here-2", "not-here-3"}),
+				err:       errors.Errorf(errFmtMissingDependencies, []string{"not-here-2", "not-here-3"}),
 			},
 		},
 		"ErrorSelfExistInvalidDependencies": {
@@ -540,7 +540,7 @@ func TestResolve(t *testing.T) {
 				total:     3,
 				installed: 3,
 				invalid:   2,
-				err:       errors.Errorf(errIncompatibleDependencyFmt, []string{"not-here-1", "not-here-2"}),
+				err:       errors.Errorf(errFmtIncompatibleDependency, []string{"not-here-1", "not-here-2"}),
 			},
 		},
 		"SuccessfulSelfExistValidDependencies": {

--- a/internal/initializer/installer_test.go
+++ b/internal/initializer/installer_test.go
@@ -34,12 +34,12 @@ import (
 )
 
 const (
-	errGetProviderFmt              = "unexpected name in provider get: %s"
-	errPatchProviderFmt            = "unexpected name in provider update: %s"
-	errPatchProviderSourceFmt      = "unexpected source in provider update: %s"
-	errGetConfigurationFmt         = "unexpected name in configuration get: %s"
-	errPatchConfigurationFmt       = "unexpected name in configuration update: %s"
-	errPatchConfigurationSourceFmt = "unexpected source in configuration update: %s"
+	errFmtGetProvider              = "unexpected name in provider get: %s"
+	errFmtPatchProvider            = "unexpected name in provider update: %s"
+	errFmtPatchProviderSource      = "unexpected source in provider update: %s"
+	errFmtGetConfiguration         = "unexpected name in configuration get: %s"
+	errFmtPatchConfiguration       = "unexpected name in configuration update: %s"
+	errFmtPatchConfigurationSource = "unexpected source in configuration update: %s"
 )
 
 var errBoom = errors.New("boom")
@@ -111,11 +111,11 @@ func TestInstaller(t *testing.T) {
 						switch obj.(type) {
 						case *v1.Provider:
 							if key.Name != p1Name {
-								t.Errorf(errGetProviderFmt, key.Name)
+								t.Errorf(errFmtGetProvider, key.Name)
 							}
 						case *v1.Configuration:
 							if key.Name != c1Name {
-								t.Errorf(errGetConfigurationFmt, key.Name)
+								t.Errorf(errFmtGetConfiguration, key.Name)
 							}
 						default:
 							t.Errorf("unexpected type")
@@ -126,11 +126,11 @@ func TestInstaller(t *testing.T) {
 						switch obj.(type) {
 						case *v1.Provider:
 							if obj.GetName() != p1Name {
-								t.Errorf(errPatchProviderFmt, obj.GetName())
+								t.Errorf(errFmtPatchProvider, obj.GetName())
 							}
 						case *v1.Configuration:
 							if obj.GetName() != c1Name {
-								t.Errorf(errPatchConfigurationFmt, obj.GetName())
+								t.Errorf(errFmtPatchConfiguration, obj.GetName())
 							}
 						default:
 							t.Errorf("unexpected type")
@@ -186,11 +186,11 @@ func TestInstaller(t *testing.T) {
 						switch obj.(type) {
 						case *v1.Provider:
 							if key.Name != p1Existing {
-								t.Errorf(errGetProviderFmt, key.Name)
+								t.Errorf(errFmtGetProvider, key.Name)
 							}
 						case *v1.Configuration:
 							if key.Name != c1Existing {
-								t.Errorf(errGetConfigurationFmt, key.Name)
+								t.Errorf(errFmtGetConfiguration, key.Name)
 							}
 						default:
 							t.Errorf("unexpected type")
@@ -201,17 +201,17 @@ func TestInstaller(t *testing.T) {
 						switch o := obj.(type) {
 						case *v1.Provider:
 							if o.GetName() != p1Existing {
-								t.Errorf(errPatchProviderFmt, o.GetName())
+								t.Errorf(errFmtPatchProvider, o.GetName())
 							}
 							if o.GetSource() != p1 {
-								t.Errorf(errPatchProviderSourceFmt, o.GetSource())
+								t.Errorf(errFmtPatchProviderSource, o.GetSource())
 							}
 						case *v1.Configuration:
 							if o.GetName() != c1Existing {
-								t.Errorf(errPatchConfigurationFmt, o.GetName())
+								t.Errorf(errFmtPatchConfiguration, o.GetName())
 							}
 							if o.GetSource() != c1 {
-								t.Errorf(errPatchConfigurationSourceFmt, o.GetSource())
+								t.Errorf(errFmtPatchConfigurationSource, o.GetSource())
 							}
 						default:
 							t.Errorf("unexpected type")
@@ -233,11 +233,11 @@ func TestInstaller(t *testing.T) {
 						switch obj.(type) {
 						case *v1.Provider:
 							if key.Name != p1Name {
-								t.Errorf(errGetProviderFmt, key.Name)
+								t.Errorf(errFmtGetProvider, key.Name)
 							}
 						case *v1.Configuration:
 							if key.Name != c1Name {
-								t.Errorf(errGetConfigurationFmt, key.Name)
+								t.Errorf(errFmtGetConfiguration, key.Name)
 							}
 						default:
 							t.Errorf("unexpected type")
@@ -293,11 +293,11 @@ func TestInstaller(t *testing.T) {
 						switch obj.(type) {
 						case *v1.Provider:
 							if key.Name != p1Name {
-								t.Errorf(errGetProviderFmt, key.Name)
+								t.Errorf(errFmtGetProvider, key.Name)
 							}
 						case *v1.Configuration:
 							if key.Name != c1Name {
-								t.Errorf(errGetConfigurationFmt, key.Name)
+								t.Errorf(errFmtGetConfiguration, key.Name)
 							}
 						default:
 							t.Errorf("unexpected type")

--- a/internal/xpkg/lint.go
+++ b/internal/xpkg/lint.go
@@ -44,7 +44,7 @@ const (
 	errNotValidatingWebhookConfiguration = "object is not an ValidatingWebhookConfiguration"
 	errNotComposition                    = "object is not a Composition"
 	errBadConstraints                    = "package version constraints are poorly formatted"
-	errCrossplaneIncompatibleFmt         = "package is not compatible with Crossplane version (%s)"
+	errFmtCrossplaneIncompatible         = "package is not compatible with Crossplane version (%s)"
 )
 
 // NewProviderLinter is a convenience function for creating a package linter for
@@ -118,10 +118,10 @@ func PackageCrossplaneCompatible(v version.Operations) parser.ObjectLinterFn {
 		}
 		in, err := v.InConstraints(p.GetCrossplaneConstraints().Version)
 		if err != nil {
-			return errors.Wrapf(err, errCrossplaneIncompatibleFmt, v.GetVersionString())
+			return errors.Wrapf(err, errFmtCrossplaneIncompatible, v.GetVersionString())
 		}
 		if !in {
-			return errors.Errorf(errCrossplaneIncompatibleFmt, v.GetVersionString())
+			return errors.Errorf(errFmtCrossplaneIncompatible, v.GetVersionString())
 		}
 		return nil
 	}

--- a/internal/xpkg/lint_test.go
+++ b/internal/xpkg/lint_test.go
@@ -294,7 +294,7 @@ func TestPackageCrossplaneCompatible(t *testing.T) {
 					MockGetVersionString: fake.NewMockGetVersionStringFn("v0.12.0"),
 				},
 			},
-			err: errors.Wrapf(errBoom, errCrossplaneIncompatibleFmt, "v0.12.0"),
+			err: errors.Wrapf(errBoom, errFmtCrossplaneIncompatible, "v0.12.0"),
 		},
 		"ErrOutsideConstraints": {
 			reason: "Should return error if Crossplane version outside constraints.",
@@ -313,7 +313,7 @@ func TestPackageCrossplaneCompatible(t *testing.T) {
 					MockGetVersionString: fake.NewMockGetVersionStringFn("v0.12.0"),
 				},
 			},
-			err: errors.Errorf(errCrossplaneIncompatibleFmt, "v0.12.0"),
+			err: errors.Errorf(errFmtCrossplaneIncompatible, "v0.12.0"),
 		},
 		"ErrNotMeta": {
 			reason: "Should return error if object is not a meta package type.",


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does, and how it is covered by tests.
Be proactive - direct your reviewers' attention to anything that needs special
consideration.

You MUST either [x] check or ~strikethrough~ every item in the checklist below.

We love pull requests that fix an open issue. If yours does, use the below line
to indicate which issue it fixes, for example "Fixes #500".
-->

Just a minor rename of error constants as discussed here to adhere to the `errFmt...` standard we use in the rest of the codebase: https://github.com/crossplane/crossplane/pull/4311#discussion_r1259691340

I have:

- [x] Read and followed Crossplane's [contribution process].
- [ ] ~Added or updated unit **and** E2E tests for my change.~
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR if necessary.~

[contribution process]: https://git.io/fj2m9