### PR TITLE
fix xfn e2e tests on osx 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -34,6 +34,7 @@ require (
 	sigs.k8s.io/controller-runtime v0.15.0
 	sigs.k8s.io/controller-tools v0.12.0
 	sigs.k8s.io/e2e-framework v0.2.0
+	sigs.k8s.io/kind v0.20.0
 	sigs.k8s.io/yaml v1.3.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -72,6 +72,7 @@ github.com/Azure/go-autorest/logger v0.2.1/go.mod h1:T9E3cAhj2VqvPOtCYAvby9aBXkZ
 github.com/Azure/go-autorest/tracing v0.6.0 h1:TYi4+3m5t6K48TGI9AUdb+IzbnSxvnvUMfuitfgcfuo=
 github.com/Azure/go-autorest/tracing v0.6.0/go.mod h1:+vhtPC754Xsa23ID7GlGsrdKBpUA79WCAKPPZVC2DeU=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
+github.com/BurntSushi/toml v1.0.0/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
 github.com/BurntSushi/toml v1.2.1/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/Masterminds/semver v1.5.0 h1:H65muMkzWKEuNDnfl9d70GUjFniHKHRbFPGBuZ3QEww=
@@ -83,6 +84,7 @@ github.com/alecthomas/assert/v2 v2.1.0 h1:tbredtNcQnoSd3QBhQWI7QZ3XHOVkw1Moklp2o
 github.com/alecthomas/kong v0.8.0 h1:ryDCzutfIqJPnNn0omnrgHLbAggDQM2VWHikE1xqK7s=
 github.com/alecthomas/kong v0.8.0/go.mod h1:n1iCIO2xS46oE8ZfYCNDqdR0b0wZNrXAIAqro/2132U=
 github.com/alecthomas/repr v0.1.0 h1:ENn2e1+J3k09gyj2shc0dHr/yjaWSHRlrJ4DPMevDqE=
+github.com/alessio/shellescape v1.4.1/go.mod h1:PZAiSCk0LJaZkiCSkPv8qIobYglO3FPpyFjDCtHLS30=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
@@ -148,6 +150,7 @@ github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnht
 github.com/cncf/xds/go v0.0.0-20210312221358-fbca930ec8ed/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/containerd/stargz-snapshotter/estargz v0.14.3 h1:OqlDCK3ZVUO6C3B/5FSkDwbkEETK84kQgEeFwDC+62k=
 github.com/containerd/stargz-snapshotter/estargz v0.14.3/go.mod h1:KY//uOCIkSuNAHhJogcZtrNHdKrA99/FCCRjE3HD36o=
+github.com/cpuguy83/go-md2man/v2 v2.0.1/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/cpuguy83/go-md2man/v2 v2.0.2 h1:p1EgwI/C7NhT0JmVkwCD2ZBK8j4aeHQX2pMHHBfMQ6w=
 github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
@@ -316,6 +319,7 @@ github.com/google/pprof v0.0.0-20211214055906-6f57359322fd/go.mod h1:KgnwoLYCZ8I
 github.com/google/pprof v0.0.0-20230602150820-91b7bce49751 h1:hR7/MlvK23p6+lIw9SN1TigNLn9ZnF3W4SYRKq2gAHs=
 github.com/google/pprof v0.0.0-20230602150820-91b7bce49751/go.mod h1:Jh3hGz2jkYak8qXPD19ryItVnUgpgeqzdkY/D0EaeuA=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
+github.com/google/safetext v0.0.0-20220905092116-b49f7bc46da2/go.mod h1:Tv1PlzqC9t8wNnpPdctvtSUOPUUg4SHeE6vR1Ir2hmg=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
 github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
@@ -359,6 +363,7 @@ github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:
 github.com/ianlancetaylor/demangle v0.0.0-20210905161508-09a460cdf81d/go.mod h1:aYm2/VgdVmcIU8iMfdMvDMsRAQjcfZSKFby6HOFvi/w=
 github.com/imdario/mergo v0.3.16 h1:wwQJbIsHYGMUyLSPrEq1CT16AhnhNJQ51+4fdHUnCl4=
 github.com/imdario/mergo v0.3.16/go.mod h1:WBLT9ZmE3lPoWsEzCh9LPo3TiwVN+ZKEjmz+hD27ysY=
+github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/jdxcode/netrc v0.0.0-20221124155335-4616370d1a84 h1:2uT3aivO7NVpUPGcQX7RbHijHMyWix/yCnIrCWc+5co=
@@ -401,6 +406,7 @@ github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovk
 github.com/mattn/go-isatty v0.0.3/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
 github.com/mattn/go-isatty v0.0.8/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
 github.com/mattn/go-isatty v0.0.10/go.mod h1:qgIWMr58cqv1PHHyhnkY9lrL7etaEgOFcMEpPG5Rm84=
+github.com/mattn/go-isatty v0.0.14/go.mod h1:7GGIvUiUoEMVVmxf/4nioHXj79iQHKdU27kJ6hsGG94=
 github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
 github.com/mattn/go-isatty v0.0.17 h1:BTarxUcIeDqL27Mc+vyvdWYSL28zpIhv3RoTdsLMPng=
 github.com/mattn/go-isatty v0.0.17/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
@@ -437,6 +443,7 @@ github.com/opencontainers/image-spec v1.1.0-rc3 h1:fzg1mXZFj8YdPeNkRXMg+zb88BFV0
 github.com/opencontainers/image-spec v1.1.0-rc3/go.mod h1:X4pATf0uXsnn3g5aiGIsVnJBR4mxhKzfwmvK/B2NTm8=
 github.com/opencontainers/runtime-spec v1.1.0-rc.3.0.20230610073135-48415de180cf h1:AGnwZS8lmjGxN2/XlzORiYESAk7HOlE3XI37uhIP9Vw=
 github.com/opencontainers/runtime-spec v1.1.0-rc.3.0.20230610073135-48415de180cf/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
+github.com/pelletier/go-toml v1.9.4/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCkoOuaOx1Y+c=
 github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8 h1:KoWmjvw+nsYOo29YJK9vDA65RGE3NrOnUtO7a+RF9HU=
 github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8/go.mod h1:HKlIX3XHQyzLZPlr7++PzdhaXEj94dEiJgZDTsxEqUI=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
@@ -473,6 +480,7 @@ github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVs
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/afero v1.9.5 h1:stMpOSZFs//0Lv29HduCmli3GUfpFoF3Y1Q/aXj/wVM=
 github.com/spf13/afero v1.9.5/go.mod h1:UBogFpq8E9Hx+xc5CNTTEpTnuHVmXDwZcZcE1eb/UhQ=
+github.com/spf13/cobra v1.4.0/go.mod h1:Wo4iy3BUC+X2Fybo0PDqwJIv3dNRiZLHQymsfxlB84g=
 github.com/spf13/cobra v1.7.0 h1:hyqWnYt1ZQShIddO5kBpj3vu05/++x6tJ6dg8EC572I=
 github.com/spf13/cobra v1.7.0/go.mod h1:uLxZILRyS/50WlhOIKD7W6V5bgeIt+4sICxh6uRMrb0=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
@@ -695,6 +703,7 @@ golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210616045830-e2b7044e8c71/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210616094352-59db8d763f22/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210819135213-f52c844e1c1c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211007075335-d3039528d8ac/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211019181941-9d821ace8654/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
@@ -963,6 +972,8 @@ sigs.k8s.io/e2e-framework v0.2.0 h1:gD6AWWAHFcHibI69E9TgkNFhh0mVwWtRCHy2RU057jQ=
 sigs.k8s.io/e2e-framework v0.2.0/go.mod h1:E6JXj/V4PIlb95jsn2WrNKG+Shb45xaaI7C0+BH4PL8=
 sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd h1:EDPBXCAspyGV4jQlpZSudPeMmr1bNJefnuqLsRAsHZo=
 sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd/go.mod h1:B8JuhiUyNFVKdsE8h686QcCxMaH6HrOAZj4vswFpcB0=
+sigs.k8s.io/kind v0.20.0 h1:f0sc3v9mQbGnjBUaqSFST1dwIuiikKVGgoTwpoP33a8=
+sigs.k8s.io/kind v0.20.0/go.mod h1:aBlbxg08cauDgZ612shr017/rZwqd7AS563FvpWKPVs=
 sigs.k8s.io/structured-merge-diff/v4 v4.2.3 h1:PRbqxJClWWYMNV1dhaG4NsibJbArud9kFxnAMREiWFE=
 sigs.k8s.io/structured-merge-diff/v4 v4.2.3/go.mod h1:qjx8mGObPmV2aSZepjQjbmb2ihdVs8cGKBraizNC69E=
 sigs.k8s.io/yaml v1.2.0/go.mod h1:yfXDCHCao9+ENCvLSE62v9VSji2MKu5jeNfTrofGhJc=

--- a/test/e2e/funcs/env.go
+++ b/test/e2e/funcs/env.go
@@ -18,12 +18,19 @@ package funcs
 
 import (
 	"context"
+	"fmt"
+	"os"
+	"path/filepath"
 	"testing"
 
+	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/e2e-framework/pkg/env"
 	"sigs.k8s.io/e2e-framework/pkg/envconf"
+	"sigs.k8s.io/e2e-framework/pkg/envfuncs"
 	"sigs.k8s.io/e2e-framework/pkg/features"
 	"sigs.k8s.io/e2e-framework/third_party/helm"
+	"sigs.k8s.io/kind/pkg/apis/config/v1alpha4"
+	"sigs.k8s.io/yaml"
 
 	"github.com/crossplane/crossplane-runtime/pkg/errors"
 
@@ -31,6 +38,8 @@ import (
 	pkgv1 "github.com/crossplane/crossplane/apis/pkg/v1"
 	secretsv1alpha1 "github.com/crossplane/crossplane/apis/secrets/v1alpha1"
 )
+
+type kindConfigContextKey string
 
 // HelmRepo manages a Helm repo.
 func HelmRepo(o ...helm.Option) env.Func {
@@ -101,4 +110,105 @@ func EnvFuncs(fns ...env.Func) env.Func {
 		}
 		return ctx, nil
 	}
+}
+
+// CreateKindClusterWithConfig create kind cluster of the given name according to
+// configuration referred via configFilePath.
+// The configuration is placed in test context afterward
+func CreateKindClusterWithConfig(clusterName, configFilePath string) env.Func {
+	return EnvFuncs(
+		envfuncs.CreateKindClusterWithConfig(clusterName, "\"\"", configFilePath),
+		func(ctx context.Context, config *envconf.Config) (context.Context, error) {
+			b, err := os.ReadFile(filepath.Clean(configFilePath))
+			if err != nil {
+				return ctx, err
+			}
+			cfg := &v1alpha4.Cluster{}
+			err = yaml.Unmarshal(b, cfg)
+			if err != nil {
+				return ctx, err
+			}
+			return context.WithValue(ctx, kindConfigContextKey(clusterName), cfg), nil
+		},
+	)
+}
+
+// ServiceIngressEndPoint returns endpoint (addr:port) that can be used for accessing
+// the service in the cluster with the given name.
+func ServiceIngressEndPoint(ctx context.Context, cfg *envconf.Config, clusterName, namespace, serviceName string) (string, error) {
+	_, found := envfuncs.GetKindClusterFromContext(ctx, clusterName)
+	client := cfg.Client()
+	service := &corev1.Service{}
+	err := client.Resources().Get(ctx, serviceName, namespace, service)
+	if err != nil {
+		return "", err
+	}
+
+	var nodePort int32
+	for _, p := range service.Spec.Ports {
+		if p.NodePort != 0 {
+			nodePort = p.NodePort
+			break
+		}
+	}
+	if nodePort == 0 {
+		return "", errors.Errorf("No nodePort found for service %s/%s at cluster %s", namespace, serviceName, clusterName)
+	}
+	if found {
+		kindCfg, err := kindConfig(ctx, clusterName)
+		if err != nil {
+			return "", err
+		}
+		hostPort, err := findHostPort(kindCfg, nodePort)
+		if err != nil {
+			return "", err
+		}
+		return fmt.Sprintf("localhost:%v", hostPort), nil
+	}
+	nodes := &corev1.NodeList{}
+	if err := client.Resources().List(ctx, nodes); err != nil {
+		return "", errors.Wrap(err, "cannot list nodes")
+	}
+	addr, err := findAnyNodeIPAddress(nodes)
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("%s:%v", addr, nodePort), nil
+}
+
+func kindConfig(ctx context.Context, clusterName string) (*v1alpha4.Cluster, error) {
+	v := ctx.Value(kindConfigContextKey(clusterName))
+	if v == nil {
+		return nil, errors.Errorf("No kind config found in context for cluster %s", clusterName)
+	}
+	kindCfg, ok := v.(*v1alpha4.Cluster)
+	if !ok {
+		return nil, errors.Errorf("kind config is not of type v1alpha4.Cluster for clustername %s", clusterName)
+	}
+	return kindCfg, nil
+}
+
+func findAnyNodeIPAddress(nodes *corev1.NodeList) (string, error) {
+	if len(nodes.Items) == 0 {
+		return "", errors.New("no nodes in the cluster")
+	}
+	for _, a := range nodes.Items[0].Status.Addresses {
+		if a.Type == corev1.NodeInternalIP {
+			return a.Address, nil
+		}
+	}
+	return "", errors.Errorf("no ip address found for nodes: %v", nodes)
+}
+
+func findHostPort(kindCfg *v1alpha4.Cluster, containerPort int32) (int32, error) {
+	for _, n := range kindCfg.Nodes {
+		if n.Role == v1alpha4.ControlPlaneRole {
+			for _, pm := range n.ExtraPortMappings {
+				if pm.ContainerPort == containerPort {
+					return pm.HostPort, nil
+				}
+			}
+		}
+	}
+	return 0, errors.Errorf("No host port found in kind config for container port: %v", containerPort)
 }

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -154,7 +154,7 @@ func TestMain(m *testing.M) {
 			os.Exit(1)
 		}
 		setup = []env.Func{
-			envfuncs.CreateKindClusterWithConfig(clusterName, "\"\"", kindCfg),
+			funcs.CreateKindClusterWithConfig(clusterName, kindCfg),
 		}
 	} else {
 		cfg.WithKubeconfigFile(conf.ResolveKubeConfigFile())

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -154,7 +154,7 @@ func TestMain(m *testing.M) {
 			os.Exit(1)
 		}
 		setup = []env.Func{
-			envfuncs.CreateKindClusterWithConfig(clusterName, "kindest/node:v1.27.3", kindCfg),
+			envfuncs.CreateKindClusterWithConfig(clusterName, "\"\"", kindCfg),
 		}
 	} else {
 		cfg.WithKubeconfigFile(conf.ResolveKubeConfigFile())

--- a/test/e2e/testdata/kindConfig.yaml
+++ b/test/e2e/testdata/kindConfig.yaml
@@ -1,0 +1,8 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+- role: control-plane
+  extraPortMappings:
+  # expose NodePort 32000 to the host
+  - containerPort: 32000
+    hostPort: 3000

--- a/test/e2e/xfn_test.go
+++ b/test/e2e/xfn_test.go
@@ -106,24 +106,31 @@ func TestXfnRunnerImagePull(t *testing.T) {
 						))),
 			).
 			WithSetup("CopyFnImageToRegistry", func(ctx context.Context, t *testing.T, config *envconf.Config) context.Context {
-				nodes := &corev1.NodeList{}
-				if err := config.Client().Resources().List(ctx, nodes); err != nil {
-					t.Fatal("cannot list nodes", err)
-				}
-				if len(nodes.Items) == 0 {
-					t.Fatalf("no nodes in the cluster")
-				}
-				var addr string
-				for _, a := range nodes.Items[0].Status.Addresses {
-					if a.Type == corev1.NodeInternalIP {
-						addr = a.Address
-						break
+				var reg string
+				_, found := envfuncs.GetKindClusterFromContext(ctx, clusterName)
+				if found {
+					reg = "localhost:3000"
+					t.Logf("Running tests against kind cluster, container registry accessible from host via %s", reg)
+				} else {
+					nodes := &corev1.NodeList{}
+					if err := config.Client().Resources().List(ctx, nodes); err != nil {
+						t.Fatal("cannot list nodes", err)
 					}
+					if len(nodes.Items) == 0 {
+						t.Fatalf("no nodes in the cluster")
+					}
+					var addr string
+					for _, a := range nodes.Items[0].Status.Addresses {
+						if a.Type == corev1.NodeInternalIP {
+							addr = a.Address
+							break
+						}
+					}
+					if addr == "" {
+						t.Fatalf("no nodes with private address")
+					}
+					reg = fmt.Sprintf("%s:32000", addr)
 				}
-				if addr == "" {
-					t.Fatalf("no nodes with private address")
-				}
-
 				srcRef, err := name.ParseReference("crossplane-e2e/fn-labelizer:latest")
 				if err != nil {
 					t.Fatal(err)
@@ -133,7 +140,7 @@ func TestXfnRunnerImagePull(t *testing.T) {
 					t.Fatal(err)
 				}
 				err = wait.For(func() (done bool, err error) {
-					err = crane.Push(src, fmt.Sprintf("%s:32000/fn-labelizer:latest", addr), crane.Insecure)
+					err = crane.Push(src, fmt.Sprintf("%s/fn-labelizer:latest", reg), crane.Insecure)
 					if err != nil {
 						return false, nil //nolint:nilerr // we want to retry and to throw error
 					}

--- a/test/e2e/xfn_test.go
+++ b/test/e2e/xfn_test.go
@@ -106,31 +106,11 @@ func TestXfnRunnerImagePull(t *testing.T) {
 						))),
 			).
 			WithSetup("CopyFnImageToRegistry", func(ctx context.Context, t *testing.T, config *envconf.Config) context.Context {
-				var reg string
-				_, found := envfuncs.GetKindClusterFromContext(ctx, clusterName)
-				if found {
-					reg = "localhost:3000"
-					t.Logf("Running tests against kind cluster, container registry accessible from host via %s", reg)
-				} else {
-					nodes := &corev1.NodeList{}
-					if err := config.Client().Resources().List(ctx, nodes); err != nil {
-						t.Fatal("cannot list nodes", err)
-					}
-					if len(nodes.Items) == 0 {
-						t.Fatalf("no nodes in the cluster")
-					}
-					var addr string
-					for _, a := range nodes.Items[0].Status.Addresses {
-						if a.Type == corev1.NodeInternalIP {
-							addr = a.Address
-							break
-						}
-					}
-					if addr == "" {
-						t.Fatalf("no nodes with private address")
-					}
-					reg = fmt.Sprintf("%s:32000", addr)
+				reg, err := funcs.ServiceIngressEndPoint(ctx, config, clusterName, "reg", "private-docker-registry")
+				if err != nil {
+					t.Fatal(err)
 				}
+				t.Logf("registry endpoint %s", reg)
 				srcRef, err := name.ParseReference("crossplane-e2e/fn-labelizer:latest")
 				if err != nil {
 					t.Fatal(err)


### PR DESCRIPTION
when docker engine runs inside a VM, it is not possible to reach k8s nodes from the hosts.

In order to make possible to copy images from host to the container registry running inside kind cluster, we need to add extra port mappings to the kind configuration as suggested in https://kind.sigs.k8s.io/docs/user/configuration/#extra-port-mappings

We start kind with such configuration and later on when image copying is needed, we detect if our cluster is kind
and use proper address to reach the registry. Otherwise, we fall back on detecting node address.

Fixes the issue reported [here](https://github.com/crossplane/crossplane/pull/4261#pullrequestreview-1523912702)

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Added or updated unit **and** E2E tests for my change.
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

[contribution process]: https://git.io/fj2m9