### PR TITLE
Update release issue templates with recent changes/learnings

### DIFF
--- a/.github/ISSUE_TEMPLATE/patch_release.md
+++ b/.github/ISSUE_TEMPLATE/patch_release.md
@@ -28,7 +28,7 @@ examples of each step, assuming vX.Y.Z is being cut.
   - [ ] `xp/getting-started-with-aws-with-vpc`
   - [ ] `xp/getting-started-with-azure`
   - [ ] `xp/getting-started-with-gcp`
-- [ ] Confirm the full set of patch versions that will be released and promote them from lowest to highest, so the highest version is the last to be promoted (e.g. `v1.12.2` should be promoted after `v1.11.3`)
+- [ ] Confirm the full set of patch versions that will be released and promote them from lowest to highest, so the **highest** version is the **last** to be promoted (e.g. `v1.12.2` should be promoted after `v1.11.3`), in order to avoid the promote workflow overwriting the latest patch release.
 - [ ] Run the [Promote workflow][promote-workflow] with channel `stable` on the `release-X.Y` branch and verified that the tagged build version exists on the [releases.crossplane.io] `stable` channel at `stable/vX.Y.Z/...`.
 - [ ] Published a [new release] for the tagged version, with the same name as the version and descriptive release notes, taking care of generating the changes list selecting as "Previous tag" `vX.Y.<Z-1>`, so the previous patch release for the same minor. Before publishing the release notes, set them as Draft and ask the rest of the team to double check them.
 - [ ] Ensured that users have been notified of the release on all communication channels:

--- a/.github/ISSUE_TEMPLATE/patch_release.md
+++ b/.github/ISSUE_TEMPLATE/patch_release.md
@@ -28,11 +28,14 @@ examples of each step, assuming vX.Y.Z is being cut.
   - [ ] `xp/getting-started-with-aws-with-vpc`
   - [ ] `xp/getting-started-with-azure`
   - [ ] `xp/getting-started-with-gcp`
+- [ ] Confirm the full set of patch versions that will be released and promote them from lowest to highest, so the highest version is the last to be promoted (e.g. `v1.12.2` should be promoted after `v1.11.3`)
 - [ ] Run the [Promote workflow][promote-workflow] with channel `stable` on the `release-X.Y` branch and verified that the tagged build version exists on the [releases.crossplane.io] `stable` channel at `stable/vX.Y.Z/...`.
 - [ ] Published a [new release] for the tagged version, with the same name as the version and descriptive release notes, taking care of generating the changes list selecting as "Previous tag" `vX.Y.<Z-1>`, so the previous patch release for the same minor. Before publishing the release notes, set them as Draft and ask the rest of the team to double check them.
 - [ ] Ensured that users have been notified of the release on all communication channels:
   - [ ] Slack: `#announcements` channel on Crossplane's Slack workspace.
   - [ ] Twitter: reach out to a Crossplane maintainer or steering committee member, see [OWNERS.md][owners].
+  - [ ] LinkedIn: same as Twitter
+- [ ] Remove any extra permissions given to release team members for this release
 
 <!-- Named Links -->
 [ci-workflow]: https://github.com/crossplane/crossplane/actions/workflows/ci.yml

--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -41,10 +41,13 @@ examples of each step, assuming release vX.Y.0 is being cut.
   - [ ] The [releases table] in the `README.md`, removing the now old unsupported release and adding the new one.
   - [ ] The `baseBranches` list in `.github/renovate.json5`, removing the now old unsupported release and adding the new one.
 - [ ] Closed the GitHub milestone for this release.
+- [ ] Publish a blog post about the release to the [crossplane blog]
 - [ ] Ensured that users have been notified of the release on all communication channels:
   - [ ] Slack: `#announcements` channel on Crossplane's Slack workspace.
   - [ ] Twitter: reach out to a Crossplane maintainer or steering committee member, see [OWNERS.md][owners].
-- [ ] Request @jbw976 to remove the EOL docs version from Google Search
+  - [ ] LinkedIn: same as Twitter
+- [ ] Request @jbw976 to remove all old docs versions from Google Search
+- [ ] Remove any extra permissions given to release team members for this release
 
 
 <!-- Named Links -->
@@ -62,3 +65,4 @@ examples of each step, assuming release vX.Y.0 is being cut.
 [tag-workflow]: https://github.com/crossplane/crossplane/actions/workflows/tag.yml
 [xpkg.upbound.io]: https://marketplace.upbound.io/configurations?query=getting-started
 [GitHub milestone]: https://github.com/crossplane/crossplane/milestones
+[crossplane blog]: https://blog.crossplane.io


### PR DESCRIPTION
### Description of your changes

This PR makes the following updates to our release issue templates. These are all recent lessons from issues we've had, or new opportunities we have to communicate about our releases.

* Promote patch releases from oldest to newest
* Ensure a blog post is published for major releases
* Remove all old docs versions from search
* Include LinkedIn in social announcements
* Remove extra permissions from release team if needed

Fixes #3922 

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Added or updated unit **and** E2E tests for my change.
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

[contribution process]: https://git.io/fj2m9