### PR TITLE
fix(alpha): re-evaluating additional fields against schema

### DIFF
--- a/pkg/validation/apiextensions/v1/composition/patches.go
+++ b/pkg/validation/apiextensions/v1/composition/patches.go
@@ -420,7 +420,8 @@ func validateFieldPathSegmentField(parent *apiextensions.JSONSchemaProps, segmen
 		// Schema is not nil.
 		// See https://github.com/kubernetes/kubernetes/blob/ff4eff24ac4fad5431aa89681717d6c4fe5733a4/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/validation/validation.go#L828
 		if parent.AdditionalProperties != nil && (parent.AdditionalProperties.Allows || parent.AdditionalProperties.Schema != nil) {
-			return parent.AdditionalProperties.Schema, nil
+			// re-evaluate the segment against the additional properties schema
+			return validateFieldPathSegmentField(parent.AdditionalProperties.Schema, segment)
 		}
 		return nil, errors.Errorf(errFmtFieldInvalid, segment.Field)
 

--- a/pkg/validation/apiextensions/v1/composition/patches_test.go
+++ b/pkg/validation/apiextensions/v1/composition/patches_test.go
@@ -444,6 +444,22 @@ func TestValidateFieldPath(t *testing.T) {
 				schema:    &apiextensions.JSONSchemaProps{Properties: map[string]apiextensions.JSONSchemaProps{"metadata": {Type: "object"}}},
 			},
 		},
+		"AcceptXPreserveUnknownFieldsInAdditionalProperties": {
+			reason: "Should properly handle x-preserve-unknown-fields even if defined in a nested schema",
+			want:   want{err: nil, fieldType: ""},
+			args: args{
+				fieldPath: "data.someField",
+				schema: &apiextensions.JSONSchemaProps{
+					Properties: map[string]apiextensions.JSONSchemaProps{
+						"data": {
+							Type: "object",
+							AdditionalProperties: &apiextensions.JSONSchemaPropsOrBool{
+								Schema: &apiextensions.JSONSchemaProps{
+									XPreserveUnknownFields: &[]bool{true}[0],
+								},
+							},
+						}}}},
+		},
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does, and how it is covered by tests.
Be proactive - direct your reviewers' attention to anything that needs special
consideration.

You MUST either [x] check or ~strikethrough~ every item in the checklist below.

We love pull requests that fix an open issue. If yours does, use the below line
to indicate which issue it fixes, for example "Fixes #500".
-->

Fixes #4344

The issue was that we handle the EnvironmentConfig schema form Environment related patches by mostly assuming they have no schema, but if, like in the issue, an EnvironmentConfig is used as source of a FromFieldPath patch, being the schema of EnvironmentConfigs as follows:
```yaml
...
          data:
            additionalProperties:
              x-kubernetes-preserve-unknown-fields: true
            description: The data of this EnvironmentConfig. This may contain any
              kind of structure that can be serialized into JSON.
            type: object
...
```
We were forgetting to re-evaluate the last segment of the fielPpath against the schema defined by `additionalProperties`.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Added or updated unit **and** E2E tests for my change.
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

[contribution process]: https://git.io/fj2m9