### PR TITLE
fix: stop rbac manager's rule expansion on timeout

### DIFF
--- a/internal/controller/rbac/provider/roles/requests.go
+++ b/internal/controller/rbac/provider/roles/requests.go
@@ -29,7 +29,9 @@ import (
 
 // Error strings.
 const (
-	errGetClusterRole = "cannot get ClusterRole"
+	errGetClusterRole           = "cannot get ClusterRole"
+	errExpandClusterRoleRules   = "cannot expand ClusterRole rules"
+	errExpandPermissionRequests = "cannot expand PermissionRequests"
 )
 
 const (
@@ -126,11 +128,17 @@ func (r Rule) path() path {
 }
 
 // Expand RBAC policy rules into our granular rules.
-func Expand(rs ...rbacv1.PolicyRule) []Rule {
+func Expand(ctx context.Context, rs ...rbacv1.PolicyRule) ([]Rule, error) { //nolint:gocyclo // Granular rules are inherently complex.
 	out := make([]Rule, 0, len(rs))
 	for _, r := range rs {
 		for _, u := range r.NonResourceURLs {
 			for _, v := range r.Verbs {
+				// exit if ctx is done
+				select {
+				case <-ctx.Done():
+					return nil, ctx.Err()
+				default:
+				}
 				out = append(out, Rule{NonResourceURL: u, Verb: v})
 			}
 		}
@@ -147,13 +155,18 @@ func Expand(rs ...rbacv1.PolicyRule) []Rule {
 			for _, rsc := range r.Resources {
 				for _, n := range names {
 					for _, v := range r.Verbs {
+						select {
+						case <-ctx.Done():
+							return nil, ctx.Err()
+						default:
+						}
 						out = append(out, Rule{APIGroup: g, Resource: rsc, ResourceName: n, Verb: v})
 					}
 				}
 			}
 		}
 	}
-	return out
+	return out, nil
 }
 
 // A ClusterRoleBackedValidator is a PermissionRequestsValidator that validates
@@ -170,7 +183,7 @@ func NewClusterRoleBackedValidator(c client.Client, roleName string) *ClusterRol
 	return &ClusterRoleBackedValidator{client: c, name: roleName}
 }
 
-// ValidatePermissionRequests against the ClusterRole.
+// ValidatePermissionRequests against the ClusterRole, returning the list of rejected rules.
 func (v *ClusterRoleBackedValidator) ValidatePermissionRequests(ctx context.Context, requests ...rbacv1.PolicyRule) ([]Rule, error) {
 	cr := &rbacv1.ClusterRole{}
 	if err := v.client.Get(ctx, types.NamespacedName{Name: v.name}, cr); err != nil {
@@ -178,12 +191,20 @@ func (v *ClusterRoleBackedValidator) ValidatePermissionRequests(ctx context.Cont
 	}
 
 	t := newNode()
-	for _, rule := range Expand(cr.Rules...) {
+	expandedCrRules, err := Expand(ctx, cr.Rules...)
+	if err != nil {
+		return nil, errors.Wrap(err, errExpandClusterRoleRules)
+	}
+	for _, rule := range expandedCrRules {
 		t.Allow(rule.path())
 	}
 
 	rejected := make([]Rule, 0)
-	for _, rule := range Expand(requests...) {
+	expandedRequests, err := Expand(ctx, requests...)
+	if err != nil {
+		return nil, errors.Wrap(err, errExpandPermissionRequests)
+	}
+	for _, rule := range expandedRequests {
 		if !t.Allowed(rule.path()) {
 			rejected = append(rejected, rule)
 		}
@@ -194,6 +215,6 @@ func (v *ClusterRoleBackedValidator) ValidatePermissionRequests(ctx context.Cont
 
 // VerySecureValidator is a PermissionRequestsValidatorFn that rejects all
 // requested permissions.
-func VerySecureValidator(_ context.Context, requests ...rbacv1.PolicyRule) ([]Rule, error) {
-	return Expand(requests...), nil
+func VerySecureValidator(ctx context.Context, requests ...rbacv1.PolicyRule) ([]Rule, error) {
+	return Expand(ctx, requests...)
 }


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does, and how it is covered by tests.
Be proactive - direct your reviewers' attention to anything that needs special
consideration.

You MUST either [x] check or ~strikethrough~ every item in the checklist below.

We love pull requests that fix an open issue. If yours does, use the below line
to indicate which issue it fixes, for example "Fixes #500".
-->

Stops RBAC manager from expanding requests rules on reconciliation loop timeout.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Added or updated unit **and** E2E tests for my change.
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

[contribution process]: https://git.io/fj2m9