### PR TITLE
fix: omitempty environmentConfigs label selector fields

### DIFF
--- a/apis/apiextensions/v1/composition_environment.go
+++ b/apis/apiextensions/v1/composition_environment.go
@@ -182,14 +182,14 @@ type EnvironmentSourceSelector struct {
 	// Mode specifies retrieval strategy: "Single" or "Multiple".
 	// +kubebuilder:validation:Enum=Single;Multiple
 	// +kubebuilder:default=Single
-	Mode EnvironmentSourceSelectorModeType `json:"mode"`
+	Mode EnvironmentSourceSelectorModeType `json:"mode,omitempty"`
 
 	// MaxMatch specifies the number of extracted EnvironmentConfigs in Multiple mode, extracts all if nil.
 	MaxMatch *uint64 `json:"maxMatch,omitempty"`
 
 	// SortByFieldPath is the path to the field based on which list of EnvironmentConfigs is alphabetically sorted.
 	// +kubebuilder:default="metadata.name"
-	SortByFieldPath string `json:"sortByFieldPath"`
+	SortByFieldPath string `json:"sortByFieldPath,omitempty"`
 
 	// MatchLabels ensures an object with matching labels is selected.
 	MatchLabels []EnvironmentSourceSelectorLabelMatcher `json:"matchLabels,omitempty"`
@@ -231,7 +231,7 @@ type EnvironmentSourceSelectorLabelMatcher struct {
 	// +optional
 	// +kubebuilder:validation:Enum=FromCompositeFieldPath;Value
 	// +kubebuilder:default=FromCompositeFieldPath
-	Type EnvironmentSourceSelectorLabelMatcherType `json:"type"`
+	Type EnvironmentSourceSelectorLabelMatcherType `json:"type,omitempty"`
 
 	// Key of the label to match.
 	Key string `json:"key"`

--- a/apis/apiextensions/v1beta1/zz_generated.composition_environment.go
+++ b/apis/apiextensions/v1beta1/zz_generated.composition_environment.go
@@ -184,14 +184,14 @@ type EnvironmentSourceSelector struct {
 	// Mode specifies retrieval strategy: "Single" or "Multiple".
 	// +kubebuilder:validation:Enum=Single;Multiple
 	// +kubebuilder:default=Single
-	Mode EnvironmentSourceSelectorModeType `json:"mode"`
+	Mode EnvironmentSourceSelectorModeType `json:"mode,omitempty"`
 
 	// MaxMatch specifies the number of extracted EnvironmentConfigs in Multiple mode, extracts all if nil.
 	MaxMatch *uint64 `json:"maxMatch,omitempty"`
 
 	// SortByFieldPath is the path to the field based on which list of EnvironmentConfigs is alphabetically sorted.
 	// +kubebuilder:default="metadata.name"
-	SortByFieldPath string `json:"sortByFieldPath"`
+	SortByFieldPath string `json:"sortByFieldPath,omitempty"`
 
 	// MatchLabels ensures an object with matching labels is selected.
 	MatchLabels []EnvironmentSourceSelectorLabelMatcher `json:"matchLabels,omitempty"`
@@ -233,7 +233,7 @@ type EnvironmentSourceSelectorLabelMatcher struct {
 	// +optional
 	// +kubebuilder:validation:Enum=FromCompositeFieldPath;Value
 	// +kubebuilder:default=FromCompositeFieldPath
-	Type EnvironmentSourceSelectorLabelMatcherType `json:"type"`
+	Type EnvironmentSourceSelectorLabelMatcherType `json:"type,omitempty"`
 
 	// Key of the label to match.
 	Key string `json:"key"`

--- a/cluster/crds/apiextensions.crossplane.io_compositionrevisions.yaml
+++ b/cluster/crds/apiextensions.crossplane.io_compositionrevisions.yaml
@@ -147,9 +147,6 @@ spec:
                                 based on which list of EnvironmentConfigs is alphabetically
                                 sorted.
                               type: string
-                          required:
-                          - mode
-                          - sortByFieldPath
                           type: object
                         type:
                           default: Reference
@@ -1628,9 +1625,6 @@ spec:
                                 based on which list of EnvironmentConfigs is alphabetically
                                 sorted.
                               type: string
-                          required:
-                          - mode
-                          - sortByFieldPath
                           type: object
                         type:
                           default: Reference

--- a/cluster/crds/apiextensions.crossplane.io_compositions.yaml
+++ b/cluster/crds/apiextensions.crossplane.io_compositions.yaml
@@ -144,9 +144,6 @@ spec:
                                 based on which list of EnvironmentConfigs is alphabetically
                                 sorted.
                               type: string
-                          required:
-                          - mode
-                          - sortByFieldPath
                           type: object
                         type:
                           default: Reference


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does, and how it is covered by tests.
Be proactive - direct your reviewers' attention to anything that needs special
consideration.

You MUST either [x] check or ~strikethrough~ every item in the checklist below.

We love pull requests that fix an open issue. If yours does, use the below line
to indicate which issue it fixes, for example "Fixes #500".
-->

Follow up to #3981, while writing E2Es I noticed that we missed to add `omitempty` to the newly introduced fields, resulting in no issue when applying with `kubectl`, but with errors such as the one below when serialized to the actual object and applied programmatically:
```
Composition.apiextensions.crossplane.io "nop.sqlinstances.example.org" is invalid: spec.environment.environmentConfigs[1].selector.mode: Unsupported value: "": supported values: "Single", "Multiple"
```

I have:

- [x] Read and followed Crossplane's [contribution process].
- [ ] ~Added or updated unit **and** E2E tests for my change.~
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

[contribution process]: https://git.io/fj2m9