### PR TITLE
fix: Include top-level description in CRDs generated from XRDs

### DIFF
--- a/internal/xcrd/crd.go
+++ b/internal/xcrd/crd.go
@@ -42,7 +42,7 @@ const (
 )
 
 const (
-	errFmtGetProps             = "cannot get %q properties from validation schema"
+	errFmtGenCrd               = "cannot generate CRD for %q %q"
 	errParseValidation         = "cannot parse validation schema"
 	errInvalidClaimNames       = "invalid resource claim names"
 	errMissingClaimNames       = "missing names"
@@ -71,48 +71,15 @@ func ForCompositeResource(xrd *v1.CompositeResourceDefinition) (*extv1.CustomRes
 	crd.Spec.Names.Categories = append(crd.Spec.Names.Categories, CategoryComposite)
 
 	for i, vr := range xrd.Spec.Versions {
-		crd.Spec.Versions[i] = extv1.CustomResourceDefinitionVersion{
-			Name:                     vr.Name,
-			Served:                   vr.Served,
-			Storage:                  vr.Referenceable,
-			Deprecated:               pointer.BoolDeref(vr.Deprecated, false),
-			DeprecationWarning:       vr.DeprecationWarning,
-			AdditionalPrinterColumns: append(vr.AdditionalPrinterColumns, CompositeResourcePrinterColumns()...),
-			Schema: &extv1.CustomResourceValidation{
-				OpenAPIV3Schema: BaseProps(),
-			},
-			Subresources: &extv1.CustomResourceSubresources{
-				Status: &extv1.CustomResourceSubresourceStatus{},
-			},
-		}
-
-		p, required, err := getProps("spec", vr.Schema)
+		crdv, err := genCrdVersion(vr)
 		if err != nil {
-			return nil, errors.Wrapf(err, errFmtGetProps, "spec")
+			return nil, errors.Wrapf(err, errFmtGenCrd, "Composite Resource", xrd.Name)
 		}
-		specProps := crd.Spec.Versions[i].Schema.OpenAPIV3Schema.Properties["spec"]
-		specProps.Required = append(specProps.Required, required...)
-		for k, v := range p {
-			specProps.Properties[k] = v
-		}
+		crdv.AdditionalPrinterColumns = append(crdv.AdditionalPrinterColumns, CompositeResourcePrinterColumns()...)
 		for k, v := range CompositeResourceSpecProps() {
-			specProps.Properties[k] = v
+			crdv.Schema.OpenAPIV3Schema.Properties["spec"].Properties[k] = v
 		}
-		crd.Spec.Versions[i].Schema.OpenAPIV3Schema.Properties["spec"] = specProps
-
-		statusP, statusRequired, err := getProps("status", vr.Schema)
-		if err != nil {
-			return nil, errors.Wrapf(err, errFmtGetProps, "status")
-		}
-		statusProps := crd.Spec.Versions[i].Schema.OpenAPIV3Schema.Properties["status"]
-		statusProps.Required = statusRequired
-		for k, v := range statusP {
-			statusProps.Properties[k] = v
-		}
-		for k, v := range CompositeResourceStatusProps() {
-			statusProps.Properties[k] = v
-		}
-		crd.Spec.Versions[i].Schema.OpenAPIV3Schema.Properties["status"] = statusProps
+		crd.Spec.Versions[i] = *crdv
 	}
 
 	return crd, nil
@@ -144,51 +111,63 @@ func ForCompositeResourceClaim(xrd *v1.CompositeResourceDefinition) (*extv1.Cust
 	crd.Spec.Names.Categories = append(crd.Spec.Names.Categories, CategoryClaim)
 
 	for i, vr := range xrd.Spec.Versions {
-		crd.Spec.Versions[i] = extv1.CustomResourceDefinitionVersion{
-			Name:                     vr.Name,
-			Served:                   vr.Served,
-			Storage:                  vr.Referenceable,
-			Deprecated:               pointer.BoolDeref(vr.Deprecated, false),
-			DeprecationWarning:       vr.DeprecationWarning,
-			AdditionalPrinterColumns: append(vr.AdditionalPrinterColumns, CompositeResourceClaimPrinterColumns()...),
-			Schema: &extv1.CustomResourceValidation{
-				OpenAPIV3Schema: BaseProps(),
-			},
-			Subresources: &extv1.CustomResourceSubresources{
-				Status: &extv1.CustomResourceSubresourceStatus{},
-			},
-		}
-
-		p, required, err := getProps("spec", vr.Schema)
+		crdv, err := genCrdVersion(vr)
 		if err != nil {
-			return nil, errors.Wrapf(err, errFmtGetProps, "spec")
+			return nil, errors.Wrapf(err, errFmtGenCrd, "Composite Resource Claim", xrd.Name)
 		}
-		specProps := crd.Spec.Versions[i].Schema.OpenAPIV3Schema.Properties["spec"]
-		specProps.Required = append(specProps.Required, required...)
-		for k, v := range p {
-			specProps.Properties[k] = v
-		}
+		crdv.AdditionalPrinterColumns = append(crdv.AdditionalPrinterColumns, CompositeResourceClaimPrinterColumns()...)
 		for k, v := range CompositeResourceClaimSpecProps() {
-			specProps.Properties[k] = v
+			crdv.Schema.OpenAPIV3Schema.Properties["spec"].Properties[k] = v
 		}
-		crd.Spec.Versions[i].Schema.OpenAPIV3Schema.Properties["spec"] = specProps
-
-		statusP, statusRequired, err := getProps("status", vr.Schema)
-		if err != nil {
-			return nil, errors.Wrapf(err, errFmtGetProps, "status")
-		}
-		statusProps := crd.Spec.Versions[i].Schema.OpenAPIV3Schema.Properties["status"]
-		statusProps.Required = statusRequired
-		for k, v := range statusP {
-			statusProps.Properties[k] = v
-		}
-		for k, v := range CompositeResourceStatusProps() {
-			statusProps.Properties[k] = v
-		}
-		crd.Spec.Versions[i].Schema.OpenAPIV3Schema.Properties["status"] = statusProps
+		crd.Spec.Versions[i] = *crdv
 	}
 
 	return crd, nil
+}
+
+func genCrdVersion(vr v1.CompositeResourceDefinitionVersion) (*extv1.CustomResourceDefinitionVersion, error) {
+	crdv := extv1.CustomResourceDefinitionVersion{
+		Name:                     vr.Name,
+		Served:                   vr.Served,
+		Storage:                  vr.Referenceable,
+		Deprecated:               pointer.BoolDeref(vr.Deprecated, false),
+		DeprecationWarning:       vr.DeprecationWarning,
+		AdditionalPrinterColumns: vr.AdditionalPrinterColumns,
+		Schema: &extv1.CustomResourceValidation{
+			OpenAPIV3Schema: BaseProps(),
+		},
+		Subresources: &extv1.CustomResourceSubresources{
+			Status: &extv1.CustomResourceSubresourceStatus{},
+		},
+	}
+	s, err := parseSchema(vr.Schema)
+	if err != nil {
+		return nil, errors.Wrapf(err, errParseValidation)
+	}
+	crdv.Schema.OpenAPIV3Schema.Description = s.Description
+
+	xSpec := s.Properties["spec"]
+	cSpec := crdv.Schema.OpenAPIV3Schema.Properties["spec"]
+	cSpec.Required = append(cSpec.Required, xSpec.Required...)
+
+	cSpec.Description = xSpec.Description
+	for k, v := range xSpec.Properties {
+		cSpec.Properties[k] = v
+	}
+	crdv.Schema.OpenAPIV3Schema.Properties["spec"] = cSpec
+
+	xStatus := s.Properties["status"]
+	cStatus := crdv.Schema.OpenAPIV3Schema.Properties["status"]
+	cStatus.Required = xStatus.Required
+	cStatus.Description = xStatus.Description
+	for k, v := range xStatus.Properties {
+		cStatus.Properties[k] = v
+	}
+	for k, v := range CompositeResourceStatusProps() {
+		cStatus.Properties[k] = v
+	}
+	crdv.Schema.OpenAPIV3Schema.Properties["status"] = cStatus
+	return &crdv, nil
 }
 
 func validateClaimNames(d *v1.CompositeResourceDefinition) error {
@@ -215,22 +194,16 @@ func validateClaimNames(d *v1.CompositeResourceDefinition) error {
 	return nil
 }
 
-func getProps(field string, v *v1.CompositeResourceValidation) (map[string]extv1.JSONSchemaProps, []string, error) {
+func parseSchema(v *v1.CompositeResourceValidation) (*extv1.JSONSchemaProps, error) {
 	if v == nil {
-		return nil, nil, nil
+		return nil, nil
 	}
 
 	s := &extv1.JSONSchemaProps{}
 	if err := json.Unmarshal(v.OpenAPIV3Schema.Raw, s); err != nil {
-		return nil, nil, errors.Wrap(err, errParseValidation)
+		return nil, errors.Wrap(err, errParseValidation)
 	}
-
-	spec, ok := s.Properties[field]
-	if !ok {
-		return nil, nil, nil
-	}
-
-	return spec.Properties, spec.Required, nil
+	return s, nil
 }
 
 // setCrdMetadata sets the labels and annotations on the CRD.

--- a/internal/xcrd/crd_test.go
+++ b/internal/xcrd/crd_test.go
@@ -409,6 +409,296 @@ func TestForCompositeResource(t *testing.T) {
 	}
 }
 
+func TestForCompositeResourceEmptyXrd(t *testing.T) {
+	name := "coolcomposites.example.org"
+	labels := map[string]string{"cool": "very"}
+	annotations := map[string]string{"example.org/cool": "very"}
+
+	group := "example.org"
+	version := "v1"
+	kind := "CoolComposite"
+	listKind := "CoolCompositeList"
+	singular := "coolcomposite"
+	plural := "coolcomposites"
+
+	schema := "{}"
+
+	d := &v1.CompositeResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        name,
+			Labels:      labels,
+			Annotations: annotations,
+			UID:         types.UID("you-you-eye-dee"),
+		},
+		Spec: v1.CompositeResourceDefinitionSpec{
+			Group: group,
+			Names: extv1.CustomResourceDefinitionNames{
+				Plural:   plural,
+				Singular: singular,
+				Kind:     kind,
+				ListKind: listKind,
+			},
+			Versions: []v1.CompositeResourceDefinitionVersion{{
+				Name:          version,
+				Referenceable: true,
+				Served:        true,
+				Schema: &v1.CompositeResourceValidation{
+					OpenAPIV3Schema: runtime.RawExtension{Raw: []byte(schema)},
+				},
+			}},
+		},
+	}
+
+	want := &extv1.CustomResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   name,
+			Labels: labels,
+			OwnerReferences: []metav1.OwnerReference{
+				meta.AsController(meta.TypedReferenceTo(d, v1.CompositeResourceDefinitionGroupVersionKind)),
+			},
+		},
+		Spec: extv1.CustomResourceDefinitionSpec{
+			Group: group,
+			Names: extv1.CustomResourceDefinitionNames{
+				Plural:     plural,
+				Singular:   singular,
+				Kind:       kind,
+				ListKind:   listKind,
+				Categories: []string{CategoryComposite},
+			},
+			Scope: extv1.ClusterScoped,
+			Versions: []extv1.CustomResourceDefinitionVersion{{
+				Name:    version,
+				Served:  true,
+				Storage: true,
+				Subresources: &extv1.CustomResourceSubresources{
+					Status: &extv1.CustomResourceSubresourceStatus{},
+				},
+				AdditionalPrinterColumns: []extv1.CustomResourceColumnDefinition{
+					{
+						Name:     "SYNCED",
+						Type:     "string",
+						JSONPath: ".status.conditions[?(@.type=='Synced')].status",
+					},
+					{
+						Name:     "READY",
+						Type:     "string",
+						JSONPath: ".status.conditions[?(@.type=='Ready')].status",
+					},
+					{
+						Name:     "COMPOSITION",
+						Type:     "string",
+						JSONPath: ".spec.compositionRef.name",
+					},
+					{
+						Name:     "AGE",
+						Type:     "date",
+						JSONPath: ".metadata.creationTimestamp",
+					},
+				},
+				Schema: &extv1.CustomResourceValidation{
+					OpenAPIV3Schema: &extv1.JSONSchemaProps{
+						Type:        "object",
+						Description: "",
+						Required:    []string{"spec"},
+						Properties: map[string]extv1.JSONSchemaProps{
+							"apiVersion": {
+								Type: "string",
+							},
+							"kind": {
+								Type: "string",
+							},
+							"metadata": {
+								// NOTE(muvaf): api-server takes care of validating
+								// metadata.
+								Type: "object",
+							},
+							"spec": {
+								Type:        "object",
+								Description: "",
+								Properties: map[string]extv1.JSONSchemaProps{
+									// From CompositeResourceSpecProps()
+									"compositionRef": {
+										Type:     "object",
+										Required: []string{"name"},
+										Properties: map[string]extv1.JSONSchemaProps{
+											"name": {Type: "string"},
+										},
+									},
+									"compositionSelector": {
+										Type:     "object",
+										Required: []string{"matchLabels"},
+										Properties: map[string]extv1.JSONSchemaProps{
+											"matchLabels": {
+												Type: "object",
+												AdditionalProperties: &extv1.JSONSchemaPropsOrBool{
+													Allows: true,
+													Schema: &extv1.JSONSchemaProps{Type: "string"},
+												},
+											},
+										},
+									},
+									"compositionRevisionRef": {
+										Type:     "object",
+										Required: []string{"name"},
+										Properties: map[string]extv1.JSONSchemaProps{
+											"name": {Type: "string"},
+										},
+									},
+									"compositionRevisionSelector": {
+										Type:     "object",
+										Required: []string{"matchLabels"},
+										Properties: map[string]extv1.JSONSchemaProps{
+											"matchLabels": {
+												Type: "object",
+												AdditionalProperties: &extv1.JSONSchemaPropsOrBool{
+													Allows: true,
+													Schema: &extv1.JSONSchemaProps{Type: "string"},
+												},
+											},
+										},
+									},
+									"compositionUpdatePolicy": {
+										Type: "string",
+										Enum: []extv1.JSON{
+											{Raw: []byte(`"Automatic"`)},
+											{Raw: []byte(`"Manual"`)},
+										},
+									},
+									"claimRef": {
+										Type:     "object",
+										Required: []string{"apiVersion", "kind", "namespace", "name"},
+										Properties: map[string]extv1.JSONSchemaProps{
+											"apiVersion": {Type: "string"},
+											"kind":       {Type: "string"},
+											"namespace":  {Type: "string"},
+											"name":       {Type: "string"},
+										},
+									},
+									"environmentConfigRefs": {
+										Type: "array",
+										Items: &extv1.JSONSchemaPropsOrArray{
+											Schema: &extv1.JSONSchemaProps{
+												Type: "object",
+												Properties: map[string]extv1.JSONSchemaProps{
+													"apiVersion": {Type: "string"},
+													"name":       {Type: "string"},
+													"kind":       {Type: "string"},
+												},
+												Required: []string{"apiVersion", "kind"},
+											},
+										},
+									},
+									"resourceRefs": {
+										Type: "array",
+										Items: &extv1.JSONSchemaPropsOrArray{
+											Schema: &extv1.JSONSchemaProps{
+												Type: "object",
+												Properties: map[string]extv1.JSONSchemaProps{
+													"apiVersion": {Type: "string"},
+													"name":       {Type: "string"},
+													"kind":       {Type: "string"},
+												},
+												Required: []string{"apiVersion", "kind"},
+											},
+										},
+									},
+									"publishConnectionDetailsTo": {
+										Type:     "object",
+										Required: []string{"name"},
+										Properties: map[string]extv1.JSONSchemaProps{
+											"name": {Type: "string"},
+											"configRef": {
+												Type:    "object",
+												Default: &extv1.JSON{Raw: []byte(`{"name": "default"}`)},
+												Properties: map[string]extv1.JSONSchemaProps{
+													"name": {
+														Type: "string",
+													},
+												},
+											},
+											"metadata": {
+												Type: "object",
+												Properties: map[string]extv1.JSONSchemaProps{
+													"labels": {
+														Type: "object",
+														AdditionalProperties: &extv1.JSONSchemaPropsOrBool{
+															Allows: true,
+															Schema: &extv1.JSONSchemaProps{Type: "string"},
+														},
+													},
+													"annotations": {
+														Type: "object",
+														AdditionalProperties: &extv1.JSONSchemaPropsOrBool{
+															Allows: true,
+															Schema: &extv1.JSONSchemaProps{Type: "string"},
+														},
+													},
+													"type": {
+														Type: "string",
+													},
+												},
+											},
+										},
+									},
+									"writeConnectionSecretToRef": {
+										Type:     "object",
+										Required: []string{"name", "namespace"},
+										Properties: map[string]extv1.JSONSchemaProps{
+											"name":      {Type: "string"},
+											"namespace": {Type: "string"},
+										},
+									},
+								},
+							},
+							"status": {
+								Type:        "object",
+								Description: "",
+								Properties: map[string]extv1.JSONSchemaProps{
+
+									// From CompositeResourceStatusProps()
+									"conditions": {
+										Description: "Conditions of the resource.",
+										Type:        "array",
+										Items: &extv1.JSONSchemaPropsOrArray{
+											Schema: &extv1.JSONSchemaProps{
+												Type:     "object",
+												Required: []string{"lastTransitionTime", "reason", "status", "type"},
+												Properties: map[string]extv1.JSONSchemaProps{
+													"lastTransitionTime": {Type: "string", Format: "date-time"},
+													"message":            {Type: "string"},
+													"reason":             {Type: "string"},
+													"status":             {Type: "string"},
+													"type":               {Type: "string"},
+												},
+											},
+										},
+									},
+									"connectionDetails": {
+										Type: "object",
+										Properties: map[string]extv1.JSONSchemaProps{
+											"lastPublishedTime": {Type: "string", Format: "date-time"},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			}},
+		},
+	}
+
+	got, err := ForCompositeResource(d)
+	if err != nil {
+		t.Fatalf("ForCompositeResource(...): %s", err)
+	}
+
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("ForCompositeResource(...): -want, +got:\n%s", diff)
+	}
+}
+
 func TestValidateClaimNames(t *testing.T) {
 	cases := map[string]struct {
 		d    *v1.CompositeResourceDefinition
@@ -789,6 +1079,284 @@ func TestForCompositeResourceClaim(t *testing.T) {
 									Properties: map[string]extv1.JSONSchemaProps{
 										"phase": {Type: "string"},
 
+										// From CompositeResourceStatusProps()
+										"conditions": {
+											Description: "Conditions of the resource.",
+											Type:        "array",
+											Items: &extv1.JSONSchemaPropsOrArray{
+												Schema: &extv1.JSONSchemaProps{
+													Type:     "object",
+													Required: []string{"lastTransitionTime", "reason", "status", "type"},
+													Properties: map[string]extv1.JSONSchemaProps{
+														"lastTransitionTime": {Type: "string", Format: "date-time"},
+														"message":            {Type: "string"},
+														"reason":             {Type: "string"},
+														"status":             {Type: "string"},
+														"type":               {Type: "string"},
+													},
+												},
+											},
+										},
+										"connectionDetails": {
+											Type: "object",
+											Properties: map[string]extv1.JSONSchemaProps{
+												"lastPublishedTime": {Type: "string", Format: "date-time"},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	got, err := ForCompositeResourceClaim(d)
+	if err != nil {
+		t.Fatalf("ForCompositeResourceClaim(...): %s", err)
+	}
+
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("ForCompositeResourceClaim(...): -want, +got:\n%s", diff)
+	}
+}
+
+func TestForCompositeResourceClaimEmptyXrd(t *testing.T) {
+	name := "coolcomposites.example.org"
+	labels := map[string]string{"cool": "very"}
+	annotations := map[string]string{"example.org/cool": "very"}
+
+	group := "example.org"
+	version := "v1"
+
+	kind := "CoolComposite"
+	listKind := "CoolCompositeList"
+	singular := "coolcomposite"
+	plural := "coolcomposites"
+
+	claimKind := "CoolClaim"
+	claimListKind := "CoolClaimList"
+	claimSingular := "coolclaim"
+	claimPlural := "coolclaims"
+
+	schema := "{}"
+
+	d := &v1.CompositeResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        name,
+			Labels:      labels,
+			Annotations: annotations,
+			UID:         types.UID("you-you-eye-dee"),
+		},
+		Spec: v1.CompositeResourceDefinitionSpec{
+			Group: group,
+			Names: extv1.CustomResourceDefinitionNames{
+				Plural:   plural,
+				Singular: singular,
+				Kind:     kind,
+				ListKind: listKind,
+			},
+			ClaimNames: &extv1.CustomResourceDefinitionNames{
+				Plural:   claimPlural,
+				Singular: claimSingular,
+				Kind:     claimKind,
+				ListKind: claimListKind,
+			},
+			Versions: []v1.CompositeResourceDefinitionVersion{{
+				Name:          version,
+				Referenceable: true,
+				Served:        true,
+				Schema: &v1.CompositeResourceValidation{
+					OpenAPIV3Schema: runtime.RawExtension{Raw: []byte(schema)},
+				},
+			}},
+		},
+	}
+
+	want := &extv1.CustomResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   claimPlural + "." + group,
+			Labels: labels,
+			OwnerReferences: []metav1.OwnerReference{
+				meta.AsController(meta.TypedReferenceTo(d, v1.CompositeResourceDefinitionGroupVersionKind)),
+			},
+		},
+		Spec: extv1.CustomResourceDefinitionSpec{
+			Group: group,
+			Names: extv1.CustomResourceDefinitionNames{
+				Plural:     claimPlural,
+				Singular:   claimSingular,
+				Kind:       claimKind,
+				ListKind:   claimListKind,
+				Categories: []string{CategoryClaim},
+			},
+			Scope: extv1.NamespaceScoped,
+			Versions: []extv1.CustomResourceDefinitionVersion{
+				{
+					Name:    version,
+					Served:  true,
+					Storage: true,
+					Subresources: &extv1.CustomResourceSubresources{
+						Status: &extv1.CustomResourceSubresourceStatus{},
+					},
+					AdditionalPrinterColumns: []extv1.CustomResourceColumnDefinition{
+						{
+							Name:     "SYNCED",
+							Type:     "string",
+							JSONPath: ".status.conditions[?(@.type=='Synced')].status",
+						},
+						{
+							Name:     "READY",
+							Type:     "string",
+							JSONPath: ".status.conditions[?(@.type=='Ready')].status",
+						},
+						{
+							Name:     "CONNECTION-SECRET",
+							Type:     "string",
+							JSONPath: ".spec.writeConnectionSecretToRef.name",
+						},
+						{
+							Name:     "AGE",
+							Type:     "date",
+							JSONPath: ".metadata.creationTimestamp",
+						},
+					},
+					Schema: &extv1.CustomResourceValidation{
+						OpenAPIV3Schema: &extv1.JSONSchemaProps{
+							Type:        "object",
+							Required:    []string{"spec"},
+							Description: "",
+							Properties: map[string]extv1.JSONSchemaProps{
+								"apiVersion": {
+									Type: "string",
+								},
+								"kind": {
+									Type: "string",
+								},
+								"metadata": {
+									// NOTE(muvaf): api-server takes care of validating
+									// metadata.
+									Type: "object",
+								},
+								"spec": {
+									Type:        "object",
+									Description: "",
+									Properties: map[string]extv1.JSONSchemaProps{
+										"compositeDeletePolicy": {
+											Type: "string",
+											Enum: []extv1.JSON{{Raw: []byte(`"Background"`)},
+												{Raw: []byte(`"Foreground"`)}},
+										},
+										// From CompositeResourceClaimSpecProps()
+										"compositionRef": {
+											Type:     "object",
+											Required: []string{"name"},
+											Properties: map[string]extv1.JSONSchemaProps{
+												"name": {Type: "string"},
+											},
+										},
+										"compositionSelector": {
+											Type:     "object",
+											Required: []string{"matchLabels"},
+											Properties: map[string]extv1.JSONSchemaProps{
+												"matchLabels": {
+													Type: "object",
+													AdditionalProperties: &extv1.JSONSchemaPropsOrBool{
+														Allows: true,
+														Schema: &extv1.JSONSchemaProps{Type: "string"},
+													},
+												},
+											},
+										},
+										"compositionRevisionRef": {
+											Type:     "object",
+											Required: []string{"name"},
+											Properties: map[string]extv1.JSONSchemaProps{
+												"name": {Type: "string"},
+											},
+										},
+										"compositionRevisionSelector": {
+											Type:     "object",
+											Required: []string{"matchLabels"},
+											Properties: map[string]extv1.JSONSchemaProps{
+												"matchLabels": {
+													Type: "object",
+													AdditionalProperties: &extv1.JSONSchemaPropsOrBool{
+														Allows: true,
+														Schema: &extv1.JSONSchemaProps{Type: "string"},
+													},
+												},
+											},
+										},
+										"compositionUpdatePolicy": {
+											Type: "string",
+											Enum: []extv1.JSON{
+												{Raw: []byte(`"Automatic"`)},
+												{Raw: []byte(`"Manual"`)},
+											},
+										},
+										"resourceRef": {
+											Type:     "object",
+											Required: []string{"apiVersion", "kind", "name"},
+											Properties: map[string]extv1.JSONSchemaProps{
+												"apiVersion": {Type: "string"},
+												"kind":       {Type: "string"},
+												"name":       {Type: "string"},
+											},
+										},
+										"publishConnectionDetailsTo": {
+											Type:     "object",
+											Required: []string{"name"},
+											Properties: map[string]extv1.JSONSchemaProps{
+												"name": {Type: "string"},
+												"configRef": {
+													Type:    "object",
+													Default: &extv1.JSON{Raw: []byte(`{"name": "default"}`)},
+													Properties: map[string]extv1.JSONSchemaProps{
+														"name": {
+															Type: "string",
+														},
+													},
+												},
+												"metadata": {
+													Type: "object",
+													Properties: map[string]extv1.JSONSchemaProps{
+														"labels": {
+															Type: "object",
+															AdditionalProperties: &extv1.JSONSchemaPropsOrBool{
+																Allows: true,
+																Schema: &extv1.JSONSchemaProps{Type: "string"},
+															},
+														},
+														"annotations": {
+															Type: "object",
+															AdditionalProperties: &extv1.JSONSchemaPropsOrBool{
+																Allows: true,
+																Schema: &extv1.JSONSchemaProps{Type: "string"},
+															},
+														},
+														"type": {
+															Type: "string",
+														},
+													},
+												},
+											},
+										},
+										"writeConnectionSecretToRef": {
+											Type:     "object",
+											Required: []string{"name"},
+											Properties: map[string]extv1.JSONSchemaProps{
+												"name": {Type: "string"},
+											},
+										},
+									},
+								},
+								"status": {
+									Type:        "object",
+									Description: "",
+									Properties: map[string]extv1.JSONSchemaProps{
 										// From CompositeResourceStatusProps()
 										"conditions": {
 											Description: "Conditions of the resource.",

--- a/internal/xcrd/crd_test.go
+++ b/internal/xcrd/crd_test.go
@@ -87,6 +87,7 @@ func TestForCompositeResource(t *testing.T) {
   ],
   "properties": {
     "spec": {
+      "description": "Specification of the resource.",
       "required": [
         "storageGB",
         "engineVersion"
@@ -100,7 +101,8 @@ func TestForCompositeResource(t *testing.T) {
           "type": "string"
         },
         "storageGB": {
-          "type": "integer"
+          "type": "integer",
+          "description": "Pretend this is useful."
         }
       },
       "type": "object"
@@ -111,10 +113,12 @@ func TestForCompositeResource(t *testing.T) {
           "type": "string"
         }
       },
-      "type": "object"
+      "type": "object",
+	  "description": "Status of the resource."
     }
   },
-  "type": "object"
+  "type": "object",
+  "description": "What the resource is for."
 }`
 
 	d := &v1.CompositeResourceDefinition{
@@ -193,6 +197,7 @@ func TestForCompositeResource(t *testing.T) {
 				Schema: &extv1.CustomResourceValidation{
 					OpenAPIV3Schema: &extv1.JSONSchemaProps{
 						Type:     "object",
+						Description: "What the resource is for.",
 						Required: []string{"spec"},
 						Properties: map[string]extv1.JSONSchemaProps{
 							"apiVersion": {
@@ -209,9 +214,10 @@ func TestForCompositeResource(t *testing.T) {
 							"spec": {
 								Type:     "object",
 								Required: []string{"storageGB", "engineVersion"},
+								Description: "Specification of the resource.",
 								Properties: map[string]extv1.JSONSchemaProps{
 									// From CRDSpecTemplate.Validation
-									"storageGB": {Type: "integer"},
+									"storageGB": {Type: "integer", Description: "Pretend this is useful."},
 									"engineVersion": {
 										Type: "string",
 										Enum: []extv1.JSON{
@@ -356,6 +362,7 @@ func TestForCompositeResource(t *testing.T) {
 							},
 							"status": {
 								Type: "object",
+								Description: "Status of the resource.",
 								Properties: map[string]extv1.JSONSchemaProps{
 									"phase": {Type: "string"},
 
@@ -522,6 +529,7 @@ func TestForCompositeResourceClaim(t *testing.T) {
 {
 	"properties": {
 		"spec": {
+			"description": "Specification of the resource.",
 			"required": [
 				"storageGB",
 				"engineVersion"
@@ -535,21 +543,24 @@ func TestForCompositeResourceClaim(t *testing.T) {
 					"type": "string"
 				},
 				"storageGB": {
-					"type": "integer"
+					"type": "integer",
+					"description": "Pretend this is useful."
 				}
 			},
 			"type": "object"
 		},
 		"status": {
-      "properties": {
-        "phase": {
-          "type": "string"
-        }
-      },
-      "type": "object"
-    }
+			"properties": {
+				"phase": {
+					"type": "string"
+				}
+			},
+			"type": "object",
+			"description": "Status of the resource."
+		}
 	},
-	"type": "object"
+	"type": "object",
+	"description": "Description of the resource."
 }`
 
 	d := &v1.CompositeResourceDefinition{
@@ -636,6 +647,7 @@ func TestForCompositeResourceClaim(t *testing.T) {
 						OpenAPIV3Schema: &extv1.JSONSchemaProps{
 							Type:     "object",
 							Required: []string{"spec"},
+							Description: "Description of the resource.",
 							Properties: map[string]extv1.JSONSchemaProps{
 								"apiVersion": {
 									Type: "string",
@@ -651,9 +663,10 @@ func TestForCompositeResourceClaim(t *testing.T) {
 								"spec": {
 									Type:     "object",
 									Required: []string{"storageGB", "engineVersion"},
+									Description: "Specification of the resource.",
 									Properties: map[string]extv1.JSONSchemaProps{
 										// From CRDSpecTemplate.Validation
-										"storageGB": {Type: "integer"},
+										"storageGB": {Type: "integer", Description: "Pretend this is useful."},
 										"engineVersion": {
 											Type: "string",
 											Enum: []extv1.JSON{
@@ -772,6 +785,7 @@ func TestForCompositeResourceClaim(t *testing.T) {
 								},
 								"status": {
 									Type: "object",
+									Description: "Status of the resource.",
 									Properties: map[string]extv1.JSONSchemaProps{
 										"phase": {Type: "string"},
 

--- a/internal/xcrd/crd_test.go
+++ b/internal/xcrd/crd_test.go
@@ -82,43 +82,43 @@ func TestForCompositeResource(t *testing.T) {
 
 	schema := `
 {
-  "required": [
-    "spec"
-  ],
-  "properties": {
-    "spec": {
-      "description": "Specification of the resource.",
-      "required": [
-        "storageGB",
-        "engineVersion"
-      ],
-      "properties": {
-        "engineVersion": {
-          "enum": [
-            "5.6",
-            "5.7"
-          ],
-          "type": "string"
-        },
-        "storageGB": {
-          "type": "integer",
-          "description": "Pretend this is useful."
-        }
-      },
-      "type": "object"
-    },
-    "status": {
-      "properties": {
-        "phase": {
-          "type": "string"
-        }
-      },
-      "type": "object",
-	  "description": "Status of the resource."
-    }
-  },
-  "type": "object",
-  "description": "What the resource is for."
+	"required": [
+		"spec"
+	],
+	"properties": {
+		"spec": {
+			"description": "Specification of the resource.",
+			"required": [
+				"storageGB",
+				"engineVersion"
+			],
+			"properties": {
+				"engineVersion": {
+					"enum": [
+						"5.6",
+						"5.7"
+					],
+					"type": "string"
+				},
+				"storageGB": {
+					"type": "integer",
+					"description": "Pretend this is useful."
+				}
+			},
+			"type": "object"
+		},
+		"status": {
+			"properties": {
+				"phase": {
+					"type": "string"
+				}
+			},
+			"type": "object",
+			"description": "Status of the resource."
+		}
+	},
+	"type": "object",
+	"description": "What the resource is for."
 }`
 
 	d := &v1.CompositeResourceDefinition{
@@ -196,9 +196,9 @@ func TestForCompositeResource(t *testing.T) {
 				},
 				Schema: &extv1.CustomResourceValidation{
 					OpenAPIV3Schema: &extv1.JSONSchemaProps{
-						Type:     "object",
+						Type:        "object",
 						Description: "What the resource is for.",
-						Required: []string{"spec"},
+						Required:    []string{"spec"},
 						Properties: map[string]extv1.JSONSchemaProps{
 							"apiVersion": {
 								Type: "string",
@@ -212,8 +212,8 @@ func TestForCompositeResource(t *testing.T) {
 								Type: "object",
 							},
 							"spec": {
-								Type:     "object",
-								Required: []string{"storageGB", "engineVersion"},
+								Type:        "object",
+								Required:    []string{"storageGB", "engineVersion"},
 								Description: "Specification of the resource.",
 								Properties: map[string]extv1.JSONSchemaProps{
 									// From CRDSpecTemplate.Validation
@@ -361,7 +361,7 @@ func TestForCompositeResource(t *testing.T) {
 								},
 							},
 							"status": {
-								Type: "object",
+								Type:        "object",
 								Description: "Status of the resource.",
 								Properties: map[string]extv1.JSONSchemaProps{
 									"phase": {Type: "string"},
@@ -935,8 +935,8 @@ func TestForCompositeResourceClaim(t *testing.T) {
 					},
 					Schema: &extv1.CustomResourceValidation{
 						OpenAPIV3Schema: &extv1.JSONSchemaProps{
-							Type:     "object",
-							Required: []string{"spec"},
+							Type:        "object",
+							Required:    []string{"spec"},
 							Description: "Description of the resource.",
 							Properties: map[string]extv1.JSONSchemaProps{
 								"apiVersion": {
@@ -951,8 +951,8 @@ func TestForCompositeResourceClaim(t *testing.T) {
 									Type: "object",
 								},
 								"spec": {
-									Type:     "object",
-									Required: []string{"storageGB", "engineVersion"},
+									Type:        "object",
+									Required:    []string{"storageGB", "engineVersion"},
 									Description: "Specification of the resource.",
 									Properties: map[string]extv1.JSONSchemaProps{
 										// From CRDSpecTemplate.Validation
@@ -1074,7 +1074,7 @@ func TestForCompositeResourceClaim(t *testing.T) {
 									},
 								},
 								"status": {
-									Type: "object",
+									Type:        "object",
 									Description: "Status of the resource.",
 									Properties: map[string]extv1.JSONSchemaProps{
 										"phase": {Type: "string"},


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does, and how it is covered by tests.
Be proactive - direct your reviewers' attention to anything that needs special
consideration.

You MUST either [x] check or ~strikethrough~ every item in the checklist below.

We love pull requests that fix an open issue. If yours does, use the below line
to indicate which issue it fixes, for example "Fixes #500".
-->

Fixes #4129

While looking at this I discovered `status` had the same problem as `spec`, so I fixed that. I slightly improved the deserialization of the openapi spec; we now do it once rather than once for `status` and again for `spec`. I also improved a few of the error paths. 

This is my first time ever coding in go. So please let me know if I've made some rookie mistakes. 

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Added or updated unit ~and E2E~ tests for my change.
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

[contribution process]: https://git.io/fj2m9