### PR TITLE
composite: fix nil-dereference

### DIFF
--- a/internal/controller/apiextensions/composite/composition_transforms.go
+++ b/internal/controller/apiextensions/composite/composition_transforms.go
@@ -194,7 +194,14 @@ func ResolveMap(t v1.MapTransform, input any) (any, error) {
 		}
 		return val, nil
 	default:
-		return nil, errors.Errorf(errFmtMapTypeNotSupported, reflect.TypeOf(input).String())
+		var inputType string
+		if input == nil {
+			inputType = "nil"
+		} else {
+			inputType = reflect.TypeOf(input).String()
+		}
+
+		return nil, errors.Errorf(errFmtMapTypeNotSupported, inputType)
 	}
 }
 


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does, and how it is covered by tests.
Be proactive - direct your reviewers' attention to anything that needs special
consideration.

You MUST either [x] check or ~strikethrough~ every item in the checklist below.

We love pull requests that fix an open issue. If yours does, use the below line
to indicate which issue it fixes, for example "Fixes #500".
-->

Fixes a nil-dereference found by OSS-Fuzz: https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=58445.

If `input` is nil, then the `reflect.TypeOf(input).String()` will throw a nil-dereference.

I have:

- [x]  Read and followed Crossplane's [contribution process].
- [x] Added or updated unit **and** E2E tests for my change.
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

[contribution process]: https://git.io/fj2m9