### PR TITLE
fix: avoid panics due to reflect.TypeOf usage

### DIFF
--- a/internal/controller/apiextensions/composite/composition_transforms.go
+++ b/internal/controller/apiextensions/composite/composition_transforms.go
@@ -24,7 +24,6 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"reflect"
 	"regexp"
 	"strconv"
 	"strings"
@@ -194,14 +193,7 @@ func ResolveMap(t v1.MapTransform, input any) (any, error) {
 		}
 		return val, nil
 	default:
-		var inputType string
-		if input == nil {
-			inputType = "nil"
-		} else {
-			inputType = reflect.TypeOf(input).String()
-		}
-
-		return nil, errors.Errorf(errFmtMapTypeNotSupported, inputType)
+		return nil, errors.Errorf(errFmtMapTypeNotSupported, fmt.Sprintf("%T", input))
 	}
 }
 
@@ -254,7 +246,7 @@ func matchesLiteral(p v1.MatchTransformPattern, input any) (bool, error) {
 	}
 	inputStr, ok := input.(string)
 	if !ok {
-		return false, errors.Errorf(errFmtMatchInputTypeInvalid, reflect.TypeOf(input).String())
+		return false, errors.Errorf(errFmtMatchInputTypeInvalid, fmt.Sprintf("%T", input))
 	}
 	return inputStr == *p.Literal, nil
 }
@@ -272,7 +264,7 @@ func matchesRegexp(p v1.MatchTransformPattern, input any) (bool, error) {
 	}
 	inputStr, ok := input.(string)
 	if !ok {
-		return false, errors.Errorf(errFmtMatchInputTypeInvalid, reflect.TypeOf(input).String())
+		return false, errors.Errorf(errFmtMatchInputTypeInvalid, fmt.Sprintf("%T", input))
 	}
 	return re.MatchString(inputStr), nil
 }
@@ -387,7 +379,7 @@ func ResolveConvert(t v1.ConvertTransform, input any) (any, error) {
 		return nil, err
 	}
 
-	from := v1.TransformIOType(reflect.TypeOf(input).String())
+	from := v1.TransformIOType(fmt.Sprintf("%T", input))
 	if !from.IsValid() {
 		return nil, errors.Errorf(errFmtConvertInputTypeNotSupported, input)
 	}

--- a/internal/controller/apiextensions/composite/environment/selector.go
+++ b/internal/controller/apiextensions/composite/environment/selector.go
@@ -191,7 +191,10 @@ func sortConfigs(ec []v1alpha1.EnvironmentConfig, f string) error { //nolint:goc
 			return err
 		}
 
-		vt := reflect.TypeOf(val).Kind()
+		var vt reflect.Kind
+		if val != nil {
+			vt = reflect.TypeOf(val).Kind()
+		}
 
 		// check only vt1 as vt1 == vt2
 		switch vt { //nolint:exhaustive // we only support these types

--- a/internal/initializer/webhook_configurations.go
+++ b/internal/initializer/webhook_configurations.go
@@ -18,7 +18,6 @@ package initializer
 
 import (
 	"context"
-	"reflect"
 
 	"github.com/spf13/afero"
 	admv1 "k8s.io/api/admissionregistration/v1"
@@ -124,7 +123,7 @@ func (c *WebhookConfigurations) Run(ctx context.Context, kube client.Client) err
 			// See https://github.com/kubernetes-sigs/controller-tools/issues/658
 			conf.SetName("crossplane")
 		default:
-			return errors.Errorf("only MutatingWebhookConfiguration and ValidatingWebhookConfiguration kinds are accepted, got %s", reflect.TypeOf(obj).String())
+			return errors.Errorf("only MutatingWebhookConfiguration and ValidatingWebhookConfiguration kinds are accepted, got %T", obj)
 		}
 		if err := pa.Apply(ctx, obj.(client.Object)); err != nil {
 			return errors.Wrap(err, errApplyWebhookConfiguration)

--- a/test/e2e/funcs/feature.go
+++ b/test/e2e/funcs/feature.go
@@ -518,7 +518,15 @@ func asUnstructured(o runtime.Object) *unstructured.Unstructured {
 func identifier(o k8s.Object) string {
 	k := o.GetObjectKind().GroupVersionKind().Kind
 	if k == "" {
-		k = reflect.TypeOf(o).Elem().Name()
+		t := reflect.TypeOf(o)
+		if t != nil {
+			if t.Kind() == reflect.Ptr {
+				t = t.Elem()
+			}
+			k = t.Name()
+		} else {
+			k = fmt.Sprintf("%T", o)
+		}
 	}
 	if o.GetNamespace() == "" {
 		return fmt.Sprintf("%s %s", k, o.GetName())


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does, and how it is covered by tests.
Be proactive - direct your reviewers' attention to anything that needs special
consideration.

You MUST either [x] check or ~strikethrough~ every item in the checklist below.

We love pull requests that fix an open issue. If yours does, use the below line
to indicate which issue it fixes, for example "Fixes #500".
-->

`reflect.TypeOf` of an interface being nil, returns nil, so will result in a nil pointer dereference and a panic if then used to call `.String()` or .Elem() on it, see example: https://go.dev/play/p/J_lEJmXrBBH
`reflect.TypeOf(input).Elem()` instead will directly panic if the underlying type is not a pointer or one of the other supported ones: https://cs.opensource.google/go/go/+/refs/tags/go1.20.6:src/reflect/type.go;l=158

Switching to `fmt.Sprintf("%T", input)`, where applicable, or properly checking returned values elsewhere.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [ ] ~Added or updated unit **and** E2E tests for my change.~
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR if necessary.~

[contribution process]: https://git.io/fj2m9