### PR TITLE
inject noop logger by default to ctrl-runtime to avoid warnings

### DIFF
--- a/cmd/crossplane/main.go
+++ b/cmd/crossplane/main.go
@@ -19,6 +19,7 @@ package main
 
 import (
 	"fmt"
+	"io"
 
 	"github.com/alecthomas/kong"
 	admv1 "k8s.io/api/admissionregistration/v1"
@@ -78,7 +79,11 @@ func (v versionFlag) BeforeApply(app *kong.Kong) error { //nolint:unparam // Bef
 
 func main() {
 	zl := zap.New().WithName("crossplane")
-
+	// Setting the controller-runtime logger to a no-op logger by default,
+	// unless debug mode is enabled. This is because the controller-runtime
+	// logger is *very* verbose even at info level. This is not really needed,
+	// but otherwise we get a warning from the controller-runtime.
+	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
 	// Note that the controller managers scheme must be a superset of the
 	// package manager's object scheme; it must contain all object types that
 	// may appear in a Crossplane package. This is because the package manager


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

controller-runtime v0.15.0 introduced a warning if the logger is not set for it through `crtl.SetLogger`. 

Except in debug mode, we dont set a logger for it as its too verbose. But as now we get a stack trace warning, adding a noop logger explicity to avoid it. 

<!--
Briefly describe what this pull request does, and how it is covered by tests.
Be proactive - direct your reviewers' attention to anything that needs special
consideration.

You MUST either [x] check or ~strikethrough~ every item in the checklist below.

We love pull requests that fix an open issue. If yours does, use the below line
to indicate which issue it fixes, for example "Fixes #500".
-->

Fixes # 

I have:

- [x] Read and followed Crossplane's [contribution process].
- [ ] ~Added or updated unit **and** E2E tests for my change.~
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

[contribution process]: https://git.io/fj2m9