### PR TITLE
Adler32 string transform implementation

### DIFF
--- a/apis/apiextensions/v1/composition_transforms.go
+++ b/apis/apiextensions/v1/composition_transforms.go
@@ -354,6 +354,7 @@ const (
 	StringConversionTypeToSHA1     StringConversionType = "ToSha1"
 	StringConversionTypeToSHA256   StringConversionType = "ToSha256"
 	StringConversionTypeToSHA512   StringConversionType = "ToSha512"
+	StringConversionTypeToAdler32  StringConversionType = "ToAdler32"
 )
 
 // A StringTransform returns a string given the supplied input.

--- a/apis/apiextensions/v1beta1/zz_generated.composition_transforms.go
+++ b/apis/apiextensions/v1beta1/zz_generated.composition_transforms.go
@@ -356,6 +356,7 @@ const (
 	StringConversionTypeToSHA1     StringConversionType = "ToSha1"
 	StringConversionTypeToSHA256   StringConversionType = "ToSha256"
 	StringConversionTypeToSHA512   StringConversionType = "ToSha512"
+	StringConversionTypeToAdler32  StringConversionType = "ToAdler32"
 )
 
 // A StringTransform returns a string given the supplied input.

--- a/internal/controller/apiextensions/composite/composition_transforms.go
+++ b/internal/controller/apiextensions/composite/composition_transforms.go
@@ -24,6 +24,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"hash/adler32"
 	"regexp"
 	"strconv"
 	"strings"
@@ -72,6 +73,7 @@ const (
 	errDecodeString = "string is not valid base64"
 	errMarshalJSON  = "cannot marshal to JSON"
 	errHash         = "cannot generate hash"
+	errAdler        = "unable to generate Adler checksum"
 )
 
 // Resolve the supplied Transform.
@@ -330,6 +332,9 @@ func stringConvertTransform(t *v1.StringConversionType, input any) (string, erro
 	case v1.StringConversionTypeToSHA512:
 		hash, err := stringGenerateHash(input, sha512.Sum512)
 		return hex.EncodeToString(hash[:]), errors.Wrap(err, errHash)
+	case v1.StringConversionTypeToAdler32:
+		checksum, err := stringGenerateHash(input, adler32.Checksum)
+		return strconv.FormatUint(uint64(checksum), 10), errors.Wrap(err, errAdler)
 	default:
 		return "", errors.Errorf(errStringConvertTypeFailed, *t)
 	}

--- a/internal/controller/apiextensions/composite/composition_transforms_test.go
+++ b/internal/controller/apiextensions/composite/composition_transforms_test.go
@@ -878,8 +878,17 @@ func TestStringResolve(t *testing.T) {
 				i:       "Crossplane",
 			},
 			want: want{
-				o: "471008351",
-				//o: "373097499",
+				o: "373097499",
+			},
+		},
+		"ConvertToAdler32Unicode": {
+			args: args{
+				stype:   v1.StringTransformTypeConvert,
+				convert: &toAdler32,
+				i:       "⡌⠁⠧⠑ ⠼⠁⠒  ⡍⠜⠇⠑⠹⠰⠎ ⡣⠕⠌",
+			},
+			want: want{
+				o: "4110427190",
 			},
 		},
 		"ConvertToAdler32Error": {

--- a/internal/controller/apiextensions/composite/composition_transforms_test.go
+++ b/internal/controller/apiextensions/composite/composition_transforms_test.go
@@ -671,6 +671,7 @@ func TestStringResolve(t *testing.T) {
 	toSha1 := v1.StringConversionTypeToSHA1
 	toSha256 := v1.StringConversionTypeToSHA256
 	toSha512 := v1.StringConversionTypeToSHA512
+	toAdler32 := v1.StringConversionTypeToAdler32
 
 	prefix := "https://"
 	suffix := "-test"
@@ -868,6 +869,28 @@ func TestStringResolve(t *testing.T) {
 			want: want{
 				o:   "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
 				err: errors.Wrap(errors.Wrap(errors.New("json: unsupported type: func()"), errMarshalJSON), errHash),
+			},
+		},
+		"ConvertToAdler32": {
+			args: args{
+				stype:   v1.StringTransformTypeConvert,
+				convert: &toAdler32,
+				i:       "Crossplane",
+			},
+			want: want{
+				o: "471008351",
+				//o: "373097499",
+			},
+		},
+		"ConvertToAdler32Error": {
+			args: args{
+				stype:   v1.StringTransformTypeConvert,
+				convert: &toAdler32,
+				i:       func() {},
+			},
+			want: want{
+				o:   "0",
+				err: errors.Wrap(errors.Wrap(errors.New("json: unsupported type: func()"), errMarshalJSON), errAdler),
 			},
 		},
 		"TrimPrefix": {


### PR DESCRIPTION
### Description of your changes

Adds an Adler-32 checksum, this is used with some Let's Encrypt configurations.

### Testing: 

I tested the hashing using the following Python script, these values matched the values generated by the transform.

```python
python3
Python 3.11.2 (main, Feb 16 2023, 02:51:42) [Clang 14.0.0 (clang-1400.0.29.202)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import zlib
>>> zlib.adler32("⡌⠁⠧⠑ ⠼⠁⠒  ⡍⠜⠇⠑⠹⠰⠎ ⡣⠕⠌".encode('utf-8'))
4110427190
>>> zlib.adler32(b'Crossplane')
373097499
>>> 
```

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Added or updated unit **and** E2E tests for my change.
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.
- [x] Opened a PR updating the [docs](https://docs.crossplane.io/contribute/contribute/), if necessary. https://github.com/crossplane/docs/pull/524 

[contribution process]: https://git.io/fj2m9