### PR TITLE
fix: copy x-kubernetes-validations from spec to composite/claim CRDs

### DIFF
--- a/internal/xcrd/crd.go
+++ b/internal/xcrd/crd.go
@@ -149,6 +149,7 @@ func genCrdVersion(vr v1.CompositeResourceDefinitionVersion) (*extv1.CustomResou
 	xSpec := s.Properties["spec"]
 	cSpec := crdv.Schema.OpenAPIV3Schema.Properties["spec"]
 	cSpec.Required = append(cSpec.Required, xSpec.Required...)
+	cSpec.XValidations = append(cSpec.XValidations, xSpec.XValidations...)
 
 	cSpec.Description = xSpec.Description
 	for k, v := range xSpec.Properties {

--- a/internal/xcrd/crd.go
+++ b/internal/xcrd/crd.go
@@ -160,6 +160,7 @@ func genCrdVersion(vr v1.CompositeResourceDefinitionVersion) (*extv1.CustomResou
 	xStatus := s.Properties["status"]
 	cStatus := crdv.Schema.OpenAPIV3Schema.Properties["status"]
 	cStatus.Required = xStatus.Required
+	cStatus.XValidations = xStatus.XValidations
 	cStatus.Description = xStatus.Description
 	for k, v := range xStatus.Properties {
 		cStatus.Properties[k] = v

--- a/internal/xcrd/crd_test.go
+++ b/internal/xcrd/crd_test.go
@@ -105,6 +105,12 @@ func TestForCompositeResource(t *testing.T) {
 					"description": "Pretend this is useful."
 				}
 			},
+			"x-kubernetes-validations": [
+				{
+					"message": "Cannot remove engineVersion",
+					"rule": "!has(oldSelf.engineVersion) || has(self.engineVersion)"
+				}
+			],
 			"type": "object"
 		},
 		"status": {
@@ -357,6 +363,12 @@ func TestForCompositeResource(t *testing.T) {
 											"name":      {Type: "string"},
 											"namespace": {Type: "string"},
 										},
+									},
+								},
+								XValidations: extv1.ValidationRules{
+									{
+										Message: "Cannot remove engineVersion",
+										Rule:    "!has(oldSelf.engineVersion) || has(self.engineVersion)",
 									},
 								},
 							},
@@ -837,6 +849,12 @@ func TestForCompositeResourceClaim(t *testing.T) {
 					"description": "Pretend this is useful."
 				}
 			},
+			"x-kubernetes-validations": [
+				{
+					"message": "Cannot remove engineVersion",
+					"rule": "!has(oldSelf.engineVersion) || has(self.engineVersion)"
+				}
+			],
 			"type": "object"
 		},
 		"status": {
@@ -1070,6 +1088,12 @@ func TestForCompositeResourceClaim(t *testing.T) {
 											Properties: map[string]extv1.JSONSchemaProps{
 												"name": {Type: "string"},
 											},
+										},
+									},
+									XValidations: extv1.ValidationRules{
+										{
+											Message: "Cannot remove engineVersion",
+											Rule:    "!has(oldSelf.engineVersion) || has(self.engineVersion)",
 										},
 									},
 								},

--- a/internal/xcrd/crd_test.go
+++ b/internal/xcrd/crd_test.go
@@ -107,8 +107,8 @@ func TestForCompositeResource(t *testing.T) {
 			},
 			"x-kubernetes-validations": [
 				{
-					"message": "Cannot remove engineVersion",
-					"rule": "!has(oldSelf.engineVersion) || has(self.engineVersion)"
+					"message": "Cannot change engine version",
+					"rule": "self.engineVersion == oldSelf.engineVersion"
 				}
 			],
 			"type": "object"
@@ -367,8 +367,8 @@ func TestForCompositeResource(t *testing.T) {
 								},
 								XValidations: extv1.ValidationRules{
 									{
-										Message: "Cannot remove engineVersion",
-										Rule:    "!has(oldSelf.engineVersion) || has(self.engineVersion)",
+										Message: "Cannot change engine version",
+										Rule:    "self.engineVersion == oldSelf.engineVersion",
 									},
 								},
 							},
@@ -851,8 +851,8 @@ func TestForCompositeResourceClaim(t *testing.T) {
 			},
 			"x-kubernetes-validations": [
 				{
-					"message": "Cannot remove engineVersion",
-					"rule": "!has(oldSelf.engineVersion) || has(self.engineVersion)"
+					"message": "Cannot change engine version",
+					"rule": "self.engineVersion == oldSelf.engineVersion"
 				}
 			],
 			"type": "object"
@@ -1092,8 +1092,8 @@ func TestForCompositeResourceClaim(t *testing.T) {
 									},
 									XValidations: extv1.ValidationRules{
 										{
-											Message: "Cannot remove engineVersion",
-											Rule:    "!has(oldSelf.engineVersion) || has(self.engineVersion)",
+											Message: "Cannot change engine version",
+											Rule:    "self.engineVersion == oldSelf.engineVersion",
 										},
 									},
 								},

--- a/internal/xcrd/crd_test.go
+++ b/internal/xcrd/crd_test.go
@@ -119,6 +119,12 @@ func TestForCompositeResource(t *testing.T) {
 					"type": "string"
 				}
 			},
+			"x-kubernetes-validations": [
+				{
+					"message": "Phase is required once set",
+					"rule": "!has(oldSelf.phase) || has(self.phase)"
+				}
+			],
 			"type": "object",
 			"description": "Status of the resource."
 		}
@@ -401,6 +407,12 @@ func TestForCompositeResource(t *testing.T) {
 										Properties: map[string]extv1.JSONSchemaProps{
 											"lastPublishedTime": {Type: "string", Format: "date-time"},
 										},
+									},
+								},
+								XValidations: extv1.ValidationRules{
+									{
+										Message: "Phase is required once set",
+										Rule:    "!has(oldSelf.phase) || has(self.phase)",
 									},
 								},
 							},
@@ -863,6 +875,12 @@ func TestForCompositeResourceClaim(t *testing.T) {
 					"type": "string"
 				}
 			},
+			"x-kubernetes-validations": [
+				{
+					"message": "Phase is required once set",
+					"rule": "!has(oldSelf.phase) || has(self.phase)"
+				}
+			],
 			"type": "object",
 			"description": "Status of the resource."
 		}
@@ -1126,6 +1144,12 @@ func TestForCompositeResourceClaim(t *testing.T) {
 											Properties: map[string]extv1.JSONSchemaProps{
 												"lastPublishedTime": {Type: "string", Format: "date-time"},
 											},
+										},
+									},
+									XValidations: extv1.ValidationRules{
+										{
+											Message: "Phase is required once set",
+											Rule:    "!has(oldSelf.phase) || has(self.phase)",
 										},
 									},
 								},


### PR DESCRIPTION
### Description of your changes

Fixes #3604

Copies the `x-kubernetes-validations` field from XRD's `spec` to CRD's `spec`s, to enable validation on the `spec` field.

- Should it be copied from/to `status` as well?
- Should e2e tests cover this change (and the `required` field from https://github.com/crossplane/crossplane/pull/2011)?
- Open to suggestions for better example in test, current validation does not really do anything as `engineVersion` is required. 

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Added or updated unit ~~**and** E2E~~ tests for my change.
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] ~~Added `backport release-x.y` labels to auto-backport this PR if necessary.~~

[contribution process]: https://git.io/fj2m9