### PR TITLE
fix(transforms): properly compute hashes for strings

### DIFF
--- a/internal/controller/apiextensions/composite/composition_transforms.go
+++ b/internal/controller/apiextensions/composite/composition_transforms.go
@@ -344,12 +344,19 @@ func stringConvertTransform(t *v1.StringConversionType, input any) (string, erro
 }
 
 func stringGenerateHash[THash any](input any, hashFunc func([]byte) THash) (THash, error) {
-	inputJSON, err := json.Marshal(input)
-	if err != nil {
-		var ret THash
-		return ret, errors.Wrap(err, errMarshalJSON)
+	var b []byte
+	var err error
+	switch v := input.(type) {
+	case string:
+		b = []byte(v)
+	default:
+		b, err = json.Marshal(input)
+		if err != nil {
+			var ret THash
+			return ret, errors.Wrap(err, errMarshalJSON)
+		}
 	}
-	return hashFunc(inputJSON), nil
+	return hashFunc(b), nil
 }
 
 func stringTrimTransform(input any, t v1.StringTransformType, trim string) string {

--- a/internal/controller/apiextensions/composite/composition_transforms_test.go
+++ b/internal/controller/apiextensions/composite/composition_transforms_test.go
@@ -794,7 +794,7 @@ func TestStringResolve(t *testing.T) {
 				i:       "Crossplane",
 			},
 			want: want{
-				o: "f9fd1da3c0cc298643ff098a0c59febf1d8b7b84",
+				o: "3b683dc8ff44122b331a5e4f253dd69d90726d75",
 			},
 		},
 		"ConvertToSha1Error": {
@@ -815,7 +815,7 @@ func TestStringResolve(t *testing.T) {
 				i:       "Crossplane",
 			},
 			want: want{
-				o: "e84ae541a0725d73154ee76b7ac3fec4b007dd01ed701d506cd7e7a45bb48935",
+				o: "19c8a7c24ed0067f606815b59e5b82d92935ff69deed04171457a55018e31224",
 			},
 		},
 		"ConvertToSha256Error": {
@@ -836,7 +836,27 @@ func TestStringResolve(t *testing.T) {
 				i:       "Crossplane",
 			},
 			want: want{
-				o: "b48622a3f487b8cb7748b356c9531cf54d9125c1456689c115744821f3dafd59c8c7d4dc5627c4a1e4082c67ee9f4528365a644a01a0c46d6dd0a6d979c8f51f",
+				o: "0016037c62c92b5cc4a282fbe30cdd228fa001624b26fd31baa9fcb76a9c60d48e2e7a16cf8729a2d9cba3d23e1d846e7721a5381b9a92dd813178e9a6686205",
+			},
+		},
+		"ConvertToSha512Int": {
+			args: args{
+				stype:   v1.StringTransformTypeConvert,
+				convert: &toSha512,
+				i:       1234,
+			},
+			want: want{
+				o: "d404559f602eab6fd602ac7680dacbfaadd13630335e951f097af3900e9de176b6db28512f2e000b9d04fba5133e8b1c6e8df59db3a8ab9d60be4b97cc9e81db",
+			},
+		},
+		"ConvertToSha512IntStr": {
+			args: args{
+				stype:   v1.StringTransformTypeConvert,
+				convert: &toSha512,
+				i:       "1234",
+			},
+			want: want{
+				o: "d404559f602eab6fd602ac7680dacbfaadd13630335e951f097af3900e9de176b6db28512f2e000b9d04fba5133e8b1c6e8df59db3a8ab9d60be4b97cc9e81db",
 			},
 		},
 		"ConvertToSha512Error": {


### PR DESCRIPTION
### Description of your changes

Update the way strings are handled during hash calculations.

Fixes #4412 

### Testing process

I created hashes first via <https://emn178.github.io/online-tools/sha512.html>, then to confirm the values generated I created a python script:

```python
if __name__ == '__main__':
  text = b'Crossplane'
  i = str(1234)
  print('sha1:', hashlib.sha1(text).hexdigest())
  print('sha256:', hashlib.sha256(text).hexdigest())
  print('sha512:', hashlib.sha512(text).hexdigest())
  print('sha512int:', hashlib.sha512(bytes(i, 'utf-8')).hexdigest())
```

```console
sha1: 3b683dc8ff44122b331a5e4f253dd69d90726d75
sha256: 19c8a7c24ed0067f606815b59e5b82d92935ff69deed04171457a55018e31224
sha512: 0016037c62c92b5cc4a282fbe30cdd228fa001624b26fd31baa9fcb76a9c60d48e2e7a16cf8729a2d9cba3d23e1d846e7721a5381b9a92dd813178e9a6686205
sha512int: d404559f602eab6fd602ac7680dacbfaadd13630335e951f097af3900e9de176b6db28512f2e000b9d04fba5133e8b1c6e8df59db3a8ab9d60be4b97cc9e81db
```

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Added or updated unit **and** E2E tests for my change.
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.
- [x] Opened a PR updating the [docs](https://docs.crossplane.io/contribute/contribute/), if necessary.

[contribution process]: https://git.io/fj2m9


