### PR TITLE
fix: migrate locks.pkg.crossplane.io from v1alpha1 to v1beta1

### DIFF
--- a/cmd/crossplane/core/init.go
+++ b/cmd/crossplane/core/init.go
@@ -71,11 +71,13 @@ func (c *initCommand) Run(s *runtime.Scheme, log logging.Logger) error {
 			initializer.NewWebhookCertificateGenerator(nn, c.Namespace,
 				log.WithValues("Step", "WebhookCertificateGenerator")),
 			initializer.NewCoreCRDsMigrator("compositionrevisions.apiextensions.crossplane.io", "v1alpha1"),
+			initializer.NewCoreCRDsMigrator("locks.pkg.crossplane.io", "v1alpha1"),
 			initializer.NewCoreCRDs("/crds", s, initializer.WithWebhookTLSSecretRef(nn)),
 			initializer.NewWebhookConfigurations("/webhookconfigurations", s, nn, svc))
 	} else {
 		steps = append(steps,
 			initializer.NewCoreCRDsMigrator("compositionrevisions.apiextensions.crossplane.io", "v1alpha1"),
+			initializer.NewCoreCRDsMigrator("locks.pkg.crossplane.io", "v1alpha1"),
 			initializer.NewCoreCRDs("/crds", s),
 		)
 	}


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does, and how it is covered by tests.
Be proactive - direct your reviewers' attention to anything that needs special
consideration.

You MUST either [x] check or ~strikethrough~ every item in the checklist below.

We love pull requests that fix an open issue. If yours does, use the below line
to indicate which issue it fixes, for example "Fixes #500".
-->

Automatically moving v1alpha1 locks to v1beta1, as the former was removed in 1.11.

Fixes #4442.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [ ] ~Added or updated unit **and** E2E tests for my change.~
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.
- [x] Opened a PR updating the [docs](https://docs.crossplane.io/contribute/contribute/), if necessary.

[contribution process]: https://git.io/fj2m9
