### PR TITLE
fix(crds): add crd migration for locks.pkg.crossplane.io v1alpha1

### DIFF
--- a/cmd/crossplane/core/init.go
+++ b/cmd/crossplane/core/init.go
@@ -71,11 +71,13 @@ func (c *initCommand) Run(s *runtime.Scheme, log logging.Logger) error {
 			initializer.NewWebhookCertificateGenerator(nn, c.Namespace,
 				log.WithValues("Step", "WebhookCertificateGenerator")),
 			initializer.NewCoreCRDsMigrator("compositionrevisions.apiextensions.crossplane.io", "v1alpha1"),
+			initializer.NewCoreCRDsMigrator("locks.pkg.crossplane.io", "v1alpha1"),
 			initializer.NewCoreCRDs("/crds", s, initializer.WithWebhookTLSSecretRef(nn)),
 			initializer.NewWebhookConfigurations("/webhookconfigurations", s, nn, svc))
 	} else {
 		steps = append(steps,
 			initializer.NewCoreCRDsMigrator("compositionrevisions.apiextensions.crossplane.io", "v1alpha1"),
+			initializer.NewCoreCRDsMigrator("locks.pkg.crossplane.io", "v1alpha1"),
 			initializer.NewCoreCRDs("/crds", s),
 		)
 	}


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes
add crd migration for locks.pkg.crossplane.io v1alpha1

background:
If you installed Crossplane prior to version `v1.4.0`, you would have the `v1alpha1` version of `locks.pkg.crossplane.io`. However, starting from version `v1.4.0`, the storageVersion was updated to `v1beta1,` and drop for `v1alpha1` was in version `v1.11.0`.

1.4.0 - Lock to v1beta1 and mark v1alpha1 as deprecated
https://github.com/crossplane/crossplane/pull/2537

v1.11.0 - Lock API v1alpha1 has been dropped
https://github.com/crossplane/crossplane/pull/3479

<!--
Briefly describe what this pull request does, and how it is covered by tests.
Be proactive - direct your reviewers' attention to anything that needs special
consideration.

You MUST either [x] check or ~strikethrough~ every item in the checklist below.

We love pull requests that fix an open issue. If yours does, use the below line
to indicate which issue it fixes, for example "Fixes #500".
-->

Fixes #4442

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Added or updated unit **and** E2E tests for my change.
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.
- [x] Opened a PR updating the [docs](https://docs.crossplane.io/contribute/contribute/), if necessary.

[contribution process]: https://git.io/fj2m9


create crossplane v1.3.2 -> upgrade to v1.7.0 -> upgrade to v1.12.2 (https://github.com/haarchri/crossplane-issue-4442) 
and we can see the following issue:


`crossplane: error: core.initCommand.Run(): cannot initialize core: cannot apply crd: cannot patch object: CustomResourceDefinition.apiextensions.k8s.io "locks.pkg.crossplane.io" is invalid: status.storedVersions[0]: Invalid value: "v1alpha1": must appear in spec.versions`

we can see the following storedVersions:

```
kubectl get crd locks.pkg.crossplane.io -o json | jq '.status.storedVersions'
[
  "v1alpha1",
  "v1beta1"
]
```

hint: i tested also if migration from multiple crds is possible ;)
```
kubectl get crd compositionrevisions.apiextensions.crossplane.io -o json | jq '.status.storedVersions'
[
  "v1alpha1",
  "v1"
]
```

after this PR the result looks like:

```
kubectl get crd locks.pkg.crossplane.io -o json | jq '.status.storedVersions'                         
[
  "v1beta1"
]
```

```
kubectl get crd compositionrevisions.apiextensions.crossplane.io -o json | jq '.status.storedVersions'
[
  "v1"
]
```