### PR TITLE
chore(renovate): enable conventional commits

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -2,7 +2,8 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:base",
-    "helpers:pinGitHubActionDigests"
+    "helpers:pinGitHubActionDigests",
+    ":semanticCommits"
   ],
 // We only want renovate to rebase PRs when they have conflicts,
 // default "auto" mode is not required.
@@ -14,9 +15,6 @@
   "baseBranches": ["master","release-1.11","release-1.12","release-1.13"],
   "ignorePaths": ["design/**"],
   "postUpdateOptions": ["gomodTidy"],
-// By default renovate will auto detect whether semantic commits have been used
-// in the recent history and comply with that, we explicitly disable it
-  "semanticCommits": "disabled",
 // All PRs should have a label
   "labels": ["automated"],
   "regexManagers": [


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does, and how it is covered by tests.
Be proactive - direct your reviewers' attention to anything that needs special
consideration.

You MUST either [x] check or ~strikethrough~ every item in the checklist below.

We love pull requests that fix an open issue. If yours does, use the below line
to indicate which issue it fixes, for example "Fixes #500".
-->

Enable [Semantic Commits](https://docs.renovatebot.com/semantic-commits/) for renovate so that both the pr titles and commits are going to use the default `chore(deps):` prefix.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [ ] ~Added or updated unit **and** E2E tests for my change.~
- [ ] ~Run `make reviewable` to ensure this PR is ready for review.~
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR if necessary.~
- [ ] ~Opened a PR updating the [docs](https://docs.crossplane.io/contribute/contribute/), if necessary.~

[contribution process]: https://git.io/fj2m9
