### PR TITLE
[release-1.12] Bump Crossplane Runtime to v1.12.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/Masterminds/semver v1.5.0
 	github.com/alecthomas/kong v0.7.2-0.20221130112736-919e70103f7a
 	github.com/bufbuild/buf v1.10.0
-	github.com/crossplane/crossplane-runtime v1.12.0
+	github.com/crossplane/crossplane-runtime v1.12.1
 	github.com/cyphar/filepath-securejoin v0.2.3
 	github.com/google/go-cmp v0.5.9
 	github.com/google/go-containerregistry v0.15.3-0.20230625233257-b8504803389b

--- a/go.sum
+++ b/go.sum
@@ -176,8 +176,8 @@ github.com/cpuguy83/go-md2man/v2 v2.0.2 h1:p1EgwI/C7NhT0JmVkwCD2ZBK8j4aeHQX2pMHH
 github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/creack/pty v1.1.18 h1:n56/Zwd5o6whRC5PMGretI4IdRLlmBXYNjScPaBgsbY=
-github.com/crossplane/crossplane-runtime v1.12.0 h1:n/UloDWQjLEOuHr5M8onu3pZmEOHLKDjrLiDv4ejTN4=
-github.com/crossplane/crossplane-runtime v1.12.0/go.mod h1:0s26RbYNrNN5kVSrPf/Hod9xCRqGfmC/Kuy1F+XmyuA=
+github.com/crossplane/crossplane-runtime v1.12.1 h1:HX3BcjwE9XyHRTaptvO/Wjng8WFoSpLiRWRhhnTI9mw=
+github.com/crossplane/crossplane-runtime v1.12.1/go.mod h1:0s26RbYNrNN5kVSrPf/Hod9xCRqGfmC/Kuy1F+XmyuA=
 github.com/cyphar/filepath-securejoin v0.2.3 h1:YX6ebbZCZP7VkM3scTTokDgBL2TY741X51MTk3ycuNI=
 github.com/cyphar/filepath-securejoin v0.2.3/go.mod h1:aPGpWjXOXUn2NCNjFvBE6aRxGGx79pTxQpKOJNYHHl4=
 github.com/dave/astrid v0.0.0-20170323122508-8c2895878b14/go.mod h1:Sth2QfxfATb/nW4EsrSi2KyJmbcniZ8TgTaji17D6ms=


### PR DESCRIPTION
### Description of your changes

Backports #4451 with corresponding crossplane-runtime version: https://github.com/crossplane/crossplane-runtime/releases/tag/v1.12.1

I have:

- [x] Read and followed Crossplane's [contribution process].
- [ ] ~Added or updated unit **and** E2E tests for my change.~
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR if necessary.~
- [ ] ~Opened a PR updating the [docs](https://docs.crossplane.io/contribute/contribute/), if necessary.~

[contribution process]: https://git.io/fj2m9
