### PR TITLE
Make docs contribution link 'reference' style

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -26,7 +26,8 @@ I have:
 - [ ] Read and followed Crossplane's [contribution process].
 - [ ] Added or updated unit **and** E2E tests for my change.
 - [ ] Run `make reviewable` to ensure this PR is ready for review.
-- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.
-- [ ] Opened a PR updating the [docs](https://docs.crossplane.io/contribute/contribute/), if necessary.
+- [ ] Added `backport release-x.y` labels to auto-backport this PR, if necessary.
+- [ ] Opened a PR updating the [docs], if necessary.
 
 [contribution process]: https://git.io/fj2m9
+[docs]: https://docs.crossplane.io/contribute/contribute


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does, and how it is covered by tests.
Be proactive - direct your reviewers' attention to anything that needs special
consideration.

You MUST either [x] check or ~strikethrough~ every item in the checklist below.

We love pull requests that fix an open issue. If yours does, use the below line
to indicate which issue it fixes, for example "Fixes #500".
-->

Anyone who opens a PR will first read this template in markdown. Moving the link to reference style (subjectively) makes the markdown easier to read, as the sentence is not interrupted by a long URL. It also matches the existing contributing link.

I have:

- [x] Read and followed Crossplane's [contribution process].
- ~[ ] Added or updated unit **and** E2E tests for my change.~
- ~[ ] Run `make reviewable` to ensure this PR is ready for review.~
- ~[ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.~
- ~[ ] Opened a PR updating the [docs](https://docs.crossplane.io/contribute/contribute/), if necessary.~

[contribution process]: https://git.io/fj2m9
