### PR TITLE
Move muvaf from maintainers to emeritus

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -43,9 +43,9 @@
 /internal/controller/pkg/            @crossplane/crossplane-reviewers @turkenh
 
 # Composition
-/apis/apiextensions/                 @crossplane/crossplane-reviewers @muvaf
-/internal/xcrd/                      @crossplane/crossplane-reviewers @muvaf
-/internal/controller/apiextensions/  @crossplane/crossplane-reviewers @muvaf
+/apis/apiextensions/                 @crossplane/crossplane-reviewers @turkenh
+/internal/xcrd/                      @crossplane/crossplane-reviewers @turkenh
+/internal/controller/apiextensions/  @crossplane/crossplane-reviewers @turkenh
 
 # RBAC
 /cmd/crossplane/rbac/                @crossplane/crossplane-reviewers @negz

--- a/OWNERS.md
+++ b/OWNERS.md
@@ -26,7 +26,6 @@ See [CODEOWNERS](CODEOWNERS) for automatic PR assignment.
 ## Maintainers
 
 * Nic Cope <negz@upbound.io> ([negz](https://github.com/negz))
-* Muvaffak Onus <monus@upbound.io> ([muvaf](https://github.com/muvaf))
 * Hasan Turken <hasan@upbound.io> ([turkenh](https://github.com/turkenh))
 * Bob Haddleton <bob.haddleton@nokia.com> ([bobh66](https://github.com/bobh66))
 * Philippe Scorsolini <philippe.scorsolini@upbound.io> ([phisco](https://github.com/phisco))
@@ -47,3 +46,4 @@ See [CODEOWNERS](CODEOWNERS) for automatic PR assignment.
 * Jared Watts <jared@upbound.io> ([jbw976](https://github.com/jbw976))
 * Illya Chekrygin <illya.chekrygin@gmail.com> ([ichekrygin](https://github.com/ichekrygin))
 * Daniel Mangum <georgedanielmangum@gmail.com> ([hasheddan](https://github.com/hasheddan))
+* Muvaffak Onus <me@muvaf.com> ([muvaf](https://github.com/muvaf))


### PR DESCRIPTION
```
It has been an honor to serve as maintainer in Crossplane
project for the last 4 years. My focus has slightly
shifted from infrastructure and I'd like to give room
for the next generation of folks stepping up. I have
full trust that they will be the best stewards of the
project going forward - it's Crossplane, it always
reconciles towards the best desired state.

"And now, I think I am quite ready to go on another
journey. Are you coming?" - Bilbo, the Oldest Hobbit

Signed-off-by: Muvaffak Onus <me@muvaf.com>
```