### PR TITLE
Add support for convert transforms from JSON to object/array

### DIFF
--- a/apis/apiextensions/v1/composition_transforms.go
+++ b/apis/apiextensions/v1/composition_transforms.go
@@ -448,12 +448,13 @@ const (
 	TransformIOTypeFloat64 TransformIOType = "float64"
 
 	TransformIOTypeObject TransformIOType = "object"
+	TransformIOTypeArray  TransformIOType = "array"
 )
 
 // IsValid checks if the given TransformIOType is valid.
 func (c TransformIOType) IsValid() bool {
 	switch c {
-	case TransformIOTypeString, TransformIOTypeBool, TransformIOTypeInt, TransformIOTypeInt64, TransformIOTypeFloat64, TransformIOTypeObject:
+	case TransformIOTypeString, TransformIOTypeBool, TransformIOTypeInt, TransformIOTypeInt64, TransformIOTypeFloat64, TransformIOTypeObject, TransformIOTypeArray:
 		return true
 	}
 	return false
@@ -467,12 +468,13 @@ type ConvertTransformFormat string
 const (
 	ConvertTransformFormatNone     ConvertTransformFormat = "none"
 	ConvertTransformFormatQuantity ConvertTransformFormat = "quantity"
+	ConvertTransformFormatJSON     ConvertTransformFormat = "json"
 )
 
 // IsValid returns true if the format is valid.
 func (c ConvertTransformFormat) IsValid() bool {
 	switch c {
-	case ConvertTransformFormatNone, ConvertTransformFormatQuantity:
+	case ConvertTransformFormatNone, ConvertTransformFormatQuantity, ConvertTransformFormatJSON:
 		return true
 	}
 	return false
@@ -481,17 +483,19 @@ func (c ConvertTransformFormat) IsValid() bool {
 // A ConvertTransform converts the input into a new object whose type is supplied.
 type ConvertTransform struct {
 	// ToType is the type of the output of this transform.
-	// +kubebuilder:validation:Enum=string;int;int64;bool;float64
+	// +kubebuilder:validation:Enum=string;int;int64;bool;float64;object;list
 	ToType TransformIOType `json:"toType"`
 
 	// The expected input format.
 	//
 	// * `quantity` - parses the input as a K8s [`resource.Quantity`](https://pkg.go.dev/k8s.io/apimachinery/pkg/api/resource#Quantity).
 	// Only used during `string -> float64` conversions.
+	// * `json` - parses the input as a JSON string.
+	// Only used during `string -> object` or `string -> list` conversions.
 	//
 	// If this property is null, the default conversion is applied.
 	//
-	// +kubebuilder:validation:Enum=none;quantity
+	// +kubebuilder:validation:Enum=none;quantity;json
 	// +kubebuilder:validation:Default=none
 	Format *ConvertTransformFormat `json:"format,omitempty"`
 }

--- a/apis/apiextensions/v1beta1/zz_generated.composition_transforms.go
+++ b/apis/apiextensions/v1beta1/zz_generated.composition_transforms.go
@@ -450,12 +450,13 @@ const (
 	TransformIOTypeFloat64 TransformIOType = "float64"
 
 	TransformIOTypeObject TransformIOType = "object"
+	TransformIOTypeArray  TransformIOType = "array"
 )
 
 // IsValid checks if the given TransformIOType is valid.
 func (c TransformIOType) IsValid() bool {
 	switch c {
-	case TransformIOTypeString, TransformIOTypeBool, TransformIOTypeInt, TransformIOTypeInt64, TransformIOTypeFloat64, TransformIOTypeObject:
+	case TransformIOTypeString, TransformIOTypeBool, TransformIOTypeInt, TransformIOTypeInt64, TransformIOTypeFloat64, TransformIOTypeObject, TransformIOTypeArray:
 		return true
 	}
 	return false
@@ -469,12 +470,13 @@ type ConvertTransformFormat string
 const (
 	ConvertTransformFormatNone     ConvertTransformFormat = "none"
 	ConvertTransformFormatQuantity ConvertTransformFormat = "quantity"
+	ConvertTransformFormatJSON     ConvertTransformFormat = "json"
 )
 
 // IsValid returns true if the format is valid.
 func (c ConvertTransformFormat) IsValid() bool {
 	switch c {
-	case ConvertTransformFormatNone, ConvertTransformFormatQuantity:
+	case ConvertTransformFormatNone, ConvertTransformFormatQuantity, ConvertTransformFormatJSON:
 		return true
 	}
 	return false
@@ -483,17 +485,19 @@ func (c ConvertTransformFormat) IsValid() bool {
 // A ConvertTransform converts the input into a new object whose type is supplied.
 type ConvertTransform struct {
 	// ToType is the type of the output of this transform.
-	// +kubebuilder:validation:Enum=string;int;int64;bool;float64
+	// +kubebuilder:validation:Enum=string;int;int64;bool;float64;object;list
 	ToType TransformIOType `json:"toType"`
 
 	// The expected input format.
 	//
 	// * `quantity` - parses the input as a K8s [`resource.Quantity`](https://pkg.go.dev/k8s.io/apimachinery/pkg/api/resource#Quantity).
 	// Only used during `string -> float64` conversions.
+	// * `json` - parses the input as a JSON string.
+	// Only used during `string -> object` or `string -> list` conversions.
 	//
 	// If this property is null, the default conversion is applied.
 	//
-	// +kubebuilder:validation:Enum=none;quantity
+	// +kubebuilder:validation:Enum=none;quantity;json
 	// +kubebuilder:validation:Default=none
 	Format *ConvertTransformFormat `json:"format,omitempty"`
 }

--- a/cluster/crds/apiextensions.crossplane.io_compositionrevisions.yaml
+++ b/cluster/crds/apiextensions.crossplane.io_compositionrevisions.yaml
@@ -264,11 +264,14 @@ spec:
                                     description: "The expected input format. \n *
                                       `quantity` - parses the input as a K8s [`resource.Quantity`](https://pkg.go.dev/k8s.io/apimachinery/pkg/api/resource#Quantity).
                                       Only used during `string -> float64` conversions.
-                                      \n If this property is null, the default conversion
-                                      is applied."
+                                      * `json` - parses the input as a JSON string.
+                                      Only used during `string -> object` or `string
+                                      -> list` conversions. \n If this property is
+                                      null, the default conversion is applied."
                                     enum:
                                     - none
                                     - quantity
+                                    - json
                                     type: string
                                   toType:
                                     description: ToType is the type of the output
@@ -279,6 +282,8 @@ spec:
                                     - int64
                                     - bool
                                     - float64
+                                    - object
+                                    - list
                                     type: string
                                 required:
                                 - toType
@@ -748,11 +753,14 @@ spec:
                                       description: "The expected input format. \n
                                         * `quantity` - parses the input as a K8s [`resource.Quantity`](https://pkg.go.dev/k8s.io/apimachinery/pkg/api/resource#Quantity).
                                         Only used during `string -> float64` conversions.
-                                        \n If this property is null, the default conversion
-                                        is applied."
+                                        * `json` - parses the input as a JSON string.
+                                        Only used during `string -> object` or `string
+                                        -> list` conversions. \n If this property
+                                        is null, the default conversion is applied."
                                       enum:
                                       - none
                                       - quantity
+                                      - json
                                       type: string
                                     toType:
                                       description: ToType is the type of the output
@@ -763,6 +771,8 @@ spec:
                                       - int64
                                       - bool
                                       - float64
+                                      - object
+                                      - list
                                       type: string
                                   required:
                                   - toType
@@ -1163,11 +1173,14 @@ spec:
                                       description: "The expected input format. \n
                                         * `quantity` - parses the input as a K8s [`resource.Quantity`](https://pkg.go.dev/k8s.io/apimachinery/pkg/api/resource#Quantity).
                                         Only used during `string -> float64` conversions.
-                                        \n If this property is null, the default conversion
-                                        is applied."
+                                        * `json` - parses the input as a JSON string.
+                                        Only used during `string -> object` or `string
+                                        -> list` conversions. \n If this property
+                                        is null, the default conversion is applied."
                                       enum:
                                       - none
                                       - quantity
+                                      - json
                                       type: string
                                     toType:
                                       description: ToType is the type of the output
@@ -1178,6 +1191,8 @@ spec:
                                       - int64
                                       - bool
                                       - float64
+                                      - object
+                                      - list
                                       type: string
                                   required:
                                   - toType
@@ -1744,11 +1759,14 @@ spec:
                                     description: "The expected input format. \n *
                                       `quantity` - parses the input as a K8s [`resource.Quantity`](https://pkg.go.dev/k8s.io/apimachinery/pkg/api/resource#Quantity).
                                       Only used during `string -> float64` conversions.
-                                      \n If this property is null, the default conversion
-                                      is applied."
+                                      * `json` - parses the input as a JSON string.
+                                      Only used during `string -> object` or `string
+                                      -> list` conversions. \n If this property is
+                                      null, the default conversion is applied."
                                     enum:
                                     - none
                                     - quantity
+                                    - json
                                     type: string
                                   toType:
                                     description: ToType is the type of the output
@@ -1759,6 +1777,8 @@ spec:
                                     - int64
                                     - bool
                                     - float64
+                                    - object
+                                    - list
                                     type: string
                                 required:
                                 - toType
@@ -2228,11 +2248,14 @@ spec:
                                       description: "The expected input format. \n
                                         * `quantity` - parses the input as a K8s [`resource.Quantity`](https://pkg.go.dev/k8s.io/apimachinery/pkg/api/resource#Quantity).
                                         Only used during `string -> float64` conversions.
-                                        \n If this property is null, the default conversion
-                                        is applied."
+                                        * `json` - parses the input as a JSON string.
+                                        Only used during `string -> object` or `string
+                                        -> list` conversions. \n If this property
+                                        is null, the default conversion is applied."
                                       enum:
                                       - none
                                       - quantity
+                                      - json
                                       type: string
                                     toType:
                                       description: ToType is the type of the output
@@ -2243,6 +2266,8 @@ spec:
                                       - int64
                                       - bool
                                       - float64
+                                      - object
+                                      - list
                                       type: string
                                   required:
                                   - toType
@@ -2643,11 +2668,14 @@ spec:
                                       description: "The expected input format. \n
                                         * `quantity` - parses the input as a K8s [`resource.Quantity`](https://pkg.go.dev/k8s.io/apimachinery/pkg/api/resource#Quantity).
                                         Only used during `string -> float64` conversions.
-                                        \n If this property is null, the default conversion
-                                        is applied."
+                                        * `json` - parses the input as a JSON string.
+                                        Only used during `string -> object` or `string
+                                        -> list` conversions. \n If this property
+                                        is null, the default conversion is applied."
                                       enum:
                                       - none
                                       - quantity
+                                      - json
                                       type: string
                                     toType:
                                       description: ToType is the type of the output
@@ -2658,6 +2686,8 @@ spec:
                                       - int64
                                       - bool
                                       - float64
+                                      - object
+                                      - list
                                       type: string
                                   required:
                                   - toType

--- a/cluster/crds/apiextensions.crossplane.io_compositions.yaml
+++ b/cluster/crds/apiextensions.crossplane.io_compositions.yaml
@@ -261,11 +261,14 @@ spec:
                                     description: "The expected input format. \n *
                                       `quantity` - parses the input as a K8s [`resource.Quantity`](https://pkg.go.dev/k8s.io/apimachinery/pkg/api/resource#Quantity).
                                       Only used during `string -> float64` conversions.
-                                      \n If this property is null, the default conversion
-                                      is applied."
+                                      * `json` - parses the input as a JSON string.
+                                      Only used during `string -> object` or `string
+                                      -> list` conversions. \n If this property is
+                                      null, the default conversion is applied."
                                     enum:
                                     - none
                                     - quantity
+                                    - json
                                     type: string
                                   toType:
                                     description: ToType is the type of the output
@@ -276,6 +279,8 @@ spec:
                                     - int64
                                     - bool
                                     - float64
+                                    - object
+                                    - list
                                     type: string
                                 required:
                                 - toType
@@ -748,11 +753,14 @@ spec:
                                       description: "The expected input format. \n
                                         * `quantity` - parses the input as a K8s [`resource.Quantity`](https://pkg.go.dev/k8s.io/apimachinery/pkg/api/resource#Quantity).
                                         Only used during `string -> float64` conversions.
-                                        \n If this property is null, the default conversion
-                                        is applied."
+                                        * `json` - parses the input as a JSON string.
+                                        Only used during `string -> object` or `string
+                                        -> list` conversions. \n If this property
+                                        is null, the default conversion is applied."
                                       enum:
                                       - none
                                       - quantity
+                                      - json
                                       type: string
                                     toType:
                                       description: ToType is the type of the output
@@ -763,6 +771,8 @@ spec:
                                       - int64
                                       - bool
                                       - float64
+                                      - object
+                                      - list
                                       type: string
                                   required:
                                   - toType
@@ -1167,11 +1177,14 @@ spec:
                                       description: "The expected input format. \n
                                         * `quantity` - parses the input as a K8s [`resource.Quantity`](https://pkg.go.dev/k8s.io/apimachinery/pkg/api/resource#Quantity).
                                         Only used during `string -> float64` conversions.
-                                        \n If this property is null, the default conversion
-                                        is applied."
+                                        * `json` - parses the input as a JSON string.
+                                        Only used during `string -> object` or `string
+                                        -> list` conversions. \n If this property
+                                        is null, the default conversion is applied."
                                       enum:
                                       - none
                                       - quantity
+                                      - json
                                       type: string
                                     toType:
                                       description: ToType is the type of the output
@@ -1182,6 +1195,8 @@ spec:
                                       - int64
                                       - bool
                                       - float64
+                                      - object
+                                      - list
                                       type: string
                                   required:
                                   - toType

--- a/internal/controller/apiextensions/composite/composition_transforms.go
+++ b/internal/controller/apiextensions/composite/composition_transforms.go
@@ -488,4 +488,12 @@ var conversions = map[conversionPair]func(any) (any, error){
 	{from: v1.TransformIOTypeFloat64, to: v1.TransformIOTypeBool, format: v1.ConvertTransformFormatNone}: func(i any) (any, error) { //nolint:unparam // See note above.
 		return i.(float64) == float64(1), nil
 	},
+	{from: v1.TransformIOTypeString, to: v1.TransformIOTypeObject, format: v1.ConvertTransformFormatJSON}: func(i any) (any, error) {
+		o := map[string]any{}
+		return o, json.Unmarshal([]byte(i.(string)), &o)
+	},
+	{from: v1.TransformIOTypeString, to: v1.TransformIOTypeArray, format: v1.ConvertTransformFormatJSON}: func(i any) (any, error) {
+		var o []any
+		return o, json.Unmarshal([]byte(i.(string)), &o)
+	},
 }

--- a/internal/controller/apiextensions/composite/composition_transforms_test.go
+++ b/internal/controller/apiextensions/composite/composition_transforms_test.go
@@ -1111,6 +1111,30 @@ func TestConvertResolve(t *testing.T) {
 				o: int64(1),
 			},
 		},
+		"StringToObject": {
+			args: args{
+				i:      "{\"foo\":\"bar\"}",
+				to:     v1.TransformIOTypeObject,
+				format: (*v1.ConvertTransformFormat)(pointer.String(string(v1.ConvertTransformFormatJSON))),
+			},
+			want: want{
+				o: map[string]any{
+					"foo": "bar",
+				},
+			},
+		},
+		"StringToList": {
+			args: args{
+				i:      "[\"foo\", \"bar\", \"baz\"]",
+				to:     v1.TransformIOTypeArray,
+				format: (*v1.ConvertTransformFormat)(pointer.String(string(v1.ConvertTransformFormatJSON))),
+			},
+			want: want{
+				o: []any{
+					"foo", "bar", "baz",
+				},
+			},
+		},
 		"InputTypeNotSupported": {
 			args: args{
 				i:  []int{64},
@@ -1234,6 +1258,38 @@ func TestConvertTransformGetConversionFunc(t *testing.T) {
 					ToType: v1.TransformIOTypeInt,
 				},
 				from: v1.TransformIOTypeBool,
+			},
+		},
+		"JSONStringToObject": {
+			reason: "JSON string to Object should be valid",
+			args: args{
+				ct: &v1.ConvertTransform{
+					ToType: v1.TransformIOTypeObject,
+					Format: &[]v1.ConvertTransformFormat{v1.ConvertTransformFormatJSON}[0],
+				},
+				from: v1.TransformIOTypeString,
+			},
+		},
+		"JSONStringToArray": {
+			reason: "JSON string to Array should be valid",
+			args: args{
+				ct: &v1.ConvertTransform{
+					ToType: v1.TransformIOTypeArray,
+					Format: &[]v1.ConvertTransformFormat{v1.ConvertTransformFormatJSON}[0],
+				},
+				from: v1.TransformIOTypeString,
+			},
+		},
+		"StringToObjectMissingFormat": {
+			reason: "String to Object without format should be invalid",
+			args: args{
+				ct: &v1.ConvertTransform{
+					ToType: v1.TransformIOTypeObject,
+				},
+				from: v1.TransformIOTypeString,
+			},
+			want: want{
+				err: fmt.Errorf("conversion from string to object is not supported with format none"),
 			},
 		},
 		"StringToIntInvalidFormat": {

--- a/pkg/validation/internal/schema/schema.go
+++ b/pkg/validation/internal/schema/schema.go
@@ -68,6 +68,8 @@ func FromTransformIOType(c v1.TransformIOType) KnownJSONType {
 		return KnownJSONTypeNumber
 	case v1.TransformIOTypeObject:
 		return KnownJSONTypeObject
+	case v1.TransformIOTypeArray:
+		return KnownJSONTypeArray
 	}
 	// should never happen
 	return ""
@@ -86,7 +88,9 @@ func FromKnownJSONType(t KnownJSONType) (v1.TransformIOType, error) {
 		return v1.TransformIOTypeFloat64, nil
 	case KnownJSONTypeObject:
 		return v1.TransformIOTypeObject, nil
-	case KnownJSONTypeArray, KnownJSONTypeNull:
+	case KnownJSONTypeArray:
+		return v1.TransformIOTypeObject, nil
+	case KnownJSONTypeNull:
 		return "", errors.Errorf(errFmtUnsupportedJSONType, t)
 	default:
 		return "", errors.Errorf(errFmtUnknownJSONType, t)


### PR DESCRIPTION
### Description of your changes

This PR adds support for convert transforms from JSON to object/array. This enables patching complex types (as proposed by @bobh66 [here](https://github.com/crossplane/crossplane/pull/3458#issuecomment-1383183093)) other than just simple ones and could be used [to patch the keys in objects/maps](https://github.com/crossplane/crossplane/issues/4065#issuecomment-1693203182).

Fixes #4065 

```yaml
    patches:
    - type: FromCompositeFieldPath
      fromFieldPath: spec.clusterName
      toFieldPath: spec.forProvider.tags
      transforms:
      - type: string
        string:
          type: Format
          fmt: '{"kubernetes.io/cluster/%s": "true"}'
      - type: convert
        convert:
          toType: object
          format: json
```

The above example enables the following composed resource (where `spec.clusterName` has the value of `dev-cluster`):

```diff
apiVersion: ec2.aws.upbound.io/v1beta1
kind: VPC
...
spec:
  deletionPolicy: Delete
  forProvider:
    cidrBlock: 172.16.0.0/16
    region: us-west-1
    tags:
      crossplane-kind: vpc.ec2.aws.upbound.io
      crossplane-name: apiextensions-composition-pandt-vpgkm-ck9g9
      crossplane-providerconfig: default
+     kubernetes.io/cluster/dev-cluster: "true"
```

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Added or updated unit **and** E2E tests for my change.
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] ~~Added `backport release-x.y` labels to auto-backport this PR, if necessary.~~
- [x] Opened a PR updating the [docs], if necessary => https://github.com/crossplane/docs/pull/541

[contribution process]: https://git.io/fj2m9
[docs]: https://docs.crossplane.io/contribute/contribute
