### PR TITLE
fix(alpha): schema aware validation properly handling ToJson string t…

### DIFF
--- a/apis/apiextensions/v1/composition_transforms.go
+++ b/apis/apiextensions/v1/composition_transforms.go
@@ -446,12 +446,14 @@ const (
 	TransformIOTypeInt     TransformIOType = "int"
 	TransformIOTypeInt64   TransformIOType = "int64"
 	TransformIOTypeFloat64 TransformIOType = "float64"
+
+	TransformIOTypeObject TransformIOType = "object"
 )
 
 // IsValid checks if the given TransformIOType is valid.
 func (c TransformIOType) IsValid() bool {
 	switch c {
-	case TransformIOTypeString, TransformIOTypeBool, TransformIOTypeInt, TransformIOTypeInt64, TransformIOTypeFloat64:
+	case TransformIOTypeString, TransformIOTypeBool, TransformIOTypeInt, TransformIOTypeInt64, TransformIOTypeFloat64, TransformIOTypeObject:
 		return true
 	}
 	return false

--- a/apis/apiextensions/v1beta1/zz_generated.composition_transforms.go
+++ b/apis/apiextensions/v1beta1/zz_generated.composition_transforms.go
@@ -448,12 +448,14 @@ const (
 	TransformIOTypeInt     TransformIOType = "int"
 	TransformIOTypeInt64   TransformIOType = "int64"
 	TransformIOTypeFloat64 TransformIOType = "float64"
+
+	TransformIOTypeObject TransformIOType = "object"
 )
 
 // IsValid checks if the given TransformIOType is valid.
 func (c TransformIOType) IsValid() bool {
 	switch c {
-	case TransformIOTypeString, TransformIOTypeBool, TransformIOTypeInt, TransformIOTypeInt64, TransformIOTypeFloat64:
+	case TransformIOTypeString, TransformIOTypeBool, TransformIOTypeInt, TransformIOTypeInt64, TransformIOTypeFloat64, TransformIOTypeObject:
 		return true
 	}
 	return false

--- a/pkg/validation/internal/schema/schema.go
+++ b/pkg/validation/internal/schema/schema.go
@@ -66,6 +66,8 @@ func FromTransformIOType(c v1.TransformIOType) KnownJSONType {
 		return KnownJSONTypeInteger
 	case v1.TransformIOTypeFloat64:
 		return KnownJSONTypeNumber
+	case v1.TransformIOTypeObject:
+		return KnownJSONTypeObject
 	}
 	// should never happen
 	return ""
@@ -82,7 +84,9 @@ func FromKnownJSONType(t KnownJSONType) (v1.TransformIOType, error) {
 		return v1.TransformIOTypeInt64, nil
 	case KnownJSONTypeNumber:
 		return v1.TransformIOTypeFloat64, nil
-	case KnownJSONTypeObject, KnownJSONTypeArray, KnownJSONTypeNull:
+	case KnownJSONTypeObject:
+		return v1.TransformIOTypeObject, nil
+	case KnownJSONTypeArray, KnownJSONTypeNull:
 		return "", errors.Errorf(errFmtUnsupportedJSONType, t)
 	default:
 		return "", errors.Errorf(errFmtUnknownJSONType, t)

--- a/test/e2e/comp_schema_validation_test.go
+++ b/test/e2e/comp_schema_validation_test.go
@@ -45,6 +45,15 @@ func TestCompositionValidation(t *testing.T) {
 			),
 		},
 		{
+			// A valid Composition should be created when validated in strict mode.
+			Name:        "ValidCompositionWithAToJsonTransformIsAcceptedStrictMode",
+			Description: "A valid Composition defining a valid ToJson String transform should be created when validated in strict mode.",
+			Assessment: funcs.AllOf(
+				funcs.ApplyResources(FieldManager, manifests, "composition-transform-tojson-valid.yaml"),
+				funcs.ResourcesCreatedWithin(30*time.Second, manifests, "composition-transform-tojson-valid.yaml"),
+			),
+		},
+		{
 			// An invalid Composition should be rejected when validated in strict mode.
 			Name:       "InvalidCompositionIsRejectedStrictMode",
 			Assessment: funcs.ResourcesFailToApply(FieldManager, manifests, "composition-invalid.yaml"),

--- a/test/e2e/manifests/apiextensions/composition/validation/composition-transform-tojson-valid.yaml
+++ b/test/e2e/manifests/apiextensions/composition/validation/composition-transform-tojson-valid.yaml
@@ -1,0 +1,33 @@
+apiVersion: apiextensions.crossplane.io/v1
+kind: Composition
+metadata:
+  name: valid-tojson-patch
+  annotations:
+    crossplane.io/composition-validation-mode: strict
+spec:
+  compositeTypeRef:
+    apiVersion: nop.example.org/v1alpha1
+    kind: XNopResource
+  resources:
+  - name: nop-resource-1
+    base:
+     apiVersion: nop.crossplane.io/v1alpha1
+     kind: NopResource
+     spec:
+      forProvider:
+        conditionAfter:
+        - conditionType: Ready
+          conditionStatus: "False"
+          time: 0s
+        - conditionType: Ready
+          conditionStatus: "True"
+          time: 10s
+    patches:
+    - type: FromCompositeFieldPath
+      fromFieldPath: spec
+      toFieldPath: metadata.annotations[spec]
+      transforms:
+      - type: string
+        string:
+         type: Convert
+         convert: ToJson


### PR DESCRIPTION
…ransform

<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does, and how it is covered by tests.
Be proactive - direct your reviewers' attention to anything that needs special
consideration.

You MUST either [x] check or ~strikethrough~ every item in the checklist below.

We love pull requests that fix an open issue. If yours does, use the below line
to indicate which issue it fixes, for example "Fixes #500".
-->

Before this patch the composition added below would have been rejected, firstly due to a crash at [pkg/validation/apiextensions/v1/composition/patches.go:328](https://github.com/crossplane/crossplane/blob/4f9d85a7714a1f4ac276f1e35f1ed397a0467d76/pkg/validation/apiextensions/v1/composition/patches.go#L328), but also due to the fact that the validation code was expecting String transforms to always have a string as input, while that was not the case for a ToJson and all the hash related functions.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Added or updated unit **and** E2E tests for my change.
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR, if necessary.
- [ ] ~Opened a PR updating the [docs], if necessary.~

[contribution process]: https://git.io/fj2m9
[docs]: https://docs.crossplane.io/contribute/contribute
