### PR TITLE
apiextensions/composite: list unready resources in condition message

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/Masterminds/semver v1.5.0
 	github.com/alecthomas/kong v0.8.0
 	github.com/bufbuild/buf v1.26.1
-	github.com/crossplane/crossplane-runtime v1.14.0-rc.0.0.20230906075713-a2674ee167ac
+	github.com/crossplane/crossplane-runtime v1.14.0-rc.0.0.20230908095748-e646d73c92a5
 	github.com/google/go-cmp v0.5.9
 	github.com/google/go-containerregistry v0.16.1
 	github.com/google/go-containerregistry/pkg/authn/k8schain v0.0.0-20230905180039-a748190e18d4

--- a/go.sum
+++ b/go.sum
@@ -146,8 +146,8 @@ github.com/cpuguy83/go-md2man/v2 v2.0.2 h1:p1EgwI/C7NhT0JmVkwCD2ZBK8j4aeHQX2pMHH
 github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/creack/pty v1.1.18 h1:n56/Zwd5o6whRC5PMGretI4IdRLlmBXYNjScPaBgsbY=
-github.com/crossplane/crossplane-runtime v1.14.0-rc.0.0.20230906075713-a2674ee167ac h1:OQHuf2Skg+h1bfBHBWjJp9dd3T4A6I6QxpJ/4f16hxQ=
-github.com/crossplane/crossplane-runtime v1.14.0-rc.0.0.20230906075713-a2674ee167ac/go.mod h1:e/YQO6ezRbtq+vp2bq7FlkkKuldMzE1JTlONWZdm1Zg=
+github.com/crossplane/crossplane-runtime v1.14.0-rc.0.0.20230908095748-e646d73c92a5 h1:JJVPhrZsJUEpmFfqxO7n8jMODCElFAr1avUfhqTkrpA=
+github.com/crossplane/crossplane-runtime v1.14.0-rc.0.0.20230908095748-e646d73c92a5/go.mod h1:e/YQO6ezRbtq+vp2bq7FlkkKuldMzE1JTlONWZdm1Zg=
 github.com/cyphar/filepath-securejoin v0.2.3 h1:YX6ebbZCZP7VkM3scTTokDgBL2TY741X51MTk3ycuNI=
 github.com/cyphar/filepath-securejoin v0.2.3/go.mod h1:aPGpWjXOXUn2NCNjFvBE6aRxGGx79pTxQpKOJNYHHl4=
 github.com/danieljoos/wincred v1.1.2/go.mod h1:GijpziifJoIBfYh+S7BbkdUTU4LfM+QnGqR5Vl2tAx0=

--- a/internal/controller/apiextensions/composite/composition_pt.go
+++ b/internal/controller/apiextensions/composite/composition_pt.go
@@ -18,7 +18,7 @@ package composite
 
 import (
 	"context"
-	"strconv"
+	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
@@ -203,7 +203,7 @@ func (c *PTComposer) Compose(ctx context.Context, xr resource.Composite, req Com
 		ta := tas[i]
 
 		// If this resource is anonymous its "name" is just its index.
-		name := pointer.StringDeref(ta.Template.Name, strconv.Itoa(i))
+		name := pointer.StringDeref(ta.Template.Name, fmt.Sprintf("resource %d", i+1))
 		r := composed.New(composed.FromReference(ta.Reference))
 
 		rerr := c.composed.Render(ctx, xr, r, ta.Template, req.Environment)

--- a/internal/controller/apiextensions/composite/reconciler.go
+++ b/internal/controller/apiextensions/composite/reconciler.go
@@ -531,8 +531,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 		r.record.Event(xr, event.Normal(reasonResolve, fmt.Sprintf("Successfully selected composition: %s", compRef.Name)))
 	}
 
-	// Note that this 'Composition' will be derived from a
-	// CompositionRevision if the relevant feature flag is enabled.
+	// Select (if there is a new one) and fetch the composition revision.
 	origRev := xr.GetCompositionRevisionReference()
 	rev, err := r.revision.Fetch(ctx, xr)
 	if err != nil {

--- a/internal/controller/apiextensions/composite/reconciler_test.go
+++ b/internal/controller/apiextensions/composite/reconciler_test.go
@@ -516,7 +516,7 @@ func TestReconcile(t *testing.T) {
 						MockGet: test.NewMockGetFn(nil),
 						MockStatusUpdate: WantComposite(t, NewComposite(func(cr resource.Composite) {
 							cr.SetCompositionReference(&corev1.ObjectReference{})
-							cr.SetConditions(xpv1.ReconcileSuccess(), xpv1.Creating())
+							cr.SetConditions(xpv1.ReconcileSuccess(), xpv1.Creating().WithMessage("Unready resources: cat, cow, elephant, and 1 more"))
 						})),
 					}),
 					WithCompositeFinalizer(resource.NewNopFinalizer()),
@@ -537,7 +537,23 @@ func TestReconcile(t *testing.T) {
 					WithComposer(ComposerFn(func(ctx context.Context, xr resource.Composite, req CompositionRequest) (CompositionResult, error) {
 						return CompositionResult{
 							Composed: []ComposedResource{{
-								Ready: false,
+								ResourceName: "elephant",
+								Ready:        false,
+							}, {
+								ResourceName: "cow",
+								Ready:        false,
+							}, {
+								ResourceName: "pig",
+								Ready:        true,
+							}, {
+								ResourceName: "cat",
+								Ready:        false,
+							}, {
+								ResourceName: "dog",
+								Ready:        true,
+							}, {
+								ResourceName: "snake",
+								Ready:        false,
 							}},
 						}, nil
 					})),

--- a/internal/controller/rbac/definition/reconciler.go
+++ b/internal/controller/rbac/definition/reconciler.go
@@ -20,7 +20,6 @@ package definition
 import (
 	"context"
 	"fmt"
-	"sort"
 	"strings"
 	"time"
 
@@ -207,8 +206,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 	}
 
 	if len(applied) > 0 {
-		sort.Strings(applied)
-		r.record.Event(d, event.Normal(reasonApplyRoles, fmt.Sprintf("Applied RBAC ClusterRoles: %s", firstNAndSomeMore(applied))))
+		r.record.Event(d, event.Normal(reasonApplyRoles, fmt.Sprintf("Applied RBAC ClusterRoles: %s", resource.StableNAndSomeMore(resource.DefaultFirstN, applied))))
 	}
 
 	// TODO(negz): Add a condition that indicates the RBAC manager is managing
@@ -225,11 +223,4 @@ func ClusterRolesDiffer(current, desired runtime.Object) bool {
 	c := current.(*rbacv1.ClusterRole)
 	d := desired.(*rbacv1.ClusterRole)
 	return !cmp.Equal(c.GetLabels(), d.GetLabels()) || !cmp.Equal(c.Rules, d.Rules)
-}
-
-func firstNAndSomeMore(names []string) string {
-	if len(names) > 3 {
-		return fmt.Sprintf("%s, and %d more", strings.Join(names[:3], ", "), len(names)-3)
-	}
-	return strings.Join(names, ", ")
 }

--- a/internal/controller/rbac/namespace/reconciler.go
+++ b/internal/controller/rbac/namespace/reconciler.go
@@ -20,7 +20,6 @@ package namespace
 import (
 	"context"
 	"fmt"
-	"sort"
 	"strings"
 	"time"
 
@@ -217,8 +216,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 	}
 
 	if len(applied) > 0 {
-		sort.Strings(applied)
-		r.record.Event(ns, event.Normal(reasonApplyRoles, fmt.Sprintf("Applied RBAC Roles: %s", firstNAndSomeMore(applied))))
+		r.record.Event(ns, event.Normal(reasonApplyRoles, fmt.Sprintf("Applied RBAC Roles: %s", resource.StableNAndSomeMore(resource.DefaultFirstN, applied))))
 	}
 
 	return reconcile.Result{Requeue: false}, nil
@@ -249,11 +247,4 @@ func equalRolesAnnotations(current, desired *rbacv1.Role) bool {
 		}
 	}
 	return cmp.Equal(currentFiltered, desiredFiltered)
-}
-
-func firstNAndSomeMore(names []string) string {
-	if len(names) > 3 {
-		return fmt.Sprintf("%s, and %d more", strings.Join(names[:3], ", "), len(names)-3)
-	}
-	return strings.Join(names, ", ")
 }

--- a/internal/controller/rbac/provider/roles/reconciler.go
+++ b/internal/controller/rbac/provider/roles/reconciler.go
@@ -20,7 +20,6 @@ package roles
 import (
 	"context"
 	"fmt"
-	"sort"
 	"strings"
 	"time"
 
@@ -351,8 +350,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 	}
 
 	if len(applied) > 0 {
-		sort.Strings(applied)
-		r.record.Event(pr, event.Normal(reasonApplyRoles, fmt.Sprintf("Applied RBAC ClusterRoles: %s", firstNAndSomeMore(applied))))
+		r.record.Event(pr, event.Normal(reasonApplyRoles, fmt.Sprintf("Applied RBAC ClusterRoles: %s", resource.StableNAndSomeMore(resource.DefaultFirstN, applied))))
 	}
 
 	// TODO(negz): Add a condition that indicates the RBAC manager is
@@ -435,11 +433,4 @@ func (d OrgDiffer) Differs(a, b string) bool {
 	ob := strings.Split(cb.RepositoryStr(), "/")[0]
 
 	return oa != ob
-}
-
-func firstNAndSomeMore(names []string) string {
-	if len(names) > 3 {
-		return fmt.Sprintf("%s, and %d more", strings.Join(names[:3], ", "), len(names)-3)
-	}
-	return strings.Join(names, ", ")
 }


### PR DESCRIPTION
### Description of your changes

Set the `Ready` condition message for reason `Creating` to be the first 3 unready resources. They are sorted in the composition and hence give a stable message.

<img width="1152" alt="Bildschirmfoto 2023-09-04 um 18 49 12" src="https://github.com/crossplane/crossplane/assets/730123/6ff9762b-8e33-4235-9b5f-901f8cfe9ab6">

Fixes https://github.com/crossplane/crossplane/issues/3441.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Added or updated unit **and** E2E tests for my change.
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR, if necessary.~
- [ ] ~Opened a PR updating the [docs], if necessary.~

[contribution process]: https://git.io/fj2m9
[docs]: https://docs.crossplane.io/contribute/contribute