### PR TITLE
Bump e2e step timeouts

### DIFF
--- a/test/e2e/environmentconfig_test.go
+++ b/test/e2e/environmentconfig_test.go
@@ -62,7 +62,7 @@ func TestEnvironmentConfigDefault(t *testing.T) {
 				funcs.ApplyResources(FieldManager, manifestsFolderEnvironmentConfigs, "setup/*.yaml"),
 				funcs.ResourcesCreatedWithin(30*time.Second, manifestsFolderEnvironmentConfigs, "setup/*.yaml"),
 				funcs.ResourcesHaveConditionWithin(1*time.Minute, manifestsFolderEnvironmentConfigs, "setup/definition.yaml", apiextensionsv1.WatchingComposite()),
-				funcs.ResourcesHaveConditionWithin(1*time.Minute, manifestsFolderEnvironmentConfigs, "setup/provider.yaml", pkgv1.Healthy(), pkgv1.Active()),
+				funcs.ResourcesHaveConditionWithin(2*time.Minute, manifestsFolderEnvironmentConfigs, "setup/provider.yaml", pkgv1.Healthy(), pkgv1.Active()),
 			)).
 			WithSetup("CreatePrerequisites", funcs.AllOf(
 				funcs.ApplyResources(FieldManager, manifestsFolderEnvironmentConfigs, filepath.Join(subfolder, "setup/*.yaml")),
@@ -116,7 +116,7 @@ func TestEnvironmentResolutionOptional(t *testing.T) {
 				funcs.ApplyResources(FieldManager, manifestsFolderEnvironmentConfigs, "setup/*.yaml"),
 				funcs.ResourcesCreatedWithin(30*time.Second, manifestsFolderEnvironmentConfigs, "setup/*.yaml"),
 				funcs.ResourcesHaveConditionWithin(1*time.Minute, manifestsFolderEnvironmentConfigs, "setup/definition.yaml", apiextensionsv1.WatchingComposite()),
-				funcs.ResourcesHaveConditionWithin(1*time.Minute, manifestsFolderEnvironmentConfigs, "setup/provider.yaml", pkgv1.Healthy(), pkgv1.Active()),
+				funcs.ResourcesHaveConditionWithin(2*time.Minute, manifestsFolderEnvironmentConfigs, "setup/provider.yaml", pkgv1.Healthy(), pkgv1.Active()),
 			)).
 			WithSetup("CreatePrerequisites", funcs.AllOf(
 				funcs.ApplyResources(FieldManager, manifestsFolderEnvironmentConfigs, filepath.Join(subfolder, "setup/*.yaml")),
@@ -170,7 +170,7 @@ func TestEnvironmentResolveIfNotPresent(t *testing.T) {
 				funcs.ApplyResources(FieldManager, manifestsFolderEnvironmentConfigs, "setup/*.yaml"),
 				funcs.ResourcesCreatedWithin(30*time.Second, manifestsFolderEnvironmentConfigs, "setup/*.yaml"),
 				funcs.ResourcesHaveConditionWithin(1*time.Minute, manifestsFolderEnvironmentConfigs, "setup/definition.yaml", apiextensionsv1.WatchingComposite()),
-				funcs.ResourcesHaveConditionWithin(1*time.Minute, manifestsFolderEnvironmentConfigs, "setup/provider.yaml", pkgv1.Healthy(), pkgv1.Active()),
+				funcs.ResourcesHaveConditionWithin(2*time.Minute, manifestsFolderEnvironmentConfigs, "setup/provider.yaml", pkgv1.Healthy(), pkgv1.Active()),
 			)).
 			WithSetup("CreatePrerequisites", funcs.AllOf(
 				funcs.ApplyResources(FieldManager, manifestsFolderEnvironmentConfigs, filepath.Join(subfolder, "setup/*.yaml")),
@@ -234,7 +234,7 @@ func TestEnvironmentResolveAlways(t *testing.T) {
 				funcs.ApplyResources(FieldManager, manifestsFolderEnvironmentConfigs, "setup/*.yaml"),
 				funcs.ResourcesCreatedWithin(30*time.Second, manifestsFolderEnvironmentConfigs, "setup/*.yaml"),
 				funcs.ResourcesHaveConditionWithin(1*time.Minute, manifestsFolderEnvironmentConfigs, "setup/definition.yaml", apiextensionsv1.WatchingComposite()),
-				funcs.ResourcesHaveConditionWithin(1*time.Minute, manifestsFolderEnvironmentConfigs, "setup/provider.yaml", pkgv1.Healthy(), pkgv1.Active()),
+				funcs.ResourcesHaveConditionWithin(2*time.Minute, manifestsFolderEnvironmentConfigs, "setup/provider.yaml", pkgv1.Healthy(), pkgv1.Active()),
 			)).
 			WithSetup("CreatePrerequisites", funcs.AllOf(
 				funcs.ApplyResources(FieldManager, manifestsFolderEnvironmentConfigs, filepath.Join(subfolder, "setup/*.yaml")),
@@ -298,7 +298,7 @@ func TestEnvironmentConfigMultipleMaxMatchNil(t *testing.T) {
 				funcs.ApplyResources(FieldManager, manifestsFolderEnvironmentConfigs, "setup/*.yaml"),
 				funcs.ResourcesCreatedWithin(30*time.Second, manifestsFolderEnvironmentConfigs, "setup/*.yaml"),
 				funcs.ResourcesHaveConditionWithin(1*time.Minute, manifestsFolderEnvironmentConfigs, "setup/definition.yaml", apiextensionsv1.WatchingComposite()),
-				funcs.ResourcesHaveConditionWithin(1*time.Minute, manifestsFolderEnvironmentConfigs, "setup/provider.yaml", pkgv1.Healthy(), pkgv1.Active()),
+				funcs.ResourcesHaveConditionWithin(2*time.Minute, manifestsFolderEnvironmentConfigs, "setup/provider.yaml", pkgv1.Healthy(), pkgv1.Active()),
 			)).
 			WithSetup("CreatePrerequisites", funcs.AllOf(
 				funcs.ApplyResources(FieldManager, manifestsFolderEnvironmentConfigs, filepath.Join(subfolder, "setup/*.yaml")),
@@ -351,7 +351,7 @@ func TestEnvironmentConfigMultipleMaxMatch1(t *testing.T) {
 				funcs.ApplyResources(FieldManager, manifestsFolderEnvironmentConfigs, "setup/*.yaml"),
 				funcs.ResourcesCreatedWithin(30*time.Second, manifestsFolderEnvironmentConfigs, "setup/*.yaml"),
 				funcs.ResourcesHaveConditionWithin(1*time.Minute, manifestsFolderEnvironmentConfigs, "setup/definition.yaml", apiextensionsv1.WatchingComposite()),
-				funcs.ResourcesHaveConditionWithin(1*time.Minute, manifestsFolderEnvironmentConfigs, "setup/provider.yaml", pkgv1.Healthy(), pkgv1.Active()),
+				funcs.ResourcesHaveConditionWithin(2*time.Minute, manifestsFolderEnvironmentConfigs, "setup/provider.yaml", pkgv1.Healthy(), pkgv1.Active()),
 			)).
 			WithSetup("CreatePrerequisites", funcs.AllOf(
 				funcs.ApplyResources(FieldManager, manifestsFolderEnvironmentConfigs, filepath.Join(subfolder, "setup/*.yaml")),

--- a/test/e2e/install_test.go
+++ b/test/e2e/install_test.go
@@ -71,7 +71,7 @@ func TestCrossplaneLifecycle(t *testing.T) {
 			WithSetup("ClaimIsAvailable", funcs.ResourcesHaveConditionWithin(2*time.Minute, manifests, "claim.yaml", xpv1.Available())).
 			Assess("DeleteClaim", funcs.AllOf(
 				funcs.DeleteResources(manifests, "claim.yaml"),
-				funcs.ResourcesDeletedWithin(2*time.Minute, manifests, "claim.yaml"),
+				funcs.ResourcesDeletedWithin(3*time.Minute, manifests, "claim.yaml"),
 			)).
 			Assess("DeletePrerequisites", funcs.AllOf(
 				funcs.DeleteResources(manifests, "setup/*.yaml"),
@@ -129,7 +129,7 @@ func TestCrossplaneLifecycle(t *testing.T) {
 				funcs.ApplyResources(FieldManager, manifests, "claim.yaml"),
 				funcs.ResourcesCreatedWithin(30*time.Second, manifests, "claim.yaml"),
 			)).
-			Assess("ClaimIsAvailable", funcs.ResourcesHaveConditionWithin(2*time.Minute, manifests, "claim.yaml", xpv1.Available())).
+			Assess("ClaimIsAvailable", funcs.ResourcesHaveConditionWithin(3*time.Minute, manifests, "claim.yaml", xpv1.Available())).
 			Assess("UpgradeCrossplane", funcs.AllOf(
 				funcs.AsFeaturesFunc(environment.HelmUpgradeCrossplaneToBase()),
 				funcs.ReadyToTestWithin(1*time.Minute, namespace),
@@ -137,7 +137,7 @@ func TestCrossplaneLifecycle(t *testing.T) {
 			Assess("CoreDeploymentIsAvailable", funcs.DeploymentBecomesAvailableWithin(1*time.Minute, namespace, "crossplane")).
 			Assess("RBACManagerDeploymentIsAvailable", funcs.DeploymentBecomesAvailableWithin(1*time.Minute, namespace, "crossplane-rbac-manager")).
 			Assess("CoreCRDsAreEstablished", funcs.ResourcesHaveConditionWithin(1*time.Minute, crdsDir, "*.yaml", funcs.CRDInitialNamesAccepted())).
-			Assess("ClaimIsStillAvailable", funcs.ResourcesHaveConditionWithin(2*time.Minute, manifests, "claim.yaml", xpv1.Available())).
+			Assess("ClaimIsStillAvailable", funcs.ResourcesHaveConditionWithin(3*time.Minute, manifests, "claim.yaml", xpv1.Available())).
 			Assess("DeleteClaim", funcs.AllOf(
 				funcs.DeleteResources(manifests, "claim.yaml"),
 				funcs.ResourcesDeletedWithin(2*time.Minute, manifests, "claim.yaml"),

--- a/test/e2e/pkg_test.go
+++ b/test/e2e/pkg_test.go
@@ -47,7 +47,7 @@ func TestConfigurationPullFromPrivateRegistry(t *testing.T) {
 				funcs.ApplyResources(FieldManager, manifests, "*.yaml"),
 				funcs.ResourcesCreatedWithin(1*time.Minute, manifests, "*.yaml"),
 			)).
-			Assess("ConfigurationIsHealthy", funcs.ResourcesHaveConditionWithin(1*time.Minute, manifests, "configuration.yaml", pkgv1.Healthy(), pkgv1.Active())).
+			Assess("ConfigurationIsHealthy", funcs.ResourcesHaveConditionWithin(2*time.Minute, manifests, "configuration.yaml", pkgv1.Healthy(), pkgv1.Active())).
 			WithTeardown("DeleteConfiguration", funcs.AllOf(
 				funcs.DeleteResources(manifests, "*.yaml"),
 				funcs.ResourcesDeletedWithin(1*time.Minute, manifests, "*.yaml"),
@@ -70,9 +70,9 @@ func TestConfigurationWithDependency(t *testing.T) {
 				funcs.ResourcesCreatedWithin(1*time.Minute, manifests, "configuration.yaml"),
 			)).
 			Assess("ConfigurationIsHealthy",
-				funcs.ResourcesHaveConditionWithin(1*time.Minute, manifests, "configuration.yaml", pkgv1.Healthy(), pkgv1.Active())).
+				funcs.ResourcesHaveConditionWithin(2*time.Minute, manifests, "configuration.yaml", pkgv1.Healthy(), pkgv1.Active())).
 			Assess("RequiredProviderIsHealthy",
-				funcs.ResourcesHaveConditionWithin(1*time.Minute, manifests, "provider-dependency.yaml", pkgv1.Healthy(), pkgv1.Active())).
+				funcs.ResourcesHaveConditionWithin(2*time.Minute, manifests, "provider-dependency.yaml", pkgv1.Healthy(), pkgv1.Active())).
 			// Dependencies are not automatically deleted.
 			WithTeardown("DeleteConfiguration", funcs.AllOf(
 				funcs.DeleteResources(manifests, "configuration.yaml"),
@@ -98,7 +98,7 @@ func TestProviderUpgrade(t *testing.T) {
 			WithSetup("ApplyInitialProvider", funcs.AllOf(
 				funcs.ApplyResources(FieldManager, manifests, "provider-initial.yaml"),
 				funcs.ResourcesCreatedWithin(1*time.Minute, manifests, "provider-initial.yaml"),
-				funcs.ResourcesHaveConditionWithin(1*time.Minute, manifests, "provider-initial.yaml", pkgv1.Healthy(), pkgv1.Active()),
+				funcs.ResourcesHaveConditionWithin(2*time.Minute, manifests, "provider-initial.yaml", pkgv1.Healthy(), pkgv1.Active()),
 			)).
 			WithSetup("InitialManagedResourceIsReady", funcs.AllOf(
 				funcs.ApplyResources(FieldManager, manifests, "mr-initial.yaml"),
@@ -106,7 +106,7 @@ func TestProviderUpgrade(t *testing.T) {
 			)).
 			Assess("UpgradeProvider", funcs.AllOf(
 				funcs.ApplyResources(FieldManager, manifests, "provider-upgrade.yaml"),
-				funcs.ResourcesHaveConditionWithin(1*time.Minute, manifests, "provider-upgrade.yaml", pkgv1.Healthy(), pkgv1.Active()),
+				funcs.ResourcesHaveConditionWithin(2*time.Minute, manifests, "provider-upgrade.yaml", pkgv1.Healthy(), pkgv1.Active()),
 			)).
 			Assess("UpgradeManagedResource", funcs.AllOf(
 				funcs.ApplyResources(FieldManager, manifests, "mr-upgrade.yaml"),


### PR DESCRIPTION
### Description of your changes

We are observing sporadically failing e2e tests as part of the CI in the recent PRs.

This PR bumps timeouts based on the observations in the failing e2e runs. 

I have:

- [x] Read and followed Crossplane's [contribution process].
- [ ] ~Added or updated unit **and** E2E tests for my change.~
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR, if necessary.~
- [ ] ~Opened a PR updating the [docs], if necessary.~

[contribution process]: https://git.io/fj2m9
[docs]: https://docs.crossplane.io/contribute/contribute
