### PR TITLE
apiextensions/composite: report environment errors in Ready condition

### DIFF
--- a/internal/controller/apiextensions/composite/reconciler.go
+++ b/internal/controller/apiextensions/composite/reconciler.go
@@ -566,7 +566,8 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 		log.Debug(errSelectEnvironment, "error", err)
 		err = errors.Wrap(err, errSelectEnvironment)
 		r.record.Event(xr, event.Warning(reasonCompose, err))
-		return reconcile.Result{}, err
+		xr.SetConditions(xpv1.ReconcileError(err))
+		return reconcile.Result{Requeue: true}, errors.Wrap(r.client.Status().Update(ctx, xr), errUpdateStatus)
 	}
 
 	env, err := r.environment.Fetch(ctx, EnvironmentFetcherRequest{
@@ -578,7 +579,8 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 		log.Debug(errFetchEnvironment, "error", err)
 		err = errors.Wrap(err, errFetchEnvironment)
 		r.record.Event(xr, event.Warning(reasonCompose, err))
-		return reconcile.Result{}, err
+		xr.SetConditions(xpv1.ReconcileError(err))
+		return reconcile.Result{Requeue: true}, errors.Wrap(r.client.Status().Update(ctx, xr), errUpdateStatus)
 	}
 
 	// TODO(negz): Pass this method a copy of xr, to make very clear that

--- a/internal/controller/apiextensions/composite/reconciler_test.go
+++ b/internal/controller/apiextensions/composite/reconciler_test.go
@@ -358,11 +358,11 @@ func TestReconcile(t *testing.T) {
 				},
 			},
 			want: want{
-				err: errors.Wrap(errBoom, errSelectEnvironment),
+				r: reconcile.Result{Requeue: true},
 			},
 		},
 		"FetchEnvironmentError": {
-			reason: "We should return any error encountered while fetching the environment.",
+			reason: "We should requeue on any error encountered while fetching the environment.",
 			args: args{
 				mgr: &fake.Manager{},
 				opts: []ReconcilerOption{
@@ -387,7 +387,7 @@ func TestReconcile(t *testing.T) {
 				},
 			},
 			want: want{
-				err: errors.Wrap(errBoom, errFetchEnvironment),
+				r: reconcile.Result{Requeue: true},
 			},
 		},
 		"ComposeResourcesError": {

--- a/test/e2e/funcs/feature.go
+++ b/test/e2e/funcs/feature.go
@@ -191,9 +191,9 @@ func ResourceDeletedWithin(d time.Duration, o k8s.Object) features.Func {
 
 // ResourcesHaveConditionWithin fails a test if the supplied resources do not
 // have (i.e. become) the supplied conditions within the supplied duration.
+// Comparison of conditions is modulo messages.
 func ResourcesHaveConditionWithin(d time.Duration, dir, pattern string, cds ...xpv1.Condition) features.Func {
 	return func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
-
 		rs, err := decoder.DecodeAllFiles(ctx, os.DirFS(dir), pattern)
 		if err != nil {
 			t.Error(err)
@@ -203,6 +203,9 @@ func ResourcesHaveConditionWithin(d time.Duration, dir, pattern string, cds ...x
 		reasons := make([]string, len(cds))
 		for i := range cds {
 			reasons[i] = string(cds[i].Reason)
+			if cds[i].Message != "" {
+				t.Errorf("message must not be set in ResourcesHaveConditionWithin: %s", cds[i].Message)
+			}
 		}
 		desired := strings.Join(reasons, ", ")
 
@@ -219,7 +222,11 @@ func ResourcesHaveConditionWithin(d time.Duration, dir, pattern string, cds ...x
 			_ = fieldpath.Pave(u.Object).GetValueInto("status", &s)
 
 			for _, want := range cds {
-				if !s.GetCondition(want.Type).Equal(want) {
+				got := s.GetCondition(want.Type)
+				// do compare modulo message as the message in e2e tests
+				// might differ between runs and is not meant for machines.
+				got.Message = ""
+				if !got.Equal(want) {
 					return false
 				}
 			}
@@ -244,10 +251,9 @@ func ResourcesHaveConditionWithin(d time.Duration, dir, pattern string, cds ...x
 // convenience.
 func CRDInitialNamesAccepted() xpv1.Condition {
 	return xpv1.Condition{
-		Type:    "Established",
-		Status:  corev1.ConditionTrue,
-		Reason:  "InitialNamesAccepted",
-		Message: "the initial names have been accepted",
+		Type:   "Established",
+		Status: corev1.ConditionTrue,
+		Reason: "InitialNamesAccepted",
 	}
 }
 


### PR DESCRIPTION
### Description of your changes

Don't leave the user in the dark guessing where to look (e.g. events) if the environment selection and/or fetch fails. Set a proper condition that reconcile failed.

@negz @phisco it would be good if we understood from an error whether it is a permanent (e.g. a validation problem) or transient (e.g. some client error or some object does not exist, but might show up eventually). Now we requeue unconditionally. Requeue=true means rate-limited requeue which will eventually backoff, but create quite a number of retries before that.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Added or updated unit **and** E2E tests for my change.
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] ~~Added `backport release-x.y` labels to auto-backport this PR, if necessary.~~
- [ ] ~~Opened a PR updating the [docs], if necessary.~~

[contribution process]: https://git.io/fj2m9
[docs]: https://docs.crossplane.io/contribute/contribute