### PR TITLE
Hardwire the XR Reconciler to use `*composite.Unstructured`

### DIFF
--- a/internal/controller/apiextensions/composite/composition_functions_test.go
+++ b/internal/controller/apiextensions/composite/composition_functions_test.go
@@ -62,7 +62,7 @@ func TestFunctionCompose(t *testing.T) {
 	}
 	type args struct {
 		ctx context.Context
-		xr  resource.Composite
+		xr  *composite.Unstructured
 		req CompositionRequest
 	}
 	type want struct {
@@ -584,7 +584,7 @@ func TestFunctionCompose(t *testing.T) {
 				},
 			},
 			args: args{
-				xr: func() resource.Composite {
+				xr: func() *composite.Unstructured {
 					// Our XR needs a GVK to survive round-tripping through a
 					// protobuf struct (which involves using the Kubernetes-aware
 					// JSON unmarshaller that requires a GVK).

--- a/internal/controller/apiextensions/composite/composition_pt.go
+++ b/internal/controller/apiextensions/composite/composition_pt.go
@@ -34,6 +34,7 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
 	"github.com/crossplane/crossplane-runtime/pkg/resource/unstructured"
 	"github.com/crossplane/crossplane-runtime/pkg/resource/unstructured/composed"
+	"github.com/crossplane/crossplane-runtime/pkg/resource/unstructured/composite"
 
 	v1 "github.com/crossplane/crossplane/apis/apiextensions/v1"
 	"github.com/crossplane/crossplane/internal/controller/apiextensions/usage"
@@ -159,7 +160,7 @@ func NewPTComposer(kube client.Client, o ...PTComposerOption) *PTComposer {
 //  3. Apply all composed resources that rendered successfully.
 //  4. Observe the readiness and connection details of all composed resources
 //     that rendered successfully.
-func (c *PTComposer) Compose(ctx context.Context, xr resource.Composite, req CompositionRequest) (CompositionResult, error) { //nolint:gocyclo // Breaking this up doesn't seem worth yet more layers of abstraction.
+func (c *PTComposer) Compose(ctx context.Context, xr *composite.Unstructured, req CompositionRequest) (CompositionResult, error) { //nolint:gocyclo // Breaking this up doesn't seem worth yet more layers of abstraction.
 	// Inline PatchSets before composing resources.
 	ct, err := ComposedTemplates(req.Revision.Spec.PatchSets, req.Revision.Spec.Resources)
 	if err != nil {

--- a/internal/controller/apiextensions/composite/composition_pt_test.go
+++ b/internal/controller/apiextensions/composite/composition_pt_test.go
@@ -36,10 +36,10 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/reconciler/managed"
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
 	"github.com/crossplane/crossplane-runtime/pkg/resource/fake"
+	"github.com/crossplane/crossplane-runtime/pkg/resource/unstructured/composite"
 	"github.com/crossplane/crossplane-runtime/pkg/test"
 
 	v1 "github.com/crossplane/crossplane/apis/apiextensions/v1"
-	"github.com/crossplane/crossplane/internal/xcrd"
 )
 
 func TestPTCompose(t *testing.T) {
@@ -53,7 +53,7 @@ func TestPTCompose(t *testing.T) {
 	}
 	type args struct {
 		ctx context.Context
-		xr  resource.Composite
+		xr  *composite.Unstructured
 		req CompositionRequest
 	}
 	type want struct {
@@ -135,11 +135,7 @@ func TestPTCompose(t *testing.T) {
 				},
 			},
 			args: args{
-				xr: &fake.Composite{
-					ObjectMeta: metav1.ObjectMeta{
-						Labels: map[string]string{xcrd.LabelKeyNamePrefixForComposed: "cool-xr"},
-					},
-				},
+				xr: WithParentLabel(),
 				req: CompositionRequest{
 					Revision: &v1.CompositionRevision{},
 				},
@@ -168,11 +164,7 @@ func TestPTCompose(t *testing.T) {
 				},
 			},
 			args: args{
-				xr: &fake.Composite{
-					ObjectMeta: metav1.ObjectMeta{
-						Labels: map[string]string{xcrd.LabelKeyNamePrefixForComposed: "cool-xr"},
-					},
-				},
+				xr: WithParentLabel(),
 				req: CompositionRequest{
 					Revision: &v1.CompositionRevision{},
 				},
@@ -204,11 +196,7 @@ func TestPTCompose(t *testing.T) {
 				},
 			},
 			args: args{
-				xr: &fake.Composite{
-					ObjectMeta: metav1.ObjectMeta{
-						Labels: map[string]string{xcrd.LabelKeyNamePrefixForComposed: "cool-xr"},
-					},
-				},
+				xr: WithParentLabel(),
 				req: CompositionRequest{
 					Revision: &v1.CompositionRevision{},
 				},
@@ -243,11 +231,7 @@ func TestPTCompose(t *testing.T) {
 				},
 			},
 			args: args{
-				xr: &fake.Composite{
-					ObjectMeta: metav1.ObjectMeta{
-						Labels: map[string]string{xcrd.LabelKeyNamePrefixForComposed: "cool-xr"},
-					},
-				},
+				xr: WithParentLabel(),
 				req: CompositionRequest{
 					Revision: &v1.CompositionRevision{},
 				},
@@ -285,11 +269,7 @@ func TestPTCompose(t *testing.T) {
 				},
 			},
 			args: args{
-				xr: &fake.Composite{
-					ObjectMeta: metav1.ObjectMeta{
-						Labels: map[string]string{xcrd.LabelKeyNamePrefixForComposed: "cool-xr"},
-					},
-				},
+				xr: WithParentLabel(),
 				req: CompositionRequest{
 					Revision: &v1.CompositionRevision{},
 				},
@@ -330,11 +310,7 @@ func TestPTCompose(t *testing.T) {
 				},
 			},
 			args: args{
-				xr: &fake.Composite{
-					ObjectMeta: metav1.ObjectMeta{
-						Labels: map[string]string{xcrd.LabelKeyNamePrefixForComposed: "cool-xr"},
-					},
-				},
+				xr: WithParentLabel(),
 				req: CompositionRequest{
 					Revision: &v1.CompositionRevision{},
 				},
@@ -362,11 +338,7 @@ func TestPTCompose(t *testing.T) {
 				},
 			},
 			args: args{
-				xr: &fake.Composite{
-					ObjectMeta: metav1.ObjectMeta{
-						Labels: map[string]string{xcrd.LabelKeyNamePrefixForComposed: "cool-xr"},
-					},
-				},
+				xr: WithParentLabel(),
 				req: CompositionRequest{
 					Revision: &v1.CompositionRevision{},
 				},
@@ -409,11 +381,7 @@ func TestPTCompose(t *testing.T) {
 				},
 			},
 			args: args{
-				xr: &fake.Composite{
-					ObjectMeta: metav1.ObjectMeta{
-						Labels: map[string]string{xcrd.LabelKeyNamePrefixForComposed: "cool-xr"},
-					},
-				},
+				xr: WithParentLabel(),
 				req: CompositionRequest{
 					Revision: &v1.CompositionRevision{},
 				},
@@ -477,11 +445,7 @@ func TestPTCompose(t *testing.T) {
 				},
 			},
 			args: args{
-				xr: &fake.Composite{
-					ObjectMeta: metav1.ObjectMeta{
-						Labels: map[string]string{xcrd.LabelKeyNamePrefixForComposed: "cool-xr"},
-					},
-				},
+				xr: WithParentLabel(),
 				req: CompositionRequest{
 					Revision: &v1.CompositionRevision{},
 				},

--- a/internal/controller/apiextensions/composite/reconciler_test.go
+++ b/internal/controller/apiextensions/composite/reconciler_test.go
@@ -416,7 +416,7 @@ func TestReconcile(t *testing.T) {
 					WithConfigurator(ConfiguratorFn(func(_ context.Context, _ resource.Composite, _ *v1.CompositionRevision) error {
 						return nil
 					})),
-					WithComposer(ComposerFn(func(ctx context.Context, xr resource.Composite, req CompositionRequest) (CompositionResult, error) {
+					WithComposer(ComposerFn(func(ctx context.Context, xr *composite.Unstructured, req CompositionRequest) (CompositionResult, error) {
 						return CompositionResult{}, errBoom
 					})),
 					WithCompositionUpdatePolicySelector(CompositionUpdatePolicySelectorFn(func(ctx context.Context, cr resource.Composite) error { return nil })),
@@ -450,7 +450,7 @@ func TestReconcile(t *testing.T) {
 					WithConfigurator(ConfiguratorFn(func(_ context.Context, _ resource.Composite, _ *v1.CompositionRevision) error {
 						return nil
 					})),
-					WithComposer(ComposerFn(func(ctx context.Context, xr resource.Composite, req CompositionRequest) (CompositionResult, error) {
+					WithComposer(ComposerFn(func(ctx context.Context, xr *composite.Unstructured, req CompositionRequest) (CompositionResult, error) {
 						return CompositionResult{}, nil
 					})),
 					WithConnectionPublishers(managed.ConnectionPublisherFns{
@@ -492,7 +492,7 @@ func TestReconcile(t *testing.T) {
 					WithConfigurator(ConfiguratorFn(func(_ context.Context, _ resource.Composite, _ *v1.CompositionRevision) error {
 						return nil
 					})),
-					WithComposer(ComposerFn(func(ctx context.Context, xr resource.Composite, req CompositionRequest) (CompositionResult, error) {
+					WithComposer(ComposerFn(func(ctx context.Context, xr *composite.Unstructured, req CompositionRequest) (CompositionResult, error) {
 						return CompositionResult{
 							Events: []event.Event{event.Warning("Warning", errBoom)},
 						}, nil
@@ -536,7 +536,7 @@ func TestReconcile(t *testing.T) {
 					WithConfigurator(ConfiguratorFn(func(_ context.Context, _ resource.Composite, _ *v1.CompositionRevision) error {
 						return nil
 					})),
-					WithComposer(ComposerFn(func(ctx context.Context, xr resource.Composite, req CompositionRequest) (CompositionResult, error) {
+					WithComposer(ComposerFn(func(ctx context.Context, xr *composite.Unstructured, req CompositionRequest) (CompositionResult, error) {
 						return CompositionResult{
 							Composed: []ComposedResource{{
 								ResourceName: "elephant",
@@ -599,7 +599,7 @@ func TestReconcile(t *testing.T) {
 					WithConfigurator(ConfiguratorFn(func(_ context.Context, _ resource.Composite, _ *v1.CompositionRevision) error {
 						return nil
 					})),
-					WithComposer(ComposerFn(func(ctx context.Context, xr resource.Composite, req CompositionRequest) (CompositionResult, error) {
+					WithComposer(ComposerFn(func(ctx context.Context, xr *composite.Unstructured, req CompositionRequest) (CompositionResult, error) {
 						return CompositionResult{ConnectionDetails: cd}, nil
 					})),
 					WithConnectionPublishers(managed.ConnectionPublisherFns{
@@ -687,7 +687,7 @@ func TestReconcile(t *testing.T) {
 					WithConfigurator(ConfiguratorFn(func(_ context.Context, _ resource.Composite, _ *v1.CompositionRevision) error {
 						return nil
 					})),
-					WithComposer(ComposerFn(func(ctx context.Context, xr resource.Composite, req CompositionRequest) (CompositionResult, error) {
+					WithComposer(ComposerFn(func(ctx context.Context, xr *composite.Unstructured, req CompositionRequest) (CompositionResult, error) {
 						return CompositionResult{}, nil
 					})),
 					WithConnectionPublishers(managed.ConnectionPublisherFns{
@@ -734,7 +734,7 @@ func TestReconcile(t *testing.T) {
 					WithConfigurator(ConfiguratorFn(func(_ context.Context, _ resource.Composite, _ *v1.CompositionRevision) error {
 						return nil
 					})),
-					WithComposer(ComposerFn(func(ctx context.Context, xr resource.Composite, req CompositionRequest) (CompositionResult, error) {
+					WithComposer(ComposerFn(func(ctx context.Context, xr *composite.Unstructured, req CompositionRequest) (CompositionResult, error) {
 						return CompositionResult{}, nil
 					})),
 					WithConnectionPublishers(managed.ConnectionPublisherFns{


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does, and how it is covered by tests.
Be proactive - direct your reviewers' attention to anything that needs special
consideration.

You MUST either [x] check or ~strikethrough~ every item in the checklist below.

We love pull requests that fix an open issue. If yours does, use the below line
to indicate which issue it fixes, for example "Fixes #500".
-->

Previously we mostly accepted the resource.Composite interface, but in practice neither Composer that the Reconciler can use would work with any underlying type apart from *composite.Unstructured. Having the Composer interface require that type makes this explicit.

The `PTComposer` needs an unstructured type in order to `fieldpath.Pave` and patch it. The `FunctionComposer` needs and unstructured type in order to use server-side apply. 

I have:

- [x] Read and followed Crossplane's [contribution process].
- [ ] ~Added or updated unit **and** E2E tests for my change.~
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR, if necessary.~
- [ ] ~Opened a PR updating the [docs], if necessary.~

[contribution process]: https://git.io/fj2m9
[docs]: https://docs.crossplane.io/contribute/contribute
