### PR TITLE
Further clarifies ControllerConfig deprecation

### DIFF
--- a/apis/pkg/v1alpha1/config.go
+++ b/apis/pkg/v1alpha1/config.go
@@ -180,7 +180,7 @@ type PodObjectMeta struct {
 // https://github.com/crossplane/crossplane/issues/3601 for more information.
 // +kubebuilder:printcolumn:name="AGE",type="date",JSONPath=".metadata.creationTimestamp"
 // +kubebuilder:resource:scope=Cluster
-// +kubebuilder:deprecatedversion:warning="ControllerConfig.pkg.crossplane.io/v1alpha1 has been deprecated and will be removed in a future release, but only after a comparable alternative is available."
+// +kubebuilder:deprecatedversion:warning="ControllerConfig.pkg.crossplane.io/v1alpha1 is deprecated. It is safe to use, but no new features will be added. Future replacement design: https://github.com/crossplane/crossplane/blob/master/design/one-pager-package-runtime-config.md"
 type ControllerConfig struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/cluster/crds/pkg.crossplane.io_controllerconfigs.yaml
+++ b/cluster/crds/pkg.crossplane.io_controllerconfigs.yaml
@@ -18,9 +18,9 @@ spec:
       name: AGE
       type: date
     deprecated: true
-    deprecationWarning: ControllerConfig.pkg.crossplane.io/v1alpha1 has been deprecated
-      and will be removed in a future release, but only after a comparable alternative
-      is available.
+    deprecationWarning: 'ControllerConfig.pkg.crossplane.io/v1alpha1 is deprecated.
+      It is safe to use, but no new features will be added. Future replacement design:
+      https://github.com/crossplane/crossplane/blob/master/design/one-pager-package-runtime-config.md'
     name: v1alpha1
     schema:
       openAPIV3Schema:


### PR DESCRIPTION
### Description of your changes

Updates the deprecation message for ControllerConfig to make it clear that it is safe to use, but there will be no further investment. Also points to the design for the replacement.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [ ] ~Added or updated unit **and** E2E tests for my change.~
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR, if necessary.~
- [x] Opened a PR updating the [docs], if necessary. https://github.com/crossplane/docs/pull/548

[contribution process]: https://git.io/fj2m9
[docs]: https://docs.crossplane.io/contribute/contribute
