### PR TITLE
Set golangci-lint to automatically fix issues

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,8 @@ GO_LDFLAGS += -X $(GO_PROJECT)/internal/version.version=$(VERSION)
 GO_SUBDIRS += cmd internal apis
 GO111MODULE = on
 GOLANGCILINT_VERSION = 1.54.2
+GO_LINT_ARGS ?= "--fix"
+
 -include build/makelib/golang.mk
 
 # ====================================================================================


### PR DESCRIPTION
### Description of your changes

Often the fix for a golangci-lint error is to simply run `golangci-lint run --fix`.
This changes enables the fix instruction by default when running `make reviewable`

It does not impact the CI check.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [ ] ~Added or updated unit **and** E2E tests for my change.~
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR, if necessary.~
- [ ] ~Opened a PR updating the [docs], if necessary.~

[contribution process]: https://git.io/fj2m9
[docs]: https://docs.crossplane.io/contribute/contribute
