### PR TITLE
controller/revision: use uncached client for secrets

### DIFF
--- a/cmd/crossplane/core/core.go
+++ b/cmd/crossplane/core/core.go
@@ -35,6 +35,7 @@ import (
 	"k8s.io/client-go/tools/leaderelection/resourcelock"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
 	"github.com/crossplane/crossplane-runtime/pkg/certificates"
@@ -170,6 +171,12 @@ func (c *startCommand) Run(s *runtime.Scheme, log logging.Logger) error { //noli
 				},
 			},
 		}),
+		Client: client.Options{
+			Cache: &client.CacheOptions{
+				DisableFor:   []client.Object{&corev1.Secret{}},
+				Unstructured: false, // this is the default to not cache unstructured objects
+			},
+		},
 
 		// controller-runtime uses both ConfigMaps and Leases for leader
 		// election by default. Leases expire after 15 seconds, with a


### PR DESCRIPTION
### Description of your changes

Use an uncached client for getting secrets in the package revision controller.

TODOs:
- [ ] ~~check that there is no other secret being read through another client. Probably there is.~~

Fixes #3565

I have:

- [x] Read and followed Crossplane's [contribution process].
- [ ] ~~Added or updated unit **and** E2E tests for my change.~~
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] ~~Added `backport release-x.y` labels to auto-backport this PR, if necessary.~~
- [ ] ~~Opened a PR updating the [docs], if necessary.~~

[contribution process]: https://git.io/fj2m9
[docs]: https://docs.crossplane.io/contribute/contribute