### PR TITLE
Add Functions to the xpkg spec

### DIFF
--- a/contributing/specifications/xpkg.md
+++ b/contributing/specifications/xpkg.md
@@ -1,15 +1,20 @@
 # xpkg Specification
 
-Crossplane supports two types of [packages]: Providers and Configurations. These
-packages are distributed as generic [OCI images], which contain [YAML] content
-informing the Crossplane package manager how to alter the state of a cluster by
-installing objects that configure new resource types, and starting controllers
-to reconcile them. An OCI image that contains valid Crossplane package content
-is commonly referred to as an `xpkg` ("ex-package"). This document provides the
-specification for a valid `xpkg`, which can be considered a superset of the
-requirements detailed in the [OCI image specification]. It is divided into two
-broad sections: requirements related to OCI image format and requirements
-related to Crossplane `package.yaml` contents.
+Crossplane supports the following types of [packages]:
+
+- Providers
+- Configurations
+- Functions
+
+These packages are distributed as generic [OCI images], which contain [YAML]
+content informing the Crossplane package manager how to alter the state of a
+cluster by installing objects that configure new resource types, and starting
+controllers to reconcile them. An OCI image that contains valid Crossplane
+package content is commonly referred to as an `xpkg` ("ex-package"). This
+document provides the specification for a valid `xpkg`, which can be considered
+a superset of the requirements detailed in the [OCI image specification]. It is
+divided into two broad sections: requirements related to OCI image format and
+requirements related to Crossplane `package.yaml` contents.
 
 - [OCI Image Format](#oci-image-format)
   - [Indexes](#indexes)
@@ -165,6 +170,21 @@ requirements:
 - Zero (0) or more `MutatingWebhookConfiguration.admissionregistration.k8s.io`
   objects MAY be defined in the YAML stream.
 - Zero (0) other object types may be defined in the YAML stream.
+
+### Function Package Requirements
+
+The `package.yaml` for Function packages must adhere to the following
+requirements:
+
+- One (1) and only one `Function.meta.pkg.crossplane.io` object MUST be defined
+  in the YAML stream.
+- Zero (0) or more `CustomResourceDefinition.apiextensions.k8s.io` objects MAY
+  be defined in the YAML stream.
+- Zero (0) other object types may be defined in the YAML stream.
+
+Note that Function packages use CustomResourceDefinitions (CRD) only to deliver
+schema for their input type(s). The package manager will not actually create the
+supplied CRDs in the API server.
 
 ### Object Annotations
 


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does, and how it is covered by tests.
Be proactive - direct your reviewers' attention to anything that needs special
consideration.

You MUST either [x] check or ~strikethrough~ every item in the checklist below.

We love pull requests that fix an open issue. If yours does, use the below line
to indicate which issue it fixes, for example "Fixes #500".
-->

This one is kinda "what it says on the tin". 😄 

One note that didn't seem like a good fit for the spec (and I'm not sure where to record) is that as a beta feature `Function` only has a `v1beta1` API version. That is, for now, the meta type will always be:

```yaml
apiVersion: meta.pkg.crossplane.io/v1beta1
kind: Function
```

This is unlike Providers and Configurations, which support `v1` and an identical `v1alpha1` type.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [ ] ~Added or updated unit **and** E2E tests for my change.~
- [ ] ~Run `make reviewable` to ensure this PR is ready for review.~
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR, if necessary.~
- [ ] ~Opened a PR updating the [docs], if necessary.~

[contribution process]: https://git.io/fj2m9
[docs]: https://docs.crossplane.io/contribute/contribute
