### PR TITLE
functions/proto: clarify that desired state must be SSA compatible

### DIFF
--- a/apis/apiextensions/fn/proto/v1beta1/run_function.pb.go
+++ b/apis/apiextensions/fn/proto/v1beta1/run_function.pb.go
@@ -165,6 +165,13 @@ type RunFunctionRequest struct {
 	// Desired state according to a Function pipeline. The state passed to a
 	// particular Function may have been accumulated by previous Functions in the
 	// pipeline.
+	//
+	// Note that the desired state must be a partial object with only the fields
+	// that this function (and its predecessors in the pipeline) wants to have
+	// set in the object. Copying a non-partial observed state to desired is most
+	// likely not what you want to do. Leaving out fields that had been returned
+	// as desired before will result in them being deleted from the objects in the
+	// cluster.
 	Desired *State `protobuf:"bytes,3,opt,name=desired,proto3" json:"desired,omitempty"`
 	// Optional input specific to this Function invocation. A JSON representation
 	// of the 'input' block of the relevant entry in a Composition's pipeline.
@@ -243,6 +250,13 @@ type RunFunctionResponse struct {
 	// state, and may mutate or delete any part of the desired state they are
 	// concerned with. A Function must pass through any part of the desired state
 	// that it is not concerned with.
+	//
+	// Note that the desired state must be a partial object with only the fields
+	// that this function (and its predecessors in the pipeline) wants to have
+	// set in the object. Copying a non-partial observed state to desired is most
+	// likely not what you want to do. Leaving out fields that had been returned
+	// as desired before will result in them being deleted from the objects in the
+	// cluster.
 	Desired *State `protobuf:"bytes,2,opt,name=desired,proto3" json:"desired,omitempty"`
 	// Results of the Function run. Results are used for observability purposes.
 	Results []*Result `protobuf:"bytes,3,rep,name=results,proto3" json:"results,omitempty"`

--- a/apis/apiextensions/fn/proto/v1beta1/run_function.proto
+++ b/apis/apiextensions/fn/proto/v1beta1/run_function.proto
@@ -42,6 +42,13 @@ message RunFunctionRequest {
   // Desired state according to a Function pipeline. The state passed to a
   // particular Function may have been accumulated by previous Functions in the
   // pipeline.
+  //
+  // Note that the desired state must be a partial object with only the fields
+  // that this function (and its predecessors in the pipeline) wants to have
+  // set in the object. Copying a non-partial observed state to desired is most
+  // likely not what you want to do. Leaving out fields that had been returned
+  // as desired before will result in them being deleted from the objects in the
+  // cluster.
   State desired = 3;
 
   // Optional input specific to this Function invocation. A JSON representation
@@ -58,6 +65,14 @@ message RunFunctionResponse {
   // state, and may mutate or delete any part of the desired state they are
   // concerned with. A Function must pass through any part of the desired state
   // that it is not concerned with.
+  //
+  //
+  // Note that the desired state must be a partial object with only the fields
+  // that this function (and its predecessors in the pipeline) wants to have
+  // set in the object. Copying a non-partial observed state to desired is most
+  // likely not what you want to do. Leaving out fields that had been returned
+  // as desired before will result in them being deleted from the objects in the
+  // cluster.
   State desired = 2;
 
   // Results of the Function run. Results are used for observability purposes.

--- a/cmd/crossplane/core/core.go
+++ b/cmd/crossplane/core/core.go
@@ -209,7 +209,7 @@ func (c *startCommand) Run(s *runtime.Scheme, log logging.Logger) error { //noli
 		filepath.Join(c.TLSClientCertsDir, corev1.TLSPrivateKeyKey),
 		false)
 	if err != nil {
-		return errors.Wrap(err, "cannot load client TLS certificates ")
+		return errors.Wrap(err, "cannot load client TLS certificates")
 	}
 
 	if !c.EnableCompositionRevisions {


### PR DESCRIPTION
### Description of your changes

Clarify semantics of the desired state in function requests and responses, namely that it must be a partial object with exactly those fields (only those and a complete set) that the function pipeline is interested in.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [ ] ~~Added or updated unit **and** E2E tests for my change.~~
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] ~~Added `backport release-x.y` labels to auto-backport this PR, if necessary.~~
- [ ] ~~Opened a PR updating the [docs], if necessary.~~

[contribution process]: https://git.io/fj2m9
[docs]: https://docs.crossplane.io/contribute/contribute