### PR TITLE
feat: enable gofumpt linter and related fixes

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -117,6 +117,7 @@ linters:
     - goconst
     - gci
     - gofmt  # We enable this as well as goimports for its simplify mode.
+    - gofumpt
     - prealloc
     - revive
     - unconvert

--- a/apis/apiextensions/v1/composition_environment.go
+++ b/apis/apiextensions/v1/composition_environment.go
@@ -80,7 +80,6 @@ func (e *EnvironmentConfiguration) Validate() field.ErrorList {
 
 // ShouldResolve specifies whether EnvironmentConfiguration should be resolved or not.
 func (e *EnvironmentConfiguration) ShouldResolve(currentRefs []corev1.ObjectReference) bool {
-
 	if e == nil || len(e.EnvironmentConfigs) == 0 {
 		return false
 	}
@@ -185,7 +184,6 @@ const (
 
 // An EnvironmentSourceSelector selects an EnvironmentConfig via labels.
 type EnvironmentSourceSelector struct {
-
 	// Mode specifies retrieval strategy: "Single" or "Multiple".
 	// +kubebuilder:validation:Enum=Single;Multiple
 	// +kubebuilder:default=Single
@@ -204,7 +202,6 @@ type EnvironmentSourceSelector struct {
 
 // Validate logically validates the EnvironmentSourceSelector.
 func (e *EnvironmentSourceSelector) Validate() *field.Error {
-
 	if e.Mode == EnvironmentSourceSelectorSingleMode && e.MaxMatch != nil {
 		return field.Forbidden(field.NewPath("maxMatch"), "maxMatch is not supported in Single mode")
 	}

--- a/apis/apiextensions/v1/composition_environment_test.go
+++ b/apis/apiextensions/v1/composition_environment_test.go
@@ -151,7 +151,6 @@ func TestEnvironmentShouldResolve(t *testing.T) {
 	}
 
 	for name, tc := range cases {
-
 		t.Run(name, func(t *testing.T) {
 			got := tc.args.ec.ShouldResolve(tc.args.refs)
 			if diff := cmp.Diff(tc.want, got); diff != "" {

--- a/apis/apiextensions/v1/composition_transforms.go
+++ b/apis/apiextensions/v1/composition_transforms.go
@@ -45,7 +45,6 @@ const (
 // Transform is a unit of process whose input is transformed into an output with
 // the supplied configuration.
 type Transform struct {
-
 	// Type of the transform to be run.
 	// +kubebuilder:validation:Enum=map;match;math;string;convert
 	Type TransformType `json:"type"`
@@ -359,7 +358,6 @@ const (
 
 // A StringTransform returns a string given the supplied input.
 type StringTransform struct {
-
 	// Type of the string transform to be run.
 	// +optional
 	// +kubebuilder:validation:Enum=Format;Convert;TrimPrefix;TrimSuffix;Regexp
@@ -421,7 +419,6 @@ func (s *StringTransform) Validate() *field.Error {
 		return field.Invalid(field.NewPath("type"), s.Type, "unknown string transform type")
 	}
 	return nil
-
 }
 
 // A StringTransformRegexp extracts a match from the input using a regular

--- a/apis/apiextensions/v1/composition_validation_test.go
+++ b/apis/apiextensions/v1/composition_validation_test.go
@@ -713,7 +713,9 @@ func TestCompositionValidateEnvironment(t *testing.T) {
 				comp: &Composition{
 					Spec: CompositionSpec{
 						Environment: &EnvironmentConfiguration{},
-					}}},
+					},
+				},
+			},
 		},
 		"ValidNilEnvironment": {
 			reason: "Should accept a nil environment",
@@ -721,7 +723,9 @@ func TestCompositionValidateEnvironment(t *testing.T) {
 				comp: &Composition{
 					Spec: CompositionSpec{
 						Environment: nil,
-					}}},
+					},
+				},
+			},
 		},
 		"ValidEnvironment": {
 			reason: "Should accept a valid environment",
@@ -751,7 +755,15 @@ func TestCompositionValidateEnvironment(t *testing.T) {
 												Type:               EnvironmentSourceSelectorLabelMatcherTypeFromCompositeFieldPath,
 												Key:                "foo",
 												ValueFromFieldPath: pointer.String("spec.foo"),
-											}}}}}}}}},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
 		},
 		"InvalidPatchEnvironment": {
 			reason: "Should reject an environment declaring an invalid patch",
@@ -770,7 +782,7 @@ func TestCompositionValidateEnvironment(t *testing.T) {
 							Patches: []EnvironmentPatch{
 								{
 									Type: PatchTypeFromCompositeFieldPath,
-									//FromFieldPath: pointer.String("spec.foo"), // missing
+									// FromFieldPath: pointer.String("spec.foo"), // missing
 									ToFieldPath: pointer.String("metadata.annotations[\"foo\"]"),
 								},
 							},
@@ -789,7 +801,15 @@ func TestCompositionValidateEnvironment(t *testing.T) {
 												Type:               EnvironmentSourceSelectorLabelMatcherTypeFromCompositeFieldPath,
 												Key:                "foo",
 												ValueFromFieldPath: pointer.String("spec.foo"),
-											}}}}}}}}},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
 		},
 		"InvalidEnvironmentSourceReferenceNoName": {
 			reason: "Should reject a invalid environment, due to a missing name",
@@ -809,7 +829,7 @@ func TestCompositionValidateEnvironment(t *testing.T) {
 								{
 									Type: EnvironmentSourceTypeReference,
 									Ref:  &EnvironmentSourceReference{
-										//Name: "foo", // missing
+										// Name: "foo", // missing
 									},
 								},
 								{
@@ -820,7 +840,15 @@ func TestCompositionValidateEnvironment(t *testing.T) {
 												Type:               EnvironmentSourceSelectorLabelMatcherTypeFromCompositeFieldPath,
 												Key:                "foo",
 												ValueFromFieldPath: pointer.String("spec.foo"),
-											}}}}}}}}},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
 		},
 		"InvalidEnvironmentSourceSelectorNoKey": {
 			reason: "Should reject a invalid environment due to a missing key in a selector",
@@ -849,9 +877,17 @@ func TestCompositionValidateEnvironment(t *testing.T) {
 										MatchLabels: []EnvironmentSourceSelectorLabelMatcher{
 											{
 												Type: EnvironmentSourceSelectorLabelMatcherTypeFromCompositeFieldPath,
-												//Key:                "foo", // missing
+												// Key:                "foo", // missing
 												ValueFromFieldPath: pointer.String("spec.foo"),
-											}}}}}}}}},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
 		},
 		"InvalidMultipleErrors": {
 			reason: "Should reject a invalid environment due to multiple errors, reporting all of them",
@@ -862,7 +898,7 @@ func TestCompositionValidateEnvironment(t *testing.T) {
 							Patches: []EnvironmentPatch{
 								{
 									Type: PatchTypeFromCompositeFieldPath,
-									//FromFieldPath: pointer.String("spec.foo"), // missing
+									// FromFieldPath: pointer.String("spec.foo"), // missing
 									ToFieldPath: pointer.String("metadata.annotations[\"foo\"]"),
 								},
 							},
@@ -870,7 +906,7 @@ func TestCompositionValidateEnvironment(t *testing.T) {
 								{
 									Type: EnvironmentSourceTypeReference,
 									Ref:  &EnvironmentSourceReference{
-										//Name: "foo", // missing
+										// Name: "foo", // missing
 									},
 								},
 								{
@@ -879,9 +915,17 @@ func TestCompositionValidateEnvironment(t *testing.T) {
 										MatchLabels: []EnvironmentSourceSelectorLabelMatcher{
 											{
 												Type: EnvironmentSourceSelectorLabelMatcherTypeFromCompositeFieldPath,
-												//Key:                "foo", // missing
+												// Key:                "foo", // missing
 												ValueFromFieldPath: pointer.String("spec.foo"),
-											}}}}}}}}},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
 			want: want{
 				output: field.ErrorList{
 					{

--- a/apis/pkg/meta/v1/interfaces.go
+++ b/apis/pkg/meta/v1/interfaces.go
@@ -16,8 +16,10 @@ limitations under the License.
 
 package v1
 
-var _ Pkg = &Configuration{}
-var _ Pkg = &Provider{}
+var (
+	_ Pkg = &Configuration{}
+	_ Pkg = &Provider{}
+)
 
 // Pkg is a description of a Crossplane package.
 // +k8s:deepcopy-gen=false

--- a/apis/pkg/v1/interfaces_test.go
+++ b/apis/pkg/v1/interfaces_test.go
@@ -16,11 +16,17 @@ limitations under the License.
 
 package v1
 
-var _ Package = &Provider{}
-var _ Package = &Configuration{}
+var (
+	_ Package = &Provider{}
+	_ Package = &Configuration{}
+)
 
-var _ PackageRevision = &ProviderRevision{}
-var _ PackageRevision = &ConfigurationRevision{}
+var (
+	_ PackageRevision = &ProviderRevision{}
+	_ PackageRevision = &ConfigurationRevision{}
+)
 
-var _ PackageRevisionList = &ProviderRevisionList{}
-var _ PackageRevisionList = &ConfigurationRevisionList{}
+var (
+	_ PackageRevisionList = &ProviderRevisionList{}
+	_ PackageRevisionList = &ConfigurationRevisionList{}
+)

--- a/apis/pkg/v1beta1/function_interfaces_test.go
+++ b/apis/pkg/v1beta1/function_interfaces_test.go
@@ -18,6 +18,8 @@ package v1beta1
 
 import v1 "github.com/crossplane/crossplane/apis/pkg/v1"
 
-var _ v1.Package = &Function{}
-var _ v1.PackageRevision = &FunctionRevision{}
-var _ v1.PackageRevisionList = &FunctionRevisionList{}
+var (
+	_ v1.Package             = &Function{}
+	_ v1.PackageRevision     = &FunctionRevision{}
+	_ v1.PackageRevisionList = &FunctionRevisionList{}
+)

--- a/apis/pkg/v1beta1/lock.go
+++ b/apis/pkg/v1beta1/lock.go
@@ -22,8 +22,10 @@ import (
 	"github.com/crossplane/crossplane/internal/dag"
 )
 
-var _ dag.Node = &Dependency{}
-var _ dag.Node = &LockPackage{}
+var (
+	_ dag.Node = &Dependency{}
+	_ dag.Node = &LockPackage{}
+)
 
 // A PackageType is a type of package.
 type PackageType string

--- a/cmd/crank/main.go
+++ b/cmd/crank/main.go
@@ -31,8 +31,10 @@ import (
 
 var _ = kong.Must(&cli)
 
-type versionFlag string
-type verboseFlag bool
+type (
+	versionFlag string
+	verboseFlag bool
+)
 
 // Decode overrides the default string decoder to be a no-op.
 func (v versionFlag) Decode(_ *kong.DecodeContext) error { return nil }

--- a/cmd/crossplane/core/core.go
+++ b/cmd/crossplane/core/core.go
@@ -126,7 +126,6 @@ func (c *startCommand) Run(s *runtime.Scheme, log logging.Logger) error { //noli
 		// controller-runtime's metrics HTTP server when it starts.
 		log.Debug("Profiling server is starting to listen", "addr", c.Profile)
 		go func() {
-
 			// Registering these explicitly ensures they're only served by the
 			// HTTP server we start explicitly for profiling.
 			mux := http.NewServeMux()

--- a/cmd/crossplane/main.go
+++ b/cmd/crossplane/main.go
@@ -41,8 +41,10 @@ import (
 	"github.com/crossplane/crossplane/internal/version"
 )
 
-type debugFlag bool
-type versionFlag bool
+type (
+	debugFlag   bool
+	versionFlag bool
+)
 
 var cli struct {
 	Debug debugFlag `short:"d" help:"Print verbose logging statements."`

--- a/cmd/crossplane/rbac/rbac.go
+++ b/cmd/crossplane/rbac/rbac.go
@@ -95,7 +95,6 @@ func (c *startCommand) Run(s *runtime.Scheme, log logging.Logger) error {
 		// controller-runtime's metrics HTTP server when it starts.
 		log.Debug("Profiling server is starting to listen", "addr", c.Profile)
 		go func() {
-
 			// Registering these explicitly ensures they're only served by the
 			// HTTP server we start specifically for profiling.
 			mux := http.NewServeMux()

--- a/internal/controller/apiextensions/claim/api_test.go
+++ b/internal/controller/apiextensions/claim/api_test.go
@@ -149,7 +149,6 @@ func TestBind(t *testing.T) {
 			}
 		})
 	}
-
 }
 
 func TestPropagateConnection(t *testing.T) {
@@ -404,7 +403,8 @@ func TestAPIDefaultsSelector(t *testing.T) {
 					MockGet: func(_ context.Context, _ client.ObjectKey, obj client.Object) error {
 						*obj.(*v1.CompositeResourceDefinition) = v1.CompositeResourceDefinition{Spec: v1.CompositeResourceDefinitionSpec{DefaultCompositeDeletePolicy: &f}}
 						return nil
-					}},
+					},
+				},
 				cm: &fake.CompositeClaim{},
 			},
 			want: want{

--- a/internal/controller/apiextensions/claim/configurator_test.go
+++ b/internal/controller/apiextensions/claim/configurator_test.go
@@ -602,7 +602,6 @@ func TestCompositeConfigure(t *testing.T) {
 			}
 		})
 	}
-
 }
 
 func TestClaimConfigure(t *testing.T) {
@@ -1127,5 +1126,4 @@ func TestClaimConfigure(t *testing.T) {
 			}
 		})
 	}
-
 }

--- a/internal/controller/apiextensions/composite/api_test.go
+++ b/internal/controller/apiextensions/composite/api_test.go
@@ -705,7 +705,8 @@ func TestSelectorResolver(t *testing.T) {
 						}
 						t.Errorf("wrong query")
 						return nil
-					}},
+					},
+				},
 				cp: &fake.Composite{
 					CompositionSelector: fake.CompositionSelector{Sel: sel},
 				},

--- a/internal/controller/apiextensions/composite/composition_functions_test.go
+++ b/internal/controller/apiextensions/composite/composition_functions_test.go
@@ -415,7 +415,8 @@ func TestFunctionCompose(t *testing.T) {
 								"status": map[string]any{
 									"widgets": 42,
 								},
-							})},
+							}),
+						},
 					}
 					return &v1beta1.RunFunctionResponse{Desired: d}, nil
 				}),
@@ -645,7 +646,6 @@ func TestFunctionCompose(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-
 			c := NewFunctionComposer(tc.params.kube, tc.params.r, tc.params.o...)
 			res, err := c.Compose(tc.args.ctx, tc.args.xr, tc.args.req)
 
@@ -866,17 +866,18 @@ func TestGetComposedResources(t *testing.T) {
 				},
 			},
 			want: want{
-				ors: ComposedResourceStates{"cool-resource": ComposedResourceState{
-					ConnectionDetails: details,
-					Resource: func() resource.Composed {
-						cd := composed.New()
-						cd.SetAPIVersion("example.org/v1")
-						cd.SetKind("Composed")
-						cd.SetName("cool-resource-42")
-						SetCompositionResourceName(cd, "cool-resource")
-						return cd
-					}(),
-				},
+				ors: ComposedResourceStates{
+					"cool-resource": ComposedResourceState{
+						ConnectionDetails: details,
+						Resource: func() resource.Composed {
+							cd := composed.New()
+							cd.SetAPIVersion("example.org/v1")
+							cd.SetKind("Composed")
+							cd.SetName("cool-resource-42")
+							SetCompositionResourceName(cd, "cool-resource")
+							return cd
+						}(),
+					},
 				},
 			},
 		},
@@ -884,7 +885,6 @@ func TestGetComposedResources(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-
 			g := NewExistingComposedResourceObserver(tc.params.c, tc.params.f)
 			ors, err := g.ObserveComposedResources(tc.args.ctx, tc.args.xr)
 
@@ -1122,7 +1122,6 @@ func TestGarbageCollectComposedResources(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-
 			d := NewDeletingComposedResourceGarbageCollector(tc.params.client)
 			err := d.GarbageCollectComposedResources(tc.args.ctx, tc.args.owner, tc.args.observed, tc.args.desired)
 
@@ -1192,13 +1191,11 @@ func TestUpdateResourceRefs(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-
 			UpdateResourceRefs(tc.args.xr, tc.args.drs)
 
 			if diff := cmp.Diff(tc.want.xr, tc.args.xr); diff != "" {
 				t.Errorf("\n%s\nUpdateResourceRefs(...): -want, +got:\n%s", tc.reason, diff)
 			}
-
 		})
 	}
 }

--- a/internal/controller/apiextensions/composite/composition_patches_test.go
+++ b/internal/controller/apiextensions/composite/composition_patches_test.go
@@ -460,7 +460,8 @@ func TestPatchApply(t *testing.T) {
 						Name: "cd",
 						Labels: map[string]string{
 							"Test": "blah",
-						}},
+						},
+					},
 				},
 				err: nil,
 			},
@@ -502,7 +503,8 @@ func TestPatchApply(t *testing.T) {
 						Name: "cd",
 						Labels: map[string]string{
 							"Test": "blah",
-						}},
+						},
+					},
 				},
 				err: nil,
 			},
@@ -545,7 +547,8 @@ func TestPatchApply(t *testing.T) {
 						Name: "cd",
 						Labels: map[string]string{
 							"Test": "blah",
-						}},
+						},
+					},
 				},
 				err: nil,
 			},
@@ -635,7 +638,8 @@ func TestPatchApply(t *testing.T) {
 						Name: "cd",
 						Labels: map[string]string{
 							"Test": "blah",
-						}},
+						},
+					},
 				},
 				err: nil,
 			},
@@ -682,7 +686,8 @@ func TestPatchApply(t *testing.T) {
 						Name: "cd",
 						Labels: map[string]string{
 							"Test": "blah",
-						}},
+						},
+					},
 				},
 				err: errors.Errorf(errFmtRequiredField, "Combine", v1.PatchTypeCombineFromComposite),
 			},
@@ -729,7 +734,8 @@ func TestPatchApply(t *testing.T) {
 						Name: "cd",
 						Labels: map[string]string{
 							"Test": "blah",
-						}},
+						},
+					},
 				},
 				err: errors.Errorf(errFmtRequiredField, "Combine", v1.PatchTypeCombineFromEnvironment),
 			},
@@ -783,7 +789,8 @@ func TestPatchApply(t *testing.T) {
 						Name: "cd",
 						Labels: map[string]string{
 							"Test": "blah",
-						}},
+						},
+					},
 				},
 				err: errors.Errorf(errFmtCombineConfigMissing, v1.CombineStrategyString),
 			},
@@ -835,7 +842,8 @@ func TestPatchApply(t *testing.T) {
 						Name: "cd",
 						Labels: map[string]string{
 							"Test": "blah",
-						}},
+						},
+					},
 				},
 				err: errors.New(errCombineRequiresVariables),
 			},
@@ -894,7 +902,8 @@ func TestPatchApply(t *testing.T) {
 						Name: "cd",
 						Labels: map[string]string{
 							"Test": "blah",
-						}},
+						},
+					},
 				},
 				err: nil,
 			},
@@ -950,7 +959,8 @@ func TestPatchApply(t *testing.T) {
 						Labels: map[string]string{
 							"Test":        "blah",
 							"destination": "foo-bar",
-						}},
+						},
+					},
 				},
 				err: nil,
 			},
@@ -1006,7 +1016,8 @@ func TestPatchApply(t *testing.T) {
 						Labels: map[string]string{
 							"source1": "foo",
 							"source2": "bar",
-						}},
+						},
+					},
 				},
 				err: nil,
 			},
@@ -1062,7 +1073,8 @@ func TestPatchApply(t *testing.T) {
 						Labels: map[string]string{
 							"source1": "foo",
 							"source2": "bar",
-						}},
+						},
+					},
 				},
 				err: nil,
 			},

--- a/internal/controller/apiextensions/composite/composition_pt_test.go
+++ b/internal/controller/apiextensions/composite/composition_pt_test.go
@@ -473,7 +473,6 @@ func TestPTCompose(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-
 			c := NewPTComposer(tc.params.kube, tc.params.o...)
 			res, err := c.Compose(tc.args.ctx, tc.args.xr, tc.args.req)
 
@@ -484,7 +483,6 @@ func TestPTCompose(t *testing.T) {
 			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\nCompose(...): -want error, +got error:\n%s", tc.reason, diff)
 			}
-
 		})
 	}
 }

--- a/internal/controller/apiextensions/composite/composition_transforms.go
+++ b/internal/controller/apiextensions/composite/composition_transforms.go
@@ -436,7 +436,6 @@ func GetConversionFunc(t *v1.ConvertTransform, from v1.TransformIOType) (func(an
 // may return an error.
 var conversions = map[conversionPair]func(any) (any, error){
 	{from: v1.TransformIOTypeString, to: v1.TransformIOTypeInt64, format: v1.ConvertTransformFormatNone}: func(i any) (any, error) {
-
 		return strconv.ParseInt(i.(string), 10, 64)
 	},
 	{from: v1.TransformIOTypeString, to: v1.TransformIOTypeBool, format: v1.ConvertTransformFormatNone}: func(i any) (any, error) {

--- a/internal/controller/apiextensions/composite/composition_transforms_test.go
+++ b/internal/controller/apiextensions/composite/composition_transforms_test.go
@@ -646,7 +646,6 @@ func TestMathResolve(t *testing.T) {
 }
 
 func TestStringResolve(t *testing.T) {
-
 	type args struct {
 		stype   v1.StringTransformType
 		fmts    *string
@@ -1020,8 +1019,8 @@ func TestStringResolve(t *testing.T) {
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-
-			tr := v1.StringTransform{Type: tc.stype,
+			tr := v1.StringTransform{
+				Type:    tc.stype,
 				Format:  tc.fmts,
 				Convert: tc.convert,
 				Trim:    tc.trim,

--- a/internal/controller/apiextensions/composite/connection_test.go
+++ b/internal/controller/apiextensions/composite/connection_test.go
@@ -456,7 +456,6 @@ func TestExtractConfigsFromTemplate(t *testing.T) {
 			if diff := cmp.Diff(tc.want.cfgs, cfgs); diff != "" {
 				t.Errorf("\n%s\nExtractConfigsFromTemplate(...): -want, +got:\n%s", tc.reason, diff)
 			}
-
 		})
 	}
 }

--- a/internal/controller/apiextensions/composite/environment_selector_test.go
+++ b/internal/controller/apiextensions/composite/environment_selector_test.go
@@ -642,13 +642,11 @@ func TestSelect(t *testing.T) {
 							APIVersion: v1alpha1.SchemeGroupVersion.String(),
 						},
 						{
-
 							Name:       "test-2",
 							Kind:       v1alpha1.EnvironmentConfigKind,
 							APIVersion: v1alpha1.SchemeGroupVersion.String(),
 						},
 						{
-
 							Name:       "test-3",
 							Kind:       v1alpha1.EnvironmentConfigKind,
 							APIVersion: v1alpha1.SchemeGroupVersion.String(),
@@ -933,13 +931,11 @@ func TestSelect(t *testing.T) {
 							APIVersion: v1alpha1.SchemeGroupVersion.String(),
 						},
 						{
-
 							Name:       "test-2",
 							Kind:       v1alpha1.EnvironmentConfigKind,
 							APIVersion: v1alpha1.SchemeGroupVersion.String(),
 						},
 						{
-
 							Name:       "test-3",
 							Kind:       v1alpha1.EnvironmentConfigKind,
 							APIVersion: v1alpha1.SchemeGroupVersion.String(),

--- a/internal/controller/apiextensions/composite/fuzz_test.go
+++ b/internal/controller/apiextensions/composite/fuzz_test.go
@@ -32,9 +32,7 @@ import (
 	pkgmetav1alpha1 "github.com/crossplane/crossplane/apis/pkg/meta/v1alpha1"
 )
 
-var (
-	fuzzScheme = runtime.NewScheme()
-)
+var fuzzScheme = runtime.NewScheme()
 
 func init() {
 	if err := pkgmetav1alpha1.SchemeBuilder.AddToScheme(fuzzScheme); err != nil {

--- a/internal/controller/apiextensions/definition/reconciler_test.go
+++ b/internal/controller/apiextensions/definition/reconciler_test.go
@@ -591,7 +591,8 @@ func TestReconcile(t *testing.T) {
 					}}),
 					WithControllerEngine(&MockEngine{
 						MockErr:   func(name string) error { return errBoom }, // This error should only be logged.
-						MockStart: func(_ string, _ kcontroller.Options, _ ...controller.Watch) error { return nil }},
+						MockStart: func(_ string, _ kcontroller.Options, _ ...controller.Watch) error { return nil },
+					},
 					),
 				},
 			},

--- a/internal/controller/apiextensions/offered/reconciler_test.go
+++ b/internal/controller/apiextensions/offered/reconciler_test.go
@@ -596,7 +596,8 @@ func TestReconcile(t *testing.T) {
 					}}),
 					WithControllerEngine(&MockEngine{
 						MockErr:   func(name string) error { return errBoom }, // This error should only be logged.
-						MockStart: func(_ string, _ kcontroller.Options, _ ...controller.Watch) error { return nil }},
+						MockStart: func(_ string, _ kcontroller.Options, _ ...controller.Watch) error { return nil },
+					},
 					),
 				},
 			},

--- a/internal/controller/apiextensions/offered/watch_test.go
+++ b/internal/controller/apiextensions/offered/watch_test.go
@@ -32,9 +32,7 @@ import (
 	v1 "github.com/crossplane/crossplane/apis/apiextensions/v1"
 )
 
-var (
-	_ handler.EventHandler = &EnqueueRequestForClaim{}
-)
+var _ handler.EventHandler = &EnqueueRequestForClaim{}
 
 func TestOffersClaim(t *testing.T) {
 	cases := map[string]struct {

--- a/internal/controller/pkg/manager/reconciler_test.go
+++ b/internal/controller/pkg/manager/reconciler_test.go
@@ -56,6 +56,7 @@ func NewMockRevisionFn(hash string, err error) func() (string, error) {
 		return hash, err
 	}
 }
+
 func (m *MockRevisioner) Revision(context.Context, v1.Package) (string, error) {
 	return m.MockRevision()
 }

--- a/internal/controller/pkg/revision/deployment.go
+++ b/internal/controller/pkg/revision/deployment.go
@@ -198,14 +198,12 @@ func buildProviderDeployment(provider *pkgmetav1.Provider, revision v1.PackageRe
 			ReadOnly:  true,
 			MountPath: webhookTLSCertDir,
 		}
-		d.Spec.Template.Spec.Containers[0].VolumeMounts =
-			append(d.Spec.Template.Spec.Containers[0].VolumeMounts, vm)
+		d.Spec.Template.Spec.Containers[0].VolumeMounts = append(d.Spec.Template.Spec.Containers[0].VolumeMounts, vm)
 
 		envs := []corev1.EnvVar{
 			{Name: webhookTLSCertDirEnvVar, Value: webhookTLSCertDir},
 		}
-		d.Spec.Template.Spec.Containers[0].Env =
-			append(d.Spec.Template.Spec.Containers[0].Env, envs...)
+		d.Spec.Template.Spec.Containers[0].Env = append(d.Spec.Template.Spec.Containers[0].Env, envs...)
 
 		port := corev1.ContainerPort{
 			Name:          webhookPortName,
@@ -423,8 +421,7 @@ func setControllerConfigConfigurations(s *corev1.ServiceAccount, cc *v1alpha1.Co
 		d.Spec.Template.Spec.Volumes = append(d.Spec.Template.Spec.Volumes, cc.Spec.Volumes...)
 	}
 	if len(cc.Spec.VolumeMounts) > 0 {
-		d.Spec.Template.Spec.Containers[0].VolumeMounts =
-			append(d.Spec.Template.Spec.Containers[0].VolumeMounts, cc.Spec.VolumeMounts...)
+		d.Spec.Template.Spec.Containers[0].VolumeMounts = append(d.Spec.Template.Spec.Containers[0].VolumeMounts, cc.Spec.VolumeMounts...)
 	}
 }
 
@@ -450,14 +447,12 @@ func mountTLSSecret(secret, volName, mountPath, envName string, d *appsv1.Deploy
 		ReadOnly:  true,
 		MountPath: mountPath,
 	}
-	d.Spec.Template.Spec.Containers[0].VolumeMounts =
-		append(d.Spec.Template.Spec.Containers[0].VolumeMounts, vm)
+	d.Spec.Template.Spec.Containers[0].VolumeMounts = append(d.Spec.Template.Spec.Containers[0].VolumeMounts, vm)
 
 	envs := []corev1.EnvVar{
 		{Name: envName, Value: mountPath},
 	}
-	d.Spec.Template.Spec.Containers[0].Env =
-		append(d.Spec.Template.Spec.Containers[0].Env, envs...)
+	d.Spec.Template.Spec.Containers[0].Env = append(d.Spec.Template.Spec.Containers[0].Env, envs...)
 }
 
 func getService(name, namespace string, owners []metav1.OwnerReference, matchLabels map[string]string) *corev1.Service {

--- a/internal/controller/pkg/revision/deployment_test.go
+++ b/internal/controller/pkg/revision/deployment_test.go
@@ -146,9 +146,7 @@ func secretClient(rev v1.PackageRevision) *corev1.Secret {
 }
 
 func deploymentProvider(provider *pkgmetav1.Provider, revision string, img string, modifiers ...deploymentModifier) *appsv1.Deployment {
-	var (
-		replicas = int32(1)
-	)
+	replicas := int32(1)
 
 	d := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
@@ -276,9 +274,7 @@ func deploymentProvider(provider *pkgmetav1.Provider, revision string, img strin
 }
 
 func deploymentFunction(function *pkgmetav1beta1.Function, revision string, img string, modifiers ...deploymentModifier) *appsv1.Deployment {
-	var (
-		replicas = int32(1)
-	)
+	replicas := int32(1)
 
 	d := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
@@ -588,7 +584,8 @@ func TestBuildProviderDeployment(t *testing.T) {
 				d: deploymentProvider(providerWithImage, revisionWithCC.GetName(), ccImg, withPodTemplateLabels(map[string]string{
 					"pkg.crossplane.io/revision": revisionWithCC.GetName(),
 					"pkg.crossplane.io/provider": providerWithImage.GetName(),
-					"k":                          "v"}),
+					"k":                          "v",
+				}),
 					withAdditionalVolume(corev1.Volume{Name: "vol-a"}),
 					withAdditionalVolume(corev1.Volume{Name: "vol-b"}),
 					withAdditionalVolumeMount(corev1.VolumeMount{Name: "vm-a"}),
@@ -622,7 +619,6 @@ func TestBuildProviderDeployment(t *testing.T) {
 			}
 		})
 	}
-
 }
 
 func TestBuildFunctionDeployment(t *testing.T) {
@@ -793,7 +789,8 @@ func TestBuildFunctionDeployment(t *testing.T) {
 				d: deploymentFunction(functionWithImage, revisionWithCC.GetName(), ccImg, withPodTemplateLabels(map[string]string{
 					"pkg.crossplane.io/revision": revisionWithCC.GetName(),
 					"pkg.crossplane.io/function": functionWithImage.GetName(),
-					"k":                          "v"}),
+					"k":                          "v",
+				}),
 					withAdditionalVolume(corev1.Volume{Name: "vol-a"}),
 					withAdditionalVolume(corev1.Volume{Name: "vol-b"}),
 					withAdditionalVolumeMount(corev1.VolumeMount{Name: "vm-a"}),
@@ -823,5 +820,4 @@ func TestBuildFunctionDeployment(t *testing.T) {
 			}
 		})
 	}
-
 }

--- a/internal/controller/pkg/revision/hook_test.go
+++ b/internal/controller/pkg/revision/hook_test.go
@@ -683,7 +683,8 @@ func TestHookPost(t *testing.T) {
 					Spec: v1.PackageRevisionSpec{
 						DesiredState:        v1.PackageRevisionActive,
 						TLSServerSecretName: &tlsServerSecret,
-						TLSClientSecretName: &tlsClientSecret},
+						TLSClientSecretName: &tlsClientSecret,
+					},
 				},
 			},
 			want: want{

--- a/internal/controller/pkg/revision/reconciler.go
+++ b/internal/controller/pkg/revision/reconciler.go
@@ -371,7 +371,6 @@ func SetupFunctionRevision(mgr ctrl.Manager, o controller.Options) error {
 
 // NewReconciler creates a new package revision reconciler.
 func NewReconciler(mgr manager.Manager, opts ...ReconcilerOption) *Reconciler {
-
 	r := &Reconciler{
 		client:    mgr.GetClient(),
 		cache:     xpkg.NewNopCache(),

--- a/internal/controller/pkg/revision/watch_test.go
+++ b/internal/controller/pkg/revision/watch_test.go
@@ -35,9 +35,7 @@ import (
 	"github.com/crossplane/crossplane/apis/pkg/v1alpha1"
 )
 
-var (
-	_ handler.EventHandler = &EnqueueRequestForReferencingProviderRevisions{}
-)
+var _ handler.EventHandler = &EnqueueRequestForReferencingProviderRevisions{}
 
 type addFn func(item any)
 

--- a/internal/controller/rbac/definition/reconciler.go
+++ b/internal/controller/rbac/definition/reconciler.go
@@ -151,7 +151,6 @@ type Reconciler struct {
 // Reconcile a CompositeResourceDefinition by creating a series of opinionated
 // ClusterRoles that may be bound to allow access to the resources it defines.
 func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
-
 	log := r.log.WithValues("request", req)
 	log.Debug("Reconciling")
 

--- a/internal/controller/rbac/namespace/reconciler.go
+++ b/internal/controller/rbac/namespace/reconciler.go
@@ -153,7 +153,6 @@ type Reconciler struct {
 // Reconcile a Namespace by creating a series of opinionated Roles that may be
 // bound to allow access to resources within that namespace.
 func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
-
 	log := r.log.WithValues("request", req)
 	log.Debug("Reconciling")
 

--- a/internal/controller/rbac/namespace/roles_test.go
+++ b/internal/controller/rbac/namespace/roles_test.go
@@ -115,7 +115,6 @@ func TestCRSelector(t *testing.T) {
 			}
 		})
 	}
-
 }
 
 func TestRenderClusterRoles(t *testing.T) {

--- a/internal/controller/rbac/namespace/watch.go
+++ b/internal/controller/rbac/namespace/watch.go
@@ -88,7 +88,6 @@ func (e *EnqueueRequestForNamespaces) add(ctx context.Context, obj runtime.Objec
 	for _, ns := range l.Items {
 		queue.Add(reconcile.Request{NamespacedName: types.NamespacedName{Name: ns.GetName()}})
 	}
-
 }
 
 func aggregates(obj metav1.Object) bool {

--- a/internal/controller/rbac/namespace/watch_test.go
+++ b/internal/controller/rbac/namespace/watch_test.go
@@ -34,9 +34,7 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/test"
 )
 
-var (
-	_ handler.EventHandler = &EnqueueRequestForNamespaces{}
-)
+var _ handler.EventHandler = &EnqueueRequestForNamespaces{}
 
 type addFn func(item any)
 

--- a/internal/controller/rbac/provider/binding/reconciler.go
+++ b/internal/controller/rbac/provider/binding/reconciler.go
@@ -134,7 +134,6 @@ type Reconciler struct {
 // Reconcile a ProviderRevision by creating a ClusterRoleBinding that binds a
 // provider's service account to its system ClusterRole.
 func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
-
 	log := r.log.WithValues("request", req)
 	log.Debug("Reconciling")
 

--- a/internal/controller/rbac/provider/roles/reconciler.go
+++ b/internal/controller/rbac/provider/roles/reconciler.go
@@ -114,7 +114,8 @@ func Setup(mgr ctrl.Manager, o controller.Options) error {
 
 	wrh := &EnqueueRequestForAllRevisionsWithRequests{
 		client:          mgr.GetClient(),
-		clusterRoleName: o.AllowClusterRole}
+		clusterRoleName: o.AllowClusterRole,
+	}
 
 	sfh := &EnqueueRequestForAllRevisionsInFamily{
 		client: mgr.GetClient(),

--- a/internal/controller/rbac/provider/roles/watch_test.go
+++ b/internal/controller/rbac/provider/roles/watch_test.go
@@ -35,9 +35,7 @@ import (
 	v1 "github.com/crossplane/crossplane/apis/pkg/v1"
 )
 
-var (
-	_ handler.EventHandler = &EnqueueRequestForAllRevisionsWithRequests{}
-)
+var _ handler.EventHandler = &EnqueueRequestForAllRevisionsWithRequests{}
 
 type addFn func(item any)
 

--- a/internal/dag/dag_test.go
+++ b/internal/dag/dag_test.go
@@ -64,8 +64,10 @@ func toNodes(n []simpleNode) []Node {
 	return nodes
 }
 
-var _ DAG = &MapDag{}
-var _ NewDAGFn = NewMapDag
+var (
+	_ DAG      = &MapDag{}
+	_ NewDAGFn = NewMapDag
+)
 
 func sortedFnNop([]simpleNode, []string) error {
 	return nil

--- a/internal/initializer/cert_generator.go
+++ b/internal/initializer/cert_generator.go
@@ -43,15 +43,13 @@ type CertificateGenerator interface {
 	Generate(*x509.Certificate, *CertificateSigner) (key []byte, crt []byte, err error)
 }
 
-var (
-	pkixName = pkix.Name{
-		CommonName:   "Crossplane",
-		Organization: []string{"Crossplane"},
-		Country:      []string{"Earth"},
-		Province:     []string{"Earth"},
-		Locality:     []string{"Earth"},
-	}
-)
+var pkixName = pkix.Name{
+	CommonName:   "Crossplane",
+	Organization: []string{"Crossplane"},
+	Country:      []string{"Earth"},
+	Province:     []string{"Earth"},
+	Locality:     []string{"Earth"},
+}
 
 // NewCertGenerator returns a new CertGenerator.
 func NewCertGenerator() *CertGenerator {

--- a/internal/initializer/crds_migrator.go
+++ b/internal/initializer/crds_migrator.go
@@ -67,7 +67,7 @@ func (c *CoreCRDsMigrator) Run(ctx context.Context, kube client.Client) error { 
 			break
 		}
 	}
-	var resources = unstructured.UnstructuredList{}
+	resources := unstructured.UnstructuredList{}
 	resources.SetGroupVersionKind(schema.GroupVersionKind{
 		Group:   crd.Spec.Group,
 		Version: storageVersion,

--- a/internal/initializer/tls_test.go
+++ b/internal/initializer/tls_test.go
@@ -488,7 +488,6 @@ func TestTLSCertificateGenerator_GenerateServerCertificate(t *testing.T) {
 		"SuccessfulGeneratedServerCert": {
 			reason: "It should be successful if the server certificate is generated and put into the Secret.",
 			args: args{
-
 				kube: &test.MockClient{
 					MockGet: func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
 						if key.Name == caCertSecretName && key.Namespace == secretNS {
@@ -650,7 +649,6 @@ func TestTLSCertificateGenerator_GenerateClientCertificate(t *testing.T) {
 		"SuccessfulGeneratedClientCert": {
 			reason: "It should be successful if the client certificate is generated and put into the Secret.",
 			args: args{
-
 				kube: &test.MockClient{
 					MockGet: func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
 						if key.Name == caCertSecretName && key.Namespace == secretNS {

--- a/internal/initializer/webhook_tls.go
+++ b/internal/initializer/webhook_tls.go
@@ -100,7 +100,6 @@ func (wt *WebhookCertificateGenerator) Run(ctx context.Context, kube client.Clie
 		KeyUsage:              x509.KeyUsageCRLSign | x509.KeyUsageCertSign,
 		BasicConstraintsValid: true,
 	}, nil)
-
 	if err != nil {
 		return errors.Wrap(err, errGenerateCertificate)
 	}

--- a/internal/transport/transport_test.go
+++ b/internal/transport/transport_test.go
@@ -55,8 +55,10 @@ func userAgentValidator(userAgent string) requestValidationFn {
 	}
 }
 
-var _ http.RoundTripper = &UserAgent{}
-var _ http.RoundTripper = &validatingRoundTripper{}
+var (
+	_ http.RoundTripper = &UserAgent{}
+	_ http.RoundTripper = &validatingRoundTripper{}
+)
 
 func TestUserAgent(t *testing.T) {
 	cases := map[string]struct {

--- a/internal/xcrd/crd_test.go
+++ b/internal/xcrd/crd_test.go
@@ -661,7 +661,6 @@ func TestForCompositeResource(t *testing.T) {
 											Type:        "object",
 											Description: "",
 											Properties: map[string]extv1.JSONSchemaProps{
-
 												// From CompositeResourceStatusProps()
 												"conditions": {
 													Description: "Conditions of the resource.",
@@ -1002,8 +1001,10 @@ func TestForCompositeResourceClaim(t *testing.T) {
 										},
 										"compositeDeletePolicy": {
 											Type: "string",
-											Enum: []extv1.JSON{{Raw: []byte(`"Background"`)},
-												{Raw: []byte(`"Foreground"`)}},
+											Enum: []extv1.JSON{
+												{Raw: []byte(`"Background"`)},
+												{Raw: []byte(`"Foreground"`)},
+											},
 										},
 										// From CompositeResourceClaimSpecProps()
 										"compositionRef": {
@@ -1294,8 +1295,10 @@ func TestForCompositeResourceClaimEmptyXrd(t *testing.T) {
 									Properties: map[string]extv1.JSONSchemaProps{
 										"compositeDeletePolicy": {
 											Type: "string",
-											Enum: []extv1.JSON{{Raw: []byte(`"Background"`)},
-												{Raw: []byte(`"Foreground"`)}},
+											Enum: []extv1.JSON{
+												{Raw: []byte(`"Background"`)},
+												{Raw: []byte(`"Foreground"`)},
+											},
 										},
 										// From CompositeResourceClaimSpecProps()
 										"compositionRef": {

--- a/internal/xpkg/fuzz_test.go
+++ b/internal/xpkg/fuzz_test.go
@@ -48,7 +48,7 @@ func FuzzFindXpkgInDir(f *testing.F) {
 				t.Skip()
 			}
 
-			if err = afero.WriteFile(fs, fname, fcontents, 0777); err != nil {
+			if err = afero.WriteFile(fs, fname, fcontents, 0o777); err != nil {
 				t.Skip()
 			}
 		}
@@ -56,5 +56,4 @@ func FuzzFindXpkgInDir(f *testing.F) {
 		_, _ = FindXpkgInDir(fs, "/")
 		_, _ = ParseNameFromMeta(fs, "/")
 	})
-
 }

--- a/pkg/validation/apiextensions/v1/composition/patches.go
+++ b/pkg/validation/apiextensions/v1/composition/patches.go
@@ -90,7 +90,6 @@ func (v *Validator) validateEnvironmentPatchesWithSchemas(ctx context.Context, c
 			compositeResGVK: compositeResGVK,
 		}), field.NewPath("spec").Child("environment", "patches").Index(i)); err != nil {
 			errs = append(errs, err)
-
 		}
 	}
 	return errs

--- a/pkg/validation/apiextensions/v1/composition/patches_test.go
+++ b/pkg/validation/apiextensions/v1/composition/patches_test.go
@@ -366,7 +366,14 @@ func TestValidateFieldPath(t *testing.T) {
 							Properties: map[string]apiextensions.JSONSchemaProps{
 								"forProvider": {
 									Properties: map[string]apiextensions.JSONSchemaProps{
-										"foo": {Type: "string"}}}}}}}},
+										"foo": {Type: "string"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
 		},
 		"AcceptMetadataLabelsValue": {
 			reason: "Should validate a valid field path",
@@ -391,7 +398,14 @@ func TestValidateFieldPath(t *testing.T) {
 							Properties: map[string]apiextensions.JSONSchemaProps{
 								"forProvider": {
 									Properties: map[string]apiextensions.JSONSchemaProps{
-										"foo": {Type: "string"}}}}}}}},
+										"foo": {Type: "string"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
 		},
 		"AcceptFieldPathXPreserveUnknownFields": {
 			reason: "Should not return an error for an undefined but accepted field path",
@@ -404,9 +418,15 @@ func TestValidateFieldPath(t *testing.T) {
 							Properties: map[string]apiextensions.JSONSchemaProps{
 								"forProvider": {
 									Properties: map[string]apiextensions.JSONSchemaProps{
-										"foo": {Type: "string"}},
+										"foo": {Type: "string"},
+									},
 									XPreserveUnknownFields: &[]bool{true}[0],
-								}}}}}},
+								},
+							},
+						},
+					},
+				},
+			},
 		},
 		"AcceptValidArray": {
 			reason: "Should validate arrays properly",
@@ -424,7 +444,18 @@ func TestValidateFieldPath(t *testing.T) {
 											Items: &apiextensions.JSONSchemaPropsOrArray{
 												Schema: &apiextensions.JSONSchemaProps{
 													Properties: map[string]apiextensions.JSONSchemaProps{
-														"bar": {Type: "string"}}}}}}}}}}}},
+														"bar": {Type: "string"},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
 		},
 		"AcceptComplexSchema": {
 			reason: "Should validate properly with complex schema",
@@ -475,7 +506,10 @@ func TestValidateFieldPath(t *testing.T) {
 									XPreserveUnknownFields: &[]bool{true}[0],
 								},
 							},
-						}}}},
+						},
+					},
+				},
+			},
 		},
 		"AcceptAnnotations": {
 			want: want{err: nil, fieldType: "string"},
@@ -896,7 +930,6 @@ func TestGetSchemaForVersion(t *testing.T) {
 			}
 		})
 	}
-
 }
 
 func TestComposedTemplateGetBaseObject(t *testing.T) {

--- a/pkg/validation/apiextensions/v1/composition/readinessChecks_test.go
+++ b/pkg/validation/apiextensions/v1/composition/readinessChecks_test.go
@@ -236,7 +236,6 @@ func TestValidateReadinessCheck(t *testing.T) {
 						crd.Spec.Versions[1].Schema.OpenAPIV3Schema.Properties["spec"].Properties["someField"] = extv1.JSONSchemaProps{
 							Type: "integer",
 						}
-
 					}).build()),
 			},
 			want: want{

--- a/pkg/validation/apiextensions/v1/composition/schema.go
+++ b/pkg/validation/apiextensions/v1/composition/schema.go
@@ -26,6 +26,7 @@ func defaultMetadataSchema(in *apiextensions.JSONSchemaProps) *apiextensions.JSO
 
 	return out
 }
+
 func defaultMetadataOnly(metadata *apiextensions.JSONSchemaProps) *apiextensions.JSONSchemaProps {
 	setDefaultType(metadata)
 	setDefaultProperty(metadata, "name", string(schema.KnownJSONTypeString))

--- a/pkg/validation/apiextensions/v1/composition/schema_test.go
+++ b/pkg/validation/apiextensions/v1/composition/schema_test.go
@@ -16,6 +16,7 @@ func getDefaultMetadataSchema() *apiextensions.JSONSchemaProps {
 func getDefaultSchema() *apiextensions.JSONSchemaProps {
 	return defaultMetadataSchema(&apiextensions.JSONSchemaProps{})
 }
+
 func TestDefaultMetadataSchema(t *testing.T) {
 	type args struct {
 		in *apiextensions.JSONSchemaProps
@@ -61,14 +62,18 @@ func TestDefaultMetadataSchema(t *testing.T) {
 		},
 		"SpecPreserved": {
 			reason: "Other properties should be preserved",
-			args: args{in: &apiextensions.JSONSchemaProps{
-				Type: string(schema.KnownJSONTypeObject),
-				Properties: map[string]apiextensions.JSONSchemaProps{
-					"spec": {
-						Type: string(schema.KnownJSONTypeObject),
-						AdditionalProperties: &apiextensions.JSONSchemaPropsOrBool{
-							Allows: true,
-						}}}},
+			args: args{
+				in: &apiextensions.JSONSchemaProps{
+					Type: string(schema.KnownJSONTypeObject),
+					Properties: map[string]apiextensions.JSONSchemaProps{
+						"spec": {
+							Type: string(schema.KnownJSONTypeObject),
+							AdditionalProperties: &apiextensions.JSONSchemaPropsOrBool{
+								Allows: true,
+							},
+						},
+					},
+				},
 			},
 			want: want{
 				out: &apiextensions.JSONSchemaProps{
@@ -79,7 +84,11 @@ func TestDefaultMetadataSchema(t *testing.T) {
 							Type: string(schema.KnownJSONTypeObject),
 							AdditionalProperties: &apiextensions.JSONSchemaPropsOrBool{
 								Allows: true,
-							}}}}},
+							},
+						},
+					},
+				},
+			},
 		},
 		"MetadataNotOverwrite": {
 			reason: "Other properties should not be overwritten in metadata if specified in the default",
@@ -91,7 +100,11 @@ func TestDefaultMetadataSchema(t *testing.T) {
 						Properties: map[string]apiextensions.JSONSchemaProps{
 							"name": {
 								Type: string(schema.KnownJSONTypeBoolean),
-							}}}}}},
+							},
+						},
+					},
+				},
+			}},
 			want: want{
 				out: func() *apiextensions.JSONSchemaProps {
 					s := getDefaultSchema()
@@ -106,16 +119,23 @@ func TestDefaultMetadataSchema(t *testing.T) {
 		},
 		"MetadataPreserved": {
 			reason: "Other properties should be preserved in if not specified in the default",
-			args: args{in: &apiextensions.JSONSchemaProps{
-				Type: string(schema.KnownJSONTypeObject),
-				Properties: map[string]apiextensions.JSONSchemaProps{
-					"metadata": {
-						Type: string(schema.KnownJSONTypeObject),
-						Properties: map[string]apiextensions.JSONSchemaProps{
-							"annotations": {
-								Type: string(schema.KnownJSONTypeObject),
-								Properties: map[string]apiextensions.JSONSchemaProps{
-									"foo": {Type: string(schema.KnownJSONTypeString)}}}}}}},
+			args: args{
+				in: &apiextensions.JSONSchemaProps{
+					Type: string(schema.KnownJSONTypeObject),
+					Properties: map[string]apiextensions.JSONSchemaProps{
+						"metadata": {
+							Type: string(schema.KnownJSONTypeObject),
+							Properties: map[string]apiextensions.JSONSchemaProps{
+								"annotations": {
+									Type: string(schema.KnownJSONTypeObject),
+									Properties: map[string]apiextensions.JSONSchemaProps{
+										"foo": {Type: string(schema.KnownJSONTypeString)},
+									},
+								},
+							},
+						},
+					},
+				},
 			},
 			want: want{
 				out: func() *apiextensions.JSONSchemaProps {

--- a/pkg/validation/apiextensions/v1/composition/validator_test.go
+++ b/pkg/validation/apiextensions/v1/composition/validator_test.go
@@ -320,7 +320,8 @@ func TestValidatorValidate(t *testing.T) {
 							Type:          v1.PatchTypeFromCompositeFieldPath,
 							FromFieldPath: pointer.String("spec.someField"),
 							ToFieldPath:   pointer.String("spec.someOtherField"),
-						}}},
+						}},
+					},
 				), withPatches(0, v1.Patch{
 					Type:         v1.PatchTypePatchSet,
 					PatchSetName: pointer.String("some-patch-set"),
@@ -360,7 +361,8 @@ func TestValidatorValidate(t *testing.T) {
 									},
 								},
 								ToFieldPath: pointer.String("spec.someOtherField"),
-							}}},
+							}},
+						},
 					), withPatches(0, v1.Patch{
 						Type:         v1.PatchTypePatchSet,
 						PatchSetName: pointer.String("some-patch-set"),
@@ -660,8 +662,10 @@ func sortFieldErrors() cmp.Option {
 	})
 }
 
-const testGroup = "resources.test.com"
-const testGroupSingular = "resource.test.com"
+const (
+	testGroup         = "resources.test.com"
+	testGroupSingular = "resource.test.com"
+)
 
 func marshalJSON(t *testing.T, obj interface{}) []byte {
 	t.Helper()

--- a/test/e2e/apiextensions_test.go
+++ b/test/e2e/apiextensions_test.go
@@ -72,7 +72,6 @@ func TestCompositionMinimal(t *testing.T) {
 // available when its composed resources do, and have a field derived from
 // the patch.
 func TestCompositionPatchAndTransform(t *testing.T) {
-
 	manifests := "test/e2e/manifests/apiextensions/composition/patch-and-transform"
 	environment.Test(t,
 		features.New(t.Name()).
@@ -110,7 +109,6 @@ func TestCompositionPatchAndTransform(t *testing.T) {
 // disabled?
 
 func TestCompositionFunctions(t *testing.T) {
-
 	manifests := "test/e2e/manifests/apiextensions/composition/functions"
 	environment.Test(t,
 		features.New(t.Name()).

--- a/test/e2e/environmentconfig_test.go
+++ b/test/e2e/environmentconfig_test.go
@@ -332,6 +332,7 @@ func TestEnvironmentConfigMultipleMaxMatchNil(t *testing.T) {
 			Feature(),
 	)
 }
+
 func TestEnvironmentConfigMultipleMaxMatch1(t *testing.T) {
 	subfolder := "multipleModeMaxMatch1"
 

--- a/test/e2e/funcs/env.go
+++ b/test/e2e/funcs/env.go
@@ -76,7 +76,6 @@ func AsFeaturesFunc(fn env.Func) features.Func {
 		}
 		return ctx
 	}
-
 }
 
 // HelmUninstall uninstalls a Helm chart.

--- a/test/e2e/funcs/feature.go
+++ b/test/e2e/funcs/feature.go
@@ -107,7 +107,6 @@ func DeploymentBecomesAvailableWithin(d time.Duration, namespace, name string) f
 // to exist within the supplied duration.
 func ResourcesCreatedWithin(d time.Duration, dir, pattern string) features.Func {
 	return func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
-
 		rs, err := decoder.DecodeAllFiles(ctx, os.DirFS(dir), pattern)
 		if err != nil {
 			t.Error(err)
@@ -151,7 +150,6 @@ func ResourceCreatedWithin(d time.Duration, o k8s.Object) features.Func {
 // within the supplied duration.
 func ResourcesDeletedWithin(d time.Duration, dir, pattern string) features.Func {
 	return func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
-
 		rs, err := decoder.DecodeAllFiles(ctx, os.DirFS(dir), pattern)
 		if err != nil {
 			t.Error(err)
@@ -265,7 +263,6 @@ func CRDInitialNamesAccepted() xpv1.Condition {
 // duration. The supplied 'want' value must cmp.Equal the actual value.
 func ResourcesHaveFieldValueWithin(d time.Duration, dir, pattern, path string, want any) features.Func {
 	return func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
-
 		rs, err := decoder.DecodeAllFiles(ctx, os.DirFS(dir), pattern)
 		if err != nil {
 			t.Error(err)

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -57,9 +57,7 @@ const (
 	helmReleaseName = "crossplane"
 )
 
-var (
-	environment = config.NewEnvironmentFromFlags()
-)
+var environment = config.NewEnvironmentFromFlags()
 
 func TestMain(m *testing.M) {
 	// TODO(negz): Global loggers are dumb and klog is dumb. Remove this when


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does, and how it is covered by tests.
Be proactive - direct your reviewers' attention to anything that needs special
consideration.

You MUST either [x] check or ~strikethrough~ every item in the checklist below.

We love pull requests that fix an open issue. If yours does, use the below line
to indicate which issue it fixes, for example "Fixes #500".
-->

While discussing with @sttts we were wondering what changes would have caused enabling [gofumpt](https://github.com/mvdan/gofumpt). So here is the PR enabling it and with all the needed changes performed by `golangci-lint` itself when run with `--fix`, which is now the default behaviour of `make reviewable`.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [ ] ~Added or updated unit **and** E2E tests for my change.~
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR, if necessary.~
- [ ] ~Opened a PR updating the [docs], if necessary.~

[contribution process]: https://git.io/fj2m9
[docs]: https://docs.crossplane.io/contribute/contribute
