### PR TITLE
fix(lock) empty package and type in lock when dependsOn is a function

### DIFF
--- a/internal/controller/pkg/revision/dependency.go
+++ b/internal/controller/pkg/revision/dependency.go
@@ -85,12 +85,16 @@ func (m *PackageDependencyManager) Resolve(ctx context.Context, pkg runtime.Obje
 	sources := make([]v1beta1.Dependency, len(pack.GetDependencies()))
 	for i, dep := range pack.GetDependencies() {
 		pdep := v1beta1.Dependency{}
-		if dep.Configuration != nil {
+		switch {
+		case dep.Configuration != nil:
 			pdep.Package = *dep.Configuration
 			pdep.Type = v1beta1.ConfigurationPackageType
-		} else if dep.Provider != nil {
+		case dep.Provider != nil:
 			pdep.Package = *dep.Provider
 			pdep.Type = v1beta1.ProviderPackageType
+		case dep.Function != nil:
+			pdep.Package = *dep.Function
+			pdep.Type = v1beta1.FunctionPackageType
 		}
 		pdep.Constraints = dep.Version
 		sources[i] = pdep

--- a/internal/controller/pkg/revision/dependency_test.go
+++ b/internal/controller/pkg/revision/dependency_test.go
@@ -563,6 +563,10 @@ func TestResolve(t *testing.T) {
 											Package: "not-here-2",
 											Type:    v1beta1.ConfigurationPackageType,
 										},
+										{
+											Package: "function-not-here-1",
+											Type:    v1beta1.FunctionPackageType,
+										},
 									},
 								},
 								{
@@ -589,9 +593,10 @@ func TestResolve(t *testing.T) {
 							},
 							MockTraceNode: func(_ string) (map[string]dag.Node, error) {
 								return map[string]dag.Node{
-									"not-here-1": &v1beta1.Dependency{},
-									"not-here-2": &v1beta1.Dependency{},
-									"not-here-3": &v1beta1.Dependency{},
+									"not-here-1":          &v1beta1.Dependency{},
+									"not-here-2":          &v1beta1.Dependency{},
+									"not-here-3":          &v1beta1.Dependency{},
+									"function-not-here-1": &v1beta1.Dependency{},
 								}, nil
 							},
 							MockGetNode: func(s string) (dag.Node, error) {
@@ -607,6 +612,13 @@ func TestResolve(t *testing.T) {
 										Version: "v0.100.1",
 									}, nil
 								}
+								if s == "function-not-here-1" {
+									return &v1beta1.LockPackage{
+										Source:  "function-not-here-1",
+										Version: "v0.1.0",
+									}, nil
+								}
+
 								return nil, nil
 							},
 						}
@@ -624,6 +636,10 @@ func TestResolve(t *testing.T) {
 									Provider: pointer.String("not-here-2"),
 									Version:  ">=v0.1.0",
 								},
+								{
+									Function: pointer.String("function-not-here-1"),
+									Version:  ">=v0.1.0",
+								},
 							},
 						},
 					},
@@ -639,8 +655,8 @@ func TestResolve(t *testing.T) {
 				},
 			},
 			want: want{
-				total:     3,
-				installed: 3,
+				total:     4,
+				installed: 4,
 				invalid:   0,
 			},
 		},


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes
it is not possible to install functions with `dependsOn` in configurations - this leads to empty package and type in lock

```
apiVersion: meta.pkg.crossplane.io/v1
kind: Configuration
metadata:
  name: configuration-caas
  annotations:
[...]
spec:
  dependsOn:
    - provider: xpkg.upbound.io/crossplane-contrib/provider-helm
      version: ">=v0.15.0"
    - provider: xpkg.upbound.io/crossplane-contrib/provider-kubernetes
      version: ">=v0.9.0"
    - function: xpkg.upbound.io/crossplane-contrib/function-patch-and-transform
      version: ">=v0.1.3"
```

this results before this PR in:
```
apiVersion: pkg.crossplane.io/v1beta1
kind: Lock
metadata:
  name: lock
packages:
- dependencies:
  - constraints: '>=v0.15.0'
    package: xpkg.upbound.io/crossplane-contrib/provider-helm
    type: Provider
  - constraints: '>=v0.9.0'
    package: xpkg.upbound.io/crossplane-contrib/provider-kubernetes
    type: Provider
  - constraints: '>=v0.1.3'
    package: ""
    type: ""
[...]
```

after this PR:
```
kubectl get lock lock -o yaml
apiVersion: pkg.crossplane.io/v1beta1
kind: Lock
metadata:
  name: lock
packages:
- dependencies:
  - constraints: '>=v0.15.0'
    package: xpkg.upbound.io/crossplane-contrib/provider-helm
    type: Provider
  - constraints: '>=v0.9.0'
    package: xpkg.upbound.io/crossplane-contrib/provider-kubernetes
    type: Provider
  - constraints: '>=v0.1.3'
    package: xpkg.upbound.io/crossplane-contrib/function-patch-and-transform
    type: Function
[...]
```


<!--
Briefly describe what this pull request does, and how it is covered by tests.
Be proactive - direct your reviewers' attention to anything that needs special
consideration.

You MUST either [x] check or ~strikethrough~ every item in the checklist below.

We love pull requests that fix an open issue. If yours does, use the below line
to indicate which issue it fixes, for example "Fixes #500".
-->

Fixes # 

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Added or updated unit **and** E2E tests for my change.
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR, if necessary.
- [x] Opened a PR updating the [docs], if necessary.

[contribution process]: https://git.io/fj2m9
[docs]: https://docs.crossplane.io/contribute/contribute
