### PR TITLE
fix(roles): System ProviderRevision named clusterRoles should have labels

### DIFF
--- a/internal/controller/rbac/provider/roles/roles.go
+++ b/internal/controller/rbac/provider/roles/roles.go
@@ -38,6 +38,7 @@ const (
 	keyAggregateToAdmin      = "rbac.crossplane.io/aggregate-to-admin"
 	keyAggregateToEdit       = "rbac.crossplane.io/aggregate-to-edit"
 	keyAggregateToView       = "rbac.crossplane.io/aggregate-to-view"
+	keyProviderName          = "rbac.crossplane.io/system"
 
 	valTrue = "true"
 
@@ -161,8 +162,13 @@ func RenderClusterRoles(pr *v1.ProviderRevision, rs []Resource) []rbacv1.Cluster
 	// The 'system' RBAC role does not aggregate; it is intended to be bound
 	// directly to the service account tha provider runs as.
 	system := &rbacv1.ClusterRole{
-		ObjectMeta: metav1.ObjectMeta{Name: SystemClusterRoleName(pr.GetName())},
-		Rules:      append(append(append(withVerbs(rules, verbsSystem), ruleFinalizers), rulesSystemExtra...), pr.Status.PermissionRequests...),
+		ObjectMeta: metav1.ObjectMeta{
+			Name: SystemClusterRoleName(pr.GetName()),
+			Labels: map[string]string{
+				keyProviderName: pr.GetName(),
+			},
+		},
+		Rules: append(append(append(withVerbs(rules, verbsSystem), ruleFinalizers), rulesSystemExtra...), pr.Status.PermissionRequests...),
 	}
 
 	roles := []rbacv1.ClusterRole{*edit, *view, *system}

--- a/internal/controller/rbac/provider/roles/roles_test.go
+++ b/internal/controller/rbac/provider/roles/roles_test.go
@@ -137,6 +137,7 @@ func TestRenderClusterRoles(t *testing.T) {
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:            nameSystem,
+						Labels:          map[string]string{keyProviderName: prName},
 						OwnerReferences: []metav1.OwnerReference{crCtrlr},
 					},
 					Rules: append([]rbacv1.PolicyRule{


### PR DESCRIPTION
### Description of your changes

Fixes [#4160](https://github.com/crossplane/crossplane/issues/4160)

This adds the provider revision name as a label with the key that was initially discussed in the issue

`rbac.crossplane.io/system`

This `pr.GetName()` is used throughout this `roles.go` and prior to its use here so it shouldnt be an issue to use it to label these cluster roles.  The tests also show that this change

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Added or updated unit **and** E2E tests for my change.
- [x] Run `make reviewable` to ensure this PR is ready for review.
```
...
ok  	github.com/crossplane/crossplane/apis/apiextensions/v1	0.236s	coverage: 17.3% of statements
testing: warning: no tests to run
PASS
coverage: 1.4% of statements
ok  	github.com/crossplane/crossplane/apis/pkg/meta/v1beta1	0.093s	coverage: 1.4% of statements [no tests to run]
?   	github.com/crossplane/crossplane/apis/pkg/v1alpha1	[no test files]
?   	github.com/crossplane/crossplane/apis/secrets	[no test files]
?   	github.com/crossplane/crossplane/apis/secrets/v1alpha1	[no test files]
testing: warning: no tests to run
PASS
coverage: 1.0% of statements
ok  	github.com/crossplane/crossplane/apis/pkg/v1	0.216s	coverage: 1.0% of statements [no tests to run]
testing: warning: no tests to run
PASS
coverage: 1.4% of statements
ok  	github.com/crossplane/crossplane/apis/pkg/v1beta1	0.205s	coverage: 1.4% of statements [no tests to run]
19:24:19 [ OK ] go test unit-test
```
- [x] Added `backport release-x.y` labels to auto-backport this PR, if necessary.
   - this does not need to be backported
- [x] Opened a PR updating the [docs], if necessary.

[contribution process]: https://git.io/fj2m9
[docs]: https://docs.crossplane.io/contribute/contribute
