### PR TITLE
chore(renovate): always update crossplane-runtime digests

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -96,7 +96,8 @@
       ],
       "enabled": false,
     },{
-      "description": "Only get dependency digest updates every month to reduce noise",
+      "description": "Only get dependency digest updates every month to reduce noise, except crossplane-runtime",
+      "excludePackageNames": ["github.com/crossplane/crossplane-runtime"],
       "matchDatasources": [
         "go"
       ],


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does, and how it is covered by tests.
Be proactive - direct your reviewers' attention to anything that needs special
consideration.

You MUST either [x] check or ~strikethrough~ every item in the checklist below.

We love pull requests that fix an open issue. If yours does, use the below line
to indicate which issue it fixes, for example "Fixes #500".
-->

To avoid forgetting to bump crossplane-runtime and having to do it manually: https://github.com/crossplane/crossplane/pull/4713.

Exclude crossplane-runtime from the rule only bumping go deps' digests once a month.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [ ] ~Added or updated unit **and** E2E tests for my change.~
- [ ] ~Run `make reviewable` to ensure this PR is ready for review.~
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR, if necessary.~
- [ ] ~Opened a PR updating the [docs], if necessary.~

[contribution process]: https://git.io/fj2m9
[docs]: https://docs.crossplane.io/contribute/contribute
