### PR TITLE
xpkg push

### DIFF
--- a/cmd/crank/xpkg/push.go
+++ b/cmd/crank/xpkg/push.go
@@ -1,0 +1,89 @@
+/*
+Copyright 2023 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package xpkg
+
+import (
+	"os"
+
+	"github.com/google/go-containerregistry/pkg/authn"
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
+	"github.com/google/go-containerregistry/pkg/v1/tarball"
+	"github.com/spf13/afero"
+
+	"github.com/crossplane/crossplane-runtime/pkg/errors"
+	"github.com/crossplane/crossplane-runtime/pkg/logging"
+
+	"github.com/crossplane/crossplane/internal/xpkg"
+)
+
+const (
+	errGetwd           = "failed to get working directory while searching for package"
+	errFindPackageinWd = "failed to find a package in current working directory"
+)
+
+// pushCmd pushes a package.
+type pushCmd struct {
+	fs afero.Fs
+
+	Tag     string `arg:"" help:"Tag of the package to be pushed. Must be a valid OCI image tag."`
+	Package string `short:"f" help:"Path to package. If not specified and only one package exists in current directory it will be used."`
+}
+
+// AfterApply sets the tag for the parent push command.
+func (c *pushCmd) AfterApply() error {
+	c.fs = afero.NewOsFs()
+	return nil
+}
+
+// Run runs the push cmd.
+func (c *pushCmd) Run(logger logging.Logger) error {
+	logger = logger.WithValues("tag", c.Tag)
+	tag, err := name.NewTag(c.Tag)
+	if err != nil {
+		logger.Debug("Failed to create tag for package", "error", err)
+		return err
+	}
+
+	// If package is not defined, attempt to find single package in current
+	// directory.
+	if c.Package == "" {
+		logger.Debug("Trying to find package in current directory")
+		wd, err := os.Getwd()
+		if err != nil {
+			logger.Debug("Failed to find package in directory", "error", errors.Wrap(err, errGetwd))
+			return errors.Wrap(err, errGetwd)
+		}
+		path, err := xpkg.FindXpkgInDir(c.fs, wd)
+		if err != nil {
+			logger.Debug("Failed to find package in directory", "error", errors.Wrap(err, errFindPackageinWd))
+			return errors.Wrap(err, errFindPackageinWd)
+		}
+		c.Package = path
+		logger.Debug("Found package in directory", "path", path)
+	}
+	img, err := tarball.ImageFromPath(c.Package, nil)
+	if err != nil {
+		logger.Debug("Failed to create image from package tarball", "error", err)
+		return err
+	}
+	if err := remote.Write(tag, img, remote.WithAuthFromKeychain(authn.DefaultKeychain)); err != nil {
+		logger.Debug("Failed to push created image to remote location", "error", err)
+		return err
+	}
+	return nil
+}

--- a/cmd/crank/xpkg/xpkg.go
+++ b/cmd/crank/xpkg/xpkg.go
@@ -18,9 +18,10 @@ limitations under the License.
 package xpkg
 
 // Cmd contains commands for interacting with xpkgs.
-// TODO(lsviben) add the rest of the commands from up (push, batch, xpextract).
+// TODO(lsviben) add the rest of the commands from up (batch, xpextract).
 type Cmd struct {
 	Build buildCmd `cmd:"" help:"Build a package, by default from the current directory."`
+	Push  pushCmd  `cmd:"" help:"Push Crossplane packages."`
 }
 
 // Help prints out the help for the xpkg command.


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

Moved a simplified version of `crossplane push provider/configuration` to `crossplane xpkg push`. 

Not moving the whole `up xpkg push`, at least for [now](https://github.com/crossplane/crossplane/issues/4669#issuecomment-1745272000).
The new version also supports functions, while the old one should be deprecated in time. 

<!--
Briefly describe what this pull request does, and how it is covered by tests.
Be proactive - direct your reviewers' attention to anything that needs special
consideration.

You MUST either [x] check or ~strikethrough~ every item in the checklist below.

We love pull requests that fix an open issue. If yours does, use the below line
to indicate which issue it fixes, for example "Fixes #500".
-->

Fixes #4669

I have:

- [x] Read and followed Crossplane's [contribution process].
- [ ] ~Added or updated unit **and** E2E tests for my change.~
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR, if necessary.~
- [ ] ~Opened a PR updating the [docs], if necessary.~
Docs PR for CLI will be done separately in https://github.com/crossplane/crossplane/issues/4671

[contribution process]: https://git.io/fj2m9
[docs]: https://docs.crossplane.io/contribute/contribute

### How has this been tested

Ran `kubectl crossplane push provider <tag>` and the new `kubectl crossplane xpkg push <tag>` and got the same result.