### PR TITLE
Speed up e2e

### DIFF
--- a/test/e2e/manifests/apiextensions/composition/functions/setup/composition-nested.yaml
+++ b/test/e2e/manifests/apiextensions/composition/functions/setup/composition-nested.yaml
@@ -35,7 +35,7 @@ spec:
                       time: 0s
                     - conditionType: Ready
                       conditionStatus: "True"
-                      time: 10s
+                      time: 1s
         results:
          - severity: SEVERITY_NORMAL
            message: "I am doing a compose!"

--- a/test/e2e/manifests/apiextensions/composition/minimal/setup/composition.yaml
+++ b/test/e2e/manifests/apiextensions/composition/minimal/setup/composition.yaml
@@ -19,4 +19,4 @@ spec:
           time: 0s
         - conditionType: Ready
           conditionStatus: "True"
-          time: 10s
+          time: 1s

--- a/test/e2e/manifests/apiextensions/composition/patch-and-transform/setup/composition.yaml
+++ b/test/e2e/manifests/apiextensions/composition/patch-and-transform/setup/composition.yaml
@@ -19,7 +19,7 @@ spec:
           time: 0s
         - conditionType: Ready
           conditionStatus: "True"
-          time: 10s
+          time: 1s
     patches:
     - type: FromCompositeFieldPath
       fromFieldPath: spec.coolField

--- a/test/e2e/manifests/apiextensions/composition/validation/composition-invalid.yaml
+++ b/test/e2e/manifests/apiextensions/composition/validation/composition-invalid.yaml
@@ -21,7 +21,7 @@ spec:
           time: 0s
         - conditionType: Ready
           conditionStatus: "True"
-          time: 10s
+          time: 1s
     patches:
     - type: FromCompositeFieldPath
       fromFieldPath: spec.coolField

--- a/test/e2e/manifests/apiextensions/composition/validation/composition-transform-tojson-valid.yaml
+++ b/test/e2e/manifests/apiextensions/composition/validation/composition-transform-tojson-valid.yaml
@@ -21,7 +21,7 @@ spec:
           time: 0s
         - conditionType: Ready
           conditionStatus: "True"
-          time: 10s
+          time: 1s
     patches:
     - type: FromCompositeFieldPath
       fromFieldPath: spec

--- a/test/e2e/manifests/apiextensions/composition/validation/composition-valid.yaml
+++ b/test/e2e/manifests/apiextensions/composition/validation/composition-valid.yaml
@@ -21,7 +21,7 @@ spec:
           time: 0s
         - conditionType: Ready
           conditionStatus: "True"
-          time: 10s
+          time: 1s
     patches:
     - type: FromCompositeFieldPath
       fromFieldPath: spec.coolField

--- a/test/e2e/manifests/apiextensions/environment/default/setup/composition.yaml
+++ b/test/e2e/manifests/apiextensions/environment/default/setup/composition.yaml
@@ -30,7 +30,7 @@ spec:
                 time: 0s
               - conditionType: Ready
                 conditionStatus: "True"
-                time: 10s
+                time: 1s
       patches:
         - type: FromEnvironmentFieldPath
           fromFieldPath: complex.c.f

--- a/test/e2e/manifests/apiextensions/environment/multipleModeMaxMatch1/setup/composition.yaml
+++ b/test/e2e/manifests/apiextensions/environment/multipleModeMaxMatch1/setup/composition.yaml
@@ -33,7 +33,7 @@ spec:
                 time: 0s
               - conditionType: Ready
                 conditionStatus: "True"
-                time: 10s
+                time: 1s
       patches:
         - type: FromEnvironmentFieldPath
           fromFieldPath: complex.c.f

--- a/test/e2e/manifests/apiextensions/environment/multipleModeMaxMatchNil/setup/composition.yaml
+++ b/test/e2e/manifests/apiextensions/environment/multipleModeMaxMatchNil/setup/composition.yaml
@@ -32,7 +32,7 @@ spec:
                 time: 0s
               - conditionType: Ready
                 conditionStatus: "True"
-                time: 10s
+                time: 1s
       patches:
         - type: FromEnvironmentFieldPath
           fromFieldPath: complex.c.f

--- a/test/e2e/manifests/apiextensions/environment/resolutionOptional/setup/composition.yaml
+++ b/test/e2e/manifests/apiextensions/environment/resolutionOptional/setup/composition.yaml
@@ -24,7 +24,7 @@ spec:
         spec:
           forProvider:
             conditionAfter:
-              - time: 10s
+              - time: 1s
                 conditionType: Ready
                 conditionStatus: "True"
           providerConfigRef:

--- a/test/e2e/manifests/apiextensions/environment/resolveAlways/setup/composition.yaml
+++ b/test/e2e/manifests/apiextensions/environment/resolveAlways/setup/composition.yaml
@@ -30,7 +30,7 @@ spec:
         spec:
           forProvider:
             conditionAfter:
-              - time: 10s
+              - time: 1s
                 conditionType: Ready
                 conditionStatus: "True"
           providerConfigRef:

--- a/test/e2e/manifests/apiextensions/environment/resolveIfNotPresent/setup/composition.yaml
+++ b/test/e2e/manifests/apiextensions/environment/resolveIfNotPresent/setup/composition.yaml
@@ -32,7 +32,7 @@ spec:
                 time: 0s
               - conditionType: Ready
                 conditionStatus: "True"
-                time: 10s
+                time: 1s
       patches:
         - type: FromEnvironmentFieldPath
           fromFieldPath: complex.c.f

--- a/test/e2e/manifests/lifecycle/upgrade/setup/composition.yaml
+++ b/test/e2e/manifests/lifecycle/upgrade/setup/composition.yaml
@@ -19,4 +19,4 @@ spec:
           time: 0s
         - conditionType: Ready
           conditionStatus: "True"
-          time: 10s
+          time: 1s

--- a/test/e2e/manifests/pkg/provider/mr-initial.yaml
+++ b/test/e2e/manifests/pkg/provider/mr-initial.yaml
@@ -14,4 +14,4 @@ spec:
      time: 0s
    - conditionType: Ready
      conditionStatus: "True"
-     time: 10s
+     time: 1s

--- a/test/e2e/manifests/pkg/provider/mr-upgrade.yaml
+++ b/test/e2e/manifests/pkg/provider/mr-upgrade.yaml
@@ -16,4 +16,4 @@ spec:
    - conditionType: Ready
      conditionStatus: "True"
      conditionReason: "Available"
-     time: 10s
+     time: 1s


### PR DESCRIPTION
### Description of your changes

No useless wait time, faster polling and output of durations.

Note: this is still not good. We must parallelize. Serial e2e tests won't scale.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [ ] ~~Added or updated unit **and** E2E tests for my change.~~
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] ~~Added `backport release-x.y` labels to auto-backport this PR, if necessary.~~
- [ ] ~~Opened a PR updating the [docs], if necessary.~~

[contribution process]: https://git.io/fj2m9
[docs]: https://docs.crossplane.io/contribute/contribute