### PR TITLE
tests(e2e): related objects working also for claims

### DIFF
--- a/test/e2e/funcs/collect.go
+++ b/test/e2e/funcs/collect.go
@@ -97,6 +97,9 @@ func buildRelatedObjectGraph(ctx context.Context, discoveryClient discovery.Disc
 				// maybe this is an XR with resource reference to the claim? Fake owner refs.
 				comp := composite.Unstructured{Unstructured: obj}
 				refs = append(refs, comp.GetResourceReferences()...)
+				if ref := comp.GetClaimReference(); ref != nil {
+					refs = append(refs, *ref)
+				}
 
 				for _, ref := range refs {
 					group, version := parseAPIVersion(ref.APIVersion)


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does, and how it is covered by tests.
Be proactive - direct your reviewers' attention to anything that needs special
consideration.

You MUST either [x] check or ~strikethrough~ every item in the checklist below.

We love pull requests that fix an open issue. If yours does, use the below line
to indicate which issue it fixes, for example "Fixes #500".
-->

Follow up to #4594 taking into account claims, which not being set as owners of the XR resulted in empty related objects, as you can see [here](https://github.com/crossplane/crossplane/actions/runs/6420436732/job/17440618907?pr=4735#step:12:451).
 
I have:

- [x] Read and followed Crossplane's [contribution process].
- [ ] ~Added or updated unit **and** E2E tests for my change.~
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR, if necessary.~
- [ ] ~Opened a PR updating the [docs], if necessary.~

[contribution process]: https://git.io/fj2m9
[docs]: https://docs.crossplane.io/contribute/contribute
