### PR TITLE
feat: add readiness and liveness probes to crossplane

### DIFF
--- a/cluster/charts/crossplane/templates/deployment.yaml
+++ b/cluster/charts/crossplane/templates/deployment.yaml
@@ -123,9 +123,17 @@ spec:
         name: {{ .Chart.Name }}
         resources:
           {{- toYaml .Values.resourcesCrossplane | nindent 12 }}
-        {{- if or .Values.metrics.enabled (.Values.webhooks.enabled) }}
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: healthz
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: healthz
         ports:
-        {{- end }}
+        - name: healthz
+          containerPort: 5000
         {{- if .Values.metrics.enabled }}
         - name: metrics
           containerPort: 8080

--- a/cmd/crossplane/core/core.go
+++ b/cmd/crossplane/core/core.go
@@ -149,7 +149,7 @@ func (c *startCommand) Run(s *runtime.Scheme, log logging.Logger) error { //noli
 
 	cfg, err := ctrl.GetConfig()
 	if err != nil {
-		return errors.Wrap(err, "Cannot get config")
+		return errors.Wrap(err, "cannot get config")
 	}
 
 	cfg.WarningHandler = rest.NewWarningWriter(os.Stderr, rest.WarningWriterOptions{
@@ -193,7 +193,7 @@ func (c *startCommand) Run(s *runtime.Scheme, log logging.Logger) error { //noli
 		HealthProbeBindAddress: ":5000",
 	})
 	if err != nil {
-		return errors.Wrap(err, "Cannot create manager")
+		return errors.Wrap(err, "cannot create manager")
 	}
 
 	o := controller.Options{
@@ -253,7 +253,7 @@ func (c *startCommand) Run(s *runtime.Scheme, log logging.Logger) error { //noli
 			filepath.Join(c.TLSClientCertsDir, corev1.TLSPrivateKeyKey),
 			false)
 		if err != nil {
-			return errors.Wrap(err, "Cannot load TLS certificates for external secret stores")
+			return errors.Wrap(err, "cannot load TLS certificates for external secret stores")
 		}
 
 		o.ESSOptions = &controller.ESSOptions{
@@ -270,7 +270,7 @@ func (c *startCommand) Run(s *runtime.Scheme, log logging.Logger) error { //noli
 	}
 
 	if err := apiextensions.Setup(mgr, ao); err != nil {
-		return errors.Wrap(err, "Cannot setup API extension controllers")
+		return errors.Wrap(err, "cannot setup API extension controllers")
 	}
 
 	po := pkgcontroller.Options{
@@ -285,13 +285,13 @@ func (c *startCommand) Run(s *runtime.Scheme, log logging.Logger) error { //noli
 	if c.CABundlePath != "" {
 		rootCAs, err := ParseCertificatesFromPath(c.CABundlePath)
 		if err != nil {
-			return errors.Wrap(err, "Cannot parse CA bundle")
+			return errors.Wrap(err, "cannot parse CA bundle")
 		}
 		po.FetcherOptions = append(po.FetcherOptions, xpkg.WithCustomCA(rootCAs))
 	}
 
 	if err := pkg.Setup(mgr, po); err != nil {
-		return errors.Wrap(err, "Cannot add packages controllers to manager")
+		return errors.Wrap(err, "cannot add packages controllers to manager")
 	}
 
 	// Registering webhooks with the manager is what actually starts the webhook
@@ -301,23 +301,23 @@ func (c *startCommand) Run(s *runtime.Scheme, log logging.Logger) error { //noli
 		// fleshed out, implement a registration pattern similar to scheme
 		// registrations.
 		if err := xrd.SetupWebhookWithManager(mgr, o); err != nil {
-			return errors.Wrap(err, "Cannot setup webhook for compositeresourcedefinitions")
+			return errors.Wrap(err, "cannot setup webhook for compositeresourcedefinitions")
 		}
 		if err := composition.SetupWebhookWithManager(mgr, o); err != nil {
-			return errors.Wrap(err, "Cannot setup webhook for compositions")
+			return errors.Wrap(err, "cannot setup webhook for compositions")
 		}
 		if o.Features.Enabled(features.EnableAlphaUsages) {
 			if err := usage.SetupWebhookWithManager(mgr, o); err != nil {
-				return errors.Wrap(err, "Cannot setup webhook for usages")
+				return errors.Wrap(err, "cannot setup webhook for usages")
 			}
 		}
 	}
 
 	if err := c.SetupProbes(mgr); err != nil {
-		return errors.Wrap(err, "Cannot setup probes")
+		return errors.Wrap(err, "cannot setup probes")
 	}
 
-	return errors.Wrap(mgr.Start(ctrl.SetupSignalHandler()), "Cannot start controller manager")
+	return errors.Wrap(mgr.Start(ctrl.SetupSignalHandler()), "cannot start controller manager")
 }
 
 // SetupProbes sets up the health and ready probes.


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does, and how it is covered by tests.
Be proactive - direct your reviewers' attention to anything that needs special
consideration.

You MUST either [x] check or ~strikethrough~ every item in the checklist below.

We love pull requests that fix an open issue. If yours does, use the below line
to indicate which issue it fixes, for example "Fixes #500".
-->

Fixes part of E2E flakiness we are observing, avoiding Crossplane to be marked as Ready before the Webhook server is actually ready. If webhook is not enabled (`webhooks.enabled=false`) both probes are just set to the default no-op.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [ ] ~Added or updated unit **and** E2E tests for my change.~
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR, if necessary.~
- [ ] ~Opened a PR updating the [docs], if necessary.~

[contribution process]: https://git.io/fj2m9
[docs]: https://docs.crossplane.io/contribute/contribute
