### PR TITLE
tests(e2e): export kind logs on failure, enable audit logs and fail fast

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -302,7 +302,16 @@ jobs:
           BUILD_ARGS: "--load"
 
       - name: Run E2E Tests
-        run: make e2e E2E_TEST_FLAGS="-test.v --test-suite ${{ matrix.test-suite }}"
+        run: make e2e E2E_TEST_FLAGS="-test.v -test.failfast -fail-fast --kind-logs-location ./logs-kind --test-suite ${{ matrix.test-suite }}"
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v3
+        if: failure()
+        with:
+          name: e2e-kind-logs-${{ matrix.test-suite }}
+          path: ./logs-kind
+          if-no-files-found: error
+          retention-days: 7
 
   publish-artifacts:
     runs-on: ubuntu-22.04

--- a/test/e2e/config/environment.go
+++ b/test/e2e/config/environment.go
@@ -48,6 +48,7 @@ type Environment struct {
 	preinstallCrossplane  *bool
 	loadImagesKindCluster *bool
 	kindClusterName       *string
+	kindLogsLocation      *string
 
 	selectedTestSuite *selectedTestSuite
 
@@ -102,6 +103,7 @@ func NewEnvironmentFromFlags() Environment {
 		suites: map[string]testSuite{},
 	}
 	c.kindClusterName = flag.String("kind-cluster-name", "", "name of the kind cluster to use")
+	c.kindLogsLocation = flag.String("kind-logs-location", "", "destination of the the kind cluster logs on failure")
 	c.createKindCluster = flag.Bool("create-kind-cluster", true, "create a kind cluster (and deploy Crossplane) before running tests, if the cluster does not already exist with the same name")
 	c.destroyKindCluster = flag.Bool("destroy-kind-cluster", true, "destroy the kind cluster when tests complete")
 	c.preinstallCrossplane = flag.Bool("preinstall-crossplane", true, "install Crossplane before running tests")
@@ -141,6 +143,11 @@ func (e *Environment) GetKindClusterName() string {
 	return *e.kindClusterName
 }
 
+// GetKindClusterLogsLocation returns the location of the kind cluster logs.
+func (e *Environment) GetKindClusterLogsLocation() string {
+	return *e.kindLogsLocation
+}
+
 // SetEnvironment sets the environment to be used by the e2e test configuration.
 func (e *Environment) SetEnvironment(env env.Environment) {
 	e.Environment = env
@@ -149,6 +156,12 @@ func (e *Environment) SetEnvironment(env env.Environment) {
 // IsKindCluster returns true if the test is running against a kind cluster.
 func (e *Environment) IsKindCluster() bool {
 	return *e.createKindCluster || *e.kindClusterName != ""
+}
+
+// ShouldCollectKindLogsOnFailure returns true if the test should collect the kind
+// cluster logs on failure.
+func (e *Environment) ShouldCollectKindLogsOnFailure() bool {
+	return *e.kindLogsLocation != "" && e.IsKindCluster()
 }
 
 // ShouldLoadImages returns true if the test should load images into the kind

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -98,7 +98,11 @@ func TestMain(m *testing.M) {
 	var finish []env.Func
 
 	if environment.IsKindCluster() {
-		setup = []env.Func{envfuncs.CreateCluster(kind.NewProvider(), environment.GetKindClusterName())}
+		setup = append(setup, envfuncs.CreateClusterWithConfig(
+			kind.NewProvider(),
+			environment.GetKindClusterName(),
+			"./test/e2e/manifests/kind/kind-config.yaml",
+		))
 	} else {
 		cfg.WithKubeconfigFile(conf.ResolveKubeConfigFile())
 	}
@@ -131,10 +135,14 @@ func TestMain(m *testing.M) {
 	// We always want to add our types to the scheme.
 	setup = append(setup, funcs.AddCrossplaneTypesToScheme())
 
+	if environment.ShouldCollectKindLogsOnFailure() {
+		finish = append(finish, envfuncs.ExportClusterLogs(environment.GetKindClusterName(), environment.GetKindClusterLogsLocation()))
+	}
+
 	// We want to destroy the cluster if we created it, but only if we created it,
 	// otherwise the random name will be meaningless.
 	if environment.ShouldDestroyKindCluster() {
-		finish = []env.Func{envfuncs.DestroyCluster(environment.GetKindClusterName())}
+		finish = append(finish, envfuncs.DestroyCluster(environment.GetKindClusterName()))
 	}
 
 	// Check that all features are specifying a suite they belong to via LabelTestSuite.

--- a/test/e2e/manifests/kind/audit-policy.yaml
+++ b/test/e2e/manifests/kind/audit-policy.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: audit.k8s.io/v1
+kind: Policy
+rules:
+  - level: RequestResponse

--- a/test/e2e/manifests/kind/kind-config.yaml
+++ b/test/e2e/manifests/kind/kind-config.yaml
@@ -1,0 +1,30 @@
+---
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+  - role: control-plane
+    kubeadmConfigPatches:
+      - |
+        kind: ClusterConfiguration
+        apiServer:
+            # enable auditing flags on the API server
+            extraArgs:
+              audit-log-path: /var/log/kubernetes/kube-apiserver-audit.log
+              audit-policy-file: /etc/kubernetes/policies/audit-policy.yaml
+            # mount new files / directories on the control plane
+            extraVolumes:
+              - name: audit-policies
+                hostPath: /etc/kubernetes/policies
+                mountPath: /etc/kubernetes/policies
+                readOnly: true
+                pathType: "DirectoryOrCreate"
+              - name: "audit-logs"
+                hostPath: "/var/log/kubernetes"
+                mountPath: "/var/log/kubernetes"
+                readOnly: false
+                pathType: DirectoryOrCreate
+    # mount the local file on the control plane
+    extraMounts:
+      - hostPath: ./test/e2e/manifests/kind/audit-policy.yaml
+        containerPath: /etc/kubernetes/policies/audit-policy.yaml
+        readOnly: true


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does, and how it is covered by tests.
Be proactive - direct your reviewers' attention to anything that needs special
consideration.

You MUST either [x] check or ~strikethrough~ every item in the checklist below.

We love pull requests that fix an open issue. If yours does, use the below line
to indicate which issue it fixes, for example "Fixes #500".
-->

Improve visibility on E2E's failure by:
- uploading kind export logs on failure
- enabling full `RequestResponse` level [audit](https://kubernetes.io/docs/tasks/debug/debug-cluster/audit/#audit-policy) logs, which can be then read from the exported logs above to better investigate the failure.
- failing fast to reduce the run time on failing runs and reduce the noise on the produced logs,  using both the native Go tests `fail-fast` to avoid other test cases to run, but also the `e2e-framework` flag [fail-fast](https://github.com/kubernetes-sigs/e2e-framework/blob/main/examples/fail_fast/README.md) to avoid performing teardowns on failure to reduce noise and because they could fail given that not all assess might have run.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [ ] ~Added or updated unit **and** E2E tests for my change.~
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR, if necessary.~
- [ ] ~Opened a PR updating the [docs], if necessary.~

[contribution process]: https://git.io/fj2m9
[docs]: https://docs.crossplane.io/contribute/contribute
