### PR TITLE
Log events automatically

### DIFF
--- a/internal/controller/apiextensions/composite/reconciler.go
+++ b/internal/controller/apiextensions/composite/reconciler.go
@@ -467,7 +467,6 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 	// Check the pause annotation and return if it has the value "true"
 	// after logging, publishing an event and updating the SYNC status condition
 	if meta.IsPaused(xr) {
-		log.Debug("Reconciliation is paused via the pause annotation", "annotation", meta.AnnotationKeyReconciliationPaused, "value", "true")
 		r.record.Event(xr, event.Normal(reasonPaused, "Reconciliation is paused via the pause annotation"))
 		xr.SetConditions(xpv1.ReconcilePaused())
 		// If the pause annotation is removed, we will have a chance to reconcile again and resume
@@ -480,7 +479,6 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 
 		xr.SetConditions(xpv1.Deleting())
 		if err := r.composite.UnpublishConnection(ctx, xr, nil); err != nil {
-			log.Debug(errUnpublish, "error", err)
 			err = errors.Wrap(err, errUnpublish)
 			r.record.Event(xr, event.Warning(reasonDelete, err))
 			xr.SetConditions(xpv1.ReconcileError(err))
@@ -488,7 +486,6 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 		}
 
 		if err := r.composite.RemoveFinalizer(ctx, xr); err != nil {
-			log.Debug(errRemoveFinalizer, "error", err)
 			if kerrors.IsConflict(err) {
 				return reconcile.Result{Requeue: true}, nil
 			}
@@ -504,7 +501,6 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 	}
 
 	if err := r.composite.AddFinalizer(ctx, xr); err != nil {
-		log.Debug(errAddFinalizer, "error", err)
 		if kerrors.IsConflict(err) {
 			return reconcile.Result{Requeue: true}, nil
 		}
@@ -515,7 +511,6 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 	}
 
 	if err := r.composite.SelectCompositionUpdatePolicy(ctx, xr); err != nil {
-		log.Debug(errSelectCompUpdatePolicy, "error", err)
 		err = errors.Wrap(err, errSelectCompUpdatePolicy)
 		r.record.Event(xr, event.Warning(reasonResolve, err))
 		xr.SetConditions(xpv1.ReconcileError(err))
@@ -524,7 +519,6 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 
 	orig := xr.GetCompositionReference()
 	if err := r.composite.SelectComposition(ctx, xr); err != nil {
-		log.Debug(errSelectComp, "error", err)
 		err = errors.Wrap(err, errSelectComp)
 		r.record.Event(xr, event.Warning(reasonResolve, err))
 		xr.SetConditions(xpv1.ReconcileError(err))

--- a/internal/controller/apiextensions/definition/reconciler.go
+++ b/internal/controller/apiextensions/definition/reconciler.go
@@ -262,7 +262,6 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 
 	crd, err := r.composite.Render(d)
 	if err != nil {
-		log.Debug(errRenderCRD, "error", err)
 		err = errors.Wrap(err, errRenderCRD)
 		r.record.Event(d, event.Warning(reasonRenderCRD, err))
 		return reconcile.Result{}, err
@@ -281,7 +280,6 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 
 		nn := types.NamespacedName{Name: crd.GetName()}
 		if err := r.client.Get(ctx, nn, crd); resource.IgnoreNotFound(err) != nil {
-			log.Debug(errGetCRD, "error", err)
 			err = errors.Wrap(err, errGetCRD)
 			r.record.Event(d, event.Warning(reasonTerminateXR, err))
 			return reconcile.Result{}, err
@@ -300,11 +298,9 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 			// just in case. This is a no-op if the controller was
 			// already stopped.
 			r.composite.Stop(composite.ControllerName(d.GetName()))
-			log.Debug("Stopped composite resource controller")
 			r.record.Event(d, event.Normal(reasonTerminateXR, "Stopped composite resource controller"))
 
 			if err := r.composite.RemoveFinalizer(ctx, d); err != nil {
-				log.Debug(errRemoveFinalizer, "error", err)
 				if kerrors.IsConflict(err) {
 					return reconcile.Result{Requeue: true}, nil
 				}
@@ -328,7 +324,6 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 		o := &kunstructured.Unstructured{}
 		o.SetGroupVersionKind(d.GetCompositeGroupVersionKind())
 		if err := r.client.DeleteAllOf(ctx, o); err != nil && !kmeta.IsNoMatchError(err) && !kerrors.IsNotFound(err) {
-			log.Debug(errDeleteCRs, "error", err)
 			err = errors.Wrap(err, errDeleteCRs)
 			r.record.Event(d, event.Warning(reasonTerminateXR, err))
 			return reconcile.Result{}, err

--- a/internal/controller/rbac/definition/reconciler.go
+++ b/internal/controller/rbac/definition/reconciler.go
@@ -195,7 +195,6 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 			continue
 		}
 		if err != nil {
-			log.Debug(errApplyRole, "error", err)
 			if kerrors.IsConflict(err) {
 				return reconcile.Result{Requeue: true}, nil
 			}

--- a/internal/controller/rbac/namespace/reconciler.go
+++ b/internal/controller/rbac/namespace/reconciler.go
@@ -189,7 +189,6 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 	// https://github.com/kubernetes-sigs/controller-runtime/blob/d6829e9/pkg/cache/internal/cache_reader.go#L131
 	l := &rbacv1.ClusterRoleList{}
 	if err := r.client.List(ctx, l); err != nil {
-		log.Debug(errListRoles, "error", err)
 		if kerrors.IsConflict(err) {
 			return reconcile.Result{Requeue: true}, nil
 		}
@@ -209,7 +208,6 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 			continue
 		}
 		if err != nil {
-			log.Debug(errApplyRole, "error", err)
 			if kerrors.IsConflict(err) {
 				return reconcile.Result{Requeue: true}, nil
 			}

--- a/internal/controller/rbac/provider/binding/reconciler.go
+++ b/internal/controller/rbac/provider/binding/reconciler.go
@@ -165,7 +165,6 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 
 	l := &corev1.ServiceAccountList{}
 	if err := r.client.List(ctx, l); err != nil {
-		log.Debug(errListSAs, "error", err)
 		err = errors.Wrap(err, errListSAs)
 		r.record.Event(pr, event.Warning(reasonBind, err))
 		return reconcile.Result{}, err
@@ -216,7 +215,6 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 		return reconcile.Result{}, nil
 	}
 	if err != nil {
-		log.Debug(errApplyBinding, "error", err)
 		if kerrors.IsConflict(err) {
 			return reconcile.Result{Requeue: true}, nil
 		}
@@ -226,7 +224,6 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 	}
 
 	r.record.Event(pr, event.Normal(reasonBind, fmt.Sprintf("Bound system ClusterRole %q to provider ServiceAccount(s): %s", n, strings.Join(subjectStrings, ", "))))
-	log.Debug("Applied system ClusterRoleBinding")
 
 	// There's no need to requeue explicitly - we're watching all PRs.
 	return reconcile.Result{Requeue: false}, nil

--- a/internal/controller/rbac/provider/roles/reconciler.go
+++ b/internal/controller/rbac/provider/roles/reconciler.go
@@ -271,7 +271,6 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 		// TODO(negz): Get active revisions in family.
 		prs := &v1.ProviderRevisionList{}
 		if err := r.client.List(ctx, prs, client.MatchingLabels{v1.LabelProviderFamily: family}); err != nil {
-			log.Debug(errListPRs, "error", err)
 			if kerrors.IsConflict(err) {
 				return reconcile.Result{Requeue: true}, nil
 			}
@@ -306,14 +305,12 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 
 	rejected, err := r.rbac.ValidatePermissionRequests(ctx, pr.Status.PermissionRequests...)
 	if err != nil {
-		log.Debug(errValidatePermissions, "error", err)
 		err = errors.Wrap(err, errValidatePermissions)
 		r.record.Event(pr, event.Warning(reasonApplyRoles, err))
 		return reconcile.Result{}, err
 	}
 
 	for _, rule := range rejected {
-		log.Debug(errRejectedPermission, "rule", rule)
 		r.record.Event(pr, event.Warning(reasonApplyRoles, errors.Errorf("%s %s", errRejectedPermission, rule)))
 	}
 
@@ -342,7 +339,6 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 			continue
 		}
 		if err != nil {
-			log.Debug(errApplyRole, "error", err)
 			if kerrors.IsConflict(err) {
 				return reconcile.Result{Requeue: true}, nil
 			}


### PR DESCRIPTION
### Description of your changes

To corrolate events and other log output easily, it's very helpful to log events too:

```
2023-10-09T10:54:16Z	INFO	crossplane	Event(v1.ObjectReference{Kind:"CompositeResourceDefinition", Namespace:"", Name:"xnopresources.nop.example.org", UID:"1a0324d0-f55e-4741-ba45-8384ddd3b971", APIVersion:"apiextensions.crossplane.io/v1", ResourceVersion:"911", FieldPath:""}): type: 'Normal' reason: 'RedactClaim' Stopped composite resource claim controller
```

With this we can also get rid of many logs that we manually create when an event is created in parallel.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [ ] ~~Added or updated unit **and** E2E tests for my change.~~
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] ~~Added `backport release-x.y` labels to auto-backport this PR, if necessary.~~
- [ ] ~~Opened a PR updating the [docs], if necessary.~~

[contribution process]: https://git.io/fj2m9
[docs]: https://docs.crossplane.io/contribute/contribute