### PR TITLE
fix(test/e2e/readme) `-installcrossplane` option is actually `-preinstallcrossplane`

### DIFF
--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -55,7 +55,7 @@ E2E_TEST_FLAGS="-create-kind-cluster=false -destroy-kind-cluster=false -kubeconf
 E2E_TEST_FLAGS="-test.v -v 4 -test.failfast \
   -destroy-kind-cluster=false \
   -kind-cluster-name=kind \
-  -install-crossplane=false \
+  -preinstall-crossplane=false \
   -feature=CrossplaneUpgrade" make e2e
 
 # Run all the tests not installing or upgrading Crossplane against the currently
@@ -64,7 +64,7 @@ E2E_TEST_FLAGS="-test.v -v 4 -test.failfast \
   -kubeconfig=$HOME/.kube/config \
   -skip-labels modify-crossplane-installation=true \
   -create-kind-cluster=false \
-  -install-crossplane=false" make go.build e2e-run-tests
+  -preinstall-crossplane=false" make go.build e2e-run-tests
 
 # Run the composition-webhook-schema-validation suite of tests, which will
 # result in all tests marked as "test-suite=base" or


### PR DESCRIPTION
End-to-end test readme refers non-existing `-installcrossplane` option. Its name is `-preinstallcrossplane`

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Added or updated unit **and** E2E tests for my change.
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR, if necessary.
- [x] Opened a PR updating the [docs], if necessary.

[contribution process]: https://git.io/fj2m9
[docs]: https://docs.crossplane.io/contribute/contribute