### PR TITLE
fix: just requeue all conflict errors

### DIFF
--- a/cmd/crank/install.go
+++ b/cmd/crank/install.go
@@ -26,7 +26,7 @@ import (
 	"github.com/alecthomas/kong"
 	"github.com/google/go-containerregistry/pkg/name"
 	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/client-go/tools/cache"
@@ -265,7 +265,7 @@ func (c *installProviderCmd) Run(k *kong.Context, logger logging.Logger) error {
 }
 
 func warnIfNotFound(err error) error {
-	serr, ok := err.(*apierrors.StatusError) //nolint:errorlint // we need to be able to extract the underlying typed error
+	serr, ok := err.(*kerrors.StatusError) //nolint:errorlint // we need to be able to extract the underlying typed error
 	if !ok {
 		return err
 	}

--- a/internal/controller/rbac/definition/reconciler.go
+++ b/internal/controller/rbac/definition/reconciler.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	rbacv1 "k8s.io/api/rbac/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -195,6 +196,9 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 		}
 		if err != nil {
 			log.Debug(errApplyRole, "error", err)
+			if kerrors.IsConflict(err) {
+				return reconcile.Result{Requeue: true}, nil
+			}
 			err = errors.Wrap(err, errApplyRole)
 			r.record.Event(d, event.Warning(reasonApplyRoles, err))
 			return reconcile.Result{}, err

--- a/internal/controller/rbac/namespace/reconciler.go
+++ b/internal/controller/rbac/namespace/reconciler.go
@@ -26,6 +26,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -189,6 +190,9 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 	l := &rbacv1.ClusterRoleList{}
 	if err := r.client.List(ctx, l); err != nil {
 		log.Debug(errListRoles, "error", err)
+		if kerrors.IsConflict(err) {
+			return reconcile.Result{Requeue: true}, nil
+		}
 		err = errors.Wrap(err, errListRoles)
 		r.record.Event(ns, event.Warning(reasonApplyRoles, err))
 		return reconcile.Result{}, err
@@ -206,6 +210,9 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 		}
 		if err != nil {
 			log.Debug(errApplyRole, "error", err)
+			if kerrors.IsConflict(err) {
+				return reconcile.Result{Requeue: true}, nil
+			}
 			err = errors.Wrap(err, errApplyRole)
 			r.record.Event(ns, event.Warning(reasonApplyRoles, err))
 			return reconcile.Result{}, err

--- a/internal/controller/rbac/provider/binding/reconciler.go
+++ b/internal/controller/rbac/provider/binding/reconciler.go
@@ -26,6 +26,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -216,6 +217,9 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 	}
 	if err != nil {
 		log.Debug(errApplyBinding, "error", err)
+		if kerrors.IsConflict(err) {
+			return reconcile.Result{Requeue: true}, nil
+		}
 		err = errors.Wrap(err, errApplyBinding)
 		r.record.Event(pr, event.Warning(reasonBind, err))
 		return reconcile.Result{}, err

--- a/internal/validation/apiextensions/v1/composition/handler.go
+++ b/internal/validation/apiextensions/v1/composition/handler.go
@@ -23,7 +23,7 @@ import (
 
 	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
 	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -88,7 +88,7 @@ func (v *validator) ValidateCreate(ctx context.Context, obj runtime.Object) (adm
 	// Validate the composition itself, we'll disable it on the Validator below.
 	warns, validationErrs := comp.Validate()
 	if len(validationErrs) != 0 {
-		return warns, apierrors.NewInvalid(comp.GroupVersionKind().GroupKind(), comp.GetName(), validationErrs)
+		return warns, kerrors.NewInvalid(comp.GroupVersionKind().GroupKind(), comp.GetName(), validationErrs)
 	}
 
 	if !v.options.Features.Enabled(features.EnableAlphaCompositionWebhookSchemaValidation) {
@@ -129,12 +129,12 @@ func (v *validator) ValidateCreate(ctx context.Context, obj runtime.Object) (adm
 		composition.WithoutLogicalValidation(),
 	)
 	if err != nil {
-		return warns, apierrors.NewInternalError(err)
+		return warns, kerrors.NewInternalError(err)
 	}
 	schemaWarns, errList := cv.Validate(ctx, comp)
 	warns = append(warns, schemaWarns...)
 	if len(errList) != 0 {
-		return warns, apierrors.NewInvalid(comp.GroupVersionKind().GroupKind(), comp.GetName(), errList)
+		return warns, kerrors.NewInvalid(comp.GroupVersionKind().GroupKind(), comp.GetName(), errList)
 	}
 	return warns, nil
 }
@@ -153,7 +153,7 @@ func (v *validator) ValidateDelete(_ context.Context, _ runtime.Object) (admissi
 // any error other than a not found error.
 func containsOtherThanNotFound(errs []error) bool {
 	for _, err := range errs {
-		if !apierrors.IsNotFound(err) {
+		if !kerrors.IsNotFound(err) {
 			return true
 		}
 	}
@@ -172,7 +172,7 @@ func (v *validator) getNeededCRDs(ctx context.Context, comp *v1.Composition) (ma
 
 	compositeCRD, err := v.getCRD(ctx, &compositeResGK)
 	if err != nil {
-		if !apierrors.IsNotFound(err) {
+		if !kerrors.IsNotFound(err) {
 			return nil, []error{err}
 		}
 		resultErrs = append(resultErrs, err)
@@ -192,7 +192,7 @@ func (v *validator) getNeededCRDs(ctx context.Context, comp *v1.Composition) (ma
 		gk := gvk.GroupKind()
 		crd, err := v.getCRD(ctx, &gk)
 		switch {
-		case apierrors.IsNotFound(err):
+		case kerrors.IsNotFound(err):
 			resultErrs = append(resultErrs, err)
 		case err != nil:
 			return nil, []error{err}
@@ -213,13 +213,13 @@ func (v *validator) getCRD(ctx context.Context, gk *schema.GroupKind) (*apiexten
 	}
 	switch {
 	case len(crds.Items) == 0:
-		return nil, apierrors.NewNotFound(schema.GroupResource{Group: "apiextensions.k8s.io", Resource: "CustomResourceDefinition"}, fmt.Sprintf("%s.%s", gk.Kind, gk.Group))
+		return nil, kerrors.NewNotFound(schema.GroupResource{Group: "apiextensions.k8s.io", Resource: "CustomResourceDefinition"}, fmt.Sprintf("%s.%s", gk.Kind, gk.Group))
 	case len(crds.Items) > 1:
 		names := []string{}
 		for _, crd := range crds.Items {
 			names = append(names, crd.Name)
 		}
-		return nil, apierrors.NewInternalError(errors.Errorf(errFmtTooManyCRDs, gk.Kind, gk.Group, names))
+		return nil, kerrors.NewInternalError(errors.Errorf(errFmtTooManyCRDs, gk.Kind, gk.Group, names))
 	}
 	crd := crds.Items[0]
 	internal := &apiextensions.CustomResourceDefinition{}

--- a/internal/validation/apiextensions/v1/xrd/handler.go
+++ b/internal/validation/apiextensions/v1/xrd/handler.go
@@ -23,7 +23,7 @@ import (
 	"fmt"
 
 	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -151,7 +151,7 @@ func (v *validator) dryRunUpdateOrCreateIfNotFound(ctx context.Context, crd *api
 		got.Spec = crd.Spec
 		return v.client.Update(ctx, got, client.DryRunAll)
 	}
-	if apierrors.IsNotFound(err) {
+	if kerrors.IsNotFound(err) {
 		return v.client.Create(ctx, crd, client.DryRunAll)
 	}
 	return err
@@ -169,7 +169,7 @@ func (v *validator) rewriteError(err error, in *v1.CompositeResourceDefinition, 
 	if err == nil {
 		return nil
 	}
-	var apiErr *apierrors.StatusError
+	var apiErr *kerrors.StatusError
 	if errors.As(err, &apiErr) {
 		apiErr.ErrStatus.Message = "invalid CRD generated for CompositeResourceDefinition: " + apiErr.ErrStatus.Message
 		apiErr.ErrStatus.Details.Kind = v1.CompositeResourceDefinitionKind

--- a/internal/validation/apiextensions/v1/xrd/handler_test.go
+++ b/internal/validation/apiextensions/v1/xrd/handler_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/validation/field"
@@ -76,7 +76,7 @@ func TestValidateUpdate(t *testing.T) {
 					},
 				},
 				client: &test.MockClient{
-					MockGet:    test.NewMockGetFn(apierrors.NewNotFound(schema.GroupResource{}, "")),
+					MockGet:    test.NewMockGetFn(kerrors.NewNotFound(schema.GroupResource{}, "")),
 					MockCreate: test.NewMockCreateFn(nil),
 				},
 			},
@@ -116,7 +116,7 @@ func TestValidateUpdate(t *testing.T) {
 					},
 				},
 				client: &test.MockClient{
-					MockGet:    test.NewMockGetFn(apierrors.NewNotFound(schema.GroupResource{}, "")),
+					MockGet:    test.NewMockGetFn(kerrors.NewNotFound(schema.GroupResource{}, "")),
 					MockCreate: test.NewMockCreateFn(nil),
 				},
 			},
@@ -264,7 +264,7 @@ func TestValidateUpdate(t *testing.T) {
 					},
 				},
 				client: &test.MockClient{
-					MockGet: test.NewMockGetFn(apierrors.NewNotFound(schema.GroupResource{}, "")),
+					MockGet: test.NewMockGetFn(kerrors.NewNotFound(schema.GroupResource{}, "")),
 					MockCreate: test.NewMockCreateFn(nil, func(obj client.Object) error {
 						p, err := fieldpath.PaveObject(obj)
 						if err != nil {
@@ -372,7 +372,7 @@ func TestValidateUpdate(t *testing.T) {
 					},
 				},
 				client: &test.MockClient{
-					MockGet: test.NewMockGetFn(apierrors.NewNotFound(schema.GroupResource{}, "")),
+					MockGet: test.NewMockGetFn(kerrors.NewNotFound(schema.GroupResource{}, "")),
 					MockCreate: test.NewMockCreateFn(nil, func(obj client.Object) error {
 						p, err := fieldpath.PaveObject(obj)
 						if err != nil {
@@ -486,7 +486,7 @@ func TestValidateCreate(t *testing.T) {
 					},
 				},
 				client: &test.MockClient{
-					MockGet:    test.NewMockGetFn(apierrors.NewNotFound(schema.GroupResource{}, "")),
+					MockGet:    test.NewMockGetFn(kerrors.NewNotFound(schema.GroupResource{}, "")),
 					MockCreate: test.NewMockCreateFn(nil),
 				},
 			},
@@ -510,7 +510,7 @@ func TestValidateCreate(t *testing.T) {
 					},
 				},
 				client: &test.MockClient{
-					MockGet:    test.NewMockGetFn(apierrors.NewNotFound(schema.GroupResource{}, "")),
+					MockGet:    test.NewMockGetFn(kerrors.NewNotFound(schema.GroupResource{}, "")),
 					MockCreate: test.NewMockCreateFn(nil),
 				},
 			},
@@ -534,7 +534,7 @@ func TestValidateCreate(t *testing.T) {
 					},
 				},
 				client: &test.MockClient{
-					MockGet: test.NewMockGetFn(apierrors.NewNotFound(schema.GroupResource{}, "")),
+					MockGet: test.NewMockGetFn(kerrors.NewNotFound(schema.GroupResource{}, "")),
 					MockCreate: test.NewMockCreateFn(nil, func(obj client.Object) error {
 						p, err := fieldpath.PaveObject(obj)
 						if err != nil {
@@ -572,7 +572,7 @@ func TestValidateCreate(t *testing.T) {
 					},
 				},
 				client: &test.MockClient{
-					MockGet: test.NewMockGetFn(apierrors.NewNotFound(schema.GroupResource{}, "")),
+					MockGet: test.NewMockGetFn(kerrors.NewNotFound(schema.GroupResource{}, "")),
 					MockCreate: test.NewMockCreateFn(nil, func(obj client.Object) error {
 						p, err := fieldpath.PaveObject(obj)
 						if err != nil {

--- a/pkg/validation/apiextensions/v1/composition/validator.go
+++ b/pkg/validation/apiextensions/v1/composition/validator.go
@@ -20,7 +20,7 @@ import (
 	"context"
 
 	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/validation/field"
@@ -87,7 +87,7 @@ func (c crdGetterMap) Get(_ context.Context, gk schema.GroupKind) (*apiextension
 	if crd, ok := c[gk]; ok {
 		return &crd, nil
 	}
-	return nil, apierrors.NewNotFound(schema.GroupResource{Group: gk.Group, Resource: "CustomResourceDefinition"}, gk.String())
+	return nil, kerrors.NewNotFound(schema.GroupResource{Group: gk.Group, Resource: "CustomResourceDefinition"}, gk.String())
 }
 
 func (c crdGetterMap) GetAll(_ context.Context) (map[schema.GroupKind]apiextensions.CustomResourceDefinition, error) {


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does, and how it is covered by tests.
Be proactive - direct your reviewers' attention to anything that needs special
consideration.

You MUST either [x] check or ~strikethrough~ every item in the checklist below.

We love pull requests that fix an open issue. If yours does, use the below line
to indicate which issue it fixes, for example "Fixes #500".
-->

Fixes https://github.com/crossplane/crossplane/issues/2114.

I went through all the Reconcilers looking at all the places we were emitting warning events on errors and checked whether the error could come from an update of a resource, if so added a check similar to what we already did for https://github.com/crossplane/crossplane-runtime/pull/540.

Took the chance to rename all aliased imports from "apierrors" to "kerrors" as the latter was the prevalent name on master already.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [ ] ~Added or updated unit **and** E2E tests for my change.~
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR, if necessary.~
- [ ] ~Opened a PR updating the [docs], if necessary.~

[contribution process]: https://git.io/fj2m9
[docs]: https://docs.crossplane.io/contribute/contribute
