### PR TITLE
chore(ci): set action to use semantic version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -320,7 +320,7 @@ jobs:
 
     steps:
       - name: Cleanup Disk
-        uses: jlumbroso/free-disk-space@main
+        uses: jlumbroso/free-disk-space@v1.3.0
         with:
           android: true
           dotnet: true


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does, and how it is covered by tests.
Be proactive - direct your reviewers' attention to anything that needs special
consideration.

You MUST either [x] check or ~strikethrough~ every item in the checklist below.

We love pull requests that fix an open issue. If yours does, use the below line
to indicate which issue it fixes, for example "Fixes #500".
-->

As pointed out by @MisterMX https://github.com/crossplane/crossplane/pull/4394#discussion_r1351954629, we were still using the `jlumbroso/free-disk-spac` gh action from `main` instead of a proper semantic version. I was expecting renovate to propose a change after merging the original PR, but it didn't happen because renovate was not able to recognise the `main` tag as a version and therefore refused to bump it. Setting it to the latest [v1.3.0](https://github.com/jlumbroso/free-disk-space/releases), renovate will take care of adding the exact digest later on.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [ ] ~Added or updated unit **and** E2E tests for my change.~
- [ ] ~Run `make reviewable` to ensure this PR is ready for review.~
- [x] Added `backport release-x.y` labels to auto-backport this PR, if necessary.
- [ ] ~Opened a PR updating the [docs], if necessary.~

[contribution process]: https://git.io/fj2m9
[docs]: https://docs.crossplane.io/contribute/contribute
