### PR TITLE
k8s API sets the default value of claim's `spec.compositeDeletePolicy` field

### DIFF
--- a/internal/controller/apiextensions/claim/api.go
+++ b/internal/controller/apiextensions/claim/api.go
@@ -28,11 +28,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/crossplane/crossplane-runtime/pkg/errors"
-	"github.com/crossplane/crossplane-runtime/pkg/event"
 	"github.com/crossplane/crossplane-runtime/pkg/meta"
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
-
-	v1 "github.com/crossplane/crossplane/apis/apiextensions/v1"
 )
 
 // Error strings.
@@ -43,8 +40,6 @@ const (
 	errGetXRD               = "cannot get composite resource definition"
 	errSecretConflict       = "cannot establish control of existing connection secret"
 	errCreateOrUpdateSecret = "cannot create or update connection secret"
-
-	reasonCompositeDeletePolicy event.Reason = "CompositeDeletePolicy"
 )
 
 // An APIBinder binds claims to composites by updating them in a Kubernetes API
@@ -136,32 +131,4 @@ func (a *APIConnectionPropagator) PropagateConnection(ctx context.Context, to re
 	}
 
 	return true, nil
-}
-
-// NewAPIDefaultSelector returns a APIDefaultSelector.
-func NewAPIDefaultSelector(c client.Client, ref corev1.ObjectReference, r event.Recorder) *APIDefaultSelector {
-	return &APIDefaultSelector{client: c, defRef: ref, recorder: r}
-}
-
-// APIDefaultSelector selects the default composite delete policy referenced in
-// the definition of the resource if the policy is not specified in the claim.
-type APIDefaultSelector struct {
-	client   client.Client
-	defRef   corev1.ObjectReference
-	recorder event.Recorder
-}
-
-// SelectDefaults selects the default composite delete policy if a policy is not
-// given in the Claim.
-func (s *APIDefaultSelector) SelectDefaults(ctx context.Context, cm resource.CompositeClaim) error {
-	if cm.GetCompositeDeletePolicy() != nil {
-		return nil
-	}
-	def := &v1.CompositeResourceDefinition{}
-	if err := s.client.Get(ctx, meta.NamespacedNameOf(&s.defRef), def); err != nil {
-		return errors.Wrap(err, errGetXRD)
-	}
-	cm.SetCompositeDeletePolicy(def.Spec.DefaultCompositeDeletePolicy)
-	s.recorder.Event(cm, event.Normal(reasonCompositeDeletePolicy, "Default composite delete policy has been selected"))
-	return nil
 }

--- a/internal/controller/apiextensions/claim/api_test.go
+++ b/internal/controller/apiextensions/claim/api_test.go
@@ -29,12 +29,9 @@ import (
 
 	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
 	"github.com/crossplane/crossplane-runtime/pkg/errors"
-	"github.com/crossplane/crossplane-runtime/pkg/event"
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
 	"github.com/crossplane/crossplane-runtime/pkg/resource/fake"
 	"github.com/crossplane/crossplane-runtime/pkg/test"
-
-	"github.com/crossplane/crossplane/apis/apiextensions/v1"
 )
 
 var (
@@ -342,84 +339,6 @@ func TestPropagateConnection(t *testing.T) {
 			api := &APIConnectionPropagator{client: tc.fields.client}
 			got, err := api.PropagateConnection(tc.args.ctx, tc.args.to, tc.args.from)
 			if diff := cmp.Diff(tc.want.propagated, got); diff != "" {
-				t.Errorf("\n%s\napi.PropagateConnection(...): -want, +got:\n%s", tc.reason, diff)
-			}
-			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
-				t.Errorf("\n%s\napi.PropagateConnection(...): -want error, +got error:\n%s", tc.reason, diff)
-			}
-		})
-	}
-}
-
-func TestAPIDefaultsSelector(t *testing.T) {
-	errBoom := errors.New("boom")
-	b := xpv1.CompositeDeleteBackground
-	f := xpv1.CompositeDeleteForeground
-	type args struct {
-		kube   client.Client
-		defRef corev1.ObjectReference
-		cm     resource.CompositeClaim
-	}
-	type want struct {
-		cm  resource.CompositeClaim
-		err error
-	}
-
-	cases := map[string]struct {
-		reason string
-		args   args
-		want   want
-	}{
-		"AlreadyResolved": {
-			reason: "Should be no-op if a composite delete policy is already specified",
-			args: args{
-				defRef: corev1.ObjectReference{},
-				cm: &fake.CompositeClaim{
-					CompositeResourceDeleter: fake.CompositeResourceDeleter{Policy: &b},
-				},
-			},
-			want: want{
-				cm: &fake.CompositeClaim{
-					CompositeResourceDeleter: fake.CompositeResourceDeleter{Policy: &b},
-				},
-			},
-		},
-		"GetDefinitionFailed": {
-			reason: "Should return error if XRD cannot be retrieved",
-			args: args{
-				kube: &test.MockClient{
-					MockGet: test.NewMockGetFn(errBoom),
-				},
-				cm: &fake.CompositeClaim{},
-			},
-			want: want{
-				err: errors.Wrap(errBoom, errGetXRD),
-				cm:  &fake.CompositeClaim{},
-			},
-		},
-		"Success": {
-			reason: "Successfully set the default composition update policy",
-			args: args{
-				kube: &test.MockClient{
-					MockGet: func(_ context.Context, _ client.ObjectKey, obj client.Object) error {
-						*obj.(*v1.CompositeResourceDefinition) = v1.CompositeResourceDefinition{Spec: v1.CompositeResourceDefinitionSpec{DefaultCompositeDeletePolicy: &f}}
-						return nil
-					}},
-				cm: &fake.CompositeClaim{},
-			},
-			want: want{
-				cm: &fake.CompositeClaim{
-					CompositeResourceDeleter: fake.CompositeResourceDeleter{Policy: &f},
-				},
-			},
-		},
-	}
-
-	for name, tc := range cases {
-		t.Run(name, func(t *testing.T) {
-			api := &APIDefaultSelector{tc.args.kube, tc.args.defRef, event.NewNopRecorder()}
-			err := api.SelectDefaults(context.Background(), tc.args.cm)
-			if diff := cmp.Diff(tc.want.cm, tc.args.cm); diff != "" {
 				t.Errorf("\n%s\napi.PropagateConnection(...): -want, +got:\n%s", tc.reason, diff)
 			}
 			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {

--- a/internal/controller/apiextensions/claim/reconciler_test.go
+++ b/internal/controller/apiextensions/claim/reconciler_test.go
@@ -393,28 +393,6 @@ func TestReconcile(t *testing.T) {
 				r: reconcile.Result{Requeue: true},
 			},
 		},
-		"SelectDefaultsError": {
-			reason: "We should return any error we encounter selecting the claim defaults",
-			args: args{
-				mgr: &fake.Manager{},
-				opts: []ReconcilerOption{
-					WithClaimFinalizer(resource.FinalizerFns{
-						AddFinalizerFn: func(ctx context.Context, obj resource.Object) error { return nil },
-					}),
-					WithDefaultsSelector(DefaultsSelectorFn(func(ctx context.Context, cm resource.CompositeClaim) error { return errBoom })),
-				},
-				claim: withClaim(func(o *claim.Unstructured) {
-					o.SetResourceReference(&corev1.ObjectReference{})
-				}),
-			},
-			want: want{
-				claim: withClaim(func(o *claim.Unstructured) {
-					o.SetResourceReference(&corev1.ObjectReference{})
-					o.SetConditions(xpv1.ReconcileError(errors.Wrap(errBoom, errSelectDefaults)))
-				}),
-				r: reconcile.Result{Requeue: true},
-			},
-		},
 
 		"ConfigureError": {
 			reason: "We should return any error we encounter configuring the composite resource",
@@ -425,7 +403,6 @@ func TestReconcile(t *testing.T) {
 						AddFinalizerFn: func(ctx context.Context, obj resource.Object) error { return nil },
 					}),
 					WithCompositeConfigurator(ConfiguratorFn(func(ctx context.Context, cm resource.CompositeClaim, cp resource.Composite) error { return errBoom })),
-					WithDefaultsSelector(DefaultsSelectorFn(func(ctx context.Context, cm resource.CompositeClaim) error { return nil })),
 				},
 				claim: withClaim(func(o *claim.Unstructured) {
 					o.SetResourceReference(&corev1.ObjectReference{})
@@ -454,7 +431,6 @@ func TestReconcile(t *testing.T) {
 					}),
 					WithCompositeConfigurator(ConfiguratorFn(func(ctx context.Context, cm resource.CompositeClaim, cp resource.Composite) error { return nil })),
 					WithBinder(BinderFn(func(ctx context.Context, cm resource.CompositeClaim, cp resource.Composite) error { return errBoom })),
-					WithDefaultsSelector(DefaultsSelectorFn(func(ctx context.Context, cm resource.CompositeClaim) error { return nil })),
 				},
 				claim: withClaim(func(o *claim.Unstructured) {
 					o.SetResourceReference(&corev1.ObjectReference{})
@@ -483,7 +459,6 @@ func TestReconcile(t *testing.T) {
 					}),
 					WithCompositeConfigurator(ConfiguratorFn(func(ctx context.Context, cm resource.CompositeClaim, cp resource.Composite) error { return nil })),
 					WithBinder(BinderFn(func(ctx context.Context, cm resource.CompositeClaim, cp resource.Composite) error { return nil })),
-					WithDefaultsSelector(DefaultsSelectorFn(func(ctx context.Context, cm resource.CompositeClaim) error { return nil })),
 				},
 				claim: withClaim(func(o *claim.Unstructured) {
 					o.SetResourceReference(&corev1.ObjectReference{})
@@ -516,7 +491,6 @@ func TestReconcile(t *testing.T) {
 					WithCompositeConfigurator(ConfiguratorFn(func(ctx context.Context, cm resource.CompositeClaim, cp resource.Composite) error { return nil })),
 					WithBinder(BinderFn(func(ctx context.Context, cm resource.CompositeClaim, cp resource.Composite) error { return nil })),
 					WithClaimConfigurator(ConfiguratorFn(func(ctx context.Context, cm resource.CompositeClaim, cp resource.Composite) error { return errBoom })),
-					WithDefaultsSelector(DefaultsSelectorFn(func(ctx context.Context, cm resource.CompositeClaim) error { return nil })),
 				},
 				claim: withClaim(func(o *claim.Unstructured) {
 					o.SetResourceReference(&corev1.ObjectReference{})
@@ -549,7 +523,6 @@ func TestReconcile(t *testing.T) {
 					WithCompositeConfigurator(ConfiguratorFn(func(ctx context.Context, cm resource.CompositeClaim, cp resource.Composite) error { return nil })),
 					WithBinder(BinderFn(func(ctx context.Context, cm resource.CompositeClaim, cp resource.Composite) error { return nil })),
 					WithClaimConfigurator(ConfiguratorFn(func(ctx context.Context, cm resource.CompositeClaim, cp resource.Composite) error { return nil })),
-					WithDefaultsSelector(DefaultsSelectorFn(func(ctx context.Context, cm resource.CompositeClaim) error { return nil })),
 				},
 				claim: withClaim(func(o *claim.Unstructured) {
 					o.SetResourceReference(&corev1.ObjectReference{})
@@ -591,7 +564,6 @@ func TestReconcile(t *testing.T) {
 					WithConnectionPropagator(ConnectionPropagatorFn(func(ctx context.Context, to resource.LocalConnectionSecretOwner, from resource.ConnectionSecretOwner) (propagated bool, err error) {
 						return false, errBoom
 					})),
-					WithDefaultsSelector(DefaultsSelectorFn(func(ctx context.Context, cm resource.CompositeClaim) error { return nil })),
 				},
 				claim: withClaim(func(o *claim.Unstructured) {
 					o.SetResourceReference(&corev1.ObjectReference{})
@@ -633,7 +605,6 @@ func TestReconcile(t *testing.T) {
 					WithConnectionPropagator(ConnectionPropagatorFn(func(ctx context.Context, to resource.LocalConnectionSecretOwner, from resource.ConnectionSecretOwner) (propagated bool, err error) {
 						return true, nil
 					})),
-					WithDefaultsSelector(DefaultsSelectorFn(func(ctx context.Context, cm resource.CompositeClaim) error { return nil })),
 				},
 				claim: withClaim(func(o *claim.Unstructured) {
 					o.SetResourceReference(&corev1.ObjectReference{})
@@ -714,7 +685,6 @@ func TestReconcile(t *testing.T) {
 					WithConnectionPropagator(ConnectionPropagatorFn(func(ctx context.Context, to resource.LocalConnectionSecretOwner, from resource.ConnectionSecretOwner) (propagated bool, err error) {
 						return true, nil
 					})),
-					WithDefaultsSelector(DefaultsSelectorFn(func(ctx context.Context, cm resource.CompositeClaim) error { return nil })),
 				},
 				claim: withClaim(func(o *claim.Unstructured) {
 					o.SetResourceReference(&corev1.ObjectReference{})
@@ -759,7 +729,6 @@ func TestReconcile(t *testing.T) {
 					WithConnectionPropagator(ConnectionPropagatorFn(func(ctx context.Context, to resource.LocalConnectionSecretOwner, from resource.ConnectionSecretOwner) (propagated bool, err error) {
 						return true, nil
 					})),
-					WithDefaultsSelector(DefaultsSelectorFn(func(ctx context.Context, cm resource.CompositeClaim) error { return nil })),
 				},
 				claim: withClaim(func(o *claim.Unstructured) {
 					o.SetResourceReference(&corev1.ObjectReference{})

--- a/internal/controller/apiextensions/offered/reconciler.go
+++ b/internal/controller/apiextensions/offered/reconciler.go
@@ -409,7 +409,6 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 		claim.WithLogger(log.WithValues("controller", claim.ControllerName(d.GetName()))),
 		claim.WithRecorder(r.record.WithAnnotations("controller", claim.ControllerName(d.GetName()))),
 		claim.WithPollInterval(r.options.PollInterval),
-		claim.WithDefaultsSelector(claim.NewAPIDefaultSelector(r.client, *meta.ReferenceTo(d, v1.CompositeResourceDefinitionGroupVersionKind), r.record.WithAnnotations("controller", claim.ControllerName(d.GetName())))),
 	}
 
 	// We only want to enable ExternalSecretStore support if the relevant

--- a/internal/xcrd/crd_test.go
+++ b/internal/xcrd/crd_test.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/pointer"
 
+	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
 	"github.com/crossplane/crossplane-runtime/pkg/errors"
 	"github.com/crossplane/crossplane-runtime/pkg/meta"
 	"github.com/crossplane/crossplane-runtime/pkg/test"
@@ -843,6 +844,7 @@ func TestForCompositeResourceClaim(t *testing.T) {
 	claimSingular := "coolclaim"
 	claimPlural := "coolclaims"
 
+	defaultPolicy := xpv1.CompositeDeletePolicy("Background")
 	schema := `
 {
 	"properties": {
@@ -893,269 +895,556 @@ func TestForCompositeResourceClaim(t *testing.T) {
 	"description": "Description of the resource."
 }`
 
-	d := &v1.CompositeResourceDefinition{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:        name,
-			Labels:      labels,
-			Annotations: annotations,
-			UID:         types.UID("you-you-eye-dee"),
-		},
-		Spec: v1.CompositeResourceDefinitionSpec{
-			Group: group,
-			Names: extv1.CustomResourceDefinitionNames{
-				Plural:   plural,
-				Singular: singular,
-				Kind:     kind,
-				ListKind: listKind,
-			},
-			ClaimNames: &extv1.CustomResourceDefinitionNames{
-				Plural:   claimPlural,
-				Singular: claimSingular,
-				Kind:     claimKind,
-				ListKind: claimListKind,
-			},
-			Versions: []v1.CompositeResourceDefinitionVersion{{
-				Name:          version,
-				Referenceable: true,
-				Served:        true,
-				Schema: &v1.CompositeResourceValidation{
-					OpenAPIV3Schema: runtime.RawExtension{Raw: []byte(schema)},
+	cases := map[string]struct {
+		reason string
+		crd    *v1.CompositeResourceDefinition
+		want   *extv1.CustomResourceDefinition
+	}{
+		"CompositeDeletionPolicyUnspecified": {
+			reason: "if default composite deletion unspecified on XRD, set no default value on claim's spec.compositeDeletionPolicy",
+			crd: &v1.CompositeResourceDefinition{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        name,
+					Labels:      labels,
+					Annotations: annotations,
+					UID:         types.UID("you-you-eye-dee"),
 				},
-			}},
-		},
-	}
-
-	want := &extv1.CustomResourceDefinition{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:   claimPlural + "." + group,
-			Labels: labels,
-			OwnerReferences: []metav1.OwnerReference{
-				meta.AsController(meta.TypedReferenceTo(d, v1.CompositeResourceDefinitionGroupVersionKind)),
-			},
-		},
-		Spec: extv1.CustomResourceDefinitionSpec{
-			Group: group,
-			Names: extv1.CustomResourceDefinitionNames{
-				Plural:     claimPlural,
-				Singular:   claimSingular,
-				Kind:       claimKind,
-				ListKind:   claimListKind,
-				Categories: []string{CategoryClaim},
-			},
-			Scope: extv1.NamespaceScoped,
-			Versions: []extv1.CustomResourceDefinitionVersion{
-				{
-					Name:    version,
-					Served:  true,
-					Storage: true,
-					Subresources: &extv1.CustomResourceSubresources{
-						Status: &extv1.CustomResourceSubresourceStatus{},
+				Spec: v1.CompositeResourceDefinitionSpec{
+					Group: group,
+					Names: extv1.CustomResourceDefinitionNames{
+						Plural:   plural,
+						Singular: singular,
+						Kind:     kind,
+						ListKind: listKind,
 					},
-					AdditionalPrinterColumns: []extv1.CustomResourceColumnDefinition{
-						{
-							Name:     "SYNCED",
-							Type:     "string",
-							JSONPath: ".status.conditions[?(@.type=='Synced')].status",
-						},
-						{
-							Name:     "READY",
-							Type:     "string",
-							JSONPath: ".status.conditions[?(@.type=='Ready')].status",
-						},
-						{
-							Name:     "CONNECTION-SECRET",
-							Type:     "string",
-							JSONPath: ".spec.writeConnectionSecretToRef.name",
-						},
-						{
-							Name:     "AGE",
-							Type:     "date",
-							JSONPath: ".metadata.creationTimestamp",
-						},
+					ClaimNames: &extv1.CustomResourceDefinitionNames{
+						Plural:   claimPlural,
+						Singular: claimSingular,
+						Kind:     claimKind,
+						ListKind: claimListKind,
 					},
-					Schema: &extv1.CustomResourceValidation{
-						OpenAPIV3Schema: &extv1.JSONSchemaProps{
-							Type:        "object",
-							Required:    []string{"spec"},
-							Description: "Description of the resource.",
-							Properties: map[string]extv1.JSONSchemaProps{
-								"apiVersion": {
-									Type: "string",
-								},
-								"kind": {
-									Type: "string",
-								},
-								"metadata": {
-									// NOTE(muvaf): api-server takes care of validating
-									// metadata.
-									Type: "object",
-								},
-								"spec": {
-									Type:        "object",
-									Required:    []string{"storageGB", "engineVersion"},
-									Description: "Specification of the resource.",
-									Properties: map[string]extv1.JSONSchemaProps{
-										// From CRDSpecTemplate.Validation
-										"storageGB": {Type: "integer", Description: "Pretend this is useful."},
-										"engineVersion": {
-											Type: "string",
-											Enum: []extv1.JSON{
-												{Raw: []byte(`"5.6"`)},
-												{Raw: []byte(`"5.7"`)},
-											},
-										},
-										"compositeDeletePolicy": {
-											Type: "string",
-											Enum: []extv1.JSON{{Raw: []byte(`"Background"`)},
-												{Raw: []byte(`"Foreground"`)}},
-										},
-										// From CompositeResourceClaimSpecProps()
-										"compositionRef": {
-											Type:     "object",
-											Required: []string{"name"},
-											Properties: map[string]extv1.JSONSchemaProps{
-												"name": {Type: "string"},
-											},
-										},
-										"compositionSelector": {
-											Type:     "object",
-											Required: []string{"matchLabels"},
-											Properties: map[string]extv1.JSONSchemaProps{
-												"matchLabels": {
-													Type: "object",
-													AdditionalProperties: &extv1.JSONSchemaPropsOrBool{
-														Allows: true,
-														Schema: &extv1.JSONSchemaProps{Type: "string"},
-													},
-												},
-											},
-										},
-										"compositionRevisionRef": {
-											Type:     "object",
-											Required: []string{"name"},
-											Properties: map[string]extv1.JSONSchemaProps{
-												"name": {Type: "string"},
-											},
-										},
-										"compositionRevisionSelector": {
-											Type:     "object",
-											Required: []string{"matchLabels"},
-											Properties: map[string]extv1.JSONSchemaProps{
-												"matchLabels": {
-													Type: "object",
-													AdditionalProperties: &extv1.JSONSchemaPropsOrBool{
-														Allows: true,
-														Schema: &extv1.JSONSchemaProps{Type: "string"},
-													},
-												},
-											},
-										},
-										"compositionUpdatePolicy": {
-											Type: "string",
-											Enum: []extv1.JSON{
-												{Raw: []byte(`"Automatic"`)},
-												{Raw: []byte(`"Manual"`)},
-											},
-										},
-										"resourceRef": {
-											Type:     "object",
-											Required: []string{"apiVersion", "kind", "name"},
-											Properties: map[string]extv1.JSONSchemaProps{
-												"apiVersion": {Type: "string"},
-												"kind":       {Type: "string"},
-												"name":       {Type: "string"},
-											},
-										},
-										"publishConnectionDetailsTo": {
-											Type:     "object",
-											Required: []string{"name"},
-											Properties: map[string]extv1.JSONSchemaProps{
-												"name": {Type: "string"},
-												"configRef": {
-													Type:    "object",
-													Default: &extv1.JSON{Raw: []byte(`{"name": "default"}`)},
-													Properties: map[string]extv1.JSONSchemaProps{
-														"name": {
-															Type: "string",
-														},
-													},
-												},
-												"metadata": {
-													Type: "object",
-													Properties: map[string]extv1.JSONSchemaProps{
-														"labels": {
-															Type: "object",
-															AdditionalProperties: &extv1.JSONSchemaPropsOrBool{
-																Allows: true,
-																Schema: &extv1.JSONSchemaProps{Type: "string"},
-															},
-														},
-														"annotations": {
-															Type: "object",
-															AdditionalProperties: &extv1.JSONSchemaPropsOrBool{
-																Allows: true,
-																Schema: &extv1.JSONSchemaProps{Type: "string"},
-															},
-														},
-														"type": {
-															Type: "string",
-														},
-													},
-												},
-											},
-										},
-										"writeConnectionSecretToRef": {
-											Type:     "object",
-											Required: []string{"name"},
-											Properties: map[string]extv1.JSONSchemaProps{
-												"name": {Type: "string"},
-											},
-										},
-									},
-									XValidations: extv1.ValidationRules{
-										{
-											Message: "Cannot change engine version",
-											Rule:    "self.engineVersion == oldSelf.engineVersion",
-										},
-									},
-								},
-								"status": {
-									Type:        "object",
-									Description: "Status of the resource.",
-									Properties: map[string]extv1.JSONSchemaProps{
-										"phase": {Type: "string"},
+					Versions: []v1.CompositeResourceDefinitionVersion{{
+						Name:          version,
+						Referenceable: true,
+						Served:        true,
+						Schema: &v1.CompositeResourceValidation{
+							OpenAPIV3Schema: runtime.RawExtension{Raw: []byte(schema)},
+						},
+					}},
+				},
+			},
 
-										// From CompositeResourceStatusProps()
-										"conditions": {
-											Description:  "Conditions of the resource.",
-											Type:         "array",
-											XListType:    pointer.String("map"),
-											XListMapKeys: []string{"type"},
-											Items: &extv1.JSONSchemaPropsOrArray{
-												Schema: &extv1.JSONSchemaProps{
-													Type:     "object",
-													Required: []string{"lastTransitionTime", "reason", "status", "type"},
-													Properties: map[string]extv1.JSONSchemaProps{
-														"lastTransitionTime": {Type: "string", Format: "date-time"},
-														"message":            {Type: "string"},
-														"reason":             {Type: "string"},
-														"status":             {Type: "string"},
-														"type":               {Type: "string"},
-													},
-												},
-											},
+			want: &extv1.CustomResourceDefinition{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   claimPlural + "." + group,
+					Labels: labels,
+					OwnerReferences: []metav1.OwnerReference{
+						meta.AsController(meta.TypedReferenceTo(d, v1.CompositeResourceDefinitionGroupVersionKind)),
+					},
+				},
+				Spec: extv1.CustomResourceDefinitionSpec{
+					Group: group,
+					Names: extv1.CustomResourceDefinitionNames{
+						Plural:     claimPlural,
+						Singular:   claimSingular,
+						Kind:       claimKind,
+						ListKind:   claimListKind,
+						Categories: []string{CategoryClaim},
+					},
+					Scope: extv1.NamespaceScoped,
+					Versions: []extv1.CustomResourceDefinitionVersion{
+						{
+							Name:    version,
+							Served:  true,
+							Storage: true,
+							Subresources: &extv1.CustomResourceSubresources{
+								Status: &extv1.CustomResourceSubresourceStatus{},
+							},
+							AdditionalPrinterColumns: []extv1.CustomResourceColumnDefinition{
+								{
+									Name:     "SYNCED",
+									Type:     "string",
+									JSONPath: ".status.conditions[?(@.type=='Synced')].status",
+								},
+								{
+									Name:     "READY",
+									Type:     "string",
+									JSONPath: ".status.conditions[?(@.type=='Ready')].status",
+								},
+								{
+									Name:     "CONNECTION-SECRET",
+									Type:     "string",
+									JSONPath: ".spec.writeConnectionSecretToRef.name",
+								},
+								{
+									Name:     "AGE",
+									Type:     "date",
+									JSONPath: ".metadata.creationTimestamp",
+								},
+							},
+							Schema: &extv1.CustomResourceValidation{
+								OpenAPIV3Schema: &extv1.JSONSchemaProps{
+									Type:        "object",
+									Required:    []string{"spec"},
+									Description: "Description of the resource.",
+									Properties: map[string]extv1.JSONSchemaProps{
+										"apiVersion": {
+											Type: "string",
 										},
-										"connectionDetails": {
+										"kind": {
+											Type: "string",
+										},
+										"metadata": {
+											// NOTE(muvaf): api-server takes care of validating
+											// metadata.
 											Type: "object",
+										},
+										"spec": {
+											Type:        "object",
+											Required:    []string{"storageGB", "engineVersion"},
+											Description: "Specification of the resource.",
 											Properties: map[string]extv1.JSONSchemaProps{
-												"lastPublishedTime": {Type: "string", Format: "date-time"},
+												// From CRDSpecTemplate.Validation
+												"storageGB": {Type: "integer", Description: "Pretend this is useful."},
+												"engineVersion": {
+													Type: "string",
+													Enum: []extv1.JSON{
+														{Raw: []byte(`"5.6"`)},
+														{Raw: []byte(`"5.7"`)},
+													},
+												},
+												"compositeDeletePolicy": {
+													Type: "string",
+													Enum: []extv1.JSON{{Raw: []byte(`"Background"`)},
+														{Raw: []byte(`"Foreground"`)}},
+												},
+												// From CompositeResourceClaimSpecProps()
+												"compositionRef": {
+													Type:     "object",
+													Required: []string{"name"},
+													Properties: map[string]extv1.JSONSchemaProps{
+														"name": {Type: "string"},
+													},
+												},
+												"compositionSelector": {
+													Type:     "object",
+													Required: []string{"matchLabels"},
+													Properties: map[string]extv1.JSONSchemaProps{
+														"matchLabels": {
+															Type: "object",
+															AdditionalProperties: &extv1.JSONSchemaPropsOrBool{
+																Allows: true,
+																Schema: &extv1.JSONSchemaProps{Type: "string"},
+															},
+														},
+													},
+												},
+												"compositionRevisionRef": {
+													Type:     "object",
+													Required: []string{"name"},
+													Properties: map[string]extv1.JSONSchemaProps{
+														"name": {Type: "string"},
+													},
+												},
+												"compositionRevisionSelector": {
+													Type:     "object",
+													Required: []string{"matchLabels"},
+													Properties: map[string]extv1.JSONSchemaProps{
+														"matchLabels": {
+															Type: "object",
+															AdditionalProperties: &extv1.JSONSchemaPropsOrBool{
+																Allows: true,
+																Schema: &extv1.JSONSchemaProps{Type: "string"},
+															},
+														},
+													},
+												},
+												"compositionUpdatePolicy": {
+													Type: "string",
+													Enum: []extv1.JSON{
+														{Raw: []byte(`"Automatic"`)},
+														{Raw: []byte(`"Manual"`)},
+													},
+												},
+												"resourceRef": {
+													Type:     "object",
+													Required: []string{"apiVersion", "kind", "name"},
+													Properties: map[string]extv1.JSONSchemaProps{
+														"apiVersion": {Type: "string"},
+														"kind":       {Type: "string"},
+														"name":       {Type: "string"},
+													},
+												},
+												"publishConnectionDetailsTo": {
+													Type:     "object",
+													Required: []string{"name"},
+													Properties: map[string]extv1.JSONSchemaProps{
+														"name": {Type: "string"},
+														"configRef": {
+															Type:    "object",
+															Default: &extv1.JSON{Raw: []byte(`{"name": "default"}`)},
+															Properties: map[string]extv1.JSONSchemaProps{
+																"name": {
+																	Type: "string",
+																},
+															},
+														},
+														"metadata": {
+															Type: "object",
+															Properties: map[string]extv1.JSONSchemaProps{
+																"labels": {
+																	Type: "object",
+																	AdditionalProperties: &extv1.JSONSchemaPropsOrBool{
+																		Allows: true,
+																		Schema: &extv1.JSONSchemaProps{Type: "string"},
+																	},
+																},
+																"annotations": {
+																	Type: "object",
+																	AdditionalProperties: &extv1.JSONSchemaPropsOrBool{
+																		Allows: true,
+																		Schema: &extv1.JSONSchemaProps{Type: "string"},
+																	},
+																},
+																"type": {
+																	Type: "string",
+																},
+															},
+														},
+													},
+												},
+												"writeConnectionSecretToRef": {
+													Type:     "object",
+													Required: []string{"name"},
+													Properties: map[string]extv1.JSONSchemaProps{
+														"name": {Type: "string"},
+													},
+												},
+											},
+											XValidations: extv1.ValidationRules{
+												{
+													Message: "Cannot change engine version",
+													Rule:    "self.engineVersion == oldSelf.engineVersion",
+												},
+											},
+										},
+										"status": {
+											Type:        "object",
+											Description: "Status of the resource.",
+											Properties: map[string]extv1.JSONSchemaProps{
+												"phase": {Type: "string"},
+
+												// From CompositeResourceStatusProps()
+												"conditions": {
+													Description:  "Conditions of the resource.",
+													Type:         "array",
+													XListType:    pointer.String("map"),
+													XListMapKeys: []string{"type"},
+													Items: &extv1.JSONSchemaPropsOrArray{
+														Schema: &extv1.JSONSchemaProps{
+															Type:     "object",
+															Required: []string{"lastTransitionTime", "reason", "status", "type"},
+															Properties: map[string]extv1.JSONSchemaProps{
+																"lastTransitionTime": {Type: "string", Format: "date-time"},
+																"message":            {Type: "string"},
+																"reason":             {Type: "string"},
+																"status":             {Type: "string"},
+																"type":               {Type: "string"},
+															},
+														},
+													},
+												},
+												"connectionDetails": {
+													Type: "object",
+													Properties: map[string]extv1.JSONSchemaProps{
+														"lastPublishedTime": {Type: "string", Format: "date-time"},
+													},
+												},
+											},
+											XValidations: extv1.ValidationRules{
+												{
+													Message: "Phase is required once set",
+													Rule:    "!has(oldSelf.phase) || has(self.phase)",
+												},
 											},
 										},
 									},
-									XValidations: extv1.ValidationRules{
-										{
-											Message: "Phase is required once set",
-											Rule:    "!has(oldSelf.phase) || has(self.phase)",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		"CompositeDeletionPolicySetToDefault": {
+			reason: "propagate default composite deletion set on XRD as the default value on claim's spec.compositeDeletionPolicy",
+			crd: &v1.CompositeResourceDefinition{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        name,
+					Labels:      labels,
+					Annotations: annotations,
+					UID:         types.UID("you-you-eye-dee"),
+				},
+				Spec: v1.CompositeResourceDefinitionSpec{
+					Group:                        group,
+					DefaultCompositeDeletePolicy: &defaultPolicy,
+					Names: extv1.CustomResourceDefinitionNames{
+						Plural:   plural,
+						Singular: singular,
+						Kind:     kind,
+						ListKind: listKind,
+					},
+					ClaimNames: &extv1.CustomResourceDefinitionNames{
+						Plural:   claimPlural,
+						Singular: claimSingular,
+						Kind:     claimKind,
+						ListKind: claimListKind,
+					},
+					Versions: []v1.CompositeResourceDefinitionVersion{{
+						Name:          version,
+						Referenceable: true,
+						Served:        true,
+						Schema: &v1.CompositeResourceValidation{
+							OpenAPIV3Schema: runtime.RawExtension{Raw: []byte(schema)},
+						},
+					}},
+				},
+			},
+
+			want: &extv1.CustomResourceDefinition{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   claimPlural + "." + group,
+					Labels: labels,
+					OwnerReferences: []metav1.OwnerReference{
+						meta.AsController(meta.TypedReferenceTo(d, v1.CompositeResourceDefinitionGroupVersionKind)),
+					},
+				},
+				Spec: extv1.CustomResourceDefinitionSpec{
+					Group: group,
+					Names: extv1.CustomResourceDefinitionNames{
+						Plural:     claimPlural,
+						Singular:   claimSingular,
+						Kind:       claimKind,
+						ListKind:   claimListKind,
+						Categories: []string{CategoryClaim},
+					},
+					Scope: extv1.NamespaceScoped,
+					Versions: []extv1.CustomResourceDefinitionVersion{
+						{
+							Name:    version,
+							Served:  true,
+							Storage: true,
+							Subresources: &extv1.CustomResourceSubresources{
+								Status: &extv1.CustomResourceSubresourceStatus{},
+							},
+							AdditionalPrinterColumns: []extv1.CustomResourceColumnDefinition{
+								{
+									Name:     "SYNCED",
+									Type:     "string",
+									JSONPath: ".status.conditions[?(@.type=='Synced')].status",
+								},
+								{
+									Name:     "READY",
+									Type:     "string",
+									JSONPath: ".status.conditions[?(@.type=='Ready')].status",
+								},
+								{
+									Name:     "CONNECTION-SECRET",
+									Type:     "string",
+									JSONPath: ".spec.writeConnectionSecretToRef.name",
+								},
+								{
+									Name:     "AGE",
+									Type:     "date",
+									JSONPath: ".metadata.creationTimestamp",
+								},
+							},
+							Schema: &extv1.CustomResourceValidation{
+								OpenAPIV3Schema: &extv1.JSONSchemaProps{
+									Type:        "object",
+									Required:    []string{"spec"},
+									Description: "Description of the resource.",
+									Properties: map[string]extv1.JSONSchemaProps{
+										"apiVersion": {
+											Type: "string",
+										},
+										"kind": {
+											Type: "string",
+										},
+										"metadata": {
+											// NOTE(muvaf): api-server takes care of validating
+											// metadata.
+											Type: "object",
+										},
+										"spec": {
+											Type:        "object",
+											Required:    []string{"storageGB", "engineVersion"},
+											Description: "Specification of the resource.",
+											Properties: map[string]extv1.JSONSchemaProps{
+												// From CRDSpecTemplate.Validation
+												"storageGB": {Type: "integer", Description: "Pretend this is useful."},
+												"engineVersion": {
+													Type: "string",
+													Enum: []extv1.JSON{
+														{Raw: []byte(`"5.6"`)},
+														{Raw: []byte(`"5.7"`)},
+													},
+												},
+												"compositeDeletePolicy": {
+													Type:    "string",
+													Default: &extv1.JSON{Raw: []byte(fmt.Sprintf("\"%s\"", defaultPolicy))},
+													Enum: []extv1.JSON{{Raw: []byte(`"Background"`)},
+														{Raw: []byte(`"Foreground"`)}},
+												},
+												// From CompositeResourceClaimSpecProps()
+												"compositionRef": {
+													Type:     "object",
+													Required: []string{"name"},
+													Properties: map[string]extv1.JSONSchemaProps{
+														"name": {Type: "string"},
+													},
+												},
+												"compositionSelector": {
+													Type:     "object",
+													Required: []string{"matchLabels"},
+													Properties: map[string]extv1.JSONSchemaProps{
+														"matchLabels": {
+															Type: "object",
+															AdditionalProperties: &extv1.JSONSchemaPropsOrBool{
+																Allows: true,
+																Schema: &extv1.JSONSchemaProps{Type: "string"},
+															},
+														},
+													},
+												},
+												"compositionRevisionRef": {
+													Type:     "object",
+													Required: []string{"name"},
+													Properties: map[string]extv1.JSONSchemaProps{
+														"name": {Type: "string"},
+													},
+												},
+												"compositionRevisionSelector": {
+													Type:     "object",
+													Required: []string{"matchLabels"},
+													Properties: map[string]extv1.JSONSchemaProps{
+														"matchLabels": {
+															Type: "object",
+															AdditionalProperties: &extv1.JSONSchemaPropsOrBool{
+																Allows: true,
+																Schema: &extv1.JSONSchemaProps{Type: "string"},
+															},
+														},
+													},
+												},
+												"compositionUpdatePolicy": {
+													Type: "string",
+													Enum: []extv1.JSON{
+														{Raw: []byte(`"Automatic"`)},
+														{Raw: []byte(`"Manual"`)},
+													},
+												},
+												"resourceRef": {
+													Type:     "object",
+													Required: []string{"apiVersion", "kind", "name"},
+													Properties: map[string]extv1.JSONSchemaProps{
+														"apiVersion": {Type: "string"},
+														"kind":       {Type: "string"},
+														"name":       {Type: "string"},
+													},
+												},
+												"publishConnectionDetailsTo": {
+													Type:     "object",
+													Required: []string{"name"},
+													Properties: map[string]extv1.JSONSchemaProps{
+														"name": {Type: "string"},
+														"configRef": {
+															Type:    "object",
+															Default: &extv1.JSON{Raw: []byte(`{"name": "default"}`)},
+															Properties: map[string]extv1.JSONSchemaProps{
+																"name": {
+																	Type: "string",
+																},
+															},
+														},
+														"metadata": {
+															Type: "object",
+															Properties: map[string]extv1.JSONSchemaProps{
+																"labels": {
+																	Type: "object",
+																	AdditionalProperties: &extv1.JSONSchemaPropsOrBool{
+																		Allows: true,
+																		Schema: &extv1.JSONSchemaProps{Type: "string"},
+																	},
+																},
+																"annotations": {
+																	Type: "object",
+																	AdditionalProperties: &extv1.JSONSchemaPropsOrBool{
+																		Allows: true,
+																		Schema: &extv1.JSONSchemaProps{Type: "string"},
+																	},
+																},
+																"type": {
+																	Type: "string",
+																},
+															},
+														},
+													},
+												},
+												"writeConnectionSecretToRef": {
+													Type:     "object",
+													Required: []string{"name"},
+													Properties: map[string]extv1.JSONSchemaProps{
+														"name": {Type: "string"},
+													},
+												},
+											},
+											XValidations: extv1.ValidationRules{
+												{
+													Message: "Cannot change engine version",
+													Rule:    "self.engineVersion == oldSelf.engineVersion",
+												},
+											},
+										},
+										"status": {
+											Type:        "object",
+											Description: "Status of the resource.",
+											Properties: map[string]extv1.JSONSchemaProps{
+												"phase": {Type: "string"},
+
+												// From CompositeResourceStatusProps()
+												"conditions": {
+													Description:  "Conditions of the resource.",
+													Type:         "array",
+													XListType:    pointer.String("map"),
+													XListMapKeys: []string{"type"},
+													Items: &extv1.JSONSchemaPropsOrArray{
+														Schema: &extv1.JSONSchemaProps{
+															Type:     "object",
+															Required: []string{"lastTransitionTime", "reason", "status", "type"},
+															Properties: map[string]extv1.JSONSchemaProps{
+																"lastTransitionTime": {Type: "string", Format: "date-time"},
+																"message":            {Type: "string"},
+																"reason":             {Type: "string"},
+																"status":             {Type: "string"},
+																"type":               {Type: "string"},
+															},
+														},
+													},
+												},
+												"connectionDetails": {
+													Type: "object",
+													Properties: map[string]extv1.JSONSchemaProps{
+														"lastPublishedTime": {Type: "string", Format: "date-time"},
+													},
+												},
+											},
+											XValidations: extv1.ValidationRules{
+												{
+													Message: "Phase is required once set",
+													Rule:    "!has(oldSelf.phase) || has(self.phase)",
+												},
+											},
 										},
 									},
 								},
@@ -1167,13 +1456,17 @@ func TestForCompositeResourceClaim(t *testing.T) {
 		},
 	}
 
-	got, err := ForCompositeResourceClaim(d)
-	if err != nil {
-		t.Fatalf("ForCompositeResourceClaim(...): %s", err)
-	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got, err := ForCompositeResourceClaim(tc.crd)
+			if err != nil {
+				t.Fatalf("ForCompositeResourceClaim(...): %s", err)
+			}
 
-	if diff := cmp.Diff(want, got); diff != "" {
-		t.Errorf("ForCompositeResourceClaim(...): -want, +got:\n%s", diff)
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("ForCompositeResourceClaim(...): -want, +got:\n%s", diff)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
### Description of your changes

* claim CRD contains now the default value for `.spec.compositeDeletePolicy` field
  copied from XRD `spec.defaultCompositeDeletePolicy`. If not specified at claim,
  it will be set by k8s API
* claim controller does not set the value for `spec.compositeDeletePolicy`,
  leading to one less claim update, and hence one less no-op reconcile loop
* added unit tests
* removed `APIDefaultSelector` as unneeded



<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->


<!--
Briefly describe what this pull request does, and how it is covered by tests.
Be proactive - direct your reviewers' attention to anything that needs special
consideration.

You MUST either [x] check or ~strikethrough~ every item in the checklist below.

We love pull requests that fix an open issue. If yours does, use the below line
to indicate which issue it fixes, for example "Fixes #500".
-->

Fixes #4691 

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Added or updated unit **and** E2E tests for my change.
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR, if necessary.
- [x] Opened a PR updating the [docs], if necessary.

[contribution process]: https://git.io/fj2m9
[docs]: https://docs.crossplane.io/contribute/contribute