### PR TITLE
internal/xcrd: limit claim and composite name length in OpenAPI to actual values

### DIFF
--- a/apis/apiextensions/v1/composition_environment_test.go
+++ b/apis/apiextensions/v1/composition_environment_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	v1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
 )
@@ -30,8 +30,8 @@ func TestEnvironmentPatchValidate(t *testing.T) {
 			args: args{
 				envPatch: &EnvironmentPatch{
 					Type:          PatchTypeFromCompositeFieldPath,
-					FromFieldPath: pointer.String("spec.foo"),
-					ToFieldPath:   pointer.String("metadata.annotations[\"foo\"]"),
+					FromFieldPath: ptr.To("spec.foo"),
+					ToFieldPath:   ptr.To("metadata.annotations[\"foo\"]"),
 				},
 			},
 			want: want{output: nil},
@@ -41,7 +41,7 @@ func TestEnvironmentPatchValidate(t *testing.T) {
 			args: args{
 				envPatch: &EnvironmentPatch{
 					Type:        PatchTypeFromCompositeFieldPath,
-					ToFieldPath: pointer.String("metadata.annotations[\"foo\"]"),
+					ToFieldPath: ptr.To("metadata.annotations[\"foo\"]"),
 				},
 			},
 			want: want{
@@ -56,7 +56,7 @@ func TestEnvironmentPatchValidate(t *testing.T) {
 			args: args{
 				envPatch: &EnvironmentPatch{
 					Type:          PatchTypeCombineToComposite,
-					FromFieldPath: pointer.String("spec.foo"),
+					FromFieldPath: ptr.To("spec.foo"),
 					Combine:       nil, // required
 				},
 			},

--- a/apis/apiextensions/v1/composition_patches_test.go
+++ b/apis/apiextensions/v1/composition_patches_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"k8s.io/apimachinery/pkg/util/validation/field"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 func TestPatchValidate(t *testing.T) {
@@ -44,7 +44,7 @@ func TestPatchValidate(t *testing.T) {
 			args: args{
 				patch: &Patch{
 					Type:          PatchTypeFromCompositeFieldPath,
-					FromFieldPath: pointer.String("spec.forProvider.foo"),
+					FromFieldPath: ptr.To("spec.forProvider.foo"),
 				},
 			},
 		},
@@ -53,7 +53,7 @@ func TestPatchValidate(t *testing.T) {
 			args: args{
 				patch: &Patch{
 					Type:          PatchTypeFromCompositeFieldPath,
-					FromFieldPath: pointer.String("spec.forProvider.foo"),
+					FromFieldPath: ptr.To("spec.forProvider.foo"),
 					Transforms: []Transform{
 						{
 							Type: TransformTypeMath,

--- a/apis/apiextensions/v1/composition_transforms_test.go
+++ b/apis/apiextensions/v1/composition_transforms_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	"github.com/crossplane/crossplane-runtime/pkg/test"
 )
@@ -49,7 +49,7 @@ func TestTransformValidate(t *testing.T) {
 					Type: TransformTypeMath,
 					Math: &MathTransform{
 						Type:     MathTransformTypeMultiply,
-						Multiply: pointer.Int64(2),
+						Multiply: ptr.To[int64](2),
 					},
 				},
 			},
@@ -60,7 +60,7 @@ func TestTransformValidate(t *testing.T) {
 				transform: &Transform{
 					Type: TransformTypeMath,
 					Math: &MathTransform{
-						Multiply: pointer.Int64(2),
+						Multiply: ptr.To[int64](2),
 					},
 				},
 			},
@@ -72,7 +72,7 @@ func TestTransformValidate(t *testing.T) {
 					Type: TransformTypeMath,
 					Math: &MathTransform{
 						Type:     MathTransformTypeClampMin,
-						ClampMin: pointer.Int64(10),
+						ClampMin: ptr.To[int64](10),
 					},
 				},
 			},
@@ -84,7 +84,7 @@ func TestTransformValidate(t *testing.T) {
 					Type: TransformTypeMath,
 					Math: &MathTransform{
 						Type:     MathTransformTypeMultiply,
-						ClampMin: pointer.Int64(10),
+						ClampMin: ptr.To[int64](10),
 					},
 				},
 			},
@@ -192,7 +192,7 @@ func TestTransformValidate(t *testing.T) {
 						Patterns: []MatchTransformPattern{
 							{
 								Type:   MatchTransformPatternTypeRegexp,
-								Regexp: pointer.String(".*"),
+								Regexp: ptr.To(".*"),
 							},
 						},
 					},
@@ -208,7 +208,7 @@ func TestTransformValidate(t *testing.T) {
 						Patterns: []MatchTransformPattern{
 							{
 								Type:   MatchTransformPatternTypeRegexp,
-								Regexp: pointer.String("?"),
+								Regexp: ptr.To("?"),
 							},
 						},
 					},
@@ -230,10 +230,10 @@ func TestTransformValidate(t *testing.T) {
 						Patterns: []MatchTransformPattern{
 							{
 								Type:    MatchTransformPatternTypeLiteral,
-								Literal: pointer.String("foo"),
+								Literal: ptr.To("foo"),
 							},
 							{
-								Literal: pointer.String("bar"),
+								Literal: ptr.To("bar"),
 							},
 						},
 					},
@@ -261,7 +261,7 @@ func TestTransformValidate(t *testing.T) {
 				transform: &Transform{
 					Type: TransformTypeString,
 					String: &StringTransform{
-						Format: pointer.String("foo"),
+						Format: ptr.To("foo"),
 					},
 				},
 			},

--- a/apis/apiextensions/v1/composition_validation_test.go
+++ b/apis/apiextensions/v1/composition_validation_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"k8s.io/apimachinery/pkg/util/validation/field"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 // SortFieldErrors sorts the given field.ErrorList by the error message.
@@ -55,7 +55,7 @@ func TestCompositionValidateMode(t *testing.T) {
 				spec: CompositionSpec{
 					Mode: &resources,
 					Resources: []ComposedTemplate{
-						{Name: pointer.String("cool-template")},
+						{Name: ptr.To("cool-template")},
 					},
 				},
 			},
@@ -69,7 +69,7 @@ func TestCompositionValidateMode(t *testing.T) {
 				spec: CompositionSpec{
 					// This Composition uses Resources mode implicitly.
 					Resources: []ComposedTemplate{
-						{Name: pointer.String("cool-template")},
+						{Name: ptr.To("cool-template")},
 					},
 				},
 			},
@@ -157,10 +157,10 @@ func TestCompositionValidateResourceName(t *testing.T) {
 				spec: CompositionSpec{
 					Resources: []ComposedTemplate{
 						{
-							Name: pointer.String("foo"),
+							Name: ptr.To("foo"),
 						},
 						{
-							Name: pointer.String("bar"),
+							Name: ptr.To("bar"),
 						},
 					},
 				},
@@ -183,7 +183,7 @@ func TestCompositionValidateResourceName(t *testing.T) {
 				spec: CompositionSpec{
 					Resources: []ComposedTemplate{
 						{},
-						{Name: pointer.String("bar")},
+						{Name: ptr.To("bar")},
 					},
 				},
 			},
@@ -202,7 +202,7 @@ func TestCompositionValidateResourceName(t *testing.T) {
 			args: args{
 				spec: CompositionSpec{
 					Resources: []ComposedTemplate{
-						{Name: pointer.String("bar")},
+						{Name: ptr.To("bar")},
 						{},
 					},
 				},
@@ -222,8 +222,8 @@ func TestCompositionValidateResourceName(t *testing.T) {
 			args: args{
 				spec: CompositionSpec{
 					Resources: []ComposedTemplate{
-						{Name: pointer.String("foo")},
-						{Name: pointer.String("bar")},
+						{Name: ptr.To("foo")},
+						{Name: ptr.To("bar")},
 					},
 					Pipeline: []PipelineStep{
 						{
@@ -262,9 +262,9 @@ func TestCompositionValidateResourceName(t *testing.T) {
 			args: args{
 				spec: CompositionSpec{
 					Resources: []ComposedTemplate{
-						{Name: pointer.String("foo")},
-						{Name: pointer.String("bar")},
-						{Name: pointer.String("foo")},
+						{Name: ptr.To("foo")},
+						{Name: ptr.To("bar")},
+						{Name: ptr.To("foo")},
 					},
 				},
 			},
@@ -335,7 +335,7 @@ func TestCompositionValidatePatchSets(t *testing.T) {
 								Name: "foo",
 								Patches: []Patch{
 									{
-										FromFieldPath: pointer.String("spec.foo"),
+										FromFieldPath: ptr.To("spec.foo"),
 									},
 								},
 							},
@@ -409,7 +409,7 @@ func TestCompositionValidatePatchSets(t *testing.T) {
 								Patches: []Patch{
 									{
 										Type:          PatchTypeFromCompositeFieldPath,
-										FromFieldPath: pointer.String("spec.something"),
+										FromFieldPath: ptr.To("spec.something"),
 									},
 								},
 							},
@@ -419,7 +419,7 @@ func TestCompositionValidatePatchSets(t *testing.T) {
 								Patches: []Patch{
 									{
 										Type:         PatchTypePatchSet,
-										PatchSetName: pointer.String("wrong"),
+										PatchSetName: ptr.To("wrong"),
 									},
 								},
 							},
@@ -549,14 +549,14 @@ func TestCompositionValidateResources(t *testing.T) {
 					Spec: CompositionSpec{
 						Resources: []ComposedTemplate{
 							{
-								Name: pointer.String("foo"),
+								Name: ptr.To("foo"),
 							},
 							{
-								Name: pointer.String("bar"),
+								Name: ptr.To("bar"),
 								Patches: []Patch{
 									{
 										Type:          PatchTypeFromCompositeFieldPath,
-										FromFieldPath: pointer.String("spec.foo"),
+										FromFieldPath: ptr.To("spec.foo"),
 									},
 								},
 								ReadinessChecks: []ReadinessCheck{
@@ -577,14 +577,14 @@ func TestCompositionValidateResources(t *testing.T) {
 					Spec: CompositionSpec{
 						Resources: []ComposedTemplate{
 							{
-								Name: pointer.String("foo"),
+								Name: ptr.To("foo"),
 							},
 							{
-								Name: pointer.String("foo"),
+								Name: ptr.To("foo"),
 								Patches: []Patch{
 									{
 										Type:          PatchTypeFromCompositeFieldPath,
-										FromFieldPath: pointer.String("spec.foo"),
+										FromFieldPath: ptr.To("spec.foo"),
 									},
 								},
 								ReadinessChecks: []ReadinessCheck{
@@ -614,13 +614,13 @@ func TestCompositionValidateResources(t *testing.T) {
 					Spec: CompositionSpec{
 						Resources: []ComposedTemplate{
 							{
-								Name: pointer.String("foo"),
+								Name: ptr.To("foo"),
 							},
 							{
 								Patches: []Patch{
 									{
 										Type:          PatchTypeFromCompositeFieldPath,
-										FromFieldPath: pointer.String("spec.foo"),
+										FromFieldPath: ptr.To("spec.foo"),
 									},
 								},
 							},
@@ -646,7 +646,7 @@ func TestCompositionValidateResources(t *testing.T) {
 						Resources: []ComposedTemplate{
 							{},
 							{
-								Name: pointer.String("foo"),
+								Name: ptr.To("foo"),
 								Patches: []Patch{
 									{
 										Type: PatchTypeFromCompositeFieldPath,
@@ -732,8 +732,8 @@ func TestCompositionValidateEnvironment(t *testing.T) {
 							Patches: []EnvironmentPatch{
 								{
 									Type:          PatchTypeFromCompositeFieldPath,
-									FromFieldPath: pointer.String("spec.foo"),
-									ToFieldPath:   pointer.String("metadata.annotations[\"foo\"]"),
+									FromFieldPath: ptr.To("spec.foo"),
+									ToFieldPath:   ptr.To("metadata.annotations[\"foo\"]"),
 								},
 							},
 							EnvironmentConfigs: []EnvironmentSource{
@@ -750,7 +750,7 @@ func TestCompositionValidateEnvironment(t *testing.T) {
 											{
 												Type:               EnvironmentSourceSelectorLabelMatcherTypeFromCompositeFieldPath,
 												Key:                "foo",
-												ValueFromFieldPath: pointer.String("spec.foo"),
+												ValueFromFieldPath: ptr.To("spec.foo"),
 											}}}}}}}}},
 		},
 		"InvalidPatchEnvironment": {
@@ -770,8 +770,8 @@ func TestCompositionValidateEnvironment(t *testing.T) {
 							Patches: []EnvironmentPatch{
 								{
 									Type: PatchTypeFromCompositeFieldPath,
-									//FromFieldPath: pointer.String("spec.foo"), // missing
-									ToFieldPath: pointer.String("metadata.annotations[\"foo\"]"),
+									//FromFieldPath: ptr.To("spec.foo"), // missing
+									ToFieldPath: ptr.To("metadata.annotations[\"foo\"]"),
 								},
 							},
 							EnvironmentConfigs: []EnvironmentSource{
@@ -788,7 +788,7 @@ func TestCompositionValidateEnvironment(t *testing.T) {
 											{
 												Type:               EnvironmentSourceSelectorLabelMatcherTypeFromCompositeFieldPath,
 												Key:                "foo",
-												ValueFromFieldPath: pointer.String("spec.foo"),
+												ValueFromFieldPath: ptr.To("spec.foo"),
 											}}}}}}}}},
 		},
 		"InvalidEnvironmentSourceReferenceNoName": {
@@ -819,7 +819,7 @@ func TestCompositionValidateEnvironment(t *testing.T) {
 											{
 												Type:               EnvironmentSourceSelectorLabelMatcherTypeFromCompositeFieldPath,
 												Key:                "foo",
-												ValueFromFieldPath: pointer.String("spec.foo"),
+												ValueFromFieldPath: ptr.To("spec.foo"),
 											}}}}}}}}},
 		},
 		"InvalidEnvironmentSourceSelectorNoKey": {
@@ -850,7 +850,7 @@ func TestCompositionValidateEnvironment(t *testing.T) {
 											{
 												Type: EnvironmentSourceSelectorLabelMatcherTypeFromCompositeFieldPath,
 												//Key:                "foo", // missing
-												ValueFromFieldPath: pointer.String("spec.foo"),
+												ValueFromFieldPath: ptr.To("spec.foo"),
 											}}}}}}}}},
 		},
 		"InvalidMultipleErrors": {
@@ -862,8 +862,8 @@ func TestCompositionValidateEnvironment(t *testing.T) {
 							Patches: []EnvironmentPatch{
 								{
 									Type: PatchTypeFromCompositeFieldPath,
-									//FromFieldPath: pointer.String("spec.foo"), // missing
-									ToFieldPath: pointer.String("metadata.annotations[\"foo\"]"),
+									//FromFieldPath: ptr.To("spec.foo"), // missing
+									ToFieldPath: ptr.To("metadata.annotations[\"foo\"]"),
 								},
 							},
 							EnvironmentConfigs: []EnvironmentSource{
@@ -880,7 +880,7 @@ func TestCompositionValidateEnvironment(t *testing.T) {
 											{
 												Type: EnvironmentSourceSelectorLabelMatcherTypeFromCompositeFieldPath,
 												//Key:                "foo", // missing
-												ValueFromFieldPath: pointer.String("spec.foo"),
+												ValueFromFieldPath: ptr.To("spec.foo"),
 											}}}}}}}}},
 			want: want{
 				output: field.ErrorList{

--- a/go.mod
+++ b/go.mod
@@ -31,7 +31,7 @@ require (
 	k8s.io/client-go v0.28.2
 	k8s.io/code-generator v0.28.2
 	k8s.io/kubectl v0.28.2
-	k8s.io/utils v0.0.0-20230505201702-9f6742963106
+	k8s.io/utils v0.0.0-20230726121419-3b25d923346b
 	sigs.k8s.io/controller-runtime v0.16.2
 	sigs.k8s.io/controller-tools v0.13.0
 	sigs.k8s.io/e2e-framework v0.3.0

--- a/go.sum
+++ b/go.sum
@@ -959,8 +959,8 @@ k8s.io/kube-openapi v0.0.0-20230717233707-2695361300d9 h1:LyMgNKD2P8Wn1iAwQU5Ohx
 k8s.io/kube-openapi v0.0.0-20230717233707-2695361300d9/go.mod h1:wZK2AVp1uHCp4VamDVgBP2COHZjqD1T68Rf0CM3YjSM=
 k8s.io/kubectl v0.28.2 h1:fOWOtU6S0smdNjG1PB9WFbqEIMlkzU5ahyHkc7ESHgM=
 k8s.io/kubectl v0.28.2/go.mod h1:6EQWTPySF1fn7yKoQZHYf9TPwIl2AygHEcJoxFekr64=
-k8s.io/utils v0.0.0-20230505201702-9f6742963106 h1:EObNQ3TW2D+WptiYXlApGNLVy0zm/JIBVY9i+M4wpAU=
-k8s.io/utils v0.0.0-20230505201702-9f6742963106/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
+k8s.io/utils v0.0.0-20230726121419-3b25d923346b h1:sgn3ZU783SCgtaSJjpcVVlRqd6GSnlTLKgpAAttJvpI=
+k8s.io/utils v0.0.0-20230726121419-3b25d923346b/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
 rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=

--- a/internal/controller/apiextensions/composite/composition_functions_test.go
+++ b/internal/controller/apiextensions/composite/composition_functions_test.go
@@ -32,7 +32,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/crossplane/crossplane-runtime/pkg/errors"
@@ -767,7 +767,7 @@ func TestGetComposedResources(t *testing.T) {
 					MockGet: test.NewMockGetFn(nil, func(obj client.Object) error {
 						_ = meta.AddControllerReference(obj, metav1.OwnerReference{
 							UID:        types.UID("someone-else"),
-							Controller: pointer.Bool(true),
+							Controller: ptr.To(true),
 						})
 
 						return nil
@@ -1039,7 +1039,7 @@ func TestGarbageCollectComposedResources(t *testing.T) {
 							ObjectMeta: metav1.ObjectMeta{
 								// This resource is controlled by the XR.
 								OwnerReferences: []metav1.OwnerReference{{
-									Controller: pointer.Bool(true),
+									Controller: ptr.To(true),
 									UID:        "cool-xr",
 								}},
 							},
@@ -1070,7 +1070,7 @@ func TestGarbageCollectComposedResources(t *testing.T) {
 							ObjectMeta: metav1.ObjectMeta{
 								// This resource is controlled by the XR.
 								OwnerReferences: []metav1.OwnerReference{{
-									Controller: pointer.Bool(true),
+									Controller: ptr.To(true),
 									UID:        "cool-xr",
 								}},
 							},
@@ -1102,7 +1102,7 @@ func TestGarbageCollectComposedResources(t *testing.T) {
 							ObjectMeta: metav1.ObjectMeta{
 								// This resource is controlled by the XR.
 								OwnerReferences: []metav1.OwnerReference{{
-									Controller: pointer.Bool(true),
+									Controller: ptr.To(true),
 									UID:        "cool-xr",
 								}},
 							},

--- a/internal/controller/apiextensions/composite/composition_patches_test.go
+++ b/internal/controller/apiextensions/composite/composition_patches_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/pkg/errors"
 	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
 	"github.com/crossplane/crossplane-runtime/pkg/fieldpath"
@@ -100,8 +100,8 @@ func TestPatchApply(t *testing.T) {
 			args: args{
 				patch: v1.Patch{
 					Type:          v1.PatchTypeFromCompositeFieldPath,
-					FromFieldPath: pointer.String("objectMeta.labels"),
-					ToFieldPath:   pointer.String("objectMeta.labels"),
+					FromFieldPath: ptr.To("objectMeta.labels"),
+					ToFieldPath:   ptr.To("objectMeta.labels"),
 				},
 				cp: &fake.Composite{
 					ObjectMeta: metav1.ObjectMeta{
@@ -133,8 +133,8 @@ func TestPatchApply(t *testing.T) {
 			args: args{
 				patch: v1.Patch{
 					Type:          v1.PatchTypeFromCompositeFieldPath,
-					FromFieldPath: pointer.String("objectMeta.labels"),
-					ToFieldPath:   pointer.String("objectMeta.labels"),
+					FromFieldPath: ptr.To("objectMeta.labels"),
+					ToFieldPath:   ptr.To("objectMeta.labels"),
 				},
 				cp: &fake.Composite{
 					ObjectMeta: metav1.ObjectMeta{
@@ -165,8 +165,8 @@ func TestPatchApply(t *testing.T) {
 			args: args{
 				patch: v1.Patch{
 					Type:          v1.PatchTypeFromCompositeFieldPath,
-					FromFieldPath: pointer.String("objectMeta.name"),
-					ToFieldPath:   pointer.String("objectMeta.ownerReferences[*].name"),
+					FromFieldPath: ptr.To("objectMeta.name"),
+					ToFieldPath:   ptr.To("objectMeta.ownerReferences[*].name"),
 				},
 				cp: &fake.Composite{
 					ObjectMeta: metav1.ObjectMeta{
@@ -211,8 +211,8 @@ func TestPatchApply(t *testing.T) {
 			args: args{
 				patch: v1.Patch{
 					Type:          v1.PatchTypeFromCompositeFieldPath,
-					FromFieldPath: pointer.String("objectMeta.name"),
-					ToFieldPath:   pointer.String("objectMeta.ownerReferences[*].badField"),
+					FromFieldPath: ptr.To("objectMeta.name"),
+					ToFieldPath:   ptr.To("objectMeta.ownerReferences[*].badField"),
 				},
 				cp: &fake.Composite{
 					ObjectMeta: metav1.ObjectMeta{
@@ -240,8 +240,8 @@ func TestPatchApply(t *testing.T) {
 			args: args{
 				patch: v1.Patch{
 					Type:          v1.PatchTypeFromCompositeFieldPath,
-					FromFieldPath: pointer.String("objectMeta.labels"),
-					ToFieldPath:   pointer.String("objectMeta.labels"),
+					FromFieldPath: ptr.To("objectMeta.labels"),
+					ToFieldPath:   ptr.To("objectMeta.labels"),
 				},
 				cp: &fake.Composite{
 					ObjectMeta: metav1.ObjectMeta{
@@ -267,14 +267,14 @@ func TestPatchApply(t *testing.T) {
 			args: args{
 				patch: v1.Patch{
 					Type:          v1.PatchTypeFromCompositeFieldPath,
-					FromFieldPath: pointer.String("wat"),
+					FromFieldPath: ptr.To("wat"),
 					Policy: &v1.PatchPolicy{
 						FromFieldPath: func() *v1.FromFieldPathPolicy {
 							s := v1.FromFieldPathPolicyRequired
 							return &s
 						}(),
 					},
-					ToFieldPath: pointer.String("wat"),
+					ToFieldPath: ptr.To("wat"),
 				},
 				cp: &fake.Composite{
 					ConnectionDetailsLastPublishedTimer: lpt,
@@ -297,8 +297,8 @@ func TestPatchApply(t *testing.T) {
 			args: args{
 				patch: v1.Patch{
 					Type:          v1.PatchTypeFromEnvironmentFieldPath,
-					FromFieldPath: pointer.String("objectMeta.labels"),
-					ToFieldPath:   pointer.String("objectMeta.labels"),
+					FromFieldPath: ptr.To("objectMeta.labels"),
+					ToFieldPath:   ptr.To("objectMeta.labels"),
 				},
 				cp: &fake.Composite{
 					ObjectMeta: metav1.ObjectMeta{
@@ -330,14 +330,14 @@ func TestPatchApply(t *testing.T) {
 			args: args{
 				patch: v1.Patch{
 					Type:          v1.PatchTypeFromEnvironmentFieldPath,
-					FromFieldPath: pointer.String("wat"),
+					FromFieldPath: ptr.To("wat"),
 					Policy: &v1.PatchPolicy{
 						FromFieldPath: func() *v1.FromFieldPathPolicy {
 							s := v1.FromFieldPathPolicyRequired
 							return &s
 						}(),
 					},
-					ToFieldPath: pointer.String("wat"),
+					ToFieldPath: ptr.To("wat"),
 				},
 				cp: &fake.Composite{
 					ConnectionDetailsLastPublishedTimer: lpt,
@@ -360,13 +360,13 @@ func TestPatchApply(t *testing.T) {
 			args: args{
 				patch: v1.Patch{
 					Type:          v1.PatchTypeFromCompositeFieldPath,
-					FromFieldPath: pointer.String("objectMeta.labels"),
+					FromFieldPath: ptr.To("objectMeta.labels"),
 					Policy: &v1.PatchPolicy{
 						MergeOptions: &xpv1.MergeOptions{
-							KeepMapValues: pointer.Bool(true),
+							KeepMapValues: ptr.To(true),
 						},
 					},
-					ToFieldPath: pointer.String("objectMeta.labels"),
+					ToFieldPath: ptr.To("objectMeta.labels"),
 				},
 				cp: &fake.Composite{
 					ObjectMeta: metav1.ObjectMeta{
@@ -406,8 +406,8 @@ func TestPatchApply(t *testing.T) {
 			args: args{
 				patch: v1.Patch{
 					Type:          v1.PatchTypeFromCompositeFieldPath,
-					FromFieldPath: pointer.String("objectMeta.labels"),
-					ToFieldPath:   pointer.String("objectMeta.labels"),
+					FromFieldPath: ptr.To("objectMeta.labels"),
+					ToFieldPath:   ptr.To("objectMeta.labels"),
 				},
 				cp: &fake.Composite{
 					ObjectMeta: metav1.ObjectMeta{
@@ -437,8 +437,8 @@ func TestPatchApply(t *testing.T) {
 			args: args{
 				patch: v1.Patch{
 					Type:          v1.PatchTypeFromCompositeFieldPath,
-					FromFieldPath: pointer.String("objectMeta.labels"),
-					ToFieldPath:   pointer.String("objectMeta.labels"),
+					FromFieldPath: ptr.To("objectMeta.labels"),
+					ToFieldPath:   ptr.To("objectMeta.labels"),
 				},
 				cp: &fake.Composite{
 					ObjectMeta: metav1.ObjectMeta{
@@ -470,7 +470,7 @@ func TestPatchApply(t *testing.T) {
 			args: args{
 				patch: v1.Patch{
 					Type:          v1.PatchTypeFromCompositeFieldPath,
-					FromFieldPath: pointer.String("objectMeta.labels"),
+					FromFieldPath: ptr.To("objectMeta.labels"),
 				},
 				cp: &fake.Composite{
 					ObjectMeta: metav1.ObjectMeta{
@@ -512,8 +512,8 @@ func TestPatchApply(t *testing.T) {
 			args: args{
 				patch: v1.Patch{
 					Type:          v1.PatchTypeToCompositeFieldPath,
-					FromFieldPath: pointer.String("objectMeta.labels"),
-					ToFieldPath:   pointer.String("objectMeta.labels"),
+					FromFieldPath: ptr.To("objectMeta.labels"),
+					ToFieldPath:   ptr.To("objectMeta.labels"),
 				},
 				cp: &fake.Composite{
 					ObjectMeta: metav1.ObjectMeta{
@@ -555,8 +555,8 @@ func TestPatchApply(t *testing.T) {
 			args: args{
 				patch: v1.Patch{
 					Type:          v1.PatchTypeToCompositeFieldPath,
-					FromFieldPath: pointer.String("objectMeta.name"),
-					ToFieldPath:   pointer.String("objectMeta.ownerReferences[*].name"),
+					FromFieldPath: ptr.To("objectMeta.name"),
+					ToFieldPath:   ptr.To("objectMeta.ownerReferences[*].name"),
 				},
 				cp: &fake.Composite{
 					ObjectMeta: metav1.ObjectMeta{
@@ -602,8 +602,8 @@ func TestPatchApply(t *testing.T) {
 			args: args{
 				patch: v1.Patch{
 					Type:          v1.PatchTypeToEnvironmentFieldPath,
-					FromFieldPath: pointer.String("objectMeta.labels"),
-					ToFieldPath:   pointer.String("objectMeta.labels"),
+					FromFieldPath: ptr.To("objectMeta.labels"),
+					ToFieldPath:   ptr.To("objectMeta.labels"),
 				},
 				cp: &fake.Composite{
 					ObjectMeta: metav1.ObjectMeta{
@@ -645,7 +645,7 @@ func TestPatchApply(t *testing.T) {
 			args: args{
 				patch: v1.Patch{
 					Type:        v1.PatchTypeCombineFromComposite,
-					ToFieldPath: pointer.String("objectMeta.labels.destination"),
+					ToFieldPath: ptr.To("objectMeta.labels.destination"),
 				},
 				cp: &fake.Composite{
 					ObjectMeta: metav1.ObjectMeta{
@@ -692,7 +692,7 @@ func TestPatchApply(t *testing.T) {
 			args: args{
 				patch: v1.Patch{
 					Type:        v1.PatchTypeCombineFromEnvironment,
-					ToFieldPath: pointer.String("objectMeta.labels.destination"),
+					ToFieldPath: ptr.To("objectMeta.labels.destination"),
 				},
 				cp: &fake.Composite{
 					ObjectMeta: metav1.ObjectMeta{
@@ -746,7 +746,7 @@ func TestPatchApply(t *testing.T) {
 						},
 						Strategy: v1.CombineStrategyString,
 					},
-					ToFieldPath: pointer.String("objectMeta.labels.destination"),
+					ToFieldPath: ptr.To("objectMeta.labels.destination"),
 				},
 				cp: &fake.Composite{
 					ObjectMeta: metav1.ObjectMeta{
@@ -798,7 +798,7 @@ func TestPatchApply(t *testing.T) {
 						Strategy:  v1.CombineStrategyString,
 						String:    &v1.StringCombine{Format: "%s-%s"},
 					},
-					ToFieldPath: pointer.String("objectMeta.labels.destination"),
+					ToFieldPath: ptr.To("objectMeta.labels.destination"),
 				},
 				cp: &fake.Composite{
 					ObjectMeta: metav1.ObjectMeta{
@@ -857,7 +857,7 @@ func TestPatchApply(t *testing.T) {
 						Strategy: v1.CombineStrategyString,
 						String:   &v1.StringCombine{Format: "%s-%s"},
 					},
-					ToFieldPath: pointer.String("objectMeta.labels.destination"),
+					ToFieldPath: ptr.To("objectMeta.labels.destination"),
 				},
 				cp: &fake.Composite{
 					ObjectMeta: metav1.ObjectMeta{
@@ -912,7 +912,7 @@ func TestPatchApply(t *testing.T) {
 						Strategy: v1.CombineStrategyString,
 						String:   &v1.StringCombine{Format: "%s-%s"},
 					},
-					ToFieldPath: pointer.String("objectMeta.labels.destination"),
+					ToFieldPath: ptr.To("objectMeta.labels.destination"),
 				},
 				cp: &fake.Composite{
 					ObjectMeta: metav1.ObjectMeta{
@@ -968,7 +968,7 @@ func TestPatchApply(t *testing.T) {
 						Strategy: v1.CombineStrategyString,
 						String:   &v1.StringCombine{Format: "%s-%s"},
 					},
-					ToFieldPath: pointer.String("objectMeta.labels.destination"),
+					ToFieldPath: ptr.To("objectMeta.labels.destination"),
 				},
 				cp: &fake.Composite{
 					ObjectMeta: metav1.ObjectMeta{
@@ -1024,7 +1024,7 @@ func TestPatchApply(t *testing.T) {
 						Strategy: v1.CombineStrategyString,
 						String:   &v1.StringCombine{Format: "%s-%s"},
 					},
-					ToFieldPath: pointer.String("objectMeta.labels.destination"),
+					ToFieldPath: ptr.To("objectMeta.labels.destination"),
 				},
 				cp: &fake.Composite{
 					ObjectMeta: metav1.ObjectMeta{
@@ -1204,11 +1204,11 @@ func TestComposedTemplates(t *testing.T) {
 						Patches: []v1.Patch{
 							{
 								Type:          v1.PatchTypeFromCompositeFieldPath,
-								FromFieldPath: pointer.String("metadata.name"),
+								FromFieldPath: ptr.To("metadata.name"),
 							},
 							{
 								Type:          v1.PatchTypeFromCompositeFieldPath,
-								FromFieldPath: pointer.String("metadata.namespace"),
+								FromFieldPath: ptr.To("metadata.namespace"),
 							},
 						},
 					},
@@ -1220,11 +1220,11 @@ func TestComposedTemplates(t *testing.T) {
 						Patches: []v1.Patch{
 							{
 								Type:          v1.PatchTypeFromCompositeFieldPath,
-								FromFieldPath: pointer.String("metadata.name"),
+								FromFieldPath: ptr.To("metadata.name"),
 							},
 							{
 								Type:          v1.PatchTypeFromCompositeFieldPath,
-								FromFieldPath: pointer.String("metadata.namespace"),
+								FromFieldPath: ptr.To("metadata.namespace"),
 							},
 						},
 					},
@@ -1238,7 +1238,7 @@ func TestComposedTemplates(t *testing.T) {
 					Patches: []v1.Patch{
 						{
 							Type:         v1.PatchTypePatchSet,
-							PatchSetName: pointer.String("patch-set-1"),
+							PatchSetName: ptr.To("patch-set-1"),
 						},
 					},
 				}},
@@ -1258,11 +1258,11 @@ func TestComposedTemplates(t *testing.T) {
 						Patches: []v1.Patch{
 							{
 								Type:          v1.PatchTypeFromCompositeFieldPath,
-								FromFieldPath: pointer.String("metadata.namespace"),
+								FromFieldPath: ptr.To("metadata.namespace"),
 							},
 							{
 								Type:          v1.PatchTypeFromCompositeFieldPath,
-								FromFieldPath: pointer.String("spec.parameters.test"),
+								FromFieldPath: ptr.To("spec.parameters.test"),
 							},
 						},
 					},
@@ -1271,11 +1271,11 @@ func TestComposedTemplates(t *testing.T) {
 						Patches: []v1.Patch{
 							{
 								Type:          v1.PatchTypeFromCompositeFieldPath,
-								FromFieldPath: pointer.String("metadata.annotations.patch-test-1"),
+								FromFieldPath: ptr.To("metadata.annotations.patch-test-1"),
 							},
 							{
 								Type:          v1.PatchTypeFromCompositeFieldPath,
-								FromFieldPath: pointer.String("metadata.annotations.patch-test-2"),
+								FromFieldPath: ptr.To("metadata.annotations.patch-test-2"),
 								Transforms: []v1.Transform{{
 									Type: v1.TransformTypeMap,
 									Map: &v1.MapTransform{
@@ -1294,15 +1294,15 @@ func TestComposedTemplates(t *testing.T) {
 						Patches: []v1.Patch{
 							{
 								Type:         v1.PatchTypePatchSet,
-								PatchSetName: pointer.String("patch-set-2"),
+								PatchSetName: ptr.To("patch-set-2"),
 							},
 							{
 								Type:          v1.PatchTypeFromCompositeFieldPath,
-								FromFieldPath: pointer.String("metadata.name"),
+								FromFieldPath: ptr.To("metadata.name"),
 							},
 							{
 								Type:         v1.PatchTypePatchSet,
-								PatchSetName: pointer.String("patch-set-1"),
+								PatchSetName: ptr.To("patch-set-1"),
 							},
 						},
 					},
@@ -1310,7 +1310,7 @@ func TestComposedTemplates(t *testing.T) {
 						Patches: []v1.Patch{
 							{
 								Type:         v1.PatchTypePatchSet,
-								PatchSetName: pointer.String("patch-set-1"),
+								PatchSetName: ptr.To("patch-set-1"),
 							},
 						},
 					},
@@ -1323,11 +1323,11 @@ func TestComposedTemplates(t *testing.T) {
 						Patches: []v1.Patch{
 							{
 								Type:          v1.PatchTypeFromCompositeFieldPath,
-								FromFieldPath: pointer.String("metadata.annotations.patch-test-1"),
+								FromFieldPath: ptr.To("metadata.annotations.patch-test-1"),
 							},
 							{
 								Type:          v1.PatchTypeFromCompositeFieldPath,
-								FromFieldPath: pointer.String("metadata.annotations.patch-test-2"),
+								FromFieldPath: ptr.To("metadata.annotations.patch-test-2"),
 								Transforms: []v1.Transform{{
 									Type: v1.TransformTypeMap,
 									Map: &v1.MapTransform{
@@ -1340,15 +1340,15 @@ func TestComposedTemplates(t *testing.T) {
 							},
 							{
 								Type:          v1.PatchTypeFromCompositeFieldPath,
-								FromFieldPath: pointer.String("metadata.name"),
+								FromFieldPath: ptr.To("metadata.name"),
 							},
 							{
 								Type:          v1.PatchTypeFromCompositeFieldPath,
-								FromFieldPath: pointer.String("metadata.namespace"),
+								FromFieldPath: ptr.To("metadata.namespace"),
 							},
 							{
 								Type:          v1.PatchTypeFromCompositeFieldPath,
-								FromFieldPath: pointer.String("spec.parameters.test"),
+								FromFieldPath: ptr.To("spec.parameters.test"),
 							},
 						},
 					},
@@ -1356,11 +1356,11 @@ func TestComposedTemplates(t *testing.T) {
 						Patches: []v1.Patch{
 							{
 								Type:          v1.PatchTypeFromCompositeFieldPath,
-								FromFieldPath: pointer.String("metadata.namespace"),
+								FromFieldPath: ptr.To("metadata.namespace"),
 							},
 							{
 								Type:          v1.PatchTypeFromCompositeFieldPath,
-								FromFieldPath: pointer.String("spec.parameters.test"),
+								FromFieldPath: ptr.To("spec.parameters.test"),
 							},
 						},
 					},
@@ -1430,7 +1430,7 @@ func TestResolveTransforms(t *testing.T) {
 				}, {
 					Type: v1.TransformTypeMath,
 					Math: &v1.MathTransform{
-						Multiply: pointer.Int64(2),
+						Multiply: ptr.To[int64](2),
 					},
 				}},
 				input: int64(2),
@@ -1450,7 +1450,7 @@ func TestResolveTransforms(t *testing.T) {
 				}, {
 					Type: v1.TransformTypeMath,
 					Math: &v1.MathTransform{
-						Multiply: pointer.Int64(2),
+						Multiply: ptr.To[int64](2),
 					},
 				}},
 				input: int64(2),

--- a/internal/controller/apiextensions/composite/composition_pt.go
+++ b/internal/controller/apiextensions/composite/composition_pt.go
@@ -24,7 +24,7 @@ import (
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/crossplane/crossplane-runtime/pkg/errors"
@@ -202,7 +202,7 @@ func (c *PTComposer) Compose(ctx context.Context, xr *composite.Unstructured, re
 		ta := tas[i]
 
 		// If this resource is anonymous its "name" is just its index.
-		name := pointer.StringDeref(ta.Template.Name, fmt.Sprintf("resource %d", i+1))
+		name := ptr.Deref(ta.Template.Name, fmt.Sprintf("resource %d", i+1))
 		r := composed.New(composed.FromReference(ta.Reference))
 
 		if err := RenderFromJSON(r, ta.Template.Base.Raw); err != nil {
@@ -228,7 +228,7 @@ func (c *PTComposer) Compose(ctx context.Context, xr *composite.Unstructured, re
 			rendered = false
 		}
 
-		if err := RenderComposedResourceMetadata(r, xr, ResourceName(pointer.StringDeref(ta.Template.Name, ""))); err != nil {
+		if err := RenderComposedResourceMetadata(r, xr, ResourceName(ptr.Deref(ta.Template.Name, ""))); err != nil {
 			events = append(events, event.Warning(reasonCompose, errors.Wrapf(err, errFmtRenderMetadata, name)))
 			rendered = false
 		}
@@ -298,7 +298,7 @@ func (c *PTComposer) Compose(ctx context.Context, xr *composite.Unstructured, re
 
 		// If this resource is anonymous its "name" is just its index within the
 		// array of composed resource templates.
-		name := ResourceName(pointer.StringDeref(t.Name, fmt.Sprintf("resource %d", i+1)))
+		name := ResourceName(ptr.Deref(t.Name, fmt.Sprintf("resource %d", i+1)))
 
 		// If we were unable to render the composed resource we should not try
 		// to observe it. We still want to return it to the Reconciler so that

--- a/internal/controller/apiextensions/composite/composition_pt_test.go
+++ b/internal/controller/apiextensions/composite/composition_pt_test.go
@@ -28,7 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/crossplane/crossplane-runtime/pkg/errors"
@@ -78,7 +78,7 @@ func TestPTCompose(t *testing.T) {
 									// This reference to a non-existent patchset
 									// triggers the error.
 									Type:         v1.PatchTypePatchSet,
-									PatchSetName: pointer.String("nonexistent-patchset"),
+									PatchSetName: ptr.To("nonexistent-patchset"),
 								}},
 							}},
 						},
@@ -115,7 +115,7 @@ func TestPTCompose(t *testing.T) {
 						tas := []TemplateAssociation{
 							{
 								Template: v1.ComposedTemplate{
-									Name: pointer.String("uncool-resource"),
+									Name: ptr.To("uncool-resource"),
 									Base: runtime.RawExtension{Raw: []byte("{}")}, // An invalid, empty base resource template.
 								},
 							},
@@ -154,7 +154,7 @@ func TestPTCompose(t *testing.T) {
 					WithTemplateAssociator(CompositionTemplateAssociatorFn(func(ctx context.Context, c resource.Composite, ct []v1.ComposedTemplate) ([]TemplateAssociation, error) {
 						tas := []TemplateAssociation{{
 							Template: v1.ComposedTemplate{
-								Name: pointer.String("cool-resource"),
+								Name: ptr.To("cool-resource"),
 								Base: base,
 							},
 						}}
@@ -186,7 +186,7 @@ func TestPTCompose(t *testing.T) {
 					WithTemplateAssociator(CompositionTemplateAssociatorFn(func(ctx context.Context, c resource.Composite, ct []v1.ComposedTemplate) ([]TemplateAssociation, error) {
 						tas := []TemplateAssociation{{
 							Template: v1.ComposedTemplate{
-								Name: pointer.String("cool-resource"),
+								Name: ptr.To("cool-resource"),
 								Base: base,
 							},
 						}}
@@ -218,7 +218,7 @@ func TestPTCompose(t *testing.T) {
 					WithTemplateAssociator(CompositionTemplateAssociatorFn(func(ctx context.Context, c resource.Composite, ct []v1.ComposedTemplate) ([]TemplateAssociation, error) {
 						tas := []TemplateAssociation{{
 							Template: v1.ComposedTemplate{
-								Name: pointer.String("cool-resource"),
+								Name: ptr.To("cool-resource"),
 								Base: base,
 							},
 						}}
@@ -253,7 +253,7 @@ func TestPTCompose(t *testing.T) {
 					WithTemplateAssociator(CompositionTemplateAssociatorFn(func(ctx context.Context, c resource.Composite, ct []v1.ComposedTemplate) ([]TemplateAssociation, error) {
 						tas := []TemplateAssociation{{
 							Template: v1.ComposedTemplate{
-								Name: pointer.String("cool-resource"),
+								Name: ptr.To("cool-resource"),
 								Base: base,
 							},
 						}}
@@ -291,7 +291,7 @@ func TestPTCompose(t *testing.T) {
 					WithTemplateAssociator(CompositionTemplateAssociatorFn(func(ctx context.Context, c resource.Composite, ct []v1.ComposedTemplate) ([]TemplateAssociation, error) {
 						tas := []TemplateAssociation{{
 							Template: v1.ComposedTemplate{
-								Name: pointer.String("cool-resource"),
+								Name: ptr.To("cool-resource"),
 								Base: base,
 							},
 						}}
@@ -362,7 +362,7 @@ func TestPTCompose(t *testing.T) {
 					WithTemplateAssociator(CompositionTemplateAssociatorFn(func(ctx context.Context, c resource.Composite, ct []v1.ComposedTemplate) ([]TemplateAssociation, error) {
 						tas := []TemplateAssociation{{
 							Template: v1.ComposedTemplate{
-								Name: pointer.String("cool-resource"),
+								Name: ptr.To("cool-resource"),
 								Base: base,
 							},
 						}}
@@ -412,7 +412,7 @@ func TestPTCompose(t *testing.T) {
 						tas := []TemplateAssociation{
 							{
 								Template: v1.ComposedTemplate{
-									Name: pointer.String("cool-resource"),
+									Name: ptr.To("cool-resource"),
 									Base: base,
 								},
 							},
@@ -420,7 +420,7 @@ func TestPTCompose(t *testing.T) {
 								// This resource won't apply successfully due to
 								// the clause below in the dry-run renderer.
 								Template: v1.ComposedTemplate{
-									Name: pointer.String("uncool-resource"),
+									Name: ptr.To("uncool-resource"),
 									Base: runtime.RawExtension{Raw: []byte(`{"apiVersion":"test.crossplane.io/v1","kind":"BrokenResource"}`)},
 								},
 							},

--- a/internal/controller/apiextensions/composite/composition_render_test.go
+++ b/internal/controller/apiextensions/composite/composition_render_test.go
@@ -24,7 +24,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/crossplane/crossplane-runtime/pkg/errors"
@@ -142,7 +142,7 @@ func TestRenderComposedResourceMetadata(t *testing.T) {
 	controlled := &fake.Composed{
 		ObjectMeta: metav1.ObjectMeta{
 			OwnerReferences: []metav1.OwnerReference{{
-				Controller: pointer.Bool(true),
+				Controller: ptr.To(true),
 				UID:        "very-random",
 			}},
 		},
@@ -179,7 +179,7 @@ func TestRenderComposedResourceMetadata(t *testing.T) {
 				cd: &fake.Composed{
 					ObjectMeta: metav1.ObjectMeta{
 						OwnerReferences: []metav1.OwnerReference{{
-							Controller: pointer.Bool(true),
+							Controller: ptr.To(true),
 							UID:        "very-random",
 						}},
 					},
@@ -190,7 +190,7 @@ func TestRenderComposedResourceMetadata(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						GenerateName: "prefix-",
 						OwnerReferences: []metav1.OwnerReference{{
-							Controller: pointer.Bool(true),
+							Controller: ptr.To(true),
 							UID:        "very-random",
 						}},
 						Labels: map[string]string{
@@ -219,7 +219,7 @@ func TestRenderComposedResourceMetadata(t *testing.T) {
 				cd: &fake.Composed{
 					ObjectMeta: metav1.ObjectMeta{
 						OwnerReferences: []metav1.OwnerReference{{
-							Controller: pointer.Bool(true),
+							Controller: ptr.To(true),
 							UID:        "somewhat-random",
 						}},
 					},
@@ -230,8 +230,8 @@ func TestRenderComposedResourceMetadata(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						GenerateName: "prefix-",
 						OwnerReferences: []metav1.OwnerReference{{
-							Controller:         pointer.Bool(true),
-							BlockOwnerDeletion: pointer.Bool(true),
+							Controller:         ptr.To(true),
+							BlockOwnerDeletion: ptr.To(true),
 							UID:                "somewhat-random",
 						}},
 						Labels: map[string]string{
@@ -264,8 +264,8 @@ func TestRenderComposedResourceMetadata(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						GenerateName: "prefix-",
 						OwnerReferences: []metav1.OwnerReference{{
-							Controller:         pointer.Bool(true),
-							BlockOwnerDeletion: pointer.Bool(true),
+							Controller:         ptr.To(true),
+							BlockOwnerDeletion: ptr.To(true),
 							UID:                "somewhat-random",
 							Name:               "cool-xr",
 						}},

--- a/internal/controller/apiextensions/composite/composition_transforms.go
+++ b/internal/controller/apiextensions/composite/composition_transforms.go
@@ -31,7 +31,7 @@ import (
 
 	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	"github.com/crossplane/crossplane-runtime/pkg/errors"
 
@@ -376,7 +376,7 @@ func stringRegexpTransform(input any, r v1.StringTransformRegexp) (string, error
 	groups := re.FindStringSubmatch(fmt.Sprintf("%v", input))
 
 	// Return the entire match (group zero) by default.
-	g := pointer.IntDeref(r.Group, 0)
+	g := ptr.Deref(r.Group, 0)
 	if len(groups) == 0 || g >= len(groups) {
 		return "", errors.Errorf(errStringTransformTypeRegexpNoMatch, r.Match, g)
 	}

--- a/internal/controller/apiextensions/composite/composition_transforms_test.go
+++ b/internal/controller/apiextensions/composite/composition_transforms_test.go
@@ -25,7 +25,7 @@ import (
 	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/util/validation/field"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	"github.com/crossplane/crossplane-runtime/pkg/errors"
 	"github.com/crossplane/crossplane-runtime/pkg/test"
@@ -167,7 +167,7 @@ func TestMatchResolve(t *testing.T) {
 					Patterns: []v1.MatchTransformPattern{
 						{
 							Type:    v1.MatchTransformPatternTypeLiteral,
-							Literal: pointer.String("5"),
+							Literal: ptr.To("5"),
 						},
 					},
 				},
@@ -256,7 +256,7 @@ func TestMatchResolve(t *testing.T) {
 					Patterns: []v1.MatchTransformPattern{
 						{
 							Type:    v1.MatchTransformPatternTypeLiteral,
-							Literal: pointer.String("foo"),
+							Literal: ptr.To("foo"),
 							Result:  asJSON("bar"),
 						},
 					},
@@ -273,12 +273,12 @@ func TestMatchResolve(t *testing.T) {
 					Patterns: []v1.MatchTransformPattern{
 						{
 							Type:    v1.MatchTransformPatternTypeLiteral,
-							Literal: pointer.String("foo"),
+							Literal: ptr.To("foo"),
 							Result:  asJSON("bar"),
 						},
 						{
 							Type:    v1.MatchTransformPatternTypeLiteral,
-							Literal: pointer.String("foo"),
+							Literal: ptr.To("foo"),
 							Result:  asJSON("not this"),
 						},
 					},
@@ -295,7 +295,7 @@ func TestMatchResolve(t *testing.T) {
 					Patterns: []v1.MatchTransformPattern{
 						{
 							Type:    v1.MatchTransformPatternTypeLiteral,
-							Literal: pointer.String("foo"),
+							Literal: ptr.To("foo"),
 							Result: asJSON(map[string]interface{}{
 								"Hello": "World",
 							}),
@@ -316,7 +316,7 @@ func TestMatchResolve(t *testing.T) {
 					Patterns: []v1.MatchTransformPattern{
 						{
 							Type:    v1.MatchTransformPatternTypeLiteral,
-							Literal: pointer.String("foo"),
+							Literal: ptr.To("foo"),
 							Result: asJSON([]string{
 								"Hello", "World",
 							}),
@@ -337,7 +337,7 @@ func TestMatchResolve(t *testing.T) {
 					Patterns: []v1.MatchTransformPattern{
 						{
 							Type:    v1.MatchTransformPatternTypeLiteral,
-							Literal: pointer.String("foo"),
+							Literal: ptr.To("foo"),
 							Result:  asJSON(5),
 						},
 					},
@@ -354,7 +354,7 @@ func TestMatchResolve(t *testing.T) {
 					Patterns: []v1.MatchTransformPattern{
 						{
 							Type:    v1.MatchTransformPatternTypeLiteral,
-							Literal: pointer.String("foo"),
+							Literal: ptr.To("foo"),
 							Result:  asJSON(true),
 						},
 					},
@@ -371,7 +371,7 @@ func TestMatchResolve(t *testing.T) {
 					Patterns: []v1.MatchTransformPattern{
 						{
 							Type:    v1.MatchTransformPatternTypeLiteral,
-							Literal: pointer.String("foo"),
+							Literal: ptr.To("foo"),
 							Result:  asJSON(nil),
 						},
 					},
@@ -386,7 +386,7 @@ func TestMatchResolve(t *testing.T) {
 					Patterns: []v1.MatchTransformPattern{
 						{
 							Type:   v1.MatchTransformPatternTypeRegexp,
-							Regexp: pointer.String("^foo.*$"),
+							Regexp: ptr.To("^foo.*$"),
 							Result: asJSON("Hello World"),
 						},
 					},
@@ -417,7 +417,7 @@ func TestMatchResolve(t *testing.T) {
 					Patterns: []v1.MatchTransformPattern{
 						{
 							Type:   v1.MatchTransformPatternTypeRegexp,
-							Regexp: pointer.String("?="),
+							Regexp: ptr.To("?="),
 						},
 					},
 				},
@@ -971,7 +971,7 @@ func TestStringResolve(t *testing.T) {
 				stype: v1.StringTransformTypeRegexp,
 				regexp: &v1.StringTransformRegexp{
 					Match: "my-([0-9]+)-string",
-					Group: pointer.Int(1),
+					Group: ptr.To[int](1),
 				},
 				i: "my-1-string",
 			},
@@ -984,7 +984,7 @@ func TestStringResolve(t *testing.T) {
 				stype: v1.StringTransformTypeRegexp,
 				regexp: &v1.StringTransformRegexp{
 					Match: "my-([0-9]+)-string",
-					Group: pointer.Int(2),
+					Group: ptr.To[int](2),
 				},
 				i: "my-1-string",
 			},
@@ -1077,7 +1077,7 @@ func TestConvertResolve(t *testing.T) {
 			args: args{
 				i:      "1000m",
 				to:     v1.TransformIOTypeFloat64,
-				format: (*v1.ConvertTransformFormat)(pointer.String(string(v1.ConvertTransformFormatQuantity))),
+				format: (*v1.ConvertTransformFormat)(ptr.To(string(v1.ConvertTransformFormatQuantity))),
 			},
 			want: want{
 				o: 1.0,
@@ -1087,7 +1087,7 @@ func TestConvertResolve(t *testing.T) {
 			args: args{
 				i:      "1000 blabla",
 				to:     v1.TransformIOTypeFloat64,
-				format: (*v1.ConvertTransformFormat)(pointer.String(string(v1.ConvertTransformFormatQuantity))),
+				format: (*v1.ConvertTransformFormat)(ptr.To(string(v1.ConvertTransformFormatQuantity))),
 			},
 			want: want{
 				err: resource.ErrFormatWrong,
@@ -1115,7 +1115,7 @@ func TestConvertResolve(t *testing.T) {
 			args: args{
 				i:      "{\"foo\":\"bar\"}",
 				to:     v1.TransformIOTypeObject,
-				format: (*v1.ConvertTransformFormat)(pointer.String(string(v1.ConvertTransformFormatJSON))),
+				format: (*v1.ConvertTransformFormat)(ptr.To(string(v1.ConvertTransformFormatJSON))),
 			},
 			want: want{
 				o: map[string]any{
@@ -1127,7 +1127,7 @@ func TestConvertResolve(t *testing.T) {
 			args: args{
 				i:      "[\"foo\", \"bar\", \"baz\"]",
 				to:     v1.TransformIOTypeArray,
-				format: (*v1.ConvertTransformFormat)(pointer.String(string(v1.ConvertTransformFormatJSON))),
+				format: (*v1.ConvertTransformFormat)(ptr.To(string(v1.ConvertTransformFormatJSON))),
 			},
 			want: want{
 				o: []any{
@@ -1148,7 +1148,7 @@ func TestConvertResolve(t *testing.T) {
 			args: args{
 				i:      100,
 				to:     v1.TransformIOTypeString,
-				format: (*v1.ConvertTransformFormat)(pointer.String(string(v1.ConvertTransformFormatQuantity))),
+				format: (*v1.ConvertTransformFormat)(ptr.To(string(v1.ConvertTransformFormatQuantity))),
 			},
 			want: want{
 				err: errors.Errorf(errFmtConvertFormatPairNotSupported, "int", "string", string(v1.ConvertTransformFormatQuantity)),

--- a/internal/controller/apiextensions/composite/connection_test.go
+++ b/internal/controller/apiextensions/composite/connection_test.go
@@ -26,7 +26,7 @@ import (
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
@@ -333,32 +333,32 @@ func TestExtractConnectionDetails(t *testing.T) {
 					{
 						Type:                    ConnectionDetailTypeFromConnectionSecretKey,
 						Name:                    "bar",
-						FromConnectionSecretKey: pointer.String("bar"),
+						FromConnectionSecretKey: ptr.To("bar"),
 					},
 					{
 						Type:                    ConnectionDetailTypeFromConnectionSecretKey,
 						Name:                    "none",
-						FromConnectionSecretKey: pointer.String("none"),
+						FromConnectionSecretKey: ptr.To("none"),
 					},
 					{
 						Type:                    ConnectionDetailTypeFromConnectionSecretKey,
 						Name:                    "convfoo",
-						FromConnectionSecretKey: pointer.String("foo"),
+						FromConnectionSecretKey: ptr.To("foo"),
 					},
 					{
 						Type:  ConnectionDetailTypeFromValue,
 						Name:  "fixed",
-						Value: pointer.String("value"),
+						Value: ptr.To("value"),
 					},
 					{
 						Type:          ConnectionDetailTypeFromFieldPath,
 						Name:          "name",
-						FromFieldPath: pointer.String("objectMeta.name"),
+						FromFieldPath: ptr.To("objectMeta.name"),
 					},
 					{
 						Type:          ConnectionDetailTypeFromFieldPath,
 						Name:          "generation",
-						FromFieldPath: pointer.String("objectMeta.generation"),
+						FromFieldPath: ptr.To("objectMeta.generation"),
 					},
 				},
 			},
@@ -415,9 +415,9 @@ func TestExtractConfigsFromTemplate(t *testing.T) {
 			args: args{
 				t: &v1.ComposedTemplate{
 					ConnectionDetails: []v1.ConnectionDetail{{
-						Name:                    pointer.String("cool-detail"),
+						Name:                    ptr.To("cool-detail"),
 						Type:                    &tfk,
-						FromConnectionSecretKey: pointer.String("cool-key"),
+						FromConnectionSecretKey: ptr.To("cool-key"),
 					}},
 				},
 			},
@@ -425,7 +425,7 @@ func TestExtractConfigsFromTemplate(t *testing.T) {
 				cfgs: []ConnectionDetailExtractConfig{{
 					Name:                    "cool-detail",
 					Type:                    ConnectionDetailTypeFromConnectionSecretKey,
-					FromConnectionSecretKey: pointer.String("cool-key"),
+					FromConnectionSecretKey: ptr.To("cool-key"),
 				}},
 			},
 		},
@@ -435,7 +435,7 @@ func TestExtractConfigsFromTemplate(t *testing.T) {
 				t: &v1.ComposedTemplate{
 					ConnectionDetails: []v1.ConnectionDetail{{
 						Type:                    &tfk,
-						FromConnectionSecretKey: pointer.String("cool-key"),
+						FromConnectionSecretKey: ptr.To("cool-key"),
 					}},
 				},
 			},
@@ -443,7 +443,7 @@ func TestExtractConfigsFromTemplate(t *testing.T) {
 				cfgs: []ConnectionDetailExtractConfig{{
 					Name:                    "cool-key",
 					Type:                    ConnectionDetailTypeFromConnectionSecretKey,
-					FromConnectionSecretKey: pointer.String("cool-key"),
+					FromConnectionSecretKey: ptr.To("cool-key"),
 				}},
 			},
 		},

--- a/internal/controller/apiextensions/composite/environment_fetcher_test.go
+++ b/internal/controller/apiextensions/composite/environment_fetcher_test.go
@@ -26,7 +26,7 @@ import (
 	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/crossplane/crossplane-runtime/pkg/resource/fake"
@@ -270,7 +270,7 @@ func TestFetch(t *testing.T) {
 						corev1.ObjectReference{Name: "a"},
 					),
 				),
-				required: pointer.Bool(false),
+				required: ptr.To(false),
 			},
 			want: want{
 				env: makeEnvironment(map[string]interface{}{}),

--- a/internal/controller/apiextensions/composite/environment_selector_test.go
+++ b/internal/controller/apiextensions/composite/environment_selector_test.go
@@ -28,7 +28,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/crossplane/crossplane-runtime/pkg/resource/fake"
@@ -205,7 +205,7 @@ func TestSelect(t *testing.T) {
 											{
 												Type:  v1.EnvironmentSourceSelectorLabelMatcherTypeValue,
 												Key:   "foo",
-												Value: pointer.String("bar"),
+												Value: ptr.To("bar"),
 											},
 										},
 									},
@@ -257,7 +257,7 @@ func TestSelect(t *testing.T) {
 											{
 												Type:               v1.EnvironmentSourceSelectorLabelMatcherTypeFromCompositeFieldPath,
 												Key:                "foo",
-												ValueFromFieldPath: pointer.String("objectMeta.name"),
+												ValueFromFieldPath: ptr.To("objectMeta.name"),
 											},
 										},
 									},
@@ -303,7 +303,7 @@ func TestSelect(t *testing.T) {
 											{
 												Type:  v1.EnvironmentSourceSelectorLabelMatcherTypeValue,
 												Key:   "foo",
-												Value: pointer.String("bar"),
+												Value: ptr.To("bar"),
 											},
 										},
 									},
@@ -353,7 +353,7 @@ func TestSelect(t *testing.T) {
 											{
 												Type:  v1.EnvironmentSourceSelectorLabelMatcherTypeValue,
 												Key:   "foo",
-												Value: pointer.String("bar"),
+												Value: ptr.To("bar"),
 											},
 										},
 									},
@@ -427,7 +427,7 @@ func TestSelect(t *testing.T) {
 											{
 												Type:  v1.EnvironmentSourceSelectorLabelMatcherTypeValue,
 												Key:   "foo",
-												Value: pointer.String("bar"),
+												Value: ptr.To("bar"),
 											},
 										},
 									},
@@ -460,7 +460,7 @@ func TestSelect(t *testing.T) {
 											{
 												Type:  v1.EnvironmentSourceSelectorLabelMatcherTypeValue,
 												Key:   "foo",
-												Value: pointer.String("bar"),
+												Value: ptr.To("bar"),
 											},
 										},
 									},
@@ -494,7 +494,7 @@ func TestSelect(t *testing.T) {
 											{
 												Type:               v1.EnvironmentSourceSelectorLabelMatcherTypeFromCompositeFieldPath,
 												Key:                "foo",
-												ValueFromFieldPath: pointer.String("wrong.path"),
+												ValueFromFieldPath: ptr.To("wrong.path"),
 											},
 										},
 									},
@@ -527,7 +527,7 @@ func TestSelect(t *testing.T) {
 											{
 												Type:                v1.EnvironmentSourceSelectorLabelMatcherTypeFromCompositeFieldPath,
 												Key:                 "foo",
-												ValueFromFieldPath:  pointer.String("wrong.path"),
+												ValueFromFieldPath:  ptr.To("wrong.path"),
 												FromFieldPathPolicy: &[]v1.FromFieldPathPolicy{v1.FromFieldPathPolicyOptional}[0],
 											},
 										},
@@ -560,7 +560,7 @@ func TestSelect(t *testing.T) {
 											{
 												Type:                v1.EnvironmentSourceSelectorLabelMatcherTypeFromCompositeFieldPath,
 												Key:                 "foo",
-												ValueFromFieldPath:  pointer.String("wrong.path"),
+												ValueFromFieldPath:  ptr.To("wrong.path"),
 												FromFieldPathPolicy: &[]v1.FromFieldPathPolicy{v1.FromFieldPathPolicyRequired}[0],
 											},
 										},
@@ -623,7 +623,7 @@ func TestSelect(t *testing.T) {
 											{
 												Type:  v1.EnvironmentSourceSelectorLabelMatcherTypeValue,
 												Key:   "foo",
-												Value: pointer.String("bar"),
+												Value: ptr.To("bar"),
 											},
 										},
 									},
@@ -719,7 +719,7 @@ func TestSelect(t *testing.T) {
 											{
 												Type:  v1.EnvironmentSourceSelectorLabelMatcherTypeValue,
 												Key:   "foo",
-												Value: pointer.String("bar"),
+												Value: ptr.To("bar"),
 											},
 										},
 									},
@@ -821,7 +821,7 @@ func TestSelect(t *testing.T) {
 											{
 												Type:  v1.EnvironmentSourceSelectorLabelMatcherTypeValue,
 												Key:   "foo",
-												Value: pointer.String("bar"),
+												Value: ptr.To("bar"),
 											},
 										},
 									},
@@ -908,13 +908,13 @@ func TestSelect(t *testing.T) {
 									Type: v1.EnvironmentSourceTypeSelector,
 									Selector: &v1.EnvironmentSourceSelector{
 										Mode:            v1.EnvironmentSourceSelectorMultiMode,
-										MaxMatch:        pointer.Uint64(3),
+										MaxMatch:        ptr.To[uint64](3),
 										SortByFieldPath: "data[int/weight]",
 										MatchLabels: []v1.EnvironmentSourceSelectorLabelMatcher{
 											{
 												Type:  v1.EnvironmentSourceSelectorLabelMatcherTypeValue,
 												Key:   "foo",
-												Value: pointer.String("bar"),
+												Value: ptr.To("bar"),
 											},
 										},
 									},
@@ -989,12 +989,12 @@ func TestSelect(t *testing.T) {
 									Selector: &v1.EnvironmentSourceSelector{
 										Mode:            v1.EnvironmentSourceSelectorMultiMode,
 										SortByFieldPath: "data[int/weight]",
-										MaxMatch:        pointer.Uint64(3),
+										MaxMatch:        ptr.To[uint64](3),
 										MatchLabels: []v1.EnvironmentSourceSelectorLabelMatcher{
 											{
 												Type:  v1.EnvironmentSourceSelectorLabelMatcherTypeValue,
 												Key:   "foo",
-												Value: pointer.String("bar"),
+												Value: ptr.To("bar"),
 											},
 										},
 									},
@@ -1052,12 +1052,12 @@ func TestSelect(t *testing.T) {
 									Selector: &v1.EnvironmentSourceSelector{
 										Mode:            v1.EnvironmentSourceSelectorMultiMode,
 										SortByFieldPath: "data[int/weight]",
-										MaxMatch:        pointer.Uint64(3),
+										MaxMatch:        ptr.To[uint64](3),
 										MatchLabels: []v1.EnvironmentSourceSelectorLabelMatcher{
 											{
 												Type:  v1.EnvironmentSourceSelectorLabelMatcherTypeValue,
 												Key:   "foo",
-												Value: pointer.String("bar"),
+												Value: ptr.To("bar"),
 											},
 										},
 									},
@@ -1105,12 +1105,12 @@ func TestSelect(t *testing.T) {
 									Selector: &v1.EnvironmentSourceSelector{
 										Mode:            v1.EnvironmentSourceSelectorMultiMode,
 										SortByFieldPath: "metadata.annotations[int/weight]",
-										MaxMatch:        pointer.Uint64(3),
+										MaxMatch:        ptr.To[uint64](3),
 										MatchLabels: []v1.EnvironmentSourceSelectorLabelMatcher{
 											{
 												Type:  v1.EnvironmentSourceSelectorLabelMatcherTypeValue,
 												Key:   "foo",
-												Value: pointer.String("bar"),
+												Value: ptr.To("bar"),
 											},
 										},
 									},

--- a/internal/controller/apiextensions/composite/ready.go
+++ b/internal/controller/apiextensions/composite/ready.go
@@ -20,7 +20,7 @@ import (
 	"context"
 
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
 	"github.com/crossplane/crossplane-runtime/pkg/errors"
@@ -98,16 +98,16 @@ func ReadinessCheckFromV1(in *v1.ReadinessCheck) ReadinessCheck {
 		Type: ReadinessCheckType(in.Type),
 	}
 	if in.FieldPath != "" {
-		out.FieldPath = pointer.String(in.FieldPath)
+		out.FieldPath = ptr.To(in.FieldPath)
 	}
 
 	// NOTE(negz): ComposedTemplate doesn't use pointer values for optional
 	// strings, so today the empty string and 0 are equivalent to "unset".
 	if in.MatchString != "" {
-		out.MatchString = pointer.String(in.MatchString)
+		out.MatchString = ptr.To(in.MatchString)
 	}
 	if in.MatchInteger != 0 {
-		out.MatchInteger = pointer.Int64(in.MatchInteger)
+		out.MatchInteger = ptr.To[int64](in.MatchInteger)
 	}
 	if in.MatchCondition != nil {
 		out.MatchCondition = &MatchConditionReadinessCheck{

--- a/internal/controller/apiextensions/composite/ready_test.go
+++ b/internal/controller/apiextensions/composite/ready_test.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
 	"github.com/crossplane/crossplane-runtime/pkg/errors"
@@ -126,7 +126,7 @@ func TestIsReady(t *testing.T) {
 				o: composed.New(),
 				rc: []ReadinessCheck{{
 					Type:      ReadinessCheckTypeNonEmpty,
-					FieldPath: pointer.String("metadata..uid"),
+					FieldPath: ptr.To("metadata..uid"),
 				}},
 			},
 			want: want{
@@ -139,7 +139,7 @@ func TestIsReady(t *testing.T) {
 				o: composed.New(),
 				rc: []ReadinessCheck{{
 					Type:      ReadinessCheckTypeNonEmpty,
-					FieldPath: pointer.String("metadata.uid"),
+					FieldPath: ptr.To("metadata.uid"),
 				}},
 			},
 			want: want{
@@ -154,7 +154,7 @@ func TestIsReady(t *testing.T) {
 				}),
 				rc: []ReadinessCheck{{
 					Type:      ReadinessCheckTypeNonEmpty,
-					FieldPath: pointer.String("metadata.uid"),
+					FieldPath: ptr.To("metadata.uid"),
 				}},
 			},
 			want: want{
@@ -167,8 +167,8 @@ func TestIsReady(t *testing.T) {
 				o: composed.New(),
 				rc: []ReadinessCheck{{
 					Type:        ReadinessCheckTypeMatchString,
-					FieldPath:   pointer.String("metadata..uid"),
-					MatchString: pointer.String("cool"),
+					FieldPath:   ptr.To("metadata..uid"),
+					MatchString: ptr.To("cool"),
 				}},
 			},
 			want: want{
@@ -181,7 +181,7 @@ func TestIsReady(t *testing.T) {
 				o: composed.New(),
 				rc: []ReadinessCheck{{
 					Type:      ReadinessCheckTypeMatchString,
-					FieldPath: pointer.String("metadata..uid"),
+					FieldPath: ptr.To("metadata..uid"),
 				}},
 			},
 			want: want{
@@ -194,8 +194,8 @@ func TestIsReady(t *testing.T) {
 				o: composed.New(),
 				rc: []ReadinessCheck{{
 					Type:        ReadinessCheckTypeMatchString,
-					FieldPath:   pointer.String("metadata.uid"),
-					MatchString: pointer.String("olala"),
+					FieldPath:   ptr.To("metadata.uid"),
+					MatchString: ptr.To("olala"),
 				}},
 			},
 			want: want{
@@ -210,8 +210,8 @@ func TestIsReady(t *testing.T) {
 				}),
 				rc: []ReadinessCheck{{
 					Type:        ReadinessCheckTypeMatchString,
-					FieldPath:   pointer.String("metadata.uid"),
-					MatchString: pointer.String("olala"),
+					FieldPath:   ptr.To("metadata.uid"),
+					MatchString: ptr.To("olala"),
 				}},
 			},
 			want: want{
@@ -224,8 +224,8 @@ func TestIsReady(t *testing.T) {
 				o: composed.New(),
 				rc: []ReadinessCheck{{
 					Type:         ReadinessCheckTypeMatchInteger,
-					FieldPath:    pointer.String("metadata..uid"),
-					MatchInteger: pointer.Int64(42),
+					FieldPath:    ptr.To("metadata..uid"),
+					MatchInteger: ptr.To[int64](42),
 				}},
 			},
 			want: want{
@@ -238,7 +238,7 @@ func TestIsReady(t *testing.T) {
 				o: composed.New(),
 				rc: []ReadinessCheck{{
 					Type:      ReadinessCheckTypeMatchInteger,
-					FieldPath: pointer.String("metadata..uid"),
+					FieldPath: ptr.To("metadata..uid"),
 				}},
 			},
 			want: want{
@@ -257,8 +257,8 @@ func TestIsReady(t *testing.T) {
 				}),
 				rc: []ReadinessCheck{{
 					Type:         ReadinessCheckTypeMatchInteger,
-					FieldPath:    pointer.String("spec.someNum"),
-					MatchInteger: pointer.Int64(5),
+					FieldPath:    ptr.To("spec.someNum"),
+					MatchInteger: ptr.To[int64](5),
 				}},
 			},
 			want: want{
@@ -277,8 +277,8 @@ func TestIsReady(t *testing.T) {
 				}),
 				rc: []ReadinessCheck{{
 					Type:         ReadinessCheckTypeMatchInteger,
-					FieldPath:    pointer.String("spec.someNum"),
-					MatchInteger: pointer.Int64(5),
+					FieldPath:    ptr.To("spec.someNum"),
+					MatchInteger: ptr.To[int64](5),
 				}},
 			},
 			want: want{
@@ -295,7 +295,7 @@ func TestIsReady(t *testing.T) {
 				}),
 				rc: []ReadinessCheck{{
 					Type:      ReadinessCheckTypeMatchTrue,
-					FieldPath: pointer.String("spec.someBool"),
+					FieldPath: ptr.To("spec.someBool"),
 				}},
 			},
 			want: want{
@@ -314,7 +314,7 @@ func TestIsReady(t *testing.T) {
 				}),
 				rc: []ReadinessCheck{{
 					Type:      ReadinessCheckTypeMatchTrue,
-					FieldPath: pointer.String("spec.someBool"),
+					FieldPath: ptr.To("spec.someBool"),
 				}},
 			},
 			want: want{
@@ -333,7 +333,7 @@ func TestIsReady(t *testing.T) {
 				}),
 				rc: []ReadinessCheck{{
 					Type:      ReadinessCheckTypeMatchTrue,
-					FieldPath: pointer.String("spec.someBool"),
+					FieldPath: ptr.To("spec.someBool"),
 				}},
 			},
 			want: want{
@@ -350,7 +350,7 @@ func TestIsReady(t *testing.T) {
 				}),
 				rc: []ReadinessCheck{{
 					Type:      ReadinessCheckTypeMatchFalse,
-					FieldPath: pointer.String("spec.someBool"),
+					FieldPath: ptr.To("spec.someBool"),
 				}},
 			},
 			want: want{
@@ -369,7 +369,7 @@ func TestIsReady(t *testing.T) {
 				}),
 				rc: []ReadinessCheck{{
 					Type:      ReadinessCheckTypeMatchFalse,
-					FieldPath: pointer.String("spec.someBool"),
+					FieldPath: ptr.To("spec.someBool"),
 				}},
 			},
 			want: want{
@@ -388,7 +388,7 @@ func TestIsReady(t *testing.T) {
 				}),
 				rc: []ReadinessCheck{{
 					Type:      ReadinessCheckTypeMatchFalse,
-					FieldPath: pointer.String("spec.someBool"),
+					FieldPath: ptr.To("spec.someBool"),
 				}},
 			},
 			want: want{

--- a/internal/controller/pkg/manager/reconciler.go
+++ b/internal/controller/pkg/manager/reconciler.go
@@ -27,7 +27,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -416,7 +416,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 	}
 
 	controlRef := meta.AsController(meta.TypedReferenceTo(p, p.GetObjectKind().GroupVersionKind()))
-	controlRef.BlockOwnerDeletion = pointer.Bool(true)
+	controlRef.BlockOwnerDeletion = ptr.To(true)
 	meta.AddOwnerReference(pr, controlRef)
 	if err := r.client.Apply(ctx, pr, resource.MustBeControllableBy(p.GetUID())); err != nil {
 		log.Debug(errApplyPackageRevision, "error", err)

--- a/internal/controller/pkg/revision/dependency_test.go
+++ b/internal/controller/pkg/revision/dependency_test.go
@@ -25,7 +25,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/crossplane/crossplane-runtime/pkg/errors"
@@ -225,10 +225,10 @@ func TestResolve(t *testing.T) {
 						MetaSpec: pkgmetav1.MetaSpec{
 							DependsOn: []pkgmetav1.Dependency{
 								{
-									Provider: pointer.String("not-here-1"),
+									Provider: ptr.To("not-here-1"),
 								},
 								{
-									Provider: pointer.String("not-here-2"),
+									Provider: ptr.To("not-here-2"),
 								},
 							},
 						},
@@ -312,10 +312,10 @@ func TestResolve(t *testing.T) {
 						MetaSpec: pkgmetav1.MetaSpec{
 							DependsOn: []pkgmetav1.Dependency{
 								{
-									Provider: pointer.String("not-here-1"),
+									Provider: ptr.To("not-here-1"),
 								},
 								{
-									Provider: pointer.String("not-here-2"),
+									Provider: ptr.To("not-here-2"),
 								},
 							},
 						},
@@ -408,11 +408,11 @@ func TestResolve(t *testing.T) {
 						MetaSpec: pkgmetav1.MetaSpec{
 							DependsOn: []pkgmetav1.Dependency{
 								{
-									Provider: pointer.String("not-here-1"),
+									Provider: ptr.To("not-here-1"),
 									Version:  ">=v0.1.0",
 								},
 								{
-									Provider: pointer.String("not-here-2"),
+									Provider: ptr.To("not-here-2"),
 									Version:  ">=v0.1.0",
 								},
 							},
@@ -522,15 +522,15 @@ func TestResolve(t *testing.T) {
 						MetaSpec: pkgmetav1.MetaSpec{
 							DependsOn: []pkgmetav1.Dependency{
 								{
-									Provider: pointer.String("not-here-1"),
+									Provider: ptr.To("not-here-1"),
 									Version:  ">=v0.1.0",
 								},
 								{
-									Provider: pointer.String("not-here-2"),
+									Provider: ptr.To("not-here-2"),
 									Version:  ">=v0.1.0",
 								},
 								{
-									Function: pointer.String("function-not-here-1"),
+									Function: ptr.To("function-not-here-1"),
 									Version:  ">=v0.1.0",
 								},
 							},

--- a/internal/controller/pkg/revision/establisher.go
+++ b/internal/controller/pkg/revision/establisher.go
@@ -30,7 +30,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
@@ -155,7 +155,7 @@ func (e *APIEstablisher) ReleaseObjects(ctx context.Context, parent v1.PackageRe
 		ors := u.GetOwnerReferences()
 		for i := range ors {
 			if ors[i].UID == parent.GetUID() {
-				ors[i].Controller = pointer.Bool(false)
+				ors[i].Controller = ptr.To(false)
 				break
 			}
 			// Note(turkenh): What if we cannot find our UID in the owner
@@ -240,7 +240,7 @@ func (e *APIEstablisher) validate(ctx context.Context, objs []runtime.Object, pa
 					}
 					conf.Webhooks[i].ClientConfig.Service.Name = parent.GetLabels()[v1.LabelParentPackage]
 					conf.Webhooks[i].ClientConfig.Service.Namespace = e.namespace
-					conf.Webhooks[i].ClientConfig.Service.Port = pointer.Int32(servicePort)
+					conf.Webhooks[i].ClientConfig.Service.Port = ptr.To[int32](servicePort)
 				}
 			case *admv1.MutatingWebhookConfiguration:
 				if len(webhookTLSCert) == 0 {
@@ -256,7 +256,7 @@ func (e *APIEstablisher) validate(ctx context.Context, objs []runtime.Object, pa
 					}
 					conf.Webhooks[i].ClientConfig.Service.Name = parent.GetLabels()[v1.LabelParentPackage]
 					conf.Webhooks[i].ClientConfig.Service.Namespace = e.namespace
-					conf.Webhooks[i].ClientConfig.Service.Port = pointer.Int32(servicePort)
+					conf.Webhooks[i].ClientConfig.Service.Port = ptr.To[int32](servicePort)
 				}
 			case *extv1.CustomResourceDefinition:
 				if conf.Spec.Conversion != nil && conf.Spec.Conversion.Strategy == extv1.WebhookConverter {
@@ -275,7 +275,7 @@ func (e *APIEstablisher) validate(ctx context.Context, objs []runtime.Object, pa
 					conf.Spec.Conversion.Webhook.ClientConfig.CABundle = webhookTLSCert
 					conf.Spec.Conversion.Webhook.ClientConfig.Service.Name = parent.GetName()
 					conf.Spec.Conversion.Webhook.ClientConfig.Service.Namespace = e.namespace
-					conf.Spec.Conversion.Webhook.ClientConfig.Service.Port = pointer.Int32(servicePort)
+					conf.Spec.Conversion.Webhook.ClientConfig.Service.Port = ptr.To[int32](servicePort)
 				}
 			}
 
@@ -389,7 +389,7 @@ func (e *APIEstablisher) create(ctx context.Context, obj resource.Object, parent
 	// get deleted when the new revision doesn't include it in order not to lose
 	// user data, such as custom resources of an old CRD.
 	if pkgRef, ok := GetPackageOwnerReference(parent); ok {
-		pkgRef.Controller = pointer.Bool(false)
+		pkgRef.Controller = ptr.To(false)
 		refs = append(refs, pkgRef)
 	}
 	// Overwrite any owner references on the desired object.
@@ -402,7 +402,7 @@ func (e *APIEstablisher) update(ctx context.Context, current, desired resource.O
 	// get deleted when the new revision doesn't include it in order not to lose
 	// user data, such as custom resources of an old CRD.
 	if pkgRef, ok := GetPackageOwnerReference(parent); ok {
-		pkgRef.Controller = pointer.Bool(false)
+		pkgRef.Controller = ptr.To(false)
 		meta.AddOwnerReference(current, pkgRef)
 	}
 

--- a/internal/controller/pkg/revision/reconciler_test.go
+++ b/internal/controller/pkg/revision/reconciler_test.go
@@ -29,7 +29,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -913,14 +913,14 @@ func TestReconcile(t *testing.T) {
 								pr := o.(*v1.ProviderRevision)
 								pr.SetGroupVersionKind(v1.ProviderRevisionGroupVersionKind)
 								pr.SetDesiredState(v1.PackageRevisionActive)
-								pr.SetSkipDependencyResolution(pointer.Bool(false))
+								pr.SetSkipDependencyResolution(ptr.To(false))
 								return nil
 							}),
 							MockStatusUpdate: test.NewMockSubResourceUpdateFn(nil, func(o client.Object) error {
 								want := &v1.ProviderRevision{}
 								want.SetGroupVersionKind(v1.ProviderRevisionGroupVersionKind)
 								want.SetDesiredState(v1.PackageRevisionActive)
-								want.SetSkipDependencyResolution(pointer.Bool(false))
+								want.SetSkipDependencyResolution(ptr.To(false))
 								want.SetAnnotations(map[string]string{"author": "crossplane"})
 								want.SetConditions(v1.UnknownHealth().WithMessage("cannot resolve package dependencies: boom"))
 
@@ -934,7 +934,7 @@ func TestReconcile(t *testing.T) {
 								want.SetGroupVersionKind(v1.ProviderRevisionGroupVersionKind)
 								want.SetDesiredState(v1.PackageRevisionActive)
 								want.SetAnnotations(map[string]string{"author": "crossplane"})
-								want.SetSkipDependencyResolution(pointer.Bool(false))
+								want.SetSkipDependencyResolution(ptr.To(false))
 								if diff := cmp.Diff(want, o); diff != "" {
 									t.Errorf("-want, +got:\n%s", diff)
 								}

--- a/internal/xcrd/crd.go
+++ b/internal/xcrd/crd.go
@@ -28,7 +28,7 @@ import (
 
 	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	"github.com/crossplane/crossplane-runtime/pkg/errors"
 	"github.com/crossplane/crossplane-runtime/pkg/meta"
@@ -72,8 +72,12 @@ func ForCompositeResource(xrd *v1.CompositeResourceDefinition) (*extv1.CustomRes
 
 	crd.Spec.Names.Categories = append(crd.Spec.Names.Categories, CategoryComposite)
 
+	// The composite name is used as a label value, so we must ensure it is not
+	// longer.
+	const maxCompositeNameLength = 63
+
 	for i, vr := range xrd.Spec.Versions {
-		crdv, err := genCrdVersion(vr)
+		crdv, err := genCrdVersion(vr, maxCompositeNameLength)
 		if err != nil {
 			return nil, errors.Wrapf(err, errFmtGenCrd, "Composite Resource", xrd.Name)
 		}
@@ -112,8 +116,13 @@ func ForCompositeResourceClaim(xrd *v1.CompositeResourceDefinition) (*extv1.Cust
 
 	crd.Spec.Names.Categories = append(crd.Spec.Names.Categories, CategoryClaim)
 
+	// 63 because the names are used as label values. We don't put 63-6
+	// (generateName suffix length) here because the name generator shortens
+	// the base to 57 automatically before appending the suffix.
+	const maxClaimNameLength = 63
+
 	for i, vr := range xrd.Spec.Versions {
-		crdv, err := genCrdVersion(vr)
+		crdv, err := genCrdVersion(vr, maxClaimNameLength)
 		if err != nil {
 			return nil, errors.Wrapf(err, errFmtGenCrd, "Composite Resource Claim", xrd.Name)
 		}
@@ -133,12 +142,12 @@ func ForCompositeResourceClaim(xrd *v1.CompositeResourceDefinition) (*extv1.Cust
 	return crd, nil
 }
 
-func genCrdVersion(vr v1.CompositeResourceDefinitionVersion) (*extv1.CustomResourceDefinitionVersion, error) {
+func genCrdVersion(vr v1.CompositeResourceDefinitionVersion, maxNameLength int64) (*extv1.CustomResourceDefinitionVersion, error) {
 	crdv := extv1.CustomResourceDefinitionVersion{
 		Name:                     vr.Name,
 		Served:                   vr.Served,
 		Storage:                  vr.Referenceable,
-		Deprecated:               pointer.BoolDeref(vr.Deprecated, false),
+		Deprecated:               ptr.Deref(vr.Deprecated, false),
 		DeprecationWarning:       vr.DeprecationWarning,
 		AdditionalPrinterColumns: vr.AdditionalPrinterColumns,
 		Schema: &extv1.CustomResourceValidation{
@@ -158,6 +167,17 @@ func genCrdVersion(vr v1.CompositeResourceDefinitionVersion) (*extv1.CustomResou
 	}
 
 	crdv.Schema.OpenAPIV3Schema.Description = s.Description
+
+	maxLength := maxNameLength
+	if old := s.Properties["metadata"].Properties["name"].MaxLength; old != nil && *old < maxLength {
+		maxLength = *old
+	}
+	xName := crdv.Schema.OpenAPIV3Schema.Properties["metadata"].Properties["name"]
+	xName.MaxLength = ptr.To(maxLength)
+	xName.Type = "string"
+	xMetaData := crdv.Schema.OpenAPIV3Schema.Properties["metadata"]
+	xMetaData.Properties = map[string]extv1.JSONSchemaProps{"name": xName}
+	crdv.Schema.OpenAPIV3Schema.Properties["metadata"] = xMetaData
 
 	xSpec := s.Properties["spec"]
 	cSpec := crdv.Schema.OpenAPIV3Schema.Properties["spec"]

--- a/internal/xcrd/crd_test.go
+++ b/internal/xcrd/crd_test.go
@@ -32,7 +32,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
 	"github.com/crossplane/crossplane-runtime/pkg/errors"
@@ -352,7 +352,7 @@ func TestForCompositeResource(t *testing.T) {
 															Required: []string{"apiVersion", "kind"},
 														},
 													},
-													XListType: pointer.String("atomic"),
+													XListType: ptr.To("atomic"),
 												},
 												"publishConnectionDetailsTo": {
 													Type:     "object",
@@ -418,7 +418,7 @@ func TestForCompositeResource(t *testing.T) {
 												"conditions": {
 													Description:  "Conditions of the resource.",
 													Type:         "array",
-													XListType:    pointer.String("map"),
+													XListType:    ptr.To("map"),
 													XListMapKeys: []string{"type"},
 													Items: &extv1.JSONSchemaPropsOrArray{
 														Schema: &extv1.JSONSchemaProps{
@@ -623,7 +623,7 @@ func TestForCompositeResource(t *testing.T) {
 															Required: []string{"apiVersion", "kind"},
 														},
 													},
-													XListType: pointer.String("atomic"),
+													XListType: ptr.To("atomic"),
 												},
 												"publishConnectionDetailsTo": {
 													Type:     "object",
@@ -682,7 +682,7 @@ func TestForCompositeResource(t *testing.T) {
 												"conditions": {
 													Description:  "Conditions of the resource.",
 													Type:         "array",
-													XListType:    pointer.String("map"),
+													XListType:    ptr.To("map"),
 													XListMapKeys: []string{"type"},
 													Items: &extv1.JSONSchemaPropsOrArray{
 														Schema: &extv1.JSONSchemaProps{
@@ -1721,7 +1721,7 @@ func TestForCompositeResourceClaim(t *testing.T) {
 												"conditions": {
 													Description:  "Conditions of the resource.",
 													Type:         "array",
-													XListType:    pointer.String("map"),
+													XListType:    ptr.To("map"),
 													XListMapKeys: []string{"type"},
 													Items: &extv1.JSONSchemaPropsOrArray{
 														Schema: &extv1.JSONSchemaProps{
@@ -2005,7 +2005,7 @@ func TestForCompositeResourceClaim(t *testing.T) {
 												"conditions": {
 													Description:  "Conditions of the resource.",
 													Type:         "array",
-													XListType:    pointer.String("map"),
+													XListType:    ptr.To("map"),
 													XListMapKeys: []string{"type"},
 													Items: &extv1.JSONSchemaPropsOrArray{
 														Schema: &extv1.JSONSchemaProps{
@@ -2303,7 +2303,7 @@ func TestForCompositeResourceClaimEmptyXrd(t *testing.T) {
 										"conditions": {
 											Description:  "Conditions of the resource.",
 											Type:         "array",
-											XListType:    pointer.String("map"),
+											XListType:    ptr.To("map"),
 											XListMapKeys: []string{"type"},
 											Items: &extv1.JSONSchemaPropsOrArray{
 												Schema: &extv1.JSONSchemaProps{

--- a/internal/xcrd/crd_test.go
+++ b/internal/xcrd/crd_test.go
@@ -24,6 +24,7 @@ package xcrd
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -244,6 +245,12 @@ func TestForCompositeResource(t *testing.T) {
 											// NOTE(muvaf): api-server takes care of validating
 											// metadata.
 											Type: "object",
+											Properties: map[string]extv1.JSONSchemaProps{
+												"name": {
+													Type:      "string",
+													MaxLength: ptr.To[int64](63),
+												},
+											},
 										},
 										"spec": {
 											Type:        "object",
@@ -520,6 +527,12 @@ func TestForCompositeResource(t *testing.T) {
 											// NOTE(muvaf): api-server takes care of validating
 											// metadata.
 											Type: "object",
+											Properties: map[string]extv1.JSONSchemaProps{
+												"name": {
+													Type:      "string",
+													MaxLength: ptr.To[int64](63),
+												},
+											},
 										},
 										"spec": {
 											Type:        "object",
@@ -690,6 +703,570 @@ func TestForCompositeResource(t *testing.T) {
 													Properties: map[string]extv1.JSONSchemaProps{
 														"lastPublishedTime": {Type: "string", Format: "date-time"},
 													},
+												},
+											},
+										},
+									},
+								},
+							},
+						}},
+					},
+				},
+			},
+		},
+		"RestrictingNameLength": {
+			reason: "A CRD should be generated from a CompositeResourceDefinitionVersion.",
+			args: args{
+				v: &v1.CompositeResourceValidation{
+					OpenAPIV3Schema: runtime.RawExtension{Raw: []byte(strings.Replace(schema, `"spec":`, `"metadata":{"type":"object","properties":{"name":{"type":"string","maxLength":10}}},"spec":`, 1))},
+				},
+			},
+			want: want{
+				c: &extv1.CustomResourceDefinition{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:   name,
+						Labels: labels,
+						OwnerReferences: []metav1.OwnerReference{
+							meta.AsController(meta.TypedReferenceTo(d, v1.CompositeResourceDefinitionGroupVersionKind)),
+						},
+					},
+					Spec: extv1.CustomResourceDefinitionSpec{
+						Group: group,
+						Names: extv1.CustomResourceDefinitionNames{
+							Plural:     plural,
+							Singular:   singular,
+							Kind:       kind,
+							ListKind:   listKind,
+							Categories: []string{CategoryComposite},
+						},
+						Scope: extv1.ClusterScoped,
+						Versions: []extv1.CustomResourceDefinitionVersion{{
+							Name:    version,
+							Served:  true,
+							Storage: true,
+							Subresources: &extv1.CustomResourceSubresources{
+								Status: &extv1.CustomResourceSubresourceStatus{},
+							},
+							AdditionalPrinterColumns: []extv1.CustomResourceColumnDefinition{
+								{
+									Name:     "SYNCED",
+									Type:     "string",
+									JSONPath: ".status.conditions[?(@.type=='Synced')].status",
+								},
+								{
+									Name:     "READY",
+									Type:     "string",
+									JSONPath: ".status.conditions[?(@.type=='Ready')].status",
+								},
+								{
+									Name:     "COMPOSITION",
+									Type:     "string",
+									JSONPath: ".spec.compositionRef.name",
+								},
+								{
+									Name:     "AGE",
+									Type:     "date",
+									JSONPath: ".metadata.creationTimestamp",
+								},
+							},
+							Schema: &extv1.CustomResourceValidation{
+								OpenAPIV3Schema: &extv1.JSONSchemaProps{
+									Type:        "object",
+									Description: "What the resource is for.",
+									Required:    []string{"spec"},
+									Properties: map[string]extv1.JSONSchemaProps{
+										"apiVersion": {
+											Type: "string",
+										},
+										"kind": {
+											Type: "string",
+										},
+										"metadata": {
+											// NOTE(muvaf): api-server takes care of validating
+											// metadata.
+											Type: "object",
+											Properties: map[string]extv1.JSONSchemaProps{
+												"name": {
+													Type:      "string",
+													MaxLength: ptr.To[int64](10),
+												},
+											},
+										},
+										"spec": {
+											Type:        "object",
+											Required:    []string{"storageGB", "engineVersion"},
+											Description: "Specification of the resource.",
+											Properties: map[string]extv1.JSONSchemaProps{
+												// From CRDSpecTemplate.Validation
+												"storageGB": {Type: "integer", Description: "Pretend this is useful."},
+												"engineVersion": {
+													Type: "string",
+													Enum: []extv1.JSON{
+														{Raw: []byte(`"5.6"`)},
+														{Raw: []byte(`"5.7"`)},
+													},
+												},
+
+												// From CompositeResourceSpecProps()
+												"compositionRef": {
+													Type:     "object",
+													Required: []string{"name"},
+													Properties: map[string]extv1.JSONSchemaProps{
+														"name": {Type: "string"},
+													},
+												},
+												"compositionSelector": {
+													Type:     "object",
+													Required: []string{"matchLabels"},
+													Properties: map[string]extv1.JSONSchemaProps{
+														"matchLabels": {
+															Type: "object",
+															AdditionalProperties: &extv1.JSONSchemaPropsOrBool{
+																Allows: true,
+																Schema: &extv1.JSONSchemaProps{Type: "string"},
+															},
+														},
+													},
+												},
+												"compositionRevisionRef": {
+													Type:     "object",
+													Required: []string{"name"},
+													Properties: map[string]extv1.JSONSchemaProps{
+														"name": {Type: "string"},
+													},
+												},
+												"compositionRevisionSelector": {
+													Type:     "object",
+													Required: []string{"matchLabels"},
+													Properties: map[string]extv1.JSONSchemaProps{
+														"matchLabels": {
+															Type: "object",
+															AdditionalProperties: &extv1.JSONSchemaPropsOrBool{
+																Allows: true,
+																Schema: &extv1.JSONSchemaProps{Type: "string"},
+															},
+														},
+													},
+												},
+												"compositionUpdatePolicy": {
+													Type: "string",
+													Enum: []extv1.JSON{
+														{Raw: []byte(`"Automatic"`)},
+														{Raw: []byte(`"Manual"`)},
+													},
+												},
+												"claimRef": {
+													Type:     "object",
+													Required: []string{"apiVersion", "kind", "namespace", "name"},
+													Properties: map[string]extv1.JSONSchemaProps{
+														"apiVersion": {Type: "string"},
+														"kind":       {Type: "string"},
+														"namespace":  {Type: "string"},
+														"name":       {Type: "string"},
+													},
+												},
+												"environmentConfigRefs": {
+													Type: "array",
+													Items: &extv1.JSONSchemaPropsOrArray{
+														Schema: &extv1.JSONSchemaProps{
+															Type: "object",
+															Properties: map[string]extv1.JSONSchemaProps{
+																"apiVersion": {Type: "string"},
+																"name":       {Type: "string"},
+																"kind":       {Type: "string"},
+															},
+															Required: []string{"apiVersion", "kind"},
+														},
+													},
+												},
+												"resourceRefs": {
+													Type: "array",
+													Items: &extv1.JSONSchemaPropsOrArray{
+														Schema: &extv1.JSONSchemaProps{
+															Type: "object",
+															Properties: map[string]extv1.JSONSchemaProps{
+																"apiVersion": {Type: "string"},
+																"name":       {Type: "string"},
+																"kind":       {Type: "string"},
+															},
+															Required: []string{"apiVersion", "kind"},
+														},
+													},
+													XListType: ptr.To("atomic"),
+												},
+												"publishConnectionDetailsTo": {
+													Type:     "object",
+													Required: []string{"name"},
+													Properties: map[string]extv1.JSONSchemaProps{
+														"name": {Type: "string"},
+														"configRef": {
+															Type:    "object",
+															Default: &extv1.JSON{Raw: []byte(`{"name": "default"}`)},
+															Properties: map[string]extv1.JSONSchemaProps{
+																"name": {
+																	Type: "string",
+																},
+															},
+														},
+														"metadata": {
+															Type: "object",
+															Properties: map[string]extv1.JSONSchemaProps{
+																"labels": {
+																	Type: "object",
+																	AdditionalProperties: &extv1.JSONSchemaPropsOrBool{
+																		Allows: true,
+																		Schema: &extv1.JSONSchemaProps{Type: "string"},
+																	},
+																},
+																"annotations": {
+																	Type: "object",
+																	AdditionalProperties: &extv1.JSONSchemaPropsOrBool{
+																		Allows: true,
+																		Schema: &extv1.JSONSchemaProps{Type: "string"},
+																	},
+																},
+																"type": {
+																	Type: "string",
+																},
+															},
+														},
+													},
+												},
+												"writeConnectionSecretToRef": {
+													Type:     "object",
+													Required: []string{"name", "namespace"},
+													Properties: map[string]extv1.JSONSchemaProps{
+														"name":      {Type: "string"},
+														"namespace": {Type: "string"},
+													},
+												},
+											},
+											XValidations: extv1.ValidationRules{
+												{
+													Message: "Cannot change engine version",
+													Rule:    "self.engineVersion == oldSelf.engineVersion",
+												},
+											},
+										},
+										"status": {
+											Type:        "object",
+											Description: "Status of the resource.",
+											Properties: map[string]extv1.JSONSchemaProps{
+												"phase": {Type: "string"},
+
+												// From CompositeResourceStatusProps()
+												"conditions": {
+													Description:  "Conditions of the resource.",
+													Type:         "array",
+													XListType:    ptr.To("map"),
+													XListMapKeys: []string{"type"},
+													Items: &extv1.JSONSchemaPropsOrArray{
+														Schema: &extv1.JSONSchemaProps{
+															Type:     "object",
+															Required: []string{"lastTransitionTime", "reason", "status", "type"},
+															Properties: map[string]extv1.JSONSchemaProps{
+																"lastTransitionTime": {Type: "string", Format: "date-time"},
+																"message":            {Type: "string"},
+																"reason":             {Type: "string"},
+																"status":             {Type: "string"},
+																"type":               {Type: "string"},
+															},
+														},
+													},
+												},
+												"connectionDetails": {
+													Type: "object",
+													Properties: map[string]extv1.JSONSchemaProps{
+														"lastPublishedTime": {Type: "string", Format: "date-time"},
+													},
+												},
+											},
+											XValidations: extv1.ValidationRules{
+												{
+													Message: "Phase is required once set",
+													Rule:    "!has(oldSelf.phase) || has(self.phase)",
+												},
+											},
+										},
+									},
+								},
+							},
+						}},
+					},
+				},
+			},
+		},
+		"WeaklyRestrictingNameLength": {
+			reason: "A CRD should be generated from a CompositeResourceDefinitionVersion.",
+			args: args{
+				v: &v1.CompositeResourceValidation{
+					OpenAPIV3Schema: runtime.RawExtension{Raw: []byte(strings.Replace(schema, `"spec":`, `"metadata":{"type":"object","properties":{"name":{"type":"string","maxLength":100}}},"spec":`, 1))},
+				},
+			},
+			want: want{
+				c: &extv1.CustomResourceDefinition{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:   name,
+						Labels: labels,
+						OwnerReferences: []metav1.OwnerReference{
+							meta.AsController(meta.TypedReferenceTo(d, v1.CompositeResourceDefinitionGroupVersionKind)),
+						},
+					},
+					Spec: extv1.CustomResourceDefinitionSpec{
+						Group: group,
+						Names: extv1.CustomResourceDefinitionNames{
+							Plural:     plural,
+							Singular:   singular,
+							Kind:       kind,
+							ListKind:   listKind,
+							Categories: []string{CategoryComposite},
+						},
+						Scope: extv1.ClusterScoped,
+						Versions: []extv1.CustomResourceDefinitionVersion{{
+							Name:    version,
+							Served:  true,
+							Storage: true,
+							Subresources: &extv1.CustomResourceSubresources{
+								Status: &extv1.CustomResourceSubresourceStatus{},
+							},
+							AdditionalPrinterColumns: []extv1.CustomResourceColumnDefinition{
+								{
+									Name:     "SYNCED",
+									Type:     "string",
+									JSONPath: ".status.conditions[?(@.type=='Synced')].status",
+								},
+								{
+									Name:     "READY",
+									Type:     "string",
+									JSONPath: ".status.conditions[?(@.type=='Ready')].status",
+								},
+								{
+									Name:     "COMPOSITION",
+									Type:     "string",
+									JSONPath: ".spec.compositionRef.name",
+								},
+								{
+									Name:     "AGE",
+									Type:     "date",
+									JSONPath: ".metadata.creationTimestamp",
+								},
+							},
+							Schema: &extv1.CustomResourceValidation{
+								OpenAPIV3Schema: &extv1.JSONSchemaProps{
+									Type:        "object",
+									Description: "What the resource is for.",
+									Required:    []string{"spec"},
+									Properties: map[string]extv1.JSONSchemaProps{
+										"apiVersion": {
+											Type: "string",
+										},
+										"kind": {
+											Type: "string",
+										},
+										"metadata": {
+											// NOTE(muvaf): api-server takes care of validating
+											// metadata.
+											Type: "object",
+											Properties: map[string]extv1.JSONSchemaProps{
+												"name": {
+													Type:      "string",
+													MaxLength: ptr.To[int64](63),
+												},
+											},
+										},
+										"spec": {
+											Type:        "object",
+											Required:    []string{"storageGB", "engineVersion"},
+											Description: "Specification of the resource.",
+											Properties: map[string]extv1.JSONSchemaProps{
+												// From CRDSpecTemplate.Validation
+												"storageGB": {Type: "integer", Description: "Pretend this is useful."},
+												"engineVersion": {
+													Type: "string",
+													Enum: []extv1.JSON{
+														{Raw: []byte(`"5.6"`)},
+														{Raw: []byte(`"5.7"`)},
+													},
+												},
+
+												// From CompositeResourceSpecProps()
+												"compositionRef": {
+													Type:     "object",
+													Required: []string{"name"},
+													Properties: map[string]extv1.JSONSchemaProps{
+														"name": {Type: "string"},
+													},
+												},
+												"compositionSelector": {
+													Type:     "object",
+													Required: []string{"matchLabels"},
+													Properties: map[string]extv1.JSONSchemaProps{
+														"matchLabels": {
+															Type: "object",
+															AdditionalProperties: &extv1.JSONSchemaPropsOrBool{
+																Allows: true,
+																Schema: &extv1.JSONSchemaProps{Type: "string"},
+															},
+														},
+													},
+												},
+												"compositionRevisionRef": {
+													Type:     "object",
+													Required: []string{"name"},
+													Properties: map[string]extv1.JSONSchemaProps{
+														"name": {Type: "string"},
+													},
+												},
+												"compositionRevisionSelector": {
+													Type:     "object",
+													Required: []string{"matchLabels"},
+													Properties: map[string]extv1.JSONSchemaProps{
+														"matchLabels": {
+															Type: "object",
+															AdditionalProperties: &extv1.JSONSchemaPropsOrBool{
+																Allows: true,
+																Schema: &extv1.JSONSchemaProps{Type: "string"},
+															},
+														},
+													},
+												},
+												"compositionUpdatePolicy": {
+													Type: "string",
+													Enum: []extv1.JSON{
+														{Raw: []byte(`"Automatic"`)},
+														{Raw: []byte(`"Manual"`)},
+													},
+												},
+												"claimRef": {
+													Type:     "object",
+													Required: []string{"apiVersion", "kind", "namespace", "name"},
+													Properties: map[string]extv1.JSONSchemaProps{
+														"apiVersion": {Type: "string"},
+														"kind":       {Type: "string"},
+														"namespace":  {Type: "string"},
+														"name":       {Type: "string"},
+													},
+												},
+												"environmentConfigRefs": {
+													Type: "array",
+													Items: &extv1.JSONSchemaPropsOrArray{
+														Schema: &extv1.JSONSchemaProps{
+															Type: "object",
+															Properties: map[string]extv1.JSONSchemaProps{
+																"apiVersion": {Type: "string"},
+																"name":       {Type: "string"},
+																"kind":       {Type: "string"},
+															},
+															Required: []string{"apiVersion", "kind"},
+														},
+													},
+												},
+												"resourceRefs": {
+													Type: "array",
+													Items: &extv1.JSONSchemaPropsOrArray{
+														Schema: &extv1.JSONSchemaProps{
+															Type: "object",
+															Properties: map[string]extv1.JSONSchemaProps{
+																"apiVersion": {Type: "string"},
+																"name":       {Type: "string"},
+																"kind":       {Type: "string"},
+															},
+															Required: []string{"apiVersion", "kind"},
+														},
+													},
+													XListType: ptr.To("atomic"),
+												},
+												"publishConnectionDetailsTo": {
+													Type:     "object",
+													Required: []string{"name"},
+													Properties: map[string]extv1.JSONSchemaProps{
+														"name": {Type: "string"},
+														"configRef": {
+															Type:    "object",
+															Default: &extv1.JSON{Raw: []byte(`{"name": "default"}`)},
+															Properties: map[string]extv1.JSONSchemaProps{
+																"name": {
+																	Type: "string",
+																},
+															},
+														},
+														"metadata": {
+															Type: "object",
+															Properties: map[string]extv1.JSONSchemaProps{
+																"labels": {
+																	Type: "object",
+																	AdditionalProperties: &extv1.JSONSchemaPropsOrBool{
+																		Allows: true,
+																		Schema: &extv1.JSONSchemaProps{Type: "string"},
+																	},
+																},
+																"annotations": {
+																	Type: "object",
+																	AdditionalProperties: &extv1.JSONSchemaPropsOrBool{
+																		Allows: true,
+																		Schema: &extv1.JSONSchemaProps{Type: "string"},
+																	},
+																},
+																"type": {
+																	Type: "string",
+																},
+															},
+														},
+													},
+												},
+												"writeConnectionSecretToRef": {
+													Type:     "object",
+													Required: []string{"name", "namespace"},
+													Properties: map[string]extv1.JSONSchemaProps{
+														"name":      {Type: "string"},
+														"namespace": {Type: "string"},
+													},
+												},
+											},
+											XValidations: extv1.ValidationRules{
+												{
+													Message: "Cannot change engine version",
+													Rule:    "self.engineVersion == oldSelf.engineVersion",
+												},
+											},
+										},
+										"status": {
+											Type:        "object",
+											Description: "Status of the resource.",
+											Properties: map[string]extv1.JSONSchemaProps{
+												"phase": {Type: "string"},
+
+												// From CompositeResourceStatusProps()
+												"conditions": {
+													Description:  "Conditions of the resource.",
+													Type:         "array",
+													XListType:    ptr.To("map"),
+													XListMapKeys: []string{"type"},
+													Items: &extv1.JSONSchemaPropsOrArray{
+														Schema: &extv1.JSONSchemaProps{
+															Type:     "object",
+															Required: []string{"lastTransitionTime", "reason", "status", "type"},
+															Properties: map[string]extv1.JSONSchemaProps{
+																"lastTransitionTime": {Type: "string", Format: "date-time"},
+																"message":            {Type: "string"},
+																"reason":             {Type: "string"},
+																"status":             {Type: "string"},
+																"type":               {Type: "string"},
+															},
+														},
+													},
+												},
+												"connectionDetails": {
+													Type: "object",
+													Properties: map[string]extv1.JSONSchemaProps{
+														"lastPublishedTime": {Type: "string", Format: "date-time"},
+													},
+												},
+											},
+											XValidations: extv1.ValidationRules{
+												{
+													Message: "Phase is required once set",
+													Rule:    "!has(oldSelf.phase) || has(self.phase)",
 												},
 											},
 										},
@@ -998,6 +1575,12 @@ func TestForCompositeResourceClaim(t *testing.T) {
 											// NOTE(muvaf): api-server takes care of validating
 											// metadata.
 											Type: "object",
+											Properties: map[string]extv1.JSONSchemaProps{
+												"name": {
+													Type:      "string",
+													MaxLength: ptr.To[int64](63),
+												},
+											},
 										},
 										"spec": {
 											Type:        "object",
@@ -1275,6 +1858,12 @@ func TestForCompositeResourceClaim(t *testing.T) {
 											// NOTE(muvaf): api-server takes care of validating
 											// metadata.
 											Type: "object",
+											Properties: map[string]extv1.JSONSchemaProps{
+												"name": {
+													Type:      "string",
+													MaxLength: ptr.To[int64](63),
+												},
+											},
 										},
 										"spec": {
 											Type:        "object",
@@ -1586,6 +2175,12 @@ func TestForCompositeResourceClaimEmptyXrd(t *testing.T) {
 									// NOTE(muvaf): api-server takes care of validating
 									// metadata.
 									Type: "object",
+									Properties: map[string]extv1.JSONSchemaProps{
+										"name": {
+											Type:      "string",
+											MaxLength: ptr.To[int64](63),
+										},
+									},
 								},
 								"spec": {
 									Type:        "object",

--- a/internal/xcrd/schemas.go
+++ b/internal/xcrd/schemas.go
@@ -18,7 +18,7 @@ package xcrd
 
 import (
 	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 // Label keys.
@@ -157,7 +157,7 @@ func CompositeResourceSpecProps() map[string]extv1.JSONSchemaProps {
 				},
 			},
 			// Controllers should replace the entire resourceRefs array.
-			XListType: pointer.String("atomic"),
+			XListType: ptr.To("atomic"),
 		},
 		"publishConnectionDetailsTo": {
 			Type:     "object",
@@ -335,7 +335,7 @@ func CompositeResourceStatusProps() map[string]extv1.JSONSchemaProps {
 			XListMapKeys: []string{
 				"type",
 			},
-			XListType: pointer.String("map"),
+			XListType: ptr.To("map"),
 			Items: &extv1.JSONSchemaPropsOrArray{
 				Schema: &extv1.JSONSchemaProps{
 					Type:     "object",

--- a/pkg/validation/apiextensions/v1/composition/connectionDetails_test.go
+++ b/pkg/validation/apiextensions/v1/composition/connectionDetails_test.go
@@ -23,7 +23,7 @@ import (
 	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/validation/field"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	v1 "github.com/crossplane/crossplane/apis/apiextensions/v1"
 )
@@ -78,7 +78,7 @@ func TestValidateConnectionDetails(t *testing.T) {
 				comp: buildDefaultComposition(t, v1.CompositionValidationModeLoose, nil, withConnectionDetails(
 					0,
 					v1.ConnectionDetail{
-						FromFieldPath: pointer.String("spec.someOtherField"),
+						FromFieldPath: ptr.To("spec.someOtherField"),
 					},
 				)),
 				gkToCRD: defaultGKToCRDs(),
@@ -93,10 +93,10 @@ func TestValidateConnectionDetails(t *testing.T) {
 				comp: buildDefaultComposition(t, v1.CompositionValidationModeLoose, nil, withConnectionDetails(
 					0,
 					v1.ConnectionDetail{
-						FromFieldPath: pointer.String("spec.someWrongField"),
+						FromFieldPath: ptr.To("spec.someWrongField"),
 					},
 					v1.ConnectionDetail{
-						FromFieldPath: pointer.String("spec.someField"),
+						FromFieldPath: ptr.To("spec.someField"),
 					},
 				)),
 				gkToCRD: buildGkToCRDs(

--- a/pkg/validation/apiextensions/v1/composition/patches.go
+++ b/pkg/validation/apiextensions/v1/composition/patches.go
@@ -24,7 +24,7 @@ import (
 	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/validation/field"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/crossplane/crossplane-runtime/pkg/errors"
@@ -412,7 +412,7 @@ func validateFieldPathSegmentField(parent *apiextensions.JSONSchemaProps, segmen
 	// TODO(phisco): any remaining fields? e.g. XValidations' CEL Rules?
 	prop, exists := parent.Properties[segment.Field]
 	if !exists {
-		if pointer.BoolDeref(parent.XPreserveUnknownFields, false) {
+		if ptr.Deref(parent.XPreserveUnknownFields, false) {
 			return nil, nil
 		}
 

--- a/pkg/validation/apiextensions/v1/composition/patches_test.go
+++ b/pkg/validation/apiextensions/v1/composition/patches_test.go
@@ -28,7 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	xperrors "github.com/crossplane/crossplane-runtime/pkg/errors"
@@ -286,7 +286,7 @@ func TestValidateTransforms(t *testing.T) {
 					{
 						Type: v1.TransformTypeMath,
 						Math: &v1.MathTransform{
-							Multiply: pointer.Int64(2),
+							Multiply: ptr.To[int64](2),
 						},
 					},
 				},
@@ -305,7 +305,7 @@ func TestValidateTransforms(t *testing.T) {
 					{
 						Type: v1.TransformTypeMath,
 						Math: &v1.MathTransform{
-							Multiply: pointer.Int64(2),
+							Multiply: ptr.To[int64](2),
 						},
 					},
 				},
@@ -982,7 +982,7 @@ func TestIsValidInputForTransform(t *testing.T) {
 					Type: v1.TransformTypeString,
 					String: &v1.StringTransform{
 						Type:    v1.StringTransformTypeConvert,
-						Convert: toPointer(v1.StringConversionTypeToUpper),
+						Convert: ptr.To(v1.StringConversionTypeToUpper),
 					},
 				},
 			},
@@ -995,7 +995,7 @@ func TestIsValidInputForTransform(t *testing.T) {
 					Type: v1.TransformTypeString,
 					String: &v1.StringTransform{
 						Type:    v1.StringTransformTypeConvert,
-						Convert: toPointer(v1.StringConversionTypeToJSON),
+						Convert: ptr.To(v1.StringConversionTypeToJSON),
 					},
 				},
 			},
@@ -1008,7 +1008,7 @@ func TestIsValidInputForTransform(t *testing.T) {
 					Type: v1.TransformTypeString,
 					String: &v1.StringTransform{
 						Type:    v1.StringTransformTypeConvert,
-						Convert: toPointer(v1.StringConversionTypeToUpper),
+						Convert: ptr.To(v1.StringConversionTypeToUpper),
 					},
 				},
 			},

--- a/pkg/validation/apiextensions/v1/composition/validator_test.go
+++ b/pkg/validation/apiextensions/v1/composition/validator_test.go
@@ -14,7 +14,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/validation/field"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	v1 "github.com/crossplane/crossplane/apis/apiextensions/v1"
 )
@@ -55,8 +55,8 @@ func TestValidatorValidate(t *testing.T) {
 			args: args{
 				comp: buildDefaultComposition(t, v1.CompositionValidationModeStrict, map[string]any{"someOtherField": "test"},
 					withPatches(0, v1.Patch{
-						FromFieldPath: pointer.String("spec.someField"),
-						ToFieldPath:   pointer.String("spec.someOtherField"),
+						FromFieldPath: ptr.To("spec.someField"),
+						ToFieldPath:   ptr.To("spec.someOtherField"),
 					})),
 				gkToCRDs: nil,
 			},
@@ -85,8 +85,8 @@ func TestValidatorValidate(t *testing.T) {
 				gkToCRDs: defaultGKToCRDs(),
 				comp: buildDefaultComposition(t, v1.CompositionValidationModeStrict, nil, withPatches(0, v1.Patch{
 					Type:          v1.PatchTypeFromCompositeFieldPath,
-					FromFieldPath: pointer.String("spec.someField"),
-					ToFieldPath:   pointer.String("spec.someOtherField"),
+					FromFieldPath: ptr.To("spec.someField"),
+					ToFieldPath:   ptr.To("spec.someOtherField"),
 				})),
 			},
 		},
@@ -104,8 +104,8 @@ func TestValidatorValidate(t *testing.T) {
 				gkToCRDs: defaultGKToCRDs(),
 				comp: buildDefaultComposition(t, v1.CompositionValidationModeStrict, nil, withPatches(0, v1.Patch{
 					Type:          v1.PatchTypeFromCompositeFieldPath,
-					FromFieldPath: pointer.String("spec.someWrongField"),
-					ToFieldPath:   pointer.String("spec.someOtherField"),
+					FromFieldPath: ptr.To("spec.someWrongField"),
+					ToFieldPath:   ptr.To("spec.someOtherField"),
 				})),
 			},
 		},
@@ -123,8 +123,8 @@ func TestValidatorValidate(t *testing.T) {
 				gkToCRDs: defaultGKToCRDs(),
 				comp: buildDefaultComposition(t, v1.CompositionValidationModeStrict, map[string]any{"someOtherField": "test"}, withPatches(0, v1.Patch{
 					Type:          v1.PatchTypeFromCompositeFieldPath,
-					FromFieldPath: pointer.String("spec.someField"),
-					ToFieldPath:   pointer.String("spec.someOtherWrongField"),
+					FromFieldPath: ptr.To("spec.someField"),
+					ToFieldPath:   ptr.To("spec.someOtherWrongField"),
 				})),
 			},
 		},
@@ -149,8 +149,8 @@ func TestValidatorValidate(t *testing.T) {
 				),
 				comp: buildDefaultComposition(t, v1.CompositionValidationModeStrict, nil, withPatches(0, v1.Patch{
 					Type:          v1.PatchTypeFromCompositeFieldPath,
-					FromFieldPath: pointer.String("spec.someField"),
-					ToFieldPath:   pointer.String("spec.someOtherField"),
+					FromFieldPath: ptr.To("spec.someField"),
+					ToFieldPath:   ptr.To("spec.someOtherField"),
 				})),
 			},
 		},
@@ -168,12 +168,12 @@ func TestValidatorValidate(t *testing.T) {
 				gkToCRDs: defaultGKToCRDs(),
 				comp: buildDefaultComposition(t, v1.CompositionValidationModeLoose, nil, withPatches(0, v1.Patch{
 					Type:          v1.PatchTypeFromCompositeFieldPath,
-					FromFieldPath: pointer.String("spec.someField"),
-					ToFieldPath:   pointer.String("spec.someOtherField"),
+					FromFieldPath: ptr.To("spec.someField"),
+					ToFieldPath:   ptr.To("spec.someOtherField"),
 					Transforms: []v1.Transform{{
 						Type: v1.TransformTypeMath,
 						Math: &v1.MathTransform{
-							Multiply: pointer.Int64(int64(2)),
+							Multiply: ptr.To[int64](int64(2)),
 						},
 					}},
 				})),
@@ -193,8 +193,8 @@ func TestValidatorValidate(t *testing.T) {
 				gkToCRDs: defaultGKToCRDs(),
 				comp: buildDefaultComposition(t, v1.CompositionValidationModeLoose, nil, withPatches(0, v1.Patch{
 					Type:          v1.PatchTypeFromCompositeFieldPath,
-					FromFieldPath: pointer.String("spec.someField"),
-					ToFieldPath:   pointer.String("spec.someOtherField"),
+					FromFieldPath: ptr.To("spec.someField"),
+					ToFieldPath:   ptr.To("spec.someOtherField"),
 					Transforms: []v1.Transform{{
 						Type: v1.TransformTypeConvert,
 						Convert: &v1.ConvertTransform{
@@ -236,7 +236,7 @@ func TestValidatorValidate(t *testing.T) {
 							Format: "%s-%s",
 						},
 					},
-					ToFieldPath: pointer.String("spec.someOtherField"),
+					ToFieldPath: ptr.To("spec.someOtherField"),
 				})),
 			},
 		},
@@ -268,7 +268,7 @@ func TestValidatorValidate(t *testing.T) {
 							Format: "%s-%s",
 						},
 					},
-					ToFieldPath: pointer.String("spec.someOtherField"),
+					ToFieldPath: ptr.To("spec.someOtherField"),
 				})),
 			},
 		},
@@ -281,8 +281,8 @@ func TestValidatorValidate(t *testing.T) {
 				gkToCRDs: defaultGKToCRDs(),
 				comp: buildDefaultComposition(t, v1.CompositionValidationModeLoose, nil, withPatches(0, v1.Patch{
 					Type:          v1.PatchTypeFromEnvironmentFieldPath,
-					FromFieldPath: pointer.String("spec.someField"),
-					ToFieldPath:   pointer.String("spec.someOtherField"),
+					FromFieldPath: ptr.To("spec.someField"),
+					ToFieldPath:   ptr.To("spec.someOtherField"),
 				})),
 			},
 		},
@@ -301,8 +301,8 @@ func TestValidatorValidate(t *testing.T) {
 				}).build(), defaultCompositeCrdBuilder().build()),
 				comp: buildDefaultComposition(t, v1.CompositionValidationModeLoose, nil, withPatches(0, v1.Patch{
 					Type:          v1.PatchTypeFromCompositeFieldPath,
-					FromFieldPath: pointer.String("spec.someField"),
-					ToFieldPath:   pointer.String("spec.someOtherField"),
+					FromFieldPath: ptr.To("spec.someField"),
+					ToFieldPath:   ptr.To("spec.someOtherField"),
 				})),
 			},
 		},
@@ -318,12 +318,12 @@ func TestValidatorValidate(t *testing.T) {
 						Name: "some-patch-set",
 						Patches: []v1.Patch{{
 							Type:          v1.PatchTypeFromCompositeFieldPath,
-							FromFieldPath: pointer.String("spec.someField"),
-							ToFieldPath:   pointer.String("spec.someOtherField"),
+							FromFieldPath: ptr.To("spec.someField"),
+							ToFieldPath:   ptr.To("spec.someOtherField"),
 						}}},
 				), withPatches(0, v1.Patch{
 					Type:         v1.PatchTypePatchSet,
-					PatchSetName: pointer.String("some-patch-set"),
+					PatchSetName: ptr.To("some-patch-set"),
 				})),
 			},
 		},
@@ -359,11 +359,11 @@ func TestValidatorValidate(t *testing.T) {
 										Format: "%s-%s",
 									},
 								},
-								ToFieldPath: pointer.String("spec.someOtherField"),
+								ToFieldPath: ptr.To("spec.someOtherField"),
 							}}},
 					), withPatches(0, v1.Patch{
 						Type:         v1.PatchTypePatchSet,
-						PatchSetName: pointer.String("some-patch-set"),
+						PatchSetName: ptr.To("some-patch-set"),
 					})),
 			},
 		},
@@ -376,8 +376,8 @@ func TestValidatorValidate(t *testing.T) {
 				gkToCRDs: defaultGKToCRDs(),
 				comp: buildDefaultComposition(t, v1.CompositionValidationModeStrict, nil, withPatches(0, v1.Patch{
 					Type:          v1.PatchTypeFromEnvironmentFieldPath,
-					FromFieldPath: pointer.String("tier.name"),
-					ToFieldPath:   pointer.String("spec.someOtherField"),
+					FromFieldPath: ptr.To("tier.name"),
+					ToFieldPath:   ptr.To("spec.someOtherField"),
 				})),
 			},
 		},
@@ -395,8 +395,8 @@ func TestValidatorValidate(t *testing.T) {
 				gkToCRDs: defaultGKToCRDs(),
 				comp: buildDefaultComposition(t, v1.CompositionValidationModeStrict, nil, withPatches(0, v1.Patch{
 					Type:          v1.PatchTypeFromEnvironmentFieldPath,
-					FromFieldPath: pointer.String("tier.name"),
-					ToFieldPath:   pointer.String("spec.someOtherWrongField"),
+					FromFieldPath: ptr.To("tier.name"),
+					ToFieldPath:   ptr.To("spec.someOtherWrongField"),
 				})),
 			},
 		},
@@ -409,8 +409,8 @@ func TestValidatorValidate(t *testing.T) {
 				gkToCRDs: defaultGKToCRDs(),
 				comp: buildDefaultComposition(t, v1.CompositionValidationModeStrict, nil, withPatches(0, v1.Patch{
 					Type:          v1.PatchTypeToEnvironmentFieldPath,
-					FromFieldPath: pointer.String("spec.someOtherField"),
-					ToFieldPath:   pointer.String("tier.name"),
+					FromFieldPath: ptr.To("spec.someOtherField"),
+					ToFieldPath:   ptr.To("tier.name"),
 				})),
 			},
 		},
@@ -428,8 +428,8 @@ func TestValidatorValidate(t *testing.T) {
 				gkToCRDs: defaultGKToCRDs(),
 				comp: buildDefaultComposition(t, v1.CompositionValidationModeStrict, nil, withPatches(0, v1.Patch{
 					Type:          v1.PatchTypeToEnvironmentFieldPath,
-					FromFieldPath: pointer.String("spec.someOtherWrongField"),
-					ToFieldPath:   pointer.String("tier.name"),
+					FromFieldPath: ptr.To("spec.someOtherWrongField"),
+					ToFieldPath:   ptr.To("tier.name"),
 				})),
 			},
 		},
@@ -456,7 +456,7 @@ func TestValidatorValidate(t *testing.T) {
 							Format: "%s-%s",
 						},
 					},
-					ToFieldPath: pointer.String("tier.name"),
+					ToFieldPath: ptr.To("tier.name"),
 				})),
 			},
 		},
@@ -483,7 +483,7 @@ func TestValidatorValidate(t *testing.T) {
 							Format: "%s-%s",
 						},
 					},
-					ToFieldPath: pointer.String("spec.someOtherField"),
+					ToFieldPath: ptr.To("spec.someOtherField"),
 				})),
 			},
 		},
@@ -515,7 +515,7 @@ func TestValidatorValidate(t *testing.T) {
 							Format: "%s-%s",
 						},
 					},
-					ToFieldPath: pointer.String("spec.someOtherWrongField"),
+					ToFieldPath: ptr.To("spec.someOtherWrongField"),
 				})),
 			},
 		},
@@ -547,7 +547,7 @@ func TestValidatorValidate(t *testing.T) {
 							Format: "%s-%s",
 						},
 					},
-					ToFieldPath: pointer.String("tier.name"),
+					ToFieldPath: ptr.To("tier.name"),
 				})),
 			},
 		},
@@ -561,18 +561,18 @@ func TestValidatorValidate(t *testing.T) {
 				comp: buildDefaultComposition(t, v1.CompositionValidationModeStrict, nil, withEnvironmentPatches(
 					v1.EnvironmentPatch{
 						Type:          v1.PatchTypeFromCompositeFieldPath,
-						FromFieldPath: pointer.String("spec.someNonRequiredField"),
-						ToFieldPath:   pointer.String("tier.name"),
+						FromFieldPath: ptr.To("spec.someNonRequiredField"),
+						ToFieldPath:   ptr.To("tier.name"),
 					},
 					v1.EnvironmentPatch{
 						Type:          v1.PatchTypeToCompositeFieldPath,
-						FromFieldPath: pointer.String("tier.name"),
-						ToFieldPath:   pointer.String("spec.someNonRequiredField"),
+						FromFieldPath: ptr.To("tier.name"),
+						ToFieldPath:   ptr.To("spec.someNonRequiredField"),
 					},
 					v1.EnvironmentPatch{
 						Type:          v1.PatchTypeFromEnvironmentFieldPath,
-						FromFieldPath: pointer.String("tier.name"),
-						ToFieldPath:   pointer.String("spec.someNonRequiredField"),
+						FromFieldPath: ptr.To("tier.name"),
+						ToFieldPath:   ptr.To("spec.someNonRequiredField"),
 					},
 				)),
 			},
@@ -592,13 +592,13 @@ func TestValidatorValidate(t *testing.T) {
 				comp: buildDefaultComposition(t, v1.CompositionValidationModeStrict, nil, withEnvironmentPatches(
 					v1.EnvironmentPatch{
 						Type:          v1.PatchTypeFromCompositeFieldPath,
-						FromFieldPath: pointer.String("spec.someWrongField"),
-						ToFieldPath:   pointer.String("tier.name"),
+						FromFieldPath: ptr.To("spec.someWrongField"),
+						ToFieldPath:   ptr.To("tier.name"),
 					},
 					v1.EnvironmentPatch{
 						Type:          v1.PatchTypeFromEnvironmentFieldPath,
-						FromFieldPath: pointer.String("tier.name"),
-						ToFieldPath:   pointer.String("spec.someNonRequiredField"),
+						FromFieldPath: ptr.To("tier.name"),
+						ToFieldPath:   ptr.To("spec.someNonRequiredField"),
 					})),
 			},
 		},
@@ -621,18 +621,18 @@ func TestValidatorValidate(t *testing.T) {
 				comp: buildDefaultComposition(t, v1.CompositionValidationModeStrict, nil, withEnvironmentPatches(
 					v1.EnvironmentPatch{
 						Type:          v1.PatchTypeFromCompositeFieldPath,
-						FromFieldPath: pointer.String("spec.someWrongField"),
-						ToFieldPath:   pointer.String("tier.name"),
+						FromFieldPath: ptr.To("spec.someWrongField"),
+						ToFieldPath:   ptr.To("tier.name"),
 					},
 					v1.EnvironmentPatch{
 						Type:          v1.PatchTypeToCompositeFieldPath,
-						FromFieldPath: pointer.String("tier.name"),
-						ToFieldPath:   pointer.String("spec.someOtherWrongField"),
+						FromFieldPath: ptr.To("tier.name"),
+						ToFieldPath:   ptr.To("spec.someOtherWrongField"),
 					},
 					v1.EnvironmentPatch{
 						Type:          v1.PatchTypeToCompositeFieldPath,
-						FromFieldPath: pointer.String("tier.name"),
-						ToFieldPath:   pointer.String("spec.someNonRequiredField"),
+						FromFieldPath: ptr.To("tier.name"),
+						ToFieldPath:   ptr.To("spec.someNonRequiredField"),
 					},
 				)),
 			},
@@ -670,10 +670,6 @@ func marshalJSON(t *testing.T, obj interface{}) []byte {
 		t.Errorf("Failed to marshal object: %v", err)
 	}
 	return b
-}
-
-func toPointer[T any](v T) *T {
-	return &v
 }
 
 func defaultCompositeCrdBuilder() *crdBuilder {
@@ -851,7 +847,7 @@ func buildDefaultComposition(t *testing.T, validationMode v1.CompositionValidati
 			},
 			Resources: []v1.ComposedTemplate{
 				{
-					Name: toPointer("test"),
+					Name: ptr.To("test"),
 					Base: runtime.RawExtension{
 						Raw: marshalJSON(t, map[string]any{
 							"apiVersion": testGroup + "/v1",

--- a/test/e2e/config/environment.go
+++ b/test/e2e/config/environment.go
@@ -22,7 +22,7 @@ import (
 	"os"
 	"sort"
 
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/e2e-framework/pkg/env"
 	"sigs.k8s.io/e2e-framework/pkg/envconf"
@@ -340,7 +340,7 @@ func (e *Environment) EnrichLabels(labels features.Labels) features.Labels {
 func (e *Environment) isSelectingTests() bool {
 	if e.specificTestSelected == nil {
 		f := flag.Lookup("test.run")
-		e.specificTestSelected = pointer.Bool(f != nil && f.Value.String() != "")
+		e.specificTestSelected = ptr.To(f != nil && f.Value.String() != "")
 	}
 	return *e.specificTestSelected
 }


### PR DESCRIPTION
### Description of your changes

This PR adds a `maxLength` constraint on the `metadata.name` of claims and XRs through OpenAPI (kube-apiserver allows that for the name).

Fixes #4645

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Added or updated unit **and** E2E tests for my change.
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] ~~Added `backport release-x.y` labels to auto-backport this PR, if necessary.~~
- [ ] ~~Opened a PR updating the [docs], if necessary.~~

[contribution process]: https://git.io/fj2m9
[docs]: https://docs.crossplane.io/contribute/contribute