### PR TITLE
feat(crank): rename build controller flags to base image

### DIFF
--- a/cmd/crank/main.go
+++ b/cmd/crank/main.go
@@ -93,8 +93,9 @@ func main() {
 		kong.Bind(buildChild, pushChild),
 		kong.BindTo(logger, (*logging.Logger)(nil)),
 		kong.ConfigureHelp(kong.HelpOptions{
-			Tree:      true,
-			FlagsLast: true,
+			Tree:           true,
+			FlagsLast:      true,
+			WrapUpperBound: 120,
 		}),
 		kong.UsageOnError())
 	err := ctx.Run()

--- a/internal/xpkg/v2/build.go
+++ b/internal/xpkg/v2/build.go
@@ -118,9 +118,9 @@ type buildOpts struct {
 // A BuildOpt modifies how a package is built.
 type BuildOpt func(*buildOpts)
 
-// WithController sets the controller image that should serve as the base for
+// WithBaseImage sets the controller image that should serve as the base for
 // the package.
-func WithController(img v1.Image) BuildOpt {
+func WithBaseImage(img v1.Image) BuildOpt {
 	return func(o *buildOpts) {
 		o.base = img
 	}


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does, and how it is covered by tests.
Be proactive - direct your reviewers' attention to anything that needs special
consideration.

You MUST either [x] check or ~strikethrough~ every item in the checklist below.

We love pull requests that fix an open issue. If yours does, use the below line
to indicate which issue it fixes, for example "Fixes #500".
-->

Fixes https://github.com/crossplane/crossplane/issues/4784.

Removed `xor` tag as it didn't actually work, just made the tar file be used instead of the image if both are specified. Looks like `xor` file actually needs to be specified on all flags that have to be in a mutually exclusive group, but even switching to the correct usage, it didn't enforce the two flags from being used for some reason I couldn't understand.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [ ] ~Added or updated unit **and** E2E tests for my change.~
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR, if necessary.~
- [ ] ~Opened a PR updating the [docs], if necessary.~

[contribution process]: https://git.io/fj2m9
[docs]: https://docs.crossplane.io/contribute/contribute
