### PR TITLE
Support loading context when running `crossplane beta render`

### DIFF
--- a/internal/controller/apiextensions/composite/composition_functions.go
+++ b/internal/controller/apiextensions/composite/composition_functions.go
@@ -236,7 +236,7 @@ func (c *FunctionComposer) Compose(ctx context.Context, xr *composite.Unstructur
 
 	events := []event.Event{}
 
-	// The Function context starts with empty desired state...
+	// The Function context starts empty...
 	fctx := &structpb.Struct{Fields: map[string]*structpb.Value{}}
 
 	// ...but we bootstrap it with the Composition environment, if there is one.
@@ -273,6 +273,7 @@ func (c *FunctionComposer) Compose(ctx context.Context, xr *composite.Unstructur
 		d = rsp.GetDesired()
 
 		// Pass the Function context returned by this Function to the next one.
+		// We intentionally discard/ignore this after the last Function runs.
 		fctx = rsp.GetContext()
 
 		// Results of fatal severity stop the Composition process. Other results


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does, and how it is covered by tests.
Be proactive - direct your reviewers' attention to anything that needs special
consideration.

You MUST either [x] check or ~strikethrough~ every item in the checklist below.

We love pull requests that fix an open issue. If yours does, use the below line
to indicate which issue it fixes, for example "Fixes #500".
-->

Context can be loaded from either values, or files. Either way, the value must be JSON. This could be used to inject "the environment" for testing `function-patch-and-transform` once https://github.com/crossplane-contrib/function-patch-and-transform/pull/17 is merged. It could also be useful for developing new Functions that read from the environment.

Examples:

```shell
$ crossplane beta render xr.yaml comp.yaml fns.yaml \
  --context-values=apiextensions.crossplane.io/environment='{"key": "value"}';other-key='"stringvalue"' \
  --context-files=apiextensions.crossplane.io/environment=env.json
```

Note that context values are not merged. If a key appears in both `--context-files` and `--context-values`, the latter wins. If a key appears multiple times in the same flag, the last appearance wins.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Added or updated unit ~**and** E2E tests~ for my change.
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR, if necessary.~
- [ ] ~Opened a PR updating the [docs], if necessary.~

[contribution process]: https://git.io/fj2m9
[docs]: https://docs.crossplane.io/contribute/contribute
