### PR TITLE
feat: switch probes port to 8081

### DIFF
--- a/cluster/charts/crossplane/templates/deployment.yaml
+++ b/cluster/charts/crossplane/templates/deployment.yaml
@@ -133,7 +133,7 @@ spec:
             port: healthz
         ports:
         - name: healthz
-          containerPort: 5000
+          containerPort: 8081
         {{- if .Values.metrics.enabled }}
         - name: metrics
           containerPort: 8080

--- a/cmd/crossplane/core/core.go
+++ b/cmd/crossplane/core/core.go
@@ -190,7 +190,7 @@ func (c *startCommand) Run(s *runtime.Scheme, log logging.Logger) error { //noli
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),
 		RenewDeadline:              func() *time.Duration { d := 50 * time.Second; return &d }(),
 
-		HealthProbeBindAddress: ":5000",
+		HealthProbeBindAddress: ":8081",
 	})
 	if err != nil {
 		return errors.Wrap(err, "cannot create manager")


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does, and how it is covered by tests.
Be proactive - direct your reviewers' attention to anything that needs special
consideration.

You MUST either [x] check or ~strikethrough~ every item in the checklist below.

We love pull requests that fix an open issue. If yours does, use the below line
to indicate which issue it fixes, for example "Fixes #500".
-->

We just introduced probes in #4748 on port 5000, unfortunately port 5000 on MacOS is [used](https://stackoverflow.com/questions/72369320/why-always-something-is-running-at-port-5000-on-my-mac) if not disabled explicitly, to avoid useless conflicts when running crossplane locally we should just switch to another port. Picked 8081 as suggested by @turkenh given that we expose metrics on port 8080.

I didn't notice it because I disabled the service listening on port 5000 a while back 😬 

I have:

- [x] Read and followed Crossplane's [contribution process].
- [ ] ~Added or updated unit **and** E2E tests for my change.~
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR, if necessary.~
- [ ] ~Opened a PR updating the [docs], if necessary.~

[contribution process]: https://git.io/fj2m9
[docs]: https://docs.crossplane.io/contribute/contribute
