### PR TITLE
e2e: wait for all nop resource deleted before deleting prerequisites

### DIFF
--- a/test/e2e/apiextensions_test.go
+++ b/test/e2e/apiextensions_test.go
@@ -20,9 +20,11 @@ import (
 	"testing"
 	"time"
 
+	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/e2e-framework/pkg/features"
 
 	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
+	"github.com/crossplane/crossplane-runtime/pkg/resource/unstructured/composed"
 
 	apiextensionsv1 "github.com/crossplane/crossplane/apis/apiextensions/v1"
 	pkgv1 "github.com/crossplane/crossplane/apis/pkg/v1"
@@ -33,6 +35,13 @@ import (
 // LabelAreaAPIExtensions is applied to all features pertaining to API
 // extensions (i.e. Composition, XRDs, etc).
 const LabelAreaAPIExtensions = "apiextensions"
+
+var (
+	nopList = composed.NewList(composed.FromReferenceToList(corev1.ObjectReference{
+		APIVersion: "nop.crossplane.io/v1alpha1",
+		Kind:       "NopResource",
+	}))
+)
 
 // TestCompositionMinimal tests Crossplane's Composition functionality,
 // checking that a claim using a very minimal Composition (with no patches,
@@ -60,10 +69,7 @@ func TestCompositionMinimal(t *testing.T) {
 				funcs.DeleteResources(manifests, "claim.yaml"),
 				funcs.ResourcesDeletedWithin(2*time.Minute, manifests, "claim.yaml"),
 			)).
-			WithTeardown("DeletePrerequisites", funcs.AllOf(
-				funcs.DeleteResources(manifests, "setup/*.yaml"),
-				funcs.ResourcesDeletedWithin(3*time.Minute, manifests, "setup/*.yaml"),
-			)).
+			WithTeardown("DeletePrerequisites", funcs.ResourcesDeletedAfterListedAreGone(3*time.Minute, manifests, "setup/*.yaml", nopList)).
 			Feature(),
 	)
 }
@@ -98,10 +104,7 @@ func TestCompositionPatchAndTransform(t *testing.T) {
 				funcs.DeleteResources(manifests, "claim.yaml"),
 				funcs.ResourcesDeletedWithin(2*time.Minute, manifests, "claim.yaml"),
 			)).
-			WithTeardown("DeletePrerequisites", funcs.AllOf(
-				funcs.DeleteResources(manifests, "setup/*.yaml"),
-				funcs.ResourcesDeletedWithin(3*time.Minute, manifests, "setup/*.yaml"),
-			)).
+			WithTeardown("DeletePrerequisites", funcs.ResourcesDeletedAfterListedAreGone(3*time.Minute, manifests, "setup/*.yaml", nopList)).
 			Feature(),
 	)
 }
@@ -139,10 +142,7 @@ func TestCompositionRealtimeRevisionSelection(t *testing.T) {
 				funcs.DeleteResources(manifests, "claim.yaml"),
 				funcs.ResourcesDeletedWithin(2*time.Minute, manifests, "claim.yaml"),
 			)).
-			WithTeardown("DeletePrerequisites", funcs.AllOf(
-				funcs.DeleteResources(manifests, "setup/*.yaml"),
-				funcs.ResourcesDeletedWithin(3*time.Minute, manifests, "setup/*.yaml"),
-			)).
+			WithTeardown("DeletePrerequisites", funcs.ResourcesDeletedAfterListedAreGone(3*time.Minute, manifests, "setup/*.yaml", nopList)).
 			Feature(),
 	)
 }
@@ -177,10 +177,7 @@ func TestCompositionFunctions(t *testing.T) {
 				funcs.DeleteResources(manifests, "claim.yaml"),
 				funcs.ResourcesDeletedWithin(2*time.Minute, manifests, "claim.yaml"),
 			)).
-			WithTeardown("DeletePrerequisites", funcs.AllOf(
-				funcs.DeleteResources(manifests, "setup/*.yaml"),
-				funcs.ResourcesDeletedWithin(3*time.Minute, manifests, "setup/*.yaml"),
-			)).
+			WithTeardown("DeletePrerequisites", funcs.ResourcesDeletedAfterListedAreGone(3*time.Minute, manifests, "setup/*.yaml", nopList)).
 			Feature(),
 	)
 }

--- a/test/e2e/comp_schema_validation_test.go
+++ b/test/e2e/comp_schema_validation_test.go
@@ -81,10 +81,7 @@ func TestCompositionValidation(t *testing.T) {
 				funcs.DeleteResources(manifests, "*-valid.yaml"),
 				funcs.ResourcesDeletedWithin(30*time.Second, manifests, "*-valid.yaml"),
 			)).
-			WithTeardown("DeletePrerequisites", funcs.AllOf(
-				funcs.DeleteResources(manifests, "setup/*.yaml"),
-				funcs.ResourcesDeletedWithin(3*time.Minute, manifests, "setup/*.yaml"),
-			)).
+			WithTeardown("DeletePrerequisites", funcs.ResourcesDeletedAfterListedAreGone(3*time.Minute, manifests, "setup/*.yaml", nopList)).
 			// Disable our feature flag.
 			WithTeardown("DisableAlphaCompositionValidation", funcs.AllOf(
 				funcs.AsFeaturesFunc(environment.HelmUpgradeCrossplaneToBase()),

--- a/test/e2e/environmentconfig_test.go
+++ b/test/e2e/environmentconfig_test.go
@@ -80,10 +80,7 @@ func TestEnvironmentConfigDefault(t *testing.T) {
 				funcs.DeleteResources(manifestsFolderEnvironmentConfigs, filepath.Join(subfolder, "*.yaml")),
 				funcs.ResourcesDeletedWithin(3*time.Minute, manifestsFolderEnvironmentConfigs, filepath.Join(subfolder, "*.yaml")),
 			)).
-			WithTeardown("DeletePrerequisites", funcs.AllOf(
-				funcs.DeleteResources(manifestsFolderEnvironmentConfigs, filepath.Join(subfolder, "setup/*.yaml")),
-				funcs.ResourcesDeletedWithin(3*time.Minute, manifestsFolderEnvironmentConfigs, filepath.Join(subfolder, "setup/*.yaml")),
-			)).
+			WithTeardown("DeletePrerequisites", funcs.ResourcesDeletedAfterListedAreGone(3*time.Minute, manifestsFolderEnvironmentConfigs, filepath.Join(subfolder, "setup/*.yaml"), nopList)).
 			WithTeardown("DeleteGlobalPrerequisites", funcs.AllOf(
 				funcs.DeleteResources(manifestsFolderEnvironmentConfigs, "setup/*.yaml"),
 				funcs.ResourcesDeletedWithin(3*time.Minute, manifestsFolderEnvironmentConfigs, "setup/*.yaml"),
@@ -134,10 +131,7 @@ func TestEnvironmentResolutionOptional(t *testing.T) {
 				funcs.DeleteResources(manifestsFolderEnvironmentConfigs, filepath.Join(subfolder, "*.yaml")),
 				funcs.ResourcesDeletedWithin(3*time.Minute, manifestsFolderEnvironmentConfigs, filepath.Join(subfolder, "*.yaml")),
 			)).
-			WithTeardown("DeletePrerequisites", funcs.AllOf(
-				funcs.DeleteResources(manifestsFolderEnvironmentConfigs, filepath.Join(subfolder, "setup/*.yaml")),
-				funcs.ResourcesDeletedWithin(3*time.Minute, manifestsFolderEnvironmentConfigs, filepath.Join(subfolder, "setup/*.yaml")),
-			)).
+			WithTeardown("DeletePrerequisites", funcs.ResourcesDeletedAfterListedAreGone(3*time.Minute, manifestsFolderEnvironmentConfigs, filepath.Join(subfolder, "setup/*.yaml"), nopList)).
 			WithTeardown("DeleteGlobalPrerequisites", funcs.AllOf(
 				funcs.DeleteResources(manifestsFolderEnvironmentConfigs, "setup/*.yaml"),
 				funcs.ResourcesDeletedWithin(3*time.Minute, manifestsFolderEnvironmentConfigs, "setup/*.yaml"),
@@ -198,10 +192,7 @@ func TestEnvironmentResolveIfNotPresent(t *testing.T) {
 				funcs.DeleteResources(manifestsFolderEnvironmentConfigs, filepath.Join(subfolder, "*.yaml")),
 				funcs.ResourcesDeletedWithin(3*time.Minute, manifestsFolderEnvironmentConfigs, filepath.Join(subfolder, "*.yaml")),
 			)).
-			WithTeardown("DeletePrerequisites", funcs.AllOf(
-				funcs.DeleteResources(manifestsFolderEnvironmentConfigs, filepath.Join(subfolder, "setup/*.yaml")),
-				funcs.ResourcesDeletedWithin(3*time.Minute, manifestsFolderEnvironmentConfigs, filepath.Join(subfolder, "setup/*.yaml")),
-			)).
+			WithTeardown("DeletePrerequisites", funcs.ResourcesDeletedAfterListedAreGone(3*time.Minute, manifestsFolderEnvironmentConfigs, filepath.Join(subfolder, "setup/*.yaml"), nopList)).
 			WithTeardown("DeleteGlobalPrerequisites", funcs.AllOf(
 				funcs.DeleteResources(manifestsFolderEnvironmentConfigs, "setup/*.yaml"),
 				funcs.ResourcesDeletedWithin(3*time.Minute, manifestsFolderEnvironmentConfigs, "setup/*.yaml"),
@@ -262,10 +253,7 @@ func TestEnvironmentResolveAlways(t *testing.T) {
 				funcs.DeleteResources(manifestsFolderEnvironmentConfigs, filepath.Join(subfolder, "*.yaml")),
 				funcs.ResourcesDeletedWithin(3*time.Minute, manifestsFolderEnvironmentConfigs, filepath.Join(subfolder, "*.yaml")),
 			)).
-			WithTeardown("DeletePrerequisites", funcs.AllOf(
-				funcs.DeleteResources(manifestsFolderEnvironmentConfigs, filepath.Join(subfolder, "setup/*.yaml")),
-				funcs.ResourcesDeletedWithin(3*time.Minute, manifestsFolderEnvironmentConfigs, filepath.Join(subfolder, "setup/*.yaml")),
-			)).
+			WithTeardown("DeletePrerequisites", funcs.ResourcesDeletedAfterListedAreGone(3*time.Minute, manifestsFolderEnvironmentConfigs, filepath.Join(subfolder, "setup/*.yaml"), nopList)).
 			WithTeardown("DeleteGlobalPrerequisites", funcs.AllOf(
 				funcs.DeleteResources(manifestsFolderEnvironmentConfigs, "setup/*.yaml"),
 				funcs.ResourcesDeletedWithin(3*time.Minute, manifestsFolderEnvironmentConfigs, "setup/*.yaml"),
@@ -316,10 +304,7 @@ func TestEnvironmentConfigMultipleMaxMatchNil(t *testing.T) {
 				funcs.DeleteResources(manifestsFolderEnvironmentConfigs, filepath.Join(subfolder, "*.yaml")),
 				funcs.ResourcesDeletedWithin(3*time.Minute, manifestsFolderEnvironmentConfigs, filepath.Join(subfolder, "*.yaml")),
 			)).
-			WithTeardown("DeletePrerequisites", funcs.AllOf(
-				funcs.DeleteResources(manifestsFolderEnvironmentConfigs, filepath.Join(subfolder, "setup/*.yaml")),
-				funcs.ResourcesDeletedWithin(3*time.Minute, manifestsFolderEnvironmentConfigs, filepath.Join(subfolder, "setup/*.yaml")),
-			)).
+			WithTeardown("DeletePrerequisites", funcs.ResourcesDeletedAfterListedAreGone(3*time.Minute, manifestsFolderEnvironmentConfigs, filepath.Join(subfolder, "setup/*.yaml"), nopList)).
 			WithTeardown("DeleteGlobalPrerequisites", funcs.AllOf(
 				funcs.DeleteResources(manifestsFolderEnvironmentConfigs, "setup/*.yaml"),
 				funcs.ResourcesDeletedWithin(3*time.Minute, manifestsFolderEnvironmentConfigs, "setup/*.yaml"),
@@ -369,10 +354,7 @@ func TestEnvironmentConfigMultipleMaxMatch1(t *testing.T) {
 				funcs.DeleteResources(manifestsFolderEnvironmentConfigs, filepath.Join(subfolder, "*.yaml")),
 				funcs.ResourcesDeletedWithin(3*time.Minute, manifestsFolderEnvironmentConfigs, filepath.Join(subfolder, "*.yaml")),
 			)).
-			WithTeardown("DeletePrerequisites", funcs.AllOf(
-				funcs.DeleteResources(manifestsFolderEnvironmentConfigs, filepath.Join(subfolder, "setup/*.yaml")),
-				funcs.ResourcesDeletedWithin(3*time.Minute, manifestsFolderEnvironmentConfigs, filepath.Join(subfolder, "setup/*.yaml")),
-			)).
+			WithTeardown("DeletePrerequisites", funcs.ResourcesDeletedAfterListedAreGone(3*time.Minute, manifestsFolderEnvironmentConfigs, filepath.Join(subfolder, "setup/*.yaml"), nopList)).
 			WithTeardown("DeleteGlobalPrerequisites", funcs.AllOf(
 				funcs.DeleteResources(manifestsFolderEnvironmentConfigs, "setup/*.yaml"),
 				funcs.ResourcesDeletedWithin(3*time.Minute, manifestsFolderEnvironmentConfigs, "setup/*.yaml"),

--- a/test/e2e/funcs/feature.go
+++ b/test/e2e/funcs/feature.go
@@ -652,6 +652,17 @@ func DeletionBlockedByUsageWebhook(dir, pattern string) features.Func {
 	}
 }
 
+// ResourcesDeletedAfterListedAreGone will ensure that the resources matching
+// the supplied pattern under the supplied directory are deleted after the
+// supplied list of resources are deleted.
+func ResourcesDeletedAfterListedAreGone(d time.Duration, dir, pattern string, list k8s.ObjectList, listOptions ...resources.ListOption) features.Func {
+	return AllOf(
+		ListedResourcesDeletedWithin(d, list, listOptions...),
+		DeleteResources(dir, pattern),
+		ResourcesDeletedWithin(d, dir, pattern),
+	)
+}
+
 // asUnstructured turns an arbitrary runtime.Object into an *Unstructured. If
 // it's already a concrete *Unstructured it just returns it, otherwise it
 // round-trips it through JSON encoding. This is necessary because types that

--- a/test/e2e/install_test.go
+++ b/test/e2e/install_test.go
@@ -75,10 +75,7 @@ func TestCrossplaneLifecycle(t *testing.T) {
 				funcs.DeleteResources(manifests, "claim.yaml"),
 				funcs.ResourcesDeletedWithin(3*time.Minute, manifests, "claim.yaml"),
 			)).
-			Assess("DeletePrerequisites", funcs.AllOf(
-				funcs.DeleteResources(manifests, "setup/*.yaml"),
-				funcs.ResourcesDeletedWithin(2*time.Minute, manifests, "setup/*.yaml"),
-			)).
+			Assess("DeletePrerequisites", funcs.ResourcesDeletedAfterListedAreGone(3*time.Minute, manifests, "setup/*.yaml", nopList)).
 			Assess("UninstallCrossplane", funcs.AllOf(
 				funcs.AsFeaturesFunc(funcs.HelmUninstall(
 					helm.WithName(helmReleaseName),
@@ -147,10 +144,7 @@ func TestCrossplaneLifecycle(t *testing.T) {
 				funcs.DeleteResources(manifests, "claim.yaml"),
 				funcs.ResourcesDeletedWithin(2*time.Minute, manifests, "claim.yaml"),
 			)).
-			WithTeardown("DeletePrerequisites", funcs.AllOf(
-				funcs.DeleteResources(manifests, "setup/*.yaml"),
-				funcs.ResourcesDeletedWithin(3*time.Minute, manifests, "setup/*.yaml"),
-			)).
+			WithTeardown("DeletePrerequisites", funcs.ResourcesDeletedAfterListedAreGone(3*time.Minute, manifests, "setup/*.yaml", nopList)).
 			Feature(),
 	)
 }

--- a/test/e2e/usage_test.go
+++ b/test/e2e/usage_test.go
@@ -123,11 +123,6 @@ func TestUsageStandalone(t *testing.T) {
 func TestUsageComposition(t *testing.T) {
 	manifests := "test/e2e/manifests/apiextensions/usage/composition"
 
-	nopList := composed.NewList(composed.FromReferenceToList(corev1.ObjectReference{
-		APIVersion: "nop.crossplane.io/v1alpha1",
-		Kind:       "NopResource",
-	}))
-
 	usageList := composed.NewList(composed.FromReferenceToList(corev1.ObjectReference{
 		APIVersion: "apiextensions.crossplane.io/v1alpha1",
 		Kind:       "Usage",


### PR DESCRIPTION
### Description of your changes

We observe [weird](https://github.com/crossplane/crossplane/pull/4791#issuecomment-1765970765), [behaviors](https://crossplane.slack.com/archives/CEF5N8X08/p1697465951646769?thread_ts=1697439864.409979&cid=CEF5N8X08) with the GC when we delete the types (XRD, CRD or MRs) before children of those  (MRs) are cleaned up properly.

This PR attempts to fix these by waiting until no composed resource is left before deleting the prerequisites, typically the manifest under setup dir. 

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Added or updated unit **and** E2E tests for my change.
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR, if necessary.~
- [ ] ~Opened a PR updating the [docs], if necessary.~

[contribution process]: https://git.io/fj2m9
[docs]: https://docs.crossplane.io/contribute/contribute
