### PR TITLE
Add ability to pause reconciliation of Provider/Configuration/Function instances

### DIFF
--- a/apis/pkg/v1/interfaces.go
+++ b/apis/pkg/v1/interfaces.go
@@ -83,6 +83,8 @@ type Package interface {
 	resource.Object
 	resource.Conditioned
 
+	CleanConditions()
+
 	GetSource() string
 	SetSource(s string)
 
@@ -122,6 +124,11 @@ func (p *Provider) GetCondition(ct xpv1.ConditionType) xpv1.Condition {
 // SetConditions of this Provider.
 func (p *Provider) SetConditions(c ...xpv1.Condition) {
 	p.Status.SetConditions(c...)
+}
+
+// CleanConditions removes all conditions
+func (p *Provider) CleanConditions() {
+	p.Status.Conditions = []xpv1.Condition{}
 }
 
 // GetSource of this Provider.
@@ -264,6 +271,11 @@ func (p *Configuration) SetConditions(c ...xpv1.Condition) {
 	p.Status.SetConditions(c...)
 }
 
+// CleanConditions removes all conditions
+func (p *Configuration) CleanConditions() {
+	p.Status.Conditions = []xpv1.Condition{}
+}
+
 // GetSource of this Configuration.
 func (p *Configuration) GetSource() string {
 	return p.Spec.Package
@@ -389,6 +401,8 @@ type PackageRevision interface {
 	resource.Object
 	resource.Conditioned
 
+	CleanConditions()
+
 	GetObjects() []xpv1.TypedReference
 	SetObjects(c []xpv1.TypedReference)
 
@@ -428,6 +442,11 @@ func (p *ProviderRevision) GetCondition(ct xpv1.ConditionType) xpv1.Condition {
 // SetConditions of this ProviderRevision.
 func (p *ProviderRevision) SetConditions(c ...xpv1.Condition) {
 	p.Status.SetConditions(c...)
+}
+
+// CleanConditions removes all conditions
+func (p *ProviderRevision) CleanConditions() {
+	p.Status.Conditions = []xpv1.Condition{}
 }
 
 // GetObjects of this ProviderRevision.
@@ -580,6 +599,11 @@ func (p *ConfigurationRevision) GetCondition(ct xpv1.ConditionType) xpv1.Conditi
 // SetConditions of this ConfigurationRevision.
 func (p *ConfigurationRevision) SetConditions(c ...xpv1.Condition) {
 	p.Status.SetConditions(c...)
+}
+
+// CleanConditions removes all conditions
+func (p *ConfigurationRevision) CleanConditions() {
+	p.Status.Conditions = []xpv1.Condition{}
 }
 
 // GetObjects of this ConfigurationRevision.

--- a/apis/pkg/v1beta1/function_interfaces.go
+++ b/apis/pkg/v1beta1/function_interfaces.go
@@ -34,6 +34,11 @@ func (f *Function) SetConditions(c ...xpv1.Condition) {
 	f.Status.SetConditions(c...)
 }
 
+// CleanConditions removes all conditions
+func (f *Function) CleanConditions() {
+	f.Status.Conditions = []xpv1.Condition{}
+}
+
 // GetSource of this Function.
 func (f *Function) GetSource() string {
 	return f.Spec.Package
@@ -170,6 +175,11 @@ func (r *FunctionRevision) GetCondition(ct xpv1.ConditionType) xpv1.Condition {
 // SetConditions of this FunctionRevision.
 func (r *FunctionRevision) SetConditions(c ...xpv1.Condition) {
 	r.Status.SetConditions(c...)
+}
+
+// CleanConditions removes all conditions
+func (r *FunctionRevision) CleanConditions() {
+	r.Status.Conditions = []xpv1.Condition{}
 }
 
 // GetObjects of this FunctionRevision.

--- a/internal/controller/apiextensions/claim/reconciler.go
+++ b/internal/controller/apiextensions/claim/reconciler.go
@@ -65,6 +65,8 @@ const (
 	errPropagateCDs       = "cannot propagate connection details from composite"
 
 	errUpdateClaimStatus = "cannot update composite resource claim status"
+
+	reconcilePausedMsg = "Reconciliation (including deletion) is paused via the pause annotation"
 )
 
 // Event reasons.
@@ -371,8 +373,8 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 	// Check the pause annotation and return if it has the value "true"
 	// after logging, publishing an event and updating the SYNC status condition
 	if meta.IsPaused(cm) {
-		r.record.Event(cm, event.Normal(reasonPaused, "Reconciliation is paused via the pause annotation"))
-		cm.SetConditions(xpv1.ReconcilePaused())
+		r.record.Event(cm, event.Normal(reasonPaused, reconcilePausedMsg))
+		cm.SetConditions(xpv1.ReconcilePaused().WithMessage(reconcilePausedMsg))
 		// If the pause annotation is removed, we will have a chance to reconcile again and resume
 		// and if status update fails, we will reconcile again to retry to update the status
 		return reconcile.Result{}, errors.Wrap(r.client.Status().Update(ctx, cm), errUpdateClaimStatus)

--- a/internal/controller/apiextensions/claim/reconciler_test.go
+++ b/internal/controller/apiextensions/claim/reconciler_test.go
@@ -630,7 +630,7 @@ func TestReconcile(t *testing.T) {
 			want: want{
 				claim: withClaim(func(o *claim.Unstructured) {
 					o.SetAnnotations(map[string]string{meta.AnnotationKeyReconciliationPaused: "true"})
-					o.SetConditions(xpv1.ReconcilePaused())
+					o.SetConditions(xpv1.ReconcilePaused().WithMessage(reconcilePausedMsg))
 				}),
 			},
 		},
@@ -653,7 +653,7 @@ func TestReconcile(t *testing.T) {
 				err: errors.Wrap(errBoom, errUpdateClaimStatus),
 				claim: withClaim(func(o *claim.Unstructured) {
 					o.SetAnnotations(map[string]string{meta.AnnotationKeyReconciliationPaused: "true"})
-					o.SetConditions(xpv1.ReconcilePaused())
+					o.SetConditions(xpv1.ReconcilePaused().WithMessage(reconcilePausedMsg))
 				}),
 			},
 		},

--- a/internal/controller/apiextensions/composite/reconciler.go
+++ b/internal/controller/apiextensions/composite/reconciler.go
@@ -72,6 +72,8 @@ const (
 	errSelectEnvironment      = "cannot select environment"
 	errCompose                = "cannot compose resources"
 	errRenderCD               = "cannot render composed resource"
+
+	reconcilePausedMsg = "Reconciliation (including deletion) is paused via the pause annotation"
 )
 
 // Event reasons.
@@ -494,7 +496,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 	// after logging, publishing an event and updating the SYNC status condition
 	if meta.IsPaused(xr) {
 		r.record.Event(xr, event.Normal(reasonPaused, "Reconciliation is paused via the pause annotation"))
-		xr.SetConditions(xpv1.ReconcilePaused())
+		xr.SetConditions(xpv1.ReconcilePaused().WithMessage(reconcilePausedMsg))
 		// If the pause annotation is removed, we will have a chance to reconcile again and resume
 		// and if status update fails, we will reconcile again to retry to update the status
 		return reconcile.Result{}, errors.Wrap(r.client.Status().Update(ctx, xr), errUpdateStatus)

--- a/internal/controller/apiextensions/composite/reconciler_test.go
+++ b/internal/controller/apiextensions/composite/reconciler_test.go
@@ -635,7 +635,7 @@ func TestReconcile(t *testing.T) {
 						})),
 						MockStatusUpdate: WantComposite(t, NewComposite(func(cr resource.Composite) {
 							cr.SetAnnotations(map[string]string{meta.AnnotationKeyReconciliationPaused: "true"})
-							cr.SetConditions(xpv1.ReconcilePaused())
+							cr.SetConditions(xpv1.ReconcilePaused().WithMessage(reconcilePausedMsg))
 						})),
 					}),
 				},

--- a/internal/controller/pkg/manager/reconciler.go
+++ b/internal/controller/pkg/manager/reconciler.go
@@ -32,6 +32,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
+	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
 	"github.com/crossplane/crossplane-runtime/pkg/errors"
 	"github.com/crossplane/crossplane-runtime/pkg/event"
 	"github.com/crossplane/crossplane-runtime/pkg/logging"
@@ -52,6 +53,8 @@ const (
 	// updated content for the given package reference. This behavior is only
 	// enabled when the packagePullPolicy is Always.
 	pullWait = 1 * time.Minute
+
+	reconcilePausedMsg = "Reconciliation (including deletion) is paused via the pause annotation"
 )
 
 func pullBasedRequeue(p *corev1.PullPolicy) reconcile.Result {
@@ -85,6 +88,7 @@ const (
 	reasonTransitionRevision event.Reason = "TransitionRevision"
 	reasonGarbageCollect     event.Reason = "GarbageCollect"
 	reasonInstall            event.Reason = "InstallPackageRevision"
+	reasonPaused             event.Reason = "ReconciliationPaused"
 )
 
 // ReconcilerOption is used to configure the Reconciler.
@@ -277,6 +281,19 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 		// we'll be requeued implicitly because we return an error.
 		log.Debug(errGetPackage, "error", err)
 		return reconcile.Result{}, errors.Wrap(resource.IgnoreNotFound(err), errGetPackage)
+	}
+
+	// Check the pause annotation and return if it has the value "true"
+	// after logging, publishing an event and updating the SYNC status condition
+	if meta.IsPaused(p) {
+		r.record.Event(p, event.Normal(reasonPaused, reconcilePausedMsg))
+		p.SetConditions(xpv1.ReconcilePaused().WithMessage(reconcilePausedMsg))
+		// If the pause annotation is removed, we will have a chance to reconcile again and resume
+		// and if status update fails, we will reconcile again to retry to update the status
+		return reconcile.Result{}, errors.Wrap(r.client.Status().Update(ctx, p), errUpdateStatus)
+	}
+	if c := p.GetCondition(xpv1.ReconcilePaused().Type); c.Reason == xpv1.ReconcilePaused().Reason {
+		p.CleanConditions()
 	}
 
 	// Get existing package revisions.

--- a/internal/controller/pkg/manager/reconciler_test.go
+++ b/internal/controller/pkg/manager/reconciler_test.go
@@ -31,9 +31,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
+	commonv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
 	"github.com/crossplane/crossplane-runtime/pkg/errors"
 	"github.com/crossplane/crossplane-runtime/pkg/event"
 	"github.com/crossplane/crossplane-runtime/pkg/logging"
+	"github.com/crossplane/crossplane-runtime/pkg/meta"
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
 	"github.com/crossplane/crossplane-runtime/pkg/test"
 
@@ -736,6 +738,101 @@ func TestReconcile(t *testing.T) {
 			},
 			want: want{
 				err: errors.Wrap(errBoom, errGCPackageRevision),
+			},
+		},
+		"PauseReconcile": {
+			reason: "Pause reconciliation if the pause annotation is set",
+			args: args{
+				req: reconcile.Request{NamespacedName: types.NamespacedName{Name: "test"}},
+				rec: &Reconciler{
+					newPackage:             func() v1.Package { return &v1.Configuration{} },
+					newPackageRevision:     func() v1.PackageRevision { return &v1.ConfigurationRevision{} },
+					newPackageRevisionList: func() v1.PackageRevisionList { return &v1.ConfigurationRevisionList{} },
+					client: resource.ClientApplicator{
+						Client: &test.MockClient{
+							MockGet: test.NewMockGetFn(nil, func(o client.Object) error {
+								p := o.(*v1.Configuration)
+								p.SetName("test")
+								p.SetGroupVersionKind(v1.ConfigurationGroupVersionKind)
+								p.SetActivationPolicy(&v1.AutomaticActivation)
+								p.SetAnnotations(map[string]string{
+									meta.AnnotationKeyReconciliationPaused: "true",
+								})
+								return nil
+							}),
+							MockStatusUpdate: test.NewMockSubResourceUpdateFn(nil, func(o client.Object) error {
+								want := &v1.Configuration{}
+								want.SetName("test")
+								want.SetAnnotations(map[string]string{
+									meta.AnnotationKeyReconciliationPaused: "true",
+								})
+								want.SetGroupVersionKind(v1.ConfigurationGroupVersionKind)
+								want.SetActivationPolicy(&v1.AutomaticActivation)
+								want.SetConditions(commonv1.ReconcilePaused().WithMessage(reconcilePausedMsg))
+								if diff := cmp.Diff(want, o); diff != "" {
+									t.Errorf("-want, +got:\n%s", diff)
+								}
+								return nil
+							}),
+						},
+					},
+					pkg: &MockRevisioner{
+						MockRevision: NewMockRevisionFn("test-1234567", nil),
+					},
+					log:    testLog,
+					record: event.NewNopRecorder(),
+				},
+			},
+			want: want{
+				r: reconcile.Result{Requeue: false},
+			},
+		},
+		"ResumeReconcile": {
+			reason: "We should be active and not requeue on successful creation of the first revision with auto activation.",
+			args: args{
+				req: reconcile.Request{NamespacedName: types.NamespacedName{Name: "test"}},
+				rec: &Reconciler{
+					newPackage:             func() v1.Package { return &v1.Configuration{} },
+					newPackageRevision:     func() v1.PackageRevision { return &v1.ConfigurationRevision{} },
+					newPackageRevisionList: func() v1.PackageRevisionList { return &v1.ConfigurationRevisionList{} },
+					client: resource.ClientApplicator{
+						Client: &test.MockClient{
+							MockGet: test.NewMockGetFn(nil, func(o client.Object) error {
+								p := o.(*v1.Configuration)
+								p.SetName("test")
+								p.SetGroupVersionKind(v1.ConfigurationGroupVersionKind)
+								p.SetActivationPolicy(&v1.AutomaticActivation)
+								p.SetConditions(commonv1.ReconcilePaused())
+								return nil
+							}),
+							MockList: test.NewMockListFn(kerrors.NewNotFound(schema.GroupResource{}, "")),
+							MockStatusUpdate: test.NewMockSubResourceUpdateFn(nil, func(o client.Object) error {
+								want := &v1.Configuration{}
+								want.SetName("test")
+								want.SetGroupVersionKind(v1.ConfigurationGroupVersionKind)
+								want.SetCurrentRevision("test-1234567")
+								want.SetActivationPolicy(&v1.AutomaticActivation)
+								want.SetConditions(v1.UnknownHealth())
+								want.SetConditions(v1.Active())
+								if diff := cmp.Diff(want, o); diff != "" {
+									t.Errorf("-want, +got:\n%s", diff)
+								}
+								return nil
+							}),
+						},
+						Applicator: resource.ApplyFn(func(_ context.Context, _ client.Object, _ ...resource.ApplyOption) error {
+							return nil
+						}),
+					},
+					pkg: &MockRevisioner{
+						MockRevision: NewMockRevisionFn("test-1234567", nil),
+					},
+					log:    testLog,
+					record: event.NewNopRecorder(),
+				},
+			},
+			want: want{
+				r: reconcile.Result{Requeue: false},
 			},
 		},
 	}

--- a/internal/controller/rbac/provider/binding/reconciler.go
+++ b/internal/controller/rbac/provider/binding/reconciler.go
@@ -134,7 +134,7 @@ type Reconciler struct {
 
 // Reconcile a ProviderRevision by creating a ClusterRoleBinding that binds a
 // provider's service account to its system ClusterRole.
-func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
+func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) { //nolint:gocyclo // Reconcile methods are often very complex. Be wary.
 
 	log := r.log.WithValues("request", req)
 	log.Debug("Reconciling")
@@ -156,6 +156,12 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 		"version", pr.GetResourceVersion(),
 		"name", pr.GetName(),
 	)
+
+	// Check the pause annotation and return if it has the value "true"
+	// after logging, publishing an event and updating the SYNC status condition
+	if meta.IsPaused(pr) {
+		return reconcile.Result{}, nil
+	}
 
 	if meta.WasDeleted(pr) {
 		// There's nothing to do if our PR is being deleted. Any ClusterRoles

--- a/internal/controller/rbac/provider/binding/reconciler_test.go
+++ b/internal/controller/rbac/provider/binding/reconciler_test.go
@@ -33,6 +33,7 @@ import (
 
 	"github.com/crossplane/crossplane-runtime/pkg/errors"
 	"github.com/crossplane/crossplane-runtime/pkg/logging"
+	"github.com/crossplane/crossplane-runtime/pkg/meta"
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
 	"github.com/crossplane/crossplane-runtime/pkg/resource/fake"
 	"github.com/crossplane/crossplane-runtime/pkg/test"
@@ -187,6 +188,30 @@ func TestReconcile(t *testing.T) {
 						Applicator: resource.ApplyFn(func(context.Context, client.Object, ...resource.ApplyOption) error {
 							return nil
 						}),
+					}),
+				},
+			},
+			want: want{
+				r: reconcile.Result{Requeue: false},
+			},
+		},
+		"PauseReconcile": {
+			reason: "Pause reconciliation if the pause annotation is set.",
+			args: args{
+				mgr: &fake.Manager{},
+				opts: []ReconcilerOption{
+					WithClientApplicator(resource.ClientApplicator{
+						Client: &test.MockClient{
+							MockGet: test.NewMockGetFn(nil, func(o client.Object) error {
+								d := o.(*v1.ProviderRevision)
+								d.SetOwnerReferences([]metav1.OwnerReference{{}})
+								d.Spec.DesiredState = v1.PackageRevisionActive
+								d.SetAnnotations(map[string]string{
+									meta.AnnotationKeyReconciliationPaused: "true",
+								})
+								return nil
+							}),
+						},
 					}),
 				},
 			},

--- a/internal/controller/rbac/provider/roles/reconciler.go
+++ b/internal/controller/rbac/provider/roles/reconciler.go
@@ -250,6 +250,12 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 		"name", pr.GetName(),
 	)
 
+	// Check the pause annotation and return if it has the value "true"
+	// after logging, publishing an event and updating the SYNC status condition
+	if meta.IsPaused(pr) {
+		return reconcile.Result{}, nil
+	}
+
 	if meta.WasDeleted(pr) {
 		// There's nothing to do if our PR is being deleted. Any ClusterRoles
 		// we created will be garbage collected by Kubernetes.

--- a/internal/controller/rbac/provider/roles/reconciler_test.go
+++ b/internal/controller/rbac/provider/roles/reconciler_test.go
@@ -37,6 +37,7 @@ import (
 	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
 	"github.com/crossplane/crossplane-runtime/pkg/errors"
 	"github.com/crossplane/crossplane-runtime/pkg/logging"
+	"github.com/crossplane/crossplane-runtime/pkg/meta"
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
 	"github.com/crossplane/crossplane-runtime/pkg/resource/fake"
 	"github.com/crossplane/crossplane-runtime/pkg/test"
@@ -259,6 +260,34 @@ func TestReconcile(t *testing.T) {
 						Applicator: resource.ApplyFn(func(context.Context, client.Object, ...resource.ApplyOption) error {
 							return nil
 						}),
+					}),
+					WithClusterRoleRenderer(ClusterRoleRenderFn(func(*v1.ProviderRevision, []Resource) []rbacv1.ClusterRole {
+						return []rbacv1.ClusterRole{{}}
+					})),
+				},
+			},
+			want: want{
+				r: reconcile.Result{Requeue: false},
+			},
+		},
+		"PauseReconcile": {
+			reason: "Pause reconciliation if the pause annotation is set.",
+			args: args{
+				mgr: &fake.Manager{},
+				opts: []ReconcilerOption{
+					WithClientApplicator(resource.ClientApplicator{
+						Client: &test.MockClient{
+							MockGet: test.NewMockGetFn(nil, func(o client.Object) error {
+								pr := o.(*v1.ProviderRevision)
+								pr.SetUID(ourUID)
+								pr.SetLabels(map[string]string{v1.LabelProviderFamily: family})
+								pr.Spec.Package = "cool/provider:v1.0.0"
+								pr.SetAnnotations(map[string]string{
+									meta.AnnotationKeyReconciliationPaused: "true",
+								})
+								return nil
+							}),
+						},
 					}),
 					WithClusterRoleRenderer(ClusterRoleRenderFn(func(*v1.ProviderRevision, []Resource) []rbacv1.ClusterRole {
 						return []rbacv1.ClusterRole{{}}


### PR DESCRIPTION
### Description of your changes

The reconciliation can be paused by adding `crossplane.io/paused: "true"`
to the requested object. Removing the annotation resumes its reconciliation.



<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->


<!--
Briefly describe what this pull request does, and how it is covered by tests.
Be proactive - direct your reviewers' attention to anything that needs special
consideration.

You MUST either [x] check or ~strikethrough~ every item in the checklist below.

We love pull requests that fix an open issue. If yours does, use the below line
to indicate which issue it fixes, for example "Fixes #500".
-->

Fixes #4619 

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Added or updated unit **and** E2E tests for my change.
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR, if necessary.
- [x] Opened a PR updating the [docs], if necessary.

[contribution process]: https://git.io/fj2m9
[docs]: https://docs.crossplane.io/contribute/contribute