### PR TITLE
Stop propagation of claim's `*.kubernetes.io`/`*.k8s.io` annotations/labels down to XR

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/afero v1.10.0
+	golang.org/x/exp v0.0.0-20230905200255-921286631fa9
 	golang.org/x/sync v0.4.0
 	google.golang.org/grpc v1.58.3
 	google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.3.0
@@ -70,7 +71,6 @@ require (
 	github.com/xanzy/ssh-agent v0.3.3 // indirect
 	github.com/xlab/treeprint v1.2.0 // indirect
 	go.starlark.net v0.0.0-20230525235612-a134d8f9ddca // indirect
-	golang.org/x/exp v0.0.0-20230905200255-921286631fa9 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
 	sigs.k8s.io/kustomize/api v0.13.5-0.20230601165947-6ce0bf390ce3 // indirect
 	sigs.k8s.io/kustomize/kyaml v0.14.3-0.20230601165947-6ce0bf390ce3 // indirect

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,6 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/afero v1.10.0
-	golang.org/x/exp v0.0.0-20230905200255-921286631fa9
 	golang.org/x/sync v0.4.0
 	google.golang.org/grpc v1.58.3
 	google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.3.0
@@ -71,6 +70,7 @@ require (
 	github.com/xanzy/ssh-agent v0.3.3 // indirect
 	github.com/xlab/treeprint v1.2.0 // indirect
 	go.starlark.net v0.0.0-20230525235612-a134d8f9ddca // indirect
+	golang.org/x/exp v0.0.0-20230905200255-921286631fa9 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
 	sigs.k8s.io/kustomize/api v0.13.5-0.20230601165947-6ce0bf390ce3 // indirect
 	sigs.k8s.io/kustomize/kyaml v0.14.3-0.20230601165947-6ce0bf390ce3 // indirect

--- a/internal/controller/apiextensions/claim/configurator_test.go
+++ b/internal/controller/apiextensions/claim/configurator_test.go
@@ -588,6 +588,72 @@ func TestCompositeConfigure(t *testing.T) {
 				},
 			},
 		},
+		"SkipK8sAnnotationPropagation": {
+			reason: "Claim's kubernetes.io annotations should not be propagated to XR",
+			c: &test.MockClient{
+				MockCreate: test.NewMockCreateFn(nil),
+			},
+			args: args{
+				cm: &claim.Unstructured{
+					Unstructured: unstructured.Unstructured{
+						Object: map[string]any{
+							"apiVersion": apiVersion,
+							"kind":       kind,
+							"metadata": map[string]any{
+								"namespace": ns,
+								"name":      name,
+								"annotations": map[string]any{
+									"foo":                   "v1",
+									"foo.kubernetes.io":     "v2",
+									"foo.kubernetes.io/bar": "v3",
+								},
+							},
+							"spec": map[string]any{
+								"coolness": 23,
+
+								// These should be preserved.
+								"compositionRef":      "ref",
+								"compositionSelector": "ref",
+
+								// These should be filtered out.
+								"resourceRef":                "ref",
+								"writeConnectionSecretToRef": "ref",
+							},
+						},
+					},
+				},
+				cp: &composite.Unstructured{},
+			},
+			want: want{
+				cp: &composite.Unstructured{
+					Unstructured: unstructured.Unstructured{
+						Object: map[string]any{
+							"metadata": map[string]any{
+								"generateName": name + "-",
+								"labels": map[string]any{
+									xcrd.LabelKeyClaimNamespace: ns,
+									xcrd.LabelKeyClaimName:      name,
+								},
+								"annotations": map[string]any{
+									"foo": "v1",
+								},
+							},
+							"spec": map[string]any{
+								"coolness":            23,
+								"compositionRef":      "ref",
+								"compositionSelector": "ref",
+								"claimRef": map[string]any{
+									"apiVersion": apiVersion,
+									"kind":       kind,
+									"namespace":  ns,
+									"name":       name,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for name, tc := range cases {

--- a/internal/controller/apiextensions/claim/configurator_test.go
+++ b/internal/controller/apiextensions/claim/configurator_test.go
@@ -606,6 +606,8 @@ func TestCompositeConfigure(t *testing.T) {
 									"foo":                   "v1",
 									"foo.kubernetes.io":     "v2",
 									"foo.kubernetes.io/bar": "v3",
+									"foo.k8s.io":            "v4",
+									"foo.k8s.io/bar":        "v5",
 								},
 							},
 							"spec": map[string]any{
@@ -636,6 +638,72 @@ func TestCompositeConfigure(t *testing.T) {
 								},
 								"annotations": map[string]any{
 									"foo": "v1",
+								},
+							},
+							"spec": map[string]any{
+								"coolness":            23,
+								"compositionRef":      "ref",
+								"compositionSelector": "ref",
+								"claimRef": map[string]any{
+									"apiVersion": apiVersion,
+									"kind":       kind,
+									"namespace":  ns,
+									"name":       name,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		"SkipK8sLabelPropagation": {
+			reason: "Claim's kubernetes.io annotations should not be propagated to XR",
+			c: &test.MockClient{
+				MockCreate: test.NewMockCreateFn(nil),
+			},
+			args: args{
+				cm: &claim.Unstructured{
+					Unstructured: unstructured.Unstructured{
+						Object: map[string]any{
+							"apiVersion": apiVersion,
+							"kind":       kind,
+							"metadata": map[string]any{
+								"namespace": ns,
+								"name":      name,
+								"labels": map[string]any{
+									"foo":                   "v1",
+									"foo.kubernetes.io":     "v2",
+									"foo.kubernetes.io/bar": "v3",
+									"foo.k8s.io":            "v4",
+									"foo.k8s.io/bar":        "v5",
+								},
+							},
+							"spec": map[string]any{
+								"coolness": 23,
+
+								// These should be preserved.
+								"compositionRef":      "ref",
+								"compositionSelector": "ref",
+
+								// These should be filtered out.
+								"resourceRef":                "ref",
+								"writeConnectionSecretToRef": "ref",
+							},
+						},
+					},
+				},
+				cp: &composite.Unstructured{},
+			},
+			want: want{
+				cp: &composite.Unstructured{
+					Unstructured: unstructured.Unstructured{
+						Object: map[string]any{
+							"metadata": map[string]any{
+								"generateName": name + "-",
+								"labels": map[string]any{
+									xcrd.LabelKeyClaimNamespace: ns,
+									xcrd.LabelKeyClaimName:      name,
+									"foo":                       "v1",
 								},
 							},
 							"spec": map[string]any{


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

All `*.kubernetes.io`/`*.k8s.io` annotations/labels declared on a claim are not passed down to XR

<!--
Briefly describe what this pull request does, and how it is covered by tests.
Be proactive - direct your reviewers' attention to anything that needs special
consideration.

You MUST either [x] check or ~strikethrough~ every item in the checklist below.

We love pull requests that fix an open issue. If yours does, use the below line
to indicate which issue it fixes, for example "Fixes #500".
-->

Fixes #4650

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Added or updated unit **and** E2E tests for my change.
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR, if necessary.
- [x] Opened a PR updating the [docs], if necessary.

[contribution process]: https://git.io/fj2m9
[docs]: https://docs.crossplane.io/contribute/contribute