### PR TITLE
WIP: feat[compositions]: realtime compositor – part 3: do not poll

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -246,6 +246,7 @@ jobs:
           - composition-webhook-schema-validation
           - environment-configs
           - usage
+          - realtime-compositions
 
     steps:
       - name: Setup QEMU

--- a/cmd/crossplane/core/core.go
+++ b/cmd/crossplane/core/core.go
@@ -108,6 +108,7 @@ type startCommand struct {
 	EnableExternalSecretStores               bool `group:"Alpha Features:" help:"Enable support for External Secret Stores."`
 	EnableCompositionWebhookSchemaValidation bool `group:"Alpha Features:" help:"Enable support for Composition validation using schemas."`
 	EnableUsages                             bool `group:"Alpha Features:" help:"Enable support for deletion ordering and resource protection with Usages."`
+	EnableRealtimeCompositions               bool `group:"Alpha Features:" help:"Enable support for realtime compositions, i.e. watching composed resources and reconciling compositions immediately when any of the composed resources is updated."`
 
 	EnableCompositionFunctions bool `group:"Beta Features:" default:"true" help:"Enable support for Composition Functions."`
 
@@ -259,6 +260,10 @@ func (c *startCommand) Run(s *runtime.Scheme, log logging.Logger) error { //noli
 		o.ESSOptions = &controller.ESSOptions{
 			TLSConfig: tcfg,
 		}
+	}
+	if c.EnableRealtimeCompositions {
+		o.Features.Enable(features.EnableRealtimeCompositions)
+		log.Info("Alpha feature enabled", "flag", features.EnableRealtimeCompositions)
 	}
 
 	ao := apiextensionscontroller.Options{

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/Masterminds/semver v1.5.0
 	github.com/alecthomas/kong v0.8.1
 	github.com/bufbuild/buf v1.27.0
-	github.com/crossplane/crossplane-runtime v1.14.0-rc.0.0.20231010042232-a8f755740977
+	github.com/crossplane/crossplane-runtime v1.14.0-rc.0.0.20231014010837-674082aae6e6
 	github.com/docker/docker v24.0.6+incompatible
 	github.com/docker/go-connections v0.4.0
 	github.com/go-git/go-billy/v5 v5.5.0
@@ -125,7 +125,7 @@ require (
 	github.com/felixge/fgprof v0.9.3 // indirect
 	github.com/fsnotify/fsnotify v1.6.0 // indirect
 	github.com/go-chi/chi/v5 v5.0.10 // indirect
-	github.com/go-logr/logr v1.2.4 // indirect
+	github.com/go-logr/logr v1.2.4
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-logr/zapr v1.2.4 // indirect
 	github.com/go-openapi/jsonpointer v0.19.6 // indirect
@@ -140,7 +140,7 @@ require (
 	github.com/google/go-containerregistry/pkg/authn/kubernetes v0.0.0-20230516205744-dbecb1de8cfa // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/google/pprof v0.0.0-20230926050212-f7f687d19a98 // indirect
-	github.com/google/uuid v1.3.0 // indirect
+	github.com/google/uuid v1.3.0
 	github.com/imdario/mergo v0.3.16 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -157,8 +157,8 @@ github.com/cpuguy83/go-md2man/v2 v2.0.2 h1:p1EgwI/C7NhT0JmVkwCD2ZBK8j4aeHQX2pMHH
 github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/creack/pty v1.1.18 h1:n56/Zwd5o6whRC5PMGretI4IdRLlmBXYNjScPaBgsbY=
-github.com/crossplane/crossplane-runtime v1.14.0-rc.0.0.20231010042232-a8f755740977 h1:avMkfeTcHlYklNsixLXYVqUzx1DRzvkmHUOe2qucGEw=
-github.com/crossplane/crossplane-runtime v1.14.0-rc.0.0.20231010042232-a8f755740977/go.mod h1:aYG2FyI1G4tggdHerYJa4qqEInf9o6DB6xJZjjb5Xd8=
+github.com/crossplane/crossplane-runtime v1.14.0-rc.0.0.20231014010837-674082aae6e6 h1:0Z77AKtTn8Ixr15Rj/XpPnAS+IJ7ZBgQZanJF+5e98Q=
+github.com/crossplane/crossplane-runtime v1.14.0-rc.0.0.20231014010837-674082aae6e6/go.mod h1:mQJmFBx6QIf413fETih/5QJ1tCYcd3Mzd6PUY2ueaJE=
 github.com/cyphar/filepath-securejoin v0.2.4 h1:Ugdm7cg7i6ZK6x3xDF1oEu1nfkyfH53EtKeQYTC3kyg=
 github.com/cyphar/filepath-securejoin v0.2.4/go.mod h1:aPGpWjXOXUn2NCNjFvBE6aRxGGx79pTxQpKOJNYHHl4=
 github.com/danieljoos/wincred v1.1.2/go.mod h1:GijpziifJoIBfYh+S7BbkdUTU4LfM+QnGqR5Vl2tAx0=

--- a/internal/controller/apiextensions/composite/reconciler.go
+++ b/internal/controller/apiextensions/composite/reconciler.go
@@ -338,6 +338,14 @@ func WithComposer(c Composer) ReconcilerOption {
 	}
 }
 
+// WithKindObserver specifies how the Reconciler should observe kinds for
+// realtime events.
+func WithKindObserver(o KindObserver) ReconcilerOption {
+	return func(r *Reconciler) {
+		r.kindObserver = o
+	}
+}
+
 type revision struct {
 	CompositionRevisionFetcher
 	CompositionRevisionValidator
@@ -368,6 +376,23 @@ type compositeResource struct {
 	EnvironmentSelector
 	Configurator
 	managed.ConnectionPublisher
+}
+
+// KindObserver tracks kinds of referenced composed resources in composite
+// resources in order to start watches for them for realtime events.
+type KindObserver interface {
+	// WatchComposedResources starts a watch of the given kinds to trigger reconciles when
+	// a referenced object of those kinds changes.
+	WatchComposedResources(kind ...schema.GroupVersionKind)
+}
+
+// KindObserverFunc implements KindObserver as a function.
+type KindObserverFunc func(kind ...schema.GroupVersionKind)
+
+// WatchComposedResources starts a watch of the given kinds to trigger reconciles when
+// a referenced object of those kinds changes.
+func (fn KindObserverFunc) WatchComposedResources(kind ...schema.GroupVersionKind) {
+	fn(kind...)
 }
 
 // NewReconciler returns a new Reconciler of composite resources.
@@ -436,7 +461,8 @@ type Reconciler struct {
 	revision  revision
 	composite compositeResource
 
-	resource Composer
+	resource     Composer
+	kindObserver KindObserver
 
 	log    logging.Logger
 	record event.Recorder
@@ -604,6 +630,14 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 		r.record.Event(xr, event.Warning(reasonCompose, err))
 		xr.SetConditions(xpv1.ReconcileError(err))
 		return reconcile.Result{Requeue: true}, errors.Wrap(r.client.Status().Update(ctx, xr), errUpdateStatus)
+	}
+
+	if r.kindObserver != nil {
+		var gvks []schema.GroupVersionKind
+		for _, ref := range xr.GetResourceReferences() {
+			gvks = append(gvks, ref.GroupVersionKind())
+		}
+		r.kindObserver.WatchComposedResources(gvks...)
 	}
 
 	published, err := r.composite.PublishConnection(ctx, xr, res.ConnectionDetails)

--- a/internal/controller/apiextensions/composite/reconciler_test.go
+++ b/internal/controller/apiextensions/composite/reconciler_test.go
@@ -48,6 +48,7 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/test"
 
 	v1 "github.com/crossplane/crossplane/apis/apiextensions/v1"
+	apiextensionscontroller "github.com/crossplane/crossplane/internal/controller/apiextensions/controller"
 )
 
 var _ Composer = ComposerSelectorFn(func(cm *v1.CompositionMode) Composer { return nil })
@@ -759,7 +760,7 @@ func TestReconcile(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			r := NewReconciler(tc.args.mgr, tc.args.of, tc.args.opts...)
+			r := NewReconciler(tc.args.mgr, tc.args.of, apiextensionscontroller.Options{}, tc.args.opts...)
 			got, err := r.Reconcile(context.Background(), reconcile.Request{})
 
 			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {

--- a/internal/controller/apiextensions/definition/composed.go
+++ b/internal/controller/apiextensions/definition/composed.go
@@ -1,0 +1,283 @@
+/*
+Copyright 2023 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package definition
+
+import (
+	"context"
+	"strings"
+	"sync"
+
+	"github.com/google/uuid"
+	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	kunstructured "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	kcache "k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
+	cache "sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/cluster"
+	runtimeevent "sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+
+	"github.com/crossplane/crossplane-runtime/pkg/controller"
+	"github.com/crossplane/crossplane-runtime/pkg/logging"
+
+	"github.com/crossplane/crossplane/internal/xcrd"
+)
+
+// composedResourceInformers manages composed resource informers referenced by
+// composite resources. It serves as an event source for realtime notifications
+// of changed composed resources, with the composite reconcilers as sinks.
+// It keeps composed resource informers alive as long as there are composites
+// referencing them. In parallel, the composite reconcilers keep track of
+// references to composed resources, and inform composedResourceInformers about
+// them via the WatchComposedResources method.
+type composedResourceInformers struct {
+	log     logging.Logger
+	cluster cluster.Cluster
+
+	gvkRoutedCache *controller.GVKRoutedCache
+
+	lock sync.RWMutex // everything below is protected by this lock
+
+	// cdCaches holds the composed resource informers. These are dynamically
+	// started and stopped based on the composites that reference them.
+	cdCaches map[schema.GroupVersionKind]cdCache
+	// xrCaches holds the composite resource informers. We use them to find
+	// composites referencing a certain composed resource GVK. If no composite
+	// is left doing so, a composed resource informer is stopped.
+	xrCaches map[schema.GroupVersionKind]cache.Cache
+	sinks    map[string]func(ev runtimeevent.UpdateEvent) // by some uid
+}
+
+type cdCache struct {
+	cache    cache.Cache
+	cancelFn context.CancelFunc
+}
+
+var _ source.Source = &composedResourceInformers{}
+
+// Start implements source.Source, i.e. starting composedResourceInformers as
+// source with h as the sink of update events. It keeps sending events until
+// ctx is done.
+// Note that Start can be called multiple times to deliver events to multiple
+// (composite resource) controllers.
+func (i *composedResourceInformers) Start(ctx context.Context, h handler.EventHandler, q workqueue.RateLimitingInterface, ps ...predicate.Predicate) error {
+	id := uuid.New().String()
+
+	i.lock.Lock()
+	defer i.lock.Unlock()
+	i.sinks[id] = func(ev runtimeevent.UpdateEvent) {
+		for _, p := range ps {
+			if !p.Update(ev) {
+				return
+			}
+		}
+		h.Update(ctx, ev, q)
+	}
+
+	go func() {
+		<-ctx.Done()
+
+		i.lock.Lock()
+		defer i.lock.Unlock()
+		delete(i.sinks, id)
+	}()
+
+	return nil
+}
+
+// RegisterComposite registers a composite resource cache with its GVK.
+// Instances of this GVK will be considered to keep composed resource informers
+// alive.
+func (i *composedResourceInformers) RegisterComposite(gvk schema.GroupVersionKind, ca cache.Cache) {
+	i.lock.Lock()
+	defer i.lock.Unlock()
+
+	if i.xrCaches == nil {
+		i.xrCaches = make(map[schema.GroupVersionKind]cache.Cache)
+	}
+	i.xrCaches[gvk] = ca
+}
+
+// UnregisterComposite removes a composite resource cache from being considered
+// to keep composed resource informers alive.
+func (i *composedResourceInformers) UnregisterComposite(gvk schema.GroupVersionKind) {
+	i.lock.Lock()
+	defer i.lock.Unlock()
+	delete(i.xrCaches, gvk)
+}
+
+// WatchComposedResources starts informers for the given composed resource GVKs.
+// The is wired into the composite reconciler, which will call this method on
+// every reconcile to make composedResourceInformers aware of the composed
+// resources the given composite resource references.
+//
+// Note that this complements cleanupComposedResourceInformers which regularly
+// garbage collects composed resource informers that are no longer referenced by
+// any composite.
+func (i *composedResourceInformers) WatchComposedResources(gvks ...schema.GroupVersionKind) {
+	i.lock.RLock()
+	defer i.lock.RUnlock()
+
+	// start new informers
+	for _, gvk := range gvks {
+		if _, found := i.cdCaches[gvk]; found {
+			continue
+		}
+
+		log := i.log.WithValues("gvk", gvk.String())
+
+		ca, err := cache.New(i.cluster.GetConfig(), cache.Options{})
+		if err != nil {
+			log.Debug("failed creating a cache", "error", err)
+			continue
+		}
+
+		// don't forget to call cancelFn in error cases to avoid leaks. In the
+		// happy case it's called from the go routine starting the cache below.
+		ctx, cancelFn := context.WithCancel(context.Background())
+
+		u := kunstructured.Unstructured{}
+		u.SetGroupVersionKind(gvk)
+		inf, err := ca.GetInformer(ctx, &u)
+		if err != nil {
+			cancelFn()
+			log.Debug("failed getting informer", "error", err)
+			continue
+		}
+
+		if _, err := inf.AddEventHandler(kcache.ResourceEventHandlerFuncs{
+			UpdateFunc: func(oldObj, newObj interface{}) {
+				old := oldObj.(client.Object)
+				obj := newObj.(client.Object)
+				if old.GetResourceVersion() == obj.GetResourceVersion() {
+					return
+				}
+
+				i.lock.RLock()
+				defer i.lock.RUnlock()
+
+				ev := runtimeevent.UpdateEvent{
+					ObjectOld: old,
+					ObjectNew: obj,
+				}
+				for _, handleFn := range i.sinks {
+					handleFn(ev)
+				}
+			},
+		}); err != nil {
+			cancelFn()
+			log.Debug("failed adding event handler", "error", err)
+			continue
+		}
+
+		go func() {
+			defer cancelFn()
+
+			log.Info("Starting composed resource watch")
+			_ = ca.Start(ctx)
+		}()
+
+		i.cdCaches[gvk] = cdCache{
+			cache:    ca,
+			cancelFn: cancelFn,
+		}
+
+		// wait for in the background, and only when synced add to the routed cache
+		go func(gvk schema.GroupVersionKind) {
+			if synced := ca.WaitForCacheSync(ctx); synced {
+				log.Debug("Composed resource cache synced")
+				i.gvkRoutedCache.AddDelegate(gvk, ca)
+			}
+		}(gvk)
+	}
+}
+
+// cleanupComposedResourceInformers garbage collects composed resource informers
+// that are no longer referenced by any composite resource.
+//
+// Note that this complements WatchComposedResources which starts informers for
+// the composed resources referenced by a composite resource.
+func (i *composedResourceInformers) cleanupComposedResourceInformers(ctx context.Context) { //nolint:gocyclo // splitting it doesn't make it easier to read.
+	crds := extv1.CustomResourceDefinitionList{}
+	if err := i.cluster.GetClient().List(ctx, &crds); err != nil {
+		i.log.Debug(errListCRDs, "error", err)
+		return
+	}
+
+	// copy map to avoid locking it for the entire duration of the loop
+	xrCaches := make(map[schema.GroupVersionKind]cache.Cache, len(i.xrCaches))
+	i.lock.RLock()
+	for gvk, ca := range i.xrCaches {
+		xrCaches[gvk] = ca
+	}
+	i.lock.RUnlock()
+
+	// find all CRDs that some XR is referencing. This is O(CRDs * XRDs * versions).
+	// In practice, CRDs are 1000ish max, and XRDs are 10ish. So this is
+	// fast enough for now. It's all in-memory.
+	referenced := make(map[schema.GroupVersionKind]bool)
+	for _, crd := range crds.Items {
+		crd := crd
+
+		if !xcrd.IsEstablished(crd.Status) {
+			continue
+		}
+
+		for _, v := range crd.Spec.Versions {
+			cdGVK := schema.GroupVersionKind{Group: crd.Spec.Group, Version: v.Name, Kind: crd.Spec.Names.Kind}
+			for xrGVK, xrCache := range xrCaches {
+				// list composites that reference this composed GVK
+				list := kunstructured.UnstructuredList{}
+				list.SetGroupVersionKind(xrGVK.GroupVersion().WithKind(xrGVK.Kind + "List"))
+				if err := xrCache.List(ctx, &list, client.MatchingFields{compositeResourceRefGVKsIndex: cdGVK.String()}); err != nil {
+					i.log.Debug("cannot list composite resources referencing a certain composed resource GVK", "error", err, "gvk", xrGVK.String(), "fieldSelector", compositeResourceRefGVKsIndex+"="+cdGVK.String())
+					continue
+				}
+				if len(list.Items) > 0 {
+					referenced[cdGVK] = true
+				}
+			}
+		}
+	}
+
+	// stop old informers
+	for gvk, inf := range i.cdCaches {
+		if referenced[gvk] {
+			continue
+		}
+		inf.cancelFn()
+		i.gvkRoutedCache.RemoveDelegate(gvk)
+		i.log.Info("Stopped composed resource watch", "gvk", gvk.String())
+		delete(i.cdCaches, gvk)
+	}
+}
+
+func parseAPIVersion(v string) (string, string) {
+	parts := strings.SplitN(v, "/", 2)
+	switch len(parts) {
+	case 1:
+		return "", parts[0]
+	case 2:
+		return parts[0], parts[1]
+	default:
+		return "", ""
+	}
+}

--- a/internal/controller/apiextensions/definition/indexes.go
+++ b/internal/controller/apiextensions/definition/indexes.go
@@ -1,0 +1,107 @@
+/*
+Copyright 2023 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package definition
+
+import (
+	"context"
+	"fmt"
+
+	kunstructured "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/workqueue"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	runtimeevent "sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"github.com/crossplane/crossplane-runtime/pkg/logging"
+	"github.com/crossplane/crossplane-runtime/pkg/resource/unstructured/composite"
+)
+
+const (
+	// compositeResourceRefGVKsIndex is an index of all GroupKinds that
+	// are in use by a Composition. It indexes from spec.resourceRefs, not
+	// from spec.resources. Hence, it will also work with functions.
+	compositeResourceRefGVKsIndex = "compositeResourceRefsGVKs"
+	// compositeResourcesRefsIndex is an index of resourceRefs that are owned
+	// by a composite.
+	compositeResourcesRefsIndex = "compositeResourcesRefs"
+)
+
+var (
+	_ client.IndexerFunc = IndexCompositeResourceRefGVKs
+	_ client.IndexerFunc = IndexCompositeResourcesRefs
+)
+
+// IndexCompositeResourceRefGVKs assumes the passed object is a composite. It
+// returns gvk keys for every resource referenced in the composite.
+func IndexCompositeResourceRefGVKs(o client.Object) []string {
+	u, ok := o.(*kunstructured.Unstructured)
+	if !ok {
+		return nil // should never happen
+	}
+	xr := composite.Unstructured{Unstructured: *u}
+	refs := xr.GetResourceReferences()
+	keys := make([]string, 0, len(refs))
+	for _, ref := range refs {
+		group, version := parseAPIVersion(ref.APIVersion)
+		keys = append(keys, schema.GroupVersionKind{Group: group, Version: version, Kind: ref.Kind}.String())
+	}
+	// unification is done by the informer.
+	return keys
+}
+
+// IndexCompositeResourcesRefs assumes the passed object is a composite. It
+// returns keys for every composed resource referenced in the composite.
+func IndexCompositeResourcesRefs(o client.Object) []string {
+	u, ok := o.(*kunstructured.Unstructured)
+	if !ok {
+		return nil // should never happen
+	}
+	xr := composite.Unstructured{Unstructured: *u}
+	refs := xr.GetResourceReferences()
+	keys := make([]string, 0, len(refs))
+	for _, ref := range refs {
+		keys = append(keys, refKey(ref.Namespace, ref.Name, ref.Kind, ref.APIVersion))
+	}
+	return keys
+}
+
+func refKey(ns, name, kind, apiVersion string) string {
+	return fmt.Sprintf("%s.%s.%s.%s", name, ns, kind, apiVersion)
+}
+
+func enqueueXRsForMR(ca cache.Cache, xrGVK schema.GroupVersionKind, log logging.Logger) func(ctx context.Context, ev runtimeevent.UpdateEvent, q workqueue.RateLimitingInterface) {
+	return func(ctx context.Context, ev runtimeevent.UpdateEvent, q workqueue.RateLimitingInterface) {
+		mrGVK := ev.ObjectNew.GetObjectKind().GroupVersionKind()
+		key := refKey(ev.ObjectNew.GetNamespace(), ev.ObjectNew.GetName(), mrGVK.Kind, mrGVK.GroupVersion().String())
+
+		composites := kunstructured.UnstructuredList{}
+		composites.SetGroupVersionKind(xrGVK.GroupVersion().WithKind(xrGVK.Kind + "List"))
+		if err := ca.List(ctx, &composites, client.MatchingFields{compositeResourcesRefsIndex: key}); err != nil {
+			log.Debug("cannot list composite resources related to a MR change", "error", err, "gvk", xrGVK.String(), "fieldSelector", compositeResourcesRefsIndex+"="+key)
+			return
+		}
+
+		// queue those composites for reconciliation
+		for _, xr := range composites.Items {
+			log.Info("Enqueueing composite resource because managed resource changed", "name", xr.GetName(), "mrGVK", mrGVK.String(), "mrName", ev.ObjectNew.GetName())
+			q.Add(reconcile.Request{NamespacedName: types.NamespacedName{Name: xr.GetName()}})
+		}
+	}
+}

--- a/internal/controller/apiextensions/definition/indexes_test.go
+++ b/internal/controller/apiextensions/definition/indexes_test.go
@@ -1,0 +1,120 @@
+/*
+Copyright 2023 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package definition
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func TestIndexCompositeResourceRefGVKs(t *testing.T) {
+	type args struct {
+		object client.Object
+	}
+	tests := map[string]struct {
+		args args
+		want []string
+	}{
+		"Nil":             {args: args{object: nil}, want: nil},
+		"NotUnstructured": {args: args{object: &corev1.Pod{}}, want: nil},
+		"NoRefs": {args: args{object: &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"spec": map[string]interface{}{},
+			},
+		}}, want: []string{}},
+		"References": {args: args{object: &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"spec": map[string]interface{}{
+					"resourceRefs": []interface{}{
+						map[string]interface{}{
+							"apiVersion": "nop.crossplane.io/v1alpha1",
+							"kind":       "NopResource",
+							"name":       "mr",
+						},
+						map[string]interface{}{
+							"apiVersion": "nop.example.org/v1alpha1",
+							"kind":       "NopResource",
+							"name":       "xr",
+						},
+					},
+				},
+			},
+		}}, want: []string{"nop.crossplane.io/v1alpha1, Kind=NopResource", "nop.example.org/v1alpha1, Kind=NopResource"}},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := IndexCompositeResourceRefGVKs(tc.args.object)
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("\n%s\nIndexCompositeResourceRefGVKs(...): -want, +got:\n%s", name, diff)
+			}
+		})
+	}
+}
+
+func TestIndexCompositeResourcesRefs(t *testing.T) {
+	type args struct {
+		object client.Object
+	}
+	tests := map[string]struct {
+		args args
+		want []string
+	}{
+		"Nil":             {args: args{object: nil}, want: nil},
+		"NotUnstructured": {args: args{object: &corev1.Pod{}}, want: nil},
+		"NoRefs": {args: args{object: &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"spec": map[string]interface{}{},
+			},
+		}}, want: []string{}},
+		"References": {args: args{object: &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"spec": map[string]interface{}{
+					"resourceRefs": []interface{}{
+						map[string]interface{}{
+							"apiVersion": "nop.crossplane.io/v1alpha1",
+							"kind":       "NopResource",
+							"name":       "mr",
+						},
+						map[string]interface{}{
+							"apiVersion": "nop.example.org/v1alpha1",
+							"kind":       "NopResource",
+							"name":       "xr",
+						},
+						map[string]interface{}{
+							"apiVersion": "v1",
+							"kind":       "ConfigMap",
+							"name":       "cm",
+							"namespace":  "ns",
+						},
+					},
+				},
+			},
+		}}, want: []string{"mr..NopResource.nop.crossplane.io/v1alpha1", "xr..NopResource.nop.example.org/v1alpha1", "cm.ns.ConfigMap.v1"}},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := IndexCompositeResourcesRefs(tc.args.object)
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("\n%s\nIndexCompositeResourcesRefs(...): -want, +got:\n%s", name, diff)
+			}
+		})
+	}
+}

--- a/internal/controller/apiextensions/definition/reconciler.go
+++ b/internal/controller/apiextensions/definition/reconciler.go
@@ -455,7 +455,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 	if r.options.Features.Enabled(features.EnableRealtimeCompositions) {
 		ro = append(ro, composite.WithKindObserver(composite.KindObserverFunc(r.xrInformers.WatchComposedResources)))
 	}
-	cr := composite.NewReconciler(r.mgr, ck, ro...)
+	cr := composite.NewReconciler(r.mgr, ck, r.options, ro...)
 	ko := r.options.ForControllerRuntime()
 	ko.Reconciler = ratelimiter.NewReconciler(composite.ControllerName(d.GetName()), errors.WithSilentRequeueOnConflict(cr), r.options.GlobalRateLimiter)
 

--- a/internal/controller/apiextensions/definition/reconciler.go
+++ b/internal/controller/apiextensions/definition/reconciler.go
@@ -28,10 +28,15 @@ import (
 	kmeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kunstructured "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/util/workqueue"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	kcontroller "sigs.k8s.io/controller-runtime/pkg/controller"
+	runtimeevent "sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -60,17 +65,20 @@ const (
 	timeout   = 2 * time.Minute
 	finalizer = "defined.apiextensions.crossplane.io"
 
-	errGetXRD          = "cannot get CompositeResourceDefinition"
-	errRenderCRD       = "cannot render composite resource CustomResourceDefinition"
-	errGetCRD          = "cannot get composite resource CustomResourceDefinition"
-	errApplyCRD        = "cannot apply rendered composite resource CustomResourceDefinition"
-	errUpdateStatus    = "cannot update status of CompositeResourceDefinition"
-	errStartController = "cannot start composite resource controller"
-	errAddFinalizer    = "cannot add composite resource finalizer"
-	errRemoveFinalizer = "cannot remove composite resource finalizer"
-	errDeleteCRD       = "cannot delete composite resource CustomResourceDefinition"
-	errListCRs         = "cannot list defined composite resources"
-	errDeleteCRs       = "cannot delete defined composite resources"
+	errGetXRD                         = "cannot get CompositeResourceDefinition"
+	errRenderCRD                      = "cannot render composite resource CustomResourceDefinition"
+	errGetCRD                         = "cannot get composite resource CustomResourceDefinition"
+	errApplyCRD                       = "cannot apply rendered composite resource CustomResourceDefinition"
+	errUpdateStatus                   = "cannot update status of CompositeResourceDefinition"
+	errStartController                = "cannot start composite resource controller"
+	errAddIndex                       = "cannot add composite GVK index"
+	errAddFinalizer                   = "cannot add composite resource finalizer"
+	errRemoveFinalizer                = "cannot remove composite resource finalizer"
+	errDeleteCRD                      = "cannot delete composite resource CustomResourceDefinition"
+	errListCRs                        = "cannot list defined composite resources"
+	errDeleteCRs                      = "cannot delete defined composite resources"
+	errListCRDs                       = "cannot list CustomResourceDefinitions"
+	errCannotAddInformerLoopToManager = "cannot add resources informer loop to manager"
 )
 
 // Wait strings.
@@ -89,6 +97,7 @@ const (
 // A ControllerEngine can start and stop Kubernetes controllers on demand.
 type ControllerEngine interface {
 	IsRunning(name string) bool
+	Create(name string, o kcontroller.Options, w ...controller.Watch) (controller.NamedController, error)
 	Start(name string, o kcontroller.Options, w ...controller.Watch) error
 	Stop(name string)
 	Err(name string) error
@@ -115,10 +124,22 @@ func (fn CRDRenderFn) Render(d *v1.CompositeResourceDefinition) (*extv1.CustomRe
 func Setup(mgr ctrl.Manager, o apiextensionscontroller.Options) error {
 	name := "defined/" + strings.ToLower(v1.CompositeResourceDefinitionGroupKind)
 
-	r := NewReconciler(mgr,
+	r := NewReconciler(mgr, o,
 		WithLogger(o.Logger.WithValues("controller", name)),
-		WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name))),
-		WithOptions(o))
+		WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name))))
+
+	if o.Features.Enabled(features.EnableRealtimeCompositions) {
+		// Register a runnable regularly checking whether the watch composed
+		// resources are still referenced by composite resources. If not, the
+		// composed resource informer is stopped.
+		if err := mgr.Add(manager.RunnableFunc(func(ctx context.Context) error {
+			// Run every minute.
+			wait.UntilWithContext(ctx, r.xrInformers.cleanupComposedResourceInformers, time.Minute)
+			return nil
+		})); err != nil {
+			return errors.Wrap(err, errCannotAddInformerLoopToManager)
+		}
+	}
 
 	return ctrl.NewControllerManagedBy(mgr).
 		Named(name).
@@ -135,6 +156,7 @@ type ReconcilerOption func(*Reconciler)
 func WithLogger(log logging.Logger) ReconcilerOption {
 	return func(r *Reconciler) {
 		r.log = log
+		r.xrInformers.log = log
 	}
 }
 
@@ -142,14 +164,6 @@ func WithLogger(log logging.Logger) ReconcilerOption {
 func WithRecorder(er event.Recorder) ReconcilerOption {
 	return func(r *Reconciler) {
 		r.record = er
-	}
-}
-
-// WithOptions lets the Reconciler know which options to pass to new composite
-// resource controllers.
-func WithOptions(o apiextensionscontroller.Options) ReconcilerOption {
-	return func(r *Reconciler) {
-		r.options = o
 	}
 }
 
@@ -192,8 +206,15 @@ type definition struct {
 }
 
 // NewReconciler returns a Reconciler of CompositeResourceDefinitions.
-func NewReconciler(mgr manager.Manager, opts ...ReconcilerOption) *Reconciler {
+func NewReconciler(mgr manager.Manager, o apiextensionscontroller.Options, opts ...ReconcilerOption) *Reconciler {
 	kube := unstructured.NewClient(mgr.GetClient())
+
+	ca := controller.NewGVKRoutedCache(mgr.GetScheme(), mgr.GetCache())
+	if o.Features.Enabled(features.EnableRealtimeCompositions) {
+		// wrap the manager's cache to route requests to dynamically started
+		// informers for managed resources.
+		mgr = controller.WithGVKRoutedCache(ca, mgr)
+	}
 
 	r := &Reconciler{
 		mgr: mgr,
@@ -209,17 +230,25 @@ func NewReconciler(mgr manager.Manager, opts ...ReconcilerOption) *Reconciler {
 			Finalizer:        resource.NewAPIFinalizer(kube, finalizer),
 		},
 
+		xrInformers: composedResourceInformers{
+			log:     logging.NewNopLogger(),
+			cluster: mgr,
+
+			gvkRoutedCache: ca,
+			cdCaches:       make(map[schema.GroupVersionKind]cdCache),
+			sinks:          make(map[string]func(ev runtimeevent.UpdateEvent)),
+		},
+
 		log:    logging.NewNopLogger(),
 		record: event.NewNopRecorder(),
 
-		options: apiextensionscontroller.Options{
-			Options: controller.DefaultOptions(),
-		},
+		options: o,
 	}
 
 	for _, f := range opts {
 		f(r)
 	}
+
 	return r
 }
 
@@ -232,6 +261,8 @@ type Reconciler struct {
 
 	log    logging.Logger
 	record event.Recorder
+
+	xrInformers composedResourceInformers
 
 	options apiextensionscontroller.Options
 }
@@ -337,13 +368,13 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 		l := &kunstructured.UnstructuredList{}
 		l.SetGroupVersionKind(d.GetCompositeGroupVersionKind())
 		if err := r.client.List(ctx, l); resource.Ignore(kmeta.IsNoMatchError, err) != nil {
-			log.Debug(errListCRs, "error", err)
+			log.Debug("cannot list composite resources to check whether the XRD can be deleted", "error", err, "gvk", d.GetCompositeGroupVersionKind().String())
 			err = errors.Wrap(err, errListCRs)
 			r.record.Event(d, event.Warning(reasonTerminateXR, err))
 			return reconcile.Result{}, err
 		}
 
-		// Controller should be stopped only after all instances are
+		// namedController should be stopped only after all instances are
 		// gone so that deletion logic of the instances are processed by
 		// the controller.
 		if len(l.Items) > 0 {
@@ -411,6 +442,9 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 	desired := v1.TypeReferenceTo(d.GetCompositeGroupVersionKind())
 	if observed.APIVersion != "" && observed != desired {
 		r.composite.Stop(composite.ControllerName(d.GetName()))
+		if r.options.Features.Enabled(features.EnableRealtimeCompositions) {
+			r.xrInformers.UnregisterComposite(d.GetCompositeGroupVersionKind())
+		}
 		log.Debug("Referenceable version changed; stopped composite resource controller",
 			"observed-version", observed.APIVersion,
 			"desired-version", desired.APIVersion)
@@ -418,24 +452,65 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 
 	ro := CompositeReconcilerOptions(r.options, d, r.client, r.log, r.record)
 	ck := resource.CompositeKind(d.GetCompositeGroupVersionKind())
+	if r.options.Features.Enabled(features.EnableRealtimeCompositions) {
+		ro = append(ro, composite.WithKindObserver(composite.KindObserverFunc(r.xrInformers.WatchComposedResources)))
+	}
 	cr := composite.NewReconciler(r.mgr, ck, ro...)
 	ko := r.options.ForControllerRuntime()
 	ko.Reconciler = ratelimiter.NewReconciler(composite.ControllerName(d.GetName()), errors.WithSilentRequeueOnConflict(cr), r.options.GlobalRateLimiter)
 
-	u := &kunstructured.Unstructured{}
-	u.SetGroupVersionKind(d.GetCompositeGroupVersionKind())
+	xrGVK := d.GetCompositeGroupVersionKind()
 
-	if err := r.composite.Start(composite.ControllerName(d.GetName()), ko,
+	u := &kunstructured.Unstructured{}
+	u.SetGroupVersionKind(xrGVK)
+
+	name := composite.ControllerName(d.GetName())
+	var ca cache.Cache
+	watches := []controller.Watch{
 		controller.For(u, &handler.EnqueueRequestForObject{}),
+		// enqueue composites whenever a matching CompositionRevision is created
 		controller.TriggeredBy(source.Kind(r.mgr.GetCache(), &v1.CompositionRevision{}), handler.Funcs{
-			// enqueue composites whenever a matching CompositionRevision is created
 			CreateFunc: composite.EnqueueForCompositionRevisionFunc(ck, r.mgr.GetCache().List, r.log),
 		}),
-	); err != nil {
+	}
+	if r.options.Features.Enabled(features.EnableRealtimeCompositions) {
+		// enqueue XRs that when a relevant MR is updated
+		watches = append(watches, controller.TriggeredBy(&r.xrInformers, handler.Funcs{
+			UpdateFunc: func(ctx context.Context, ev runtimeevent.UpdateEvent, q workqueue.RateLimitingInterface) {
+				enqueueXRsForMR(ca, xrGVK, log)(ctx, ev, q)
+			},
+		}))
+	}
+
+	c, err := r.composite.Create(name, ko, watches...)
+	if err != nil {
 		log.Debug(errStartController, "error", err)
 		err = errors.Wrap(err, errStartController)
 		r.record.Event(d, event.Warning(reasonEstablishXR, err))
 		return reconcile.Result{}, err
+	}
+
+	if r.options.Features.Enabled(features.EnableRealtimeCompositions) {
+		ca = c.GetCache()
+		if err := ca.IndexField(ctx, u, compositeResourceRefGVKsIndex, IndexCompositeResourceRefGVKs); err != nil {
+			log.Debug(errAddIndex, "error", err)
+			// Nothing we can do. At worst, we won't have realtime updates.
+		}
+		if err := ca.IndexField(ctx, u, compositeResourcesRefsIndex, IndexCompositeResourcesRefs); err != nil {
+			log.Debug(errAddIndex, "error", err)
+			// Nothing we can do. At worst, we won't have realtime updates.
+		}
+	}
+
+	if err := c.Start(context.Background()); err != nil { //nolint:contextcheck // the controller actually runs in the background.
+		log.Debug(errStartController, "error", err)
+		err = errors.Wrap(err, errStartController)
+		r.record.Event(d, event.Warning(reasonEstablishXR, err))
+		return reconcile.Result{}, err
+	}
+
+	if r.options.Features.Enabled(features.EnableRealtimeCompositions) {
+		r.xrInformers.RegisterComposite(xrGVK, ca)
 	}
 
 	d.Status.Controllers.CompositeResourceTypeRef = v1.TypeReferenceTo(d.GetCompositeGroupVersionKind())

--- a/internal/controller/apiextensions/definition/reconciler_test.go
+++ b/internal/controller/apiextensions/definition/reconciler_test.go
@@ -21,15 +21,20 @@ import (
 	"io"
 	"testing"
 
+	"github.com/go-logr/logr"
 	"github.com/google/go-cmp/cmp"
 	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	ctrlconfig "sigs.k8s.io/controller-runtime/pkg/config"
 	kcontroller "sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -37,19 +42,27 @@ import (
 
 	"github.com/crossplane/crossplane-runtime/pkg/controller"
 	"github.com/crossplane/crossplane-runtime/pkg/errors"
+	"github.com/crossplane/crossplane-runtime/pkg/feature"
 	"github.com/crossplane/crossplane-runtime/pkg/logging"
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
 	"github.com/crossplane/crossplane-runtime/pkg/resource/fake"
 	"github.com/crossplane/crossplane-runtime/pkg/test"
 
 	v1 "github.com/crossplane/crossplane/apis/apiextensions/v1"
+	apiextensionscontroller "github.com/crossplane/crossplane/internal/controller/apiextensions/controller"
+	"github.com/crossplane/crossplane/internal/features"
 )
 
 type MockEngine struct {
 	ControllerEngine
-	MockStart func(name string, o kcontroller.Options, w ...controller.Watch) error
-	MockStop  func(name string)
-	MockErr   func(name string) error
+	MockCreate func(name string, o kcontroller.Options, w ...controller.Watch) (controller.NamedController, error)
+	MockStart  func(name string, o kcontroller.Options, w ...controller.Watch) error
+	MockStop   func(name string)
+	MockErr    func(name string) error
+}
+
+func (m *MockEngine) Create(name string, o kcontroller.Options, w ...controller.Watch) (controller.NamedController, error) {
+	return m.MockCreate(name, o, w...)
 }
 
 func (m *MockEngine) Start(name string, o kcontroller.Options, w ...controller.Watch) error {
@@ -520,7 +533,7 @@ func TestReconcile(t *testing.T) {
 				r: reconcile.Result{Requeue: true},
 			},
 		},
-		"StartControllerError": {
+		"CreateControllerError": {
 			reason: "We should return any error we encounter while starting our controller.",
 			args: args{
 				mgr: &mockManager{
@@ -531,6 +544,10 @@ func TestReconcile(t *testing.T) {
 					},
 					GetClientFn: func() client.Client {
 						return &test.MockClient{MockList: test.NewMockListFn(nil)}
+					},
+					GetSchemeFn: runtime.NewScheme,
+					GetRESTMapperFn: func() meta.RESTMapper {
+						return meta.NewDefaultRESTMapper([]schema.GroupVersion{v1.SchemeGroupVersion})
 					},
 				},
 				opts: []ReconcilerOption{
@@ -555,8 +572,10 @@ func TestReconcile(t *testing.T) {
 						return nil
 					}}),
 					WithControllerEngine(&MockEngine{
-						MockErr:   func(_ string) error { return nil },
-						MockStart: func(_ string, _ kcontroller.Options, _ ...controller.Watch) error { return errBoom },
+						MockErr: func(_ string) error { return nil },
+						MockCreate: func(_ string, _ kcontroller.Options, _ ...controller.Watch) (controller.NamedController, error) {
+							return nil, errBoom
+						},
 					}),
 				},
 			},
@@ -576,6 +595,10 @@ func TestReconcile(t *testing.T) {
 					},
 					GetClientFn: func() client.Client {
 						return &test.MockClient{MockList: test.NewMockListFn(nil)}
+					},
+					GetSchemeFn: runtime.NewScheme,
+					GetRESTMapperFn: func() meta.RESTMapper {
+						return meta.NewDefaultRESTMapper([]schema.GroupVersion{v1.SchemeGroupVersion})
 					},
 				},
 				opts: []ReconcilerOption{
@@ -609,9 +632,23 @@ func TestReconcile(t *testing.T) {
 						return nil
 					}}),
 					WithControllerEngine(&MockEngine{
-						MockErr:   func(name string) error { return errBoom }, // This error should only be logged.
-						MockStart: func(_ string, _ kcontroller.Options, _ ...controller.Watch) error { return nil }},
-					),
+						MockErr: func(name string) error { return errBoom }, // This error should only be logged.
+						MockCreate: func(_ string, _ kcontroller.Options, _ ...controller.Watch) (controller.NamedController, error) {
+							return mockNamedController{
+								MockStart: func(ctx context.Context) error { return nil },
+								MockGetCache: func() cache.Cache {
+									return &mockCache{
+										IndexFieldFn: func(ctx context.Context, obj client.Object, field string, extractValue client.IndexerFunc) error {
+											return nil
+										},
+										WaitForCacheSyncFn: func(ctx context.Context) bool {
+											return true
+										},
+									}
+								},
+							}, nil
+						},
+					}),
 				},
 			},
 			want: want{
@@ -629,6 +666,10 @@ func TestReconcile(t *testing.T) {
 					},
 					GetClientFn: func() client.Client {
 						return &test.MockClient{MockList: test.NewMockListFn(nil)}
+					},
+					GetSchemeFn: runtime.NewScheme,
+					GetRESTMapperFn: func() meta.RESTMapper {
+						return meta.NewDefaultRESTMapper([]schema.GroupVersion{v1.SchemeGroupVersion})
 					},
 				},
 				opts: []ReconcilerOption{
@@ -675,9 +716,23 @@ func TestReconcile(t *testing.T) {
 						return nil
 					}}),
 					WithControllerEngine(&MockEngine{
-						MockErr:   func(name string) error { return nil },
-						MockStart: func(_ string, _ kcontroller.Options, _ ...controller.Watch) error { return nil },
-						MockStop:  func(_ string) {},
+						MockErr: func(name string) error { return nil },
+						MockCreate: func(_ string, _ kcontroller.Options, _ ...controller.Watch) (controller.NamedController, error) {
+							return mockNamedController{
+								MockStart: func(ctx context.Context) error { return nil },
+								MockGetCache: func() cache.Cache {
+									return &mockCache{
+										IndexFieldFn: func(ctx context.Context, obj client.Object, field string, extractValue client.IndexerFunc) error {
+											return nil
+										},
+										WaitForCacheSyncFn: func(ctx context.Context) bool {
+											return true
+										},
+									}
+								},
+							}, nil
+						},
+						MockStop: func(_ string) {},
 					}),
 				},
 			},
@@ -687,26 +742,58 @@ func TestReconcile(t *testing.T) {
 		},
 	}
 
-	for name, tc := range cases {
-		t.Run(name, func(t *testing.T) {
-			r := NewReconciler(tc.args.mgr, append(tc.args.opts, WithLogger(testLog))...)
-			got, err := r.Reconcile(context.Background(), reconcile.Request{})
+	withRealtimeComposition := feature.Flags{}
+	withRealtimeComposition.Enable(features.EnableRealtimeCompositions)
 
-			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
-				t.Errorf("\n%s\nr.Reconcile(...): -want error, +got error:\n%s", tc.reason, diff)
-			}
-			if diff := cmp.Diff(tc.want.r, got, test.EquateErrors()); diff != "" {
-				t.Errorf("\n%s\nr.Reconcile(...): -want, +got:\n%s", tc.reason, diff)
+	type mode struct {
+		name    string
+		options apiextensionscontroller.Options
+	}
+	for _, m := range []mode{
+		{name: "polling", options: apiextensionscontroller.Options{Options: controller.DefaultOptions()}},
+		{name: "realtime", options: apiextensionscontroller.Options{Options: controller.Options{Features: &withRealtimeComposition}}},
+	} {
+		t.Run(m.name, func(t *testing.T) {
+			for name, tc := range cases {
+				t.Run(name, func(t *testing.T) {
+					r := NewReconciler(tc.args.mgr, m.options, append(tc.args.opts, WithLogger(testLog))...)
+					got, err := r.Reconcile(context.Background(), reconcile.Request{})
+
+					if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
+						t.Errorf("\n%s\nr.Reconcile(...): -want error, +got error:\n%s", tc.reason, diff)
+					}
+					if diff := cmp.Diff(tc.want.r, got, test.EquateErrors()); diff != "" {
+						t.Errorf("\n%s\nr.Reconcile(...): -want, +got:\n%s", tc.reason, diff)
+					}
+				})
 			}
 		})
 	}
 }
 
+type mockNamedController struct {
+	MockStart    func(ctx context.Context) error
+	MockGetCache func() cache.Cache
+}
+
+func (m mockNamedController) Start(ctx context.Context) error {
+	return m.MockStart(ctx)
+}
+
+func (m mockNamedController) GetCache() cache.Cache {
+	return m.MockGetCache()
+}
+
 type mockManager struct {
 	manager.Manager
 
-	GetCacheFn  func() cache.Cache
-	GetClientFn func() client.Client
+	GetCacheFn             func() cache.Cache
+	GetClientFn            func() client.Client
+	GetSchemeFn            func() *runtime.Scheme
+	GetRESTMapperFn        func() meta.RESTMapper
+	GetConfigFn            func() *rest.Config
+	GetLoggerFn            func() logr.Logger
+	GetControllerOptionsFn func() ctrlconfig.Controller
 }
 
 func (m *mockManager) GetCache() cache.Cache {
@@ -717,12 +804,42 @@ func (m *mockManager) GetClient() client.Client {
 	return m.GetClientFn()
 }
 
+func (m *mockManager) GetScheme() *runtime.Scheme {
+	return m.GetSchemeFn()
+}
+
+func (m *mockManager) GetRESTMapper() meta.RESTMapper {
+	return m.GetRESTMapperFn()
+}
+
+func (m *mockManager) GetConfig() *rest.Config {
+	return m.GetConfigFn()
+}
+
+func (m *mockManager) GetLogger() logr.Logger {
+	return m.GetLoggerFn()
+}
+
+func (m *mockManager) GetControllerOptions() ctrlconfig.Controller {
+	return m.GetControllerOptionsFn()
+}
+
 type mockCache struct {
 	cache.Cache
 
-	ListFn func(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error
+	ListFn             func(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error
+	IndexFieldFn       func(ctx context.Context, obj client.Object, field string, extractValue client.IndexerFunc) error
+	WaitForCacheSyncFn func(ctx context.Context) bool
 }
 
 func (m *mockCache) List(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
 	return m.ListFn(ctx, list, opts...)
+}
+
+func (m *mockCache) IndexField(ctx context.Context, obj client.Object, field string, extractValue client.IndexerFunc) error {
+	return m.IndexFieldFn(ctx, obj, field, extractValue)
+}
+
+func (m *mockCache) WaitForCacheSync(ctx context.Context) bool {
+	return m.WaitForCacheSyncFn(ctx)
 }

--- a/internal/features/features.go
+++ b/internal/features/features.go
@@ -41,6 +41,11 @@ const (
 	// protection with Usage resource. See the below design for more details.
 	// https://github.com/crossplane/crossplane/blob/19ea23e7c1fc16b20581755540f9f45afdf89338/design/one-pager-generic-usage-type.md
 	EnableAlphaUsages feature.Flag = "EnableAlphaUsages"
+
+	// EnableRealtimeCompositions enables alpha support for realtime
+	// compositions, i.e. watching MRs and reconciling compositions immediately
+	// when any MR is updated.
+	EnableRealtimeCompositions feature.Flag = "EnableRealtimeCompositions"
 )
 
 // Beta Feature Flags

--- a/test/e2e/apiextensions_test.go
+++ b/test/e2e/apiextensions_test.go
@@ -20,9 +20,11 @@ import (
 	"testing"
 	"time"
 
+	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/e2e-framework/pkg/features"
 
 	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
+	"github.com/crossplane/crossplane-runtime/pkg/resource/unstructured/composed"
 
 	apiextensionsv1 "github.com/crossplane/crossplane/apis/apiextensions/v1"
 	pkgv1 "github.com/crossplane/crossplane/apis/pkg/v1"
@@ -40,6 +42,20 @@ const LabelAreaAPIExtensions = "apiextensions"
 // resources do.
 func TestCompositionMinimal(t *testing.T) {
 	manifests := "test/e2e/manifests/apiextensions/composition/minimal"
+
+	nopCrossplaneList := composed.NewList(composed.FromReferenceToList(corev1.ObjectReference{
+		APIVersion: "nop.crossplane.io/v1alpha1",
+		Kind:       "NopResource",
+	}))
+	nopList := composed.NewList(composed.FromReferenceToList(corev1.ObjectReference{
+		APIVersion: "nop.example.org/v1alpha1",
+		Kind:       "NopResource",
+	}))
+	xnopList := composed.NewList(composed.FromReferenceToList(corev1.ObjectReference{
+		APIVersion: "nop.example.org/v1alpha1",
+		Kind:       "XNopResource",
+	}))
+
 	environment.Test(t,
 		features.New(t.Name()).
 			WithLabel(LabelArea, LabelAreaAPIExtensions).
@@ -53,6 +69,9 @@ func TestCompositionMinimal(t *testing.T) {
 			)).
 			Assess("CreateClaim", funcs.AllOf(
 				funcs.ApplyResources(FieldManager, manifests, "claim.yaml"),
+				funcs.InBackground(funcs.LogResources(nopList)),
+				funcs.InBackground(funcs.LogResources(xnopList)),
+				funcs.InBackground(funcs.LogResources(nopCrossplaneList)),
 				funcs.ResourcesCreatedWithin(30*time.Second, manifests, "claim.yaml"),
 				funcs.ResourcesHaveConditionWithin(5*time.Minute, manifests, "claim.yaml", xpv1.Available()),
 			)).

--- a/test/e2e/funcs/feature.go
+++ b/test/e2e/funcs/feature.go
@@ -42,6 +42,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/json"
+	apimachinerywait "k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/cli-runtime/pkg/printers"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
@@ -69,6 +70,14 @@ func AllOf(fns ...features.Func) features.Func {
 		for _, fn := range fns {
 			ctx = fn(ctx, t, c)
 		}
+		return ctx
+	}
+}
+
+// InBackground runs the supplied function in a goroutine.
+func InBackground(fn features.Func) features.Func {
+	return func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+		go fn(ctx, t, c)
 		return ctx
 	}
 }
@@ -238,7 +247,7 @@ func ResourcesHaveConditionWithin(d time.Duration, dir, pattern string, cds ...x
 				got := s.GetCondition(want.Type)
 				if !got.Equal(old[i]) {
 					old[i] = got
-					t.Logf("- %s: %s=%s Reason=%s: %s (%s)", identifier(u), got.Type, got.Status, got.Reason, or(got.Message, `""`), got.LastTransitionTime)
+					t.Logf("- CONDITION: %s: %s=%s Reason=%s: %s (%s)", identifier(u), got.Type, got.Status, got.Reason, or(got.Message, `""`), got.LastTransitionTime)
 				}
 
 				// do compare modulo message as the message in e2e tests
@@ -627,6 +636,69 @@ func ListedResourcesModifiedWith(list k8s.ObjectList, min int, modify func(objec
 	}
 }
 
+// LogResources polls the given kind of resources and logs creations, deletions
+// and changed conditions.
+func LogResources(list k8s.ObjectList, listOptions ...resources.ListOption) features.Func { //nolint:gocyclo // this is a test helper
+	return func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+		prev := map[string]map[xpv1.ConditionType]xpv1.Condition{}
+
+		_ = apimachinerywait.PollUntilContextCancel(ctx, 500*time.Millisecond, true, func(ctx context.Context) (done bool, err error) {
+			if err := c.Client().Resources().List(ctx, list, listOptions...); err != nil {
+				return false, nil //nolint:nilerr // retry and ignore the error
+			}
+			metaList, err := meta.ExtractList(list)
+			if err != nil {
+				return false, err
+			}
+
+			found := map[string]bool{}
+			for _, obj := range metaList {
+				obj, ok := obj.(k8s.Object)
+				if !ok {
+					return false, fmt.Errorf("unexpected type %T in list, does not satisfy k8s.Object", obj)
+				}
+				id := fmt.Sprintf("%s/%s", obj.GetNamespace(), obj.GetName())
+				if _, ok := prev[id]; !ok {
+					t.Logf("- CREATED:   %s (%s)", identifier(obj), obj.GetCreationTimestamp().String())
+				}
+
+				u := asUnstructured(obj)
+				s := xpv1.ConditionedStatus{}
+				_ = fieldpath.Pave(u.Object).GetValueInto("status", &s)
+
+				got := map[xpv1.ConditionType]xpv1.Condition{}
+				for _, c := range s.Conditions {
+					got[c.Type] = c
+				}
+
+				for ty, c := range got {
+					if !c.Equal(prev[id][ty]) {
+						t.Logf("- CONDITION: %s: %s=%s Reason=%s: %s (%s)", identifier(u), c.Type, c.Status, c.Reason, or(c.Message, `""`), c.LastTransitionTime)
+					}
+				}
+				for ty, c := range prev[id] {
+					if _, ok := got[ty]; !ok {
+						t.Logf("- %s: %s disappeared", identifier(u), c.Type)
+					}
+				}
+
+				prev[id] = got
+				found[id] = true
+			}
+
+			for id := range prev {
+				if _, ok := found[id]; !ok {
+					t.Logf("- DELETED:   %s", id)
+					delete(prev, id)
+				}
+			}
+
+			return false, nil
+		})
+		return ctx
+	}
+}
+
 // DeletionBlockedByUsageWebhook attempts deleting all resources
 // defined by the manifests under the supplied directory that match the supplied
 // glob pattern (e.g. *.yaml) and verifies that they are blocked by the usage
@@ -668,7 +740,7 @@ func asUnstructured(o runtime.Object) *unstructured.Unstructured {
 	return u
 }
 
-// identifier returns the supplied resource's kind, name, and (if any)
+// identifier returns the supplied resource's kind, group, name, and (if any)
 // namespace.
 func identifier(o k8s.Object) string {
 	k := o.GetObjectKind().GroupVersionKind().Kind
@@ -683,10 +755,14 @@ func identifier(o k8s.Object) string {
 			k = fmt.Sprintf("%T", o)
 		}
 	}
-	if o.GetNamespace() == "" {
-		return fmt.Sprintf("%s %s", k, o.GetName())
+	groupSuffix := ""
+	if g := o.GetObjectKind().GroupVersionKind().Group; g != "" {
+		groupSuffix = "." + g
 	}
-	return fmt.Sprintf("%s %s/%s", k, o.GetNamespace(), o.GetName())
+	if o.GetNamespace() == "" {
+		return fmt.Sprintf("%s%s %s", k, groupSuffix, o.GetName())
+	}
+	return fmt.Sprintf("%s%s %s/%s", k, groupSuffix, o.GetNamespace(), o.GetName())
 }
 
 // FilterByGK returns a filter function that returns true if the supplied object is of the supplied GroupKind.

--- a/test/e2e/manifests/apiextensions/composition/realtime-compositions/claim.yaml
+++ b/test/e2e/manifests/apiextensions/composition/realtime-compositions/claim.yaml
@@ -1,0 +1,12 @@
+apiVersion: realtime-compositions.e2e.crossplane.io/v1alpha1
+kind: NopResource
+metadata:
+  namespace: default
+  name: realtime-composition
+  labels:
+    realtime-compositions: "true"
+spec:
+  coolField: "I'm cool!"
+  # This is necessary to ensure the claim's MRs are actually gone before we
+  # delete the Provider - https://github.com/crossplane/crossplane/issues/4251
+  compositeDeletePolicy: Foreground

--- a/test/e2e/manifests/apiextensions/composition/realtime-compositions/setup/composition.yaml
+++ b/test/e2e/manifests/apiextensions/composition/realtime-compositions/setup/composition.yaml
@@ -1,0 +1,26 @@
+apiVersion: apiextensions.crossplane.io/v1
+kind: Composition
+metadata:
+  name: xnopresources.realtime-compositions.e2e.crossplane.io
+spec:
+  compositeTypeRef:
+    apiVersion: realtime-compositions.e2e.crossplane.io/v1alpha1
+    kind: XNopResource
+  resources:
+  - name: nop-resource-1
+    base:
+      apiVersion: nop.crossplane.io/v1alpha1
+      kind: NopResource
+      metadata:
+        labels:
+          realtime-compositions: "true"
+      spec:
+        forProvider:
+          conditionAfter:
+          - conditionType: Ready
+            conditionStatus: "True"
+            time: 0s
+    patches:
+    - type: ToCompositeFieldPath
+      fromFieldPath: metadata.annotations[cool-field]
+      toFieldPath: status.coolerField

--- a/test/e2e/manifests/apiextensions/composition/realtime-compositions/setup/definition.yaml
+++ b/test/e2e/manifests/apiextensions/composition/realtime-compositions/setup/definition.yaml
@@ -1,0 +1,34 @@
+apiVersion: apiextensions.crossplane.io/v1
+kind: CompositeResourceDefinition
+metadata:
+  name: xnopresources.realtime-compositions.e2e.crossplane.io
+spec:
+  group: realtime-compositions.e2e.crossplane.io
+  names:
+    kind: XNopResource
+    plural: xnopresources
+  claimNames:
+    kind: NopResource
+    plural: nopresources
+  connectionSecretKeys:
+  - test
+  versions:
+  - name: v1alpha1
+    served: true
+    referenceable: true
+    schema:
+     openAPIV3Schema:
+       type: object
+       properties:
+        spec:
+          type: object
+          properties:
+            coolField:
+              type: string
+          required:
+          - coolField
+        status:
+          type: object
+          properties:
+            coolerField:
+              type: string

--- a/test/e2e/manifests/apiextensions/composition/realtime-compositions/setup/provider.yaml
+++ b/test/e2e/manifests/apiextensions/composition/realtime-compositions/setup/provider.yaml
@@ -1,0 +1,7 @@
+apiVersion: pkg.crossplane.io/v1
+kind: Provider
+metadata:
+  name: provider-nop
+spec:
+  package: xpkg.upbound.io/crossplane-contrib/provider-nop:v0.2.0
+  ignoreCrossplaneConstraints: true

--- a/test/e2e/realtimecompositions_test.go
+++ b/test/e2e/realtimecompositions_test.go
@@ -1,0 +1,111 @@
+package e2e
+
+import (
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"sigs.k8s.io/e2e-framework/klient/k8s"
+	"sigs.k8s.io/e2e-framework/klient/k8s/resources"
+	"sigs.k8s.io/e2e-framework/pkg/features"
+	"sigs.k8s.io/e2e-framework/third_party/helm"
+
+	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
+	"github.com/crossplane/crossplane-runtime/pkg/resource/unstructured/composed"
+
+	apiextensionsv1 "github.com/crossplane/crossplane/apis/apiextensions/v1"
+	pkgv1 "github.com/crossplane/crossplane/apis/pkg/v1"
+	"github.com/crossplane/crossplane/test/e2e/config"
+	"github.com/crossplane/crossplane/test/e2e/funcs"
+)
+
+const (
+	// SuiteRealtimeCompositions is the value for the config.LabelTestSuite
+	// label to be assigned to tests that should be part of the Usage test
+	// suite.
+	SuiteRealtimeCompositions = "realtime-compositions"
+)
+
+func init() {
+	environment.AddTestSuite(SuiteRealtimeCompositions,
+		config.WithHelmInstallOpts(
+			helm.WithArgs("--set args={--debug,--enable-realtime-compositions}"),
+		),
+		config.WithLabelsToSelect(features.Labels{
+			config.LabelTestSuite: []string{SuiteRealtimeCompositions, config.TestSuiteDefault},
+		}),
+	)
+}
+
+// TestRealtimeCompositions tests scenarios for compositions with realtime
+// reconciles through MR updates.
+func TestRealtimeCompositions(t *testing.T) {
+	manifests := "test/e2e/manifests/apiextensions/composition/realtime-compositions"
+
+	nopCrossplaneList := composed.NewList(composed.FromReferenceToList(corev1.ObjectReference{
+		APIVersion: "nop.crossplane.io/v1alpha1",
+		Kind:       "NopResource",
+	}))
+	nopList := composed.NewList(composed.FromReferenceToList(corev1.ObjectReference{
+		APIVersion: "realtime-revision-selection.e2e.crossplane.io/v1alpha1",
+		Kind:       "NopResource",
+	}))
+	xnopList := composed.NewList(composed.FromReferenceToList(corev1.ObjectReference{
+		APIVersion: "realtime-revision-selection.e2e.crossplane.io/v1alpha1",
+		Kind:       "XNopResource",
+	}))
+	withTestLabels := resources.WithLabelSelector(labels.FormatLabels(map[string]string{"realtime-compositions": "true"}))
+
+	environment.Test(t,
+		features.New(t.Name()).
+			WithLabel(LabelStage, LabelStageAlpha).
+			WithLabel(LabelArea, LabelAreaAPIExtensions).
+			WithLabel(LabelSize, LabelSizeSmall).
+			WithLabel(LabelModifyCrossplaneInstallation, LabelModifyCrossplaneInstallationTrue).
+			WithLabel(config.LabelTestSuite, SuiteRealtimeCompositions).
+			WithSetup("EnableAlphaRealtimeCompositions", funcs.AllOf(
+				funcs.AsFeaturesFunc(environment.HelmUpgradeCrossplaneToSuite(SuiteRealtimeCompositions)),
+				funcs.ReadyToTestWithin(1*time.Minute, namespace),
+			)).
+			WithSetup("PrerequisitesAreCreated", funcs.AllOf(
+				funcs.ApplyResources(FieldManager, manifests, "setup/*.yaml"),
+				funcs.ResourcesCreatedWithin(30*time.Second, manifests, "setup/*.yaml"),
+				funcs.ResourcesHaveConditionWithin(1*time.Minute, manifests, "setup/definition.yaml", apiextensionsv1.WatchingComposite()),
+				funcs.ResourcesHaveConditionWithin(2*time.Minute, manifests, "setup/provider.yaml", pkgv1.Healthy(), pkgv1.Active()),
+			)).
+			Assess("CreateClaim", funcs.AllOf(
+				funcs.ApplyResources(FieldManager, manifests, "claim.yaml"),
+				funcs.InBackground(funcs.LogResources(nopList, withTestLabels)),
+				funcs.InBackground(funcs.LogResources(xnopList, withTestLabels)),
+				funcs.InBackground(funcs.LogResources(nopCrossplaneList, withTestLabels)),
+				funcs.ResourcesCreatedWithin(30*time.Second, manifests, "claim.yaml"),
+				funcs.ResourcesHaveConditionWithin(5*time.Minute, manifests, "claim.yaml", xpv1.Available()),
+			)).
+			Assess("UpdateMR", funcs.AllOf(
+				funcs.ListedResourcesModifiedWith(nopCrossplaneList, 1, func(object k8s.Object) {
+					anns := object.GetAnnotations()
+					if anns == nil {
+						anns = make(map[string]string)
+					}
+					anns["cool-field"] = "I'M COOL!"
+					object.SetAnnotations(anns)
+				}, withTestLabels),
+			)).
+			Assess("ClaimHasPatchedField",
+				// 10 seconds is a long time for a realtime composition, but
+				// considerably below the normal reconcile time for a XR.
+				funcs.ResourcesHaveFieldValueWithin(10*time.Second, manifests, "claim.yaml", "status.coolerField", "I'M COOL!"),
+			).
+			WithTeardown("DeletePrerequisites", funcs.AllOf(
+				funcs.DeleteResources(manifests, "setup/*.yaml"),
+				funcs.ResourcesDeletedWithin(3*time.Minute, manifests, "setup/*.yaml"),
+			)).
+			// Disable our feature flag.
+			WithTeardown("DisableAlphaRealtimeCompositions", funcs.AllOf(
+				funcs.AsFeaturesFunc(environment.HelmUpgradeCrossplaneToBase()),
+				funcs.ReadyToTestWithin(1*time.Minute, namespace),
+			)).
+			Feature(),
+	)
+}


### PR DESCRIPTION
### Description of your changes

This PR removes the 60s polling in realtime mode. Likely, for now this will break, at least with environments as these are not watches yet.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [ ] Added or updated unit **and** E2E tests for my change.
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] ~~Added `backport release-x.y` labels to auto-backport this PR, if necessary.~~
- [ ] ~~Opened a PR updating the [docs], if necessary.~~

[contribution process]: https://git.io/fj2m9
[docs]: https://docs.crossplane.io/contribute/contribute