### PR TITLE
fix convert transforms toType field validation

### DIFF
--- a/apis/apiextensions/v1/composition_transforms.go
+++ b/apis/apiextensions/v1/composition_transforms.go
@@ -483,7 +483,7 @@ func (c ConvertTransformFormat) IsValid() bool {
 // A ConvertTransform converts the input into a new object whose type is supplied.
 type ConvertTransform struct {
 	// ToType is the type of the output of this transform.
-	// +kubebuilder:validation:Enum=string;int;int64;bool;float64;object;list
+	// +kubebuilder:validation:Enum=string;int;int64;bool;float64;object;array
 	ToType TransformIOType `json:"toType"`
 
 	// The expected input format.

--- a/apis/apiextensions/v1beta1/zz_generated.composition_transforms.go
+++ b/apis/apiextensions/v1beta1/zz_generated.composition_transforms.go
@@ -485,7 +485,7 @@ func (c ConvertTransformFormat) IsValid() bool {
 // A ConvertTransform converts the input into a new object whose type is supplied.
 type ConvertTransform struct {
 	// ToType is the type of the output of this transform.
-	// +kubebuilder:validation:Enum=string;int;int64;bool;float64;object;list
+	// +kubebuilder:validation:Enum=string;int;int64;bool;float64;object;array
 	ToType TransformIOType `json:"toType"`
 
 	// The expected input format.

--- a/cluster/crds/apiextensions.crossplane.io_compositionrevisions.yaml
+++ b/cluster/crds/apiextensions.crossplane.io_compositionrevisions.yaml
@@ -308,7 +308,7 @@ spec:
                                     - bool
                                     - float64
                                     - object
-                                    - list
+                                    - array
                                     type: string
                                 required:
                                 - toType
@@ -689,7 +689,7 @@ spec:
                                       - bool
                                       - float64
                                       - object
-                                      - list
+                                      - array
                                       type: string
                                   required:
                                   - toType
@@ -1148,7 +1148,7 @@ spec:
                                       - bool
                                       - float64
                                       - object
-                                      - list
+                                      - array
                                       type: string
                                   required:
                                   - toType
@@ -1762,7 +1762,7 @@ spec:
                                     - bool
                                     - float64
                                     - object
-                                    - list
+                                    - array
                                     type: string
                                 required:
                                 - toType
@@ -2143,7 +2143,7 @@ spec:
                                       - bool
                                       - float64
                                       - object
-                                      - list
+                                      - array
                                       type: string
                                   required:
                                   - toType
@@ -2602,7 +2602,7 @@ spec:
                                       - bool
                                       - float64
                                       - object
-                                      - list
+                                      - array
                                       type: string
                                   required:
                                   - toType

--- a/cluster/crds/apiextensions.crossplane.io_compositions.yaml
+++ b/cluster/crds/apiextensions.crossplane.io_compositions.yaml
@@ -303,7 +303,7 @@ spec:
                                     - bool
                                     - float64
                                     - object
-                                    - list
+                                    - array
                                     type: string
                                 required:
                                 - toType
@@ -684,7 +684,7 @@ spec:
                                       - bool
                                       - float64
                                       - object
-                                      - list
+                                      - array
                                       type: string
                                   required:
                                   - toType
@@ -1143,7 +1143,7 @@ spec:
                                       - bool
                                       - float64
                                       - object
-                                      - list
+                                      - array
                                       type: string
                                   required:
                                   - toType


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

- Updates https://github.com/crossplane/crossplane/pull/4524

Updates the toType enum validation to include `array` instead of `list`.  the docs PR https://github.com/crossplane/docs/pull/541 already captures it as `array`.

On the xp `master` and [v1.13.2-up.2](https://github.com/upbound/universal-crossplane/releases/tag/v1.13.2-up.2) release currently, kubectl apply'ing a composition with `transforms[].convert.toType` set to array results in validation error:
```
the Composition "compose-v1alpha1.example.com" is invalid: 
* spec.resources[1].patches[3].transforms[0].convert.toType: Unsupported value: "array": supported values: "string", "int", "int64", "bool", "float64", "object", "list"
```

trying to apply with `list` also results in validation error:
```
The Composition "compose-v1alpha1.example.com" is invalid: 
* spec.resources[1].patches[3].transforms[0].convert.toType: Invalid value: "list": invalid type
```

With this change, a `transforms[].convert.toType` set to array, applies fine.


Fixes # 

I have:

- [X] Read and followed Crossplane's [contribution process].
- [ ] Added or updated unit tests.
- [ ] Added or updated e2e tests, if necessary. (check with reviewers/maintainers if you're unsure whether E2E tests are necessary for the change).
- [X] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, if necessary.
- [x] Opened a PR updating the [docs], if necessary.

[contribution process]: https://git.io/fj2m9
[docs]: https://docs.crossplane.io/contribute/contribute
