### PR TITLE
Update Helm chart to install Crossplane images from xpkg.upbound.io

### DIFF
--- a/cluster/charts/crossplane/README.md
+++ b/cluster/charts/crossplane/README.md
@@ -78,7 +78,7 @@ and their default values.
 | `extraVolumesCrossplane` | Add custom `volumes` to the Crossplane pod. | `{}` |
 | `hostNetwork` | Enable `hostNetwork` for the Crossplane deployment. Caution: enabling `hostNetwork`` grants the Crossplane Pod access to the host network namespace. | `false` |
 | `image.pullPolicy` | The image pull policy used for Crossplane and RBAC Manager pods. | `"IfNotPresent"` |
-| `image.repository` | Repository for the Crossplane pod image. | `"crossplane/crossplane"` |
+| `image.repository` | Repository for the Crossplane pod image. | `"xpkg.upbound.io/crossplane/crossplane"` |
 | `image.tag` | The Crossplane image tag. Defaults to the value of `appVersion` in Chart.yaml. | `""` |
 | `imagePullSecrets` | The imagePullSecret names to add to the Crossplane ServiceAccount. | `{}` |
 | `leaderElection` | Enable [leader election](https://docs.crossplane.io/latest/concepts/pods/#leader-election) for the Crossplane pod. | `true` |
@@ -152,7 +152,7 @@ replicas: 1
 deploymentStrategy: RollingUpdate
 
 image:
-  repository: crossplane/crossplane
+  repository: xpkg.upbound.io/crossplane/crossplane
   tag: alpha
   pullPolicy: Always
 ```

--- a/cluster/charts/crossplane/README.md.gotmpl
+++ b/cluster/charts/crossplane/README.md.gotmpl
@@ -93,7 +93,7 @@ replicas: 1
 deploymentStrategy: RollingUpdate
 
 image:
-  repository: crossplane/crossplane
+  repository: xpkg.upbound.io/crossplane/crossplane
   tag: alpha
   pullPolicy: Always
 ```

--- a/cluster/charts/crossplane/values.yaml
+++ b/cluster/charts/crossplane/values.yaml
@@ -9,7 +9,7 @@ deploymentStrategy: RollingUpdate
 
 image:
   # -- Repository for the Crossplane pod image.
-  repository: crossplane/crossplane
+  repository: xpkg.upbound.io/crossplane/crossplane
   # -- The Crossplane image tag. Defaults to the value of `appVersion` in Chart.yaml.
   tag: ""
   # -- The image pull policy used for Crossplane and RBAC Manager pods.


### PR DESCRIPTION
### Description of your changes

This PR simply updates Crossplane's Helm chart to install the Crossplane image from `xpkg.upbound.io`.

Fixes #3560

I have:

- [x] Read and followed Crossplane's [contribution process].
- [ ] ~Added or updated unit tests.~
- [ ] ~Added or updated e2e tests, if necessary. (check with reviewers/maintainers if you're unsure whether E2E tests are necessary for the change).~
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR, if necessary.~
- [x] Opened a PR updating the [docs], if necessary.
  - https://github.com/crossplane/docs/pull/572

### How has this PR been tested?

I tested these changes locally in a kind cluster by installing the local Helm chart with a `helm` client and setting the most recent version of the Crossplane image that has been published to `xpkg.upbound.io`: `v1.14.0-rc.0.611.g8121e6d6`:

```
❯ .cache/tools/darwin_arm64/helm-v3.13.1 install crossplane --namespace crossplane-system --create-namespace cluster/charts/crossplane --set image.tag=v1.14.0-rc.0.611.g8121e6d6 --set 'args={"--debug"}'
```

Note this doesn't set `image.repository`, so the new value of `xpkg.upbound.io/crossplane/crossplane` in the chart that is updated in this PR is used.

The Crossplane pods get to `Running` successfully:

```
❯ kcs get pod
NAME                                       READY   STATUS    RESTARTS   AGE
crossplane-7dd756b54d-jpxql                1/1     Running   0          29s
crossplane-rbac-manager-765d64bb64-wp4gw   1/1     Running   0          29s
```

And we can see that both pods are using the expected container image from `xpkg.upbound.io`:

```
❯ kcs get pod -o json | jq '.items[] | .metadata.name + " " + .spec.containers[].image'
"crossplane-7dd756b54d-jpxql xpkg.upbound.io/crossplane/crossplane:v1.14.0-rc.0.611.g8121e6d6"
"crossplane-rbac-manager-765d64bb64-wp4gw xpkg.upbound.io/crossplane/crossplane:v1.14.0-rc.0.611.g8121e6d6"
```

[contribution process]: https://git.io/fj2m9
[docs]: https://docs.crossplane.io/contribute/contribute
