### PR TITLE
e2e: fix provider upgrade by waiting correct revision

### DIFF
--- a/test/e2e/pkg_test.go
+++ b/test/e2e/pkg_test.go
@@ -110,6 +110,12 @@ func TestProviderUpgrade(t *testing.T) {
 			)).
 			Assess("UpgradeProvider", funcs.AllOf(
 				funcs.ApplyResources(FieldManager, manifests, "provider-upgrade.yaml"),
+				// Note(turkenh): There is a tiny instant after the upgrade where
+				// the provider was still reporting Installed/Healthy but the
+				// new version was not yet installed. This causes flakes in the
+				// test as ".spec.forProvider.conditionAfter[0].conditionReason: field not declared in schema" error.
+				// The following check is to avoid that.
+				funcs.ResourcesHaveFieldValueWithin(2*time.Minute, manifests, "provider-upgrade.yaml", "status.currentIdentifier", "xpkg.upbound.io/crossplane-contrib/provider-nop:v0.2.0"),
 				funcs.ResourcesHaveConditionWithin(2*time.Minute, manifests, "provider-upgrade.yaml", pkgv1.Healthy(), pkgv1.Active()),
 			)).
 			Assess("UpgradeManagedResource", funcs.AllOf(


### PR DESCRIPTION
### Description of your changes

This PR fixes the following (sporadic?) e2e issue, which seems to be revealed after the recent e2e speed-up attempts:

```
 === RUN   TestProviderUpgrade/TestProviderUpgrade/UpgradeManagedResource
    feature.go:396: failed to create typed patch object (/pkg-provider-upgrade; nop.crossplane.io/v1alpha1, Kind=NopResource): errors:
          .spec.forProvider.conditionAfter[0].conditionReason: field not declared in schema
          .spec.forProvider.conditionAfter[1].conditionReason: field not declared in schema
```

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Added or updated unit tests.
- [x] Added or updated e2e tests, if necessary. (check with reviewers/maintainers if you're unsure whether E2E tests are necessary for the change).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR, if necessary.~
- [ ] ~Opened a PR updating the [docs], if necessary.~

[contribution process]: https://git.io/fj2m9
[docs]: https://docs.crossplane.io/contribute/contribute
