### PR TITLE
e2e: in realtime compositions test delete claim and wait for nop resources

### DIFF
--- a/test/e2e/apiextensions_test.go
+++ b/test/e2e/apiextensions_test.go
@@ -86,7 +86,7 @@ func TestCompositionMinimal(t *testing.T) {
 				funcs.DeleteResources(manifests, "claim.yaml"),
 				funcs.ResourcesDeletedWithin(2*time.Minute, manifests, "claim.yaml"),
 			)).
-			WithTeardown("DeletePrerequisites", funcs.ResourcesDeletedAfterListedAreGone(3*time.Minute, manifests, "setup/*.yaml", nopList)).
+			WithTeardown("DeletePrerequisites", funcs.ResourcesDeletedAfterListedAreGone(3*time.Minute, manifests, "setup/*.yaml", nopCrossplaneList)).
 			Feature(),
 	)
 }

--- a/test/e2e/apiextensions_test.go
+++ b/test/e2e/apiextensions_test.go
@@ -50,15 +50,11 @@ var (
 func TestCompositionMinimal(t *testing.T) {
 	manifests := "test/e2e/manifests/apiextensions/composition/minimal"
 
-	nopCrossplaneList := composed.NewList(composed.FromReferenceToList(corev1.ObjectReference{
-		APIVersion: "nop.crossplane.io/v1alpha1",
-		Kind:       "NopResource",
-	}))
-	nopList := composed.NewList(composed.FromReferenceToList(corev1.ObjectReference{
+	claimList := composed.NewList(composed.FromReferenceToList(corev1.ObjectReference{
 		APIVersion: "nop.example.org/v1alpha1",
 		Kind:       "NopResource",
 	}))
-	xnopList := composed.NewList(composed.FromReferenceToList(corev1.ObjectReference{
+	xrList := composed.NewList(composed.FromReferenceToList(corev1.ObjectReference{
 		APIVersion: "nop.example.org/v1alpha1",
 		Kind:       "XNopResource",
 	}))
@@ -76,9 +72,9 @@ func TestCompositionMinimal(t *testing.T) {
 			)).
 			Assess("CreateClaim", funcs.AllOf(
 				funcs.ApplyResources(FieldManager, manifests, "claim.yaml"),
+				funcs.InBackground(funcs.LogResources(claimList)),
+				funcs.InBackground(funcs.LogResources(xrList)),
 				funcs.InBackground(funcs.LogResources(nopList)),
-				funcs.InBackground(funcs.LogResources(xnopList)),
-				funcs.InBackground(funcs.LogResources(nopCrossplaneList)),
 				funcs.ResourcesCreatedWithin(30*time.Second, manifests, "claim.yaml"),
 				funcs.ResourcesHaveConditionWithin(5*time.Minute, manifests, "claim.yaml", xpv1.Available()),
 			)).
@@ -86,7 +82,7 @@ func TestCompositionMinimal(t *testing.T) {
 				funcs.DeleteResources(manifests, "claim.yaml"),
 				funcs.ResourcesDeletedWithin(2*time.Minute, manifests, "claim.yaml"),
 			)).
-			WithTeardown("DeletePrerequisites", funcs.ResourcesDeletedAfterListedAreGone(3*time.Minute, manifests, "setup/*.yaml", nopCrossplaneList)).
+			WithTeardown("DeletePrerequisites", funcs.ResourcesDeletedAfterListedAreGone(3*time.Minute, manifests, "setup/*.yaml", nopList)).
 			Feature(),
 	)
 }

--- a/test/e2e/realtimecompositions_test.go
+++ b/test/e2e/realtimecompositions_test.go
@@ -97,13 +97,13 @@ func TestRealtimeCompositions(t *testing.T) {
 				// considerably below the normal reconcile time for a XR.
 				funcs.ResourcesHaveFieldValueWithin(10*time.Second, manifests, "claim.yaml", "status.coolerField", "I'M COOL!"),
 			).
-			WithTeardown("DeletePrerequisites", funcs.AllOf(
-				funcs.DeleteResources(manifests, "setup/*.yaml"),
-				funcs.ResourcesDeletedWithin(3*time.Minute, manifests, "setup/*.yaml"),
+			WithTeardown("DeleteClaim", funcs.AllOf(
+				funcs.DeleteResources(manifests, "claim.yaml"),
+				funcs.ResourcesDeletedWithin(2*time.Minute, manifests, "claim.yaml"),
 			)).
-			// Disable our feature flag.
+			WithTeardown("DeletePrerequisites", funcs.ResourcesDeletedAfterListedAreGone(3*time.Minute, manifests, "setup/*.yaml", nopCrossplaneList)).
 			WithTeardown("DisableAlphaRealtimeCompositions", funcs.AllOf(
-				funcs.AsFeaturesFunc(environment.HelmUpgradeCrossplaneToBase()),
+				funcs.AsFeaturesFunc(environment.HelmUpgradeCrossplaneToBase()), // Disable our feature flag.
 				funcs.ReadyToTestWithin(1*time.Minute, namespace),
 			)).
 			Feature(),


### PR DESCRIPTION
### Description of your changes

Follow-up of https://github.com/crossplane/crossplane/pull/4637, adding the e2e tear down fix of waiting for managed resources before deleting the provider.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [ ] ~~Added or updated unit tests.~~
- [ ] ~~Added or updated e2e tests, if necessary. (check with reviewers/maintainers if you're unsure whether E2E tests are necessary for the change).~~
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] ~~Added `backport release-x.y` labels to auto-backport this PR, if necessary.~~
- [ ] ~~Opened a PR updating the [docs], if necessary.~~

[contribution process]: https://git.io/fj2m9
[docs]: https://docs.crossplane.io/contribute/contribute