### PR TITLE
Update ControllerConfig deprecation notice to point DeploymentRuntimeConfig

### DIFF
--- a/apis/pkg/v1alpha1/config.go
+++ b/apis/pkg/v1alpha1/config.go
@@ -176,11 +176,12 @@ type PodObjectMeta struct {
 // +genclient:nonNamespaced
 
 // ControllerConfig is the CRD type for a packaged controller configuration.
-// Deprecated: This API is scheduled to be removed in a future release. See
-// https://github.com/crossplane/crossplane/issues/3601 for more information.
+// Deprecated: This API is replaced by DeploymentRuntimeConfig, and is scheduled
+// to be removed in a future release. See the design doc for more details:
+// https://github.com/crossplane/crossplane/blob/11bbe13ea3604928cc4e24e8d0d18f3f5f7e847c/design/one-pager-package-runtime-config.md
 // +kubebuilder:printcolumn:name="AGE",type="date",JSONPath=".metadata.creationTimestamp"
 // +kubebuilder:resource:scope=Cluster
-// +kubebuilder:deprecatedversion:warning="ControllerConfig.pkg.crossplane.io/v1alpha1 is deprecated. It is safe to use, but no new features will be added. Future replacement design: https://github.com/crossplane/crossplane/blob/master/design/one-pager-package-runtime-config.md"
+// +kubebuilder:deprecatedversion:warning="ControllerConfig.pkg.crossplane.io/v1alpha1 is deprecated. Use DeploymentRuntimeConfig from pkg.crossplane.io/v1beta1 instead."
 type ControllerConfig struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/cluster/crds/pkg.crossplane.io_controllerconfigs.yaml
+++ b/cluster/crds/pkg.crossplane.io_controllerconfigs.yaml
@@ -18,15 +18,15 @@ spec:
       name: AGE
       type: date
     deprecated: true
-    deprecationWarning: 'ControllerConfig.pkg.crossplane.io/v1alpha1 is deprecated.
-      It is safe to use, but no new features will be added. Future replacement design:
-      https://github.com/crossplane/crossplane/blob/master/design/one-pager-package-runtime-config.md'
+    deprecationWarning: ControllerConfig.pkg.crossplane.io/v1alpha1 is deprecated.
+      Use DeploymentRuntimeConfig from pkg.crossplane.io/v1beta1 instead.
     name: v1alpha1
     schema:
       openAPIV3Schema:
         description: 'ControllerConfig is the CRD type for a packaged controller configuration.
-          Deprecated: This API is scheduled to be removed in a future release. See
-          https://github.com/crossplane/crossplane/issues/3601 for more information.'
+          Deprecated: This API is replaced by DeploymentRuntimeConfig, and is scheduled
+          to be removed in a future release. See the design doc for more details:
+          https://github.com/crossplane/crossplane/blob/11bbe13ea3604928cc4e24e8d0d18f3f5f7e847c/design/one-pager-package-runtime-config.md'
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation


### PR DESCRIPTION
### Description of your changes

It changes from:

```bash
❯ kubectl create -f controller-config.yaml
Warning: ControllerConfig.pkg.crossplane.io/v1alpha1 is deprecated. It is safe to use, but no new features will be added. Future replacement design: https://github.com/crossplane/crossplane/blob/master/design/one-pager-package-runtime-config.md
controllerconfig.pkg.crossplane.io/cc-debug created
```

To:

```bash
❯ kubectl create -f controller-config.yaml
Warning: ControllerConfig.pkg.crossplane.io/v1alpha1 is deprecated. Use DeploymentRuntimeConfig from pkg.crossplane.io/v1beta1 instead.
controllerconfig.pkg.crossplane.io/cc-debug2 created
```

Fixes #4844

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] ~Added or updated unit tests.~
- [ ] ~Added or updated e2e tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/master/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/master/contributing#checklist-cheat-sheet
