### PR TITLE
e2e: fix flakes with environment-configs suite

### DIFF
--- a/test/e2e/environmentconfig_test.go
+++ b/test/e2e/environmentconfig_test.go
@@ -9,6 +9,8 @@ import (
 	"sigs.k8s.io/e2e-framework/pkg/features"
 	"sigs.k8s.io/e2e-framework/third_party/helm"
 
+	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
+
 	apiextensionsv1 "github.com/crossplane/crossplane/apis/apiextensions/v1"
 	pkgv1 "github.com/crossplane/crossplane/apis/pkg/v1"
 	"github.com/crossplane/crossplane/test/e2e/config"
@@ -71,9 +73,10 @@ func TestEnvironmentConfigDefault(t *testing.T) {
 			Assess("CreateClaim", funcs.AllOf(
 				funcs.ApplyResources(FieldManager, manifestsFolderEnvironmentConfigs, filepath.Join(subfolder, "00-claim.yaml")),
 				funcs.ResourcesCreatedWithin(30*time.Second, manifestsFolderEnvironmentConfigs, filepath.Join(subfolder, "00-claim.yaml")),
+				funcs.ResourcesHaveConditionWithin(3*time.Minute, manifestsFolderEnvironmentConfigs, filepath.Join(subfolder, "00-claim.yaml"), xpv1.Available()),
 			)).
 			Assess("MRHasAnnotation",
-				funcs.ComposedResourcesOfClaimHaveFieldValueWithin(5*time.Minute, manifestsFolderEnvironmentConfigs, filepath.Join(subfolder, "00-claim.yaml"),
+				funcs.ComposedResourcesOfClaimHaveFieldValueWithin(2*time.Minute, manifestsFolderEnvironmentConfigs, filepath.Join(subfolder, "00-claim.yaml"),
 					"metadata.annotations[valueFromEnv]", "2",
 					funcs.FilterByGK(schema.GroupKind{Group: "nop.crossplane.io", Kind: "NopResource"}))).
 			WithTeardown("DeleteCreatedResources", funcs.AllOf(
@@ -122,9 +125,10 @@ func TestEnvironmentResolutionOptional(t *testing.T) {
 			Assess("CreateClaim", funcs.AllOf(
 				funcs.ApplyResources(FieldManager, manifestsFolderEnvironmentConfigs, filepath.Join(subfolder, "00-claim.yaml")),
 				funcs.ResourcesCreatedWithin(30*time.Second, manifestsFolderEnvironmentConfigs, filepath.Join(subfolder, "00-claim.yaml")),
+				funcs.ResourcesHaveConditionWithin(3*time.Minute, manifestsFolderEnvironmentConfigs, filepath.Join(subfolder, "00-claim.yaml"), xpv1.Available()),
 			)).
 			Assess("MRHasAnnotation",
-				funcs.ComposedResourcesOfClaimHaveFieldValueWithin(5*time.Minute, manifestsFolderEnvironmentConfigs, filepath.Join(subfolder, "00-claim.yaml"),
+				funcs.ComposedResourcesOfClaimHaveFieldValueWithin(2*time.Minute, manifestsFolderEnvironmentConfigs, filepath.Join(subfolder, "00-claim.yaml"),
 					"metadata.annotations[valueFromEnv]", "1",
 					funcs.FilterByGK(schema.GroupKind{Group: "nop.crossplane.io", Kind: "NopResource"}))).
 			WithTeardown("DeleteCreatedResources", funcs.AllOf(
@@ -173,9 +177,10 @@ func TestEnvironmentResolveIfNotPresent(t *testing.T) {
 			Assess("CreateClaim", funcs.AllOf(
 				funcs.ApplyResources(FieldManager, manifestsFolderEnvironmentConfigs, filepath.Join(subfolder, "00-claim.yaml")),
 				funcs.ResourcesCreatedWithin(30*time.Second, manifestsFolderEnvironmentConfigs, filepath.Join(subfolder, "00-claim.yaml")),
+				funcs.ResourcesHaveConditionWithin(3*time.Minute, manifestsFolderEnvironmentConfigs, filepath.Join(subfolder, "00-claim.yaml"), xpv1.Available()),
 			)).
 			Assess("MRHasAnnotation",
-				funcs.ComposedResourcesOfClaimHaveFieldValueWithin(5*time.Minute, manifestsFolderEnvironmentConfigs, filepath.Join(subfolder, "00-claim.yaml"),
+				funcs.ComposedResourcesOfClaimHaveFieldValueWithin(2*time.Minute, manifestsFolderEnvironmentConfigs, filepath.Join(subfolder, "00-claim.yaml"),
 					"metadata.annotations[valueFromEnv]", "2",
 					funcs.FilterByGK(schema.GroupKind{Group: "nop.crossplane.io", Kind: "NopResource"}))).
 			Assess("CreateAdditionalEnvironmentConfigMatchingSelector", funcs.AllOf(
@@ -234,9 +239,10 @@ func TestEnvironmentResolveAlways(t *testing.T) {
 			Assess("CreateClaim", funcs.AllOf(
 				funcs.ApplyResources(FieldManager, manifestsFolderEnvironmentConfigs, filepath.Join(subfolder, "00-claim.yaml")),
 				funcs.ResourcesCreatedWithin(30*time.Second, manifestsFolderEnvironmentConfigs, filepath.Join(subfolder, "00-claim.yaml")),
+				funcs.ResourcesHaveConditionWithin(3*time.Minute, manifestsFolderEnvironmentConfigs, filepath.Join(subfolder, "00-claim.yaml"), xpv1.Available()),
 			)).
 			Assess("MRHasAnnotation",
-				funcs.ComposedResourcesOfClaimHaveFieldValueWithin(5*time.Minute, manifestsFolderEnvironmentConfigs, filepath.Join(subfolder, "00-claim.yaml"),
+				funcs.ComposedResourcesOfClaimHaveFieldValueWithin(2*time.Minute, manifestsFolderEnvironmentConfigs, filepath.Join(subfolder, "00-claim.yaml"),
 					"metadata.annotations[valueFromEnv]", "2",
 					funcs.FilterByGK(schema.GroupKind{Group: "nop.crossplane.io", Kind: "NopResource"}))).
 			Assess("CreateAdditionalEnvironmentConfigMatchingSelector", funcs.AllOf(
@@ -295,9 +301,10 @@ func TestEnvironmentConfigMultipleMaxMatchNil(t *testing.T) {
 			Assess("CreateClaim", funcs.AllOf(
 				funcs.ApplyResources(FieldManager, manifestsFolderEnvironmentConfigs, filepath.Join(subfolder, "00-claim.yaml")),
 				funcs.ResourcesCreatedWithin(30*time.Second, manifestsFolderEnvironmentConfigs, filepath.Join(subfolder, "00-claim.yaml")),
+				funcs.ResourcesHaveConditionWithin(3*time.Minute, manifestsFolderEnvironmentConfigs, filepath.Join(subfolder, "00-claim.yaml"), xpv1.Available()),
 			)).
 			Assess("MRHasAnnotation",
-				funcs.ComposedResourcesOfClaimHaveFieldValueWithin(5*time.Minute, manifestsFolderEnvironmentConfigs, filepath.Join(subfolder, "00-claim.yaml"),
+				funcs.ComposedResourcesOfClaimHaveFieldValueWithin(2*time.Minute, manifestsFolderEnvironmentConfigs, filepath.Join(subfolder, "00-claim.yaml"),
 					"metadata.annotations[valueFromEnv]", "3",
 					funcs.FilterByGK(schema.GroupKind{Group: "nop.crossplane.io", Kind: "NopResource"}))).
 			WithTeardown("DeleteCreatedResources", funcs.AllOf(
@@ -345,9 +352,10 @@ func TestEnvironmentConfigMultipleMaxMatch1(t *testing.T) {
 			Assess("CreateClaim", funcs.AllOf(
 				funcs.ApplyResources(FieldManager, manifestsFolderEnvironmentConfigs, filepath.Join(subfolder, "00-claim.yaml")),
 				funcs.ResourcesCreatedWithin(30*time.Second, manifestsFolderEnvironmentConfigs, filepath.Join(subfolder, "00-claim.yaml")),
+				funcs.ResourcesHaveConditionWithin(3*time.Minute, manifestsFolderEnvironmentConfigs, filepath.Join(subfolder, "00-claim.yaml"), xpv1.Available()),
 			)).
 			Assess("MRHasAnnotation",
-				funcs.ComposedResourcesOfClaimHaveFieldValueWithin(5*time.Minute, manifestsFolderEnvironmentConfigs, filepath.Join(subfolder, "00-claim.yaml"),
+				funcs.ComposedResourcesOfClaimHaveFieldValueWithin(2*time.Minute, manifestsFolderEnvironmentConfigs, filepath.Join(subfolder, "00-claim.yaml"),
 					"metadata.annotations[valueFromEnv]", "2",
 					funcs.FilterByGK(schema.GroupKind{Group: "nop.crossplane.io", Kind: "NopResource"}))).
 			WithTeardown("DeleteCreatedResources", funcs.AllOf(


### PR DESCRIPTION
### Description of your changes

Fixes the following flakes that we're observing with the recent PRs:

```
=== RUN   TestEnvironmentConfigMultipleMaxMatch1/TestEnvironmentConfigMultipleMaxMatch1/MRHasAnnotation
    feature.go:575: there were no unfiltered referred managed resources to check
--- FAIL: TestEnvironmentConfigMultipleMaxMatch1 (10.30s)
    --- FAIL: TestEnvironmentConfigMultipleMaxMatch1/TestEnvironmentConfigMultipleMaxMatch1 (10.30s)
        --- PASS: TestEnvironmentConfigMultipleMaxMatch1/TestEnvironmentConfigMultipleMaxMatch1/CreateClaim (0.51s)
        --- FAIL: TestEnvironmentConfigMultipleMaxMatch1/TestEnvironmentConfigMultipleMaxMatch1/MRHasAnnotation (0.51s)
```


See https://github.com/crossplane/crossplane/actions/runs/6570834969/job/17848891695?pr=4846

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] ~Added or updated unit tests.~
- [x] Added or updated e2e tests.
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/master/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/master/contributing#checklist-cheat-sheet
