### PR TITLE
Add feature flag for DeploymentRuntimeConfig as beta

### DIFF
--- a/cmd/crossplane/core/core.go
+++ b/cmd/crossplane/core/core.go
@@ -115,6 +115,7 @@ type startCommand struct {
 
 	EnableCompositionFunctions               bool `group:"Beta Features:" default:"true" help:"Enable support for Composition Functions."`
 	EnableCompositionWebhookSchemaValidation bool `group:"Beta Features:" default:"true" help:"Enable support for Composition validation using schemas."`
+	EnableDeploymentRuntimeConfigs           bool `group:"Beta Features:" default:"true" help:"Enable support for Deployment Runtime Configs."`
 
 	// These are GA features that previously had alpha or beta feature flags.
 	// You can't turn off a GA feature. We maintain the flags to avoid breaking
@@ -276,6 +277,10 @@ func (c *startCommand) Run(s *runtime.Scheme, log logging.Logger) error { //noli
 	if c.EnableRealtimeCompositions {
 		o.Features.Enable(features.EnableRealtimeCompositions)
 		log.Info("Alpha feature enabled", "flag", features.EnableRealtimeCompositions)
+	}
+	if c.EnableDeploymentRuntimeConfigs {
+		o.Features.Enable(features.EnableBetaDeploymentRuntimeConfigs)
+		log.Info("Beta feature enabled", "flag", features.EnableBetaDeploymentRuntimeConfigs)
 	}
 
 	ao := apiextensionscontroller.Options{

--- a/internal/controller/pkg/revision/reconciler.go
+++ b/internal/controller/pkg/revision/reconciler.go
@@ -903,6 +903,13 @@ func (r *Reconciler) runtimeManifestBuilderOptions(ctx context.Context, pwr v1.P
 		opts = append(opts, RuntimeManifestBuilderWithRuntimeConfig(rc))
 	}
 
+	// Note(turkenh): Until we completely remove the old controller config
+	// reference, we support both the old and the new way with DeploymentRuntimeConfig.
+	// If both are specified, we will start with DeploymentRuntimeConfig as the
+	// base, apply optional and mandatory overrides and finally apply the
+	// ControllerConfig on top. While it sounds like we are giving precedence
+	// to the ControllerConfig, this is to make sure that we keep the old
+	// behavior of the controller config reference for existing users.
 	cc := &v1alpha1.ControllerConfig{}
 	if ccRef := pwr.GetControllerConfigRef(); ccRef != nil {
 		if err := r.client.Get(ctx, types.NamespacedName{Name: ccRef.Name}, cc); err != nil {

--- a/internal/controller/pkg/revision/runtime_test.go
+++ b/internal/controller/pkg/revision/runtime_test.go
@@ -197,7 +197,7 @@ func TestRuntimeManifestBuilderDeployment(t *testing.T) {
 				builder: &RuntimeManifestBuilder{
 					revision:  providerRevision,
 					namespace: namespace,
-					runtimeConfig: v1beta1.DeploymentRuntimeConfig{
+					runtimeConfig: &v1beta1.DeploymentRuntimeConfig{
 						Spec: v1beta1.DeploymentRuntimeConfigSpec{
 							DeploymentTemplate: &v1beta1.DeploymentTemplate{
 								Spec: &appsv1.DeploymentSpec{
@@ -252,7 +252,7 @@ func TestRuntimeManifestBuilderDeployment(t *testing.T) {
 				builder: &RuntimeManifestBuilder{
 					revision:  providerRevision,
 					namespace: namespace,
-					runtimeConfig: v1beta1.DeploymentRuntimeConfig{
+					runtimeConfig: &v1beta1.DeploymentRuntimeConfig{
 						Spec: v1beta1.DeploymentRuntimeConfigSpec{
 							DeploymentTemplate: &v1beta1.DeploymentTemplate{
 								Metadata: &v1beta1.ObjectMeta{

--- a/internal/features/features.go
+++ b/internal/features/features.go
@@ -54,4 +54,9 @@ const (
 	// details.
 	// https://github.com/crossplane/crossplane/blob/f32496bed53a393c8239376fd8266ddf2ef84d61/design/design-doc-composition-validating-webhook.md
 	EnableBetaCompositionWebhookSchemaValidation feature.Flag = "EnableBetaCompositionWebhookSchemaValidation"
+
+	// EnableBetaDeploymentRuntimeConfigs enables beta support for deployment
+	// runtime configs. See the below design for more details.
+	// https://github.com/crossplane/crossplane/blob/c2e206/design/one-pager-package-runtime-config.md
+	EnableBetaDeploymentRuntimeConfigs feature.Flag = "EnableBetaDeploymentRuntimeConfigs"
 )


### PR DESCRIPTION
### Description of your changes

This PR is a follow-up to the [previous](https://github.com/crossplane/crossplane/pull/4744#discussion_r1358949693) discussion, putting the `DeploymentRuntimeConfig` behind a feature flag as beta, i.e. enabled by default.

The feature could now be disabled by `--enable-deployment-runtime-configs=false` if needed.

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added or updated unit tests.
- [ ] ~Added or updated e2e tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/master/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/master/contributing#checklist-cheat-sheet
