### PR TITLE
feat: switch probes to only startupProbe

### DIFF
--- a/cluster/charts/crossplane/templates/deployment.yaml
+++ b/cluster/charts/crossplane/templates/deployment.yaml
@@ -123,16 +123,13 @@ spec:
         name: {{ .Chart.Name }}
         resources:
           {{- toYaml .Values.resourcesCrossplane | nindent 12 }}
-        livenessProbe:
-          httpGet:
-            path: /healthz
-            port: healthz
-        readinessProbe:
-          httpGet:
-            path: /readyz
-            port: healthz
+        startupProbe:
+          tcpSocket:
+            port: readyz
+            failureThreshold: 30
+            periodSeconds: 2
         ports:
-        - name: healthz
+        - name: readyz
           containerPort: 8081
         {{- if .Values.metrics.enabled }}
         - name: metrics

--- a/cmd/crossplane/core/core.go
+++ b/cmd/crossplane/core/core.go
@@ -349,7 +349,7 @@ func (c *startCommand) Run(s *runtime.Scheme, log logging.Logger) error { //noli
 	return errors.Wrap(mgr.Start(ctrl.SetupSignalHandler()), "cannot start controller manager")
 }
 
-// SetupProbes sets up the health and ready probes.
+// SetupProbes sets up the health and readiness probes.
 func (c *startCommand) SetupProbes(mgr ctrl.Manager) error {
 	// Add default readiness probe
 	if err := mgr.AddReadyzCheck("ping", healthz.Ping); err != nil {


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane! Please read the contribution docs
(linked below) if this is your first Crossplane pull request.
-->

### Description of your changes

<!--
Briefly describe what this pull request does, and how it is covered by tests.
Be proactive - direct your reviewers' attention to anything that needs special
consideration.

We love pull requests that fix an open issue. If yours does, use the below line
to indicate which issue it fixes, for example "Fixes #500".
-->

The probes introduced in #4748 could be too aggressive and lead to some undesired restarts under heavier operations, e.g. in my case installing `platform-ref-aws`, if the resources are constrained.

The original issue we were trying to solve was that we were seeing some failures in the e2es at startup due to the webhooks not being yet ready to receive requests. So, a [startupProbe](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#define-startup-probes) could be enough, although it could lead to the pod being restarted after the `failureThreshold * periodSeconds` time window, I've set it to be 60s (30*2s), but we could be even more permissive and increase the failureThreshold if needed. To compensate, I've configured the probe to be just a `tcpProbe`, which should be less affected even if for some reason the pod was under heavier usage.

I hit this while testing it locally on the latest [commit](https://github.com/crossplane/crossplane/commit/48f9ed536161cad46231a08ed8c593fe9d86e459), by just applying the following manifest:
```yaml
apiVersion: pkg.crossplane.io/v1
kind: Configuration
metadata:
  name: platform-ref-aws
spec:
  package: xpkg.upbound.io/upbound/platform-ref-aws:v0.6.0
```
Seeing a few restarts of the Crossplane pod after that.

With this change I couldn't see any restart, and even killing the crossplane pod while it was trying to deploy `platform-ref-aws` didn't result in any issue at restart. Has to be seen whether it's actually solving the flakiness we were seeing.

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] ~Added or updated unit tests.~
- [ ] ~Added or updated e2e tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/master/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/master/contributing#checklist-cheat-sheet
