### PR TITLE
Enhance release process template for release candidates as pre releases

### DIFF
--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -23,20 +23,28 @@ examples of each step, assuming release vX.Y.0 is being cut.
 
 - [ ] **[In Crossplane Runtime]**: Prepared the release branch `release-X.Y` at the beginning of [Code Freeze]:
   - [ ] Created the release branch using the [GitHub UI][create-branch].
-  - [ ] Created and merged an empty commit to the `master` branch, if required to have it at least one commit ahead of the release branch.
-  - [ ] Run the [Tag workflow][tag-workflow] on the `master` branch with the release candidate tag for the next release `vX.Y+1.0-rc.0`.
+  - [ ] (On the **Master** Branch) Created and merged an empty commit, if required to have it at least one commit ahead of the release branch.
+  - [ ] (On the **Master** Branch) Run the [Tag workflow][tag-workflow-runtime] with the release candidate tag for the next release `vX.Y+1.0-rc.0`.
+  - [ ] (On the **Release** Branch) Run the [Tag workflow][tag-workflow-runtime] with the release candidate tag for the next release `vX.Y.0-rc.1` (assuming the latest rc tag for `vX.Y.0` is `vX.Y.0-rc.0`).
 - [ ] **[In Core Crossplane]:** Prepared the release branch `release-X.Y` at the beginning of [Code Freeze]:
   - [ ] Created the release branch using the [GitHub UI][create-branch].
-  - [ ] Created and merged an empty commit to the `master` branch, if required to have it at least one commit ahead of the release branch.
-  - [ ] Run the [Tag workflow][tag-workflow] on the `master` branch with the release candidate tag for the next release `vX.Y+1.0-rc.0`.
+  - [ ] (On the **Master** Branch) created and merged a PR bumping the Crossplane Runtime dependency to the release candidate tag from master, `vX.Y+1.0-rc.0`.
+  - [ ] (On the **Master** Branch) Run the [Tag workflow][tag-workflow] with the release candidate tag for the next release, `vX.Y+1.0-rc.0`.
+  - [ ] (On the **Release** Branch) created and merged a PR bumping the Crossplane Runtime dependency to the release candidate tag on the release branch, `vX.Y.0-rc.1`.
+- [ ] **[In Core Crossplane]:** Cut a Crossplane **release candidate** from the release branch `release-X.Y` at the beginning of [Code Freeze]:
+  - [ ] (On the **Release** Branch) Run the [Tag workflow][tag-workflow] with the release candidate tag for the release `vX.Y.0-rc.1` (assuming the latest rc tag for `vX.Y.0` is `vX.Y.0-rc.0`).
+  - [ ] (On the **Release** Branch) Run the [CI workflow][ci-workflow] and verified that the tagged build version exists on the [releases.crossplane.io] `build` channel, e.g. `build/release-X.Y/vX.Y.0-rc.1/...` should contain all the relevant binaries.
+  - [ ] (On the **Release** Branch) Run the [Promote workflow][promote-workflow] with channel `stable` and verified that the tagged build version exists on the [releases.crossplane.io] `stable` channel at `stable/vX.Y.0-rc.1/...`.
+  - [ ] Published a [new release] for the tagged version as `pre-release`, with the same name as the version and descriptive release notes, taking care of generating the changes list selecting as "Previous tag" `vX.<Y-1>.0`, so the first of the releases for the previous minor. 
+  - [ ] Ensured that users have been notified of the `pre-release` on the `#announcement` channel of the Crossplane's Slack workspace.
 - [ ] Opened a [docs release issue].
 - [ ] Checked that the [GitHub milestone] for this release only contains closed issues.
 - [ ] Cut a Crossplane Runtime version and consume it from Crossplane.
   - [ ] **[In Crossplane Runtime]**: Run the [Tag workflow][tag-workflow] on the `release-X.Y` branch with the proper release version, `vX.Y.0`. Message suggested, but not required: `Release vX.Y.0`.
   - [ ] **[In Core Crossplane]:** Update the Crossplane Runtime dependency on master and backport it to `release-X.Y` branch.
-- [ ] Run the [Tag workflow][tag-workflow] on the `release-X.Y` branch with the proper release version, `vX.Y.0`. Message suggested, but not required: `Release vX.Y.0`.
-- [ ] Run the [CI workflow][ci-workflow] on the release branch and verified that the tagged build version exists on the [releases.crossplane.io] `build` channel, e.g. `build/release-X.Y/vX.Y.0/...` should contain all the relevant binaries.
-- [ ] Run the [Promote workflow][promote-workflow] with channel `stable` on the `release-X.Y` branch and verified that the tagged build version exists on the [releases.crossplane.io] `stable` channel at `stable/vX.Y.0/...`.
+- [ ] (On the **Release** Branch) Run the [Tag workflow][tag-workflow] with the proper release version, `vX.Y.0`. Message suggested, but not required: `Release vX.Y.0`.
+- [ ] (On the **Release** Branch) Run the [CI workflow][ci-workflow] and verified that the tagged build version exists on the [releases.crossplane.io] `build` channel, e.g. `build/release-X.Y/vX.Y.0/...` should contain all the relevant binaries.
+- [ ] (On the **Release** Branch) Run the [Promote workflow][promote-workflow] with channel `stable` and verified that the tagged build version exists on the [releases.crossplane.io] `stable` channel at `stable/vX.Y.0/...`.
 - [ ] Published a [new release] for the tagged version, with the same name as the version and descriptive release notes, taking care of generating the changes list selecting as "Previous tag" `vX.<Y-1>.0`, so the first of the releases for the previous minor. Before publishing the release notes, set them as Draft and ask the rest of the team to double check them.
 - [ ] Checked that the [docs release issue] created previously has been completed.
 - [ ] Updated, in a single PR, the following on `master`:
@@ -64,6 +72,7 @@ examples of each step, assuming release vX.Y.0 is being cut.
 [release-1.11.0]: https://github.com/crossplane/crossplane/issues/3600
 [releases table]: https://github.com/crossplane/crossplane#releases
 [releases.crossplane.io]: https://releases.crossplane.io
+[tag-workflow-runtime]: https://github.com/crossplane/crossplane-runtime/actions/workflows/tag.yml
 [tag-workflow]: https://github.com/crossplane/crossplane/actions/workflows/tag.yml
 [GitHub milestone]: https://github.com/crossplane/crossplane/milestones
 [crossplane blog]: https://blog.crossplane.io


### PR DESCRIPTION
### Description of your changes

This PR enhances the release process template for release candidates as pre-releases.

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [ ] ~Run `make reviewable` to ensure this PR is ready for review.~
- [ ] ~Added or updated unit tests.~
- [ ] ~Added or updated e2e tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/master/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/master/contributing#checklist-cheat-sheet
