### PR TITLE
Fix log for composition webhook schema validation as beta

### DIFF
--- a/cmd/crossplane/core/core.go
+++ b/cmd/crossplane/core/core.go
@@ -249,8 +249,8 @@ func (c *startCommand) Run(s *runtime.Scheme, log logging.Logger) error { //noli
 		log.Info("Alpha feature enabled", "flag", features.EnableAlphaEnvironmentConfigs)
 	}
 	if c.EnableCompositionWebhookSchemaValidation {
-		o.Features.Enable(features.EnableAlphaCompositionWebhookSchemaValidation)
-		log.Info("Alpha feature enabled", "flag", features.EnableAlphaCompositionWebhookSchemaValidation)
+		o.Features.Enable(features.EnableBetaCompositionWebhookSchemaValidation)
+		log.Info("Beta feature enabled", "flag", features.EnableBetaCompositionWebhookSchemaValidation)
 	}
 	if c.EnableUsages {
 		o.Features.Enable(features.EnableAlphaUsages)

--- a/internal/features/features.go
+++ b/internal/features/features.go
@@ -31,12 +31,6 @@ const (
 	// https://github.com/crossplane/crossplane/blob/390ddd/design/design-doc-external-secret-stores.md
 	EnableAlphaExternalSecretStores feature.Flag = "EnableAlphaExternalSecretStores"
 
-	// EnableAlphaCompositionWebhookSchemaValidation enables alpha support for
-	// composition webhook schema validation. See the below design for more
-	// details.
-	// https://github.com/crossplane/crossplane/blob/f32496bed53a393c8239376fd8266ddf2ef84d61/design/design-doc-composition-validating-webhook.md
-	EnableAlphaCompositionWebhookSchemaValidation feature.Flag = "EnableAlphaCompositionWebhookSchemaValidation"
-
 	// EnableAlphaUsages enables alpha support for deletion ordering and
 	// protection with Usage resource. See the below design for more details.
 	// https://github.com/crossplane/crossplane/blob/19ea23e7c1fc16b20581755540f9f45afdf89338/design/one-pager-generic-usage-type.md
@@ -54,4 +48,10 @@ const (
 	// functions. See the below design for more details.
 	// https://github.com/crossplane/crossplane/blob/863ff6/design/design-doc-composition-functions.md
 	EnableBetaCompositionFunctions feature.Flag = "EnableBetaCompositionFunctions"
+
+	// EnableBetaCompositionWebhookSchemaValidation enables alpha support for
+	// composition webhook schema validation. See the below design for more
+	// details.
+	// https://github.com/crossplane/crossplane/blob/f32496bed53a393c8239376fd8266ddf2ef84d61/design/design-doc-composition-validating-webhook.md
+	EnableBetaCompositionWebhookSchemaValidation feature.Flag = "EnableBetaCompositionWebhookSchemaValidation"
 )

--- a/internal/validation/apiextensions/v1/composition/handler.go
+++ b/internal/validation/apiextensions/v1/composition/handler.go
@@ -55,7 +55,7 @@ const (
 
 // SetupWebhookWithManager sets up the webhook with the manager.
 func SetupWebhookWithManager(mgr ctrl.Manager, options controller.Options) error {
-	if options.Features.Enabled(features.EnableAlphaCompositionWebhookSchemaValidation) {
+	if options.Features.Enabled(features.EnableBetaCompositionWebhookSchemaValidation) {
 		// Setup an index on CRDs so we can retrieve them by group and kind.
 		// The index is used by the getCRD function below.
 		indexer := mgr.GetFieldIndexer()
@@ -91,7 +91,7 @@ func (v *validator) ValidateCreate(ctx context.Context, obj runtime.Object) (adm
 		return warns, kerrors.NewInvalid(comp.GroupVersionKind().GroupKind(), comp.GetName(), validationErrs)
 	}
 
-	if !v.options.Features.Enabled(features.EnableAlphaCompositionWebhookSchemaValidation) {
+	if !v.options.Features.Enabled(features.EnableBetaCompositionWebhookSchemaValidation) {
 		return warns, nil
 	}
 


### PR DESCRIPTION
### Description of your changes

Looks like we missed changing the log message in https://github.com/crossplane/crossplane/pull/4814. 

I am getting the following logs on the latest master by default:

```
Defaulted container "crossplane" out of: crossplane, crossplane-init (init)
2023-10-23T05:47:12Z	INFO	crossplane	Beta feature enabled	{"flag": "EnableBetaCompositionFunctions"}
2023-10-23T05:47:12Z	INFO	crossplane	Alpha feature enabled	{"flag": "EnableAlphaCompositionWebhookSchemaValidation"}
```

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] ~Added or updated unit tests.~
- [ ] ~Added or updated e2e tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/master/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/master/contributing#checklist-cheat-sheet
