### PR TITLE
fix(crank): properly load yaml files from directories

### DIFF
--- a/cmd/crank/beta/render/load.go
+++ b/cmd/crank/beta/render/load.go
@@ -19,10 +19,9 @@ package render
 import (
 	"bufio"
 	"io"
-	"os"
 	"path/filepath"
-	"strings"
 
+	"github.com/spf13/afero"
 	"k8s.io/apimachinery/pkg/util/yaml"
 
 	"github.com/crossplane/crossplane-runtime/pkg/errors"
@@ -34,8 +33,8 @@ import (
 )
 
 // LoadCompositeResource from a YAML manifest.
-func LoadCompositeResource(file string) (*composite.Unstructured, error) {
-	y, err := os.ReadFile(file) //nolint:gosec // Taking this input is intentional.
+func LoadCompositeResource(fs afero.Fs, file string) (*composite.Unstructured, error) {
+	y, err := afero.ReadFile(fs, file)
 	if err != nil {
 		return nil, errors.Wrap(err, "cannot read composite resource file")
 	}
@@ -48,21 +47,21 @@ func LoadCompositeResource(file string) (*composite.Unstructured, error) {
 // we match XRs to Compositions (e.g. selectors, refs etc)
 
 // LoadComposition form a YAML manifest.
-func LoadComposition(file string) (*apiextensionsv1.Composition, error) {
-	y, err := os.ReadFile(file) //nolint:gosec // Taking this as input is intentional.
+func LoadComposition(fs afero.Fs, file string) (*apiextensionsv1.Composition, error) {
+	y, err := afero.ReadFile(fs, file)
 	if err != nil {
-		return nil, errors.Wrap(err, "cannot read composite resource file")
+		return nil, errors.Wrap(err, "cannot read composition file")
 	}
 	comp := &apiextensionsv1.Composition{}
-	return comp, errors.Wrap(yaml.Unmarshal(y, comp), "cannot unmarshal composite resource YAML")
+	return comp, errors.Wrap(yaml.Unmarshal(y, comp), "cannot unmarshal composition resource YAML")
 }
 
 // TODO(negz): Support optionally loading functions and observed resources from
 // a directory of manifests instead of a single stream.
 
 // LoadFunctions from a stream of YAML manifests.
-func LoadFunctions(file string) ([]pkgv1beta1.Function, error) {
-	stream, err := LoadYAMLStream(file)
+func LoadFunctions(filesys afero.Fs, file string) ([]pkgv1beta1.Function, error) {
+	stream, err := LoadYAMLStream(filesys, file)
 	if err != nil {
 		return nil, errors.Wrap(err, "cannot load YAML stream from file")
 	}
@@ -80,8 +79,8 @@ func LoadFunctions(file string) ([]pkgv1beta1.Function, error) {
 }
 
 // LoadObservedResources from a stream of YAML manifests.
-func LoadObservedResources(file string) ([]composed.Unstructured, error) {
-	stream, err := LoadYAMLStream(file)
+func LoadObservedResources(fs afero.Fs, file string) ([]composed.Unstructured, error) {
+	stream, err := LoadYAMLStream(fs, file)
 	if err != nil {
 		return nil, errors.Wrap(err, "cannot load YAML stream from file")
 	}
@@ -100,16 +99,20 @@ func LoadObservedResources(file string) ([]composed.Unstructured, error) {
 
 // LoadYAMLStream from the supplied file or directory. Returns an array of byte
 // arrays, where each byte array is expected to be a YAML manifest.
-func LoadYAMLStream(fileOrDir string) ([][]byte, error) {
+func LoadYAMLStream(filesys afero.Fs, fileOrDir string) ([][]byte, error) {
 	var files []string
-	info, err := os.Stat(fileOrDir)
+	f, err := filesys.Open(fileOrDir)
+	if err != nil {
+		return nil, errors.Wrap(err, "cannot open file")
+	}
+	info, err := f.Stat()
 	if err != nil {
 		return nil, errors.Wrap(err, "cannot stat file")
 	}
 	if !info.IsDir() {
 		files = append(files, fileOrDir)
 	} else {
-		yamls, err := getYAMLFiles(fileOrDir)
+		yamls, err := getYAMLFiles(filesys, fileOrDir)
 		if err != nil {
 			return nil, errors.Wrap(err, "cannot get YAML files")
 		}
@@ -121,7 +124,7 @@ func LoadYAMLStream(fileOrDir string) ([][]byte, error) {
 
 	out := make([][]byte, 0)
 	for i := range files {
-		o, err := LoadYAMLStreamFromFile(files[i])
+		o, err := LoadYAMLStreamFromFile(filesys, files[i])
 		if err != nil {
 			return nil, errors.Wrap(err, "cannot load YAML stream from file")
 		}
@@ -132,8 +135,9 @@ func LoadYAMLStream(fileOrDir string) ([][]byte, error) {
 }
 
 // getYAMLFiles returns a list of YAML files in the supplied directory, ignoring any subdirectory.
-func getYAMLFiles(dir string) (yamls []string, err error) {
-	entries, err := os.ReadDir(dir)
+func getYAMLFiles(fs afero.Fs, dir string) (files []string, err error) {
+	// We don't care about nested directories.
+	entries, err := afero.ReadDir(fs, dir)
 	if err != nil {
 		return nil, errors.Wrap(err, "cannot read directory")
 	}
@@ -142,18 +146,19 @@ func getYAMLFiles(dir string) (yamls []string, err error) {
 			// We don't care about nested directories.
 			continue
 		}
-		if ext := strings.ToLower(filepath.Ext(entry.Name())); ext == ".yaml" || ext == ".yml" {
-			yamls = append(yamls, filepath.Join(dir, entry.Name()))
+		switch filepath.Ext(entry.Name()) {
+		case ".yaml", ".yml":
+			files = append(files, filepath.Join(dir, entry.Name()))
 		}
 	}
-	return yamls, nil
+	return files, nil
 }
 
 // LoadYAMLStreamFromFile from the supplied file. Returns an array of byte
 // arrays, where each byte array is expected to be a YAML manifest.
-func LoadYAMLStreamFromFile(file string) ([][]byte, error) {
+func LoadYAMLStreamFromFile(fs afero.Fs, file string) ([][]byte, error) {
 	out := make([][]byte, 0)
-	f, err := os.Open(file) //nolint:gosec // Taking this input is intentional.
+	f, err := fs.Open(file)
 	if err != nil {
 		return nil, errors.Wrap(err, "cannot open file")
 	}

--- a/cmd/crank/beta/render/load.go
+++ b/cmd/crank/beta/render/load.go
@@ -134,9 +134,16 @@ func LoadYAMLStream(filesys afero.Fs, fileOrDir string) ([][]byte, error) {
 	return out, nil
 }
 
-// getYAMLFiles returns a list of YAML files in the supplied directory, ignoring any subdirectory.
+// getYAMLFiles returns a list of YAML files from the supplied directory, sorted
+// by file name, ignoring any subdirectory.
 func getYAMLFiles(fs afero.Fs, dir string) (files []string, err error) {
-	// We don't care about nested directories.
+	// We don't care about nested directories, so we decided to go with a plain
+	// ReadDir, instead of a Walk.
+	//
+	// Previously we used Glob, but the pattern doesn't support the
+	// `.{yaml,yml}` syntax, so we would have had to run it twice, merge the
+	// results and sort them again. This just felt easier to switch to afero.Walk if
+	// we ever decided to support subdirectories.
 	entries, err := afero.ReadDir(fs, dir)
 	if err != nil {
 		return nil, errors.Wrap(err, "cannot read directory")

--- a/cmd/crank/beta/render/load_test.go
+++ b/cmd/crank/beta/render/load_test.go
@@ -362,6 +362,9 @@ test: "file-2"
 					"testdata/file-3.txt": &fstest.MapFile{
 						Data: []byte(`THIS SHOULD NOT BE LOADED`),
 					},
+					"testdata/subdir/file-4.yaml": &fstest.MapFile{
+						Data: []byte(`THIS IS IN A SUBDIRECTORY AND SHOULD NOT BE LOADED`),
+					},
 				}},
 			},
 			want: want{


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane! Please read the contribution docs
(linked below) if this is your first Crossplane pull request.
-->

### Description of your changes

<!--
Briefly describe what this pull request does, and how it is covered by tests.
Be proactive - direct your reviewers' attention to anything that needs special
consideration.

We love pull requests that fix an open issue. If yours does, use the below line
to indicate which issue it fixes, for example "Fixes #500".
-->

Fixes #4854.

`filepath.Glob` was not properly handling the `*.{yaml,yml}` format, so I switched to manually iterating over the directory entries.

We should switch to an afero.FS so that we can write some proper tests for this, but that can be done in a separate PR.

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] ~Added or updated unit tests.~
- [ ] ~Added or updated e2e tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/master/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/master/contributing#checklist-cheat-sheet
