### PR TITLE
fix(schema-aware-validation): readiness check with no target field type

### DIFF
--- a/pkg/validation/apiextensions/v1/composition/readinessChecks.go
+++ b/pkg/validation/apiextensions/v1/composition/readinessChecks.go
@@ -68,6 +68,10 @@ func validateReadinessChecks(resource v1.ComposedTemplate, schema *apiextensions
 			errs = append(errs, field.Invalid(field.NewPath("readinessCheck").Index(j).Child("fieldPath"), r.FieldPath, err.Error()))
 			continue
 		}
+		if fieldType == "" {
+			// nothing to do, we don't have a type defined for the field
+			continue
+		}
 		if matchType := getReadinessCheckExpectedType(r); matchType != "" && matchType != fieldType {
 			errs = append(errs, field.Invalid(field.NewPath("readinessCheck").Index(j).Child("fieldPath"), r.FieldPath, fmt.Sprintf("expected field path to be of type %s", matchType)))
 			continue

--- a/pkg/validation/apiextensions/v1/composition/readinessChecks_test.go
+++ b/pkg/validation/apiextensions/v1/composition/readinessChecks_test.go
@@ -23,6 +23,7 @@ import (
 	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/utils/ptr"
 
 	v1 "github.com/crossplane/crossplane/apis/apiextensions/v1"
 )
@@ -247,6 +248,39 @@ func TestValidateReadinessCheck(t *testing.T) {
 						BadValue: "spec.someField",
 					},
 				},
+			},
+		},
+		{
+			name: "should accept valid readiness check - matchInteger type - free object allowed",
+			args: args{
+				comp: buildDefaultComposition(t, v1.CompositionValidationModeLoose, nil, withReadinessChecks(
+					0,
+					v1.ReadinessCheck{
+						Type:         v1.ReadinessCheckTypeMatchInteger,
+						MatchInteger: 10,
+						FieldPath:    "status.atProvider.manifest.status.readyReplicas",
+					},
+				)),
+				gkToCRD: buildGkToCRDs(
+					defaultManagedCrdBuilder().withOption(func(crd *extv1.CustomResourceDefinition) {
+						crd.Spec.Versions[0].Schema.OpenAPIV3Schema.Properties["status"] = extv1.JSONSchemaProps{
+							Type: "object",
+							Properties: map[string]extv1.JSONSchemaProps{
+								"atProvider": {
+									Type: "object",
+									Properties: map[string]extv1.JSONSchemaProps{
+										"manifest": {
+											Type:                   "object",
+											XPreserveUnknownFields: ptr.To(true),
+										},
+									},
+								},
+							},
+						}
+					}).build()),
+			},
+			want: want{
+				errs: nil,
 			},
 		},
 	}


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane! Please read the contribution docs
(linked below) if this is your first Crossplane pull request.
-->

### Description of your changes

<!--
Briefly describe what this pull request does, and how it is covered by tests.
Be proactive - direct your reviewers' attention to anything that needs special
consideration.

We love pull requests that fix an open issue. If yours does, use the below line
to indicate which issue it fixes, for example "Fixes #500".
-->

Fixes issue reported by @sttts about schema-aware validation rejecting a Composition with a readiness check targeting a provider-kubernetes Object where the target field was actually with no known type.   

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added or updated unit tests.
- [ ] ~Added or updated e2e tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [x] Added `backport release-x.y` labels to auto-backport this PR.

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/master/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/master/contributing#checklist-cheat-sheet
