### PR TITLE
feat(schema-aware-validation): only emit warnings by default

### DIFF
--- a/apis/apiextensions/v1/composition_webhooks.go
+++ b/apis/apiextensions/v1/composition_webhooks.go
@@ -36,10 +36,13 @@ type CompositionValidationMode string
 
 var (
 	// DefaultCompositionValidationMode is the default validation mode for Compositions.
-	DefaultCompositionValidationMode = CompositionValidationModeLoose
+	DefaultCompositionValidationMode = CompositionValidationModeWarn
 	// CompositionValidationModeLoose means that Compositions will be validated loosely, so no errors will be returned
 	// in case of missing referenced resources, e.g. Managed Resources or Composite Resources.
 	CompositionValidationModeLoose CompositionValidationMode = "loose"
+	// CompositionValidationModeWarn means only warnings will be returned in
+	// case of errors during validation.
+	CompositionValidationModeWarn CompositionValidationMode = "warn"
 	// CompositionValidationModeStrict means that Compositions will be validated strictly, so errors will be returned
 	// in case of missing referenced resources, e.g. Managed Resources or Composite Resources.
 	CompositionValidationModeStrict CompositionValidationMode = "strict"
@@ -57,7 +60,7 @@ func (in *Composition) GetValidationMode() (CompositionValidationMode, error) {
 	}
 
 	switch mode := CompositionValidationMode(mode); mode {
-	case CompositionValidationModeStrict, CompositionValidationModeLoose:
+	case CompositionValidationModeStrict, CompositionValidationModeLoose, CompositionValidationModeWarn:
 		return mode, nil
 	}
 	return "", errors.Errorf(errFmtInvalidCompositionValidationMode, mode)

--- a/apis/apiextensions/v1/composition_webhooks.go
+++ b/apis/apiextensions/v1/composition_webhooks.go
@@ -25,42 +25,43 @@ import (
 const (
 	// CompositionValidatingWebhookPath is the path for the Composition's validating webhook, should be kept in sync with the annotation above.
 	CompositionValidatingWebhookPath = "/validate-apiextensions-crossplane-io-v1-composition"
-	// CompositionValidationModeAnnotation is the annotation that can be used to specify the validation mode for a Composition.
-	CompositionValidationModeAnnotation = "crossplane.io/composition-validation-mode"
+	// SchemaAwareCompositionValidationModeAnnotation is the annotation that can be used to specify the schema-aware validation mode for a Composition.
+	SchemaAwareCompositionValidationModeAnnotation = "crossplane.io/composition-schema-aware-validation-mode"
 
-	errFmtInvalidCompositionValidationMode = "invalid composition validation mode: %s"
+	errFmtInvalidCompositionValidationMode = "invalid schema-aware composition validation mode: %s"
 )
 
 // CompositionValidationMode is the validation mode for a Composition.
 type CompositionValidationMode string
 
 var (
-	// DefaultCompositionValidationMode is the default validation mode for Compositions.
-	DefaultCompositionValidationMode = CompositionValidationModeWarn
-	// CompositionValidationModeLoose means that Compositions will be validated loosely, so no errors will be returned
+	// DefaultSchemaAwareCompositionValidationMode is the default validation mode for Compositions.
+	DefaultSchemaAwareCompositionValidationMode = SchemaAwareCompositionValidationModeWarn
+	// SchemaAwareCompositionValidationModeWarn means only warnings will be
+	// returned in case of errors during schema-aware validation, both for missing CRDs or any schema related error.
+	SchemaAwareCompositionValidationModeWarn CompositionValidationMode = "warn"
+	// SchemaAwareCompositionValidationModeLoose means that Compositions will be validated loosely, so no errors will be returned
 	// in case of missing referenced resources, e.g. Managed Resources or Composite Resources.
-	CompositionValidationModeLoose CompositionValidationMode = "loose"
-	// CompositionValidationModeWarn means only warnings will be returned in
-	// case of errors during validation.
-	CompositionValidationModeWarn CompositionValidationMode = "warn"
-	// CompositionValidationModeStrict means that Compositions will be validated strictly, so errors will be returned
-	// in case of missing referenced resources, e.g. Managed Resources or Composite Resources.
-	CompositionValidationModeStrict CompositionValidationMode = "strict"
+	SchemaAwareCompositionValidationModeLoose CompositionValidationMode = "loose"
+	// SchemaAwareCompositionValidationModeStrict means that Compositions will
+	// be validated strictly, so errors will be returned in case of errors
+	// during schema-aware validation or for missing resources' CRDs.
+	SchemaAwareCompositionValidationModeStrict CompositionValidationMode = "strict"
 )
 
-// GetValidationMode returns the validation mode set for the composition.
-func (in *Composition) GetValidationMode() (CompositionValidationMode, error) {
+// GetSchemaAwareValidationMode returns the schema-aware validation mode set for the Composition.
+func (in *Composition) GetSchemaAwareValidationMode() (CompositionValidationMode, error) {
 	if in.Annotations == nil {
-		return DefaultCompositionValidationMode, nil
+		return DefaultSchemaAwareCompositionValidationMode, nil
 	}
 
-	mode, ok := in.Annotations[CompositionValidationModeAnnotation]
+	mode, ok := in.Annotations[SchemaAwareCompositionValidationModeAnnotation]
 	if !ok {
-		return DefaultCompositionValidationMode, nil
+		return DefaultSchemaAwareCompositionValidationMode, nil
 	}
 
 	switch mode := CompositionValidationMode(mode); mode {
-	case CompositionValidationModeStrict, CompositionValidationModeLoose, CompositionValidationModeWarn:
+	case SchemaAwareCompositionValidationModeStrict, SchemaAwareCompositionValidationModeLoose, SchemaAwareCompositionValidationModeWarn:
 		return mode, nil
 	}
 	return "", errors.Errorf(errFmtInvalidCompositionValidationMode, mode)

--- a/apis/apiextensions/v1/composition_webhooks_test.go
+++ b/apis/apiextensions/v1/composition_webhooks_test.go
@@ -31,7 +31,7 @@ func TestCompositionGetValidationMode(t *testing.T) {
 				},
 			},
 			want: want{
-				mode: DefaultCompositionValidationMode,
+				mode: DefaultSchemaAwareCompositionValidationMode,
 			},
 		},
 		"ValidStrict": {
@@ -40,13 +40,13 @@ func TestCompositionGetValidationMode(t *testing.T) {
 				comp: &Composition{
 					ObjectMeta: v1.ObjectMeta{
 						Annotations: map[string]string{
-							CompositionValidationModeAnnotation: string(CompositionValidationModeStrict),
+							SchemaAwareCompositionValidationModeAnnotation: string(SchemaAwareCompositionValidationModeStrict),
 						},
 					},
 				},
 			},
 			want: want{
-				mode: CompositionValidationModeStrict,
+				mode: SchemaAwareCompositionValidationModeStrict,
 			},
 		},
 		"ValidLoose": {
@@ -55,13 +55,13 @@ func TestCompositionGetValidationMode(t *testing.T) {
 				comp: &Composition{
 					ObjectMeta: v1.ObjectMeta{
 						Annotations: map[string]string{
-							CompositionValidationModeAnnotation: string(CompositionValidationModeLoose),
+							SchemaAwareCompositionValidationModeAnnotation: string(SchemaAwareCompositionValidationModeLoose),
 						},
 					},
 				},
 			},
 			want: want{
-				mode: CompositionValidationModeLoose,
+				mode: SchemaAwareCompositionValidationModeLoose,
 			},
 		},
 		"ValidWarn": {
@@ -70,13 +70,13 @@ func TestCompositionGetValidationMode(t *testing.T) {
 				comp: &Composition{
 					ObjectMeta: v1.ObjectMeta{
 						Annotations: map[string]string{
-							CompositionValidationModeAnnotation: string(CompositionValidationModeWarn),
+							SchemaAwareCompositionValidationModeAnnotation: string(SchemaAwareCompositionValidationModeWarn),
 						},
 					},
 				},
 			},
 			want: want{
-				mode: CompositionValidationModeWarn,
+				mode: SchemaAwareCompositionValidationModeWarn,
 			},
 		},
 		"InvalidValue": {
@@ -85,7 +85,7 @@ func TestCompositionGetValidationMode(t *testing.T) {
 				comp: &Composition{
 					ObjectMeta: v1.ObjectMeta{
 						Annotations: map[string]string{
-							CompositionValidationModeAnnotation: "invalid",
+							SchemaAwareCompositionValidationModeAnnotation: "invalid",
 						},
 					},
 				},
@@ -97,7 +97,7 @@ func TestCompositionGetValidationMode(t *testing.T) {
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			got, err := tc.args.comp.GetValidationMode()
+			got, err := tc.args.comp.GetSchemaAwareValidationMode()
 			if diff := cmp.Diff(tc.want.mode, got); diff != "" {
 				t.Errorf("\n%s\nGetValidationMode(...) -want, +got:\n%s", tc.reason, diff)
 			}

--- a/apis/apiextensions/v1/composition_webhooks_test.go
+++ b/apis/apiextensions/v1/composition_webhooks_test.go
@@ -31,7 +31,7 @@ func TestCompositionGetValidationMode(t *testing.T) {
 				},
 			},
 			want: want{
-				mode: CompositionValidationModeLoose,
+				mode: DefaultCompositionValidationMode,
 			},
 		},
 		"ValidStrict": {
@@ -47,6 +47,36 @@ func TestCompositionGetValidationMode(t *testing.T) {
 			},
 			want: want{
 				mode: CompositionValidationModeStrict,
+			},
+		},
+		"ValidLoose": {
+			reason: "Loose mode should be returned if specified",
+			args: args{
+				comp: &Composition{
+					ObjectMeta: v1.ObjectMeta{
+						Annotations: map[string]string{
+							CompositionValidationModeAnnotation: string(CompositionValidationModeLoose),
+						},
+					},
+				},
+			},
+			want: want{
+				mode: CompositionValidationModeLoose,
+			},
+		},
+		"ValidWarn": {
+			reason: "Warn mode should be returned if specified",
+			args: args{
+				comp: &Composition{
+					ObjectMeta: v1.ObjectMeta{
+						Annotations: map[string]string{
+							CompositionValidationModeAnnotation: string(CompositionValidationModeWarn),
+						},
+					},
+				},
+			},
+			want: want{
+				mode: CompositionValidationModeWarn,
 			},
 		},
 		"InvalidValue": {

--- a/design/design-doc-composition-validating-webhook.md
+++ b/design/design-doc-composition-validating-webhook.md
@@ -155,7 +155,7 @@ In order to address the possible absence of Managed Resources' CRDs, Composite
 Resources' CRDs or any other required external resource at validation time we
 should allow explicitly setting one of 2 modes, `strict` and `loose`(default) .
 These should be configurable through an annotation, e.g.
-`crossplane.io/composition-validation-mode`, on a Composition or maybe even
+`crossplane.io/composition-schema-aware-validation-mode`, on a Composition or maybe even
 globally via a flag, and would respectively imply that any missing resource
 should result in a direct rejection or a possibly incomplete validation.
 
@@ -245,7 +245,7 @@ kind: Composition
 metadata:
   name: xpostgresqlinstances.aws.database.example.org
   annotations:
-    crossplane.io/composition-validation-mode: <selected_mode> # "loose" or "strict"
+    crossplane.io/composition-schema-aware-validation-mode: <selected_mode> # "loose" or "strict"
   labels:
     provider: aws
     guide: quickstart
@@ -305,7 +305,7 @@ kind: Composition
 metadata:
   name: xpostgresqlinstances.aws.database.example.org
   annotations:
-    crossplane.io/composition-validation-mode: <selected_mode> # "loose" or "strict"
+    crossplane.io/composition-schema-aware-validation-mode: <selected_mode> # "loose" or "strict"
   labels:
     provider: aws
     guide: quickstart

--- a/internal/validation/apiextensions/v1/composition/handler.go
+++ b/internal/validation/apiextensions/v1/composition/handler.go
@@ -134,7 +134,12 @@ func (v *validator) ValidateCreate(ctx context.Context, obj runtime.Object) (adm
 	schemaWarns, errList := cv.Validate(ctx, comp)
 	warns = append(warns, schemaWarns...)
 	if len(errList) != 0 {
-		return warns, kerrors.NewInvalid(comp.GroupVersionKind().GroupKind(), comp.GetName(), errList)
+		if validationMode != v1.CompositionValidationModeWarn {
+			return warns, kerrors.NewInvalid(comp.GroupVersionKind().GroupKind(), comp.GetName(), errList)
+		}
+		for _, err := range errList {
+			warns = append(warns, err.Error())
+		}
 	}
 	return warns, nil
 }

--- a/pkg/validation/apiextensions/v1/composition/connectionDetails_test.go
+++ b/pkg/validation/apiextensions/v1/composition/connectionDetails_test.go
@@ -50,7 +50,7 @@ func TestValidateConnectionDetails(t *testing.T) {
 		{
 			name: "should accept empty connection details",
 			args: args{
-				comp:    buildDefaultComposition(t, v1.CompositionValidationModeLoose, nil),
+				comp:    buildDefaultComposition(t, v1.SchemaAwareCompositionValidationModeLoose, nil),
 				gkToCRD: defaultGKToCRDs(),
 			},
 			want: want{
@@ -60,7 +60,7 @@ func TestValidateConnectionDetails(t *testing.T) {
 		{
 			name: "should accept valid connection details, unknown type",
 			args: args{
-				comp: buildDefaultComposition(t, v1.CompositionValidationModeLoose, nil, withConnectionDetails(
+				comp: buildDefaultComposition(t, v1.SchemaAwareCompositionValidationModeLoose, nil, withConnectionDetails(
 					0,
 					v1.ConnectionDetail{
 						Type: &[]v1.ConnectionDetailType{v1.ConnectionDetailTypeUnknown}[0],
@@ -75,7 +75,7 @@ func TestValidateConnectionDetails(t *testing.T) {
 		{
 			name: "should accept valid connection detail specifying a valid fromFieldPath",
 			args: args{
-				comp: buildDefaultComposition(t, v1.CompositionValidationModeLoose, nil, withConnectionDetails(
+				comp: buildDefaultComposition(t, v1.SchemaAwareCompositionValidationModeLoose, nil, withConnectionDetails(
 					0,
 					v1.ConnectionDetail{
 						FromFieldPath: ptr.To("spec.someOtherField"),
@@ -90,7 +90,7 @@ func TestValidateConnectionDetails(t *testing.T) {
 		{
 			name: "should reject invalid connection detail specifying an invalid fromFieldPath",
 			args: args{
-				comp: buildDefaultComposition(t, v1.CompositionValidationModeLoose, nil, withConnectionDetails(
+				comp: buildDefaultComposition(t, v1.SchemaAwareCompositionValidationModeLoose, nil, withConnectionDetails(
 					0,
 					v1.ConnectionDetail{
 						FromFieldPath: ptr.To("spec.someWrongField"),

--- a/pkg/validation/apiextensions/v1/composition/readinessChecks_test.go
+++ b/pkg/validation/apiextensions/v1/composition/readinessChecks_test.go
@@ -50,7 +50,7 @@ func TestValidateReadinessCheck(t *testing.T) {
 		{
 			name: "should accept empty readiness check",
 			args: args{
-				comp:    buildDefaultComposition(t, v1.CompositionValidationModeLoose, nil),
+				comp:    buildDefaultComposition(t, v1.SchemaAwareCompositionValidationModeLoose, nil),
 				gkToCRD: defaultGKToCRDs(),
 			},
 			want: want{
@@ -60,7 +60,7 @@ func TestValidateReadinessCheck(t *testing.T) {
 		{
 			name: "should accept valid readiness check - none type",
 			args: args{
-				comp: buildDefaultComposition(t, v1.CompositionValidationModeLoose, nil, withReadinessChecks(
+				comp: buildDefaultComposition(t, v1.SchemaAwareCompositionValidationModeLoose, nil, withReadinessChecks(
 					0,
 					v1.ReadinessCheck{
 						Type: v1.ReadinessCheckTypeNone,
@@ -75,7 +75,7 @@ func TestValidateReadinessCheck(t *testing.T) {
 		{
 			name: "should accept valid readiness check - nonEmpty type",
 			args: args{
-				comp: buildDefaultComposition(t, v1.CompositionValidationModeLoose, nil, withReadinessChecks(
+				comp: buildDefaultComposition(t, v1.SchemaAwareCompositionValidationModeLoose, nil, withReadinessChecks(
 					0,
 					v1.ReadinessCheck{
 						Type:      v1.ReadinessCheckTypeNonEmpty,
@@ -91,7 +91,7 @@ func TestValidateReadinessCheck(t *testing.T) {
 		{
 			name: "should accept valid readiness check - matchTrue type",
 			args: args{
-				comp: buildDefaultComposition(t, v1.CompositionValidationModeLoose, nil, withReadinessChecks(
+				comp: buildDefaultComposition(t, v1.SchemaAwareCompositionValidationModeLoose, nil, withReadinessChecks(
 					0,
 					v1.ReadinessCheck{
 						Type:      v1.ReadinessCheckTypeMatchTrue,
@@ -107,7 +107,7 @@ func TestValidateReadinessCheck(t *testing.T) {
 		{
 			name: "should accept valid readiness check - matchFalse type",
 			args: args{
-				comp: buildDefaultComposition(t, v1.CompositionValidationModeLoose, nil, withReadinessChecks(
+				comp: buildDefaultComposition(t, v1.SchemaAwareCompositionValidationModeLoose, nil, withReadinessChecks(
 					0,
 					v1.ReadinessCheck{
 						Type:      v1.ReadinessCheckTypeMatchFalse,
@@ -123,7 +123,7 @@ func TestValidateReadinessCheck(t *testing.T) {
 		{
 			name: "should accept valid readiness check - matchString type",
 			args: args{
-				comp: buildDefaultComposition(t, v1.CompositionValidationModeLoose, nil, withReadinessChecks(
+				comp: buildDefaultComposition(t, v1.SchemaAwareCompositionValidationModeLoose, nil, withReadinessChecks(
 					0,
 					v1.ReadinessCheck{
 						Type:        v1.ReadinessCheckTypeMatchString,
@@ -140,7 +140,7 @@ func TestValidateReadinessCheck(t *testing.T) {
 		{
 			name: "should reject invalid readiness check - matchInteger type",
 			args: args{
-				comp: buildDefaultComposition(t, v1.CompositionValidationModeLoose, nil, withReadinessChecks(
+				comp: buildDefaultComposition(t, v1.SchemaAwareCompositionValidationModeLoose, nil, withReadinessChecks(
 					0,
 					v1.ReadinessCheck{
 						Type:         v1.ReadinessCheckTypeMatchInteger,
@@ -168,7 +168,7 @@ func TestValidateReadinessCheck(t *testing.T) {
 		{
 			name: "should accept valid readiness check - matchInteger type",
 			args: args{
-				comp: buildDefaultComposition(t, v1.CompositionValidationModeLoose, nil, withReadinessChecks(
+				comp: buildDefaultComposition(t, v1.SchemaAwareCompositionValidationModeLoose, nil, withReadinessChecks(
 					0,
 					v1.ReadinessCheck{
 						Type:         v1.ReadinessCheckTypeMatchInteger,
@@ -190,7 +190,7 @@ func TestValidateReadinessCheck(t *testing.T) {
 		{
 			name: "should reject invalid readiness check - matchInteger type - type mismatch",
 			args: args{
-				comp: buildDefaultComposition(t, v1.CompositionValidationModeLoose, nil, withReadinessChecks(
+				comp: buildDefaultComposition(t, v1.SchemaAwareCompositionValidationModeLoose, nil, withReadinessChecks(
 					0,
 					v1.ReadinessCheck{
 						Type:         v1.ReadinessCheckTypeMatchInteger,
@@ -218,7 +218,7 @@ func TestValidateReadinessCheck(t *testing.T) {
 		{
 			name: "should reject invalid readiness check - matchInteger type - type mismatch - multiple versions",
 			args: args{
-				comp: buildDefaultComposition(t, v1.CompositionValidationModeLoose, nil, withReadinessChecks(
+				comp: buildDefaultComposition(t, v1.SchemaAwareCompositionValidationModeLoose, nil, withReadinessChecks(
 					0,
 					v1.ReadinessCheck{
 						Type:         v1.ReadinessCheckTypeMatchInteger,
@@ -253,7 +253,7 @@ func TestValidateReadinessCheck(t *testing.T) {
 		{
 			name: "should accept valid readiness check - matchInteger type - free object allowed",
 			args: args{
-				comp: buildDefaultComposition(t, v1.CompositionValidationModeLoose, nil, withReadinessChecks(
+				comp: buildDefaultComposition(t, v1.SchemaAwareCompositionValidationModeLoose, nil, withReadinessChecks(
 					0,
 					v1.ReadinessCheck{
 						Type:         v1.ReadinessCheckTypeMatchInteger,

--- a/pkg/validation/apiextensions/v1/composition/validator_test.go
+++ b/pkg/validation/apiextensions/v1/composition/validator_test.go
@@ -38,7 +38,7 @@ func TestValidatorValidate(t *testing.T) {
 				errs: nil,
 			},
 			args: args{
-				comp:     buildDefaultComposition(t, v1.CompositionValidationModeStrict, map[string]any{"someOtherField": "test"}),
+				comp:     buildDefaultComposition(t, v1.SchemaAwareCompositionValidationModeStrict, map[string]any{"someOtherField": "test"}),
 				gkToCRDs: nil,
 			},
 		},
@@ -53,7 +53,7 @@ func TestValidatorValidate(t *testing.T) {
 				},
 			},
 			args: args{
-				comp: buildDefaultComposition(t, v1.CompositionValidationModeStrict, map[string]any{"someOtherField": "test"},
+				comp: buildDefaultComposition(t, v1.SchemaAwareCompositionValidationModeStrict, map[string]any{"someOtherField": "test"},
 					withPatches(0, v1.Patch{
 						FromFieldPath: ptr.To("spec.someField"),
 						ToFieldPath:   ptr.To("spec.someOtherField"),
@@ -66,7 +66,7 @@ func TestValidatorValidate(t *testing.T) {
 			want:   want{errs: nil},
 			args: args{
 				gkToCRDs: defaultGKToCRDs(),
-				comp:     buildDefaultComposition(t, v1.CompositionValidationModeStrict, map[string]any{"someOtherField": "test"}),
+				comp:     buildDefaultComposition(t, v1.SchemaAwareCompositionValidationModeStrict, map[string]any{"someOtherField": "test"}),
 			},
 		},
 		"AcceptStrictInvalid": {
@@ -75,7 +75,7 @@ func TestValidatorValidate(t *testing.T) {
 			want: want{errs: nil},
 			args: args{
 				gkToCRDs: defaultGKToCRDs(),
-				comp:     buildDefaultComposition(t, v1.CompositionValidationModeStrict, nil),
+				comp:     buildDefaultComposition(t, v1.SchemaAwareCompositionValidationModeStrict, nil),
 			},
 		},
 		"AcceptStrictRequiredFieldByPatch": {
@@ -83,7 +83,7 @@ func TestValidatorValidate(t *testing.T) {
 			want:   want{errs: nil},
 			args: args{
 				gkToCRDs: defaultGKToCRDs(),
-				comp: buildDefaultComposition(t, v1.CompositionValidationModeStrict, nil, withPatches(0, v1.Patch{
+				comp: buildDefaultComposition(t, v1.SchemaAwareCompositionValidationModeStrict, nil, withPatches(0, v1.Patch{
 					Type:          v1.PatchTypeFromCompositeFieldPath,
 					FromFieldPath: ptr.To("spec.someField"),
 					ToFieldPath:   ptr.To("spec.someOtherField"),
@@ -102,7 +102,7 @@ func TestValidatorValidate(t *testing.T) {
 			},
 			args: args{
 				gkToCRDs: defaultGKToCRDs(),
-				comp: buildDefaultComposition(t, v1.CompositionValidationModeStrict, nil, withPatches(0, v1.Patch{
+				comp: buildDefaultComposition(t, v1.SchemaAwareCompositionValidationModeStrict, nil, withPatches(0, v1.Patch{
 					Type:          v1.PatchTypeFromCompositeFieldPath,
 					FromFieldPath: ptr.To("spec.someWrongField"),
 					ToFieldPath:   ptr.To("spec.someOtherField"),
@@ -121,7 +121,7 @@ func TestValidatorValidate(t *testing.T) {
 			},
 			args: args{
 				gkToCRDs: defaultGKToCRDs(),
-				comp: buildDefaultComposition(t, v1.CompositionValidationModeStrict, map[string]any{"someOtherField": "test"}, withPatches(0, v1.Patch{
+				comp: buildDefaultComposition(t, v1.SchemaAwareCompositionValidationModeStrict, map[string]any{"someOtherField": "test"}, withPatches(0, v1.Patch{
 					Type:          v1.PatchTypeFromCompositeFieldPath,
 					FromFieldPath: ptr.To("spec.someField"),
 					ToFieldPath:   ptr.To("spec.someOtherWrongField"),
@@ -147,7 +147,7 @@ func TestValidatorValidate(t *testing.T) {
 					}).build(),
 					defaultManagedCrdBuilder().build(),
 				),
-				comp: buildDefaultComposition(t, v1.CompositionValidationModeStrict, nil, withPatches(0, v1.Patch{
+				comp: buildDefaultComposition(t, v1.SchemaAwareCompositionValidationModeStrict, nil, withPatches(0, v1.Patch{
 					Type:          v1.PatchTypeFromCompositeFieldPath,
 					FromFieldPath: ptr.To("spec.someField"),
 					ToFieldPath:   ptr.To("spec.someOtherField"),
@@ -166,7 +166,7 @@ func TestValidatorValidate(t *testing.T) {
 			},
 			args: args{
 				gkToCRDs: defaultGKToCRDs(),
-				comp: buildDefaultComposition(t, v1.CompositionValidationModeLoose, nil, withPatches(0, v1.Patch{
+				comp: buildDefaultComposition(t, v1.SchemaAwareCompositionValidationModeLoose, nil, withPatches(0, v1.Patch{
 					Type:          v1.PatchTypeFromCompositeFieldPath,
 					FromFieldPath: ptr.To("spec.someField"),
 					ToFieldPath:   ptr.To("spec.someOtherField"),
@@ -191,7 +191,7 @@ func TestValidatorValidate(t *testing.T) {
 			},
 			args: args{
 				gkToCRDs: defaultGKToCRDs(),
-				comp: buildDefaultComposition(t, v1.CompositionValidationModeLoose, nil, withPatches(0, v1.Patch{
+				comp: buildDefaultComposition(t, v1.SchemaAwareCompositionValidationModeLoose, nil, withPatches(0, v1.Patch{
 					Type:          v1.PatchTypeFromCompositeFieldPath,
 					FromFieldPath: ptr.To("spec.someField"),
 					ToFieldPath:   ptr.To("spec.someOtherField"),
@@ -220,7 +220,7 @@ func TestValidatorValidate(t *testing.T) {
 					}).build(),
 					defaultManagedCrdBuilder().build(),
 				),
-				comp: buildDefaultComposition(t, v1.CompositionValidationModeLoose, nil, withPatches(0, v1.Patch{
+				comp: buildDefaultComposition(t, v1.SchemaAwareCompositionValidationModeLoose, nil, withPatches(0, v1.Patch{
 					Type: v1.PatchTypeCombineFromComposite,
 					Combine: &v1.Combine{
 						Variables: []v1.CombineVariable{
@@ -252,7 +252,7 @@ func TestValidatorValidate(t *testing.T) {
 			},
 			args: args{
 				gkToCRDs: defaultGKToCRDs(),
-				comp: buildDefaultComposition(t, v1.CompositionValidationModeStrict, nil, withPatches(0, v1.Patch{
+				comp: buildDefaultComposition(t, v1.SchemaAwareCompositionValidationModeStrict, nil, withPatches(0, v1.Patch{
 					Type: v1.PatchTypeCombineFromComposite,
 					Combine: &v1.Combine{
 						Variables: []v1.CombineVariable{
@@ -279,7 +279,7 @@ func TestValidatorValidate(t *testing.T) {
 			},
 			args: args{
 				gkToCRDs: defaultGKToCRDs(),
-				comp: buildDefaultComposition(t, v1.CompositionValidationModeLoose, nil, withPatches(0, v1.Patch{
+				comp: buildDefaultComposition(t, v1.SchemaAwareCompositionValidationModeLoose, nil, withPatches(0, v1.Patch{
 					Type:          v1.PatchTypeFromEnvironmentFieldPath,
 					FromFieldPath: ptr.To("spec.someField"),
 					ToFieldPath:   ptr.To("spec.someOtherField"),
@@ -299,7 +299,7 @@ func TestValidatorValidate(t *testing.T) {
 						Type: "string",
 					}
 				}).build(), defaultCompositeCrdBuilder().build()),
-				comp: buildDefaultComposition(t, v1.CompositionValidationModeLoose, nil, withPatches(0, v1.Patch{
+				comp: buildDefaultComposition(t, v1.SchemaAwareCompositionValidationModeLoose, nil, withPatches(0, v1.Patch{
 					Type:          v1.PatchTypeFromCompositeFieldPath,
 					FromFieldPath: ptr.To("spec.someField"),
 					ToFieldPath:   ptr.To("spec.someOtherField"),
@@ -313,7 +313,7 @@ func TestValidatorValidate(t *testing.T) {
 			},
 			args: args{
 				gkToCRDs: defaultGKToCRDs(),
-				comp: buildDefaultComposition(t, v1.CompositionValidationModeLoose, nil, withPatchSets(
+				comp: buildDefaultComposition(t, v1.SchemaAwareCompositionValidationModeLoose, nil, withPatchSets(
 					v1.PatchSet{
 						Name: "some-patch-set",
 						Patches: []v1.Patch{{
@@ -339,7 +339,7 @@ func TestValidatorValidate(t *testing.T) {
 			},
 			args: args{
 				gkToCRDs: defaultGKToCRDs(),
-				comp: buildDefaultComposition(t, v1.CompositionValidationModeStrict, nil,
+				comp: buildDefaultComposition(t, v1.SchemaAwareCompositionValidationModeStrict, nil,
 					withPatchSets(
 						v1.PatchSet{
 							Name: "some-patch-set",
@@ -374,7 +374,7 @@ func TestValidatorValidate(t *testing.T) {
 			},
 			args: args{
 				gkToCRDs: defaultGKToCRDs(),
-				comp: buildDefaultComposition(t, v1.CompositionValidationModeStrict, nil, withPatches(0, v1.Patch{
+				comp: buildDefaultComposition(t, v1.SchemaAwareCompositionValidationModeStrict, nil, withPatches(0, v1.Patch{
 					Type:          v1.PatchTypeFromEnvironmentFieldPath,
 					FromFieldPath: ptr.To("tier.name"),
 					ToFieldPath:   ptr.To("spec.someOtherField"),
@@ -393,7 +393,7 @@ func TestValidatorValidate(t *testing.T) {
 			},
 			args: args{
 				gkToCRDs: defaultGKToCRDs(),
-				comp: buildDefaultComposition(t, v1.CompositionValidationModeStrict, nil, withPatches(0, v1.Patch{
+				comp: buildDefaultComposition(t, v1.SchemaAwareCompositionValidationModeStrict, nil, withPatches(0, v1.Patch{
 					Type:          v1.PatchTypeFromEnvironmentFieldPath,
 					FromFieldPath: ptr.To("tier.name"),
 					ToFieldPath:   ptr.To("spec.someOtherWrongField"),
@@ -407,7 +407,7 @@ func TestValidatorValidate(t *testing.T) {
 			},
 			args: args{
 				gkToCRDs: defaultGKToCRDs(),
-				comp: buildDefaultComposition(t, v1.CompositionValidationModeStrict, nil, withPatches(0, v1.Patch{
+				comp: buildDefaultComposition(t, v1.SchemaAwareCompositionValidationModeStrict, nil, withPatches(0, v1.Patch{
 					Type:          v1.PatchTypeToEnvironmentFieldPath,
 					FromFieldPath: ptr.To("spec.someOtherField"),
 					ToFieldPath:   ptr.To("tier.name"),
@@ -426,7 +426,7 @@ func TestValidatorValidate(t *testing.T) {
 			},
 			args: args{
 				gkToCRDs: defaultGKToCRDs(),
-				comp: buildDefaultComposition(t, v1.CompositionValidationModeStrict, nil, withPatches(0, v1.Patch{
+				comp: buildDefaultComposition(t, v1.SchemaAwareCompositionValidationModeStrict, nil, withPatches(0, v1.Patch{
 					Type:          v1.PatchTypeToEnvironmentFieldPath,
 					FromFieldPath: ptr.To("spec.someOtherWrongField"),
 					ToFieldPath:   ptr.To("tier.name"),
@@ -440,7 +440,7 @@ func TestValidatorValidate(t *testing.T) {
 			},
 			args: args{
 				gkToCRDs: defaultGKToCRDs(),
-				comp: buildDefaultComposition(t, v1.CompositionValidationModeStrict, nil, withPatches(0, v1.Patch{
+				comp: buildDefaultComposition(t, v1.SchemaAwareCompositionValidationModeStrict, nil, withPatches(0, v1.Patch{
 					Type: v1.PatchTypeCombineToEnvironment,
 					Combine: &v1.Combine{
 						Variables: []v1.CombineVariable{
@@ -467,7 +467,7 @@ func TestValidatorValidate(t *testing.T) {
 			},
 			args: args{
 				gkToCRDs: defaultGKToCRDs(),
-				comp: buildDefaultComposition(t, v1.CompositionValidationModeStrict, nil, withPatches(0, v1.Patch{
+				comp: buildDefaultComposition(t, v1.SchemaAwareCompositionValidationModeStrict, nil, withPatches(0, v1.Patch{
 					Type: v1.PatchTypeCombineFromEnvironment,
 					Combine: &v1.Combine{
 						Variables: []v1.CombineVariable{
@@ -499,7 +499,7 @@ func TestValidatorValidate(t *testing.T) {
 			},
 			args: args{
 				gkToCRDs: defaultGKToCRDs(),
-				comp: buildDefaultComposition(t, v1.CompositionValidationModeStrict, nil, withPatches(0, v1.Patch{
+				comp: buildDefaultComposition(t, v1.SchemaAwareCompositionValidationModeStrict, nil, withPatches(0, v1.Patch{
 					Type: v1.PatchTypeCombineFromEnvironment,
 					Combine: &v1.Combine{
 						Variables: []v1.CombineVariable{
@@ -531,7 +531,7 @@ func TestValidatorValidate(t *testing.T) {
 			},
 			args: args{
 				gkToCRDs: defaultGKToCRDs(),
-				comp: buildDefaultComposition(t, v1.CompositionValidationModeStrict, nil, withPatches(0, v1.Patch{
+				comp: buildDefaultComposition(t, v1.SchemaAwareCompositionValidationModeStrict, nil, withPatches(0, v1.Patch{
 					Type: v1.PatchTypeCombineToEnvironment,
 					Combine: &v1.Combine{
 						Variables: []v1.CombineVariable{
@@ -558,7 +558,7 @@ func TestValidatorValidate(t *testing.T) {
 			},
 			args: args{
 				gkToCRDs: defaultGKToCRDs(),
-				comp: buildDefaultComposition(t, v1.CompositionValidationModeStrict, nil, withEnvironmentPatches(
+				comp: buildDefaultComposition(t, v1.SchemaAwareCompositionValidationModeStrict, nil, withEnvironmentPatches(
 					v1.EnvironmentPatch{
 						Type:          v1.PatchTypeFromCompositeFieldPath,
 						FromFieldPath: ptr.To("spec.someNonRequiredField"),
@@ -589,7 +589,7 @@ func TestValidatorValidate(t *testing.T) {
 			},
 			args: args{
 				gkToCRDs: defaultGKToCRDs(),
-				comp: buildDefaultComposition(t, v1.CompositionValidationModeStrict, nil, withEnvironmentPatches(
+				comp: buildDefaultComposition(t, v1.SchemaAwareCompositionValidationModeStrict, nil, withEnvironmentPatches(
 					v1.EnvironmentPatch{
 						Type:          v1.PatchTypeFromCompositeFieldPath,
 						FromFieldPath: ptr.To("spec.someWrongField"),
@@ -618,7 +618,7 @@ func TestValidatorValidate(t *testing.T) {
 			},
 			args: args{
 				gkToCRDs: defaultGKToCRDs(),
-				comp: buildDefaultComposition(t, v1.CompositionValidationModeStrict, nil, withEnvironmentPatches(
+				comp: buildDefaultComposition(t, v1.SchemaAwareCompositionValidationModeStrict, nil, withEnvironmentPatches(
 					v1.EnvironmentPatch{
 						Type:          v1.PatchTypeFromCompositeFieldPath,
 						FromFieldPath: ptr.To("spec.someWrongField"),
@@ -837,7 +837,7 @@ func buildDefaultComposition(t *testing.T, validationMode v1.CompositionValidati
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "testComposition",
 			Annotations: map[string]string{
-				v1.CompositionValidationModeAnnotation: string(validationMode),
+				v1.SchemaAwareCompositionValidationModeAnnotation: string(validationMode),
 			},
 		},
 		Spec: v1.CompositionSpec{

--- a/test/e2e/comp_schema_validation_test.go
+++ b/test/e2e/comp_schema_validation_test.go
@@ -39,6 +39,14 @@ func TestCompositionValidation(t *testing.T) {
 			Name:       "InvalidCompositionIsRejectedStrictMode",
 			Assessment: funcs.ResourcesFailToApply(FieldManager, manifests, "composition-invalid.yaml"),
 		},
+		{
+			// An invalid Composition should be accepted when validated in warn mode.
+			Name: "InvalidCompositionIsAcceptedWarnMode",
+			Assessment: funcs.AllOf(
+				funcs.ApplyResources(FieldManager, manifests, "composition-warn-valid.yaml"),
+				funcs.ResourcesCreatedWithin(30*time.Second, manifests, "composition-warn-valid.yaml"),
+			),
+		},
 	}
 	environment.Test(t,
 		cases.Build(t.Name()).

--- a/test/e2e/manifests/apiextensions/composition/validation/composition-invalid.yaml
+++ b/test/e2e/manifests/apiextensions/composition/validation/composition-invalid.yaml
@@ -3,7 +3,7 @@ kind: Composition
 metadata:
   name: invalid
   annotations:
-    crossplane.io/composition-validation-mode: strict
+    crossplane.io/composition-schema-aware-validation-mode: strict
 spec:
   compositeTypeRef:
     apiVersion: nop.example.org/v1alpha1

--- a/test/e2e/manifests/apiextensions/composition/validation/composition-transform-tojson-valid.yaml
+++ b/test/e2e/manifests/apiextensions/composition/validation/composition-transform-tojson-valid.yaml
@@ -3,7 +3,7 @@ kind: Composition
 metadata:
   name: valid-tojson-patch
   annotations:
-    crossplane.io/composition-validation-mode: strict
+    crossplane.io/composition-schema-aware-validation-mode: strict
 spec:
   compositeTypeRef:
     apiVersion: nop.example.org/v1alpha1

--- a/test/e2e/manifests/apiextensions/composition/validation/composition-valid.yaml
+++ b/test/e2e/manifests/apiextensions/composition/validation/composition-valid.yaml
@@ -3,7 +3,7 @@ kind: Composition
 metadata:
   name: valid
   annotations:
-    crossplane.io/composition-validation-mode: strict
+    crossplane.io/composition-schema-aware-validation-mode: strict
 spec:
   compositeTypeRef:
     apiVersion: nop.example.org/v1alpha1

--- a/test/e2e/manifests/apiextensions/composition/validation/composition-warn-valid.yaml
+++ b/test/e2e/manifests/apiextensions/composition/validation/composition-warn-valid.yaml
@@ -1,0 +1,41 @@
+apiVersion: apiextensions.crossplane.io/v1
+kind: Composition
+metadata:
+  name: valid-with-warnings
+  annotations:
+    crossplane.io/composition-validation-mode: warn
+spec:
+  compositeTypeRef:
+    apiVersion: nop.example.org/v1alpha1
+    kind: XNopResource
+  resources:
+  - name: nop-resource-1
+    base:
+     apiVersion: nop.crossplane.io/v1alpha1
+     kind: NopResource
+     spec:
+      forProvider:
+        conditionAfter:
+        - conditionType: Ready
+          conditionStatus: "False"
+          time: 0s
+        - conditionType: Ready
+          conditionStatus: "True"
+          time: 1s
+    patches:
+    - type: FromCompositeFieldPath
+      fromFieldPath: spec.coolField
+      toFieldPath: metadata.annotations[cool-field]
+      transforms:
+      - type: string
+        string:
+         type: Convert
+         convert: ToUpper
+    - type: ToCompositeFieldPath
+      fromFieldPath: metadata.annotations[cool-field]
+      toFieldPath: status.coolerField
+    # This patch should result in an error, because we're patching from a string
+    # to an integer field.
+    - type: ToCompositeFieldPath
+      fromFieldPath: metadata.annotations[cool-field]
+      toFieldPath: status.evenCoolerField

--- a/test/e2e/manifests/apiextensions/composition/validation/composition-warn-valid.yaml
+++ b/test/e2e/manifests/apiextensions/composition/validation/composition-warn-valid.yaml
@@ -3,7 +3,7 @@ kind: Composition
 metadata:
   name: valid-with-warnings
   annotations:
-    crossplane.io/composition-validation-mode: warn
+    crossplane.io/composition-schema-aware-validation-mode: warn
 spec:
   compositeTypeRef:
     apiVersion: nop.example.org/v1alpha1


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane! Please read the contribution docs
(linked below) if this is your first Crossplane pull request.
-->

### Description of your changes

<!--
Briefly describe what this pull request does, and how it is covered by tests.
Be proactive - direct your reviewers' attention to anything that needs special
consideration.

We love pull requests that fix an open issue. If yours does, use the below line
to indicate which issue it fixes, for example "Fixes #500".
-->

As discussed, this PR sets schema-aware composition validation to emit warnings only by default:
<img width="773" alt="image" src="https://github.com/crossplane/crossplane/assets/5697904/53d2e217-d77d-4e1e-9f22-207376b3636e">


I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added or updated unit tests.
- [x] Added or updated e2e tests.
- [ ] Linked a PR or a [docs tracking issue] to [document this change].
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/master/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/master/contributing#checklist-cheat-sheet
