### PR TITLE
crank/trace: fix order of column to match managed resources

### DIFF
--- a/cmd/crank/beta/trace/internal/printer/default.go
+++ b/cmd/crank/beta/trace/internal/printer/default.go
@@ -45,16 +45,16 @@ var _ Printer = &DefaultPrinter{}
 
 type defaultPrinterRow struct {
 	name   string
-	ready  string
 	synced string
+	ready  string
 	status string
 }
 
 func (r *defaultPrinterRow) String() string {
 	return strings.Join([]string{
 		r.name,
-		r.ready,
 		r.synced,
+		r.ready,
 		r.status,
 	}, "\t") + "\t"
 }
@@ -66,8 +66,8 @@ func (p *DefaultPrinter) Print(w io.Writer, root *resource.Resource) error {
 
 	headers := defaultPrinterRow{
 		name:   "NAME",
-		ready:  "READY",
 		synced: "SYNCED",
+		ready:  "READY",
 		status: "STATUS",
 	}
 	if _, err := fmt.Fprintln(tw, headers.String()); err != nil {
@@ -181,10 +181,10 @@ func getResourceStatus(r *resource.Resource, wide bool) (ready string, synced st
 		status = fmt.Sprintf("%s: %s", status, m)
 	}
 
-	return mapEmtyStatusToDash(readyCond.Status), mapEmtyStatusToDash(syncedCond.Status), status
+	return mapEmptyStatusToDash(readyCond.Status), mapEmptyStatusToDash(syncedCond.Status), status
 }
 
-func mapEmtyStatusToDash(s corev1.ConditionStatus) string {
+func mapEmptyStatusToDash(s corev1.ConditionStatus) string {
 	if s == "" {
 		return "-"
 	}

--- a/cmd/crank/beta/trace/internal/printer/default_test.go
+++ b/cmd/crank/beta/trace/internal/printer/default_test.go
@@ -52,15 +52,15 @@ func TestDefaultPrinter(t *testing.T) {
 			want: want{
 				// Note: Use spaces instead of tabs for intendation
 				output: `
-NAME                                                   READY   SYNCED    STATUS                                              
-ObjectStorage/test-resource (default)                  True    True                                                          
-└─ XObjectStorage/test-resource-hash                   True    True                                                          
-   ├─ Bucket/test-resource-bucket-hash                 True    True                                                          
-   │  ├─ User/test-resource-child-1-bucket-hash        False   True      SomethingWrongHappened: Error with bucket child 1   
-   │  ├─ User/test-resource-child-mid-bucket-hash      True    False     CantSync: Sync error with bucket child mid          
-   │  └─ User/test-resource-child-2-bucket-hash        False   True      SomethingWrongHappened: Error with bucket child 2   
-   │     └─ User/test-resource-child-2-1-bucket-hash   -       True                                                          
-   └─ User/test-resource-user-hash                     True    Unknown                                                       
+NAME                                                   SYNCED    READY   STATUS                                              
+ObjectStorage/test-resource (default)                  True      True                                                        
+└─ XObjectStorage/test-resource-hash                   True      True                                                        
+   ├─ Bucket/test-resource-bucket-hash                 True      True                                                        
+   │  ├─ User/test-resource-child-1-bucket-hash        True      False   SomethingWrongHappened: Error with bucket child 1   
+   │  ├─ User/test-resource-child-mid-bucket-hash      False     True    CantSync: Sync error with bucket child mid          
+   │  └─ User/test-resource-child-2-bucket-hash        True      False   SomethingWrongHappened: Error with bucket child 2   
+   │     └─ User/test-resource-child-2-1-bucket-hash   True      -                                                           
+   └─ User/test-resource-user-hash                     Unknown   True                                                        
 `,
 				err: nil,
 			},


### PR DESCRIPTION
### Description of your changes

Crossplane resources via kubectl show SYNCED READY in that order. Let's keep our mind sane by using the same order in the trace command :)

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added or updated unit tests.
- [ ] ~~Added or updated e2e tests.~~
- [ ] ~~Linked a PR or a [docs tracking issue] to [document this change].~~
- [ ] ~~Added `backport release-x.y` labels to auto-backport this PR.~~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/master/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/master/contributing#checklist-cheat-sheet