### PR TITLE
Promote Action: expose pre-release option

### DIFF
--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -10,6 +10,14 @@ on:
         description: 'Release channel'
         required: true
         default: 'stable'
+      # Note: For pre-releases, we want to promote the pre-release version to
+      # the (stable) channel, but not set it as the "current" version.
+      # See: https://github.com/upbound/build/pull/243
+      pre-release:
+        type: boolean
+        description: 'This is a pre-release'
+        required: true
+        default: false
 
 env:
   # Common versions
@@ -61,6 +69,7 @@ jobs:
         env:
           VERSION: ${{ github.event.inputs.version }}
           CHANNEL: ${{ github.event.inputs.channel }}
+          PRE_RELEASE: ${{ github.event.inputs.pre-release }}
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_USR }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_PSW }}
           AWS_DEFAULT_REGION: us-east-1


### PR DESCRIPTION
### Description of your changes

This PR exposes the `pre-release` input in the Promote Workflow.

We would like to ship pre-releases to get some early eyes on the release.
However, we don't want this release to be set as the "current" version, which is used by the cli [installation](https://github.com/crossplane/crossplane/blob/ee4cff4f70505083bf3f054e32ec938ecb373d01/install.sh#L6) script to identify the latest stable version.

See the relevant discussion [here](https://github.com/crossplane/crossplane/pull/4871#discussion_r1371900396).

Needs https://github.com/upbound/build/pull/243

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] ~Added or updated unit tests.~
- [ ] ~Added or updated e2e tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [x] Added `backport release-x.y` labels to auto-backport this PR.

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/master/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/master/contributing#checklist-cheat-sheet
