### PR TITLE
feat(cli/trace): support resource/name format

### DIFF
--- a/cmd/crank/beta/trace/trace_test.go
+++ b/cmd/crank/beta/trace/trace_test.go
@@ -1,0 +1,98 @@
+package trace
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+)
+
+func TestCmd_getResourceAndName(t *testing.T) {
+	type args struct {
+		Resource string
+		Name     string
+	}
+	type want struct {
+		resource string
+		name     string
+		err      error
+	}
+	tests := map[string]struct {
+		reason string
+		fields args
+		want   want
+	}{
+		"Splitted": {
+			reason: "Should return the resource and name if both are provided",
+			fields: args{
+				Resource: "resource",
+				Name:     "name",
+			},
+			want: want{
+				resource: "resource",
+				name:     "name",
+				err:      nil,
+			},
+		},
+		"OnlyResource": {
+			reason: "Should return an error if only resource is provided",
+			fields: args{
+				Resource: "resource",
+				Name:     "",
+			},
+			want: want{
+				err: cmpopts.AnyError,
+			},
+		},
+		"Empty": {
+			reason: "Should return an error if no resource is provided",
+			fields: args{
+				Resource: "",
+				Name:     "",
+			},
+			want: want{
+				err: cmpopts.AnyError,
+			},
+		},
+		"Combined": {
+			reason: "Should return the resource and name if both are provided combined as resource",
+			fields: args{
+				Resource: "resource/name",
+				Name:     "",
+			},
+			want: want{
+				resource: "resource",
+				name:     "name",
+			},
+		},
+		"MoreSlashes": {
+			reason: "Should return an error if the resource contains more than one slashes",
+			fields: args{
+				Resource: "resource/name/other",
+				Name:     "",
+			},
+			want: want{
+				err: cmpopts.AnyError,
+			},
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			c := &Cmd{
+				Resource: tt.fields.Resource,
+				Name:     tt.fields.Name,
+			}
+			gotResource, gotName, err := c.getResourceAndName()
+			if diff := cmp.Diff(tt.want.err, err, cmpopts.EquateErrors()); diff != "" {
+				t.Errorf("Cmd.getResourceAndName() error = %v, wantErr %v", err, tt.want.err)
+				return
+			}
+			if diff := cmp.Diff(tt.want.resource, gotResource); diff != "" {
+				t.Errorf("Cmd.getResourceAndName() resource = %v, want %v", gotResource, tt.want.resource)
+			}
+			if diff := cmp.Diff(tt.want.name, gotName); diff != "" {
+				t.Errorf("Cmd.getResourceAndName() name = %v, want %v", gotName, tt.want.name)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane! Please read the contribution docs
(linked below) if this is your first Crossplane pull request.
-->

### Description of your changes

<!--
Briefly describe what this pull request does, and how it is covered by tests.
Be proactive - direct your reviewers' attention to anything that needs special
consideration.

We love pull requests that fix an open issue. If yours does, use the below line
to indicate which issue it fixes, for example "Fixes #500".
-->

Fixes https://github.com/crossplane/crossplane/issues/4907.
Allow using trace subcommand with both syntaxes, same as `kubectl get`:
```
crossplane beta trace <RESOURCE>/<NAME>

crossplane beta trace <RESOURCE> <NAME>
```

```
$ crossplane beta trace --help
Usage: crossplane beta trace <resource> [<name>]

Trace a Crossplane resource to get a detailed output of its relationships,
helpful for troubleshooting.

This command trace a Crossplane resource (Claim, Composite, or Managed Resource)
to get a detailed output of its relationships, helpful for troubleshooting.

If needed the resource kind can be also specified further,
'TYPE[.VERSION][.GROUP]', e.g. mykind.example.org or
mykind.v1alpha1.example.org.

Examples:

    # Trace a MyKind resource (mykinds.example.org/v1alpha1) named 'my-res' in the namespace 'my-ns'
    crossplane beta trace mykind my-res -n my-ns

    # Output wide format, showing full errors and condition messages
    crossplane beta trace mykind my-res -n my-ns -o wide

    # Show connection secrets in the output
    crossplane beta trace mykind my-res -n my-ns --show-connection-secrets

    # Output a graph in dot format and pipe to dot to generate a png
    crossplane beta trace mykind my-res -n my-ns -o dot | dot -Tpng -o output.png

    # Output all retrieved resources to json and pipe to jq to have it coloured
    crossplane beta trace mykind my-res -n my-ns -o json | jq

    # Output debug logs to stderr while redirecting a dot formatted graph to dot
    crossplane beta trace mykind my-res -n my-ns -o dot --verbose | dot -Tpng -o output.png

Arguments:
  <resource>    Kind of the Crossplane resource, accepts the
                'TYPE[.VERSION][.GROUP][/NAME]' format.
  [<name>]      Name of the Crossplane resource, can be passed as part of the
                resource too.

Flags:
  -h, --help                       Show context-sensitive help.
      --verbose                    Print verbose logging statements.
  -v, --version                    Print version and quit.

  -n, --namespace="default"        Namespace of the resource.
  -o, --output="default"           Output format. One of: default, wide, json,
                                   dot.
  -s, --show-connection-secrets    Show connection secrets in the output.
```

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added or updated unit tests.
- [ ] ~Added or updated e2e tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [x] Added `backport release-x.y` labels to auto-backport this PR.

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/master/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/master/contributing#checklist-cheat-sheet
