### PR TITLE
curl should fail on 404

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -62,7 +62,7 @@ case $OS in
 esac
 
 url="https://releases.crossplane.io/${XP_CHANNEL}/${XP_VERSION}/bin/${OS_ARCH}/${BIN}"
-if ! curl -sLo crossplane "${url}"; then
+if ! curl -sfLo crossplane "${url}"; then
   echo "Failed to download Crossplane CLI. Please make sure version ${XP_VERSION} exists on channel ${XP_CHANNEL}."
   exit 1
 fi


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane! Please read the contribution docs
(linked below) if this is your first Crossplane pull request.
-->

### Description of your changes

<!--
Briefly describe what this pull request does, and how it is covered by tests.
Be proactive - direct your reviewers' attention to anything that needs special
consideration.

We love pull requests that fix an open issue. If yours does, use the below line
to indicate which issue it fixes, for example "Fixes #500".
-->

This adds the `-f` flag to the curl command.

```
 -f, --fail                 Fail fast with no output on HTTP errors
```

Today if there is a 404 response but a response body (i.e., a 404 page) curl doesn't fail and saves the HTML as `crossplane`. Unfortunately releases.crossplane.io does this.

This is confusing when you use the wrong `XP_VERSION` or `XP_CHANNEL` values. 

This causes the curl command to exit != 0 on any 404 response.

This was tested on Mac OS and Ubuntu.

```shell
cat ./install.sh | XP_VERSION=banana sh      
Failed to download Crossplane CLI. Please make sure version banana exists on channel stable.
```

Fixes # 

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
~- [ ] Run `make reviewable` to ensure this PR is ready for review.~
~- [ ] Added or updated unit tests.~
~- [ ] Added or updated e2e tests.~
~- [ ] Linked a PR or a [docs tracking issue] to [document this change].~
~- [ ] Added `backport release-x.y` labels to auto-backport this PR.~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/master/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/master/contributing#checklist-cheat-sheet
