### PR TITLE
Skip reconciliation on no-op claim and composite changes

### DIFF
--- a/internal/controller/apiextensions/definition/reconciler.go
+++ b/internal/controller/apiextensions/definition/reconciler.go
@@ -59,6 +59,7 @@ import (
 	apiextensionscontroller "github.com/crossplane/crossplane/internal/controller/apiextensions/controller"
 	"github.com/crossplane/crossplane/internal/features"
 	"github.com/crossplane/crossplane/internal/xcrd"
+	"github.com/crossplane/crossplane/pkg/controller/predicate"
 )
 
 const (
@@ -462,7 +463,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 	name := composite.ControllerName(d.GetName())
 	var ca cache.Cache
 	watches := []controller.Watch{
-		controller.For(u, &handler.EnqueueRequestForObject{}),
+		controller.For(u, &handler.EnqueueRequestForObject{}, predicate.IgnoreStatusChanges()),
 		// enqueue composites whenever a matching CompositionRevision is created
 		controller.TriggeredBy(source.Kind(r.mgr.GetCache(), &v1.CompositionRevision{}), handler.Funcs{
 			CreateFunc: composite.EnqueueForCompositionRevisionFunc(ck, r.mgr.GetCache().List, r.log),

--- a/internal/controller/apiextensions/offered/reconciler.go
+++ b/internal/controller/apiextensions/offered/reconciler.go
@@ -50,6 +50,7 @@ import (
 	apiextensionscontroller "github.com/crossplane/crossplane/internal/controller/apiextensions/controller"
 	"github.com/crossplane/crossplane/internal/features"
 	"github.com/crossplane/crossplane/internal/xcrd"
+	"github.com/crossplane/crossplane/pkg/controller/predicate"
 )
 
 const (
@@ -439,8 +440,8 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 	cp.SetGroupVersionKind(d.GetCompositeGroupVersionKind())
 
 	if err := r.claim.Start(claim.ControllerName(d.GetName()), ko,
-		controller.For(cm, &handler.EnqueueRequestForObject{}),
-		controller.For(cp, &EnqueueRequestForClaim{}),
+		controller.For(cm, &handler.EnqueueRequestForObject{}, predicate.IgnoreStatusChanges()),
+		controller.For(cp, &EnqueueRequestForClaim{}, predicate.IgnoreMetadataChanges()),
 	); err != nil {
 		err = errors.Wrap(err, errStartController)
 		r.record.Event(d, event.Warning(reasonOfferXRC, err))

--- a/pkg/controller/predicate/predicates.go
+++ b/pkg/controller/predicate/predicates.go
@@ -1,0 +1,71 @@
+/*
+Copyright 2020 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package predicate implements some useful event filters
+package predicate
+
+import (
+	"reflect"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+)
+
+// IgnoreStatusChanges does not trigger reconciliation
+// when object's status has been changed
+func IgnoreStatusChanges() predicate.Predicate {
+	return predicate.Or(
+		predicate.LabelChangedPredicate{},
+		predicate.AnnotationChangedPredicate{},
+		predicate.GenerationChangedPredicate{},
+	)
+}
+
+// IgnoreMetadataChanges does not trigger reconciliation
+// when object's metadata has been changed
+func IgnoreMetadataChanges() predicate.Predicate {
+	return predicate.Or(
+		predicate.GenerationChangedPredicate{},
+		StatusChangedPredicate{},
+	)
+}
+
+// StatusChangedPredicate triggers reconciliation
+// when object's status has been changed
+type StatusChangedPredicate struct {
+	predicate.Funcs
+}
+
+// Update implements default UpdateEvent filter for validating status change.
+func (p StatusChangedPredicate) Update(e event.UpdateEvent) bool {
+	if e.ObjectOld == nil {
+		return false
+	}
+	if e.ObjectNew == nil {
+		return false
+	}
+
+	uOld, err := runtime.DefaultUnstructuredConverter.ToUnstructured(e.ObjectOld)
+	if err != nil {
+		return false
+	}
+	uNew, err := runtime.DefaultUnstructuredConverter.ToUnstructured(e.ObjectNew)
+	if err != nil {
+		return false
+	}
+	return !reflect.DeepEqual(uNew["status"], uOld["status"])
+}

--- a/pkg/controller/predicate/predicates_test.go
+++ b/pkg/controller/predicate/predicates_test.go
@@ -1,0 +1,119 @@
+/*
+Copyright 2020 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package predicate
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+)
+
+func TestStatusChangedPredicate(t *testing.T) {
+	tests := map[string]struct {
+		reason string
+		event  event.UpdateEvent
+		want   bool
+	}{
+		"NoOldObject": {
+			reason: "update event is filtered out when the old object not exists",
+			event: event.UpdateEvent{
+				ObjectNew: &unstructured.Unstructured{},
+			},
+			want: false,
+		},
+		"NoNewObject": {
+			reason: "update event is filtered out when the new object not exists",
+			event: event.UpdateEvent{
+				ObjectOld: &unstructured.Unstructured{},
+			},
+			want: false,
+		},
+		"NoOldObjectStatus": {
+			reason: "update event not filtered out when old status does not exist but the new status exists",
+			event: event.UpdateEvent{
+				ObjectOld: &unstructured.Unstructured{},
+				ObjectNew: &unstructured.Unstructured{
+					Object: map[string]any{
+						"status": map[string]any{},
+					},
+				},
+			},
+			want: true,
+		},
+		"NoNewObjectStatus": {
+			reason: "update event not filtered out when old status exists but the new status does not",
+			event: event.UpdateEvent{
+				ObjectNew: &unstructured.Unstructured{},
+				ObjectOld: &unstructured.Unstructured{
+					Object: map[string]any{
+						"status": map[string]any{},
+					},
+				},
+			},
+			want: true,
+		},
+		"DifferentStatuses": {
+			reason: "update event not filtered out when statuses are different",
+			event: event.UpdateEvent{
+				ObjectNew: &unstructured.Unstructured{
+					Object: map[string]any{
+						"status": map[string]any{
+							"bar": "foo",
+						},
+					},
+				},
+				ObjectOld: &unstructured.Unstructured{
+					Object: map[string]any{
+						"status": map[string]any{
+							"foo": "bar",
+						},
+					},
+				},
+			},
+			want: true,
+		},
+		"EqualStatuses": {
+			reason: "update event filtered out when statuses are equal",
+			event: event.UpdateEvent{
+				ObjectNew: &unstructured.Unstructured{
+					Object: map[string]any{
+						"status": map[string]any{
+							"foo": "bar",
+						},
+					},
+				},
+				ObjectOld: &unstructured.Unstructured{
+					Object: map[string]any{
+						"status": map[string]any{
+							"foo": "bar",
+						},
+					},
+				},
+			},
+			want: false,
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			p := StatusChangedPredicate{}
+			if got := p.Update(tc.event); got != tc.want {
+				t.Errorf("%s: Update() = %v, want %v", tc.reason, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Description of your changes

Claim reconciliation needs to happen only on:
* a non-status claim change and/or
* a non-metadata composite change for the given claim

Composite reconciliation needs to happen only on:
* a non-status composite change

Changes:
* Added `IgnoreStatusChanges` and `IgnoreMetadataChanges` predicates for proper event filtering

Fixes #4703 

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added or updated unit tests.
- ~[ ] Added or updated e2e tests.~
- ~[ ] Linked a PR or a [docs tracking issue] to [document this change].~
- ~[ ] Added `backport release-x.y` labels to auto-backport this PR.~


[contribution process]: https://github.com/crossplane/crossplane/tree/master/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/master/contributing#checklist-cheat-sheet