### PR TITLE
Fix indentation in startup probe

### DIFF
--- a/cluster/charts/crossplane/templates/deployment.yaml
+++ b/cluster/charts/crossplane/templates/deployment.yaml
@@ -124,10 +124,10 @@ spec:
         resources:
           {{- toYaml .Values.resourcesCrossplane | nindent 12 }}
         startupProbe:
+          failureThreshold: 30
+          periodSeconds: 2
           tcpSocket:
             port: readyz
-            failureThreshold: 30
-            periodSeconds: 2
         ports:
         - name: readyz
           containerPort: 8081


### PR DESCRIPTION
### Description of your changes

Fixes the issue reported by @thoec [here](https://github.com/crossplane/crossplane/discussions/4906#discussioncomment-7403074).

With recent versions of helm, this is reported as `warning` without failing the installation:

```
W1027 15:25:09.222877   92835 warnings.go:70] unknown field "spec.template.spec.containers[0].startupProbe.tcpSocket.failureThreshold"
W1027 15:25:09.222891   92835 warnings.go:70] unknown field "spec.template.spec.containers[0].startupProbe.tcpSocket.periodSeconds"
```

I couldn't (yet) find a helm flag to configure failing in such cases, which could help us catch these kind of issues in our e2e. automatically.

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] ~Added or updated unit tests.~
- [ ] ~Added or updated e2e tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [x] Added `backport release-x.y` labels to auto-backport this PR.

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/master/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/master/contributing#checklist-cheat-sheet
