### PR TITLE
Handle externally managed Provider service accounts properly

### DIFF
--- a/cluster/charts/crossplane/templates/rbac-manager-clusterrole.yaml
+++ b/cluster/charts/crossplane/templates/rbac-manager-clusterrole.yaml
@@ -20,11 +20,18 @@ rules:
   - ""
   resources:
   - namespaces
-  - serviceaccounts
   verbs:
   - get
   - list
   - watch
+- apiGroups:
+    - apps
+  resources:
+    - deployments
+  verbs:
+    - get
+    - list
+    - watch
 # The RBAC manager creates a series of RBAC roles for each namespace it sees.
 # These RBAC roles are controlled (in the owner reference sense) by the namespace.
 # The RBAC manager needs permission to set finalizers on Namespaces in order to

--- a/internal/controller/pkg/revision/runtime.go
+++ b/internal/controller/pkg/revision/runtime.go
@@ -207,12 +207,12 @@ func (b *RuntimeManifestBuilder) Deployment(serviceAccount string, overrides ...
 			Privileged:               &privileged,
 			RunAsNonRoot:             &runAsNonRoot,
 		}),
+		DeploymentWithOptionalServiceAccount(serviceAccount),
 
 		// Overrides that we are opinionated about.
 		DeploymentWithNamespace(b.namespace),
 		DeploymentWithOwnerReferences([]metav1.OwnerReference{meta.AsController(meta.TypedReferenceTo(b.revision, b.revision.GetObjectKind().GroupVersionKind()))}),
 		DeploymentWithSelectors(b.podSelectors()),
-		DeploymentWithServiceAccount(serviceAccount),
 		DeploymentWithImagePullSecrets(b.revision.GetPackagePullSecrets()),
 		DeploymentRuntimeWithAdditionalPorts([]corev1.ContainerPort{
 			{

--- a/internal/controller/pkg/revision/runtime_function_test.go
+++ b/internal/controller/pkg/revision/runtime_function_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/utils/ptr"
@@ -188,6 +189,9 @@ func TestFunctionPostHook(t *testing.T) {
 				manifests: &MockManifestBuilder{
 					ServiceAccountFn: func(overrides ...ServiceAccountOverride) *corev1.ServiceAccount {
 						return &corev1.ServiceAccount{}
+					},
+					DeploymentFn: func(serviceAccount string, overrides ...DeploymentOverride) *appsv1.Deployment {
+						return &appsv1.Deployment{}
 					},
 				},
 				client: &test.MockClient{
@@ -368,6 +372,69 @@ func TestFunctionPostHook(t *testing.T) {
 								Status: corev1.ConditionTrue,
 							}}
 							return nil
+						}
+						return nil
+					},
+				},
+			},
+			want: want{
+				rev: &v1beta1.FunctionRevision{
+					Spec: v1beta1.FunctionRevisionSpec{
+						PackageRevisionSpec: v1.PackageRevisionSpec{
+							DesiredState: v1.PackageRevisionActive,
+						},
+					},
+				},
+			},
+		},
+		"SuccessfulWithExternallyManagedSA": {
+			reason: "Should be successful without creating an SA, when the SA is managed externally",
+			args: args{
+				pkg: &pkgmetav1beta1.Function{},
+				rev: &v1beta1.FunctionRevision{
+					Spec: v1beta1.FunctionRevisionSpec{
+						PackageRevisionSpec: v1.PackageRevisionSpec{
+							DesiredState: v1.PackageRevisionActive,
+						},
+					},
+				},
+				manifests: &MockManifestBuilder{
+					ServiceAccountFn: func(overrides ...ServiceAccountOverride) *corev1.ServiceAccount {
+						return &corev1.ServiceAccount{}
+					},
+					DeploymentFn: func(serviceAccount string, overrides ...DeploymentOverride) *appsv1.Deployment {
+						return &appsv1.Deployment{}
+					},
+				},
+				client: &test.MockClient{
+					MockGet: func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
+						if sa, ok := obj.(*corev1.ServiceAccount); ok {
+							if sa.GetName() == xpManagedSA {
+								return kerrors.NewNotFound(corev1.Resource("serviceaccount"), xpManagedSA)
+							}
+						}
+						return nil
+					},
+					MockCreate: func(ctx context.Context, obj client.Object, opts ...client.CreateOption) error {
+						if sa, ok := obj.(*corev1.ServiceAccount); ok {
+							if sa.GetName() == xpManagedSA {
+								t.Error("unexpected call to create SA when SA is managed externally")
+							}
+						}
+						return nil
+					},
+					MockPatch: func(ctx context.Context, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+						if d, ok := obj.(*appsv1.Deployment); ok {
+							d.Status.Conditions = []appsv1.DeploymentCondition{{
+								Type:   appsv1.DeploymentAvailable,
+								Status: corev1.ConditionTrue,
+							}}
+							return nil
+						}
+						if sa, ok := obj.(*corev1.ServiceAccount); ok {
+							if sa.GetName() == xpManagedSA {
+								t.Error("unexpected call to patch SA when the SA is managed externally")
+							}
 						}
 						return nil
 					},

--- a/internal/controller/pkg/revision/runtime_override_options.go
+++ b/internal/controller/pkg/revision/runtime_override_options.go
@@ -127,10 +127,12 @@ func DeploymentWithSelectors(selectors map[string]string) DeploymentOverride {
 	}
 }
 
-// DeploymentWithServiceAccount overrides the service account of a Deployment.
-func DeploymentWithServiceAccount(sa string) DeploymentOverride {
+// DeploymentWithOptionalServiceAccount overrides the service account of a Deployment.
+func DeploymentWithOptionalServiceAccount(sa string) DeploymentOverride {
 	return func(d *appsv1.Deployment) {
-		d.Spec.Template.Spec.ServiceAccountName = sa
+		if d.Spec.Template.Spec.ServiceAccountName == "" {
+			d.Spec.Template.Spec.ServiceAccountName = sa
+		}
 	}
 }
 

--- a/internal/controller/rbac/provider/binding/reconciler.go
+++ b/internal/controller/rbac/provider/binding/reconciler.go
@@ -25,7 +25,6 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	appsv1 "k8s.io/api/apps/v1"
-	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -76,7 +75,7 @@ func Setup(mgr ctrl.Manager, o controller.Options) error {
 		Named(name).
 		For(&v1.ProviderRevision{}).
 		Owns(&rbacv1.ClusterRoleBinding{}).
-		Watches(&corev1.ServiceAccount{}, handler.EnqueueRequestForOwner(mgr.GetScheme(), mgr.GetRESTMapper(), &v1.ProviderRevision{})).
+		Watches(&appsv1.Deployment{}, handler.EnqueueRequestForOwner(mgr.GetScheme(), mgr.GetRESTMapper(), &v1.ProviderRevision{})).
 		WithOptions(o.ForControllerRuntime()).
 		Complete(ratelimiter.NewReconciler(name, errors.WithSilentRequeueOnConflict(r), o.GlobalRateLimiter))
 }

--- a/internal/controller/rbac/provider/binding/reconciler.go
+++ b/internal/controller/rbac/provider/binding/reconciler.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
@@ -50,7 +51,7 @@ const (
 	timeout = 2 * time.Minute
 
 	errGetPR        = "cannot get ProviderRevision"
-	errListSAs      = "cannot list ServiceAccounts"
+	errDeployments  = "cannot list Deployments"
 	errApplyBinding = "cannot apply ClusterRoleBinding"
 
 	kindClusterRole = "ClusterRole"
@@ -169,27 +170,30 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 		return reconcile.Result{Requeue: false}, nil
 	}
 
-	l := &corev1.ServiceAccountList{}
+	l := &appsv1.DeploymentList{}
 	if err := r.client.List(ctx, l); err != nil {
-		err = errors.Wrap(err, errListSAs)
+		err = errors.Wrap(err, errDeployments)
 		r.record.Event(pr, event.Warning(reasonBind, err))
 		return reconcile.Result{}, err
 	}
 
-	// Filter down to the ServiceAccounts that are owned by this
+	// Filter down to the Deployments that are owned by this
 	// ProviderRevision. Each revision should control at most one, but it's easy
 	// and relatively harmless for us to handle there being many.
 	subjects := make([]rbacv1.Subject, 0)
 	subjectStrings := make([]string, 0)
-	for _, sa := range l.Items {
-		for _, ref := range sa.GetOwnerReferences() {
+	for _, d := range l.Items {
+		for _, ref := range d.GetOwnerReferences() {
 			if ref.UID == pr.GetUID() {
+				sa := d.Spec.Template.Spec.ServiceAccountName
+				ns := d.Namespace
+
 				subjects = append(subjects, rbacv1.Subject{
 					Kind:      rbacv1.ServiceAccountKind,
-					Namespace: sa.GetNamespace(),
-					Name:      sa.GetName(),
+					Namespace: ns,
+					Name:      sa,
 				})
-				subjectStrings = append(subjectStrings, sa.GetNamespace()+"/"+sa.GetName())
+				subjectStrings = append(subjectStrings, ns+"/"+sa)
 			}
 		}
 	}

--- a/internal/controller/rbac/provider/binding/reconciler_test.go
+++ b/internal/controller/rbac/provider/binding/reconciler_test.go
@@ -22,7 +22,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	corev1 "k8s.io/api/core/v1"
+	appsv1 "k8s.io/api/apps/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -112,8 +112,8 @@ func TestReconcile(t *testing.T) {
 				r: reconcile.Result{Requeue: false},
 			},
 		},
-		"ListServiceAccountsError": {
-			reason: "We should return an error encountered listing ServiceAccounts.",
+		"ListDeploymentsError": {
+			reason: "We should return an error encountered listing Deployments.",
 			args: args{
 				mgr: &fake.Manager{},
 				opts: []ReconcilerOption{
@@ -130,7 +130,7 @@ func TestReconcile(t *testing.T) {
 				},
 			},
 			want: want{
-				err: errors.Wrap(errBoom, errListSAs),
+				err: errors.Wrap(errBoom, errDeployments),
 			},
 		},
 		"ApplyClusterRoleBindingError": {
@@ -178,8 +178,8 @@ func TestReconcile(t *testing.T) {
 								// owned's UID matches that of the
 								// ProviderRevision because they're both the
 								// empty string.
-								l := o.(*corev1.ServiceAccountList)
-								l.Items = []corev1.ServiceAccount{{
+								l := o.(*appsv1.DeploymentList)
+								l.Items = []appsv1.Deployment{{
 									ObjectMeta: metav1.ObjectMeta{OwnerReferences: []metav1.OwnerReference{{}}},
 								}}
 								return nil

--- a/test/e2e/funcs/feature.go
+++ b/test/e2e/funcs/feature.go
@@ -361,7 +361,7 @@ func ResourceHasFieldValueWithin(d time.Duration, o k8s.Object, path string, wan
 		match := func(o k8s.Object) bool {
 			u := asUnstructured(o)
 			got, err := fieldpath.Pave(u.Object).GetValue(path)
-			if err != nil {
+			if err != nil && !fieldpath.IsNotFound(err) {
 				return false
 			}
 

--- a/test/e2e/manifests/pkg/externally-managed-service-account/claim.yaml
+++ b/test/e2e/manifests/pkg/externally-managed-service-account/claim.yaml
@@ -1,0 +1,10 @@
+apiVersion: nop.example.org/v1alpha1
+kind: NopResource
+metadata:
+  namespace: default
+  name: apiextensions-composition-functions
+spec:
+  coolField: "I'm cool!"
+  # This is necessary to ensure the claim's MRs are actually gone before we
+  # delete the Provider - https://github.com/crossplane/crossplane/issues/4251
+  compositeDeletePolicy: Foreground

--- a/test/e2e/manifests/pkg/externally-managed-service-account/setup/composition.yaml
+++ b/test/e2e/manifests/pkg/externally-managed-service-account/setup/composition.yaml
@@ -1,0 +1,44 @@
+apiVersion: apiextensions.crossplane.io/v1
+kind: Composition
+metadata:
+  name: xnopresources.nop.example.org
+spec:
+  compositeTypeRef:
+    apiVersion: nop.example.org/v1alpha1
+    kind: XNopResource
+  mode: Pipeline
+  pipeline:
+  - step: be-a-dummy
+    functionRef:
+      name: function-dummy
+    input:
+      apiVersion: dummy.fn.crossplane.io/v1beta1
+      kind: Response
+      # This is a YAML-serialized RunFunctionResponse. function-dummy will
+      # overlay the desired state on any that was passed into it.
+      response:
+        desired:
+          composite:
+            resource:
+              status:
+                coolerField: "I'M COOLER!"
+          resources:
+            nop-resource-1:
+              resource:
+                apiVersion: nop.crossplane.io/v1alpha1
+                kind: NopResource
+                spec:
+                  forProvider:
+                    conditionAfter:
+                    - conditionType: Ready
+                      conditionStatus: "False"
+                      time: 0s
+                    - conditionType: Ready
+                      conditionStatus: "True"
+                      time: 10s
+        results:
+         - severity: SEVERITY_NORMAL
+           message: "I am doing a compose!"
+  - step: detect-readiness
+    functionRef:
+      name: function-auto-ready

--- a/test/e2e/manifests/pkg/externally-managed-service-account/setup/definition.yaml
+++ b/test/e2e/manifests/pkg/externally-managed-service-account/setup/definition.yaml
@@ -1,0 +1,34 @@
+apiVersion: apiextensions.crossplane.io/v1
+kind: CompositeResourceDefinition
+metadata:
+  name: xnopresources.nop.example.org
+spec:
+  group: nop.example.org
+  names:
+    kind: XNopResource
+    plural: xnopresources
+  claimNames:
+    kind: NopResource
+    plural: nopresources
+  connectionSecretKeys:
+  - test
+  versions:
+  - name: v1alpha1
+    served: true
+    referenceable: true
+    schema:
+     openAPIV3Schema:
+       type: object
+       properties:
+        spec:
+          type: object
+          properties:
+            coolField:
+              type: string
+          required:
+          - coolField
+        status:
+          type: object
+          properties:
+            coolerField:
+              type: string

--- a/test/e2e/manifests/pkg/externally-managed-service-account/setup/deployment-runtime-config.yaml
+++ b/test/e2e/manifests/pkg/externally-managed-service-account/setup/deployment-runtime-config.yaml
@@ -1,0 +1,14 @@
+apiVersion: pkg.crossplane.io/v1beta1
+kind: DeploymentRuntimeConfig
+metadata:
+  name: provider-external-sa
+spec:
+  deploymentTemplate:
+    metadata:
+      name: provider-runtime
+    spec:
+      selector: {}
+      template:
+        spec:
+          containers: []
+          serviceAccountName: external-sa

--- a/test/e2e/manifests/pkg/externally-managed-service-account/setup/functions.yaml
+++ b/test/e2e/manifests/pkg/externally-managed-service-account/setup/functions.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: pkg.crossplane.io/v1beta1
+kind: Function
+metadata:
+  name: function-dummy
+spec:
+  # NOTE(negz): This is currently manually pushed. See README.md at
+  # https://github.com/crossplane-contrib/function-dummy.
+  package: xpkg.upbound.io/crossplane-contrib/function-dummy:v0.2.1
+---
+apiVersion: pkg.crossplane.io/v1beta1
+kind: Function
+metadata:
+  name: function-auto-ready
+spec:
+  # NOTE(negz): This is also currently manually pushed.
+  package: xpkg.upbound.io/crossplane-contrib/function-auto-ready:v0.1.2

--- a/test/e2e/manifests/pkg/externally-managed-service-account/setup/provider.yaml
+++ b/test/e2e/manifests/pkg/externally-managed-service-account/setup/provider.yaml
@@ -1,0 +1,9 @@
+apiVersion: pkg.crossplane.io/v1
+kind: Provider
+metadata:
+  name: provider-nop
+spec:
+  package: xpkg.upbound.io/crossplane-contrib/provider-nop:v0.2.0
+  ignoreCrossplaneConstraints: true
+  runtimeConfigRef:
+    name: provider-external-sa

--- a/test/e2e/manifests/pkg/externally-managed-service-account/setup/serviceaccount.yaml
+++ b/test/e2e/manifests/pkg/externally-managed-service-account/setup/serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: external-sa
+  namespace: crossplane-system


### PR DESCRIPTION
### Description of your changes

This PR:
- Changes the mechanism to find the Service Account used by a ProviderRevision from relying on owner references on the ServiceAccounts to checking the ServiceAccount used by the runtime Deployment. (Fixes #4552)
- Allows passing an externally managed Service Account via `DeploymentRuntimeConfig` and skipping the creation of the Service Account. (Fixes #4908)

After this PR, if the `deploymentTemplate.spec.template.spec.serviceAccountName` is set in the referenced `DeploymentRuntimeConfig`, Crossplane will:

- Just use it without trying to own it or creating a new one.
- Bind necessary RBAC permission to that Service Account.

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added or updated unit tests.
- [ ] ~Added or updated e2e tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [x] Added `backport release-x.y` labels to auto-backport this PR.

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/master/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/master/contributing#checklist-cheat-sheet
