### PR TITLE
More descriptive error for package parsing

### DIFF
--- a/internal/controller/pkg/revision/imageback.go
+++ b/internal/controller/pkg/revision/imageback.go
@@ -39,7 +39,7 @@ const (
 	errFetchLayer              = "failed to fetch annotated base layer from remote"
 	errGetUncompressed         = "failed to get uncompressed contents from layer"
 	errMultipleAnnotatedLayers = "package is invalid due to multiple annotated base layers"
-	errOpenPackageStream       = "failed to open package stream file"
+	errFmtNoPackageFileFound   = "couldn't find \"" + xpkg.StreamFile + "\" file after checking %d files in the archive (annotated layer: %v)"
 	errFmtMaxManifestLayers    = "package has %d layers, but only %d are allowed"
 	errValidateLayer           = "invalid package layer"
 	errValidateImage           = "invalid package image"
@@ -154,14 +154,16 @@ func (i *ImageBackend) Init(ctx context.Context, bo ...parser.BackendOption) (io
 	// layer contents or flattened filesystem content. Either way, we only want
 	// the package YAML stream.
 	t := tar.NewReader(tarc)
+	var read int
 	for {
 		h, err := t.Next()
 		if err != nil {
-			return nil, errors.Wrap(err, errOpenPackageStream)
+			return nil, errors.Wrapf(err, errFmtNoPackageFileFound, read, foundAnnotated)
 		}
 		if h.Name == xpkg.StreamFile {
 			break
 		}
+		read++
 	}
 
 	// NOTE(hasheddan): we return a JoinedReadCloser such that closing will free

--- a/internal/controller/pkg/revision/imageback_test.go
+++ b/internal/controller/pkg/revision/imageback_test.go
@@ -125,7 +125,7 @@ func TestImageBackend(t *testing.T) {
 					},
 				})},
 			},
-			want: errors.Wrap(io.EOF, errOpenPackageStream),
+			want: errors.Wrapf(io.EOF, errFmtNoPackageFileFound, 1, true),
 		},
 		"ErrEmptyImage": {
 			reason: "Should return error if image is empty.",
@@ -141,7 +141,7 @@ func TestImageBackend(t *testing.T) {
 					},
 				})},
 			},
-			want: errors.Wrap(io.EOF, errOpenPackageStream),
+			want: errors.Wrapf(io.EOF, errFmtNoPackageFileFound, 0, false),
 		},
 		"ErrFetchPackage": {
 			reason: "Should return error if package is not in cache and we fail to fetch it.",


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane! Please read the contribution docs
(linked below) if this is your first Crossplane pull request.
-->

### Description of your changes

<!--
Briefly describe what this pull request does, and how it is covered by tests.
Be proactive - direct your reviewers' attention to anything that needs special
consideration.

We love pull requests that fix an open issue. If yours does, use the below line
to indicate which issue it fixes, for example "Fixes #500".
-->

The original error message was not so useful to understand what was wrong in case of missing `package.yaml` file:
```
cannot initialize parser backend: failed to open package stream file: EOF
```

So, I'm adding the number of files read before erroring out to be able to understand whether the layer/image was empty and whether an annotated layer was found:
```
couldn't find "package.yaml" file after checking 1 files in the archive (annotated layer: true): EOF
```

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added or updated unit tests.
- [ ] ~Added or updated e2e tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [x] Added `backport release-x.y` labels to auto-backport this PR.

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/master/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/master/contributing#checklist-cheat-sheet
