### PR TITLE
DO NOT MERGE: Attempt to reproduce #4968

### DIFF
--- a/test/e2e/manifests/apiextensions/composition/functions/setup/composition.yaml
+++ b/test/e2e/manifests/apiextensions/composition/functions/setup/composition.yaml
@@ -22,6 +22,17 @@ spec:
             resource:
               status:
                 coolerField: "I'M COOLER!"
+                coolMap:
+                - name: kinda-cool
+                  coolness: 10
+                - name: a-bit-cooler
+                  coolness: 20
+                - name: getting-pretty-cool
+                  coolness: 30
+                - name: almost-there
+                  coolness: 40
+                - name: so-cool
+                  coolness: 50
           resources:
             # We compose a nested XR, which in turn composes an MR. This tests
             # regression of https://github.com/crossplane/crossplane/issues/4715.

--- a/test/e2e/manifests/apiextensions/composition/functions/setup/definition.yaml
+++ b/test/e2e/manifests/apiextensions/composition/functions/setup/definition.yaml
@@ -32,3 +32,17 @@ spec:
           properties:
             coolerField:
               type: string
+            coolMap:
+              type: array
+              items:
+                type: object
+                properties:
+                  name:
+                    type: string
+                  coolness:
+                    type: integer
+                required:
+                - name
+              x-kubernetes-list-type: map
+              x-kubernetes-list-map-keys:
+              - name


### PR DESCRIPTION
This commit adds an array of objects to the status returned by a composition function in order to try reproduce the issue in #4968 where the XR and claim never become ready.

<!--
Thank you for helping to improve Crossplane! Please read the contribution docs
(linked below) if this is your first Crossplane pull request.
-->

### Description of your changes

<!--
Briefly describe what this pull request does, and how it is covered by tests.
Be proactive - direct your reviewers' attention to anything that needs special
consideration.

We love pull requests that fix an open issue. If yours does, use the below line
to indicate which issue it fixes, for example "Fixes #500".
-->

Fixes # 

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added or updated unit tests.
- [ ] Added or updated e2e tests.
- [ ] Linked a PR or a [docs tracking issue] to [document this change].
- [ ] Added `backport release-x.y` labels to auto-backport this PR.

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/master/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/master/contributing#checklist-cheat-sheet
