### PR TITLE
Return after single arch push

### DIFF
--- a/cmd/crank/xpkg/push.go
+++ b/cmd/crank/xpkg/push.go
@@ -132,7 +132,7 @@ func (c *pushCmd) Run(logger logging.Logger) error { //nolint:gocyclo // This fe
 			return errors.Wrapf(err, errFmtPushPackage, c.PackageFiles[0])
 		}
 		logger.Debug("Pushed package", "path", c.PackageFiles[0], "ref", tag.String())
-        return nil
+		return nil
 	}
 
 	// If there's more than one package file we'll write (push) them all by

--- a/cmd/crank/xpkg/push.go
+++ b/cmd/crank/xpkg/push.go
@@ -132,6 +132,7 @@ func (c *pushCmd) Run(logger logging.Logger) error { //nolint:gocyclo // This fe
 			return errors.Wrapf(err, errFmtPushPackage, c.PackageFiles[0])
 		}
 		logger.Debug("Pushed package", "path", c.PackageFiles[0], "ref", tag.String())
+        return nil
 	}
 
 	// If there's more than one package file we'll write (push) them all by


### PR DESCRIPTION
When running `crossplane xpkg push` with a package built with a single architecture, the push command mistakenly falls through to the code block that adds an index to the manifest list. If done with a package built on anything other than linux/amd64, this confuses the package manager later, which will error out with a message like the following:

>```0s          Warning   ParsePackage              configurationrevision/platform-ref-apigateway-187041da383f   cannot initialize parser backend: failed to fetch package from remote: no child with platform linux/amd64 in index index.docker.io/steve/platform-ref-apigateway:v0.1.0```

This PR adds a return statement inside the  `len(c.PackageFiles) == 1` case.