### PR TITLE
Add a gRPC interceptor for function metrics

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/google/go-containerregistry v0.16.1
 	github.com/google/go-containerregistry/pkg/authn/k8schain v0.0.0-20230919002926-dbcd01c402b2
 	github.com/jmattheis/goverter v1.1.0
+	github.com/grpc-ecosystem/go-grpc-middleware/providers/prometheus v1.0.0
 	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/afero v1.10.0
@@ -67,6 +68,7 @@ require (
 	github.com/google/gnostic-models v0.6.8 // indirect
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 // indirect
 	github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7 // indirect
+	github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.0.0-rc.3 // indirect
 	github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 // indirect
 	github.com/jdx/go-netrc v1.0.0 // indirect
 	github.com/kevinburke/ssh_config v1.2.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,6 @@ require (
 	github.com/google/go-containerregistry v0.16.1
 	github.com/google/go-containerregistry/pkg/authn/k8schain v0.0.0-20230919002926-dbcd01c402b2
 	github.com/jmattheis/goverter v1.1.0
-	github.com/grpc-ecosystem/go-grpc-middleware/providers/prometheus v1.0.0
 	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/afero v1.10.0
@@ -68,7 +67,6 @@ require (
 	github.com/google/gnostic-models v0.6.8 // indirect
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 // indirect
 	github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7 // indirect
-	github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.0.0-rc.3 // indirect
 	github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 // indirect
 	github.com/jdx/go-netrc v1.0.0 // indirect
 	github.com/kevinburke/ssh_config v1.2.0 // indirect
@@ -176,7 +174,7 @@ require (
 	github.com/opencontainers/image-spec v1.1.0-rc5 // indirect
 	github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8 // indirect
 	github.com/pkg/profile v1.7.0 // indirect
-	github.com/prometheus/client_golang v1.16.0 // indirect
+	github.com/prometheus/client_golang v1.16.0
 	github.com/prometheus/client_model v0.4.0 // indirect
 	github.com/prometheus/common v0.44.0 // indirect
 	github.com/prometheus/procfs v0.10.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -212,7 +212,6 @@ github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.m
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=
 github.com/envoyproxy/go-control-plane v0.9.7/go.mod h1:cwu0lG7PUMfa9snN8LXBig5ynNVH9qI8YYLbd1fK2po=
 github.com/envoyproxy/go-control-plane v0.9.9-0.20201210154907-fd9021fe5dad/go.mod h1:cXg6YxExXjJnVBQHBLXeUAgxn2UodCpnH306RInaBQk=
-github.com/envoyproxy/go-control-plane v0.9.9-0.20210217033140-668b12f5399d/go.mod h1:cXg6YxExXjJnVBQHBLXeUAgxn2UodCpnH306RInaBQk=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/envoyproxy/protoc-gen-validate v1.0.2 h1:QkIBuU5k+x7/QXPvPPnWXWlCdaBFApVqftFV6k087DA=
 github.com/evanphx/json-patch v5.6.0+incompatible h1:jBYDEEiFBPxA0v50tFdvOzQQTCvpL6mnFh5mB2/l16U=
@@ -300,7 +299,6 @@ github.com/golang/protobuf v1.4.1/go.mod h1:U8fpvMrcmy5pZrNK1lt4xCsGvpyWQ/VVv6QD
 github.com/golang/protobuf v1.4.2/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw735rRwI=
 github.com/golang/protobuf v1.4.3/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw735rRwI=
 github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
-github.com/golang/protobuf v1.5.2/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
 github.com/golang/protobuf v1.5.3 h1:KhyjKVUg7Usr/dYsdSqoFveMYd5ko72D+zANwlG1mmg=
 github.com/golang/protobuf v1.5.3/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
@@ -363,10 +361,6 @@ github.com/googleapis/google-cloud-go-testing v0.0.0-20200911160855-bcd43fbb19e8
 github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7 h1:pdN6V1QBWetyv/0+wjACpqVH+eVULgEjkurDLq3goeM=
 github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=
-github.com/grpc-ecosystem/go-grpc-middleware/providers/prometheus v1.0.0 h1:f4tggROQKKcnh4eItay6z/HbHLqghBxS8g7pyMhmDio=
-github.com/grpc-ecosystem/go-grpc-middleware/providers/prometheus v1.0.0/go.mod h1:hKAkSgNkL0FII46ZkJcpVEAai4KV+swlIWCKfekd1pA=
-github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.0.0-rc.3 h1:o95KDiV/b1xdkumY5YbLR0/n2+wBxUpgf3HgfKgTyLI=
-github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.0.0-rc.3/go.mod h1:hTxjzRcX49ogbTGVJ1sM5mz5s+SSgiGIyL3jjPxl32E=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hexops/gotextdiff v1.0.3 h1:gitA9+qJrrTCsiCl7+kh75nPqQt1cx4ZkudSTLoUqJM=
@@ -652,7 +646,6 @@ golang.org/x/net v0.0.0-20201209123823-ac852fbbde11/go.mod h1:m0MpNAwzfU5UDzcl9v
 golang.org/x/net v0.0.0-20201224014010-6772e930b67b/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4/go.mod h1:p54w0d4576C0XHj96bSt6lcn1PtDYWL6XObtHCRCNQM=
-golang.org/x/net v0.0.0-20210423184538-5f58ad60dda6/go.mod h1:OJAsFXCWl8Ukc7SiCT/9KSuxbyM7479/AVlXFRxuMCk=
 golang.org/x/net v0.0.0-20211015210444-4f30a5c0130f/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20220722155237-a158d28d115b/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
@@ -671,7 +664,6 @@ golang.org/x/oauth2 v0.0.0-20200902213428-5d25da1a8d43/go.mod h1:KelEdhl1UZF7XfJ
 golang.org/x/oauth2 v0.0.0-20201109201403-9fd604954f58/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
 golang.org/x/oauth2 v0.0.0-20201208152858-08078c50e5b5/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
 golang.org/x/oauth2 v0.0.0-20210218202405-ba52d332ba99/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
-golang.org/x/oauth2 v0.0.0-20210413134643-5e61552d6c78/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
 golang.org/x/oauth2 v0.11.0 h1:vPL4xzxBM4niKCW6g9whtaWVXTJf1U5e4aZxxFx/gbU=
 golang.org/x/oauth2 v0.11.0/go.mod h1:LdF7O/8bLR/qWK9DrpXmbHLTouvRHK0SgJl0GmDBchk=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -893,7 +885,6 @@ google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013/go.mod h1:NbSheEEY
 google.golang.org/genproto v0.0.0-20200618031413-b414f8b61790/go.mod h1:jDfRM7FcilCzHH/e9qn6dsT145K34l5v+OpcnNgKAAA=
 google.golang.org/genproto v0.0.0-20200729003335-053ba62fc06f/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20200804131852-c06518451d9c/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
-google.golang.org/genproto v0.0.0-20200806141610-86f49bd18e98/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20200825200019-8632dd797987/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20200904004341-0bd0a958aa1d/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20201109203340-2640f1f9cdfb/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
@@ -922,12 +913,10 @@ google.golang.org/grpc v1.31.1/go.mod h1:N36X2cJ7JwdamYAgDz+s+rVMFjt3numwzf/HckM
 google.golang.org/grpc v1.33.2/go.mod h1:JMHMWHQWaTccqQQlmk3MJZS+GWXOdAesneDmEnv2fbc=
 google.golang.org/grpc v1.34.0/go.mod h1:WotjhfgOW/POjDeRt8vscBtXq+2VjORFy659qA51WJ8=
 google.golang.org/grpc v1.35.0/go.mod h1:qjiiYl8FncCW8feJPdyg3v6XW24KsRHe+dy9BAGRRjU=
-google.golang.org/grpc v1.37.0/go.mod h1:NREThFqKR1f3iQ6oBuvc5LadQuXVGo9rkm5ZGrQdJfM=
 google.golang.org/grpc v1.59.0 h1:Z5Iec2pjwb+LEOqzpB2MR12/eKFhDPhuqW91O+4bwUk=
 google.golang.org/grpc v1.59.0/go.mod h1:aUPDwccQo6OTjy7Hct4AfBPD1GptF4fyUjIkQ9YtF98=
 google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.3.0 h1:rNBFJjBCOgVr9pWD7rs/knKL4FRTKgpZmsRfV214zcA=
 google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.3.0/go.mod h1:Dk1tviKTvMCz5tvh7t+fh94dhmQVHuCt2OzJB3CTW9Y=
-google.golang.org/grpc/examples v0.0.0-20210424002626-9572fd6faeae/go.mod h1:Ly7ZA/ARzg8fnPU9TyZIxoz33sEUuWX7txiqs8lPTgE=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=
 google.golang.org/protobuf v0.0.0-20200221191635-4d8936d0db64/go.mod h1:kwYJMbMJ01Woi6D6+Kah6886xMZcty6N08ah7+eCXa0=
 google.golang.org/protobuf v0.0.0-20200228230310-ab0ca4ff8a60/go.mod h1:cfTl7dwQJ+fmap5saPgwCLgHXTUD7jkjRqWcaiX5VyM=

--- a/go.sum
+++ b/go.sum
@@ -212,6 +212,7 @@ github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.m
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=
 github.com/envoyproxy/go-control-plane v0.9.7/go.mod h1:cwu0lG7PUMfa9snN8LXBig5ynNVH9qI8YYLbd1fK2po=
 github.com/envoyproxy/go-control-plane v0.9.9-0.20201210154907-fd9021fe5dad/go.mod h1:cXg6YxExXjJnVBQHBLXeUAgxn2UodCpnH306RInaBQk=
+github.com/envoyproxy/go-control-plane v0.9.9-0.20210217033140-668b12f5399d/go.mod h1:cXg6YxExXjJnVBQHBLXeUAgxn2UodCpnH306RInaBQk=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/envoyproxy/protoc-gen-validate v1.0.2 h1:QkIBuU5k+x7/QXPvPPnWXWlCdaBFApVqftFV6k087DA=
 github.com/evanphx/json-patch v5.6.0+incompatible h1:jBYDEEiFBPxA0v50tFdvOzQQTCvpL6mnFh5mB2/l16U=
@@ -299,6 +300,7 @@ github.com/golang/protobuf v1.4.1/go.mod h1:U8fpvMrcmy5pZrNK1lt4xCsGvpyWQ/VVv6QD
 github.com/golang/protobuf v1.4.2/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw735rRwI=
 github.com/golang/protobuf v1.4.3/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw735rRwI=
 github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
+github.com/golang/protobuf v1.5.2/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
 github.com/golang/protobuf v1.5.3 h1:KhyjKVUg7Usr/dYsdSqoFveMYd5ko72D+zANwlG1mmg=
 github.com/golang/protobuf v1.5.3/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
@@ -361,6 +363,10 @@ github.com/googleapis/google-cloud-go-testing v0.0.0-20200911160855-bcd43fbb19e8
 github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7 h1:pdN6V1QBWetyv/0+wjACpqVH+eVULgEjkurDLq3goeM=
 github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=
+github.com/grpc-ecosystem/go-grpc-middleware/providers/prometheus v1.0.0 h1:f4tggROQKKcnh4eItay6z/HbHLqghBxS8g7pyMhmDio=
+github.com/grpc-ecosystem/go-grpc-middleware/providers/prometheus v1.0.0/go.mod h1:hKAkSgNkL0FII46ZkJcpVEAai4KV+swlIWCKfekd1pA=
+github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.0.0-rc.3 h1:o95KDiV/b1xdkumY5YbLR0/n2+wBxUpgf3HgfKgTyLI=
+github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.0.0-rc.3/go.mod h1:hTxjzRcX49ogbTGVJ1sM5mz5s+SSgiGIyL3jjPxl32E=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hexops/gotextdiff v1.0.3 h1:gitA9+qJrrTCsiCl7+kh75nPqQt1cx4ZkudSTLoUqJM=
@@ -646,6 +652,7 @@ golang.org/x/net v0.0.0-20201209123823-ac852fbbde11/go.mod h1:m0MpNAwzfU5UDzcl9v
 golang.org/x/net v0.0.0-20201224014010-6772e930b67b/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4/go.mod h1:p54w0d4576C0XHj96bSt6lcn1PtDYWL6XObtHCRCNQM=
+golang.org/x/net v0.0.0-20210423184538-5f58ad60dda6/go.mod h1:OJAsFXCWl8Ukc7SiCT/9KSuxbyM7479/AVlXFRxuMCk=
 golang.org/x/net v0.0.0-20211015210444-4f30a5c0130f/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20220722155237-a158d28d115b/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
@@ -664,6 +671,7 @@ golang.org/x/oauth2 v0.0.0-20200902213428-5d25da1a8d43/go.mod h1:KelEdhl1UZF7XfJ
 golang.org/x/oauth2 v0.0.0-20201109201403-9fd604954f58/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
 golang.org/x/oauth2 v0.0.0-20201208152858-08078c50e5b5/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
 golang.org/x/oauth2 v0.0.0-20210218202405-ba52d332ba99/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
+golang.org/x/oauth2 v0.0.0-20210413134643-5e61552d6c78/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
 golang.org/x/oauth2 v0.11.0 h1:vPL4xzxBM4niKCW6g9whtaWVXTJf1U5e4aZxxFx/gbU=
 golang.org/x/oauth2 v0.11.0/go.mod h1:LdF7O/8bLR/qWK9DrpXmbHLTouvRHK0SgJl0GmDBchk=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -885,6 +893,7 @@ google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013/go.mod h1:NbSheEEY
 google.golang.org/genproto v0.0.0-20200618031413-b414f8b61790/go.mod h1:jDfRM7FcilCzHH/e9qn6dsT145K34l5v+OpcnNgKAAA=
 google.golang.org/genproto v0.0.0-20200729003335-053ba62fc06f/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20200804131852-c06518451d9c/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
+google.golang.org/genproto v0.0.0-20200806141610-86f49bd18e98/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20200825200019-8632dd797987/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20200904004341-0bd0a958aa1d/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20201109203340-2640f1f9cdfb/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
@@ -913,10 +922,12 @@ google.golang.org/grpc v1.31.1/go.mod h1:N36X2cJ7JwdamYAgDz+s+rVMFjt3numwzf/HckM
 google.golang.org/grpc v1.33.2/go.mod h1:JMHMWHQWaTccqQQlmk3MJZS+GWXOdAesneDmEnv2fbc=
 google.golang.org/grpc v1.34.0/go.mod h1:WotjhfgOW/POjDeRt8vscBtXq+2VjORFy659qA51WJ8=
 google.golang.org/grpc v1.35.0/go.mod h1:qjiiYl8FncCW8feJPdyg3v6XW24KsRHe+dy9BAGRRjU=
+google.golang.org/grpc v1.37.0/go.mod h1:NREThFqKR1f3iQ6oBuvc5LadQuXVGo9rkm5ZGrQdJfM=
 google.golang.org/grpc v1.59.0 h1:Z5Iec2pjwb+LEOqzpB2MR12/eKFhDPhuqW91O+4bwUk=
 google.golang.org/grpc v1.59.0/go.mod h1:aUPDwccQo6OTjy7Hct4AfBPD1GptF4fyUjIkQ9YtF98=
 google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.3.0 h1:rNBFJjBCOgVr9pWD7rs/knKL4FRTKgpZmsRfV214zcA=
 google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.3.0/go.mod h1:Dk1tviKTvMCz5tvh7t+fh94dhmQVHuCt2OzJB3CTW9Y=
+google.golang.org/grpc/examples v0.0.0-20210424002626-9572fd6faeae/go.mod h1:Ly7ZA/ARzg8fnPU9TyZIxoz33sEUuWX7txiqs8lPTgE=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=
 google.golang.org/protobuf v0.0.0-20200221191635-4d8936d0db64/go.mod h1:kwYJMbMJ01Woi6D6+Kah6886xMZcty6N08ah7+eCXa0=
 google.golang.org/protobuf v0.0.0-20200228230310-ab0ca4ff8a60/go.mod h1:cfTl7dwQJ+fmap5saPgwCLgHXTUD7jkjRqWcaiX5VyM=

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -1,0 +1,24 @@
+/*
+Copyright 2023 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+this file except in compliance with the License. You may obtain a copy of the
+License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed
+under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+*/
+
+// Package metrics contains functionality for emitting Prometheus metrics.
+package metrics
+
+import "sigs.k8s.io/controller-runtime/pkg/metrics"
+
+// Registry is a Prometheus metrics registry. All Crossplane metrics should be
+// registered with it. Crossplane adds metrics to the registry created and
+// served by controller-runtime.
+var Registry = metrics.Registry

--- a/internal/xfn/function_runner.go
+++ b/internal/xfn/function_runner.go
@@ -67,7 +67,7 @@ const (
 type PackagedFunctionRunner struct {
 	client       client.Reader
 	creds        credentials.TransportCredentials
-	interceptors []grpc.UnaryClientInterceptor
+	interceptors []InterceptorCreator
 
 	connsMx sync.RWMutex
 	conns   map[string]*grpc.ClientConn
@@ -75,16 +75,16 @@ type PackagedFunctionRunner struct {
 	log logging.Logger
 }
 
+// An InterceptorCreator creates gRPC UnaryClientInterceptors for functions.
+type InterceptorCreator interface {
+	// CreateInterceptor creates an interceptor for the named function. It also
+	// accepts the function's package OCI reference, which may be used by the
+	// interceptor (e.g. to label metrics).
+	CreateInterceptor(name, pkg string) grpc.UnaryClientInterceptor
+}
+
 // A PackagedFunctionRunnerOption configures a PackagedFunctionRunner.
 type PackagedFunctionRunnerOption func(r *PackagedFunctionRunner)
-
-// WithInterceptors configures gRPC client interceptors (i.e. middlewares) that
-// the PackagedFunctionRunner should use.
-func WithInterceptors(i ...grpc.UnaryClientInterceptor) PackagedFunctionRunnerOption {
-	return func(r *PackagedFunctionRunner) {
-		r.interceptors = i
-	}
-}
 
 // WithLogger configures the logger the PackagedFunctionRunner should use.
 func WithLogger(l logging.Logger) PackagedFunctionRunnerOption {
@@ -97,6 +97,14 @@ func WithLogger(l logging.Logger) PackagedFunctionRunnerOption {
 func WithTLSConfig(cfg *tls.Config) PackagedFunctionRunnerOption {
 	return func(r *PackagedFunctionRunner) {
 		r.creds = credentials.NewTLS(cfg)
+	}
+}
+
+// WithInterceptorCreators configures the interceptors the
+// PackagedFunctionRunner should create for each function.
+func WithInterceptorCreators(ics ...InterceptorCreator) PackagedFunctionRunnerOption {
+	return func(r *PackagedFunctionRunner) {
+		r.interceptors = ics
 	}
 }
 
@@ -200,10 +208,15 @@ func (r *PackagedFunctionRunner) getClientConn(ctx context.Context, name string)
 	ctx, cancel := context.WithTimeout(ctx, dialFunctionTimeout)
 	defer cancel()
 
+	is := make([]grpc.UnaryClientInterceptor, len(r.interceptors))
+	for i := range r.interceptors {
+		is[i] = r.interceptors[i].CreateInterceptor(name, active.Spec.Package)
+	}
+
 	conn, err := grpc.DialContext(ctx, active.Status.Endpoint,
 		grpc.WithTransportCredentials(r.creds),
 		grpc.WithDefaultServiceConfig(lbRoundRobin),
-		grpc.WithChainUnaryInterceptor(r.interceptors...))
+		grpc.WithChainUnaryInterceptor(is...))
 	if err != nil {
 		return nil, errors.Wrapf(err, errFmtDialFunction, active.Status.Endpoint, active.GetName())
 	}

--- a/internal/xfn/function_runner_metrics.go
+++ b/internal/xfn/function_runner_metrics.go
@@ -41,20 +41,20 @@ func NewMetrics() *Metrics {
 			Subsystem: "composition",
 			Name:      "run_function_request_total",
 			Help:      "Total number of RunFunctionRequests sent.",
-		}, []string{"name", "package", "target"}),
+		}, []string{"function_name", "function_package", "grpc_target"}),
 
 		responses: prometheus.NewCounterVec(prometheus.CounterOpts{
 			Subsystem: "composition",
 			Name:      "run_function_response_total",
 			Help:      "Total number of RunFunctionResponses received.",
-		}, []string{"name", "package", "target", "grpc_code", "severity"}),
+		}, []string{"function_name", "function_package", "grpc_target", "grpc_code", "result_severity"}),
 
 		duration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
 			Subsystem: "composition",
 			Name:      "run_function_seconds",
 			Help:      "Histogram of RunFunctionResponse latency (seconds).",
 			Buckets:   prometheus.DefBuckets,
-		}, []string{"name", "package", "target", "grpc_code", "severity"}),
+		}, []string{"function_name", "function_package", "grpc_target", "grpc_code", "result_severity"}),
 	}
 }
 
@@ -80,7 +80,7 @@ func (m *Metrics) Collect(ch chan<- prometheus.Metric) {
 // function. The supplied package (pkg) should be the package's OCI reference.
 func (m *Metrics) CreateInterceptor(name, pkg string) grpc.UnaryClientInterceptor {
 	return func(ctx context.Context, method string, req, reply any, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
-		l := prometheus.Labels{"name": name, "package": pkg, "target": cc.Target()}
+		l := prometheus.Labels{"function_name": name, "function_package": pkg, "grpc_target": cc.Target()}
 
 		m.requests.With(l).Inc()
 
@@ -95,18 +95,18 @@ func (m *Metrics) CreateInterceptor(name, pkg string) grpc.UnaryClientIntercepto
 		// normal results, has severity "Normal". A response with warnings, but
 		// no fatal results, has severity "Warning". A response with fatal
 		// results has severity "Fatal".
-		l["severity"] = "Normal"
+		l["result_severity"] = "Normal"
 		if rsp, ok := reply.(*v1beta1.RunFunctionResponse); ok {
 			for _, r := range rsp.GetResults() {
 				// Keep iterating if we see a warning result - we might still
 				// see a fatal result.
 				if r.GetSeverity() == v1beta1.Severity_SEVERITY_WARNING {
-					l["severity"] = "Warning"
+					l["result_severity"] = "Warning"
 				}
 				// Break if we see a fatal result, to ensure we don't downgrade
 				// the severity to warning.
 				if r.GetSeverity() == v1beta1.Severity_SEVERITY_FATAL {
-					l["severity"] = "Fatal"
+					l["result_severity"] = "Fatal"
 					break
 				}
 			}

--- a/internal/xfn/function_runner_metrics.go
+++ b/internal/xfn/function_runner_metrics.go
@@ -88,7 +88,8 @@ func (m *Metrics) CreateInterceptor(name, pkg string) grpc.UnaryClientIntercepto
 		err := invoker(ctx, method, req, reply, cc, opts...)
 		duration := time.Since(start)
 
-		l["grpc_code"] = FromError(err).Code().String()
+		s, _ := status.FromError(err)
+		l["grpc_code"] = s.Code().String()
 
 		// We consider the 'severity' of the response to be that of the most
 		// severe result in the response. A response with no results, or only
@@ -117,15 +118,4 @@ func (m *Metrics) CreateInterceptor(name, pkg string) grpc.UnaryClientIntercepto
 
 		return err
 	}
-}
-
-// FromError returns a grpc status. If the error code is neither a valid grpc
-// status nor a context error, codes.Unknown will be set.
-func FromError(err error) *status.Status {
-	s, ok := status.FromError(err)
-	// Mirror what the grpc server itself does, i.e. also convert context errors to status
-	if !ok {
-		s = status.FromContextError(err)
-	}
-	return s
 }

--- a/internal/xfn/function_runner_metrics.go
+++ b/internal/xfn/function_runner_metrics.go
@@ -1,0 +1,131 @@
+/*
+Copyright 2023 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+this file except in compliance with the License. You may obtain a copy of the
+License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed
+under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+*/
+
+package xfn
+
+import (
+	"context"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/status"
+
+	"github.com/crossplane/crossplane/apis/apiextensions/fn/proto/v1beta1"
+)
+
+// Metrics are requests, errors, and duration (RED) metrics for composition
+// function runs.
+type Metrics struct {
+	requests  *prometheus.CounterVec
+	responses *prometheus.CounterVec
+	duration  *prometheus.HistogramVec
+}
+
+// NewMetrics creates metrics for composition function runs.
+func NewMetrics() *Metrics {
+	return &Metrics{
+		requests: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Subsystem: "composition",
+			Name:      "run_function_request_total",
+			Help:      "Total number of RunFunctionRequests sent.",
+		}, []string{"name", "package", "target"}),
+
+		responses: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Subsystem: "composition",
+			Name:      "run_function_response_total",
+			Help:      "Total number of RunFunctionResponses received.",
+		}, []string{"name", "package", "target", "grpc_code", "severity"}),
+
+		duration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
+			Subsystem: "composition",
+			Name:      "run_function_seconds",
+			Help:      "Histogram of RunFunctionResponse latency (seconds).",
+			Buckets:   prometheus.DefBuckets,
+		}, []string{"name", "package", "target", "grpc_code", "severity"}),
+	}
+}
+
+// Describe sends the super-set of all possible descriptors of metrics
+// collected by this Collector to the provided channel and returns once
+// the last descriptor has been sent.
+func (m *Metrics) Describe(ch chan<- *prometheus.Desc) {
+	m.requests.Describe(ch)
+	m.responses.Describe(ch)
+	m.duration.Describe(ch)
+}
+
+// Collect is called by the Prometheus registry when collecting
+// metrics. The implementation sends each collected metric via the
+// provided channel and returns once the last metric has been sent.
+func (m *Metrics) Collect(ch chan<- prometheus.Metric) {
+	m.requests.Collect(ch)
+	m.responses.Collect(ch)
+	m.duration.Collect(ch)
+}
+
+// CreateInterceptor returns a gRPC UnaryClientInterceptor for the named
+// function. The supplied package (pkg) should be the package's OCI reference.
+func (m *Metrics) CreateInterceptor(name, pkg string) grpc.UnaryClientInterceptor {
+	return func(ctx context.Context, method string, req, reply any, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
+		l := prometheus.Labels{"name": name, "package": pkg, "target": cc.Target()}
+
+		m.requests.With(l).Inc()
+
+		start := time.Now()
+		err := invoker(ctx, method, req, reply, cc, opts...)
+		duration := time.Since(start)
+
+		l["grpc_code"] = FromError(err).Code().String()
+
+		// We consider the 'severity' of the response to be that of the most
+		// severe result in the response. A response with no results, or only
+		// normal results, has severity "Normal". A response with warnings, but
+		// no fatal results, has severity "Warning". A response with fatal
+		// results has severity "Fatal".
+		l["severity"] = "Normal"
+		if rsp, ok := reply.(*v1beta1.RunFunctionResponse); ok {
+			for _, r := range rsp.GetResults() {
+				// Keep iterating if we see a warning result - we might still
+				// see a fatal result.
+				if r.GetSeverity() == v1beta1.Severity_SEVERITY_WARNING {
+					l["severity"] = "Warning"
+				}
+				// Break if we see a fatal result, to ensure we don't downgrade
+				// the severity to warning.
+				if r.GetSeverity() == v1beta1.Severity_SEVERITY_FATAL {
+					l["severity"] = "Fatal"
+					break
+				}
+			}
+		}
+
+		m.responses.With(l).Inc()
+		m.duration.With(l).Observe(duration.Seconds())
+
+		return err
+	}
+}
+
+// FromError returns a grpc status. If the error code is neither a valid grpc
+// status nor a context error, codes.Unknown will be set.
+func FromError(err error) *status.Status {
+	s, ok := status.FromError(err)
+	// Mirror what the grpc server itself does, i.e. also convert context errors to status
+	if !ok {
+		s = status.FromContextError(err)
+	}
+	return s
+}

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -82,6 +82,7 @@ func TestMain(m *testing.M) {
 				"--set args={--debug}",
 				"--set image.repository="+strings.Split(imgcore, ":")[0],
 				"--set image.tag="+strings.Split(imgcore, ":")[1],
+				"--set metrics.enabled=true",
 			),
 		),
 		config.WithLabelsToSelect(features.Labels{


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane! Please read the contribution docs
(linked below) if this is your first Crossplane pull request.
-->

### Description of your changes

<!--
Briefly describe what this pull request does, and how it is covered by tests.
Be proactive - direct your reviewers' attention to anything that needs special
consideration.

We love pull requests that fix an open issue. If yours does, use the below line
to indicate which issue it fixes, for example "Fixes #500".
-->

Fixes https://github.com/crossplane/crossplane/issues/5001

This adds some basic [RED](https://www.weave.works/blog/the-red-method-key-metrics-for-microservices-architecture/) metrics for functions:

* RunFunctionRequests sent (count)
* RunFunctionResponses received (count)
* RunFunction duration (histogram)

All metrics are labelled by function name, package, and gRPC target. Responses are also labelled with gRPC status code and "severity". The gRPC status code represents whether the function successfully returned a response. The severity indicates whether the response was successful. We consider the severity of the response to be the severity of the most severe result in the response. So a response that returns a fatal result has a severity of fatal. This will allow folks to monitor how often a function is successfully returning a response, but a fatal response.

Example metrics from an E2E test run:

```shell
# HELP composition_run_function_request_total Total number of RunFunctionRequests sent.
# TYPE composition_run_function_request_total counter
composition_run_function_request_total{function_name="function-auto-ready",function_package="xpkg.upbound.io/crossplane-contrib/function-auto-ready:v0.1.2",grpc_target="dns:///function-auto-ready.crossplane-system:9443"} 9
composition_run_function_request_total{function_name="function-dummy",function_package="xpkg.upbound.io/crossplane-contrib/function-dummy:v0.2.1",grpc_target="dns:///function-dummy.crossplane-system:9443"} 14
# HELP composition_run_function_response_total Total number of RunFunctionResponses received.
# TYPE composition_run_function_response_total counter
composition_run_function_response_total{function_name="function-auto-ready",function_package="xpkg.upbound.io/crossplane-contrib/function-auto-ready:v0.1.2",grpc_code="OK",grpc_target="dns:///function-auto-ready.crossplane-system:9443",result_severity="Normal"} 9
composition_run_function_response_total{function_name="function-dummy",function_package="xpkg.upbound.io/crossplane-contrib/function-dummy:v0.2.1",grpc_code="OK",grpc_target="dns:///function-dummy.crossplane-system:9443",result_severity="Normal"} 14
# HELP composition_run_function_seconds Histogram of RunFunctionResponse latency (seconds).
# TYPE composition_run_function_seconds histogram
composition_run_function_seconds_bucket{function_name="function-auto-ready",function_package="xpkg.upbound.io/crossplane-contrib/function-auto-ready:v0.1.2",grpc_code="OK",grpc_target="dns:///function-auto-ready.crossplane-system:9443",result_severity="Normal",le="0.005"} 6
composition_run_function_seconds_bucket{function_name="function-auto-ready",function_package="xpkg.upbound.io/crossplane-contrib/function-auto-ready:v0.1.2",grpc_code="OK",grpc_target="dns:///function-auto-ready.crossplane-system:9443",result_severity="Normal",le="0.01"} 7
composition_run_function_seconds_bucket{function_name="function-auto-ready",function_package="xpkg.upbound.io/crossplane-contrib/function-auto-ready:v0.1.2",grpc_code="OK",grpc_target="dns:///function-auto-ready.crossplane-system:9443",result_severity="Normal",le="0.025"} 7
composition_run_function_seconds_bucket{function_name="function-auto-ready",function_package="xpkg.upbound.io/crossplane-contrib/function-auto-ready:v0.1.2",grpc_code="OK",grpc_target="dns:///function-auto-ready.crossplane-system:9443",result_severity="Normal",le="0.05"} 7
composition_run_function_seconds_bucket{function_name="function-auto-ready",function_package="xpkg.upbound.io/crossplane-contrib/function-auto-ready:v0.1.2",grpc_code="OK",grpc_target="dns:///function-auto-ready.crossplane-system:9443",result_severity="Normal",le="0.1"} 8
composition_run_function_seconds_bucket{function_name="function-auto-ready",function_package="xpkg.upbound.io/crossplane-contrib/function-auto-ready:v0.1.2",grpc_code="OK",grpc_target="dns:///function-auto-ready.crossplane-system:9443",result_severity="Normal",le="0.25"} 9
composition_run_function_seconds_bucket{function_name="function-auto-ready",function_package="xpkg.upbound.io/crossplane-contrib/function-auto-ready:v0.1.2",grpc_code="OK",grpc_target="dns:///function-auto-ready.crossplane-system:9443",result_severity="Normal",le="0.5"} 9
composition_run_function_seconds_bucket{function_name="function-auto-ready",function_package="xpkg.upbound.io/crossplane-contrib/function-auto-ready:v0.1.2",grpc_code="OK",grpc_target="dns:///function-auto-ready.crossplane-system:9443",result_severity="Normal",le="1"} 9
composition_run_function_seconds_bucket{function_name="function-auto-ready",function_package="xpkg.upbound.io/crossplane-contrib/function-auto-ready:v0.1.2",grpc_code="OK",grpc_target="dns:///function-auto-ready.crossplane-system:9443",result_severity="Normal",le="2.5"} 9
composition_run_function_seconds_bucket{function_name="function-auto-ready",function_package="xpkg.upbound.io/crossplane-contrib/function-auto-ready:v0.1.2",grpc_code="OK",grpc_target="dns:///function-auto-ready.crossplane-system:9443",result_severity="Normal",le="5"} 9
composition_run_function_seconds_bucket{function_name="function-auto-ready",function_package="xpkg.upbound.io/crossplane-contrib/function-auto-ready:v0.1.2",grpc_code="OK",grpc_target="dns:///function-auto-ready.crossplane-system:9443",result_severity="Normal",le="10"} 9
composition_run_function_seconds_bucket{function_name="function-auto-ready",function_package="xpkg.upbound.io/crossplane-contrib/function-auto-ready:v0.1.2",grpc_code="OK",grpc_target="dns:///function-auto-ready.crossplane-system:9443",result_severity="Normal",le="+Inf"} 9
composition_run_function_seconds_sum{function_name="function-auto-ready",function_package="xpkg.upbound.io/crossplane-contrib/function-auto-ready:v0.1.2",grpc_code="OK",grpc_target="dns:///function-auto-ready.crossplane-system:9443",result_severity="Normal"} 0.23078379300000001
composition_run_function_seconds_count{function_name="function-auto-ready",function_package="xpkg.upbound.io/crossplane-contrib/function-auto-ready:v0.1.2",grpc_code="OK",grpc_target="dns:///function-auto-ready.crossplane-system:9443",result_severity="Normal"} 9
composition_run_function_seconds_bucket{function_name="function-dummy",function_package="xpkg.upbound.io/crossplane-contrib/function-dummy:v0.2.1",grpc_code="OK",grpc_target="dns:///function-dummy.crossplane-system:9443",result_severity="Normal",le="0.005"} 9
composition_run_function_seconds_bucket{function_name="function-dummy",function_package="xpkg.upbound.io/crossplane-contrib/function-dummy:v0.2.1",grpc_code="OK",grpc_target="dns:///function-dummy.crossplane-system:9443",result_severity="Normal",le="0.01"} 9
composition_run_function_seconds_bucket{function_name="function-dummy",function_package="xpkg.upbound.io/crossplane-contrib/function-dummy:v0.2.1",grpc_code="OK",grpc_target="dns:///function-dummy.crossplane-system:9443",result_severity="Normal",le="0.025"} 10
composition_run_function_seconds_bucket{function_name="function-dummy",function_package="xpkg.upbound.io/crossplane-contrib/function-dummy:v0.2.1",grpc_code="OK",grpc_target="dns:///function-dummy.crossplane-system:9443",result_severity="Normal",le="0.05"} 10
composition_run_function_seconds_bucket{function_name="function-dummy",function_package="xpkg.upbound.io/crossplane-contrib/function-dummy:v0.2.1",grpc_code="OK",grpc_target="dns:///function-dummy.crossplane-system:9443",result_severity="Normal",le="0.1"} 13
composition_run_function_seconds_bucket{function_name="function-dummy",function_package="xpkg.upbound.io/crossplane-contrib/function-dummy:v0.2.1",grpc_code="OK",grpc_target="dns:///function-dummy.crossplane-system:9443",result_severity="Normal",le="0.25"} 13
composition_run_function_seconds_bucket{function_name="function-dummy",function_package="xpkg.upbound.io/crossplane-contrib/function-dummy:v0.2.1",grpc_code="OK",grpc_target="dns:///function-dummy.crossplane-system:9443",result_severity="Normal",le="0.5"} 13
composition_run_function_seconds_bucket{function_name="function-dummy",function_package="xpkg.upbound.io/crossplane-contrib/function-dummy:v0.2.1",grpc_code="OK",grpc_target="dns:///function-dummy.crossplane-system:9443",result_severity="Normal",le="1"} 13
composition_run_function_seconds_bucket{function_name="function-dummy",function_package="xpkg.upbound.io/crossplane-contrib/function-dummy:v0.2.1",grpc_code="OK",grpc_target="dns:///function-dummy.crossplane-system:9443",result_severity="Normal",le="2.5"} 14
composition_run_function_seconds_bucket{function_name="function-dummy",function_package="xpkg.upbound.io/crossplane-contrib/function-dummy:v0.2.1",grpc_code="OK",grpc_target="dns:///function-dummy.crossplane-system:9443",result_severity="Normal",le="5"} 14
composition_run_function_seconds_bucket{function_name="function-dummy",function_package="xpkg.upbound.io/crossplane-contrib/function-dummy:v0.2.1",grpc_code="OK",grpc_target="dns:///function-dummy.crossplane-system:9443",result_severity="Normal",le="10"} 14
composition_run_function_seconds_bucket{function_name="function-dummy",function_package="xpkg.upbound.io/crossplane-contrib/function-dummy:v0.2.1",grpc_code="OK",grpc_target="dns:///function-dummy.crossplane-system:9443",result_severity="Normal",le="+Inf"} 14
composition_run_function_seconds_sum{function_name="function-dummy",function_package="xpkg.upbound.io/crossplane-contrib/function-dummy:v0.2.1",grpc_code="OK",grpc_target="dns:///function-dummy.crossplane-system:9443",result_severity="Normal"} 1.5026575030000002
composition_run_function_seconds_count{function_name="function-dummy",function_package="xpkg.upbound.io/crossplane-contrib/function-dummy:v0.2.1",grpc_code="OK",grpc_target="dns:///function-dummy.crossplane-system:9443",result_severity="Normal"} 14
```

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] ~Added or updated unit tests.~
- [ ] ~Added or updated e2e tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/master/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/master/contributing#checklist-cheat-sheet
