### PR TITLE
feat(cli): sort composed resources in the render output

### DIFF
--- a/cmd/crank/beta/render/cmd.go
+++ b/cmd/crank/beta/render/cmd.go
@@ -190,8 +190,7 @@ func (c *Cmd) Run(k *kong.Context, _ logging.Logger) error { //nolint:gocyclo //
 	for i := range out.ComposedResources {
 		fmt.Fprintln(k.Stdout, "---")
 		if err := s.Encode(&out.ComposedResources[i], os.Stdout); err != nil {
-			// TODO(negz): Use composed name annotation instead.
-			return errors.Wrapf(err, "cannot marshal composed resource %q to YAML", out.ComposedResources[i].GetName())
+			return errors.Wrapf(err, "cannot marshal composed resource %q to YAML", out.ComposedResources[i].GetAnnotations()[AnnotationKeyCompositionResourceName])
 		}
 	}
 

--- a/cmd/crank/beta/render/render_test.go
+++ b/cmd/crank/beta/render/render_test.go
@@ -216,10 +216,19 @@ func TestRender(t *testing.T) {
 										}`),
 									},
 									Resources: map[string]*fnv1beta1.Resource{
-										"cool-resource": {
+										"b-cool-resource": {
 											Resource: MustStructJSON(`{
-												"apiVersion": "test.crossplane.io/v1",
-												"kind": "Composed",
+												"apiVersion": "atest.crossplane.io/v1",
+												"kind": "AComposed",
+												"spec": {
+													"widgets": 9003
+												}
+											}`),
+										},
+										"a-cool-resource": {
+											Resource: MustStructJSON(`{
+												"apiVersion": "btest.crossplane.io/v1",
+												"kind": "BComposed",
 												"spec": {
 													"widgets": 9002
 												}
@@ -266,14 +275,14 @@ func TestRender(t *testing.T) {
 						{
 							Unstructured: unstructured.Unstructured{
 								Object: MustLoadJSON(`{
-									"apiVersion": "test.crossplane.io/v1",
+									"apiVersion": "btest.crossplane.io/v1",
 									"metadata": {
 										"generateName": "test-render-",
 										"labels": {
 											"crossplane.io/composite": "test-render"
 										},
 										"annotations": {
-											"crossplane.io/composition-resource-name": "cool-resource"
+											"crossplane.io/composition-resource-name": "a-cool-resource"
 										},
 										"ownerReferences": [{
 											"apiVersion": "nop.example.org/v1alpha1",
@@ -284,9 +293,37 @@ func TestRender(t *testing.T) {
 											"uid": ""
 										}]
 									},
-									"kind": "Composed",
+									"kind": "BComposed",
 									"spec": {
 										"widgets": 9002
+									}
+								}`),
+							},
+						},
+						{
+							Unstructured: unstructured.Unstructured{
+								Object: MustLoadJSON(`{
+									"apiVersion": "atest.crossplane.io/v1",
+									"metadata": {
+										"generateName": "test-render-",
+										"labels": {
+											"crossplane.io/composite": "test-render"
+										},
+										"annotations": {
+											"crossplane.io/composition-resource-name": "b-cool-resource"
+										},
+										"ownerReferences": [{
+											"apiVersion": "nop.example.org/v1alpha1",
+											"kind": "XNopResource",
+											"name": "test-render",
+											"blockOwnerDeletion": true,
+											"controller": true,
+											"uid": ""
+										}]
+									},
+									"kind": "AComposed",
+									"spec": {
+										"widgets": 9003
 									}
 								}`),
 							},


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane! Please read the contribution docs
(linked below) if this is your first Crossplane pull request.
-->

### Description of your changes

<!--
Briefly describe what this pull request does, and how it is covered by tests.
Be proactive - direct your reviewers' attention to anything that needs special
consideration.

We love pull requests that fix an open issue. If yours does, use the below line
to indicate which issue it fixes, for example "Fixes #500".
-->

Fixes #5008 by sorting composed resources by composed resource name (`crossplane.io/composition-resource-name` annotation) to ensure the output is stable.

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added or updated unit tests.
- [ ] ~Added or updated e2e tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/master/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/master/contributing#checklist-cheat-sheet
