### PR TITLE
Leave deletion of package service account to garbage collector

### DIFF
--- a/internal/controller/pkg/revision/runtime_function_test.go
+++ b/internal/controller/pkg/revision/runtime_function_test.go
@@ -484,24 +484,6 @@ func TestFunctionDeactivateHook(t *testing.T) {
 		args   args
 		want   want
 	}{
-		"ErrDeleteSA": {
-			reason: "Should return error if we fail to delete service account.",
-			args: args{
-				manifests: &MockManifestBuilder{
-					ServiceAccountFn: func(overrides ...ServiceAccountOverride) *corev1.ServiceAccount {
-						return &corev1.ServiceAccount{}
-					},
-				},
-				client: &test.MockClient{
-					MockDelete: func(ctx context.Context, obj client.Object, opts ...client.DeleteOption) error {
-						return errBoom
-					},
-				},
-			},
-			want: want{
-				err: errors.Wrap(errBoom, errDeleteFunctionSA),
-			},
-		},
 		"ErrDeleteDeployment": {
 			reason: "Should return error if we fail to delete deployment.",
 			args: args{
@@ -560,10 +542,7 @@ func TestFunctionDeactivateHook(t *testing.T) {
 					MockDelete: func(ctx context.Context, obj client.Object, opts ...client.DeleteOption) error {
 						switch obj.(type) {
 						case *corev1.ServiceAccount:
-							if obj.GetName() != "some-sa" {
-								return errors.New("unexpected service account name")
-							}
-							return nil
+							return errors.New("service account should not be deleted during deactivation")
 						case *appsv1.Deployment:
 							if obj.GetName() != "some-deployment" {
 								return errors.New("unexpected deployment name")

--- a/internal/controller/pkg/revision/runtime_provider_test.go
+++ b/internal/controller/pkg/revision/runtime_provider_test.go
@@ -568,24 +568,6 @@ func TestProviderDeactivateHook(t *testing.T) {
 		args   args
 		want   want
 	}{
-		"ErrDeleteSA": {
-			reason: "Should return error if we fail to delete service account.",
-			args: args{
-				manifests: &MockManifestBuilder{
-					ServiceAccountFn: func(overrides ...ServiceAccountOverride) *corev1.ServiceAccount {
-						return &corev1.ServiceAccount{}
-					},
-				},
-				client: &test.MockClient{
-					MockDelete: func(ctx context.Context, obj client.Object, opts ...client.DeleteOption) error {
-						return errBoom
-					},
-				},
-			},
-			want: want{
-				err: errors.Wrap(errBoom, errDeleteProviderSA),
-			},
-		},
 		"ErrDeleteDeployment": {
 			reason: "Should return error if we fail to delete deployment.",
 			args: args{
@@ -649,10 +631,7 @@ func TestProviderDeactivateHook(t *testing.T) {
 					MockDelete: func(ctx context.Context, obj client.Object, opts ...client.DeleteOption) error {
 						switch obj.(type) {
 						case *corev1.ServiceAccount:
-							if obj.GetName() != "some-sa" {
-								return errors.New("unexpected service account name")
-							}
-							return nil
+							return errors.New("service account should not be deleted during deactivation")
 						case *appsv1.Deployment:
 							if obj.GetName() != "some-deployment" {
 								return errors.New("unexpected deployment name")


### PR DESCRIPTION
### Description of your changes

When a package revision is inactive, it is unnecessary to keep its Service Account around; hence, we have been deleting it during deactivation. However, this causes unexpected behaviors when a Service Account name is specified via the deprecated `ControllerConfig` or the new `DeploymentRuntimeConfig` since the deleted Service Account is shared between revisions.

How was it working before v1.14? We always had the delete call for SA during deactivation, however, we were not [passing](https://github.com/crossplane/crossplane/blob/f9c3d3a9a7f135a94690a5f5bc0239195ff9fe67/internal/controller/pkg/revision/hook.go#L99-L101) ControllerConfig to the function building the SA, hence SA with the name provided there was not deleted. 

Fixes #5017

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added or updated unit tests.
- [ ] ~Added or updated e2e tests.~
- [x] Linked a PR or a [docs tracking issue] to [document this change].
- [x] Added `backport release-x.y` labels to auto-backport this PR.

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/master/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/master/contributing#checklist-cheat-sheet
