### PR TITLE
Improve robustness of releasing objects

### DIFF
--- a/internal/controller/pkg/revision/establisher.go
+++ b/internal/controller/pkg/revision/establisher.go
@@ -128,7 +128,7 @@ func (e *APIEstablisher) Establish(ctx context.Context, objs []runtime.Object, p
 
 // ReleaseObjects removes control of owned resources in the API server for a
 // package revision.
-func (e *APIEstablisher) ReleaseObjects(ctx context.Context, parent v1.PackageRevision) error {
+func (e *APIEstablisher) ReleaseObjects(ctx context.Context, parent v1.PackageRevision) error { //nolint:gocyclo // complexity coming from parallelism.
 	// Note(turkenh): We rely on status.objectRefs to get the list of objects
 	// that are controlled by the package revision. Relying on the status is
 	// not ideal as it might get lost (e.g. if the status subresource is
@@ -137,39 +137,64 @@ func (e *APIEstablisher) ReleaseObjects(ctx context.Context, parent v1.PackageRe
 	// referenced resources available and rebuilding the status.
 	// In the next reconciliation loop, and we will be able to remove the
 	// control/ownership of the objects using the new status.
-	objRefs := parent.GetObjects()
-	// Stop controlling objects.
-	for _, ref := range objRefs {
-		u := unstructured.Unstructured{}
-		u.SetAPIVersion(ref.APIVersion)
-		u.SetKind(ref.Kind)
-		u.SetName(ref.Name)
-
-		if err := e.client.Get(ctx, types.NamespacedName{Name: u.GetName()}, &u); err != nil {
-			if kerrors.IsNotFound(err) {
-				// This is not expected, but still not an error for relinquishing.
-				continue
-			}
-			return errors.Wrapf(err, errFmtGetOwnedObject, u.GetKind(), u.GetName())
-		}
-		ors := u.GetOwnerReferences()
-		for i := range ors {
-			if ors[i].UID == parent.GetUID() {
-				ors[i].Controller = ptr.To(false)
-				break
-			}
-			// Note(turkenh): What if we cannot find our UID in the owner
-			// references? This is not expected unless another party stripped
-			// out ownerRefs. I believe this is a fairly unlikely scenario,
-			// and we can ignore it for now especially considering that if that
-			// happens active revision or the package itself will still take
-			// over the ownership of such resources.
-		}
-		u.SetOwnerReferences(ors)
-		if err := e.client.Update(ctx, &u); err != nil {
-			return errors.Wrapf(err, errFmtUpdateOwnedObject, u.GetKind(), u.GetName())
-		}
+	allObjs := parent.GetObjects()
+	if len(allObjs) == 0 {
+		return nil
 	}
+
+	g, ctx := errgroup.WithContext(ctx)
+	g.SetLimit(maxConcurrentEstablishers)
+	for _, ref := range allObjs {
+		ref := ref // Pin the loop variable.
+		g.Go(func() error {
+			u := unstructured.Unstructured{}
+			u.SetAPIVersion(ref.APIVersion)
+			u.SetKind(ref.Kind)
+			u.SetName(ref.Name)
+
+			if err := e.client.Get(ctx, types.NamespacedName{Name: u.GetName()}, &u); err != nil {
+				if kerrors.IsNotFound(err) {
+					// This is not expected, but still not an error for releasing objects.
+					return nil
+				}
+				return errors.Wrapf(err, errFmtGetOwnedObject, u.GetKind(), u.GetName())
+			}
+			ors := u.GetOwnerReferences()
+			changed := false
+			for i := range ors {
+				if ors[i].UID == parent.GetUID() {
+					if ors[i].Controller != nil && *ors[i].Controller {
+						ors[i].Controller = ptr.To(false)
+						changed = true
+					}
+					break
+				}
+				// Note(turkenh): What if we cannot find our UID in the owner
+				// references? This is not expected unless another party stripped
+				// out ownerRefs. I believe this is a fairly unlikely scenario,
+				// and we can ignore it for now especially considering that if that
+				// happens active revision or the package itself will still take
+				// over the ownership of such resources.
+			}
+			if changed {
+				u.SetOwnerReferences(ors)
+				if err := e.client.Update(ctx, &u); err != nil {
+					return errors.Wrapf(err, errFmtUpdateOwnedObject, u.GetKind(), u.GetName())
+				}
+			}
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			default:
+				return nil
+			}
+		})
+	}
+
+	if err := g.Wait(); err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/internal/controller/pkg/revision/establisher.go
+++ b/internal/controller/pkg/revision/establisher.go
@@ -147,6 +147,12 @@ func (e *APIEstablisher) ReleaseObjects(ctx context.Context, parent v1.PackageRe
 	for _, ref := range allObjs {
 		ref := ref // Pin the loop variable.
 		g.Go(func() error {
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			default:
+			}
+
 			u := unstructured.Unstructured{}
 			u.SetAPIVersion(ref.APIVersion)
 			u.SetKind(ref.Kind)
@@ -182,12 +188,7 @@ func (e *APIEstablisher) ReleaseObjects(ctx context.Context, parent v1.PackageRe
 					return errors.Wrapf(err, errFmtUpdateOwnedObject, u.GetKind(), u.GetName())
 				}
 			}
-			select {
-			case <-ctx.Done():
-				return ctx.Err()
-			default:
-				return nil
-			}
+			return nil
 		})
 	}
 


### PR DESCRIPTION
### Description of your changes

Deactivation of package revisions may fail with the following log/event when there is a high number of objects managed by the package and Crossplane/K8s is under load. 

```
2023-11-20T12:01:18Z    DEBUG   crossplane      Event(v1.ObjectReference{Kind:"ConfigurationRevision", Namespace:"", : type: 'Warning' reason: 'DeactivateRevision' cannot deactivate package revision: cannot release objects: cannot update owned object: Composition/redacted: Put "[https://redacted:443/apis/apiextensions.crossplane.io/v1/compositions/redacted](https://redacted/apis/apiextensions.crossplane.io/v1/compositions/redacted)": http2: client connection force closed via ClientConn.Close
```
or 
```
  Warning  DeactivateRevision  8m47s  packages/configurationrevision.pkg.crossplane.io  cannot deactivate package revision: cannot release objects: cannot update owned object: Composition/redacted: Put "https://redacted:443/apis/apiextensions.crossplane.io/v1/compositions/redacted": context canceled
```

The code is brittle as is since it goes over all managed objects sequentially and returns in case of failure at any point. It also makes an update call against kube API no matter there is a change in the owner references or not.

This PR aims to improve this situation with the following in the release object method:
- Run in parallel (similar to establishment)
- Only update if needed
 
I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added or updated unit tests.
- [ ] ~Added or updated e2e tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [x] Added `backport release-x.y` labels to auto-backport this PR.

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/master/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/master/contributing#checklist-cheat-sheet
