### PR TITLE
Fix linter in release object by removing redundant if

### DIFF
--- a/internal/controller/pkg/revision/establisher.go
+++ b/internal/controller/pkg/revision/establisher.go
@@ -192,11 +192,7 @@ func (e *APIEstablisher) ReleaseObjects(ctx context.Context, parent v1.PackageRe
 		})
 	}
 
-	if err := g.Wait(); err != nil {
-		return err
-	}
-
-	return nil
+	return g.Wait()
 }
 
 func (e *APIEstablisher) addLabels(objs []runtime.Object, parent v1.PackageRevision) error {


### PR DESCRIPTION
### Description of your changes

Interestingly, the linter [failed](https://github.com/crossplane/crossplane/actions/runs/6943181695/job/18887703365?pr=5048) on the [backport](https://github.com/crossplane/crossplane/actions/runs/6943181695/job/18887703365?pr=5048) PR against release 1.14 branch with this but not on master. I'll backport after fixing on master.

```
14:37:36 [ .. ] golangci-lint
internal/controller/pkg/revision/establisher.go:195:2: if-return: redundant if ...; err != nil check, just return error instead. (revive)
	if err := g.Wait(); err != nil {
		return err
	}
```


I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] ~Added or updated unit tests.~
- [ ] ~Added or updated e2e tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [x] Added `backport release-x.y` labels to auto-backport this PR.

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/master/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/master/contributing#checklist-cheat-sheet
