### PR TITLE
Use `NameGenerator` for composite name generation

### DIFF
--- a/internal/controller/apiextensions/claim/configurator.go
+++ b/internal/controller/apiextensions/claim/configurator.go
@@ -32,6 +32,7 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/resource/unstructured/claim"
 	"github.com/crossplane/crossplane-runtime/pkg/resource/unstructured/composite"
 
+	"github.com/crossplane/crossplane/internal/names"
 	"github.com/crossplane/crossplane/internal/xcrd"
 )
 
@@ -40,25 +41,21 @@ const (
 	errUnsupportedDstObject = "destination object was not valid object"
 	errUnsupportedSrcObject = "source object was not valid object"
 
-	errName                  = "cannot use dry-run create to name composite resource"
 	errBindCompositeConflict = "cannot bind composite resource that references a different claim"
 
 	errMergeClaimSpec   = "unable to merge claim spec"
 	errMergeClaimStatus = "unable to merge claim status"
 )
 
-// An APIDryRunCompositeConfigurator configures composite resources. It may
-// perform a dry-run create against an API server in order to name and validate
-// the configured resource.
-type APIDryRunCompositeConfigurator struct {
-	client client.Client
+type apiCompositeConfigurator struct {
+	names.NameGenerator
 }
 
-// NewAPIDryRunCompositeConfigurator returns a Configurator of composite
+// NewAPICompositeConfigurator returns a Configurator of composite
 // resources that may perform a dry-run create against an API server in order to
 // name and validate the configured resource.
-func NewAPIDryRunCompositeConfigurator(c client.Client) *APIDryRunCompositeConfigurator {
-	return &APIDryRunCompositeConfigurator{client: c}
+func NewAPICompositeConfigurator(ng names.NameGenerator) Configurator {
+	return &apiCompositeConfigurator{NameGenerator: ng}
 }
 
 // Configure the supplied composite resource by propagating configuration from
@@ -66,7 +63,7 @@ func NewAPIDryRunCompositeConfigurator(c client.Client) *APIDryRunCompositeConfi
 // composite may or may not have been created in the API server when passed to
 // this method. The configured composite may be submitted to an API server via a
 // dry run create in order to name and validate it.
-func (c *APIDryRunCompositeConfigurator) Configure(ctx context.Context, cm resource.CompositeClaim, cp resource.Composite) error { //nolint:gocyclo // Only slightly over (12).
+func (c *apiCompositeConfigurator) Configure(ctx context.Context, cm resource.CompositeClaim, cp resource.Composite) error { //nolint:gocyclo // Only slightly over (12).
 	ucm, ok := cm.(*claim.Unstructured)
 	if !ok {
 		return nil
@@ -144,13 +141,15 @@ func (c *APIDryRunCompositeConfigurator) Configure(ctx context.Context, cm resou
 	ucp.SetClaimReference(proposed)
 
 	if !meta.WasCreated(cp) {
-		// The API server returns an available name derived from
-		// generateName when we perform a dry-run create. This name is
-		// likely (but not guaranteed) to be available when we create
-		// the composite resource. If the API server generates a name
-		// that is unavailable it will return a 500 ServerTimeout error.
 		cp.SetGenerateName(fmt.Sprintf("%s-", cm.GetName()))
-		return errors.Wrap(c.client.Create(ctx, cp, client.DryRunAll), errName)
+
+		// Generated name is likely (but not guaranteed) to be available
+		// when we create the composite resource. If taken,
+		// then we are going to update an existing composite,
+		// hijacking it from another claim. Depending on context/environment
+		// the consequences could be more or less serious.
+		// TODO: decide if we must prevent it.
+		return c.GenerateName(ctx, cp)
 	}
 
 	return nil

--- a/internal/controller/apiextensions/claim/reconciler.go
+++ b/internal/controller/apiextensions/claim/reconciler.go
@@ -41,6 +41,8 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/resource/unstructured"
 	"github.com/crossplane/crossplane-runtime/pkg/resource/unstructured/claim"
 	"github.com/crossplane/crossplane-runtime/pkg/resource/unstructured/composite"
+
+	"github.com/crossplane/crossplane/internal/names"
 )
 
 const (
@@ -210,7 +212,7 @@ type crComposite struct {
 
 func defaultCRComposite(c client.Client) crComposite {
 	return crComposite{
-		Configurator:         NewAPIDryRunCompositeConfigurator(c),
+		Configurator:         NewAPICompositeConfigurator(names.NewNameGenerator(c)),
 		ConnectionPropagator: NewAPIConnectionPropagator(c),
 	}
 }

--- a/internal/controller/apiextensions/composite/composition_functions.go
+++ b/internal/controller/apiextensions/composite/composition_functions.go
@@ -41,6 +41,7 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/resource/unstructured/composite"
 
 	"github.com/crossplane/crossplane/apis/apiextensions/fn/proto/v1beta1"
+	"github.com/crossplane/crossplane/internal/names"
 )
 
 // Error strings.
@@ -99,7 +100,7 @@ type FunctionComposer struct {
 }
 
 type xr struct {
-	NameGenerator
+	names.NameGenerator
 	managed.ConnectionDetailsFetcher
 	ComposedResourceObserver
 	ComposedResourceGarbageCollector
@@ -191,7 +192,7 @@ func NewFunctionComposer(kube client.Client, r FunctionRunner, o ...FunctionComp
 			ConnectionDetailsFetcher:         f,
 			ComposedResourceObserver:         NewExistingComposedResourceObserver(kube, f),
 			ComposedResourceGarbageCollector: NewDeletingComposedResourceGarbageCollector(kube),
-			NameGenerator:                    NewAPINameGenerator(kube),
+			NameGenerator:                    names.NewNameGenerator(kube),
 		},
 
 		pipeline: r,

--- a/internal/controller/apiextensions/composite/composition_pt.go
+++ b/internal/controller/apiextensions/composite/composition_pt.go
@@ -38,6 +38,7 @@ import (
 
 	v1 "github.com/crossplane/crossplane/apis/apiextensions/v1"
 	"github.com/crossplane/crossplane/internal/controller/apiextensions/usage"
+	"github.com/crossplane/crossplane/internal/names"
 )
 
 // Error strings
@@ -73,7 +74,7 @@ func WithTemplateAssociator(a CompositionTemplateAssociator) PTComposerOption {
 
 // WithComposedNameGenerator configures how the PTComposer should generate names
 // for unnamed composed resources.
-func WithComposedNameGenerator(r NameGenerator) PTComposerOption {
+func WithComposedNameGenerator(r names.NameGenerator) PTComposerOption {
 	return func(c *PTComposer) {
 		c.composed.NameGenerator = r
 	}
@@ -105,7 +106,7 @@ func WithComposedConnectionDetailsExtractor(e ConnectionDetailsExtractor) PTComp
 }
 
 type composedResource struct {
-	NameGenerator
+	names.NameGenerator
 	managed.ConnectionDetailsFetcher
 	ConnectionDetailsExtractor
 	ReadinessChecker
@@ -134,7 +135,7 @@ func NewPTComposer(kube client.Client, o ...PTComposerOption) *PTComposer {
 
 		composition: NewGarbageCollectingAssociator(kube),
 		composed: composedResource{
-			NameGenerator:              NewAPINameGenerator(kube),
+			NameGenerator:              names.NewNameGenerator(kube),
 			ReadinessChecker:           ReadinessCheckerFn(IsReady),
 			ConnectionDetailsFetcher:   NewSecretConnectionDetailsFetcher(kube),
 			ConnectionDetailsExtractor: ConnectionDetailsExtractorFn(ExtractConnectionDetails),

--- a/internal/controller/apiextensions/composite/composition_pt_test.go
+++ b/internal/controller/apiextensions/composite/composition_pt_test.go
@@ -40,6 +40,7 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/test"
 
 	v1 "github.com/crossplane/crossplane/apis/apiextensions/v1"
+	"github.com/crossplane/crossplane/internal/names"
 )
 
 func TestPTCompose(t *testing.T) {
@@ -122,7 +123,7 @@ func TestPTCompose(t *testing.T) {
 						}
 						return tas, nil
 					})),
-					WithComposedNameGenerator(NameGeneratorFn(func(ctx context.Context, cd resource.Object) error { return nil })),
+					WithComposedNameGenerator(names.NameGeneratorFn(func(ctx context.Context, cd resource.Object) error { return nil })),
 					WithComposedConnectionDetailsFetcher(ConnectionDetailsFetcherFn(func(ctx context.Context, o resource.ConnectionSecretOwner) (managed.ConnectionDetails, error) {
 						return nil, nil
 					})),
@@ -160,7 +161,7 @@ func TestPTCompose(t *testing.T) {
 						}}
 						return tas, nil
 					})),
-					WithComposedNameGenerator(NameGeneratorFn(func(ctx context.Context, cd resource.Object) error { return nil })),
+					WithComposedNameGenerator(names.NameGeneratorFn(func(ctx context.Context, cd resource.Object) error { return nil })),
 				},
 			},
 			args: args{
@@ -192,7 +193,7 @@ func TestPTCompose(t *testing.T) {
 						}}
 						return tas, nil
 					})),
-					WithComposedNameGenerator(NameGeneratorFn(func(ctx context.Context, cd resource.Object) error { return nil })),
+					WithComposedNameGenerator(names.NameGeneratorFn(func(ctx context.Context, cd resource.Object) error { return nil })),
 				},
 			},
 			args: args{
@@ -224,7 +225,7 @@ func TestPTCompose(t *testing.T) {
 						}}
 						return tas, nil
 					})),
-					WithComposedNameGenerator(NameGeneratorFn(func(ctx context.Context, cd resource.Object) error { return nil })),
+					WithComposedNameGenerator(names.NameGeneratorFn(func(ctx context.Context, cd resource.Object) error { return nil })),
 					WithComposedConnectionDetailsFetcher(ConnectionDetailsFetcherFn(func(ctx context.Context, o resource.ConnectionSecretOwner) (managed.ConnectionDetails, error) {
 						return nil, errBoom
 					})),
@@ -259,7 +260,7 @@ func TestPTCompose(t *testing.T) {
 						}}
 						return tas, nil
 					})),
-					WithComposedNameGenerator(NameGeneratorFn(func(ctx context.Context, cd resource.Object) error { return nil })),
+					WithComposedNameGenerator(names.NameGeneratorFn(func(ctx context.Context, cd resource.Object) error { return nil })),
 					WithComposedConnectionDetailsFetcher(ConnectionDetailsFetcherFn(func(ctx context.Context, o resource.ConnectionSecretOwner) (managed.ConnectionDetails, error) {
 						return nil, nil
 					})),
@@ -297,7 +298,7 @@ func TestPTCompose(t *testing.T) {
 						}}
 						return tas, nil
 					})),
-					WithComposedNameGenerator(NameGeneratorFn(func(ctx context.Context, cd resource.Object) error { return nil })),
+					WithComposedNameGenerator(names.NameGeneratorFn(func(ctx context.Context, cd resource.Object) error { return nil })),
 					WithComposedConnectionDetailsFetcher(ConnectionDetailsFetcherFn(func(ctx context.Context, o resource.ConnectionSecretOwner) (managed.ConnectionDetails, error) {
 						return nil, nil
 					})),
@@ -368,7 +369,7 @@ func TestPTCompose(t *testing.T) {
 						}}
 						return tas, nil
 					})),
-					WithComposedNameGenerator(NameGeneratorFn(func(ctx context.Context, cd resource.Object) error { return nil })),
+					WithComposedNameGenerator(names.NameGeneratorFn(func(ctx context.Context, cd resource.Object) error { return nil })),
 					WithComposedConnectionDetailsFetcher(ConnectionDetailsFetcherFn(func(ctx context.Context, o resource.ConnectionSecretOwner) (managed.ConnectionDetails, error) {
 						return nil, nil
 					})),
@@ -427,7 +428,7 @@ func TestPTCompose(t *testing.T) {
 						}
 						return tas, nil
 					})),
-					WithComposedNameGenerator(NameGeneratorFn(func(ctx context.Context, cd resource.Object) error {
+					WithComposedNameGenerator(names.NameGeneratorFn(func(ctx context.Context, cd resource.Object) error {
 						if cd.GetObjectKind().GroupVersionKind().Kind == "BrokenResource" {
 							return errBoom
 						}

--- a/internal/controller/apiextensions/composite/composition_render_test.go
+++ b/internal/controller/apiextensions/composite/composition_render_test.go
@@ -16,19 +16,14 @@ specific language governing permissions and limitations under the License.
 package composite
 
 import (
-	"context"
 	"encoding/json"
-	"strconv"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 	corev1 "k8s.io/api/core/v1"
-	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/utils/ptr"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/crossplane/crossplane-runtime/pkg/errors"
 	"github.com/crossplane/crossplane-runtime/pkg/meta"
@@ -293,139 +288,4 @@ func TestRenderComposedResourceMetadata(t *testing.T) {
 			}
 		})
 	}
-}
-
-func TestGenerateName(t *testing.T) {
-	errBoom := errors.New("boom")
-
-	type args struct {
-		ctx context.Context
-		cd  resource.Composed
-	}
-	type want struct {
-		cd  resource.Composed
-		err error
-	}
-	cases := map[string]struct {
-		reason string
-		client client.Client
-		args
-		want
-	}{
-		"SkipGenerateNamedResources": {
-			reason: "We should not try naming a resource that already have a name",
-			// We must be returning early, or else we'd hit this error.
-			client: &test.MockClient{MockCreate: test.NewMockCreateFn(errBoom)},
-			args: args{
-				cd: &fake.Composed{ObjectMeta: metav1.ObjectMeta{
-					Name: "already-has-a-cool-name",
-				}},
-			},
-			want: want{
-				cd: &fake.Composed{ObjectMeta: metav1.ObjectMeta{
-					Name: "already-has-a-cool-name",
-				}},
-				err: nil,
-			},
-		},
-		"SkipGenerateNameForResourcesWithoutGenerateName": {
-			reason: "We should not try to name resources that don't have a generate name (though that should never happen)",
-			// We must be returning early, or else we'd hit this error.
-			client: &test.MockClient{MockCreate: test.NewMockCreateFn(errBoom)},
-			args: args{
-				cd: &fake.Composed{}, // Conspicously missing a generate name.
-			},
-			want: want{
-				cd:  &fake.Composed{},
-				err: nil,
-			},
-		},
-		"NameGeneratorClientError": {
-			reason: "Client error finding a free name for a composed resource",
-			client: &test.MockClient{MockGet: test.NewMockGetFn(errBoom)},
-			args: args{
-				cd: &fake.Composed{ObjectMeta: metav1.ObjectMeta{
-					GenerateName: "cool-resource-",
-				}},
-			},
-			want: want{
-				cd: &fake.Composed{ObjectMeta: metav1.ObjectMeta{
-					GenerateName: "cool-resource-",
-				}},
-				err: errBoom,
-			},
-		},
-		"Success": {
-			reason: "Name is found on first try",
-			client: &test.MockClient{MockGet: test.NewMockGetFn(kerrors.NewNotFound(schema.GroupResource{Resource: "CoolResource"}, "cool-resource-42"))},
-			args: args{
-				cd: &fake.Composed{ObjectMeta: metav1.ObjectMeta{
-					GenerateName: "cool-resource-",
-				}},
-			},
-			want: want{
-				cd: &fake.Composed{ObjectMeta: metav1.ObjectMeta{
-					GenerateName: "cool-resource-",
-					Name:         "cool-resource-42",
-				}},
-			},
-		},
-		"SuccessAfterConflict": {
-			reason: "Name is found on second try",
-			client: &test.MockClient{MockGet: func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
-				if key.Name == "cool-resource-42" {
-					return nil
-				}
-				return kerrors.NewNotFound(schema.GroupResource{Resource: "CoolResource"}, key.Name)
-			}},
-			args: args{
-				cd: &fake.Composed{ObjectMeta: metav1.ObjectMeta{
-					GenerateName: "cool-resource-",
-				}},
-			},
-			want: want{
-				cd: &fake.Composed{ObjectMeta: metav1.ObjectMeta{
-					GenerateName: "cool-resource-",
-					Name:         "cool-resource-43",
-				}},
-			},
-		},
-		"AlwaysConflict": {
-			reason: "Name cannot be found",
-			client: &test.MockClient{MockGet: test.NewMockGetFn(nil)},
-			args: args{
-				cd: &fake.Composed{ObjectMeta: metav1.ObjectMeta{
-					GenerateName: "cool-resource-",
-				}},
-			},
-			want: want{
-				cd: &fake.Composed{ObjectMeta: metav1.ObjectMeta{
-					GenerateName: "cool-resource-",
-				}},
-				err: errors.New(errGenerateName),
-			},
-		},
-	}
-	for name, tc := range cases {
-		t.Run(name, func(t *testing.T) {
-			r := NewAPINameGenerator(tc.client)
-			r.namer = &mockNameGenerator{last: 41}
-			err := r.GenerateName(tc.args.ctx, tc.args.cd)
-			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
-				t.Errorf("\n%s\nDryRunRender(...): -want, +got:\n%s", tc.reason, diff)
-			}
-			if diff := cmp.Diff(tc.want.cd, tc.args.cd); diff != "" {
-				t.Errorf("\n%s\nDryRunRender(...): -want, +got:\n%s", tc.reason, diff)
-			}
-		})
-	}
-}
-
-type mockNameGenerator struct {
-	last int
-}
-
-func (m *mockNameGenerator) GenerateName(prefix string) string {
-	m.last++
-	return prefix + strconv.Itoa(m.last)
 }

--- a/internal/names/generate.go
+++ b/internal/names/generate.go
@@ -1,0 +1,103 @@
+/*
+Copyright 2023 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package names implements name generator
+package names
+
+import (
+	"context"
+
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apiserver/pkg/storage/names"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/crossplane/crossplane-runtime/pkg/errors"
+	"github.com/crossplane/crossplane-runtime/pkg/resource"
+	"github.com/crossplane/crossplane-runtime/pkg/resource/unstructured/composite"
+)
+
+const (
+	errGenerateName = "cannot generate a name for a resource"
+)
+
+// A NameGenerator finds a free/available name for a resource with a
+// specified metadata.generateName value. The name is temporary available,
+// but might be taken by the time the resource is created.
+type NameGenerator interface {
+	GenerateName(ctx context.Context, cd resource.Object) error
+}
+
+// A NameGeneratorFn is a function that satisfies NameGenerator.
+type NameGeneratorFn func(ctx context.Context, cd resource.Object) error
+
+// GenerateName generates a name using the same algorithm as the API server, and
+// verifies temporary name availability. It does not submit the
+// resource to the API server and hence it does not fall over validation errors.
+func (fn NameGeneratorFn) GenerateName(ctx context.Context, cd resource.Object) error {
+	return fn(ctx, cd)
+}
+
+// nameGenerator generates a name using the same algorithm as the API
+// server and verifies temporary name availability via the API.
+type nameGenerator struct {
+	reader client.Reader
+	namer  names.NameGenerator
+}
+
+// NewNameGenerator returns a new NameGenerator.
+func NewNameGenerator(c client.Client) NameGenerator {
+	return &nameGenerator{reader: c, namer: names.SimpleNameGenerator}
+}
+
+// GenerateName generates a name using the same algorithm as the API server, and
+// verifies temporary name availability. It does not submit the resource
+// to the API server and hence it does not fall over validation errors.
+func (r *nameGenerator) GenerateName(ctx context.Context, cd resource.Object) error {
+	// Don't rename.
+	if cd.GetName() != "" || cd.GetGenerateName() == "" {
+		return nil
+	}
+
+	// We guess a random name and verify that it is available. Names can become
+	// unavailable shortly after. We accept that very little risk of a name collision though:
+	// 1. with 8 million names, a collision against 10k names is 0.01%. We retry
+	//    name generation 10 times, to reduce the risks to 0.01%^10, which is
+	//    acceptable.
+	// 2. the risk that a name gets taken between the client.Get and the
+	//    client.Create is that of a name conflict between objects just created
+	//    in that short time-span. There are 8 million (minus 10k) free names.
+	//    And if there are 100 objects created in parallel, chance of conflict
+	//    is 0.06% (birthday paradoxon). This is the best we can do here
+	//    locally. To reduce that risk even further the caller must employ a
+	//    conflict recovery mechanism.
+	maxTries := 10
+	for i := 0; i < maxTries; i++ {
+		name := r.namer.GenerateName(cd.GetGenerateName())
+		obj := composite.Unstructured{}
+		obj.SetGroupVersionKind(cd.GetObjectKind().GroupVersionKind())
+		err := r.reader.Get(ctx, client.ObjectKey{Name: name}, &obj)
+		if kerrors.IsNotFound(err) {
+			// The name is available.
+			cd.SetName(name)
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+	}
+
+	return errors.New(errGenerateName)
+}

--- a/internal/names/generate_test.go
+++ b/internal/names/generate_test.go
@@ -1,0 +1,168 @@
+/*
+Copyright 2023 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package names
+
+import (
+	"context"
+	"strconv"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/crossplane/crossplane-runtime/pkg/errors"
+	"github.com/crossplane/crossplane-runtime/pkg/resource"
+	"github.com/crossplane/crossplane-runtime/pkg/resource/fake"
+	"github.com/crossplane/crossplane-runtime/pkg/test"
+)
+
+func TestGenerateName(t *testing.T) {
+	errBoom := errors.New("boom")
+
+	type args struct {
+		ctx context.Context
+		cd  resource.Composed
+	}
+	type want struct {
+		cd  resource.Composed
+		err error
+	}
+	cases := map[string]struct {
+		reason string
+		client client.Client
+		args
+		want
+	}{
+		"SkipGenerateNamedResources": {
+			reason: "We should not try naming a resource that already have a name",
+			// We must be returning early, or else we'd hit this error.
+			client: &test.MockClient{MockCreate: test.NewMockCreateFn(errBoom)},
+			args: args{
+				cd: &fake.Composed{ObjectMeta: metav1.ObjectMeta{
+					Name: "already-has-a-cool-name",
+				}},
+			},
+			want: want{
+				cd: &fake.Composed{ObjectMeta: metav1.ObjectMeta{
+					Name: "already-has-a-cool-name",
+				}},
+				err: nil,
+			},
+		},
+		"SkipGenerateNameForResourcesWithoutGenerateName": {
+			reason: "We should not try to name resources that don't have a generate name (though that should never happen)",
+			// We must be returning early, or else we'd hit this error.
+			client: &test.MockClient{MockCreate: test.NewMockCreateFn(errBoom)},
+			args: args{
+				cd: &fake.Composed{}, // Conspicously missing a generate name.
+			},
+			want: want{
+				cd:  &fake.Composed{},
+				err: nil,
+			},
+		},
+		"NameGeneratorClientError": {
+			reason: "Client error finding a free name for a composed resource",
+			client: &test.MockClient{MockGet: test.NewMockGetFn(errBoom)},
+			args: args{
+				cd: &fake.Composed{ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "cool-resource-",
+				}},
+			},
+			want: want{
+				cd: &fake.Composed{ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "cool-resource-",
+				}},
+				err: errBoom,
+			},
+		},
+		"Success": {
+			reason: "Name is found on first try",
+			client: &test.MockClient{MockGet: test.NewMockGetFn(kerrors.NewNotFound(schema.GroupResource{Resource: "CoolResource"}, "cool-resource-42"))},
+			args: args{
+				cd: &fake.Composed{ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "cool-resource-",
+				}},
+			},
+			want: want{
+				cd: &fake.Composed{ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "cool-resource-",
+					Name:         "cool-resource-42",
+				}},
+			},
+		},
+		"SuccessAfterConflict": {
+			reason: "Name is found on second try",
+			client: &test.MockClient{MockGet: func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
+				if key.Name == "cool-resource-42" {
+					return nil
+				}
+				return kerrors.NewNotFound(schema.GroupResource{Resource: "CoolResource"}, key.Name)
+			}},
+			args: args{
+				cd: &fake.Composed{ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "cool-resource-",
+				}},
+			},
+			want: want{
+				cd: &fake.Composed{ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "cool-resource-",
+					Name:         "cool-resource-43",
+				}},
+			},
+		},
+		"AlwaysConflict": {
+			reason: "Name cannot be found",
+			client: &test.MockClient{MockGet: test.NewMockGetFn(nil)},
+			args: args{
+				cd: &fake.Composed{ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "cool-resource-",
+				}},
+			},
+			want: want{
+				cd: &fake.Composed{ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "cool-resource-",
+				}},
+				err: errors.New(errGenerateName),
+			},
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			r := &nameGenerator{reader: tc.client, namer: &mockNameGenerator{last: 41}}
+			err := r.GenerateName(tc.args.ctx, tc.args.cd)
+			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
+				t.Errorf("\n%s\nDryRunRender(...): -want, +got:\n%s", tc.reason, diff)
+			}
+			if diff := cmp.Diff(tc.want.cd, tc.args.cd); diff != "" {
+				t.Errorf("\n%s\nDryRunRender(...): -want, +got:\n%s", tc.reason, diff)
+			}
+		})
+	}
+}
+
+type mockNameGenerator struct {
+	last int
+}
+
+func (m *mockNameGenerator) GenerateName(prefix string) string {
+	m.last++
+	return prefix + strconv.Itoa(m.last)
+}


### PR DESCRIPTION
### Description of your changes

The generator is already used for MR name generation.

Changes:

* since used by two controllers, `NameGenerator` moved under `internal/names` package
* `configurator_test.go` updated


<!--
Briefly describe what this pull request does, and how it is covered by tests.
Be proactive - direct your reviewers' attention to anything that needs special
consideration.

We love pull requests that fix an open issue. If yours does, use the below line
to indicate which issue it fixes, for example "Fixes #500".
-->

Related #4858  

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added or updated unit tests.
- ~[ ] Added or updated e2e tests.~
- ~[ ] Linked a PR or a [docs tracking issue] to [document this change].~
- ~[ ] Added `backport release-x.y` labels to auto-backport this PR.~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/master/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/master/contributing#checklist-cheat-sheet