### PR TITLE
fix(xrd): Limit deprecation warning length to 256

### DIFF
--- a/apis/apiextensions/v1/xrd_types.go
+++ b/apis/apiextensions/v1/xrd_types.go
@@ -151,6 +151,7 @@ type CompositeResourceDefinitionVersion struct {
 	// DeprecationWarning specifies the message that should be shown to the user
 	// when using this version.
 	// +optional
+	// +kubebuilder:validation:MaxLength=256
 	DeprecationWarning *string `json:"deprecationWarning,omitempty"`
 
 	// Schema describes the schema used for validation, pruning, and defaulting

--- a/cluster/crds/apiextensions.crossplane.io_compositeresourcedefinitions.yaml
+++ b/cluster/crds/apiextensions.crossplane.io_compositeresourcedefinitions.yaml
@@ -384,6 +384,7 @@ spec:
                     deprecationWarning:
                       description: DeprecationWarning specifies the message that should
                         be shown to the user when using this version.
+                      maxLength: 256
                       type: string
                     name:
                       description: Name of this version, e.g. “v1”, “v2beta1”, etc.


### PR DESCRIPTION
### Description of your changes

K8s CRDs have a 256 character limit for deprecation warnings. This limit is not caught within Crossplane but will lead to a reconcile error when applying an XRD with a deprecation warning that is longer than 256 characters. This PR adds the length limit to the XRD schema to prevent this from happening and notify the user upfront.

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added or updated unit tests.
- [x] Added or updated e2e tests.
- [x] Linked a PR or a [docs tracking issue] to [document this change].
- [x] Added `backport release-x.y` labels to auto-backport this PR.

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/master/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/master/contributing#checklist-cheat-sheet
