### PR TITLE
rbac: add finalizer update permissions to claim resource

### DIFF
--- a/internal/controller/rbac/definition/roles.go
+++ b/internal/controller/rbac/definition/roles.go
@@ -161,7 +161,17 @@ func RenderClusterRoles(d *v1.CompositeResourceDefinition) []rbacv1.ClusterRole 
 				d.Spec.ClaimNames.Plural + suffixStatus,
 			},
 			Verbs: verbsEdit,
-		})
+		},
+			rbacv1.PolicyRule{
+				// Crossplane needs permission to set finalizers on Claims in order to create resources
+				// that block their deletion when the OwnerReferencesPermissionEnforcement admission controller is enabled.
+				APIGroups: []string{d.Spec.Group},
+				Resources: []string{
+					d.Spec.ClaimNames.Plural + suffixFinalizers,
+				},
+				Verbs: verbsUpdate,
+			},
+		)
 
 		edit.Rules = append(edit.Rules, rbacv1.PolicyRule{
 			APIGroups: []string{d.Spec.Group},

--- a/internal/controller/rbac/definition/roles_test.go
+++ b/internal/controller/rbac/definition/roles_test.go
@@ -173,6 +173,11 @@ func TestRenderClusterRoles(t *testing.T) {
 							Resources: []string{pluralXRC, pluralXRC + suffixStatus},
 							Verbs:     verbsEdit,
 						},
+						{
+							APIGroups: []string{group},
+							Resources: []string{pluralXRC + suffixFinalizers},
+							Verbs:     verbsUpdate,
+						},
 					},
 				},
 				{


### PR DESCRIPTION
### Description of your changes

Added finalizer update permissions to the claim resource.

Fixes #5077

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [X] Read and followed Crossplane's [contribution process].
- [X] Run `make reviewable` to ensure this PR is ready for review.
- [X] Added or updated unit tests.
~- [ ] Added or updated e2e tests.~
~- [] Linked a PR or a [docs tracking issue] to [document this change].~
- [X] Added `backport release-x.y` labels to auto-backport this PR.

Tested in an OpenShift cluster and verified that the ClusterRole for the composite includes update permissions on the finalizer subresource for the claim.

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/master/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/master/contributing#checklist-cheat-sheet
