### PR TITLE
renovate: configure to automatically bump e2e dependencies

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,7 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:base",
+    "config:recommended",
     "helpers:pinGitHubActionDigests",
     ":semanticCommits"
   ],
@@ -17,8 +17,9 @@
   "postUpdateOptions": ["gomodTidy"],
 // All PRs should have a label
   "labels": ["automated"],
-  "regexManagers": [
+  "customManagers": [
     {
+      "customType": "regex",
       "description": "Bump Go version used in workflows",
       "fileMatch": ["^\\.github\\/workflows\\/[^/]+\\.ya?ml$"],
       "matchStrings": [
@@ -27,6 +28,7 @@
       "datasourceTemplate": "golang-version",
       "depNameTemplate": "golang"
     }, {
+      "customType": "regex",
       "description": "Bump golangci-lint version in workflows and the Makefile",
       "fileMatch": ["^\\.github\\/workflows\\/[^/]+\\.ya?ml$","^Makefile$"],
       "matchStrings": [
@@ -37,6 +39,7 @@
       "depNameTemplate": "golangci/golangci-lint",
       "extractVersionTemplate": "^v(?<version>.*)$"
     }, {
+      "customType": "regex",
       "description": "Bump helm version in the Makefile",
       "fileMatch": ["^Makefile$"],
       "matchStrings": [
@@ -45,6 +48,7 @@
       "datasourceTemplate": "github-tags",
       "depNameTemplate": "helm/helm",
     }, {
+      "customType": "regex",
       "description": "Bump kind version in the Makefile",
       "fileMatch": ["^Makefile$"],
       "matchStrings": [

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -54,6 +54,9 @@
       "depNameTemplate": "kubernetes-sigs/kind",
     }
   ],
+  "crossplane": {
+    "fileMatch": ["(^|/)test/e2e/.*\\.ya?ml$"]
+  },
 // PackageRules disabled below should be enabled in case of vulnerabilities
   "vulnerabilityAlerts": {
     "enabled": true
@@ -63,6 +66,10 @@
 // be at the beginning, high priority at the end
   "packageRules": [
     {
+      "matchManagers": ["crossplane"],
+      "matchFileNames": ["test/e2e/**"],
+      "groupName": "e2e-manifests",
+    }, {
       "description": "Ignore non-security related updates to release branches",
       matchBaseBranches: [ "/^release-.*/"],
       enabled: false,


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane! Please read the contribution docs
(linked below) if this is your first Crossplane pull request.
-->

### Description of your changes

<!--
Briefly describe what this pull request does, and how it is covered by tests.
Be proactive - direct your reviewers' attention to anything that needs special
consideration.

We love pull requests that fix an open issue. If yours does, use the below line
to indicate which issue it fixes, for example "Fixes #500".
-->

See https://github.com/phisco/crossplane/pull/257 for an example PR this will enable.

Took the chance to update the configuration to the new format as the current one was marked as deprecated.

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [ ] ~Run `make reviewable` to ensure this PR is ready for review.~
- [ ] ~Added or updated unit tests.~
- [ ] ~Added or updated e2e tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/master/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/master/contributing#checklist-cheat-sheet
