### PR TITLE
Log at info level reconciliation progress

### DIFF
--- a/internal/controller/apiextensions/definition/reconciler_test.go
+++ b/internal/controller/apiextensions/definition/reconciler_test.go
@@ -751,7 +751,7 @@ func TestReconcile(t *testing.T) {
 	}
 	for _, m := range []mode{
 		{name: "polling", options: apiextensionscontroller.Options{Options: controller.DefaultOptions()}},
-		{name: "realtime", options: apiextensionscontroller.Options{Options: controller.Options{Features: &withRealtimeComposition}}},
+		{name: "realtime", options: apiextensionscontroller.Options{Options: controller.Options{Logger: logging.NewNopLogger(), Features: &withRealtimeComposition}}},
 	} {
 		t.Run(m.name, func(t *testing.T) {
 			for name, tc := range cases {

--- a/pkg/controller/interceptor/interceptors.go
+++ b/pkg/controller/interceptor/interceptors.go
@@ -1,0 +1,47 @@
+/*
+Copyright 2020 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package interceptor offers reconciler interceptors
+package interceptor
+
+import (
+	"context"
+	"time"
+
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"github.com/crossplane/crossplane-runtime/pkg/logging"
+)
+
+// LoggingInterceptor wraps a Reconciler and logs messages
+// before and after the reconciliation,
+// reporting if the operation was successful together with its duration.
+func LoggingInterceptor(log logging.Logger, r reconcile.Reconciler) reconcile.Func {
+	return func(ctx context.Context, req reconcile.Request) (res reconcile.Result, err error) {
+		l := log.WithValues("request", req)
+		l.Info("Reconciling")
+		start := time.Now()
+		defer func() {
+			d := time.Since(start).String()
+			if err == nil {
+				l.Info("Reconciliation done", "result", res, "duration", d)
+			} else {
+				l.Info("Reconciliation failed", "error", err, "duration", d)
+			}
+		}()
+		return r.Reconcile(ctx, req)
+	}
+}


### PR DESCRIPTION
### Description of your changes

* In order to get better insights how often the reconciliation
  gets triggered for a given claim/composite, added
  `LoggingInterceptor` that logs info messages before
  and after.
* Consolidated the claim/composite logger context, i.e.
  removed unneeded noise,
  so that we have now the following fields available for filtering:
    * level
    * ts
    * msg
    * controller
    * request
* Composite controller name in the logs follows the convention `composite/<XR_NAME_PLURAL>.<XRD_GROUP>`
* Claim controller name follows in the logs the convention `claim/<CLAIM_NAME_PLURAL>.<XRD_GROUP>`

For example, running `TestCompositionMinimal` e2e tests produces the following log:

```sh
{"level":"info","ts":"2023-10-27T10:25:17Z","logger":"crossplane","msg":"Reconciling","controller":"composite/xnopresources.nop.example.org","request":{"name":"apiextensions-composition-minimal-pdh85"}}
{"level":"info","ts":"2023-10-27T10:25:17Z","logger":"crossplane","msg":"Reconciling","controller":"claim/nopresources.nop.example.org","request":{"name":"apiextensions-composition-minimal","namespace":"default"}}
{"level":"info","ts":"2023-10-27T10:25:17Z","logger":"crossplane","msg":"Reconciliation done","controller":"claim/nopresources.nop.example.org","request":{"name":"apiextensions-composition-minimal","namespace":"default"},"result":{"Requeue":false,"RequeueAfter":0},"duration":"324.429155ms"}
{"level":"info","ts":"2023-10-27T10:25:17Z","logger":"crossplane","msg":"Reconciling","controller":"claim/nopresources.nop.example.org","request":{"name":"apiextensions-composition-minimal","namespace":"default"}}
{"level":"info","ts":"2023-10-27T10:25:17Z","logger":"crossplane","msg":"Reconciliation done","controller":"composite/xnopresources.nop.example.org","request":{"name":"apiextensions-composition-minimal-pdh85"},"result":{"Requeue":false,"RequeueAfter":60000000000},"duration":"330.229859ms"}
{"level":"info","ts":"2023-10-27T10:25:17Z","logger":"crossplane","msg":"Reconciling","controller":"composite/xnopresources.nop.example.org","request":{"name":"apiextensions-composition-minimal-pdh85"}}
{"level":"info","ts":"2023-10-27T10:25:17Z","logger":"crossplane","msg":"Reconciliation done","controller":"claim/nopresources.nop.example.org","request":{"name":"apiextensions-composition-minimal","namespace":"default"},"result":{"Requeue":false,"RequeueAfter":0},"duration":"127.127239ms"}
{"level":"info","ts":"2023-10-27T10:25:17Z","logger":"crossplane","msg":"Reconciliation done","controller":"composite/xnopresources.nop.example.org","request":{"name":"apiextensions-composition-minimal-pdh85"},"result":{"Requeue":false,"RequeueAfter":60000000000},"duration":"168.077422ms"}
```

A json log viewer like [fblog](https://github.com/brocode/fblog) or [humanlog](https://github.com/humanlogio/humanlog) can be applied for further analysis.


<!--
Thank you for helping to improve Crossplane! Please read the contribution docs
(linked below) if this is your first Crossplane pull request.
-->


<!--
Briefly describe what this pull request does, and how it is covered by tests.
Be proactive - direct your reviewers' attention to anything that needs special
consideration.

We love pull requests that fix an open issue. If yours does, use the below line
to indicate which issue it fixes, for example "Fixes #500".
-->

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- ~[ ] Added or updated unit tests.~
- ~[ ] Added or updated e2e tests.~
- ~[ ] Linked a PR or a [docs tracking issue] to [document this change].~
- ~[ ] Added `backport release-x.y` labels to auto-backport this PR.~