### PR TITLE
Fix synchronization between composition/XR and composed resources

### DIFF
--- a/internal/controller/apiextensions/composite/api.go
+++ b/internal/controller/apiextensions/composite/api.go
@@ -125,13 +125,13 @@ func (a *APIFilteredSecretPublisher) UnpublishConnection(_ context.Context, _ re
 // for compatibility with existing Composition logic while CompositionRevisions
 // are in alpha.
 type APIRevisionFetcher struct {
-	ca resource.ClientApplicator
+	client client.Client
 }
 
 // NewAPIRevisionFetcher returns a RevisionFetcher that fetches the
 // Revision referenced by a composite resource.
-func NewAPIRevisionFetcher(ca resource.ClientApplicator) *APIRevisionFetcher {
-	return &APIRevisionFetcher{ca: ca}
+func NewAPIRevisionFetcher(client client.Client) *APIRevisionFetcher {
+	return &APIRevisionFetcher{client: client}
 }
 
 // Fetch the appropriate CompositionRevision for the supplied XR. Panics if the
@@ -145,7 +145,7 @@ func (f *APIRevisionFetcher) Fetch(ctx context.Context, cr resource.Composite) (
 	// Just fetch and return the selected revision.
 	if current != nil && pol != nil && *pol == xpv1.UpdateManual {
 		rev := &v1.CompositionRevision{}
-		err := f.ca.Get(ctx, meta.NamespacedNameOf(current), rev)
+		err := f.client.Get(ctx, meta.NamespacedNameOf(current), rev)
 		return rev, errors.Wrap(err, errGetCompositionRevision)
 	}
 
@@ -153,7 +153,7 @@ func (f *APIRevisionFetcher) Fetch(ctx context.Context, cr resource.Composite) (
 	// automatic. Either way we need to determine the latest revision.
 
 	comp := &v1.Composition{}
-	if err := f.ca.Get(ctx, meta.NamespacedNameOf(cr.GetCompositionReference()), comp); err != nil {
+	if err := f.client.Get(ctx, meta.NamespacedNameOf(cr.GetCompositionReference()), comp); err != nil {
 		return nil, errors.Wrap(err, errGetComposition)
 	}
 
@@ -165,13 +165,6 @@ func (f *APIRevisionFetcher) Fetch(ctx context.Context, cr resource.Composite) (
 	latest := v1.LatestRevision(comp, rl.Items)
 	if latest == nil {
 		return nil, errors.New(errNoCompatibleCompositionRevision)
-	}
-
-	if current == nil || current.Name != latest.GetName() {
-		cr.SetCompositionRevisionReference(meta.ReferenceTo(latest, v1.CompositionRevisionGroupVersionKind))
-		if err := f.ca.Apply(ctx, cr); err != nil {
-			return nil, errors.Wrap(err, errUpdate)
-		}
 	}
 
 	return latest, nil
@@ -187,7 +180,7 @@ func (f *APIRevisionFetcher) getCompositionRevisionList(ctx context.Context, cr 
 	}
 
 	ml[v1.LabelCompositionName] = comp.GetName()
-	if err := f.ca.List(ctx, rl, ml); err != nil {
+	if err := f.client.List(ctx, rl, ml); err != nil {
 		return nil, errors.Wrap(err, errListCompositionRevisions)
 	}
 	return rl, nil
@@ -205,13 +198,17 @@ type CompositionSelectorChain struct {
 
 // SelectComposition calls all SelectComposition functions of CompositionSelectors
 // in the list.
-func (r *CompositionSelectorChain) SelectComposition(ctx context.Context, cp resource.Composite) error {
+func (r *CompositionSelectorChain) SelectComposition(ctx context.Context, cr resource.Composite) (*corev1.ObjectReference, error) {
 	for _, cs := range r.list {
-		if err := cs.SelectComposition(ctx, cp); err != nil {
-			return err
+		ref, err := cs.SelectComposition(ctx, cr)
+		if err != nil {
+			return nil, err
+		}
+		if ref != nil {
+			return ref, nil
 		}
 	}
-	return nil
+	return nil, nil
 }
 
 // NewAPILabelSelectorResolver returns a SelectorResolver for composite resource.
@@ -226,14 +223,14 @@ type APILabelSelectorResolver struct {
 }
 
 // SelectComposition resolves selector to a reference if it doesn't exist.
-func (r *APILabelSelectorResolver) SelectComposition(ctx context.Context, cp resource.Composite) error {
+func (r *APILabelSelectorResolver) SelectComposition(ctx context.Context, cp resource.Composite) (*corev1.ObjectReference, error) {
 	// TODO(muvaf): need to block the deletion of composition via finalizer once
 	// it's selected since it's integral to this resource.
 	// TODO(muvaf): We don't rely on UID in practice. It should not be there
 	// because it will make confusion if the resource is backed up and restored
 	// to another cluster
-	if cp.GetCompositionReference() != nil {
-		return nil
+	if ref := cp.GetCompositionReference(); ref != nil {
+		return ref, nil
 	}
 	labels := map[string]string{}
 	sel := cp.GetCompositionSelector()
@@ -242,7 +239,7 @@ func (r *APILabelSelectorResolver) SelectComposition(ctx context.Context, cp res
 	}
 	list := &v1.CompositionList{}
 	if err := r.client.List(ctx, list, client.MatchingLabels(labels)); err != nil {
-		return errors.Wrap(err, errListCompositions)
+		return nil, errors.Wrap(err, errListCompositions)
 	}
 
 	candidates := make([]string, 0, len(list.Items))
@@ -256,13 +253,12 @@ func (r *APILabelSelectorResolver) SelectComposition(ctx context.Context, cp res
 	}
 
 	if len(candidates) == 0 {
-		return errors.New(errNoCompatibleComposition)
+		return nil, errors.New(errNoCompatibleComposition)
 	}
 
 	random := rand.New(rand.NewSource(time.Now().UnixNano())) //nolint:gosec // We don't need this to be cryptographically random.
 	selected := candidates[random.Intn(len(candidates))]
-	cp.SetCompositionReference(&corev1.ObjectReference{Name: selected})
-	return errors.Wrap(r.client.Update(ctx, cp), errUpdateComposite)
+	return &corev1.ObjectReference{Name: selected}, nil
 }
 
 // NewAPIDefaultCompositionSelector returns a APIDefaultCompositionSelector.
@@ -279,22 +275,21 @@ type APIDefaultCompositionSelector struct {
 	recorder event.Recorder
 }
 
-// SelectComposition selects the default compositionif neither a reference nor
+// SelectComposition selects the default composition if neither a reference nor
 // selector is given in composite resource.
-func (s *APIDefaultCompositionSelector) SelectComposition(ctx context.Context, cp resource.Composite) error {
-	if cp.GetCompositionReference() != nil || cp.GetCompositionSelector() != nil {
-		return nil
+func (s *APIDefaultCompositionSelector) SelectComposition(ctx context.Context, cp resource.Composite) (*corev1.ObjectReference, error) {
+	if ref := cp.GetCompositionReference(); ref != nil {
+		return ref, nil
 	}
 	def := &v1.CompositeResourceDefinition{}
 	if err := s.client.Get(ctx, meta.NamespacedNameOf(&s.defRef), def); err != nil {
-		return errors.Wrap(err, errGetXRD)
+		return nil, errors.Wrap(err, errGetXRD)
 	}
 	if def.Spec.DefaultCompositionRef == nil {
-		return nil
+		return nil, nil
 	}
-	cp.SetCompositionReference(&corev1.ObjectReference{Name: def.Spec.DefaultCompositionRef.Name})
 	s.recorder.Event(cp, event.Normal(reasonCompositionSelection, "Default composition has been selected"))
-	return nil
+	return &corev1.ObjectReference{Name: def.Spec.DefaultCompositionRef.Name}, nil
 }
 
 // NewEnforcedCompositionSelector returns a EnforcedCompositionSelector.
@@ -310,21 +305,16 @@ type EnforcedCompositionSelector struct {
 }
 
 // SelectComposition selects the enforced composition if it's given in definition.
-func (s *EnforcedCompositionSelector) SelectComposition(_ context.Context, cp resource.Composite) error {
+func (s *EnforcedCompositionSelector) SelectComposition(_ context.Context, cp resource.Composite) (*corev1.ObjectReference, error) {
 	// We don't need to fetch the CompositeResourceDefinition at every reconcile
 	// because enforced composition ref is immutable as opposed to default
 	// composition ref.
 	if s.def.Spec.EnforcedCompositionRef == nil {
-		return nil
+		return nil, nil
 	}
-	// If the composition is already chosen, we don't need to check for compatibility
-	// as its target type reference is immutable.
-	if cp.GetCompositionReference() != nil && cp.GetCompositionReference().Name == s.def.Spec.EnforcedCompositionRef.Name {
-		return nil
-	}
-	cp.SetCompositionReference(&corev1.ObjectReference{Name: s.def.Spec.EnforcedCompositionRef.Name})
 	s.recorder.Event(cp, event.Normal(reasonCompositionSelection, "Enforced composition has been selected"))
-	return nil
+
+	return &corev1.ObjectReference{Name: s.def.Spec.EnforcedCompositionRef.Name}, nil
 }
 
 // NewConfiguratorChain returns a new *ConfiguratorChain.
@@ -338,64 +328,37 @@ type ConfiguratorChain struct {
 }
 
 // Configure calls Configure function of every Configurator in the list.
-func (cc *ConfiguratorChain) Configure(ctx context.Context, cp resource.Composite, rev *v1.CompositionRevision) error {
+func (cc *ConfiguratorChain) Configure(ctx context.Context, cr resource.Composite, rev *v1.CompositionRevision) error {
 	for _, c := range cc.list {
-		if err := c.Configure(ctx, cp, rev); err != nil {
+		if err := c.Configure(ctx, cr, rev); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-// NewAPIConfigurator returns a Configurator that configures a
-// composite resource using its composition.
-func NewAPIConfigurator(c client.Client) *APIConfigurator {
-	return &APIConfigurator{client: c}
-}
-
-// An APIConfigurator configures a composite resource using its
-// composition.
-type APIConfigurator struct {
-	client client.Client
-}
-
-// Configure any required fields that were omitted from the composite resource
+// APIConfigure any required fields that were omitted from the composite resource
 // by copying them from its composition.
-func (c *APIConfigurator) Configure(ctx context.Context, cp resource.Composite, rev *v1.CompositionRevision) error {
-	apiVersion, kind := cp.GetObjectKind().GroupVersionKind().ToAPIVersionAndKind()
+func APIConfigure(_ context.Context, xr resource.Composite, rev *v1.CompositionRevision) error {
+	apiVersion, kind := xr.GetObjectKind().GroupVersionKind().ToAPIVersionAndKind()
 	if rev.Spec.CompositeTypeRef.APIVersion != apiVersion || rev.Spec.CompositeTypeRef.Kind != kind {
 		return errors.New(errCompositionNotCompatible)
 	}
 
-	if cp.GetWriteConnectionSecretToReference() != nil || rev.Spec.WriteConnectionSecretsToNamespace == nil {
+	if rev.Spec.WriteConnectionSecretsToNamespace == nil {
 		return nil
 	}
 
-	cp.SetWriteConnectionSecretToReference(&xpv1.SecretReference{
-		Name:      string(cp.GetUID()),
+	xr.SetWriteConnectionSecretToReference(&xpv1.SecretReference{
+		Name:      string(xr.GetUID()),
 		Namespace: *rev.Spec.WriteConnectionSecretsToNamespace,
 	})
 
-	return errors.Wrap(c.client.Update(ctx, cp), errUpdateComposite)
+	return nil
 }
 
-// NewAPINamingConfigurator returns a Configurator that sets the root name prefixKu
-// to its own name if it is not already set.
-func NewAPINamingConfigurator(c client.Client) *APINamingConfigurator {
-	return &APINamingConfigurator{client: c}
-}
-
-// An APINamingConfigurator sets the root name prefix to its own name if it is not
-// already set.
-type APINamingConfigurator struct {
-	client client.Client
-}
-
-// Configure the supplied composite resource's root name prefix.
-func (c *APINamingConfigurator) Configure(ctx context.Context, cp resource.Composite, _ *v1.CompositionRevision) error {
-	if cp.GetLabels()[xcrd.LabelKeyNamePrefixForComposed] != "" {
-		return nil
-	}
-	meta.AddLabels(cp, map[string]string{xcrd.LabelKeyNamePrefixForComposed: cp.GetName()})
-	return errors.Wrap(c.client.Update(ctx, cp), errUpdateComposite)
+// APINamingConfigure the supplied composite resource's root name prefix.
+func APINamingConfigure(_ context.Context, xr resource.Composite, _ *v1.CompositionRevision) error {
+	xr.SetLabels(map[string]string{xcrd.LabelKeyNamePrefixForComposed: xr.GetName()})
+	return nil
 }

--- a/internal/controller/apiextensions/composite/composition_functions_test.go
+++ b/internal/controller/apiextensions/composite/composition_functions_test.go
@@ -401,55 +401,6 @@ func TestFunctionCompose(t *testing.T) {
 				err: errors.Wrap(errBoom, errApplyXRRefs),
 			},
 		},
-		"ApplyXRStatusError": {
-			reason: "We should return any error we encounter when applying the composite resource status",
-			params: params{
-				kube: &test.MockClient{
-					MockPatch:       test.NewMockPatchFn(nil),
-					MockStatusPatch: test.NewMockSubResourcePatchFn(errBoom),
-				},
-				r: FunctionRunnerFn(func(ctx context.Context, name string, req *v1beta1.RunFunctionRequest) (rsp *v1beta1.RunFunctionResponse, err error) {
-					d := &v1beta1.State{
-						Composite: &v1beta1.Resource{
-							Resource: MustStruct(map[string]any{
-								"status": map[string]any{
-									"widgets": 42,
-								},
-							})},
-					}
-					return &v1beta1.RunFunctionResponse{Desired: d}, nil
-				}),
-				o: []FunctionComposerOption{
-					WithCompositeConnectionDetailsFetcher(ConnectionDetailsFetcherFn(func(ctx context.Context, o resource.ConnectionSecretOwner) (managed.ConnectionDetails, error) {
-						return nil, nil
-					})),
-					WithComposedResourceObserver(ComposedResourceObserverFn(func(ctx context.Context, xr resource.Composite) (ComposedResourceStates, error) {
-						return nil, nil
-					})),
-					WithComposedResourceGarbageCollector(ComposedResourceGarbageCollectorFn(func(ctx context.Context, owner metav1.Object, observed, desired ComposedResourceStates) error {
-						return nil
-					})),
-				},
-			},
-			args: args{
-				xr: composite.New(),
-				req: CompositionRequest{
-					Revision: &v1.CompositionRevision{
-						Spec: v1.CompositionRevisionSpec{
-							Pipeline: []v1.PipelineStep{
-								{
-									Step:        "run-cool-function",
-									FunctionRef: v1.FunctionReference{Name: "cool-function"},
-								},
-							},
-						},
-					},
-				},
-			},
-			want: want{
-				err: errors.Wrap(errBoom, errApplyXRStatus),
-			},
-		},
 		"ApplyComposedResourceError": {
 			reason: "We should return any error we encounter when applying a composed resource",
 			params: params{

--- a/internal/controller/apiextensions/composite/connection.go
+++ b/internal/controller/apiextensions/composite/connection.go
@@ -158,13 +158,13 @@ type SecretStoreConnectionDetailsConfigurator struct {
 
 // Configure any required fields that were omitted from the composite resource
 // by copying them from its composition.
-func (c *SecretStoreConnectionDetailsConfigurator) Configure(ctx context.Context, cp resource.Composite, rev *v1.CompositionRevision) error {
+func (c *SecretStoreConnectionDetailsConfigurator) Configure(_ context.Context, cp resource.Composite, rev *v1.CompositionRevision) error {
 	apiVersion, kind := cp.GetObjectKind().GroupVersionKind().ToAPIVersionAndKind()
 	if rev.Spec.CompositeTypeRef.APIVersion != apiVersion || rev.Spec.CompositeTypeRef.Kind != kind {
 		return errors.New(errCompositionNotCompatible)
 	}
 
-	if cp.GetPublishConnectionDetailsTo() != nil || rev.Spec.PublishConnectionDetailsWithStoreConfigRef == nil {
+	if rev.Spec.PublishConnectionDetailsWithStoreConfigRef == nil {
 		return nil
 	}
 
@@ -175,7 +175,7 @@ func (c *SecretStoreConnectionDetailsConfigurator) Configure(ctx context.Context
 		},
 	})
 
-	return errors.Wrap(c.client.Update(ctx, cp), errUpdateComposite)
+	return nil
 }
 
 // ConnectionDetailsExtractor extracts the connection details of a resource.

--- a/internal/controller/apiextensions/composite/overlay.go
+++ b/internal/controller/apiextensions/composite/overlay.go
@@ -1,0 +1,141 @@
+/*
+Copyright 2023 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package composite
+
+import (
+	"context"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
+	"github.com/crossplane/crossplane-runtime/pkg/meta"
+	"github.com/crossplane/crossplane-runtime/pkg/resource"
+	"github.com/crossplane/crossplane-runtime/pkg/resource/unstructured/composite"
+)
+
+var _ resource.Composite = &overlayComposite{}
+var _ runtime.Unstructured = &overlayComposite{}
+
+type overlayComposite struct {
+	*composite.Unstructured
+	patch *composite.Unstructured
+}
+
+func newOverlayComposite(base *composite.Unstructured) *overlayComposite {
+	p := &composite.Unstructured{}
+	p.SetKind(base.GetKind())
+	p.SetAPIVersion(base.GetAPIVersion())
+	p.SetName(base.GetName())
+
+	return &overlayComposite{Unstructured: base, patch: p}
+}
+
+func (r *overlayComposite) GetCompositionReference() *corev1.ObjectReference {
+	if ref := r.patch.GetCompositionReference(); ref != nil {
+		return ref
+	}
+	return r.Unstructured.GetCompositionReference()
+}
+
+func (r *overlayComposite) SetCompositionReference(ref *corev1.ObjectReference) {
+	r.patch.SetCompositionReference(ref)
+	r.Unstructured.SetCompositionReference(ref)
+}
+
+func (r *overlayComposite) GetCompositionRevisionReference() *corev1.ObjectReference {
+	if ref := r.patch.GetCompositionRevisionReference(); ref != nil {
+		return ref
+	}
+	return r.Unstructured.GetCompositionRevisionReference()
+}
+
+func (r *overlayComposite) SetCompositionRevisionReference(ref *corev1.ObjectReference) {
+	r.patch.SetCompositionRevisionReference(ref)
+	r.Unstructured.SetCompositionRevisionReference(ref)
+}
+
+func (r *overlayComposite) GetEnvironmentConfigReferences() []corev1.ObjectReference {
+	if refs := r.patch.GetEnvironmentConfigReferences(); len(refs) > 0 {
+		return refs
+	}
+	return r.Unstructured.GetEnvironmentConfigReferences()
+}
+
+func (r *overlayComposite) SetEnvironmentConfigReferences(refs []corev1.ObjectReference) {
+	r.patch.SetEnvironmentConfigReferences(refs)
+	r.Unstructured.SetEnvironmentConfigReferences(refs)
+}
+
+func (r *overlayComposite) SetResourceReferences(refs []corev1.ObjectReference) {
+	r.patch.SetResourceReferences(refs)
+	r.Unstructured.SetResourceReferences(refs)
+}
+
+func (r *overlayComposite) SetWriteConnectionSecretToReference(sr *xpv1.SecretReference) {
+	r.patch.SetWriteConnectionSecretToReference(sr)
+	r.Unstructured.SetWriteConnectionSecretToReference(sr)
+}
+
+func (r *overlayComposite) GetPatch() *composite.Unstructured {
+	r.patch.SetName(r.Unstructured.GetName())
+	r.patch.SetKind(r.Unstructured.GetKind())
+	r.patch.SetAPIVersion(r.Unstructured.GetAPIVersion())
+	return r.patch
+}
+
+func (r *overlayComposite) GetBase() *composite.Unstructured {
+	return r.Unstructured
+}
+
+func (r *overlayComposite) GetUnstructured() *unstructured.Unstructured {
+	return r.Unstructured.GetUnstructured()
+}
+
+func (r *overlayComposite) SetFinalizers(finalizers []string) {
+	r.patch.SetFinalizers(finalizers)
+	r.Unstructured.SetFinalizers(finalizers)
+}
+
+func (r *overlayComposite) SetLabels(labels map[string]string) {
+	r.patch.SetLabels(labels)
+	meta.AddLabels(r.Unstructured, labels)
+}
+
+func (r *overlayComposite) SetPublishConnectionDetailsTo(c *xpv1.PublishConnectionDetailsTo) {
+	r.patch.SetPublishConnectionDetailsTo(c)
+	r.Unstructured.SetPublishConnectionDetailsTo(c)
+}
+
+type overlayAwareClient struct {
+	client.Client
+}
+
+func (c *overlayAwareClient) Patch(ctx context.Context, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+	if pc, ok := obj.(*overlayComposite); ok {
+		pobj := pc.GetPatch()
+		if err := c.Client.Patch(ctx, pobj, patch, opts...); err != nil {
+			return err
+		}
+		pc.GetBase().SetUnstructuredContent(pobj.UnstructuredContent())
+		pobj.SetUnstructuredContent(map[string]any{})
+		return nil
+	}
+	return c.Client.Patch(ctx, obj, patch, opts...)
+}

--- a/internal/controller/apiextensions/definition/reconciler.go
+++ b/internal/controller/apiextensions/definition/reconciler.go
@@ -564,8 +564,8 @@ func CompositeReconcilerOptions(co apiextensionscontroller.Options, d *v1.Compos
 		}
 
 		cc := composite.NewConfiguratorChain(
-			composite.NewAPINamingConfigurator(c),
-			composite.NewAPIConfigurator(c),
+			composite.ConfiguratorFn(composite.APINamingConfigure),
+			composite.ConfiguratorFn(composite.APIConfigure),
 			composite.NewSecretStoreConnectionDetailsConfigurator(c),
 		)
 

--- a/internal/csaupgrade/csaupgrade.go
+++ b/internal/csaupgrade/csaupgrade.go
@@ -1,0 +1,88 @@
+/*
+Copyright 2023 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package csaupgrade contains helper functions
+// for migrating client-side to server-side apply
+package csaupgrade
+
+import (
+	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+type filterFn func(e v1.ManagedFieldsEntry) bool
+
+var (
+	// field manager names used by previous Crossplane versions
+	csaManagerNames = []string{"Go-http-client", "crossplane"}
+
+	// SkipSubresources skips migration of field managers set on subresource
+	SkipSubresources = func(e v1.ManagedFieldsEntry) bool {
+		return e.Subresource != ""
+	}
+
+	// OnlySubresources migrates field manager on subresources only
+	OnlySubresources = func(e v1.ManagedFieldsEntry) bool {
+		return e.Subresource == ""
+	}
+
+	// All migrates field manager both on main and subresources
+	All = func(e v1.ManagedFieldsEntry) bool {
+		return false
+	}
+)
+
+// MaybeFixFieldOwnership migrates field managers from client-side
+// to server-side approach, and returns true if the migration was performed.
+// For the background, check https://github.com/kubernetes/kubernetes/issues/99003
+// Managed fields owner key is a pair (manager name, used operation).
+// Previous versions of Crossplane create a composite using patching applicator.
+// Even if the server-side apply is not used, api server derives manager name
+// from the submitted user agent (see net/http/request.go).
+// After Crossplane update, we need to replace the ownership so that
+// field removals can be propagated properly.
+// In order to fix that, we need to manually change operation to "Apply",
+// and the manager name, before the first composite patch is sent to k8s api server.
+// Returns true if the ownership was fixed.
+// TODO: this code can be removed once Crossplane v1.13 is not longer supported
+func MaybeFixFieldOwnership(obj *unstructured.Unstructured, ssaManagerName string, filter filterFn) bool {
+	mfs := obj.GetManagedFields()
+	umfs := make([]v1.ManagedFieldsEntry, len(mfs))
+	copy(umfs, mfs)
+	fixed := false
+	for j := range csaManagerNames {
+		for i := range umfs {
+			if umfs[i].Manager == ssaManagerName {
+				return fixed
+			}
+			if filter(umfs[i]) {
+				continue
+			}
+
+			if umfs[i].Manager == csaManagerNames[j] && umfs[i].Operation == v1.ManagedFieldsOperationUpdate {
+				umfs[i].Operation = v1.ManagedFieldsOperationApply
+				umfs[i].Manager = ssaManagerName
+				fixed = true
+			}
+		}
+		if fixed {
+			obj.SetManagedFields(umfs)
+		}
+	}
+
+	return fixed
+
+}

--- a/internal/csaupgrade/csaupgrade_test.go
+++ b/internal/csaupgrade/csaupgrade_test.go
@@ -1,0 +1,215 @@
+/*
+Copyright 2023 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package csaupgrade
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func TestMaybeFixFieldOwnership(t *testing.T) {
+	type args struct {
+		managedFields  []v1.ManagedFieldsEntry
+		ssaManagerName string
+		filter         filterFn
+	}
+	type want struct {
+		migrated      bool
+		managedFields []v1.ManagedFieldsEntry
+	}
+	tests := map[string]struct {
+		reason string
+		args   args
+		want   want
+	}{
+		"MigrateMainResource": {
+			reason: "Migrate field manager on main resource only",
+			args: args{
+				managedFields: []v1.ManagedFieldsEntry{
+					{
+						Manager:   csaManagerNames[0],
+						Operation: v1.ManagedFieldsOperationUpdate,
+					},
+					{
+						Manager:     csaManagerNames[0],
+						Operation:   v1.ManagedFieldsOperationUpdate,
+						Subresource: "status",
+					},
+					{
+						Manager:   "foo",
+						Operation: v1.ManagedFieldsOperationUpdate,
+					},
+				},
+				ssaManagerName: "ssa",
+				filter:         SkipSubresources,
+			},
+			want: want{
+				migrated: true,
+				managedFields: []v1.ManagedFieldsEntry{
+					{
+						Manager:   "ssa",
+						Operation: v1.ManagedFieldsOperationApply,
+					},
+					{
+						Manager:     csaManagerNames[0],
+						Operation:   v1.ManagedFieldsOperationUpdate,
+						Subresource: "status",
+					},
+					{
+						Manager:   "foo",
+						Operation: v1.ManagedFieldsOperationUpdate,
+					},
+				},
+			},
+		},
+		"MigrateSubresource": {
+			reason: "Migrate field manager on subresource only",
+			args: args{
+				managedFields: []v1.ManagedFieldsEntry{
+					{
+						Manager:   csaManagerNames[0],
+						Operation: v1.ManagedFieldsOperationUpdate,
+					},
+					{
+						Manager:     csaManagerNames[0],
+						Operation:   v1.ManagedFieldsOperationUpdate,
+						Subresource: "status",
+					},
+					{
+						Manager:   "foo",
+						Operation: v1.ManagedFieldsOperationUpdate,
+					},
+				},
+				ssaManagerName: "ssa",
+				filter:         OnlySubresources,
+			},
+			want: want{
+				migrated: true,
+				managedFields: []v1.ManagedFieldsEntry{
+					{
+						Manager:   csaManagerNames[0],
+						Operation: v1.ManagedFieldsOperationUpdate,
+					},
+					{
+						Manager:     "ssa",
+						Operation:   v1.ManagedFieldsOperationApply,
+						Subresource: "status",
+					},
+					{
+						Manager:   "foo",
+						Operation: v1.ManagedFieldsOperationUpdate,
+					},
+				},
+			},
+		},
+		"MigrateAllResource": {
+			reason: "Migrate field manager both on main and sub resource",
+			args: args{
+				managedFields: []v1.ManagedFieldsEntry{
+					{
+						Manager:   csaManagerNames[0],
+						Operation: v1.ManagedFieldsOperationUpdate,
+					},
+					{
+						Manager:     csaManagerNames[0],
+						Operation:   v1.ManagedFieldsOperationUpdate,
+						Subresource: "status",
+					},
+					{
+						Manager:   "foo",
+						Operation: v1.ManagedFieldsOperationUpdate,
+					},
+				},
+				ssaManagerName: "ssa",
+				filter:         All,
+			},
+			want: want{
+				migrated: true,
+				managedFields: []v1.ManagedFieldsEntry{
+					{
+						Manager:   "ssa",
+						Operation: v1.ManagedFieldsOperationApply,
+					},
+					{
+						Manager:     "ssa",
+						Operation:   v1.ManagedFieldsOperationApply,
+						Subresource: "status",
+					},
+					{
+						Manager:   "foo",
+						Operation: v1.ManagedFieldsOperationUpdate,
+					},
+				},
+			},
+		},
+		"MigrateNoResource": {
+			reason: "Do not migrate if client-side managers are not found",
+			args: args{
+				managedFields: []v1.ManagedFieldsEntry{
+					{
+						Manager:   "bar",
+						Operation: v1.ManagedFieldsOperationUpdate,
+					},
+					{
+						Manager:     "bar",
+						Operation:   v1.ManagedFieldsOperationUpdate,
+						Subresource: "status",
+					},
+					{
+						Manager:   "foo",
+						Operation: v1.ManagedFieldsOperationUpdate,
+					},
+				},
+				ssaManagerName: "ssa",
+				filter:         All,
+			},
+			want: want{
+				migrated: false,
+				managedFields: []v1.ManagedFieldsEntry{
+					{
+						Manager:   "bar",
+						Operation: v1.ManagedFieldsOperationUpdate,
+					},
+					{
+						Manager:     "bar",
+						Operation:   v1.ManagedFieldsOperationUpdate,
+						Subresource: "status",
+					},
+					{
+						Manager:   "foo",
+						Operation: v1.ManagedFieldsOperationUpdate,
+					},
+				},
+			},
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			u := &unstructured.Unstructured{}
+			u.SetManagedFields(tc.args.managedFields)
+			if got := MaybeFixFieldOwnership(u, tc.args.ssaManagerName, tc.args.filter); got != tc.want.migrated {
+				t.Errorf("MaybeFixFieldOwnership() = %v, want %v\n%s\n", got, tc.want.migrated, tc.reason)
+			}
+			if diff := cmp.Diff(tc.want.managedFields, u.GetManagedFields()); diff != "" {
+				t.Errorf("\nMaybeFixFieldOwnership(...) unexpected managed fields: %s: -want, +got:%s", tc.reason, diff)
+			}
+		})
+	}
+}

--- a/test/e2e/manifests/apiextensions/composition/propagate-field-updates-mr/claim-update.yaml
+++ b/test/e2e/manifests/apiextensions/composition/propagate-field-updates-mr/claim-update.yaml
@@ -1,0 +1,9 @@
+apiVersion: nop.example.org/v1alpha1
+kind: NopResource
+metadata:
+  namespace: default
+  name: propagate-field-updates-mr
+spec:
+  coolField: "foo"
+  numbers:
+    - "3"

--- a/test/e2e/manifests/apiextensions/composition/propagate-field-updates-mr/claim.yaml
+++ b/test/e2e/manifests/apiextensions/composition/propagate-field-updates-mr/claim.yaml
@@ -1,0 +1,10 @@
+apiVersion: nop.example.org/v1alpha1
+kind: NopResource
+metadata:
+  namespace: default
+  name: propagate-field-updates-mr
+spec:
+  coolField: "foo"
+  numbers:
+    - "1"
+    - "2"

--- a/test/e2e/manifests/apiextensions/composition/propagate-field-updates-mr/composition-update.yaml
+++ b/test/e2e/manifests/apiextensions/composition/propagate-field-updates-mr/composition-update.yaml
@@ -1,0 +1,45 @@
+apiVersion: apiextensions.crossplane.io/v1
+kind: Composition
+metadata:
+  name: xnopresources.nop.example.org
+spec:
+  compositeTypeRef:
+    apiVersion: nop.example.org/v1alpha1
+    kind: XNopResource
+  resources:
+  - name: nop-resource-1
+    base:
+      apiVersion: nop.crossplane.io/v1alpha1
+      kind: NopResource
+      spec:
+        forProvider:
+          fields:
+            bArr:
+              - name: f
+            # someField is removed, and otherField introduced
+            otherField: "otherValue"
+          conditionAfter:
+          - conditionType: Ready
+            conditionStatus: "False"
+            time: 0s
+          - conditionType: Ready
+            conditionStatus: "True"
+            time: 1s
+    patches:
+      - fromFieldPath: "spec.coolField"
+        toFieldPath: spec.forProvider.fields.bArr[0].targetSelector.matchLabels[key2]
+      - type: FromCompositeFieldPath
+        fromFieldPath: "spec.numbers"
+        toFieldPath: spec.forProvider.fields.numbers
+        policy:
+          mergeOptions:
+            appendSlice: true
+      - type: ToCompositeFieldPath
+        fromFieldPath: spec.forProvider.fields.otherNumbers
+        toFieldPath: status.numbers
+        policy:
+          mergeOptions:
+            appendSlice: true
+
+
+

--- a/test/e2e/manifests/apiextensions/composition/propagate-field-updates-mr/crd-update.yaml
+++ b/test/e2e/manifests/apiextensions/composition/propagate-field-updates-mr/crd-update.yaml
@@ -1,0 +1,371 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.11.1
+  name: nopresources.nop.crossplane.io
+spec:
+  conversion:
+    strategy: None
+  group: nop.crossplane.io
+  names:
+    categories:
+    - crossplane
+    - managed
+    - nop
+    kind: NopResource
+    listKind: NopResourceList
+    plural: nopresources
+    singular: nopresource
+  scope: Cluster
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.conditions[?(@.type=='Ready')].status
+      name: READY
+      type: string
+    - jsonPath: .status.conditions[?(@.type=='Synced')].status
+      name: SYNCED
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: AGE
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: A NopResource is an example API type.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: A NopResourceSpec defines the desired state of a NopResource.
+            properties:
+              deletionPolicy:
+                default: Delete
+                description: DeletionPolicy specifies what will happen to the underlying
+                  external when this managed resource is deleted - either "Delete"
+                  or "Orphan" the external resource.
+                enum:
+                - Orphan
+                - Delete
+                type: string
+              forProvider:
+                description: NopResourceParameters are the configurable fields of
+                  a NopResource.
+                properties:
+                  conditionAfter:
+                    description: 'ConditionAfter can be used to set status conditions
+                      after a specified time. By default a NopResource will only have
+                      a status condition of Type: Synced. It will never have a status
+                      condition of Type: Ready unless one is configured here.'
+                    items:
+                      description: ResourceConditionAfter specifies a condition of
+                        a NopResource that should be set after a certain duration.
+                      properties:
+                        conditionReason:
+                          description: ConditionReason to set - e.g. Available.
+                          type: string
+                        conditionStatus:
+                          description: ConditionStatus to set - e.g. True.
+                          type: string
+                        conditionType:
+                          description: ConditionType to set - e.g. Ready.
+                          type: string
+                        time:
+                          description: Time is the duration after which the condition
+                            should be set.
+                          type: string
+                      required:
+                      - conditionStatus
+                      - conditionType
+                      - time
+                      type: object
+                    type: array
+                  connectionDetails:
+                    description: ConnectionDetails that this NopResource should emit
+                      on each reconcile.
+                    items:
+                      description: ResourceConnectionDetail specifies a connection
+                        detail a NopResource should emit.
+                      properties:
+                        name:
+                          description: Name of the connection detail.
+                          type: string
+                        value:
+                          description: Value of the connection detail.
+                          type: string
+                      required:
+                      - name
+                      - value
+                      type: object
+                    type: array
+                  fields:
+                    description: Fields is an arbitrary object you can patch to and
+                      from. It has no schema, is not validated, and is not used by
+                      the NopResource controller.
+                    type: object
+                    properties:
+                      # add schema to bArr, declaring it as list of maps
+                      bArr:
+                        items:
+                          properties:
+                            name:
+                              type: string
+                            targetRefs:
+                              items:
+                                properties:
+                                  name:
+                                    type: string
+                                type: object
+                              type: array
+                            targetSelector:
+                              properties:
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                              type: object
+                          type: object
+                          required:
+                            - name
+                        type: array
+                        x-kubernetes-list-map-keys:
+                          - name
+                        x-kubernetes-list-type: map
+                    x-kubernetes-preserve-unknown-fields: true
+                type: object
+              providerConfigRef:
+                default:
+                  name: default
+                description: ProviderConfigReference specifies how the provider that
+                  will be used to create, observe, update, and delete this managed
+                  resource should be configured.
+                properties:
+                  name:
+                    description: Name of the referenced object.
+                    type: string
+                  policy:
+                    description: Policies for referencing.
+                    properties:
+                      resolution:
+                        default: Required
+                        description: Resolution specifies whether resolution of this
+                          reference is required. The default is 'Required', which
+                          means the reconcile will fail if the reference cannot be
+                          resolved. 'Optional' means this reference will be a no-op
+                          if it cannot be resolved.
+                        enum:
+                        - Required
+                        - Optional
+                        type: string
+                      resolve:
+                        description: Resolve specifies when this reference should
+                          be resolved. The default is 'IfNotPresent', which will attempt
+                          to resolve the reference only when the corresponding field
+                          is not present. Use 'Always' to resolve the reference on
+                          every reconcile.
+                        enum:
+                        - Always
+                        - IfNotPresent
+                        type: string
+                    type: object
+                required:
+                - name
+                type: object
+              providerRef:
+                description: 'ProviderReference specifies the provider that will be
+                  used to create, observe, update, and delete this managed resource.
+                  Deprecated: Please use ProviderConfigReference, i.e. `providerConfigRef`'
+                properties:
+                  name:
+                    description: Name of the referenced object.
+                    type: string
+                  policy:
+                    description: Policies for referencing.
+                    properties:
+                      resolution:
+                        default: Required
+                        description: Resolution specifies whether resolution of this
+                          reference is required. The default is 'Required', which
+                          means the reconcile will fail if the reference cannot be
+                          resolved. 'Optional' means this reference will be a no-op
+                          if it cannot be resolved.
+                        enum:
+                        - Required
+                        - Optional
+                        type: string
+                      resolve:
+                        description: Resolve specifies when this reference should
+                          be resolved. The default is 'IfNotPresent', which will attempt
+                          to resolve the reference only when the corresponding field
+                          is not present. Use 'Always' to resolve the reference on
+                          every reconcile.
+                        enum:
+                        - Always
+                        - IfNotPresent
+                        type: string
+                    type: object
+                required:
+                - name
+                type: object
+              publishConnectionDetailsTo:
+                description: PublishConnectionDetailsTo specifies the connection secret
+                  config which contains a name, metadata and a reference to secret
+                  store config to which any connection details for this managed resource
+                  should be written. Connection details frequently include the endpoint,
+                  username, and password required to connect to the managed resource.
+                properties:
+                  configRef:
+                    default:
+                      name: default
+                    description: SecretStoreConfigRef specifies which secret store
+                      config should be used for this ConnectionSecret.
+                    properties:
+                      name:
+                        description: Name of the referenced object.
+                        type: string
+                      policy:
+                        description: Policies for referencing.
+                        properties:
+                          resolution:
+                            default: Required
+                            description: Resolution specifies whether resolution of
+                              this reference is required. The default is 'Required',
+                              which means the reconcile will fail if the reference
+                              cannot be resolved. 'Optional' means this reference
+                              will be a no-op if it cannot be resolved.
+                            enum:
+                            - Required
+                            - Optional
+                            type: string
+                          resolve:
+                            description: Resolve specifies when this reference should
+                              be resolved. The default is 'IfNotPresent', which will
+                              attempt to resolve the reference only when the corresponding
+                              field is not present. Use 'Always' to resolve the reference
+                              on every reconcile.
+                            enum:
+                            - Always
+                            - IfNotPresent
+                            type: string
+                        type: object
+                    required:
+                    - name
+                    type: object
+                  metadata:
+                    description: Metadata is the metadata for connection secret.
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: Annotations are the annotations to be added to
+                          connection secret. - For Kubernetes secrets, this will be
+                          used as "metadata.annotations". - It is up to Secret Store
+                          implementation for others store types.
+                        type: object
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: Labels are the labels/tags to be added to connection
+                          secret. - For Kubernetes secrets, this will be used as "metadata.labels".
+                          - It is up to Secret Store implementation for others store
+                          types.
+                        type: object
+                      type:
+                        description: Type is the SecretType for the connection secret.
+                          - Only valid for Kubernetes Secret Stores.
+                        type: string
+                    type: object
+                  name:
+                    description: Name is the name of the connection secret.
+                    type: string
+                required:
+                - name
+                type: object
+              writeConnectionSecretToRef:
+                description: WriteConnectionSecretToReference specifies the namespace
+                  and name of a Secret to which any connection details for this managed
+                  resource should be written. Connection details frequently include
+                  the endpoint, username, and password required to connect to the
+                  managed resource. This field is planned to be replaced in a future
+                  release in favor of PublishConnectionDetailsTo. Currently, both
+                  could be set independently and connection details would be published
+                  to both without affecting each other.
+                properties:
+                  name:
+                    description: Name of the secret.
+                    type: string
+                  namespace:
+                    description: Namespace of the secret.
+                    type: string
+                required:
+                - name
+                - namespace
+                type: object
+            required:
+            - forProvider
+            type: object
+          status:
+            description: A NopResourceStatus represents the observed state of a NopResource.
+            properties:
+              atProvider:
+                description: NopResourceObservation are the observable fields of a
+                  NopResource.
+                properties:
+                  fields:
+                    description: Fields is an arbitrary object you can patch to and
+                      from. It has no schema, is not validated, and is not used by
+                      the NopResource controller.
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
+                type: object
+              conditions:
+                description: Conditions of the resource.
+                items:
+                  description: A Condition that may apply to a resource.
+                  properties:
+                    lastTransitionTime:
+                      description: LastTransitionTime is the last time this condition
+                        transitioned from one status to another.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A Message containing details about this condition's
+                        last transition from one status to another, if any.
+                      type: string
+                    reason:
+                      description: A Reason for this condition's last transition from
+                        one status to another.
+                      type: string
+                    status:
+                      description: Status of this condition; is it currently True,
+                        False, or Unknown?
+                      type: string
+                    type:
+                      description: Type of this condition. At most one of each condition
+                        type may apply to a resource at any point in time.
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/test/e2e/manifests/apiextensions/composition/propagate-field-updates-mr/mr-update.yaml
+++ b/test/e2e/manifests/apiextensions/composition/propagate-field-updates-mr/mr-update.yaml
@@ -1,0 +1,17 @@
+apiVersion: nop.crossplane.io/v1alpha1
+kind: NopResource
+metadata:
+  # the name is set to concrete MR name during the test
+  name: xxx
+spec:
+  # MR is updated via server-side apply, hence
+  # we specify here only fields we are interested to be updated
+  forProvider:
+    fields:
+      otherNumbers:
+        - "1"
+        - "2"
+      bArr:
+      - name: f
+        targetRefs:
+          - name: bar

--- a/test/e2e/manifests/apiextensions/composition/propagate-field-updates-mr/mr-update2.yaml
+++ b/test/e2e/manifests/apiextensions/composition/propagate-field-updates-mr/mr-update2.yaml
@@ -1,0 +1,17 @@
+apiVersion: nop.crossplane.io/v1alpha1
+kind: NopResource
+metadata:
+  # the name is set to concrete MR name during the test
+  name: xxx
+spec:
+  # MR is updated via server-side apply, hence
+  # we specify here only fields we are interested to be updated
+  forProvider:
+    fields:
+      otherNumbers:
+        - "3"
+        - "4"
+      bArr:
+      - name: f
+        targetRefs:
+          - name: bar

--- a/test/e2e/manifests/apiextensions/composition/propagate-field-updates-mr/setup/composition.yaml
+++ b/test/e2e/manifests/apiextensions/composition/propagate-field-updates-mr/setup/composition.yaml
@@ -1,0 +1,37 @@
+apiVersion: apiextensions.crossplane.io/v1
+kind: Composition
+metadata:
+  name: xnopresources.nop.example.org
+spec:
+  compositeTypeRef:
+    apiVersion: nop.example.org/v1alpha1
+    kind: XNopResource
+  resources:
+  - name: nop-resource-1
+    base:
+      apiVersion: nop.crossplane.io/v1alpha1
+      kind: NopResource
+      spec:
+        forProvider:
+          fields:
+            bArr:
+              - name: f
+            someField: "someValue"
+          conditionAfter:
+          - conditionType: Ready
+            conditionStatus: "False"
+            time: 0s
+          - conditionType: Ready
+            conditionStatus: "True"
+            time: 1s
+    patches:
+      - fromFieldPath: "spec.coolField"
+        toFieldPath: spec.forProvider.fields.bArr[0].targetSelector.matchLabels[key2]
+      - type: FromCompositeFieldPath
+        fromFieldPath: "spec.numbers"
+        toFieldPath: spec.forProvider.fields.numbers
+        policy:
+          mergeOptions:
+            appendSlice: true
+
+

--- a/test/e2e/manifests/apiextensions/composition/propagate-field-updates-mr/setup/definition.yaml
+++ b/test/e2e/manifests/apiextensions/composition/propagate-field-updates-mr/setup/definition.yaml
@@ -1,0 +1,52 @@
+apiVersion: apiextensions.crossplane.io/v1
+kind: CompositeResourceDefinition
+metadata:
+  name: xnopresources.nop.example.org
+spec:
+  group: nop.example.org
+  names:
+    kind: XNopResource
+    plural: xnopresources
+  claimNames:
+    kind: NopResource
+    plural: nopresources
+  connectionSecretKeys:
+  - test
+  versions:
+  - name: v1alpha1
+    served: true
+    referenceable: true
+    schema:
+     openAPIV3Schema:
+       type: object
+       properties:
+        spec:
+          type: object
+          properties:
+            coolField:
+              type: string
+            numbers:
+              type: array
+              items:
+                type: string
+            parameters:
+              type: object
+              properties:
+                tags:
+                  type: object
+                  properties:
+                    tag:
+                      type: string
+                    newtag:
+                      type: string
+          required:
+          - coolField
+        status:
+          type: object
+          properties:
+            coolerField:
+              type: string
+            numbers:
+              type: array
+              items:
+                type: string

--- a/test/e2e/manifests/apiextensions/composition/propagate-field-updates-mr/setup/provider.yaml
+++ b/test/e2e/manifests/apiextensions/composition/propagate-field-updates-mr/setup/provider.yaml
@@ -1,0 +1,7 @@
+apiVersion: pkg.crossplane.io/v1
+kind: Provider
+metadata:
+  name: provider-nop
+spec:
+  package: xpkg.upbound.io/crossplane-contrib/provider-nop:v0.2.0
+  ignoreCrossplaneConstraints: true


### PR DESCRIPTION
### Description of your changes

* Removing a field in P&T template is correctly propagated to the composed resource
* Changes to composed resources performed by providers and other non-crossplane actors
  are preserved

The changes are propagated using [k8s server-side apply](https://kubernetes.io/docs/reference/using-api/server-side-apply/).

Implementing the server-side apply requested the following changes on the composite reconciler:

* Given that the submitted patch needs to contain all fields that a reconciler
  care about and wants to take the ownership, the existing configurators and composers
  cannot perform partial updates.
* In order to minimize code changes, `overlayComposite` type got introduced to
  catch all changes on the composite during the reconciliation, applying them
  as a patch with the help of `overlayAwareClient`.
* Composite status subresource is still modified by sending UPDATE requests, because
  the controller should own it completely. That is expressed explicitly by setting
  the status field ownership.
* `composition_function.go` adjusted to use `overlayAwareClient` and to let
  reconciler update the composite status at the end.
* in order to adjust to the improved added by `composition_function.go`,
  changes on composite `.spec` and `.metadata` are ignored even for P&T compositions
* unit tests reworked/updated to verify the new implementation
* e2e test added
* resource migration from Crossplane 1.13+ supported


Fixes:

* #3335
* #4162 
* #3993 

Part of https://github.com/crossplane/crossplane/issues/4047 epic.

Implements: https://github.com/crossplane/crossplane/issues/4581

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added or updated unit tests.
- [x] Added or updated e2e tests.
- ~[ ] Linked a PR or a [docs tracking issue] to [document this change].~
- ~[ ] Added `backport release-x.y` labels to auto-backport this PR.~

[contribution process]: https://github.com/crossplane/crossplane/tree/master/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/master/contributing#checklist-cheat-sheet