### PR TITLE
Indicate in log/events the composite readiness

### DIFF
--- a/internal/controller/apiextensions/claim/reconciler.go
+++ b/internal/controller/apiextensions/claim/reconciler.go
@@ -554,7 +554,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 		return reconcile.Result{}, errors.Wrap(r.client.Status().Update(ctx, cm, client.FieldOwner(fieldOwnerName)), errUpdateClaimStatus)
 	}
 
-	record.Event(cm, event.Normal(reasonBind, "Successfully bound composite resource"))
+	record.Event(cm, event.Normal(reasonBind, "Composite resource is ready"))
 
 	propagated, err := r.composite.PropagateConnection(ctx, cm, cp)
 	if err != nil {


### PR DESCRIPTION
### Description of your changes

Previously the message was "Successfully bound composite resource".
To improve the clarity, the message got changed to:

"Composite resource is ready"



<!--
Thank you for helping to improve Crossplane! Please read the contribution docs
(linked below) if this is your first Crossplane pull request.
-->


<!--
Briefly describe what this pull request does, and how it is covered by tests.
Be proactive - direct your reviewers' attention to anything that needs special
consideration.

We love pull requests that fix an open issue. If yours does, use the below line
to indicate which issue it fixes, for example "Fixes #500".
-->

Followup of [another PR review discussion](https://github.com/crossplane/crossplane/pull/4896#discussion_r1392304459).

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- ~[ ] Added or updated unit tests.~
- ~[ ] Added or updated e2e tests.~
- ~[ ] Linked a PR or a [docs tracking issue] to [document this change].~
- ~[ ] Added `backport release-x.y` labels to auto-backport this PR.~

[contribution process]: https://github.com/crossplane/crossplane/tree/master/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/master/contributing#checklist-cheat-sheet