### PR TITLE
Do not reconcile Provider and Functions on serviceaccount and secret changes

### DIFF
--- a/internal/controller/pkg/revision/reconciler.go
+++ b/internal/controller/pkg/revision/reconciler.go
@@ -299,8 +299,6 @@ func SetupProviderRevision(mgr ctrl.Manager, o controller.Options) error {
 		For(&v1.ProviderRevision{}).
 		Owns(&appsv1.Deployment{}).
 		Owns(&corev1.Service{}).
-		Owns(&corev1.Secret{}).
-		Owns(&corev1.ServiceAccount{}).
 		Watches(&v1alpha1.ControllerConfig{}, &EnqueueRequestForReferencingProviderRevisions{
 			client: mgr.GetClient(),
 		})
@@ -407,8 +405,6 @@ func SetupFunctionRevision(mgr ctrl.Manager, o controller.Options) error {
 		For(&v1beta1.FunctionRevision{}).
 		Owns(&appsv1.Deployment{}).
 		Owns(&corev1.Service{}).
-		Owns(&corev1.Secret{}).
-		Owns(&corev1.ServiceAccount{}).
 		Watches(&v1alpha1.ControllerConfig{}, &EnqueueRequestForReferencingFunctionRevisions{
 			client: mgr.GetClient(),
 		})


### PR DESCRIPTION
### Description of your changes

After provider/function deployment got created there is no need to watch
the created service account and secrets for changes:

* changes to secrets are propagated automatically to the pods:

https://kubernetes.io/docs/concepts/configuration/secret/#using-secrets-as-files-from-a-pod

* the service account is referred inside the deployment by its name,
and its content has no impact on the provider/function reconciliation

We should allow other controllers to decorate our service account with
extra annotations/labels/pull secrets and there is no need to react on
these changes.

Openshift is known to use a huge number of secrets for managing various
internal states. They are changed quite frequently.

A fresh OpenShift cluster with no user workload contains >1200 secrets.

Such number of secrets creates a pressure on our informer - it needs to
process all 1200 secrets at least initially, even if none of them is
owned by Crossplane.



<!--
Thank you for helping to improve Crossplane! Please read the contribution docs
(linked below) if this is your first Crossplane pull request.
-->


<!--
Briefly describe what this pull request does, and how it is covered by tests.
Be proactive - direct your reviewers' attention to anything that needs special
consideration.

We love pull requests that fix an open issue. If yours does, use the below line
to indicate which issue it fixes, for example "Fixes #500".
-->

Fixes #5142 

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- ~[ ] Added or updated unit tests.~
- ~[ ] Added or updated e2e tests.~
- ~[ ] Linked a PR or a [docs tracking issue] to [document this change].~
- ~[ ] Added `backport release-x.y` labels to auto-backport this PR.~


[contribution process]: https://github.com/crossplane/crossplane/tree/master/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/master/contributing#checklist-cheat-sheet