### PR TITLE
Change type assertion on packages to enable correct use of --runtime-…

### DIFF
--- a/cmd/crank/xpkg/install.go
+++ b/cmd/crank/xpkg/install.go
@@ -142,7 +142,7 @@ func (c *installCmd) Run(k *kong.Context, logger logging.Logger) error { //nolin
 	}
 
 	if c.RuntimeConfig != "" {
-		rpkg, ok := pkg.(v1.PackageRevisionWithRuntime)
+		rpkg, ok := pkg.(v1.PackageWithRuntime)
 		if !ok {
 			return errors.Errorf("package kind %T does not support runtime configuration", pkg)
 		}


### PR DESCRIPTION
…config flag

### Description of your changes
Crossplane CLI was mis-identifying Provider and Function packages as not supporting the `--runtime-config` flag. This PR adjusts the type assertion in the crossplane xpkg install command to properly allow it.

Fixes #5164

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] ~Added or updated unit tests.~
- [ ] ~Added or updated e2e tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~

[contribution process]: https://github.com/crossplane/crossplane/tree/master/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
