### PR TITLE
Add CODEOWNERS entry for ADOPTERS.md

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -33,6 +33,9 @@
 /ROADMAP.md                          @crossplane/steering-committee
 /LICENSE                             @crossplane/steering-committee
 
+# Adopters list - steering committee and maintainers
+/ADOPTERS.md                         @crossplane/steering-committee @crossplane/crossplane-maintainers
+
 # Design documents
 /design/                             @crossplane/crossplane-maintainers @negz
 


### PR DESCRIPTION
### Description of your changes

While approving and merging a bunch of recent additions to the ADOPTERS.md file, I realized steering committee doesn't have explicit approval via CODEOWNERS for that file.  I'd like to add steering committee for this file so they can also approve/merge changes to it freely.

Since the adopters file isn't explicitly governance related, I am also including maintainers for this file so they can approve/merge changes to it in addition to steering committee.

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [ ] ~Run `make reviewable` to ensure this PR is ready for review.~
- [ ] ~Added or updated unit tests.~
- [ ] ~Added or updated e2e tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/master/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/master/contributing#checklist-cheat-sheet
