### PR TITLE
Update release dates for full quarterly cycles after v1.14

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,14 +21,14 @@ Currently maintained releases, as well as the next few upcoming releases are
 listed below. For more information take a look at the Crossplane [release cycle
 documentation].
 
-| Release | Release Date |   EOL    |
-|:-------:|:------------:|:--------:|
-|  v1.12  | Apr 25, 2023 | Jan 2024 |
-|  v1.13  | Jul 27, 2023 | Apr 2024 |
-|  v1.14  | Nov 1, 2023  | Jul 2024 |
-|  v1.15  | Late Jan '24 | Oct 2024 |
-|  v1.16  | Late Apr '24 | Jan 2025 |
-|  v1.17  | Late Jul '24 | Apr 2025 |
+| Release | Release Date  |   EOL    |
+|:-------:|:-------------:|:--------:|
+|  v1.12  | Apr 25, 2023  | Feb 2024 |
+|  v1.13  | Jul 27, 2023  | May 2024 |
+|  v1.14  | Nov 1, 2023   | Aug 2024 |
+|  v1.15  | Early Feb '24 | Nov 2024 |
+|  v1.16  | Early May '24 | Feb 2025 |
+|  v1.17  | Early Aug '24 | May 2025 |
 
 You can subscribe to the [community calendar] to track all release dates, and
 find the most recent releases on the [releases] page.


### PR DESCRIPTION
### Description of your changes

This PR simply updates the releases table in the main README.md to get back in sync on full quarterly release cycles after v1.14 was pushed back from Late Oct to Early Nov 2023.

The [community calendar](https://calendar.google.com/calendar/embed?src=c_2cdn0hs9e2m05rrv1233cjoj1k%40group.calendar.google.com) has also been updated the same way.

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [ ] ~Run `make reviewable` to ensure this PR is ready for review.~
- [ ] ~Added or updated unit tests.~
- [ ] ~Added or updated e2e tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/master/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/master/contributing#checklist-cheat-sheet
