### PR TITLE
Ensure ownerRef on objects for inactive package revisions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -115,7 +115,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sso v1.12.10 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.14.10 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sts v1.19.0 // indirect
-	github.com/aws/smithy-go v1.13.5 // indirect
+	github.com/aws/smithy-go v1.13.5
 	github.com/awslabs/amazon-ecr-credential-helper/ecr-login v0.0.0-20230510185313-f5e39e5f34c7 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/bufbuild/protocompile v0.6.1-0.20231108163138-146b831231f7 // indirect

--- a/internal/controller/pkg/revision/establisher_test.go
+++ b/internal/controller/pkg/revision/establisher_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/aws/smithy-go/ptr"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	admv1 "k8s.io/api/admissionregistration/v1"
@@ -603,6 +604,67 @@ func TestAPIEstablisherReleaseObjects(t *testing.T) {
 					},
 				},
 				parent: &v1.ProviderRevision{
+					ObjectMeta: metav1.ObjectMeta{
+						UID: "some-unique-uid-2312",
+					},
+					Status: v1.PackageRevisionStatus{
+						ObjectRefs: []xpv1.TypedReference{
+							{
+								APIVersion: "apiextensions.k8s.io/v1",
+								Kind:       "CustomResourceDefinition",
+								Name:       "releases.helm.crossplane.io",
+							},
+						},
+					},
+				},
+			},
+			want: want{
+				err: nil,
+			},
+		},
+		"OwnedIfNotAlready": {
+			reason: "ReleaseObjects should put owner reference back if we are not already the owner.",
+			args: args{
+				est: &APIEstablisher{
+					client: &test.MockClient{
+						MockGet: func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
+							o := obj.(*unstructured.Unstructured)
+							o.SetOwnerReferences([]metav1.OwnerReference{
+								{
+									APIVersion: "pkg.crossplane.io/v1",
+									Kind:       "Provider",
+									Name:       "provider-helm",
+									UID:        "some-other-uid-1234",
+									Controller: &noControl,
+								},
+							})
+							return nil
+						},
+						MockUpdate: func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
+							o := obj.(*unstructured.Unstructured)
+							if len(o.GetOwnerReferences()) != 2 {
+								t.Errorf("expected 2 owner references, got %d", len(o.GetOwnerReferences()))
+							}
+							found := false
+							for _, ref := range o.GetOwnerReferences() {
+								if ref.Kind == "ProviderRevision" && ref.UID == "some-unique-uid-2312" {
+									found = true
+									if ptr.ToBool(ref.Controller) {
+										t.Errorf("expected controller to be false, got %t", *ref.Controller)
+									}
+								}
+							}
+							if !found {
+								t.Errorf("expected to find owner reference for revision with uid some-unique-uid-2312")
+							}
+							return nil
+						},
+					},
+				},
+				parent: &v1.ProviderRevision{
+					TypeMeta: metav1.TypeMeta{
+						Kind: "ProviderRevision",
+					},
 					ObjectMeta: metav1.ObjectMeta{
 						UID: "some-unique-uid-2312",
 					},


### PR DESCRIPTION
### Description of your changes

This PR, extends the `ReleaseObjects` method to also make sure the owner ref for the revision exist instead of just setting controller to false only there is the owner ref. This could be considered as an extra precaution not to lose ownership (hence trigger a garbage collection) on object (i.e. CRDs).

After https://github.com/crossplane/crossplane/pull/4071, we do not execute full pull/parse flow for inactive revisions with existing object references (i.e. `status.objectRefs`), rather only release objects (i.e. controller=false) so that active revisions could take control of them. 

Test Scenario:

1. Install provider-helm v0.15.0
2. Update provider-helm to v0.16.0
3. Edit CRD `releases.helm.crossplane.io` and remove owner ref for inactive revision.
4. Wait for some time (or put a random label on inactive revision to trigger a reconciliation)
5. Make sure manually removed owner ref is put back but not as a controller.

P.S.: The closest scenario which could be relevant here is the [migration](https://docs.upbound.io/providers/migration/#manual-migration) to family providers. During migration, an inactive provider revision of family providers create to take ownership of CRDs created by the monolith provider. However, since the inactive revision comes without having object references (i.e. `status.objectRefs`) set, the full pull/parse flow executed and ownerRef for inactive revision added to the objects. So, this PR is not mandatory there.

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added or updated unit tests.
- [ ] ~Added or updated e2e tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [x] Added `backport release-x.y` labels to auto-backport this PR.

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/master/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/master/contributing#checklist-cheat-sheet
