### PR TITLE
docs: document registry credential fallback

### DIFF
--- a/cmd/crank/xpkg/push.go
+++ b/cmd/crank/xpkg/push.go
@@ -73,7 +73,8 @@ func (c *pushCmd) Help() string {
 	return `
 Packages can be pushed to any OCI registry. Packages are pushed to the
 xpkg.upbound.io registry by default. A package's OCI tag must be a semantic
-version.
+version. Credentials for the registry are automatically retrieved from xpkg login 
+and dockers configuration as fallback.
 
 Examples:
 


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane! Please read the contribution docs
(linked below) if this is your first Crossplane pull request.
-->

### Description of your changes

Adds a sentence about the registry credential retrieval process to the help of the `xpkg push` command.


I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] ~Added or updated unit tests.~
- [ ] ~Added or updated e2e tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/master/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/master/contributing#checklist-cheat-sheet
