### PR TITLE
Update default registry to xpkg.upbound.io

### DIFF
--- a/cmd/crank/xpkg/install.go
+++ b/cmd/crank/xpkg/install.go
@@ -87,7 +87,7 @@ Examples:
 func (c *installCmd) Run(k *kong.Context, logger logging.Logger) error { //nolint:gocyclo // TODO(negz): Can anything be broken out here?
 	pkgName := c.Name
 	if pkgName == "" {
-		ref, err := name.ParseReference(c.Package, name.WithDefaultRegistry(DefaultRegistry))
+		ref, err := name.ParseReference(c.Package, name.WithDefaultRegistry(xpkg.DefaultRegistry))
 		if err != nil {
 			logger.Debug(errPkgIdentifier, "error", err)
 			return errors.Wrap(err, errPkgIdentifier)

--- a/cmd/crank/xpkg/push.go
+++ b/cmd/crank/xpkg/push.go
@@ -54,9 +54,6 @@ const (
 	errFmtWriteIndex    = "failed to push an OCI image index of %d packages"
 )
 
-// DefaultRegistry for pushing Crossplane packages.
-const DefaultRegistry = "xpkg.upbound.io"
-
 // pushCmd pushes a package.
 type pushCmd struct {
 	// Arguments.
@@ -94,7 +91,7 @@ func (c *pushCmd) AfterApply() error {
 
 // Run runs the push cmd.
 func (c *pushCmd) Run(logger logging.Logger) error { //nolint:gocyclo // This feels easier to read as-is.
-	tag, err := name.NewTag(c.Package, name.WithDefaultRegistry(DefaultRegistry))
+	tag, err := name.NewTag(c.Package, name.WithDefaultRegistry(xpkg.DefaultRegistry))
 	if err != nil {
 		return errors.Wrapf(err, errFmtNewTag, c.Package)
 	}
@@ -159,7 +156,7 @@ func (c *pushCmd) Run(logger logging.Logger) error { //nolint:gocyclo // This fe
 				return errors.Wrapf(err, errFmtGetDigest, file)
 			}
 			n := fmt.Sprintf("%s@%s", tag.Repository.Name(), d.String())
-			ref, err := name.NewDigest(n, name.WithDefaultRegistry(DefaultRegistry))
+			ref, err := name.NewDigest(n, name.WithDefaultRegistry(xpkg.DefaultRegistry))
 			if err != nil {
 				return errors.Wrapf(err, errFmtNewDigest, n, file)
 			}

--- a/cmd/crank/xpkg/update.go
+++ b/cmd/crank/xpkg/update.go
@@ -64,7 +64,7 @@ Examples:
 func (c *updateCmd) Run(k *kong.Context, logger logging.Logger) error {
 	pkgName := c.Name
 	if pkgName == "" {
-		ref, err := name.ParseReference(c.Package, name.WithDefaultRegistry(DefaultRegistry))
+		ref, err := name.ParseReference(c.Package, name.WithDefaultRegistry(xpkg.DefaultRegistry))
 		if err != nil {
 			logger.Debug(errPkgIdentifier, "error", err)
 			return errors.Wrap(err, errPkgIdentifier)

--- a/cmd/crossplane/core/core.go
+++ b/cmd/crossplane/core/core.go
@@ -26,7 +26,6 @@ import (
 	"time"
 
 	"github.com/alecthomas/kong"
-	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/spf13/afero"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -70,7 +69,7 @@ type Command struct {
 // KongVars represent the kong variables associated with the CLI parser
 // required for the Registry default variable interpolation.
 var KongVars = kong.Vars{
-	"default_registry":   name.DefaultRegistry,
+	"default_registry":   xpkg.DefaultRegistry,
 	"default_user_agent": transport.DefaultUserAgent,
 }
 
@@ -264,7 +263,6 @@ func (c *startCommand) Run(s *runtime.Scheme, log logging.Logger) error { //noli
 		Options:        o,
 		Namespace:      c.Namespace,
 		ServiceAccount: c.ServiceAccount,
-		Registry:       c.Registry,
 		FunctionRunner: functionRunner,
 	}
 

--- a/cmd/crossplane/rbac/rbac.go
+++ b/cmd/crossplane/rbac/rbac.go
@@ -22,7 +22,6 @@ import (
 	"time"
 
 	"github.com/alecthomas/kong"
-	"github.com/google/go-containerregistry/pkg/name"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/leaderelection/resourcelock"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -35,6 +34,7 @@ import (
 
 	"github.com/crossplane/crossplane/internal/controller/rbac"
 	rbaccontroller "github.com/crossplane/crossplane/internal/controller/rbac/controller"
+	"github.com/crossplane/crossplane/internal/xpkg"
 )
 
 // Available RBAC management policies.
@@ -53,7 +53,7 @@ var KongVars = kong.Vars{
 			ManagementPolicyBasic,
 		},
 		", "),
-	"default_registry": name.DefaultRegistry,
+	"rbac_default_registry": xpkg.DefaultRegistry,
 }
 
 // Command runs the crossplane RBAC controllers
@@ -74,7 +74,7 @@ type startCommand struct {
 
 	ProviderClusterRole string `name:"provider-clusterrole" help:"A ClusterRole enumerating the permissions provider packages may request."`
 	LeaderElection      bool   `name:"leader-election" short:"l" help:"Use leader election for the controller manager." env:"LEADER_ELECTION"`
-	Registry            string `short:"r" help:"Default registry used to fetch packages when not specified in tag." default:"${default_registry}" env:"REGISTRY"`
+	Registry            string `short:"r" help:"Default registry used to fetch packages when not specified in tag." default:"${rbac_default_registry}" env:"REGISTRY"`
 
 	ManagementPolicy           string `name:"manage" short:"m" hidden:""`
 	DeprecatedManagementPolicy string `name:"deprecated-manage" hidden:"" default:"${rbac_manage_default_var}" enum:"${rbac_manage_enum_var}"`

--- a/internal/controller/apiextensions/controller/options.go
+++ b/internal/controller/apiextensions/controller/options.go
@@ -35,10 +35,6 @@ type Options struct {
 	// private registry authentication when pulling Composition Functions.
 	ServiceAccount string
 
-	// Registry is the default registry to use when pulling containers for
-	// Composition Functions
-	Registry string
-
 	// FunctionRunner used to run Composition Functions.
 	FunctionRunner *xfn.PackagedFunctionRunner
 }

--- a/internal/controller/pkg/revision/reconciler.go
+++ b/internal/controller/pkg/revision/reconciler.go
@@ -321,7 +321,7 @@ func SetupProviderRevision(mgr ctrl.Manager, o controller.Options) error {
 	}
 
 	if o.PackageRuntime == controller.PackageRuntimeDeployment {
-		ro = append(ro, WithRuntimeHooks(NewProviderHooks(mgr.GetClient())))
+		ro = append(ro, WithRuntimeHooks(NewProviderHooks(mgr.GetClient(), o.DefaultRegistry)))
 
 		if o.Features.Enabled(features.EnableBetaDeploymentRuntimeConfigs) {
 			cb = cb.Watches(&v1beta1.DeploymentRuntimeConfig{}, &EnqueueRequestForReferencingProviderRevisions{
@@ -429,7 +429,7 @@ func SetupFunctionRevision(mgr ctrl.Manager, o controller.Options) error {
 	}
 
 	if o.PackageRuntime == controller.PackageRuntimeDeployment {
-		ro = append(ro, WithRuntimeHooks(NewFunctionHooks(mgr.GetClient())))
+		ro = append(ro, WithRuntimeHooks(NewFunctionHooks(mgr.GetClient(), o.DefaultRegistry)))
 
 		if o.Features.Enabled(features.EnableBetaDeploymentRuntimeConfigs) {
 			cb = cb.Watches(&v1beta1.DeploymentRuntimeConfig{}, &EnqueueRequestForReferencingFunctionRevisions{

--- a/internal/controller/pkg/revision/runtime_function_test.go
+++ b/internal/controller/pkg/revision/runtime_function_test.go
@@ -36,6 +36,7 @@ import (
 	pkgmetav1beta1 "github.com/crossplane/crossplane/apis/pkg/meta/v1beta1"
 	v1 "github.com/crossplane/crossplane/apis/pkg/v1"
 	"github.com/crossplane/crossplane/apis/pkg/v1beta1"
+	"github.com/crossplane/crossplane/internal/xpkg"
 )
 
 func TestFunctionPreHook(t *testing.T) {
@@ -116,7 +117,7 @@ func TestFunctionPreHook(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			h := NewFunctionHooks(tc.args.client)
+			h := NewFunctionHooks(tc.args.client, xpkg.DefaultRegistry)
 			err := h.Pre(context.TODO(), tc.args.pkg, tc.args.rev, tc.args.manifests)
 
 			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
@@ -182,6 +183,7 @@ func TestFunctionPostHook(t *testing.T) {
 				rev: &v1beta1.FunctionRevision{
 					Spec: v1beta1.FunctionRevisionSpec{
 						PackageRevisionSpec: v1.PackageRevisionSpec{
+							Package:      functionImage,
 							DesiredState: v1.PackageRevisionActive,
 						},
 					},
@@ -207,6 +209,7 @@ func TestFunctionPostHook(t *testing.T) {
 				rev: &v1beta1.FunctionRevision{
 					Spec: v1beta1.FunctionRevisionSpec{
 						PackageRevisionSpec: v1.PackageRevisionSpec{
+							Package:      functionImage,
 							DesiredState: v1.PackageRevisionActive,
 						},
 					},
@@ -221,6 +224,7 @@ func TestFunctionPostHook(t *testing.T) {
 				rev: &v1beta1.FunctionRevision{
 					Spec: v1beta1.FunctionRevisionSpec{
 						PackageRevisionSpec: v1.PackageRevisionSpec{
+							Package:      functionImage,
 							DesiredState: v1.PackageRevisionActive,
 						},
 					},
@@ -249,6 +253,7 @@ func TestFunctionPostHook(t *testing.T) {
 				rev: &v1beta1.FunctionRevision{
 					Spec: v1beta1.FunctionRevisionSpec{
 						PackageRevisionSpec: v1.PackageRevisionSpec{
+							Package:      functionImage,
 							DesiredState: v1.PackageRevisionActive,
 						},
 					},
@@ -263,6 +268,7 @@ func TestFunctionPostHook(t *testing.T) {
 				rev: &v1beta1.FunctionRevision{
 					Spec: v1beta1.FunctionRevisionSpec{
 						PackageRevisionSpec: v1.PackageRevisionSpec{
+							Package:      functionImage,
 							DesiredState: v1.PackageRevisionActive,
 						},
 					},
@@ -288,6 +294,7 @@ func TestFunctionPostHook(t *testing.T) {
 				rev: &v1beta1.FunctionRevision{
 					Spec: v1beta1.FunctionRevisionSpec{
 						PackageRevisionSpec: v1.PackageRevisionSpec{
+							Package:      functionImage,
 							DesiredState: v1.PackageRevisionActive,
 						},
 					},
@@ -302,6 +309,7 @@ func TestFunctionPostHook(t *testing.T) {
 				rev: &v1beta1.FunctionRevision{
 					Spec: v1beta1.FunctionRevisionSpec{
 						PackageRevisionSpec: v1.PackageRevisionSpec{
+							Package:      functionImage,
 							DesiredState: v1.PackageRevisionActive,
 						},
 					},
@@ -335,6 +343,7 @@ func TestFunctionPostHook(t *testing.T) {
 				rev: &v1beta1.FunctionRevision{
 					Spec: v1beta1.FunctionRevisionSpec{
 						PackageRevisionSpec: v1.PackageRevisionSpec{
+							Package:      functionImage,
 							DesiredState: v1.PackageRevisionActive,
 						},
 					},
@@ -349,6 +358,7 @@ func TestFunctionPostHook(t *testing.T) {
 				rev: &v1beta1.FunctionRevision{
 					Spec: v1beta1.FunctionRevisionSpec{
 						PackageRevisionSpec: v1.PackageRevisionSpec{
+							Package:      functionImage,
 							DesiredState: v1.PackageRevisionActive,
 						},
 					},
@@ -381,6 +391,7 @@ func TestFunctionPostHook(t *testing.T) {
 				rev: &v1beta1.FunctionRevision{
 					Spec: v1beta1.FunctionRevisionSpec{
 						PackageRevisionSpec: v1.PackageRevisionSpec{
+							Package:      functionImage,
 							DesiredState: v1.PackageRevisionActive,
 						},
 					},
@@ -394,6 +405,7 @@ func TestFunctionPostHook(t *testing.T) {
 				rev: &v1beta1.FunctionRevision{
 					Spec: v1beta1.FunctionRevisionSpec{
 						PackageRevisionSpec: v1.PackageRevisionSpec{
+							Package:      functionImage,
 							DesiredState: v1.PackageRevisionActive,
 						},
 					},
@@ -444,6 +456,7 @@ func TestFunctionPostHook(t *testing.T) {
 				rev: &v1beta1.FunctionRevision{
 					Spec: v1beta1.FunctionRevisionSpec{
 						PackageRevisionSpec: v1.PackageRevisionSpec{
+							Package:      functionImage,
 							DesiredState: v1.PackageRevisionActive,
 						},
 					},
@@ -454,7 +467,7 @@ func TestFunctionPostHook(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			h := NewFunctionHooks(tc.args.client)
+			h := NewFunctionHooks(tc.args.client, xpkg.DefaultRegistry)
 			err := h.Post(context.TODO(), tc.args.pkg, tc.args.rev, tc.args.manifests)
 
 			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
@@ -558,7 +571,7 @@ func TestFunctionDeactivateHook(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			h := NewFunctionHooks(tc.args.client)
+			h := NewFunctionHooks(tc.args.client, xpkg.DefaultRegistry)
 			err := h.Deactivate(context.TODO(), tc.args.rev, tc.args.manifests)
 
 			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
@@ -566,6 +579,105 @@ func TestFunctionDeactivateHook(t *testing.T) {
 			}
 			if diff := cmp.Diff(tc.want.rev, tc.args.rev, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\nh.Pre(...): -want, +got:\n%s", tc.reason, diff)
+			}
+		})
+	}
+}
+
+func TestGetFunctionImage(t *testing.T) {
+	type args struct {
+		functionMeta     *pkgmetav1beta1.Function
+		functionRevision *v1beta1.FunctionRevision
+		defaultRegistry  string
+	}
+
+	type want struct {
+		err   error
+		image string
+	}
+
+	cases := map[string]struct {
+		reason string
+		args   args
+		want   want
+	}{
+		"NoOverrideFromMeta": {
+			reason: "Should use the image from the package revision and add default registry when no override is present.",
+			args: args{
+				functionMeta: &pkgmetav1beta1.Function{
+					Spec: pkgmetav1beta1.FunctionSpec{
+						Image: nil,
+					},
+				},
+				functionRevision: &v1beta1.FunctionRevision{
+					Spec: v1beta1.FunctionRevisionSpec{
+						PackageRevisionSpec: v1.PackageRevisionSpec{
+							Package: "crossplane/func-bar:v1.2.3",
+						},
+					},
+				},
+				defaultRegistry: "registry.default.io",
+			},
+			want: want{
+				err:   nil,
+				image: "registry.default.io/crossplane/func-bar:v1.2.3",
+			},
+		},
+		"WithOverrideFromMeta": {
+			reason: "Should use the override from the function meta when present and add default registry.",
+			args: args{
+				functionMeta: &pkgmetav1beta1.Function{
+					Spec: pkgmetav1beta1.FunctionSpec{
+						Image: ptr.To("crossplane/func-bar-server:v1.2.3"),
+					},
+				},
+				functionRevision: &v1beta1.FunctionRevision{
+					Spec: v1beta1.FunctionRevisionSpec{
+						PackageRevisionSpec: v1.PackageRevisionSpec{
+							Package: "crossplane/func-bar:v1.2.3",
+						},
+					},
+				},
+				defaultRegistry: "registry.default.io",
+			},
+			want: want{
+				err:   nil,
+				image: "registry.default.io/crossplane/func-bar-server:v1.2.3",
+			},
+		},
+		"RegistrySpecified": {
+			reason: "Should honor the registry as specified on the package, even if its different than the default registry.",
+			args: args{
+				functionMeta: &pkgmetav1beta1.Function{
+					Spec: pkgmetav1beta1.FunctionSpec{
+						Image: nil,
+					},
+				},
+				functionRevision: &v1beta1.FunctionRevision{
+					Spec: v1beta1.FunctionRevisionSpec{
+						PackageRevisionSpec: v1.PackageRevisionSpec{
+							Package: "registry.notdefault.io/crossplane/func-bar:v1.2.3",
+						},
+					},
+				},
+				defaultRegistry: "registry.default.io",
+			},
+			want: want{
+				err:   nil,
+				image: "registry.notdefault.io/crossplane/func-bar:v1.2.3",
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			image, err := getFunctionImage(tc.args.functionMeta, tc.args.functionRevision, tc.args.defaultRegistry)
+
+			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
+				t.Errorf("\n%s\ngetFunctionImage(): -want error, +got error:\n%s", tc.reason, diff)
+			}
+			if diff := cmp.Diff(tc.want.image, image, test.EquateErrors()); diff != "" {
+				t.Errorf("\n%s\ngetFunctionImage(): -want, +got:\n%s", tc.reason, diff)
 			}
 		})
 	}

--- a/internal/controller/pkg/revision/runtime_override_options.go
+++ b/internal/controller/pkg/revision/runtime_override_options.go
@@ -144,8 +144,9 @@ func DeploymentWithImagePullSecrets(secrets []corev1.LocalObjectReference) Deplo
 	}
 }
 
-// DeploymentRuntimeWithOptionalImage set the image for the runtime container
-// if it is unset, e.g. not specified in the DeploymentRuntimeConfig.
+// DeploymentRuntimeWithOptionalImage set the image for the runtime container if
+// it is unset, e.g. not specified in the DeploymentRuntimeConfig. Note that if
+// the image was already set, we use it exactly as is (i.e., no default registry).
 func DeploymentRuntimeWithOptionalImage(image string) DeploymentOverride {
 	return func(d *appsv1.Deployment) {
 		if d.Spec.Template.Spec.Containers[0].Image == "" {

--- a/internal/controller/pkg/revision/runtime_provider_test.go
+++ b/internal/controller/pkg/revision/runtime_provider_test.go
@@ -35,6 +35,7 @@ import (
 
 	pkgmetav1 "github.com/crossplane/crossplane/apis/pkg/meta/v1"
 	v1 "github.com/crossplane/crossplane/apis/pkg/v1"
+	"github.com/crossplane/crossplane/internal/xpkg"
 )
 
 const (
@@ -188,7 +189,7 @@ func TestProviderPreHook(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			h := NewProviderHooks(tc.args.client)
+			h := NewProviderHooks(tc.args.client, xpkg.DefaultRegistry)
 			err := h.Pre(context.TODO(), tc.args.pkg, tc.args.rev, tc.args.manifests)
 
 			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
@@ -254,6 +255,7 @@ func TestProviderPostHook(t *testing.T) {
 				rev: &v1.ProviderRevision{
 					Spec: v1.ProviderRevisionSpec{
 						PackageRevisionSpec: v1.PackageRevisionSpec{
+							Package:      providerImage,
 							DesiredState: v1.PackageRevisionActive,
 						},
 					},
@@ -279,6 +281,7 @@ func TestProviderPostHook(t *testing.T) {
 				rev: &v1.ProviderRevision{
 					Spec: v1.ProviderRevisionSpec{
 						PackageRevisionSpec: v1.PackageRevisionSpec{
+							Package:      providerImage,
 							DesiredState: v1.PackageRevisionActive,
 						},
 					},
@@ -293,6 +296,7 @@ func TestProviderPostHook(t *testing.T) {
 				rev: &v1.ProviderRevision{
 					Spec: v1.ProviderRevisionSpec{
 						PackageRevisionSpec: v1.PackageRevisionSpec{
+							Package:      providerImage,
 							DesiredState: v1.PackageRevisionActive,
 						},
 					},
@@ -321,6 +325,7 @@ func TestProviderPostHook(t *testing.T) {
 				rev: &v1.ProviderRevision{
 					Spec: v1.ProviderRevisionSpec{
 						PackageRevisionSpec: v1.PackageRevisionSpec{
+							Package:      providerImage,
 							DesiredState: v1.PackageRevisionActive,
 						},
 					},
@@ -335,6 +340,7 @@ func TestProviderPostHook(t *testing.T) {
 				rev: &v1.ProviderRevision{
 					Spec: v1.ProviderRevisionSpec{
 						PackageRevisionSpec: v1.PackageRevisionSpec{
+							Package:      providerImage,
 							DesiredState: v1.PackageRevisionActive,
 						},
 					},
@@ -360,6 +366,7 @@ func TestProviderPostHook(t *testing.T) {
 				rev: &v1.ProviderRevision{
 					Spec: v1.ProviderRevisionSpec{
 						PackageRevisionSpec: v1.PackageRevisionSpec{
+							Package:      providerImage,
 							DesiredState: v1.PackageRevisionActive,
 						},
 					},
@@ -374,6 +381,7 @@ func TestProviderPostHook(t *testing.T) {
 				rev: &v1.ProviderRevision{
 					Spec: v1.ProviderRevisionSpec{
 						PackageRevisionSpec: v1.PackageRevisionSpec{
+							Package:      providerImage,
 							DesiredState: v1.PackageRevisionActive,
 						},
 					},
@@ -407,6 +415,7 @@ func TestProviderPostHook(t *testing.T) {
 				rev: &v1.ProviderRevision{
 					Spec: v1.ProviderRevisionSpec{
 						PackageRevisionSpec: v1.PackageRevisionSpec{
+							Package:      providerImage,
 							DesiredState: v1.PackageRevisionActive,
 						},
 					},
@@ -421,6 +430,7 @@ func TestProviderPostHook(t *testing.T) {
 				rev: &v1.ProviderRevision{
 					Spec: v1.ProviderRevisionSpec{
 						PackageRevisionSpec: v1.PackageRevisionSpec{
+							Package:      providerImage,
 							DesiredState: v1.PackageRevisionActive,
 						},
 					},
@@ -453,6 +463,7 @@ func TestProviderPostHook(t *testing.T) {
 				rev: &v1.ProviderRevision{
 					Spec: v1.ProviderRevisionSpec{
 						PackageRevisionSpec: v1.PackageRevisionSpec{
+							Package:      providerImage,
 							DesiredState: v1.PackageRevisionActive,
 						},
 					},
@@ -466,6 +477,7 @@ func TestProviderPostHook(t *testing.T) {
 				rev: &v1.ProviderRevision{
 					Spec: v1.ProviderRevisionSpec{
 						PackageRevisionSpec: v1.PackageRevisionSpec{
+							Package:      providerImage,
 							DesiredState: v1.PackageRevisionActive,
 						},
 					},
@@ -528,6 +540,7 @@ func TestProviderPostHook(t *testing.T) {
 				rev: &v1.ProviderRevision{
 					Spec: v1.ProviderRevisionSpec{
 						PackageRevisionSpec: v1.PackageRevisionSpec{
+							Package:      providerImage,
 							DesiredState: v1.PackageRevisionActive,
 						},
 					},
@@ -538,7 +551,7 @@ func TestProviderPostHook(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			h := NewProviderHooks(tc.args.client)
+			h := NewProviderHooks(tc.args.client, xpkg.DefaultRegistry)
 			err := h.Post(context.TODO(), tc.args.pkg, tc.args.rev, tc.args.manifests)
 
 			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
@@ -660,7 +673,7 @@ func TestProviderDeactivateHook(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			h := NewProviderHooks(tc.args.client)
+			h := NewProviderHooks(tc.args.client, xpkg.DefaultRegistry)
 			err := h.Deactivate(context.TODO(), tc.args.rev, tc.args.manifests)
 
 			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
@@ -668,6 +681,111 @@ func TestProviderDeactivateHook(t *testing.T) {
 			}
 			if diff := cmp.Diff(tc.want.rev, tc.args.rev, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\nh.Pre(...): -want, +got:\n%s", tc.reason, diff)
+			}
+		})
+	}
+}
+
+func TestGetProviderImage(t *testing.T) {
+	type args struct {
+		providerMeta     *pkgmetav1.Provider
+		providerRevision *v1.ProviderRevision
+		defaultRegistry  string
+	}
+
+	type want struct {
+		err   error
+		image string
+	}
+
+	cases := map[string]struct {
+		reason string
+		args   args
+		want   want
+	}{
+		"NoOverrideFromMeta": {
+			reason: "Should use the image from the package revision and add default registry when no override is present.",
+			args: args{
+				providerMeta: &pkgmetav1.Provider{
+					Spec: pkgmetav1.ProviderSpec{
+						Controller: pkgmetav1.ControllerSpec{
+							Image: nil,
+						},
+					},
+				},
+				providerRevision: &v1.ProviderRevision{
+					Spec: v1.ProviderRevisionSpec{
+						PackageRevisionSpec: v1.PackageRevisionSpec{
+							Package: "crossplane/provider-bar:v1.2.3",
+						},
+					},
+				},
+				defaultRegistry: "registry.default.io",
+			},
+			want: want{
+				err:   nil,
+				image: "registry.default.io/crossplane/provider-bar:v1.2.3",
+			},
+		},
+		"WithOverrideFromMeta": {
+			reason: "Should use the override from the function meta when present and add default registry.",
+			args: args{
+				providerMeta: &pkgmetav1.Provider{
+					Spec: pkgmetav1.ProviderSpec{
+						Controller: pkgmetav1.ControllerSpec{
+							Image: ptr.To("crossplane/provider-bar-controller:v1.2.3"),
+						},
+					},
+				},
+				providerRevision: &v1.ProviderRevision{
+					Spec: v1.ProviderRevisionSpec{
+						PackageRevisionSpec: v1.PackageRevisionSpec{
+							Package: "crossplane/provider-bar:v1.2.3",
+						},
+					},
+				},
+				defaultRegistry: "registry.default.io",
+			},
+			want: want{
+				err:   nil,
+				image: "registry.default.io/crossplane/provider-bar-controller:v1.2.3",
+			},
+		},
+		"RegistrySpecified": {
+			reason: "Should honor the registry as specified on the package, even if its different than the default registry.",
+			args: args{
+				providerMeta: &pkgmetav1.Provider{
+					Spec: pkgmetav1.ProviderSpec{
+						Controller: pkgmetav1.ControllerSpec{
+							Image: nil,
+						},
+					},
+				},
+				providerRevision: &v1.ProviderRevision{
+					Spec: v1.ProviderRevisionSpec{
+						PackageRevisionSpec: v1.PackageRevisionSpec{
+							Package: "registry.notdefault.io/crossplane/provider-bar:v1.2.3",
+						},
+					},
+				},
+				defaultRegistry: "registry.default.io",
+			},
+			want: want{
+				err:   nil,
+				image: "registry.notdefault.io/crossplane/provider-bar:v1.2.3",
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			image, err := getProviderImage(tc.args.providerMeta, tc.args.providerRevision, tc.args.defaultRegistry)
+
+			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
+				t.Errorf("\n%s\ngetFunctionImage(): -want error, +got error:\n%s", tc.reason, diff)
+			}
+			if diff := cmp.Diff(tc.want.image, image, test.EquateErrors()); diff != "" {
+				t.Errorf("\n%s\ngetFunctionImage(): -want, +got:\n%s", tc.reason, diff)
 			}
 		})
 	}

--- a/internal/controller/pkg/revision/runtime_test.go
+++ b/internal/controller/pkg/revision/runtime_test.go
@@ -27,7 +27,6 @@ import (
 	"k8s.io/utils/ptr"
 
 	pkgmetav1 "github.com/crossplane/crossplane/apis/pkg/meta/v1"
-	pkgmetav1beta1 "github.com/crossplane/crossplane/apis/pkg/meta/v1beta1"
 	v1 "github.com/crossplane/crossplane/apis/pkg/v1"
 	"github.com/crossplane/crossplane/apis/pkg/v1alpha1"
 	"github.com/crossplane/crossplane/apis/pkg/v1beta1"
@@ -116,34 +115,10 @@ func TestRuntimeManifestBuilderDeployment(t *testing.T) {
 					namespace: namespace,
 				},
 				serviceAccountName: providerRevisionName,
-				overrides:          providerDeploymentOverrides(&pkgmetav1.Provider{ObjectMeta: metav1.ObjectMeta{Name: providerMetaName}}, providerRevision),
+				overrides:          providerDeploymentOverrides(&pkgmetav1.Provider{ObjectMeta: metav1.ObjectMeta{Name: providerMetaName}}, providerRevision, providerImage),
 			},
 			want: want{
 				want: deploymentProvider(providerName, providerRevisionName, providerImage, DeploymentWithSelectors(map[string]string{
-					"pkg.crossplane.io/provider": providerMetaName,
-					"pkg.crossplane.io/revision": providerRevisionName,
-				})),
-			},
-		},
-		"ProviderDeploymentWithImageOverride": {
-			reason: "Image should be overridden if specified in the function spec",
-			args: args{
-				builder: &RuntimeManifestBuilder{
-					revision:  providerRevision,
-					namespace: namespace,
-				},
-				serviceAccountName: providerRevisionName,
-				overrides: providerDeploymentOverrides(&pkgmetav1.Provider{
-					ObjectMeta: metav1.ObjectMeta{Name: providerMetaName},
-					Spec: pkgmetav1.ProviderSpec{
-						Controller: pkgmetav1.ControllerSpec{
-							Image: ptr.To("crossplane/provider-foo-controller:v1.2.3"),
-						},
-					},
-				}, providerRevision),
-			},
-			want: want{
-				want: deploymentProvider(providerName, providerRevisionName, "crossplane/provider-foo-controller:v1.2.3", DeploymentWithSelectors(map[string]string{
 					"pkg.crossplane.io/provider": providerMetaName,
 					"pkg.crossplane.io/revision": providerRevisionName,
 				})),
@@ -176,7 +151,7 @@ func TestRuntimeManifestBuilderDeployment(t *testing.T) {
 					},
 				},
 				serviceAccountName: providerRevisionName,
-				overrides:          providerDeploymentOverrides(&pkgmetav1.Provider{ObjectMeta: metav1.ObjectMeta{Name: providerMetaName}}, providerRevision),
+				overrides:          providerDeploymentOverrides(&pkgmetav1.Provider{ObjectMeta: metav1.ObjectMeta{Name: providerMetaName}}, providerRevision, providerImage),
 			},
 			want: want{
 				want: deploymentProvider(providerName, providerRevisionName, providerImage, DeploymentWithSelectors(map[string]string{
@@ -231,7 +206,7 @@ func TestRuntimeManifestBuilderDeployment(t *testing.T) {
 					},
 				},
 				serviceAccountName: providerRevisionName,
-				overrides:          providerDeploymentOverrides(&pkgmetav1.Provider{ObjectMeta: metav1.ObjectMeta{Name: providerMetaName}}, providerRevision),
+				overrides:          providerDeploymentOverrides(&pkgmetav1.Provider{ObjectMeta: metav1.ObjectMeta{Name: providerMetaName}}, providerRevision, providerImage),
 			},
 			want: want{
 				want: deploymentProvider(providerName, providerRevisionName, providerImage, DeploymentWithSelectors(map[string]string{
@@ -309,7 +284,7 @@ func TestRuntimeManifestBuilderDeployment(t *testing.T) {
 					},
 				},
 				serviceAccountName: providerRevisionName,
-				overrides:          providerDeploymentOverrides(&pkgmetav1.Provider{ObjectMeta: metav1.ObjectMeta{Name: providerMetaName}}, providerRevision),
+				overrides:          providerDeploymentOverrides(&pkgmetav1.Provider{ObjectMeta: metav1.ObjectMeta{Name: providerMetaName}}, providerRevision, providerImage),
 			},
 			want: want{
 				want: deploymentProvider(providerName, providerRevisionName, providerImage, DeploymentWithSelectors(map[string]string{
@@ -353,28 +328,10 @@ func TestRuntimeManifestBuilderDeployment(t *testing.T) {
 					namespace: namespace,
 				},
 				serviceAccountName: functionRevisionName,
-				overrides:          functionDeploymentOverrides(&pkgmetav1beta1.Function{}, functionRevision),
+				overrides:          functionDeploymentOverrides(functionImage),
 			},
 			want: want{
 				want: deploymentFunction(functionName, functionRevisionName, functionImage),
-			},
-		},
-		"FunctionDeploymentWithImageOverride": {
-			reason: "Image should be overridden if specified in the function spec",
-			args: args{
-				builder: &RuntimeManifestBuilder{
-					revision:  functionRevision,
-					namespace: namespace,
-				},
-				serviceAccountName: functionRevisionName,
-				overrides: functionDeploymentOverrides(&pkgmetav1beta1.Function{
-					Spec: pkgmetav1beta1.FunctionSpec{
-						Image: ptr.To("crossplane/function-foo-server:v1.2.3"),
-					},
-				}, functionRevision),
-			},
-			want: want{
-				want: deploymentFunction(functionName, functionRevisionName, "crossplane/function-foo-server:v1.2.3"),
 			},
 		},
 		"FunctionDeploymentWithControllerConfig": {
@@ -390,7 +347,7 @@ func TestRuntimeManifestBuilderDeployment(t *testing.T) {
 					},
 				},
 				serviceAccountName: functionRevisionName,
-				overrides:          functionDeploymentOverrides(&pkgmetav1beta1.Function{}, functionRevision),
+				overrides:          functionDeploymentOverrides(functionImage),
 			},
 			want: want{
 				want: deploymentFunction(functionName, functionRevisionName, functionImage, func(deployment *appsv1.Deployment) {

--- a/internal/controller/rbac/provider/roles/reconciler_test.go
+++ b/internal/controller/rbac/provider/roles/reconciler_test.go
@@ -458,6 +458,12 @@ func TestOrgDiffer(t *testing.T) {
 			b:        "index.docker.io/cool/other-provider:v1.0.0",
 			want:     true,
 		},
+		"DifferentRegistriesWithDefaulting": {
+			registry: "xpkg.example.org",
+			a:        "index.docker.io/cool/provider:v1.0.0",
+			b:        "cool/other-provider:v1.0.0",
+			want:     true,
+		},
 	}
 
 	for name, tc := range cases {

--- a/internal/xpkg/name.go
+++ b/internal/xpkg/name.go
@@ -58,6 +58,10 @@ const (
 	// layer.
 	// TODO(lsviben) Consider changing this to "examples".
 	ExamplesAnnotation string = "upbound"
+
+	// DefaultRegistry is the registry name that will be used when no registry
+	// is provided.
+	DefaultRegistry string = "xpkg.upbound.io"
 )
 
 const (

--- a/test/e2e/manifests/apiextensions/usage/composition/setup/provider.yaml
+++ b/test/e2e/manifests/apiextensions/usage/composition/setup/provider.yaml
@@ -3,5 +3,5 @@ kind: Provider
 metadata:
   name: provider-nop
 spec:
-  package: crossplane/provider-nop:v0.1.1
+  package: xpkg.upbound.io/crossplane-contrib/provider-nop:v0.2.1
   ignoreCrossplaneConstraints: true

--- a/test/e2e/manifests/apiextensions/usage/standalone/setup/provider.yaml
+++ b/test/e2e/manifests/apiextensions/usage/standalone/setup/provider.yaml
@@ -3,5 +3,5 @@ kind: Provider
 metadata:
   name: provider-nop
 spec:
-  package: crossplane/provider-nop:v0.1.1
+  package: xpkg.upbound.io/crossplane-contrib/provider-nop:v0.2.1
   ignoreCrossplaneConstraints: true

--- a/test/e2e/manifests/pkg/configuration/dependency/configuration.yaml
+++ b/test/e2e/manifests/pkg/configuration/dependency/configuration.yaml
@@ -1,6 +1,10 @@
+# This package does not specify a registry, so the default registry will be used
+# during installation. The package expresses a dependency on provider-nop, also
+# without specifying a registry, so the default registry path is exercised
+# heavily in this test.
 apiVersion: pkg.crossplane.io/v1
 kind: Configuration
 metadata:
   name: depends-on-provider-nop
 spec:
-  package: crossplane/e2e-depends-on-provider-nop:v0.1.0
+  package: crossplane/e2e-depends-on-provider-nop:v0.2.0

--- a/test/e2e/manifests/pkg/configuration/dependency/package/crossplane.yaml
+++ b/test/e2e/manifests/pkg/configuration/dependency/package/crossplane.yaml
@@ -1,10 +1,16 @@
 # This is the package metadata for the Configuration installed by
 # configuration.yaml.
+#
+# This package is manually built/pushed to
+# xpkg.upbound.io/crossplane/e2e-depends-on-provider-nop.
+#
+# The dependency does not specify a registry, so the default registry will be
+# used during installation.
 apiVersion: meta.pkg.crossplane.io/v1
 kind: Configuration
 metadata:
   name: e2e-depends-on-provider-nop
 spec:
   dependsOn:
-  - provider: crossplane/provider-nop
-    version: "=v0.1.1"
+  - provider: crossplane-contrib/provider-nop
+    version: "=v0.2.0"

--- a/test/e2e/manifests/pkg/configuration/dependency/provider-dependency.yaml
+++ b/test/e2e/manifests/pkg/configuration/dependency/provider-dependency.yaml
@@ -3,7 +3,7 @@
 apiVersion: pkg.crossplane.io/v1
 kind: Provider
 metadata:
-  name: crossplane-provider-nop
+  name: crossplane-contrib-provider-nop
 spec:
-  package: xpkg.upbound.io/crossplane-contrib/provider-nop:v0.2.0
+  package: crossplane-contrib/provider-nop:v0.2.0
   ignoreCrossplaneConstraints: true

--- a/test/e2e/manifests/pkg/provider/mr-initial.yaml
+++ b/test/e2e/manifests/pkg/provider/mr-initial.yaml
@@ -4,14 +4,12 @@ metadata:
   name: pkg-provider-upgrade
 spec:
  forProvider:
-   # In provider-nop v0.1.x there was no conditionReason field. Every condition
-   # was hardwired to have reason: Available, even when that didn't make sense.
-   # Therefore we simulate an upgrade by first applying this manifest, then
-   # specifying the new (optional) reason field after we update to 0.2.x.
    conditionAfter:
    - conditionType: Ready
      conditionStatus: "False"
+     conditionReason: "Creating"
      time: 0s
    - conditionType: Ready
      conditionStatus: "True"
+     conditionReason: "Available"
      time: 1s

--- a/test/e2e/manifests/pkg/provider/mr-upgrade.yaml
+++ b/test/e2e/manifests/pkg/provider/mr-upgrade.yaml
@@ -5,10 +5,6 @@ metadata:
 spec:
  forProvider:
    conditionAfter:
-   # In provider-nop v0.1.x there was no conditionReason field. Every condition
-   # was hardwired to have reason: Available, even when that didn't make sense.
-   # Therefore we simulate an upgrade by first applying this manifest, then
-   # specifying the new (optional) reason field after we update to 0.2.x.
    - conditionType: Ready
      conditionStatus: "False"
      conditionReason: "Creating"

--- a/test/e2e/manifests/pkg/provider/provider-initial.yaml
+++ b/test/e2e/manifests/pkg/provider/provider-initial.yaml
@@ -3,8 +3,7 @@ kind: Provider
 metadata:
   name: provider-nop
 spec:
-  # We only started pushing to xpkg.upbound.io/crossplane-contrib with v0.2.0
   # This should not be updated by renovate as we need this to be not on the
   # latest version, ignored explicitly in renovate's configuration
-  package: crossplanecontrib/provider-nop:v0.1.1
+  package: xpkg.upbound.io/crossplane-contrib/provider-nop:v0.2.0
   ignoreCrossplaneConstraints: true

--- a/test/e2e/manifests/pkg/provider/provider-upgrade.yaml
+++ b/test/e2e/manifests/pkg/provider/provider-upgrade.yaml
@@ -3,5 +3,5 @@ kind: Provider
 metadata:
   name: provider-nop
 spec:
-  package: xpkg.upbound.io/crossplane-contrib/provider-nop:v0.2.0
+  package: xpkg.upbound.io/crossplane-contrib/provider-nop:v0.2.1
   ignoreCrossplaneConstraints: true

--- a/test/e2e/pkg_test.go
+++ b/test/e2e/pkg_test.go
@@ -110,12 +110,6 @@ func TestProviderUpgrade(t *testing.T) {
 			)).
 			Assess("UpgradeProvider", funcs.AllOf(
 				funcs.ApplyResources(FieldManager, manifests, "provider-upgrade.yaml"),
-				// Note(turkenh): There is a tiny instant after the upgrade where
-				// the provider was still reporting Installed/Healthy but the
-				// new version was not yet installed. This causes flakes in the
-				// test as ".spec.forProvider.conditionAfter[0].conditionReason: field not declared in schema" error.
-				// The following check is to avoid that.
-				funcs.ResourcesHaveFieldValueWithin(2*time.Minute, manifests, "provider-upgrade.yaml", "status.currentIdentifier", "xpkg.upbound.io/crossplane-contrib/provider-nop:v0.2.0"),
 				funcs.ResourcesHaveConditionWithin(2*time.Minute, manifests, "provider-upgrade.yaml", pkgv1.Healthy(), pkgv1.Active()),
 			)).
 			Assess("UpgradeManagedResource", funcs.AllOf(


### PR DESCRIPTION
### Description of your changes

This PR updates the default value for the registry that Crossplane's package manager will install packages from. The default was previously `index.docker.io`, and the new default will be `xpkg.upbound.io`.  Details about the motivation for this change can be ready in #5012.

In addition to the simple change of the default value, it was necessary to update the package manager logic that creates deployment manifests that run providers and functions. That logic is now aware of the default registry so it can include it into manifests it creates when the user has not specified an explicit registry source. 

Feedback is welcome ASAP so we can gain confidence that these changes are thorough and we aren't missing any scenarios.

Fixes #5012 

### Testing

The following scenarios have been tested so far and their behavior is described briefly.  Links to gists with specific testing steps are provided for the more complicated scenarios in the table.

| Pkg Registry Set | Default Set | Upgrade Performed | Scenario | Behavior | 
| --------------------------- | ------------------| -------------------------------- | --------- | -------- |
| ❌  | ❌  | ❌  | Install new package w/o explicit registry specified: Providers, Functions, and Configurations | ✅ Package is installed from xpkg.upbound.io, can create resources OK |
| ✅  | ❌  | ❌  | Install new package with explicit registry specified  | ✅ Package is installed from specified registry, can create resources OK | 
| ❌  | ❌  | ✅  | Package installed on v1.14 w/o explicit registry specified, then Crossplane upgraded to this PR</br>Steps: [gist link](https://gist.github.com/jbw976/793210f26f2dfbb458a41d5dc437ce7e) | ⚠️  Behavior change: the package manager will attempt to update the existing package to the new default registry location. If the package does not exist on the new registry location, the package will become unhealthy. | 
| ✅  | ❌  | ✅  | Package installed on v1.14 w/ explicit registry specified, then Crossplane upgraded to this PR</br>Steps: [gist link](https://gist.github.com/jbw976/83695c4a31f7149bfbaea8249ed638c8) | ✅ Package stays healthy after the upgrade, existing resources stay healthy, can create new resources OK | 
| ❌  | ✅  | ✅  | Package installed on v1.14 w/o explicit registry specified, then Crossplane is upgraded to this PR with `--registry=index.docker.io` to keep previous behavior</br>[gist link](https://gist.github.com/jbw976/094cdfab0eb502e8369259f605761bda) | ✅ The behavior from previous releases of Crossplane remains intact, package stays healthy and installed from dockerhub. |
| ❌  | ❌  | ❌  | Dependencies in a package that are specified w/o an explicit registry [gist link](https://gist.github.com/jbw976/afd49f0a5fdc59a2c7aff559b00fb5ac) | ✅   Package and its dependency are installed from the default registry OK and everything reaches a healthy state. | 
| ✅  | ❌  | ❌  | `DeploymentRuntimeConfig` specifies an image w/ no registry set that overrides the image the package was installed with [gist link](https://gist.github.com/jbw976/f518c7c8f2d1d384c88f75f078d5119a)  | ✅  The image specified in the `DeploymentRuntimeConfig` is used exactly as is, no default is taken into account. If this image doesn't exist then the package will not get healthy, but we will honor exactly what the user specifies in the DRC. | 
| ❌  | ❌  | ❌  | `ControllerConfig` specifies an image w no registry set that overrides the image the package was installed with [gist link](https://gist.github.com/jbw976/fff6dc20c1042079182e55579fa5a1a2) | ✅  The image specified in the `ControllerConfig` is used exactly as is, no default is taken into account. Same behavior as `DeploymentRuntimeConfig`. | 


The most challenging behavior will be the likely common scenario of having existing packages installed implicitly from dockerhub (by previously not explicitly specifying a registry), then upgrading Crossplane to the functionality in this PR. Since the package manager will essentially try to upgrade the package from its previous location (dockerhub) to its new location on the default registry (xpkg.upbound.io), the package can become unhealthy if it doesn't exist there.

**Note** that this will happen for all the `crossplanecontrib` packages on dockerhub because that organization is called `crossplane-contrib` on `xpkg.upbound.io` (note the lack of a `-` on dockerhub), and therefore those packages won't exist.

We will absolutely need clear messaging about this change in the release notes and we should write a blog post too.  For anyone that has an environment where this behavior will cause problems, **ANY** of these options would be recommended:

* update your packages so they all have an explicit registry specified, e.g. `index.docker.io/myorg/mypkg`
* copy/push your packages to `xpkg.upbound.io` so they exist there in addition to dockerhub
* keep the previous behavior by using `--set args='{"--registry=index.docker.io"}'` during the helm upgrade of Crossplane v1.15

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added or updated unit tests.
- [x] Added or updated e2e tests.
- [x] Linked a PR or a [docs tracking issue] to [document this change]: https://github.com/crossplane/docs/issues/680
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/master/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/master/contributing#checklist-cheat-sheet
