### PR TITLE
Fix default registry issue in dependency resolution

### DIFF
--- a/apis/pkg/v1beta1/lock.go
+++ b/apis/pkg/v1beta1/lock.go
@@ -65,8 +65,8 @@ func ToNodes(pkgs ...LockPackage) []dag.Node {
 }
 
 // Identifier returns the source of a LockPackage.
-func (l *LockPackage) Identifier() string {
-	return l.Source
+func (l *LockPackage) Identifier(reg string) string {
+	return dag.AddDefaultRegistry(l.Source, reg)
 }
 
 // Neighbors returns dependencies of a LockPackage.
@@ -100,8 +100,8 @@ type Dependency struct {
 }
 
 // Identifier returns a dependency's source.
-func (d *Dependency) Identifier() string {
-	return d.Package
+func (d *Dependency) Identifier(reg string) string {
+	return dag.AddDefaultRegistry(d.Package, reg)
 }
 
 // Neighbors in is a no-op for dependencies because we are not yet aware of its

--- a/internal/controller/pkg/resolver/reconciler.go
+++ b/internal/controller/pkg/resolver/reconciler.go
@@ -207,7 +207,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 		"name", lock.GetName(),
 	)
 
-	dag := r.newDag()
+	dag := r.newDag(r.registry)
 	implied, err := dag.Init(v1beta1.ToNodes(lock.Packages...))
 	if err != nil {
 		log.Debug(errBuildDAG, "error", err)
@@ -232,7 +232,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 	// check for missing nodes again.
 	dep, ok := implied[0].(*v1beta1.Dependency)
 	if !ok {
-		log.Debug(errInvalidDependency, "error", errors.Errorf(errFmtMissingDependency, dep.Identifier()))
+		log.Debug(errInvalidDependency, "error", errors.Errorf(errFmtMissingDependency, dep.Identifier(r.registry)))
 		return reconcile.Result{Requeue: false}, nil
 	}
 	c, err := semver.NewConstraint(dep.Constraints)
@@ -276,7 +276,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 	// NOTE(hasheddan): consider creating event on package revision
 	// dictating constraints.
 	if addVer == "" {
-		log.Debug(errNoValidVersion, "error", errors.Errorf(errFmtNoValidVersion, dep.Identifier(), dep.Constraints))
+		log.Debug(errNoValidVersion, "error", errors.Errorf(errFmtNoValidVersion, dep.Identifier(r.registry), dep.Constraints))
 		return reconcile.Result{Requeue: false}, nil
 	}
 

--- a/internal/controller/pkg/resolver/reconciler_test.go
+++ b/internal/controller/pkg/resolver/reconciler_test.go
@@ -163,7 +163,7 @@ func TestReconcile(t *testing.T) {
 				},
 				req: reconcile.Request{NamespacedName: types.NamespacedName{Name: "test"}},
 				rec: []ReconcilerOption{
-					WithNewDagFn(func() dag.DAG {
+					WithNewDagFn(func(string) dag.DAG {
 						return &fakedag.MockDag{
 							MockInit: func(nodes []dag.Node) ([]dag.Node, error) {
 								return nil, errBoom
@@ -199,7 +199,7 @@ func TestReconcile(t *testing.T) {
 				},
 				req: reconcile.Request{NamespacedName: types.NamespacedName{Name: "test"}},
 				rec: []ReconcilerOption{
-					WithNewDagFn(func() dag.DAG {
+					WithNewDagFn(func(string) dag.DAG {
 						return &fakedag.MockDag{
 							MockInit: func(nodes []dag.Node) ([]dag.Node, error) {
 								return nil, nil
@@ -238,7 +238,7 @@ func TestReconcile(t *testing.T) {
 				},
 				req: reconcile.Request{NamespacedName: types.NamespacedName{Name: "test"}},
 				rec: []ReconcilerOption{
-					WithNewDagFn(func() dag.DAG {
+					WithNewDagFn(func(string) dag.DAG {
 						return &fakedag.MockDag{
 							MockInit: func(nodes []dag.Node) ([]dag.Node, error) {
 								return nil, nil
@@ -277,7 +277,7 @@ func TestReconcile(t *testing.T) {
 				},
 				req: reconcile.Request{NamespacedName: types.NamespacedName{Name: "test"}},
 				rec: []ReconcilerOption{
-					WithNewDagFn(func() dag.DAG {
+					WithNewDagFn(func(string) dag.DAG {
 						return &fakedag.MockDag{
 							MockInit: func(nodes []dag.Node) ([]dag.Node, error) {
 								return []dag.Node{
@@ -320,7 +320,7 @@ func TestReconcile(t *testing.T) {
 				},
 				req: reconcile.Request{NamespacedName: types.NamespacedName{Name: "test"}},
 				rec: []ReconcilerOption{
-					WithNewDagFn(func() dag.DAG {
+					WithNewDagFn(func(string) dag.DAG {
 						return &fakedag.MockDag{
 							MockInit: func(nodes []dag.Node) ([]dag.Node, error) {
 								return []dag.Node{
@@ -367,7 +367,7 @@ func TestReconcile(t *testing.T) {
 				},
 				req: reconcile.Request{NamespacedName: types.NamespacedName{Name: "test"}},
 				rec: []ReconcilerOption{
-					WithNewDagFn(func() dag.DAG {
+					WithNewDagFn(func(string) dag.DAG {
 						return &fakedag.MockDag{
 							MockInit: func(nodes []dag.Node) ([]dag.Node, error) {
 								return []dag.Node{
@@ -415,7 +415,7 @@ func TestReconcile(t *testing.T) {
 				},
 				req: reconcile.Request{NamespacedName: types.NamespacedName{Name: "test"}},
 				rec: []ReconcilerOption{
-					WithNewDagFn(func() dag.DAG {
+					WithNewDagFn(func(string) dag.DAG {
 						return &fakedag.MockDag{
 							MockInit: func(nodes []dag.Node) ([]dag.Node, error) {
 								return []dag.Node{
@@ -464,7 +464,7 @@ func TestReconcile(t *testing.T) {
 				},
 				req: reconcile.Request{NamespacedName: types.NamespacedName{Name: "test"}},
 				rec: []ReconcilerOption{
-					WithNewDagFn(func() dag.DAG {
+					WithNewDagFn(func(string) dag.DAG {
 						return &fakedag.MockDag{
 							MockInit: func(nodes []dag.Node) ([]dag.Node, error) {
 								return []dag.Node{

--- a/internal/controller/pkg/revision/dependency.go
+++ b/internal/controller/pkg/revision/dependency.go
@@ -127,6 +127,8 @@ func (m *PackageDependencyManager) Resolve(ctx context.Context, pkg runtime.Obje
 	}
 
 	lockRef := xpkg.ParsePackageSourceFromReference(prRef)
+	lockRef = dag.AddDefaultRegistry(lockRef, m.defaultRegistry) // Add default registry if not present.
+
 	// NOTE(hasheddan): consider adding health of package to lock so that it can
 	// be rolled up to any dependent packages.
 	self := v1beta1.LockPackage{

--- a/internal/controller/pkg/revision/fuzz_test.go
+++ b/internal/controller/pkg/revision/fuzz_test.go
@@ -56,18 +56,18 @@ func init() {
 	}
 }
 
-func newFuzzDag(ff *fuzz.ConsumeFuzzer) (func() dag.DAG, error) {
+func newFuzzDag(ff *fuzz.ConsumeFuzzer) (func(string) dag.DAG, error) {
 	traceNodeMap := make(map[string]dag.Node)
 	err := ff.FuzzMap(&traceNodeMap)
 	if err != nil {
-		return func() dag.DAG { return nil }, err
+		return func(string) dag.DAG { return nil }, err
 	}
 	lp := &v1beta1.LockPackage{}
 	err = ff.GenerateStruct(lp)
 	if err != nil {
-		return func() dag.DAG { return nil }, err
+		return func(string) dag.DAG { return nil }, err
 	}
-	return func() dag.DAG {
+	return func(string) dag.DAG {
 		return &dagfake.MockDag{
 			MockInit: func(nodes []dag.Node) ([]dag.Node, error) {
 				return nil, nil
@@ -78,7 +78,7 @@ func newFuzzDag(ff *fuzz.ConsumeFuzzer) (func() dag.DAG, error) {
 			MockTraceNode: func(_ string) (map[string]dag.Node, error) {
 				return traceNodeMap, nil
 			},
-			MockGetNode: func(s string) (dag.Node, error) {
+			MockGetNode: func(s, r string) (dag.Node, error) {
 				return lp, nil
 			},
 		}

--- a/internal/controller/pkg/revision/reconciler.go
+++ b/internal/controller/pkg/revision/reconciler.go
@@ -307,7 +307,7 @@ func SetupProviderRevision(mgr ctrl.Manager, o controller.Options) error {
 
 	ro := []ReconcilerOption{
 		WithCache(o.Cache),
-		WithDependencyManager(NewPackageDependencyManager(mgr.GetClient(), dag.NewMapDag, v1beta1.ProviderPackageType)),
+		WithDependencyManager(NewPackageDependencyManager(mgr.GetClient(), o.DefaultRegistry, dag.NewMapDag, v1beta1.ProviderPackageType)),
 		WithEstablisher(NewAPIEstablisher(mgr.GetClient(), o.Namespace)),
 		WithNewPackageRevisionFn(nr),
 		WithParser(parser.New(metaScheme, objScheme)),
@@ -359,7 +359,7 @@ func SetupConfigurationRevision(mgr ctrl.Manager, o controller.Options) error {
 
 	r := NewReconciler(mgr,
 		WithCache(o.Cache),
-		WithDependencyManager(NewPackageDependencyManager(mgr.GetClient(), dag.NewMapDag, v1beta1.ConfigurationPackageType)),
+		WithDependencyManager(NewPackageDependencyManager(mgr.GetClient(), o.DefaultRegistry, dag.NewMapDag, v1beta1.ConfigurationPackageType)),
 		WithNewPackageRevisionFn(nr),
 		WithEstablisher(NewAPIEstablisher(mgr.GetClient(), o.Namespace)),
 		WithParser(parser.New(metaScheme, objScheme)),
@@ -415,7 +415,7 @@ func SetupFunctionRevision(mgr ctrl.Manager, o controller.Options) error {
 
 	ro := []ReconcilerOption{
 		WithCache(o.Cache),
-		WithDependencyManager(NewPackageDependencyManager(mgr.GetClient(), dag.NewMapDag, v1beta1.FunctionPackageType)),
+		WithDependencyManager(NewPackageDependencyManager(mgr.GetClient(), o.DefaultRegistry, dag.NewMapDag, v1beta1.FunctionPackageType)),
 		WithEstablisher(NewAPIEstablisher(mgr.GetClient(), o.Namespace)),
 		WithNewPackageRevisionFn(nr),
 		WithParser(parser.New(metaScheme, objScheme)),

--- a/internal/dag/fake/mocks.go
+++ b/internal/dag/fake/mocks.go
@@ -29,7 +29,7 @@ type MockDag struct {
 	MockAddNode          func(dag.Node) error
 	MockAddNodes         func(...dag.Node) error
 	MockAddOrUpdateNodes func(...dag.Node)
-	MockGetNode          func(identifier string) (dag.Node, error)
+	MockGetNode          func(identifier, reg string) (dag.Node, error)
 	MockAddEdge          func(from string, to dag.Node) (bool, error)
 	MockAddEdges         func(edges map[string][]dag.Node) ([]dag.Node, error)
 	MockNodeExists       func(identifier string) bool
@@ -59,8 +59,8 @@ func (d *MockDag) AddOrUpdateNodes(n ...dag.Node) {
 }
 
 // GetNode calls the underlying MockGetNode.
-func (d *MockDag) GetNode(i string) (dag.Node, error) {
-	return d.MockGetNode(i)
+func (d *MockDag) GetNode(i, r string) (dag.Node, error) {
+	return d.MockGetNode(i, r)
 }
 
 // AddEdge calls the underlying MockAddEdge.

--- a/internal/dag/fuzz_test.go
+++ b/internal/dag/fuzz_test.go
@@ -21,6 +21,8 @@ import (
 	"testing"
 
 	fuzz "github.com/AdaLogics/go-fuzz-headers"
+
+	"github.com/crossplane/crossplane/internal/xpkg"
 )
 
 type SimpleFuzzNode struct {
@@ -46,12 +48,12 @@ func (s *SimpleFuzzNode) AddNeighbors(nodes ...Node) error {
 		if s.NeighborsField == nil {
 			s.NeighborsField = make(map[string]SimpleFuzzNode)
 		}
-		s.NeighborsField[sn.Identifier()] = *sn
+		s.NeighborsField[sn.Identifier(xpkg.DefaultRegistry)] = *sn
 	}
 	return nil
 }
 
-func (s *SimpleFuzzNode) Identifier() string {
+func (s *SimpleFuzzNode) Identifier(string) string {
 	return s.IdentifierString
 }
 
@@ -79,7 +81,7 @@ func FuzzDag(f *testing.F) {
 				n.NeighborsField = make(map[string]SimpleFuzzNode)
 			}
 		}
-		d := NewMapDag()
+		d := NewMapDag(xpkg.DefaultRegistry)
 
 		_, _ = d.Init(toNodesFuzz(nodes))
 		identifier, err := c.GetString()


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane! Please read the contribution docs
(linked below) if this is your first Crossplane pull request.
-->

### Description of your changes

This PR propagates the default registry to the `PackageDependencyManager` and `DAG` to use it while identifying the images. 

I've tested the PR with the following steps:

- Installed XP v1.14.5
- Installed `xpkg.upbound.io/crossplane-contrib/provider-helm:v0.16.0` and waited until ready
- Installed `xpkg.upbound.io/ezgi/function-go-templating:v0.0.3-dep` which has a dependency with no registry and verified that the package cannot become ready
- Upgraded XP with this change and verified that function becomes ready


<!--
Briefly describe what this pull request does, and how it is covered by tests.
Be proactive - direct your reviewers' attention to anything that needs special
consideration.

We love pull requests that fix an open issue. If yours does, use the below line
to indicate which issue it fixes, for example "Fixes #500".
-->

Fixes #5270 

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added or updated unit tests.
- [ ] ~Added or updated e2e tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [x] Added `backport release-x.y` labels to auto-backport this PR.

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/master/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/master/contributing#checklist-cheat-sheet
