### PR TITLE
fix(crank/trace): show state for not true conditions

### DIFF
--- a/cmd/crank/beta/trace/internal/printer/default_test.go
+++ b/cmd/crank/beta/trace/internal/printer/default_test.go
@@ -73,13 +73,14 @@ ObjectStorage/test-resource (default)                  True      True
 			want: want{
 				// Note: Use spaces instead of tabs for indentation
 				output: `
-NAME                                                                                   VERSION   INSTALLED   HEALTHY   STATE    STATUS                                                                                          
-Configuration/platform-ref-aws                                                         v0.9.0    True        True      -        HealthyPackageRevision                                                                          
-├─ ConfigurationRevision/platform-ref-aws-9ad7b5db2899                                 v0.9.0    True        True      Active   HealthyPackageRevision                                                                          
-└─ Configuration/upbound-configuration-aws-network upbound-configuration-aws-network   v0.7.0    True        True      -        HealthyPackageRevision                                                                          
-   ├─ ConfigurationRevision/upbound-configuration-aws-network-97be9100cfe1             v0.7.0    True        True      Active   HealthyPackageRevision                                                                          
-   └─ Provider/upbound-provider-aws-ec2                                                v0.47.0   True        False     -        UnhealthyPackageRevision: ...ider package deployment has no condition of type "Available" yet   
-      └─ ProviderRevision/upbound-provider-aws-ec2-9ad7b5db2899                        v0.47.0   True        False     Active   UnhealthyPackageRevision: ...ider package deployment has no condition of type "Available" yet   
+NAME                                                                                   VERSION   INSTALLED   HEALTHY   STATE    STATUS                                                                                              
+Configuration/platform-ref-aws                                                         v0.9.0    True        True      -        HealthyPackageRevision                                                                              
+├─ ConfigurationRevision/platform-ref-aws-9ad7b5db2899                                 v0.9.0    True        True      Active   HealthyPackageRevision                                                                              
+└─ Configuration/upbound-configuration-aws-network upbound-configuration-aws-network   v0.7.0    True        True      -        HealthyPackageRevision                                                                              
+   ├─ ConfigurationRevision/upbound-configuration-aws-network-97be9100cfe1             v0.7.0    True        True      Active   HealthyPackageRevision                                                                              
+   └─ Provider/upbound-provider-aws-ec2                                                v0.47.0   True        Unknown   -        UnknownPackageRevisionHealth: ...der-helm xpkg.upbound.io/crossplane-contrib/provider-kubernetes]   
+      ├─ ProviderRevision/upbound-provider-aws-ec2-9ad7b5db2899                        v0.47.0   True        False     Active   UnhealthyPackageRevision: ...ider package deployment has no condition of type "Available" yet       
+      └─ Provider/upbound-provider-aws-something                                       v0.47.0   True        -         -        ActivePackageRevision                                                                               
 `,
 				err: nil,
 			},

--- a/cmd/crank/beta/trace/internal/printer/dot_test.go
+++ b/cmd/crank/beta/trace/internal/printer/dot_test.go
@@ -69,13 +69,15 @@ func TestPrintDotGraph(t *testing.T) {
 	n2[label="Name: platform-ref-aws-9ad7b5db2899\nApiVersion: pkg.crossplane.io/v1\nPackage: xpkg.upbound.io/upbound/platform-ref-aws:v0.9.0\nHealthy: True\nState: HealthyPackageRevision\n",penwidth="2"];
 	n3[label="Name: upbound-configuration-aws-network upbound-configuration-aws-network\nApiVersion: pkg.crossplane.io/v1\nPackage: xpkg.upbound.io/upbound/configuration-aws-network:v0.7.0\nInstalled: True\nHealthy: True\n",penwidth="2"];
 	n4[label="Name: upbound-configuration-aws-network-97be9100cfe1\nApiVersion: pkg.crossplane.io/v1\nPackage: xpkg.upbound.io/upbound/configuration-aws-network:v0.7.0\nHealthy: True\nState: HealthyPackageRevision\n",penwidth="2"];
-	n5[label="Name: upbound-provider-aws-ec2\nApiVersion: pkg.crossplane.io/v1\nPackage: xpkg.upbound.io/upbound/provider-aws-ec2:v0.47.0\nInstalled: True\nHealthy: False\n",penwidth="2"];
+	n5[label="Name: upbound-provider-aws-ec2\nApiVersion: pkg.crossplane.io/v1\nPackage: xpkg.upbound.io/upbound/provider-aws-ec2:v0.47.0\nInstalled: True\nHealthy: Unknown\n",penwidth="2"];
 	n6[label="Name: upbound-provider-aws-ec2-9ad7b5db2899\nApiVersion: pkg.crossplane.io/v1\nPackage: xpkg.upbound.io/upbound/provider-aws-ec2:v0.47.0\nHealthy: False\nState: UnhealthyPackageRevision\n",penwidth="2"];
+	n7[label="Name: upbound-provider-aws-something\nApiVersion: pkg.crossplane.io/v1\nPackage: xpkg.upbound.io/upbound/provider-aws-something:v0.47.0\nInstalled: True\nHealthy: \n",penwidth="2"];
 	n1--n2;
 	n1--n3;
 	n3--n4;
 	n3--n5;
 	n5--n6;
+	n5--n7;
 	
 }
 `,

--- a/cmd/crank/beta/trace/internal/printer/printer_test.go
+++ b/cmd/crank/beta/trace/internal/printer/printer_test.go
@@ -215,9 +215,8 @@ func GetComplexPackage() *resource.Resource {
 					},
 					{
 						Unstructured: DummyPackage(v1.ProviderGroupVersionKind, "upbound-provider-aws-ec2",
-							WithConditions(v1.Active(), v1.Unhealthy().WithMessage("post establish runtime hook failed for package: provider package deployment has no condition of type \"Available\" yet")),
+							WithConditions(v1.Active(), v1.UnknownHealth().WithMessage("cannot resolve package dependencies: incompatible dependencies: [xpkg.upbound.io/crossplane-contrib/provider-helm xpkg.upbound.io/crossplane-contrib/provider-kubernetes]")),
 							WithPackage("xpkg.upbound.io/upbound/provider-aws-ec2:v0.47.0"),
-							WithDesiredState(v1.PackageRevisionActive),
 						),
 						Children: []*resource.Resource{
 							{
@@ -225,6 +224,12 @@ func GetComplexPackage() *resource.Resource {
 									WithConditions(v1.Active(), v1.Unhealthy().WithMessage("post establish runtime hook failed for package: provider package deployment has no condition of type \"Available\" yet")),
 									WithImage("xpkg.upbound.io/upbound/provider-aws-ec2:v0.47.0"),
 									WithDesiredState(v1.PackageRevisionActive)),
+							},
+							{
+								Unstructured: DummyPackage(v1.ProviderGroupVersionKind, "upbound-provider-aws-something",
+									WithConditions(v1.Active()), // Missing healthy condition on purpose.
+									WithPackage("xpkg.upbound.io/upbound/provider-aws-something:v0.47.0"),
+								),
 							},
 						},
 					},


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane! Please read the contribution docs
(linked below) if this is your first Crossplane pull request.
-->

### Description of your changes

<!--
Briefly describe what this pull request does, and how it is covered by tests.
Be proactive - direct your reviewers' attention to anything that needs special
consideration.

We love pull requests that fix an open issue. If yours does, use the below line
to indicate which issue it fixes, for example "Fixes #500".
-->

Fixes an issue reported by @Piotr1215 where a Configuration with the following conditions didn't show any useful message in the trace output:
```json
...
        {
          "lastTransitionTime": "2024-01-26T12:38:06Z",
          "message": "cannot resolve package dependencies: incompatible dependencies: [xpkg.upbound.io/crossplane-contrib/provider-helm xpkg.upbound.io/crossplane-contrib/provider-kubernetes]",
          "reason": "UnknownPackageRevisionHealth",
          "status": "Unknown",
          "type": "Healthy"
        },
        {
          "lastTransitionTime": "2024-01-26T12:33:40Z",
          "reason": "ActivePackageRevision",
          "status": "True",
          "type": "Installed"
        }
...
```
It showed just:
```
$ crossplane beta trace configuration.pkg.crossplane.io/configuration-caas
NAME                                                                          VERSION   INSTALLED   HEALTHY   STATE    STATUS
Configuration/configuration-caas                                              v0.2.0    True        Unknown   -        
├─ ConfigurationRevision/configuration-caas-1df38f85537b                      v0.2.0    -           Unknown   Active   
... omitted for brevity ...

```
With this change it would have shown:
```
$ crossplane beta trace configuration.pkg.crossplane.io/configuration-caas
NAME                                                                          VERSION   INSTALLED   HEALTHY   STATE    STATUS
Configuration/configuration-caas                                              v0.2.0    True        Unknown   -        UnknownPackageRevisionHealth: ...der-helm [xpkg.upbound.io/crossplane-contrib/provider-kubernetes](http://xpkg.upbound.io/crossplane-contrib/provider-kubernetes)]
├─ ConfigurationRevision/configuration-caas-1df38f85537b                      v0.2.0    -           Unknown   Active   UnknownPackageRevisionHealth: ...der-helm [xpkg.upbound.io/crossplane-contrib/provider-kubernetes](http://xpkg.upbound.io/crossplane-contrib/provider-kubernetes)]

... omitted for brevity ...
```

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added or updated unit tests.
- [ ] ~Added or updated e2e tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/master/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/master/contributing#checklist-cheat-sheet
