### PR TITLE
Display package images unmodified in trace pkg output

### DIFF
--- a/cmd/crank/beta/trace/internal/printer/default.go
+++ b/cmd/crank/beta/trace/internal/printer/default.go
@@ -319,9 +319,12 @@ func getPkgResourceStatus(r *resource.Resource, name string, wide bool) fmt.Stri
 	}
 
 	// Parse the image reference extracting the tag, we'll leave it empty if we
-	// couldn't parse it and leave the whole thing as package instead.
+	// couldn't parse it and leave the whole thing as package instead. We pass
+	// an empty default registry here so the displayed package image will be
+	// unmodified from what we found in the spec, similar to how kubectl output
+	// behaves.
 	var packageImgTag string
-	if tag, err := gcrname.NewTag(packageImg); err == nil {
+	if tag, err := gcrname.NewTag(packageImg, gcrname.WithDefaultRegistry("")); err == nil {
 		packageImgTag = tag.TagStr()
 		packageImg = tag.RepositoryStr()
 		if tag.RegistryStr() != "" {


### PR DESCRIPTION
### Description of your changes

This PR modifies the output of `crossplane beta trace` so that the image for a package is displayed unmodified from its spec. Currently, due to the parsing we do of the tag, we inadvertently add on the default registry for `"github.com/google/go-containerregistry/pkg/name"` which is `index.docker.io`, if the package has no registry specified.

This PR instead attempts to keep the package image unmodified from its spec for display in the output of `trace`, which is the same way the output for `kubectl get pkg` behaves.

Fixes #5298  

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added or updated unit tests.
- [ ] ~Added or updated e2e tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [x] Added `backport release-x.y` labels to auto-backport this PR.

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/master/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/master/contributing#checklist-cheat-sheet
