### PR TITLE
controller/usage: remove debug output

### DIFF
--- a/internal/controller/apiextensions/usage/reconciler.go
+++ b/internal/controller/apiextensions/usage/reconciler.go
@@ -223,8 +223,6 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 		return reconcile.Result{}, err
 	}
 
-	r.record.Event(u, event.Normal(reasonResolveSelectors, "Selectors resolved, if any."))
-
 	of := u.Spec.Of
 	by := u.Spec.By
 

--- a/internal/controller/apiextensions/usage/reconciler.go
+++ b/internal/controller/apiextensions/usage/reconciler.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
 	v1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -215,6 +216,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 		log.Debug(errGetUsage, "error", err)
 		return reconcile.Result{}, errors.Wrap(xpresource.IgnoreNotFound(err), errGetUsage)
 	}
+	orig := u.DeepCopy()
 
 	if err := r.usage.resolveSelectors(ctx, u); err != nil {
 		log.Debug(errResolveSelectors, "error", err)
@@ -404,11 +406,16 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 	}
 
 	u.Status.SetConditions(xpv1.Available())
-	r.record.Event(u, event.Normal(reasonUsageConfigured, "Usage configured successfully."))
+
 	// We are only watching the Usage itself but not using or used resources.
 	// So, we need to reconcile the Usage periodically to check if the using
 	// or used resources are still there.
-	return reconcile.Result{RequeueAfter: r.pollInterval}, errors.Wrap(r.client.Status().Update(ctx, u), errUpdateStatus)
+	if !cmp.Equal(u, orig) {
+		r.record.Event(u, event.Normal(reasonUsageConfigured, "Usage configured successfully."))
+		return reconcile.Result{RequeueAfter: r.pollInterval}, errors.Wrap(r.client.Status().Update(ctx, u), errUpdateStatus)
+	}
+
+	return reconcile.Result{RequeueAfter: r.pollInterval}, nil
 }
 
 func detailsAnnotation(u *v1alpha1.Usage) string {


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane! Please read the contribution docs
(linked below) if this is your first Crossplane pull request.
-->

### Description of your changes

That event is useless and even harms production systems as it congests the API, with that leads to throttling and the log is full of only these events.

**We should have a rule: every event that is 1:1 with reconciles is a blocker.**

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- ~~[ ] Added or updated unit tests.~~
- ~~[ ] Added or updated e2e tests.~~
- ~~[ ] Linked a PR or a [docs tracking issue] to [document this change].~~
- [ ] Added `backport release-x.y` labels to auto-backport this PR.

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/master/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/master/contributing#checklist-cheat-sheet