### PR TITLE
Added debug logs for render command

### DIFF
--- a/cmd/crank/beta/render/cmd.go
+++ b/cmd/crank/beta/render/cmd.go
@@ -119,7 +119,7 @@ func (c *Cmd) AfterApply() error {
 }
 
 // Run render.
-func (c *Cmd) Run(k *kong.Context, _ logging.Logger) error { //nolint:gocyclo // Only a touch over.
+func (c *Cmd) Run(k *kong.Context, logger logging.Logger) error { //nolint:gocyclo // Only a touch over.
 	xr, err := LoadCompositeResource(c.fs, c.CompositeResource)
 	if err != nil {
 		return errors.Wrapf(err, "cannot load composite resource from %q", c.CompositeResource)
@@ -180,7 +180,7 @@ func (c *Cmd) Run(k *kong.Context, _ logging.Logger) error { //nolint:gocyclo //
 	ctx, cancel := context.WithTimeout(context.Background(), c.Timeout)
 	defer cancel()
 
-	out, err := Render(ctx, Inputs{
+	out, err := Render(ctx, logger, Inputs{
 		CompositeResource: xr,
 		Composition:       comp,
 		Functions:         fns,

--- a/cmd/crank/beta/render/render.go
+++ b/cmd/crank/beta/render/render.go
@@ -32,6 +32,7 @@ import (
 
 	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
 	"github.com/crossplane/crossplane-runtime/pkg/errors"
+	"github.com/crossplane/crossplane-runtime/pkg/logging"
 	"github.com/crossplane/crossplane-runtime/pkg/meta"
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
 	"github.com/crossplane/crossplane-runtime/pkg/resource/unstructured/composed"
@@ -91,7 +92,7 @@ type Outputs struct {
 }
 
 // Render the desired XR and composed resources, sorted by resource name, given the supplied inputs.
-func Render(ctx context.Context, in Inputs) (Outputs, error) { //nolint:gocyclo // TODO(negz): Should we refactor to break this up a bit?
+func Render(ctx context.Context, logger logging.Logger, in Inputs) (Outputs, error) { //nolint:gocyclo // TODO(negz): Should we refactor to break this up a bit?
 	// Run our Functions.
 	conns := map[string]*grpc.ClientConn{}
 	for _, fn := range in.Functions {
@@ -99,7 +100,7 @@ func Render(ctx context.Context, in Inputs) (Outputs, error) { //nolint:gocyclo 
 		if err != nil {
 			return Outputs{}, errors.Wrapf(err, "cannot get runtime for Function %q", fn.GetName())
 		}
-		rctx, err := runtime.Start(ctx)
+		rctx, err := runtime.Start(ctx, logger)
 		if err != nil {
 			return Outputs{}, errors.Wrapf(err, "cannot start Function %q", fn.GetName())
 		}

--- a/cmd/crank/beta/render/render_test.go
+++ b/cmd/crank/beta/render/render_test.go
@@ -32,6 +32,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 
+	"github.com/crossplane/crossplane-runtime/pkg/logging"
 	"github.com/crossplane/crossplane-runtime/pkg/resource/unstructured/composed"
 	"github.com/crossplane/crossplane-runtime/pkg/resource/unstructured/composite"
 
@@ -739,7 +740,7 @@ func TestRender(t *testing.T) {
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 
-			out, err := Render(tc.args.ctx, tc.args.in)
+			out, err := Render(tc.args.ctx, logging.NewNopLogger(), tc.args.in)
 
 			if diff := cmp.Diff(tc.want.out, out, cmpopts.EquateEmpty()); diff != "" {
 				t.Errorf("%s\nRender(...): -want, +got:\n%s", tc.reason, diff)

--- a/cmd/crank/beta/render/runtime.go
+++ b/cmd/crank/beta/render/runtime.go
@@ -20,6 +20,7 @@ import (
 	"context"
 
 	"github.com/crossplane/crossplane-runtime/pkg/errors"
+	"github.com/crossplane/crossplane-runtime/pkg/logging"
 
 	pkgv1beta1 "github.com/crossplane/crossplane/apis/pkg/v1beta1"
 )
@@ -49,7 +50,7 @@ const (
 // A Runtime runs a Function.
 type Runtime interface {
 	// Start the Function.
-	Start(ctx context.Context) (RuntimeContext, error)
+	Start(ctx context.Context, logger logging.Logger) (RuntimeContext, error)
 }
 
 // RuntimeContext contains context on how a Function is being run.

--- a/cmd/crank/beta/render/runtime_development.go
+++ b/cmd/crank/beta/render/runtime_development.go
@@ -19,6 +19,8 @@ package render
 import (
 	"context"
 
+	"github.com/crossplane/crossplane-runtime/pkg/logging"
+
 	pkgv1beta1 "github.com/crossplane/crossplane/apis/pkg/v1beta1"
 )
 
@@ -50,6 +52,6 @@ func GetRuntimeDevelopment(fn pkgv1beta1.Function) *RuntimeDevelopment {
 var _ Runtime = &RuntimeDevelopment{}
 
 // Start does nothing. It returns a Stop function that also does nothing.
-func (r *RuntimeDevelopment) Start(_ context.Context) (RuntimeContext, error) {
+func (r *RuntimeDevelopment) Start(_ context.Context, _ logging.Logger) (RuntimeContext, error) {
 	return RuntimeContext{Target: r.Target, Stop: func(_ context.Context) error { return nil }}, nil
 }

--- a/cmd/crank/beta/render/runtime_development.go
+++ b/cmd/crank/beta/render/runtime_development.go
@@ -37,12 +37,14 @@ type RuntimeDevelopment struct {
 	// Target is the gRPC target for the running function, for example
 	// localhost:9443.
 	Target string
+	// Function is the name of the function to be run.
+	Function string
 }
 
 // GetRuntimeDevelopment extracts RuntimeDevelopment configuration from the
 // supplied Function.
 func GetRuntimeDevelopment(fn pkgv1beta1.Function) *RuntimeDevelopment {
-	r := &RuntimeDevelopment{Target: "localhost:9443"}
+	r := &RuntimeDevelopment{Target: "localhost:9443", Function: fn.GetName()}
 	if t := fn.GetAnnotations()[AnnotationKeyRuntimeDevelopmentTarget]; t != "" {
 		r.Target = t
 	}
@@ -52,6 +54,7 @@ func GetRuntimeDevelopment(fn pkgv1beta1.Function) *RuntimeDevelopment {
 var _ Runtime = &RuntimeDevelopment{}
 
 // Start does nothing. It returns a Stop function that also does nothing.
-func (r *RuntimeDevelopment) Start(_ context.Context, _ logging.Logger) (RuntimeContext, error) {
+func (r *RuntimeDevelopment) Start(_ context.Context, logger logging.Logger) (RuntimeContext, error) {
+	logger.Debug("Starting development runtime. Remember to run the function manually.", "function", r.Function, "target", r.Target)
 	return RuntimeContext{Target: r.Target, Stop: func(_ context.Context) error { return nil }}, nil
 }

--- a/cmd/crank/beta/render/runtime_docker.go
+++ b/cmd/crank/beta/render/runtime_docker.go
@@ -29,6 +29,7 @@ import (
 	"github.com/docker/go-connections/nat"
 
 	"github.com/crossplane/crossplane-runtime/pkg/errors"
+	"github.com/crossplane/crossplane-runtime/pkg/logging"
 
 	pkgv1beta1 "github.com/crossplane/crossplane/apis/pkg/v1beta1"
 )
@@ -149,7 +150,7 @@ func GetRuntimeDocker(fn pkgv1beta1.Function) (*RuntimeDocker, error) {
 var _ Runtime = &RuntimeDocker{}
 
 // Start a Function as a Docker container.
-func (r *RuntimeDocker) Start(ctx context.Context) (RuntimeContext, error) { //nolint:gocyclo // TODO(phisco): Refactor to break this up a bit, not so easy.
+func (r *RuntimeDocker) Start(ctx context.Context, logger logging.Logger) (RuntimeContext, error) { //nolint:gocyclo // TODO(phisco): Refactor to break this up a bit, not so easy.
 	c, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
 	if err != nil {
 		return RuntimeContext{}, errors.Wrap(err, "cannot create Docker client using environment variables")
@@ -180,6 +181,7 @@ func (r *RuntimeDocker) Start(ctx context.Context) (RuntimeContext, error) { //n
 	}
 
 	if r.PullPolicy == AnnotationValueRuntimeDockerPullPolicyAlways {
+		logger.Debug("Pulling image with pullPolicy: Always", "image", r.Image)
 		err = PullImage(ctx, c, r.Image)
 		if err != nil {
 			return RuntimeContext{}, errors.Wrapf(err, "cannot pull Docker image %q", r.Image)
@@ -187,6 +189,7 @@ func (r *RuntimeDocker) Start(ctx context.Context) (RuntimeContext, error) { //n
 	}
 
 	// TODO(negz): Set a container name? Presumably unique across runs.
+	logger.Debug("Creating Docker container", "image", r.Image, "address", addr)
 	rsp, err := c.ContainerCreate(ctx, cfg, hcfg, nil, nil, "")
 	if err != nil {
 		if !errdefs.IsNotFound(err) || r.PullPolicy == AnnotationValueRuntimeDockerPullPolicyNever {
@@ -194,6 +197,7 @@ func (r *RuntimeDocker) Start(ctx context.Context) (RuntimeContext, error) { //n
 		}
 
 		// The image was not found, but we're allowed to pull it.
+		logger.Debug("Image not found, pulling", "image", r.Image)
 		err = PullImage(ctx, c, r.Image)
 		if err != nil {
 			return RuntimeContext{}, errors.Wrapf(err, "cannot pull Docker image %q", r.Image)
@@ -210,7 +214,7 @@ func (r *RuntimeDocker) Start(ctx context.Context) (RuntimeContext, error) { //n
 	}
 
 	stop := func(_ context.Context) error {
-		// TODO(negz): Maybe log to stderr that we're leaving the container running?
+		logger.Debug("Container left running", "container", rsp.ID, "image", r.Image)
 		return nil
 	}
 	if r.Stop {

--- a/cmd/crank/beta/render/runtime_docker.go
+++ b/cmd/crank/beta/render/runtime_docker.go
@@ -151,6 +151,7 @@ var _ Runtime = &RuntimeDocker{}
 
 // Start a Function as a Docker container.
 func (r *RuntimeDocker) Start(ctx context.Context, logger logging.Logger) (RuntimeContext, error) { //nolint:gocyclo // TODO(phisco): Refactor to break this up a bit, not so easy.
+	logger.Debug("Starting Docker container runtime", "image", r.Image)
 	c, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
 	if err != nil {
 		return RuntimeContext{}, errors.Wrap(err, "cannot create Docker client using environment variables")


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane! Please read the contribution docs
(linked below) if this is your first Crossplane pull request.
-->

### Description of your changes

Adds debug logs to `crossplane beta render`.

For `render` the output is expected to be a valid yaml file, so we should be carefull where and when to log. Actually we dont need to do anything special as the CLI logger is already active only when `--verbose` flag is provider, plus it [logs by default to stderr](https://github.com/kubernetes-sigs/controller-runtime/blob/4000e996a202917ad7d40f02ed8a2079a9ce25e9/pkg/log/zap/zap.go#L148-L150), so users can filter the command output from the logs if needed.

How it looks like:
`crossplane beta render ...` - no changes

`crossplane beta render ... --verbose`:
```bash
~/go/crossplane/_output/bin/darwin_arm64/crank beta render example/inline/xr.yaml example/inline/composition.yaml example/inline/functions.yaml --verbose
2024-02-02T12:44:53+01:00	DEBUG	Starting Docker container runtime	{"image": "xpkg.upbound.io/crossplane-contrib/function-go-templating:v0.4.0"}
2024-02-02T12:44:53+01:00	DEBUG	Creating Docker container	{"image": "xpkg.upbound.io/crossplane-contrib/function-go-templating:v0.4.0", "address": "127.0.0.1:54299"}
2024-02-02T12:44:55+01:00	DEBUG	Container left running	{"container": "80dd5af1330130f12abe20acb273f4520b8dd2174f267b41b66b30a769faec6d", "image": "xpkg.upbound.io/crossplane-contrib/function-go-templating:v0.4.0"}
---
apiVersion: example.crossplane.io/v1beta1
kind: XR
metadata:
  name: example
...
```

`crossplane beta render ... --verbose 2>`
```
~/go/crossplane/_output/bin/darwin_arm64/crank beta render example/inline/xr.yaml example/inline/composition.yaml example/inline/functions.yaml --verbose 2> echo
---
apiVersion: example.crossplane.io/v1beta1
kind: XR
metadata:
  name: example
status:
  dummy: cool-status
---
...
```

`crossplane beta render ... --verbose 1>`
```
~/go/crossplane/_output/bin/darwin_arm64/crank beta render example/inline/xr.yaml example/inline/composition.yaml example/inline/functions.yaml --verbose 1> echo
2024-02-02T12:44:53+01:00	DEBUG	Starting Docker container runtime	{"image": "xpkg.upbound.io/crossplane-contrib/function-go-templating:v0.4.0"}
2024-02-02T10:48:59+01:00	DEBUG	Creating Docker container	{"image": "xpkg.upbound.io/crossplane-contrib/function-go-templating:v0.4.0", "address": "127.0.0.1:53294"}
2024-02-02T10:48:59+01:00	DEBUG	Image not found, pulling	{"image": "xpkg.upbound.io/crossplane-contrib/function-go-templating:v0.4.0"}
2024-02-02T10:49:03+01:00	DEBUG	Container left running	{"container": "caeb76d7b427194a148b3af42191ee1c9bf90c59231c9b49f938bcab45c34e90", "image": "xpkg.upbound.io/crossplane-contrib/function-go-templating:v0.4.0"}
```

<!--
Briefly describe what this pull request does, and how it is covered by tests.
Be proactive - direct your reviewers' attention to anything that needs special
consideration.

We love pull requests that fix an open issue. If yours does, use the below line
to indicate which issue it fixes, for example "Fixes #500".
-->

Fixes #4809 

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- ~[] Added or updated unit tests.~
- ~[] Added or updated e2e tests.~
- ~[] Linked a PR or a [docs tracking issue] to [document this change].~
- ~[] Added `backport release-x.y` labels to auto-backport this PR.~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/master/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/master/contributing#checklist-cheat-sheet
