### PR TITLE
fix(crank/render): conditions' lastTransitionTime can not be null

### DIFF
--- a/cmd/crank/beta/render/render.go
+++ b/cmd/crank/beta/render/render.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"reflect"
 	"sort"
+	"time"
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
@@ -290,8 +291,9 @@ func Render(ctx context.Context, logger logging.Logger, in Inputs) (Outputs, err
 	if len(unready) > 0 {
 		xrCond = xpv1.Creating().WithMessage(fmt.Sprintf("Unready resources: %s", resource.StableNAndSomeMore(resource.DefaultFirstN, unready)))
 	}
-	// lastTransitionTime would just be noise, so we drop it.
-	xrCond.LastTransitionTime = metav1.Time{}
+	// lastTransitionTime would just be noise, but we can't drop it as it's a
+	// required field and null is not allowed, so we set a random time.
+	xrCond.LastTransitionTime = metav1.NewTime(time.Date(2024, time.January, 1, 0, 0, 0, 0, time.UTC))
 	xr.SetConditions(xrCond)
 
 	out := Outputs{CompositeResource: xr, ComposedResources: desired, Results: results}

--- a/cmd/crank/beta/render/render_test.go
+++ b/cmd/crank/beta/render/render_test.go
@@ -214,7 +214,7 @@ func TestRender(t *testing.T) {
 											"status": {
 												"widgets": 9001,
 												"conditions": [{
-													"lastTransitionTime": null,
+													"lastTransitionTime": "2024-01-01T00:00:00Z",
 													"type": "Ready",
 													"status": "False",
 													"reason": "Creating",
@@ -276,7 +276,7 @@ func TestRender(t *testing.T) {
 								"status": {
 									"widgets": 9001,
 									"conditions": [{
-										"lastTransitionTime": null,
+										"lastTransitionTime": "2024-01-01T00:00:00Z",
 										"type": "Ready",
 										"status": "False",
 										"reason": "Creating",
@@ -383,7 +383,7 @@ func TestRender(t *testing.T) {
 											"status": {
 												"widgets": 9001,
 												"conditions": [{
-													"lastTransitionTime": null,
+													"lastTransitionTime": "2024-01-01T00:00:00Z",
 													"type": "Ready",
 													"status": "False",
 													"reason": "Creating",
@@ -447,7 +447,7 @@ func TestRender(t *testing.T) {
 								"status": {
 									"widgets": 9001,
 									"conditions": [{
-										"lastTransitionTime": null,
+										"lastTransitionTime": "2024-01-01T00:00:00Z",
 										"type": "Ready",
 										"status": "True",
 										"reason": "Available"
@@ -664,7 +664,7 @@ func TestRender(t *testing.T) {
 								"status": {
 									"widgets": "bar",
 									"conditions": [{
-										"lastTransitionTime": null,
+										"lastTransitionTime": "2024-01-01T00:00:00Z",
 										"type": "Ready",
 										"status": "False",
 										"reason": "Creating",


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane! Please read the contribution docs
(linked below) if this is your first Crossplane pull request.
-->

### Description of your changes

<!--
Briefly describe what this pull request does, and how it is covered by tests.
Be proactive - direct your reviewers' attention to anything that needs special
consideration.

We love pull requests that fix an open issue. If yours does, use the below line
to indicate which issue it fixes, for example "Fixes #500".
-->

Follow up for https://github.com/crossplane/crossplane/pull/5305, testing out https://github.com/phisco/function-environment-configs I noticed that lastTransitionTime can not be set to null 🤦‍♂️:
```shell
$ /Users/phisco/github.com/crossplane/crossplane/_output/bin/darwin_arm64/crank beta render  \
  --extra-resources example/environmentConfigs.yaml \
  --include-full-xr \
  example/xr.yaml example/composition.yaml example/functions.yaml | /Users/phisco/github.com/crossplane/crossplane/_output/bin/darwin_arm64/crank beta validate example -
[x] schema validation error example.crossplane.io/v1, Kind=XR, example-xr : status.conditions[0].lastTransitionTime: Invalid value: "null": status.conditions[0].lastTransitionTime in body must be of type string: "null"
Total 1 resources: 0 missing schemas, 0 success cases, 1 failure cases
crossplane: error: cannot validate resources: could not validate all resources
```
With this we set it to a random fixed date, so that it's still consistent for downstream consumers:
```shell
/Users/phisco/github.com/crossplane/crossplane/_output/bin/darwin_arm64/crank beta render  \
  --extra-resources example/environmentConfigs.yaml \
  --include-full-xr \
  example/xr.yaml example/composition.yaml example/functions.yaml | /Users/phisco/github.com/crossplane/crossplane/_output/bin/darwin_arm64/crank beta validate example -
[✓] example.crossplane.io/v1, Kind=XR, example-xr validated successfully
Total 1 resources: 0 missing schemas, 1 success cases, 0 failure cases
```

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added or updated unit tests.
- [ ] ~Added or updated e2e tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/master/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/master/contributing#checklist-cheat-sheet
