### PR TITLE
Do not use version when indexing Used resources in Usage Handler

### DIFF
--- a/internal/controller/apiextensions/usage/reconciler.go
+++ b/internal/controller/apiextensions/usage/reconciler.go
@@ -28,6 +28,7 @@ import (
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -70,6 +71,7 @@ const (
 	errAddFinalizer         = "cannot add finalizer"
 	errRemoveFinalizer      = "cannot remove finalizer"
 	errUpdateStatus         = "cannot update status of usage"
+	errParseAPIVersion      = "cannot parse APIVersion"
 )
 
 // Event reasons.
@@ -216,6 +218,14 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 		log.Debug(errGetUsage, "error", err)
 		return reconcile.Result{}, errors.Wrap(xpresource.IgnoreNotFound(err), errGetUsage)
 	}
+
+	// Validate APIVersion of used object provided as input.
+	// We parse this value while indexing the objects, and we need to make sure it is valid.
+	_, err := schema.ParseGroupVersion(u.Spec.Of.APIVersion)
+	if err != nil {
+		return reconcile.Result{}, errors.Wrap(err, errParseAPIVersion)
+	}
+
 	orig := u.DeepCopy()
 
 	if err := r.usage.resolveSelectors(ctx, u); err != nil {

--- a/internal/controller/apiextensions/usage/reconciler_test.go
+++ b/internal/controller/apiextensions/usage/reconciler_test.go
@@ -82,6 +82,27 @@ func TestReconcile(t *testing.T) {
 				r: reconcile.Result{},
 			},
 		},
+		"CannotParseApiVersion": {
+			reason: "We should return an error if we cannot parse APIVersion of used resource.",
+			args: args{
+				mgr: &fake.Manager{},
+				opts: []ReconcilerOption{
+					WithClientApplicator(xpresource.ClientApplicator{
+						Client: &test.MockClient{
+							MockGet: test.NewMockGetFn(nil, func(obj client.Object) error {
+								o := obj.(*v1alpha1.Usage)
+								o.Spec.Of.APIVersion = "/invalid/"
+								o.Spec.Of.ResourceSelector = &v1alpha1.ResourceSelector{MatchLabels: map[string]string{"foo": "bar"}}
+								return nil
+							}),
+						},
+					}),
+				},
+			},
+			want: want{
+				err: errors.Wrap(errors.New("unexpected GroupVersion string: /invalid/"), errParseAPIVersion),
+			},
+		},
 		"CannotResolveSelectors": {
 			reason: "We should return an error if we cannot resolve selectors.",
 			args: args{


### PR DESCRIPTION
### Description of your changes

This PR fixes a bug in the Usage handler with multi versioned CRDs by dropping the usage of the `version` from the index string used by the handler. 

Example Scenario:

We define the following Usage resource:

```yaml
apiVersion: apiextensions.crossplane.io/v1alpha1
kind: Usage
metadata:
  name: do-not-delete-namespace
spec:
  of:
    apiVersion: kubernetes.crossplane.io/v1alpha1
    kind: Object
    resourceRef:
      name: ns-test-namespace
  reason: Namespace should not be deleted
```

For the following Object:

```yaml
apiVersion: kubernetes.crossplane.io/v1alpha1
kind: Object
metadata:
  name: ns-test-namespace
spec:
  forProvider:
    manifest:
      apiVersion: v1
      kind: Namespace
      metadata:
        name: test-namespace
  readiness:
    policy: SuccessfulCreate
```

And we're running the [latest](https://github.com/crossplane-contrib/provider-kubernetes/releases/tag/v0.11.4) provider kubernetes which has a `v1alpha2` as the storage version for `Object`. So, when we get the `Object` back after creation, we already see the version as `v1alpha2`.

Prior to this PR, deletion of the `ns-test-namespace` `Object` is not blocked by the Usage since we were using the version in the indexer, so `v1alpha1` `Object`s blocked but not `v1alpha2`s. With this PR, we will drop the version from the index, hence it will block `Objects` independent of versions.

Related previous discussion: https://github.com/crossplane/crossplane/pull/4215#discussion_r1236484305

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added or updated unit tests.
- [ ] ~Added or updated e2e tests.~
- [x] Linked a PR or a [docs tracking issue] to [document this change].
- [x] Added `backport release-x.y` labels to auto-backport this PR.

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/master/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/master/contributing#checklist-cheat-sheet
