### PR TITLE
fix: ignore invalid resources when composing

### DIFF
--- a/internal/controller/apiextensions/composite/composed.go
+++ b/internal/controller/apiextensions/composite/composed.go
@@ -35,8 +35,14 @@ type ComposedResource struct {
 	ResourceName ResourceName
 
 	// Ready indicates whether this composed resource is ready - i.e. whether
-	// all of its readiness checks passed.
+	// all of its readiness checks passed. Setting it to false will cause the
+	// XR to be marked as not ready.
 	Ready bool
+
+	// Synced indicates whether the composition process was able to sync the
+	// composed resource with its desired state. Setting it to false will cause
+	// the XR to be marked as not synced.
+	Synced bool
 }
 
 // ComposedResourceState represents a composed resource (either desired or

--- a/internal/controller/apiextensions/composite/composition_functions_test.go
+++ b/internal/controller/apiextensions/composite/composition_functions_test.go
@@ -615,8 +615,8 @@ func TestFunctionCompose(t *testing.T) {
 			want: want{
 				res: CompositionResult{
 					Composed: []ComposedResource{
-						{ResourceName: "desired-resource-a"},
-						{ResourceName: "observed-resource-a", Ready: true},
+						{ResourceName: "desired-resource-a", Synced: true},
+						{ResourceName: "observed-resource-a", Ready: true, Synced: true},
 					},
 					ConnectionDetails: managed.ConnectionDetails{
 						"from": []byte("function-pipeline"),
@@ -816,8 +816,8 @@ func TestFunctionCompose(t *testing.T) {
 			want: want{
 				res: CompositionResult{
 					Composed: []ComposedResource{
-						{ResourceName: "desired-resource-a"},
-						{ResourceName: "observed-resource-a", Ready: true},
+						{ResourceName: "desired-resource-a", Synced: true},
+						{ResourceName: "observed-resource-a", Ready: true, Synced: true},
 					},
 					ConnectionDetails: managed.ConnectionDetails{
 						"from": []byte("function-pipeline"),

--- a/internal/controller/apiextensions/composite/composition_pt.go
+++ b/internal/controller/apiextensions/composite/composition_pt.go
@@ -273,6 +273,21 @@ func (c *PTComposer) Compose(ctx context.Context, xr *composite.Unstructured, re
 		o := []resource.ApplyOption{resource.MustBeControllableBy(xr.GetUID()), usage.RespectOwnerRefs()}
 		o = append(o, mergeOptions(filterPatches(t.Patches, patchTypesFromXR()...))...)
 		if err := c.client.Apply(ctx, cd, o...); err != nil {
+			if kerrors.IsInvalid(err) {
+				// We tried applying an invalid resource, we can't tell whether
+				// this means the resource will never be valid or it will if we
+				// run again the composition after some other resource is
+				// created or updated successfully. So, we emit a warning event
+				// and move on.
+				events = append(events, event.Warning(reasonCompose, errors.Wrap(err, errApplyComposed)))
+				// We unset the cd here so that we don't try to observe it
+				// later. This will also mean we report it as not ready and not
+				// synced. Resulting in the XR being reported as not ready nor
+				// synced too.
+				cds[i] = nil
+				continue
+			}
+
 			// TODO(negz): Include the template name (if any) in this error.
 			// Including the rendered resource's kind may help too (e.g. if the
 			// template is anonymous).
@@ -298,7 +313,7 @@ func (c *PTComposer) Compose(ctx context.Context, xr *composite.Unstructured, re
 		// to observe it. We still want to return it to the Reconciler so that
 		// it knows that this desired composed resource is not ready.
 		if cd == nil {
-			resources[i] = ComposedResource{ResourceName: name, Ready: false}
+			resources[i] = ComposedResource{ResourceName: name, Synced: false, Ready: false}
 			continue
 		}
 
@@ -328,7 +343,7 @@ func (c *PTComposer) Compose(ctx context.Context, xr *composite.Unstructured, re
 			return CompositionResult{}, errors.Wrapf(err, errFmtCheckReadiness, name)
 		}
 
-		resources[i] = ComposedResource{ResourceName: name, Ready: ready}
+		resources[i] = ComposedResource{ResourceName: name, Ready: ready, Synced: true}
 	}
 
 	// Call Apply so that we do not just replace fields on existing XR but

--- a/internal/controller/apiextensions/composite/composition_pt_test.go
+++ b/internal/controller/apiextensions/composite/composition_pt_test.go
@@ -392,6 +392,7 @@ func TestPTCompose(t *testing.T) {
 					Composed: []ComposedResource{{
 						ResourceName: "cool-resource",
 						Ready:        true,
+						Synced:       true,
 					}},
 					ConnectionDetails: details,
 				},
@@ -457,10 +458,12 @@ func TestPTCompose(t *testing.T) {
 						{
 							ResourceName: "cool-resource",
 							Ready:        true,
+							Synced:       true,
 						},
 						{
 							ResourceName: "uncool-resource",
 							Ready:        false,
+							Synced:       false,
 						},
 					},
 					ConnectionDetails: details,

--- a/internal/controller/apiextensions/composite/reconciler.go
+++ b/internal/controller/apiextensions/composite/reconciler.go
@@ -677,9 +677,9 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 		}
 
 		if !cd.Synced {
-			log.Debug("Composed resource is not yet synced", "id", id)
+			log.Debug("Composed resource is not yet valid", "id", id)
 			unsynced = append(unsynced, cd)
-			r.record.Event(xr, event.Normal(reasonCompose, fmt.Sprintf("Composed resource %q is not yet synced", id)))
+			r.record.Event(xr, event.Normal(reasonCompose, fmt.Sprintf("Composed resource %q is not yet valid", id)))
 			continue
 		}
 

--- a/internal/controller/apiextensions/composite/reconciler.go
+++ b/internal/controller/apiextensions/composite/reconciler.go
@@ -711,7 +711,7 @@ func updateXRConditions(xr *composite.Unstructured, unsynced, unready []Composed
 	if len(unsynced) > 0 {
 		// We want to requeue to wait for our composed resources to
 		// become ready, since we can't watch them.
-		syncedCond = xpv1.ReconcileError(errors.New(errSyncResources)).WithMessage(fmt.Sprintf("Unsynced resources: %s", resource.StableNAndSomeMore(resource.DefaultFirstN, getComposerResourcesNames(unsynced))))
+		syncedCond = xpv1.ReconcileError(errors.New(errSyncResources)).WithMessage(fmt.Sprintf("Invalid resources: %s", resource.StableNAndSomeMore(resource.DefaultFirstN, getComposerResourcesNames(unsynced))))
 		requeueImmediately = true
 	}
 	if len(unready) > 0 {

--- a/internal/controller/apiextensions/composite/reconciler.go
+++ b/internal/controller/apiextensions/composite/reconciler.go
@@ -74,6 +74,7 @@ const (
 	errCompose                = "cannot compose resources"
 	errInvalidResources       = "some resources were invalid, check events"
 	errRenderCD               = "cannot render composed resource"
+	errSyncResources          = "cannot sync composed resources"
 
 	reconcilePausedMsg = "Reconciliation (including deletion) is paused via the pause annotation"
 )
@@ -666,12 +667,20 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 	}
 
 	var unready []ComposedResource
+	var unsynced []ComposedResource
 	for i, cd := range res.Composed {
 		// Specifying a name for P&T templates is optional but encouraged.
 		// If there was no name, fall back to using the index.
 		id := string(cd.ResourceName)
 		if id == "" {
 			id = strconv.Itoa(i)
+		}
+
+		if !cd.Synced {
+			log.Debug("Composed resource is not yet synced", "id", id)
+			unsynced = append(unsynced, cd)
+			r.record.Event(xr, event.Normal(reasonCompose, fmt.Sprintf("Composed resource %q is not yet synced", id)))
+			continue
 		}
 
 		if !cd.Ready {
@@ -682,21 +691,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 		}
 	}
 
-	xr.SetConditions(xpv1.ReconcileSuccess())
-
-	// TODO(muvaf): If a resource becomes Unavailable at some point, should we
-	// still report it as Creating?
-	if len(unready) > 0 {
-		// We want to requeue to wait for our composed resources to
-		// become ready, since we can't watch them.
-		names := make([]string, len(unready))
-		for i, cd := range unready {
-			names[i] = string(cd.ResourceName)
-		}
-		// Sort for stable condition messages. With functions, we don't have a
-		// stable order otherwise.
-		xr.SetConditions(xpv1.Creating().WithMessage(fmt.Sprintf("Unready resources: %s", resource.StableNAndSomeMore(resource.DefaultFirstN, names))))
-
+	if updateXRConditions(xr, unsynced, unready) {
 		// This requeue is subject to rate limiting. Requeues will exponentially
 		// backoff from 1 to 30 seconds. See the 'definition' (XRD) reconciler
 		// that sets up the ratelimiter.
@@ -706,8 +701,37 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 	// We requeue after our poll interval because we can't watch composed
 	// resources - we can't know what type of resources we might compose
 	// when this controller is started.
-	xr.SetConditions(xpv1.Available())
 	return reconcile.Result{RequeueAfter: r.pollInterval(ctx, xr)}, errors.Wrap(r.client.Status().Update(ctx, xr), errUpdateStatus)
+}
+
+// updateXRConditions updates the conditions of the supplied composite resource
+// based on the supplied composed resources. It returns true if the XR should be
+// requeued immediately.
+func updateXRConditions(xr *composite.Unstructured, unsynced, unready []ComposedResource) (requeueImmediately bool) {
+	readyCond := xpv1.Available()
+	syncedCond := xpv1.ReconcileSuccess()
+	if len(unsynced) > 0 {
+		// We want to requeue to wait for our composed resources to
+		// become ready, since we can't watch them.
+		syncedCond = xpv1.ReconcileError(errors.New(errSyncResources)).WithMessage(fmt.Sprintf("Unsynced resources: %s", resource.StableNAndSomeMore(resource.DefaultFirstN, getComposerResourcesNames(unsynced))))
+		requeueImmediately = true
+	}
+	if len(unready) > 0 {
+		// We want to requeue to wait for our composed resources to
+		// become ready, since we can't watch them.
+		readyCond = xpv1.Creating().WithMessage(fmt.Sprintf("Unready resources: %s", resource.StableNAndSomeMore(resource.DefaultFirstN, getComposerResourcesNames(unready))))
+		requeueImmediately = true
+	}
+	xr.SetConditions(syncedCond, readyCond)
+	return requeueImmediately
+}
+
+func getComposerResourcesNames(cds []ComposedResource) []string {
+	names := make([]string, len(cds))
+	for i, cd := range cds {
+		names[i] = string(cd.ResourceName)
+	}
+	return names
 }
 
 // EnqueueForCompositionRevisionFunc returns a function that enqueues (the

--- a/internal/controller/apiextensions/composite/reconciler.go
+++ b/internal/controller/apiextensions/composite/reconciler.go
@@ -680,14 +680,12 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 			log.Debug("Composed resource is not yet valid", "id", id)
 			unsynced = append(unsynced, cd)
 			r.record.Event(xr, event.Normal(reasonCompose, fmt.Sprintf("Composed resource %q is not yet valid", id)))
-			continue
 		}
 
 		if !cd.Ready {
 			log.Debug("Composed resource is not yet ready", "id", id)
 			unready = append(unready, cd)
 			r.record.Event(xr, event.Normal(reasonCompose, fmt.Sprintf("Composed resource %q is not yet ready", id)))
-			continue
 		}
 	}
 

--- a/internal/controller/apiextensions/composite/reconciler_test.go
+++ b/internal/controller/apiextensions/composite/reconciler_test.go
@@ -517,21 +517,27 @@ func TestReconcile(t *testing.T) {
 							Composed: []ComposedResource{{
 								ResourceName: "elephant",
 								Ready:        false,
+								Synced:       true,
 							}, {
 								ResourceName: "cow",
 								Ready:        false,
+								Synced:       true,
 							}, {
 								ResourceName: "pig",
 								Ready:        true,
+								Synced:       true,
 							}, {
 								ResourceName: "cat",
 								Ready:        false,
+								Synced:       true,
 							}, {
 								ResourceName: "dog",
 								Ready:        true,
+								Synced:       true,
 							}, {
 								ResourceName: "snake",
 								Ready:        false,
+								Synced:       true,
 							}},
 						}, nil
 					})),

--- a/test/e2e/apiextensions_test.go
+++ b/test/e2e/apiextensions_test.go
@@ -103,6 +103,50 @@ func TestCompositionMinimal(t *testing.T) {
 	)
 }
 
+// TestCompositionInvalidComposed tests Crossplane's Composition functionality,
+// checking that although a composed resource is invalid, i.e. it didn't apply
+// successfully.
+func TestCompositionInvalidComposed(t *testing.T) {
+	manifests := "test/e2e/manifests/apiextensions/composition/invalid-composed"
+
+	xrList := composed.NewList(composed.FromReferenceToList(corev1.ObjectReference{
+		APIVersion: "example.org/v1alpha1",
+		Kind:       "XParent",
+	}), composed.FromReferenceToList(corev1.ObjectReference{
+		APIVersion: "example.org/v1alpha1",
+		Kind:       "XChild",
+	}))
+
+	environment.Test(t,
+		features.New(t.Name()).
+			WithLabel(LabelArea, LabelAreaAPIExtensions).
+			WithLabel(LabelSize, LabelSizeSmall).
+			WithLabel(config.LabelTestSuite, config.TestSuiteDefault).
+			WithSetup("PrerequisitesAreCreated", funcs.AllOf(
+				funcs.ApplyResources(FieldManager, manifests, "setup/*.yaml"),
+				funcs.ResourcesCreatedWithin(30*time.Second, manifests, "setup/*.yaml"),
+				funcs.ResourcesHaveConditionWithin(1*time.Minute, manifests, "setup/definition.yaml", apiextensionsv1.WatchingComposite()),
+				funcs.ResourcesHaveConditionWithin(2*time.Minute, manifests, "setup/provider.yaml", pkgv1.Healthy(), pkgv1.Active()),
+			)).
+			Assess("CreateXR", funcs.AllOf(
+				funcs.ApplyResources(FieldManager, manifests, "xr.yaml"),
+				funcs.InBackground(funcs.LogResources(xrList)),
+				funcs.InBackground(funcs.LogResources(nopList)),
+				funcs.ResourcesCreatedWithin(30*time.Second, manifests, "xr.yaml"),
+			)).
+			Assess("XRStillAnnotated", funcs.AllOf(
+				// Check the XR it has metadata.annotations set
+				funcs.ResourcesHaveFieldValueWithin(1*time.Minute, manifests, "xr.yaml", "metadata.annotations[exampleVal]", "foo"),
+			)).
+			WithTeardown("DeleteXR", funcs.AllOf(
+				funcs.DeleteResources(manifests, "xr.yaml"),
+				funcs.ResourcesDeletedWithin(2*time.Minute, manifests, "xr.yaml"),
+			)).
+			WithTeardown("DeletePrerequisites", funcs.ResourcesDeletedAfterListedAreGone(3*time.Minute, manifests, "setup/*.yaml", nopList)).
+			Feature(),
+	)
+}
+
 // TestCompositionPatchAndTransform tests Crossplane's Composition functionality,
 // checking that a claim using patch-and-transform Composition will become
 // available when its composed resources do, and have a field derived from

--- a/test/e2e/manifests/apiextensions/composition/invalid-composed/setup/composition.yaml
+++ b/test/e2e/manifests/apiextensions/composition/invalid-composed/setup/composition.yaml
@@ -1,0 +1,75 @@
+---
+apiVersion: apiextensions.crossplane.io/v1
+kind: Composition
+metadata:
+  name: parent
+spec:
+  compositeTypeRef:
+    apiVersion: example.org/v1alpha1
+    kind: XParent
+  resources:
+    - name: child
+      base:
+        apiVersion: example.org/v1alpha1
+        kind: XChild
+        spec: {}
+      patches:
+        - type: FromCompositeFieldPath
+          # this is going to be 1
+          fromFieldPath: spec.someField
+          # this will fail because it's supposed to be > 1
+          toFieldPath: spec.someField
+    - name: nop-resource-1
+      base:
+        apiVersion: nop.crossplane.io/v1alpha1
+        kind: NopResource
+        metadata:
+          annotations:
+            exampleVal: "foo"
+        spec:
+          forProvider:
+            conditionAfter:
+              - conditionType: Ready
+                conditionStatus: "False"
+                time: 0s
+              - conditionType: Ready
+                conditionStatus: "True"
+                time: 1s
+      patches:
+        - type: FromCompositeFieldPath
+          fromFieldPath: metadata.name
+          # we should still see this in the child
+          toFieldPath: metadata.annotations[something]
+        - type: ToCompositeFieldPath
+          fromFieldPath: metadata.annotations[exampleVal]
+          # we should still see this in the composite
+          toFieldPath: metadata.annotations[exampleVal]
+---
+apiVersion: apiextensions.crossplane.io/v1
+kind: Composition
+metadata:
+  name: child
+spec:
+  compositeTypeRef:
+    apiVersion: example.org/v1alpha1
+    kind: XChild
+  resources:
+    # we don't really care about what happens here, it's not going to work
+    # because the composite resource will be invalid
+    - name: nop-resource-1
+      base:
+        apiVersion: nop.crossplane.io/v1alpha1
+        kind: NopResource
+        spec:
+          forProvider:
+            conditionAfter:
+              - conditionType: Ready
+                conditionStatus: "False"
+                time: 0s
+              - conditionType: Ready
+                conditionStatus: "True"
+                time: 1s
+      patches:
+        - type: FromCompositeFieldPath
+          fromFieldPath: metadata.name
+          toFieldPath: metadata.annotations[something]

--- a/test/e2e/manifests/apiextensions/composition/invalid-composed/setup/definition.yaml
+++ b/test/e2e/manifests/apiextensions/composition/invalid-composed/setup/definition.yaml
@@ -1,0 +1,51 @@
+apiVersion: apiextensions.crossplane.io/v1
+kind: CompositeResourceDefinition
+metadata:
+  name: xparents.example.org
+spec:
+  defaultCompositionRef:
+    name: parent
+  group: example.org
+  names:
+    kind: XParent
+    plural: xparents
+  versions:
+    - name: v1alpha1
+      served: true
+      referenceable: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                someField:
+                  # no limits on its value
+                  type: integer
+---
+apiVersion: apiextensions.crossplane.io/v1
+kind: CompositeResourceDefinition
+metadata:
+  name: xchildren.example.org
+spec:
+  defaultCompositionRef:
+    name: child
+  group: example.org
+  names:
+    kind: XChild
+    plural: xchildren
+  versions:
+    - name: v1alpha1
+      served: true
+      referenceable: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                someField:
+                  minimum: 2
+                  type: integer

--- a/test/e2e/manifests/apiextensions/composition/invalid-composed/setup/provider.yaml
+++ b/test/e2e/manifests/apiextensions/composition/invalid-composed/setup/provider.yaml
@@ -1,0 +1,7 @@
+apiVersion: pkg.crossplane.io/v1
+kind: Provider
+metadata:
+  name: provider-nop
+spec:
+  package: xpkg.upbound.io/crossplane-contrib/provider-nop:v0.2.1
+  ignoreCrossplaneConstraints: true

--- a/test/e2e/manifests/apiextensions/composition/invalid-composed/xr.yaml
+++ b/test/e2e/manifests/apiextensions/composition/invalid-composed/xr.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: example.org/v1alpha1
+kind: XParent
+metadata:
+  name: test
+#  Expected:
+#  annotations:
+#    exampleVal: "foo"
+spec:
+  # this should be > 1 in the XChild composed resource, so it will fail applying it
+  someField: 1


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane! Please read the contribution docs
(linked below) if this is your first Crossplane pull request.
-->

### Description of your changes

<!--
Briefly describe what this pull request does, and how it is covered by tests.
Be proactive - direct your reviewers' attention to anything that needs special
consideration.

We love pull requests that fix an open issue. If yours does, use the below line
to indicate which issue it fixes, for example "Fixes #500".
-->

Fixes https://github.com/crossplane/crossplane/issues/5292.
Fixes https://github.com/crossplane/crossplane/issues/5114.

This PR fixes  the stated issues by implementing a change in the resource application approach. Even in cases where one of the composed resources is invalid, we will proceed to apply other resources. This adjustment ensures that eventually consistent Compositions work as intended, while still emitting Warnings events and setting the XR's Sync Condition to false to signal the issue to consumers.

`Sync` and `Ready` conditions will adhere to the following logic:
- for both `Resources` and `Pipeline` compositions: if any of the composed resources fails to apply, the XR's `Sync` condition is set to false.
- only for `Resources` compositions, in the above scenario, also the XR's `Ready` condition is set to false.

While at it, we decided to revise the execution order of the XR status update for `Pipeline` Compositions, ensuring it occurs after the application of composed resources. This modification serves two key purposes: firstly, it ensures the process aligns with the execution order in the PTComposer. Secondly, it prevents an invalid XR status from obstructing the application of composed resources, thereby enabling eventually consistent compositions to subsequently yield a valid XR status.

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added or updated unit tests.
- [x] Added or updated e2e tests.
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [x] Added `backport release-x.y` labels to auto-backport this PR.

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/master/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/master/contributing#checklist-cheat-sheet
