### PR TITLE
fix(crank/xpkg): push properly retrieve upbound credentials

### DIFF
--- a/internal/xpkg/upbound/credhelper/credhelper.go
+++ b/internal/xpkg/upbound/credhelper/credhelper.go
@@ -113,8 +113,10 @@ func (h *Helper) List() (map[string]string, error) {
 // Get gets credentials for the supplied server.
 func (h *Helper) Get(serverURL string) (string, string, error) {
 	if !strings.Contains(serverURL, h.domain) {
+		h.log.Debug("Supplied server URL is not supported by this credentials helper", "serverURL", serverURL, "domain", h.domain)
 		return "", "", errors.New(errUnsupportedDomain)
 	}
+	h.log.Debug("Getting credentials for server", "serverURL", serverURL)
 	if err := h.src.Initialize(); err != nil {
 		return "", "", errors.Wrap(err, errInitializeSource)
 	}
@@ -124,11 +126,13 @@ func (h *Helper) Get(serverURL string) (string, string, error) {
 	}
 	var p config.Profile
 	if h.profile == "" {
+		h.log.Debug("No profile specified, using default profile")
 		_, p, err = conf.GetDefaultUpboundProfile()
 		if err != nil {
 			return "", "", errors.Wrap(err, errGetDefaultProfile)
 		}
 	} else {
+		h.log.Debug("Using specified profile", "profile", h.profile)
 		p, err = conf.GetUpboundProfile(h.profile)
 		if err != nil {
 			return "", "", errors.Wrap(err, errGetProfile)


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane! Please read the contribution docs
(linked below) if this is your first Crossplane pull request.
-->

### Description of your changes

<!--
Briefly describe what this pull request does, and how it is covered by tests.
Be proactive - direct your reviewers' attention to anything that needs special
consideration.

We love pull requests that fix an open issue. If yours does, use the below line
to indicate which issue it fixes, for example "Fixes #500".
-->

As reported by a @mariuszgomse on [Slack](https://crossplane.slack.com/archives/CEG3T90A1/p1707545116931119?thread_ts=1707506974.083189&cid=CEG3T90A1).

Previously pushing an image while logged into the upbound marketplace didn't work as we forgot to pass the required context to the credential helper, which therefore was always returning the credentials stored in `~/.crossplane/config.json` instead of falling back to the default keychain.

We missed this while porting the functionality over from `up`, which properly configures it as you can see [here](https://github.com/upbound/up/blob/main/cmd/up/xpkg/push.go#L112C1-L113C1).

Using v1.15.0-rc.1 (but the same will apply for 1.14), it works fine if we have no `~/.crossplane/config.json` at all:
```shell
$ rm -f ~/.crossplane/config.json
$ crossplane xpkg push index.docker.io/phisco/function-environment-configs:delete-me-1 -f amd64.xpkg,arm64.xpkg && echo ok
ok
```

Then logging in using `crossplane xpkg login`, will result in a failure when trying to push the image:

```shell
$ crossplane xpkg login
Username: phiscor
Password:
Login successful.
$ crossplane xpkg push index.docker.io/phisco/function-environment-configs:delete-me-2 -f amd64.xpkg,arm64.xpkg && echo ok
crossplane: error: failed to push package file /Users/phisco/github.com/phisco/function-environment-configs/arm64.xpkg: GET https://auth.docker.io/token?scope=repository%3Aphisco%2Ffunction-environment-configs%3Apush%2Cpull&service=registry.docker.io: unexpected status code 401 Unauthorized: {"details":"incorrect username or password"}
```

With this patch instead:
```shell
$ make build # to build the binary
...
$ rm -f ~/.crossplane/config.json
$ /Users/phisco/github.com/crossplane/crossplane/_output/bin/darwin_arm64/crank xpkg push index.docker.io/phisco/function-environment-configs:delete-me-2 -f amd64.xpkg,arm64.xpkg && echo ok
ok
$ /Users/phisco/github.com/crossplane/crossplane/_output/bin/darwin_arm64/crank xpkg login
Username: phiscor
Password:
Login successful.
$ crossplane xpkg push index.docker.io/phisco/function-environment-configs:delete-me-2 -f amd64.xpkg,arm64.xpkg && echo ok
ok
```
While still working with images that should be pushed to `xpkg.upbound.io`, either explicitly or implicitly:
<img width="1440" alt="image" src="https://github.com/crossplane/crossplane/assets/5697904/d34fde12-78f2-41d9-851b-a05c9a47dd02">

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] ~Added or updated unit tests.~
- [ ] ~Added or updated e2e tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/master/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/master/contributing#checklist-cheat-sheet
