### PR TITLE
Accept version changes in composed templates

### DIFF
--- a/internal/controller/apiextensions/composite/composition_render.go
+++ b/internal/controller/apiextensions/composite/composition_render.go
@@ -32,8 +32,8 @@ const (
 	errMarshalProtoStruct = "cannot marshal protobuf Struct to JSON"
 	errSetControllerRef   = "cannot set controller reference"
 
-	errFmtKindChanged     = "cannot change the kind of a composed resource from %s to %s (possible composed resource template mismatch)"
-	errFmtNamePrefixLabel = "cannot find top-level composite resource name label %q in composite resource metadata"
+	errFmtKindOrGroupChanged = "cannot change the kind or group of a composed resource from %s to %s (possible composed resource template mismatch)"
+	errFmtNamePrefixLabel    = "cannot find top-level composite resource name label %q in composite resource metadata"
 
 	// TODO(negz): Include more detail such as field paths if they exist.
 	// Perhaps require each patch type to have a String() method to help
@@ -61,13 +61,16 @@ func RenderFromJSON(o resource.Object, data []byte) error {
 	o.SetName(name)
 	o.SetNamespace(namespace)
 
-	// This resource already had a GVK (probably because it already exists), but
+	// This resource already had a GK (probably because it already exists), but
 	// when we rendered its template it changed. This shouldn't happen. Either
-	// someone changed the kind in the template or we're trying to use the wrong
-	// template (e.g. because the order of an array of anonymous templates
+	// someone changed the kind or group in the template, or we're trying to use the
+	// wrong template (e.g. because the order of an array of anonymous templates
 	// changed).
-	if !gvk.Empty() && o.GetObjectKind().GroupVersionKind() != gvk {
-		return errors.Errorf(errFmtKindChanged, gvk, o.GetObjectKind().GroupVersionKind())
+	// Please note, we don't check for version changes, as versions can change. For example,
+	// if a composed resource was created with a template that has a version of "v1alpha1",
+	// and then the template is updated to "v1beta1", the composed resource will still be valid.
+	if !gvk.Empty() && o.GetObjectKind().GroupVersionKind().GroupKind() != gvk.GroupKind() {
+		return errors.Errorf(errFmtKindOrGroupChanged, gvk, o.GetObjectKind().GroupVersionKind())
 	}
 
 	return nil

--- a/internal/controller/apiextensions/composite/composition_render_test.go
+++ b/internal/controller/apiextensions/composite/composition_render_test.go
@@ -62,8 +62,25 @@ func TestRenderFromJSON(t *testing.T) {
 				err: errors.Wrap(errInvalidChar, errUnmarshalJSON),
 			},
 		},
-		"ExistingGVKChanged": {
-			reason: "We should return an error if unmarshalling the base template changed the composed resource's group, version, or kind",
+		"ExistingGroupChanged": {
+			reason: "We should return an error if unmarshalling the base template changed the composed resource's group.",
+			args: args{
+				o: composed.New(composed.FromReference(corev1.ObjectReference{
+					APIVersion: "example.org/v1",
+					Kind:       "Potato",
+				})),
+				data: []byte(`{"apiVersion": "foo.io/v1", "kind": "Potato"}`),
+			},
+			want: want{
+				o: composed.New(composed.FromReference(corev1.ObjectReference{
+					APIVersion: "foo.io/v1",
+					Kind:       "Potato",
+				})),
+				err: errors.Errorf(errFmtKindOrGroupChanged, "example.org/v1, Kind=Potato", "foo.io/v1, Kind=Potato"),
+			},
+		},
+		"ExistingKindChanged": {
+			reason: "We should return an error if unmarshalling the base template changed the composed resource's kind.",
 			args: args{
 				o: composed.New(composed.FromReference(corev1.ObjectReference{
 					APIVersion: "example.org/v1",
@@ -76,7 +93,23 @@ func TestRenderFromJSON(t *testing.T) {
 					APIVersion: "example.org/v1",
 					Kind:       "Different",
 				})),
-				err: errors.Errorf(errFmtKindChanged, "example.org/v1, Kind=Potato", "example.org/v1, Kind=Different"),
+				err: errors.Errorf(errFmtKindOrGroupChanged, "example.org/v1, Kind=Potato", "example.org/v1, Kind=Different"),
+			},
+		},
+		"VersionCanChange": {
+			reason: "We should accept version changes in the base template.",
+			args: args{
+				o: composed.New(composed.FromReference(corev1.ObjectReference{
+					APIVersion: "example.org/v1alpha1",
+					Kind:       "Potato",
+				})),
+				data: []byte(`{"apiVersion": "example.org/v1beta1", "kind": "Potato"}`),
+			},
+			want: want{
+				o: composed.New(composed.FromReference(corev1.ObjectReference{
+					APIVersion: "example.org/v1beta1",
+					Kind:       "Potato",
+				})),
 			},
 		},
 		"NewComposedResource": {


### PR DESCRIPTION
### Description of your changes

This PR fixes the linked issue where composite controller erroring out when the version of a composed resource updated in the composition. This is a valid use case and we will see this more with the introduction of multi-versioned managed resources in the provider ecosystem.

Prior to v1.14, we were [only checking kind](https://github.com/crossplane/crossplane/blob/cb232d32a595876a98ab3a7f5125e3fa26e2f2ac/internal/controller/apiextensions/composite/composition_pt.go#L512), however, with [this PR](https://github.com/crossplane/crossplane/pull/4500), we started checking all GVK. I believe, we should rather check Group and Kind, and accept changes in the version. 

Fixes #5368

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added or updated unit tests.
- [ ] ~Added or updated e2e tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [x] Added `backport release-x.y` labels to auto-backport this PR.

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/master/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/master/contributing#checklist-cheat-sheet
