### PR TITLE
fix: capitalization of printcolumns

### DIFF
--- a/apis/apiextensions/v1/composition_revision_types.go
+++ b/apis/apiextensions/v1/composition_revision_types.go
@@ -135,10 +135,10 @@ type CompositionRevisionStatus struct {
 
 // A CompositionRevision represents a revision in time of a Composition.
 // Revisions are created by Crossplane; they should be treated as immutable.
-// +kubebuilder:printcolumn:name="REVISION",type="string",JSONPath=".spec.revision"
-// +kubebuilder:printcolumn:name="XR-KIND",type="string",JSONPath=".spec.compositeTypeRef.kind"
-// +kubebuilder:printcolumn:name="XR-APIVERSION",type="string",JSONPath=".spec.compositeTypeRef.apiVersion"
-// +kubebuilder:printcolumn:name="AGE",type="date",JSONPath=".metadata.creationTimestamp"
+// +kubebuilder:printcolumn:name="Revision",type="string",JSONPath=".spec.revision"
+// +kubebuilder:printcolumn:name="XR-Kind",type="string",JSONPath=".spec.compositeTypeRef.kind"
+// +kubebuilder:printcolumn:name="XR-APIVersion",type="string",JSONPath=".spec.compositeTypeRef.apiVersion"
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 // +kubebuilder:resource:scope=Cluster,categories=crossplane,shortName=comprev
 // +kubebuilder:subresource:status
 type CompositionRevision struct {

--- a/apis/apiextensions/v1/composition_types.go
+++ b/apis/apiextensions/v1/composition_types.go
@@ -110,9 +110,9 @@ type CompositionSpec struct {
 // +genclient:nonNamespaced
 
 // A Composition specifies how a composite resource should be composed.
-// +kubebuilder:printcolumn:name="XR-KIND",type="string",JSONPath=".spec.compositeTypeRef.kind"
-// +kubebuilder:printcolumn:name="XR-APIVERSION",type="string",JSONPath=".spec.compositeTypeRef.apiVersion"
-// +kubebuilder:printcolumn:name="AGE",type="date",JSONPath=".metadata.creationTimestamp"
+// +kubebuilder:printcolumn:name="XR-Kind",type="string",JSONPath=".spec.compositeTypeRef.kind"
+// +kubebuilder:printcolumn:name="XR-APIVersion",type="string",JSONPath=".spec.compositeTypeRef.apiVersion"
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 // +kubebuilder:resource:scope=Cluster,categories=crossplane,shortName=comp
 type Composition struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/apis/apiextensions/v1/xrd_types.go
+++ b/apis/apiextensions/v1/xrd_types.go
@@ -215,9 +215,9 @@ type CompositeResourceDefinitionControllerStatus struct {
 // A CompositeResourceDefinition defines a new kind of composite infrastructure
 // resource. The new resource is composed of other composite or managed
 // infrastructure resources.
-// +kubebuilder:printcolumn:name="ESTABLISHED",type="string",JSONPath=".status.conditions[?(@.type=='Established')].status"
-// +kubebuilder:printcolumn:name="OFFERED",type="string",JSONPath=".status.conditions[?(@.type=='Offered')].status"
-// +kubebuilder:printcolumn:name="AGE",type="date",JSONPath=".metadata.creationTimestamp"
+// +kubebuilder:printcolumn:name="Established",type="string",JSONPath=".status.conditions[?(@.type=='Established')].status"
+// +kubebuilder:printcolumn:name="Offered",type="string",JSONPath=".status.conditions[?(@.type=='Offered')].status"
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:scope=Cluster,categories=crossplane,shortName=xrd;xrds
 type CompositeResourceDefinition struct {

--- a/apis/apiextensions/v1alpha1/environment_config_types.go
+++ b/apis/apiextensions/v1alpha1/environment_config_types.go
@@ -27,7 +27,7 @@ import (
 // +genclient:nonNamespaced
 
 // A EnvironmentConfig contains a set of arbitrary, unstructured values.
-// +kubebuilder:printcolumn:name="AGE",type="date",JSONPath=".metadata.creationTimestamp"
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 // +kubebuilder:resource:scope=Cluster,categories=crossplane,shortName=envcfg
 type EnvironmentConfig struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/apis/apiextensions/v1alpha1/usage_types.go
+++ b/apis/apiextensions/v1alpha1/usage_types.go
@@ -78,9 +78,9 @@ type UsageStatus struct {
 // A Usage defines a deletion blocking relationship between two resources.
 // +kubebuilder:object:root=true
 // +kubebuilder:storageversion
-// +kubebuilder:printcolumn:name="DETAILS",type="string",JSONPath=".metadata.annotations.crossplane\\.io/usage-details"
-// +kubebuilder:printcolumn:name="READY",type="string",JSONPath=".status.conditions[?(@.type=='Ready')].status"
-// +kubebuilder:printcolumn:name="AGE",type="date",JSONPath=".metadata.creationTimestamp"
+// +kubebuilder:printcolumn:name="Details",type="string",JSONPath=".metadata.annotations.crossplane\\.io/usage-details"
+// +kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.conditions[?(@.type=='Ready')].status"
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 // +kubebuilder:resource:scope=Cluster,categories=crossplane
 // +kubebuilder:subresource:status
 type Usage struct {

--- a/apis/apiextensions/v1beta1/zz_generated.composition_revision_types.go
+++ b/apis/apiextensions/v1beta1/zz_generated.composition_revision_types.go
@@ -136,10 +136,10 @@ type CompositionRevisionStatus struct {
 
 // A CompositionRevision represents a revision in time of a Composition.
 // Revisions are created by Crossplane; they should be treated as immutable.
-// +kubebuilder:printcolumn:name="REVISION",type="string",JSONPath=".spec.revision"
-// +kubebuilder:printcolumn:name="XR-KIND",type="string",JSONPath=".spec.compositeTypeRef.kind"
-// +kubebuilder:printcolumn:name="XR-APIVERSION",type="string",JSONPath=".spec.compositeTypeRef.apiVersion"
-// +kubebuilder:printcolumn:name="AGE",type="date",JSONPath=".metadata.creationTimestamp"
+// +kubebuilder:printcolumn:name="Revision",type="string",JSONPath=".spec.revision"
+// +kubebuilder:printcolumn:name="XR-Kind",type="string",JSONPath=".spec.compositeTypeRef.kind"
+// +kubebuilder:printcolumn:name="XR-APIVersion",type="string",JSONPath=".spec.compositeTypeRef.apiVersion"
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 // +kubebuilder:resource:scope=Cluster,categories=crossplane,shortName=comprev
 // +kubebuilder:subresource:status
 type CompositionRevision struct {

--- a/apis/pkg/v1/configuration_types.go
+++ b/apis/pkg/v1/configuration_types.go
@@ -29,10 +29,10 @@ import (
 // Configuration is the CRD type for a request to add a configuration to Crossplane.
 // +kubebuilder:subresource:status
 // +kubebuilder:storageversion
-// +kubebuilder:printcolumn:name="INSTALLED",type="string",JSONPath=".status.conditions[?(@.type=='Installed')].status"
-// +kubebuilder:printcolumn:name="HEALTHY",type="string",JSONPath=".status.conditions[?(@.type=='Healthy')].status"
-// +kubebuilder:printcolumn:name="PACKAGE",type="string",JSONPath=".spec.package"
-// +kubebuilder:printcolumn:name="AGE",type="date",JSONPath=".metadata.creationTimestamp"
+// +kubebuilder:printcolumn:name="Installed",type="string",JSONPath=".status.conditions[?(@.type=='Installed')].status"
+// +kubebuilder:printcolumn:name="Healthy",type="string",JSONPath=".status.conditions[?(@.type=='Healthy')].status"
+// +kubebuilder:printcolumn:name="Package",type="string",JSONPath=".spec.package"
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 // +kubebuilder:resource:scope=Cluster,categories={crossplane,pkg}
 type Configuration struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/apis/pkg/v1/configuration_types.go
+++ b/apis/pkg/v1/configuration_types.go
@@ -70,13 +70,13 @@ type ConfigurationList struct {
 // A ConfigurationRevision that has been added to Crossplane.
 // +kubebuilder:subresource:status
 // +kubebuilder:storageversion
-// +kubebuilder:printcolumn:name="HEALTHY",type="string",JSONPath=".status.conditions[?(@.type=='Healthy')].status"
-// +kubebuilder:printcolumn:name="REVISION",type="string",JSONPath=".spec.revision"
-// +kubebuilder:printcolumn:name="IMAGE",type="string",JSONPath=".spec.image"
-// +kubebuilder:printcolumn:name="STATE",type="string",JSONPath=".spec.desiredState"
-// +kubebuilder:printcolumn:name="DEP-FOUND",type="string",JSONPath=".status.foundDependencies"
-// +kubebuilder:printcolumn:name="DEP-INSTALLED",type="string",JSONPath=".status.installedDependencies"
-// +kubebuilder:printcolumn:name="AGE",type="date",JSONPath=".metadata.creationTimestamp"
+// +kubebuilder:printcolumn:name="Healthy",type="string",JSONPath=".status.conditions[?(@.type=='Healthy')].status"
+// +kubebuilder:printcolumn:name="Revision",type="string",JSONPath=".spec.revision"
+// +kubebuilder:printcolumn:name="Image",type="string",JSONPath=".spec.image"
+// +kubebuilder:printcolumn:name="State",type="string",JSONPath=".spec.desiredState"
+// +kubebuilder:printcolumn:name="Dep-Found",type="string",JSONPath=".status.foundDependencies"
+// +kubebuilder:printcolumn:name="Dep-Installed",type="string",JSONPath=".status.installedDependencies"
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 // +kubebuilder:resource:scope=Cluster,categories={crossplane,pkgrev}
 type ConfigurationRevision struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/apis/pkg/v1/provider_types.go
+++ b/apis/pkg/v1/provider_types.go
@@ -77,13 +77,13 @@ type ProviderRevisionSpec struct {
 // A ProviderRevision that has been added to Crossplane.
 // +kubebuilder:subresource:status
 // +kubebuilder:storageversion
-// +kubebuilder:printcolumn:name="HEALTHY",type="string",JSONPath=".status.conditions[?(@.type=='Healthy')].status"
-// +kubebuilder:printcolumn:name="REVISION",type="string",JSONPath=".spec.revision"
-// +kubebuilder:printcolumn:name="IMAGE",type="string",JSONPath=".spec.image"
-// +kubebuilder:printcolumn:name="STATE",type="string",JSONPath=".spec.desiredState"
-// +kubebuilder:printcolumn:name="DEP-FOUND",type="string",JSONPath=".status.foundDependencies"
-// +kubebuilder:printcolumn:name="DEP-INSTALLED",type="string",JSONPath=".status.installedDependencies"
-// +kubebuilder:printcolumn:name="AGE",type="date",JSONPath=".metadata.creationTimestamp"
+// +kubebuilder:printcolumn:name="Healthy",type="string",JSONPath=".status.conditions[?(@.type=='Healthy')].status"
+// +kubebuilder:printcolumn:name="Revision",type="string",JSONPath=".spec.revision"
+// +kubebuilder:printcolumn:name="Image",type="string",JSONPath=".spec.image"
+// +kubebuilder:printcolumn:name="State",type="string",JSONPath=".spec.desiredState"
+// +kubebuilder:printcolumn:name="Dep-Found",type="string",JSONPath=".status.foundDependencies"
+// +kubebuilder:printcolumn:name="Dep-Installed",type="string",JSONPath=".status.installedDependencies"
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 // +kubebuilder:resource:scope=Cluster,categories={crossplane,pkgrev}
 type ProviderRevision struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/apis/pkg/v1/provider_types.go
+++ b/apis/pkg/v1/provider_types.go
@@ -29,10 +29,10 @@ import (
 // Provider is the CRD type for a request to add a provider to Crossplane.
 // +kubebuilder:subresource:status
 // +kubebuilder:storageversion
-// +kubebuilder:printcolumn:name="INSTALLED",type="string",JSONPath=".status.conditions[?(@.type=='Installed')].status"
-// +kubebuilder:printcolumn:name="HEALTHY",type="string",JSONPath=".status.conditions[?(@.type=='Healthy')].status"
-// +kubebuilder:printcolumn:name="PACKAGE",type="string",JSONPath=".spec.package"
-// +kubebuilder:printcolumn:name="AGE",type="date",JSONPath=".metadata.creationTimestamp"
+// +kubebuilder:printcolumn:name="Installed",type="string",JSONPath=".status.conditions[?(@.type=='Installed')].status"
+// +kubebuilder:printcolumn:name="Healthy",type="string",JSONPath=".status.conditions[?(@.type=='Healthy')].status"
+// +kubebuilder:printcolumn:name="Package",type="string",JSONPath=".spec.package"
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 // +kubebuilder:resource:scope=Cluster,categories={crossplane,pkg}
 type Provider struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/apis/pkg/v1alpha1/config.go
+++ b/apis/pkg/v1alpha1/config.go
@@ -179,7 +179,7 @@ type PodObjectMeta struct {
 // Deprecated: This API is replaced by DeploymentRuntimeConfig, and is scheduled
 // to be removed in a future release. See the design doc for more details:
 // https://github.com/crossplane/crossplane/blob/11bbe13ea3604928cc4e24e8d0d18f3f5f7e847c/design/one-pager-package-runtime-config.md
-// +kubebuilder:printcolumn:name="AGE",type="date",JSONPath=".metadata.creationTimestamp"
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 // +kubebuilder:resource:scope=Cluster
 // +kubebuilder:deprecatedversion:warning="ControllerConfig.pkg.crossplane.io/v1alpha1 is deprecated. Use DeploymentRuntimeConfig from pkg.crossplane.io/v1beta1 instead."
 type ControllerConfig struct {

--- a/apis/pkg/v1beta1/deployment_runtime_config_types.go
+++ b/apis/pkg/v1beta1/deployment_runtime_config_types.go
@@ -91,7 +91,7 @@ type DeploymentRuntimeConfigSpec struct {
 // the package uses a runtime and the package manager is running with
 // --package-runtime=Deployment (the default). See the following design doc for
 // more details:https://github.com/crossplane/crossplane/blob/91edeae3fcac96c6c8a1759a723981eea4bb77e4/design/one-pager-package-runtime-config.md#migration-from-controllerconfig
-// +kubebuilder:printcolumn:name="AGE",type="date",JSONPath=".metadata.creationTimestamp"
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 // +kubebuilder:resource:scope=Cluster,categories={crossplane}
 type DeploymentRuntimeConfig struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/apis/pkg/v1beta1/function_types.go
+++ b/apis/pkg/v1beta1/function_types.go
@@ -37,10 +37,10 @@ import (
 // Function is the CRD type for a request to deploy a long-running Function.
 // +kubebuilder:subresource:status
 // +kubebuilder:storageversion
-// +kubebuilder:printcolumn:name="INSTALLED",type="string",JSONPath=".status.conditions[?(@.type=='Installed')].status"
-// +kubebuilder:printcolumn:name="HEALTHY",type="string",JSONPath=".status.conditions[?(@.type=='Healthy')].status"
-// +kubebuilder:printcolumn:name="PACKAGE",type="string",JSONPath=".spec.package"
-// +kubebuilder:printcolumn:name="AGE",type="date",JSONPath=".metadata.creationTimestamp"
+// +kubebuilder:printcolumn:name="Installed",type="string",JSONPath=".status.conditions[?(@.type=='Installed')].status"
+// +kubebuilder:printcolumn:name="Healthy",type="string",JSONPath=".status.conditions[?(@.type=='Healthy')].status"
+// +kubebuilder:printcolumn:name="Package",type="string",JSONPath=".spec.package"
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 // +kubebuilder:resource:scope=Cluster,categories={crossplane,pkg}
 type Function struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/apis/pkg/v1beta1/function_types.go
+++ b/apis/pkg/v1beta1/function_types.go
@@ -85,13 +85,13 @@ type FunctionRevisionSpec struct {
 // A FunctionRevision that has been added to Crossplane.
 // +kubebuilder:subresource:status
 // +kubebuilder:storageversion
-// +kubebuilder:printcolumn:name="HEALTHY",type="string",JSONPath=".status.conditions[?(@.type=='Healthy')].status"
-// +kubebuilder:printcolumn:name="REVISION",type="string",JSONPath=".spec.revision"
-// +kubebuilder:printcolumn:name="IMAGE",type="string",JSONPath=".spec.image"
-// +kubebuilder:printcolumn:name="STATE",type="string",JSONPath=".spec.desiredState"
-// +kubebuilder:printcolumn:name="DEP-FOUND",type="string",JSONPath=".status.foundDependencies"
-// +kubebuilder:printcolumn:name="DEP-INSTALLED",type="string",JSONPath=".status.installedDependencies"
-// +kubebuilder:printcolumn:name="AGE",type="date",JSONPath=".metadata.creationTimestamp"
+// +kubebuilder:printcolumn:name="Healthy",type="string",JSONPath=".status.conditions[?(@.type=='Healthy')].status"
+// +kubebuilder:printcolumn:name="Revision",type="string",JSONPath=".spec.revision"
+// +kubebuilder:printcolumn:name="Image",type="string",JSONPath=".spec.image"
+// +kubebuilder:printcolumn:name="State",type="string",JSONPath=".spec.desiredState"
+// +kubebuilder:printcolumn:name="Dep-Found",type="string",JSONPath=".status.foundDependencies"
+// +kubebuilder:printcolumn:name="Dep-Installed",type="string",JSONPath=".status.installedDependencies"
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 // +kubebuilder:resource:scope=Cluster,categories={crossplane,pkgrev}
 type FunctionRevision struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/apis/pkg/v1beta1/lock.go
+++ b/apis/pkg/v1beta1/lock.go
@@ -123,7 +123,7 @@ func (d *Dependency) AddNeighbors(...dag.Node) error {
 // Lock is the CRD type that tracks package dependencies.
 // +kubebuilder:storageversion
 // +kubebuilder:subresource:status
-// +kubebuilder:printcolumn:name="AGE",type="date",JSONPath=".metadata.creationTimestamp"
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 // +kubebuilder:resource:scope=Cluster
 type Lock struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/apis/secrets/v1alpha1/storeconfig_types.go
+++ b/apis/secrets/v1alpha1/storeconfig_types.go
@@ -30,9 +30,9 @@ type StoreConfigSpec struct {
 // +kubebuilder:object:root=true
 
 // A StoreConfig configures how Crossplane controllers should store connection details.
-// +kubebuilder:printcolumn:name="AGE",type="date",JSONPath=".metadata.creationTimestamp"
-// +kubebuilder:printcolumn:name="TYPE",type="string",JSONPath=".spec.type"
-// +kubebuilder:printcolumn:name="DEFAULT-SCOPE",type="string",JSONPath=".spec.defaultScope"
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
+// +kubebuilder:printcolumn:name="Type",type="string",JSONPath=".spec.type"
+// +kubebuilder:printcolumn:name="Default-Scope",type="string",JSONPath=".spec.defaultScope"
 // +kubebuilder:resource:scope=Cluster,categories={crossplane,store}
 type StoreConfig struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/cluster/crds/apiextensions.crossplane.io_compositeresourcedefinitions.yaml
+++ b/cluster/crds/apiextensions.crossplane.io_compositeresourcedefinitions.yaml
@@ -20,13 +20,13 @@ spec:
   versions:
   - additionalPrinterColumns:
     - jsonPath: .status.conditions[?(@.type=='Established')].status
-      name: ESTABLISHED
+      name: Established
       type: string
     - jsonPath: .status.conditions[?(@.type=='Offered')].status
-      name: OFFERED
+      name: Offered
       type: string
     - jsonPath: .metadata.creationTimestamp
-      name: AGE
+      name: Age
       type: date
     name: v1
     schema:

--- a/cluster/crds/apiextensions.crossplane.io_compositionrevisions.yaml
+++ b/cluster/crds/apiextensions.crossplane.io_compositionrevisions.yaml
@@ -19,16 +19,16 @@ spec:
   versions:
   - additionalPrinterColumns:
     - jsonPath: .spec.revision
-      name: REVISION
+      name: Revision
       type: string
     - jsonPath: .spec.compositeTypeRef.kind
-      name: XR-KIND
+      name: XR-Kind
       type: string
     - jsonPath: .spec.compositeTypeRef.apiVersion
-      name: XR-APIVERSION
+      name: XR-APIVersion
       type: string
     - jsonPath: .metadata.creationTimestamp
-      name: AGE
+      name: Age
       type: date
     name: v1
     schema:
@@ -1595,16 +1595,16 @@ spec:
       status: {}
   - additionalPrinterColumns:
     - jsonPath: .spec.revision
-      name: REVISION
+      name: Revision
       type: string
     - jsonPath: .spec.compositeTypeRef.kind
-      name: XR-KIND
+      name: XR-Kind
       type: string
     - jsonPath: .spec.compositeTypeRef.apiVersion
-      name: XR-APIVERSION
+      name: XR-APIVersion
       type: string
     - jsonPath: .metadata.creationTimestamp
-      name: AGE
+      name: Age
       type: date
     name: v1beta1
     schema:

--- a/cluster/crds/apiextensions.crossplane.io_compositions.yaml
+++ b/cluster/crds/apiextensions.crossplane.io_compositions.yaml
@@ -19,13 +19,13 @@ spec:
   versions:
   - additionalPrinterColumns:
     - jsonPath: .spec.compositeTypeRef.kind
-      name: XR-KIND
+      name: XR-Kind
       type: string
     - jsonPath: .spec.compositeTypeRef.apiVersion
-      name: XR-APIVERSION
+      name: XR-APIVersion
       type: string
     - jsonPath: .metadata.creationTimestamp
-      name: AGE
+      name: Age
       type: date
     name: v1
     schema:

--- a/cluster/crds/apiextensions.crossplane.io_environmentconfigs.yaml
+++ b/cluster/crds/apiextensions.crossplane.io_environmentconfigs.yaml
@@ -19,7 +19,7 @@ spec:
   versions:
   - additionalPrinterColumns:
     - jsonPath: .metadata.creationTimestamp
-      name: AGE
+      name: Age
       type: date
     name: v1alpha1
     schema:

--- a/cluster/crds/apiextensions.crossplane.io_usages.yaml
+++ b/cluster/crds/apiextensions.crossplane.io_usages.yaml
@@ -17,13 +17,13 @@ spec:
   versions:
   - additionalPrinterColumns:
     - jsonPath: .metadata.annotations.crossplane\.io/usage-details
-      name: DETAILS
+      name: Details
       type: string
     - jsonPath: .status.conditions[?(@.type=='Ready')].status
-      name: READY
+      name: Ready
       type: string
     - jsonPath: .metadata.creationTimestamp
-      name: AGE
+      name: Age
       type: date
     name: v1alpha1
     schema:

--- a/cluster/crds/pkg.crossplane.io_configurationrevisions.yaml
+++ b/cluster/crds/pkg.crossplane.io_configurationrevisions.yaml
@@ -18,25 +18,25 @@ spec:
   versions:
   - additionalPrinterColumns:
     - jsonPath: .status.conditions[?(@.type=='Healthy')].status
-      name: HEALTHY
+      name: Healthy
       type: string
     - jsonPath: .spec.revision
-      name: REVISION
+      name: Revision
       type: string
     - jsonPath: .spec.image
-      name: IMAGE
+      name: Image
       type: string
     - jsonPath: .spec.desiredState
-      name: STATE
+      name: State
       type: string
     - jsonPath: .status.foundDependencies
-      name: DEP-FOUND
+      name: Dep-Found
       type: string
     - jsonPath: .status.installedDependencies
-      name: DEP-INSTALLED
+      name: Dep-Installed
       type: string
     - jsonPath: .metadata.creationTimestamp
-      name: AGE
+      name: Age
       type: date
     name: v1
     schema:

--- a/cluster/crds/pkg.crossplane.io_configurations.yaml
+++ b/cluster/crds/pkg.crossplane.io_configurations.yaml
@@ -18,16 +18,16 @@ spec:
   versions:
   - additionalPrinterColumns:
     - jsonPath: .status.conditions[?(@.type=='Installed')].status
-      name: INSTALLED
+      name: Installed
       type: string
     - jsonPath: .status.conditions[?(@.type=='Healthy')].status
-      name: HEALTHY
+      name: Healthy
       type: string
     - jsonPath: .spec.package
-      name: PACKAGE
+      name: Package
       type: string
     - jsonPath: .metadata.creationTimestamp
-      name: AGE
+      name: Age
       type: date
     name: v1
     schema:

--- a/cluster/crds/pkg.crossplane.io_controllerconfigs.yaml
+++ b/cluster/crds/pkg.crossplane.io_controllerconfigs.yaml
@@ -15,7 +15,7 @@ spec:
   versions:
   - additionalPrinterColumns:
     - jsonPath: .metadata.creationTimestamp
-      name: AGE
+      name: Age
       type: date
     deprecated: true
     deprecationWarning: ControllerConfig.pkg.crossplane.io/v1alpha1 is deprecated.

--- a/cluster/crds/pkg.crossplane.io_deploymentruntimeconfigs.yaml
+++ b/cluster/crds/pkg.crossplane.io_deploymentruntimeconfigs.yaml
@@ -17,7 +17,7 @@ spec:
   versions:
   - additionalPrinterColumns:
     - jsonPath: .metadata.creationTimestamp
-      name: AGE
+      name: Age
       type: date
     name: v1beta1
     schema:

--- a/cluster/crds/pkg.crossplane.io_functionrevisions.yaml
+++ b/cluster/crds/pkg.crossplane.io_functionrevisions.yaml
@@ -18,25 +18,25 @@ spec:
   versions:
   - additionalPrinterColumns:
     - jsonPath: .status.conditions[?(@.type=='Healthy')].status
-      name: HEALTHY
+      name: Healthy
       type: string
     - jsonPath: .spec.revision
-      name: REVISION
+      name: Revision
       type: string
     - jsonPath: .spec.image
-      name: IMAGE
+      name: Image
       type: string
     - jsonPath: .spec.desiredState
-      name: STATE
+      name: State
       type: string
     - jsonPath: .status.foundDependencies
-      name: DEP-FOUND
+      name: Dep-Found
       type: string
     - jsonPath: .status.installedDependencies
-      name: DEP-INSTALLED
+      name: Dep-Installed
       type: string
     - jsonPath: .metadata.creationTimestamp
-      name: AGE
+      name: Age
       type: date
     name: v1beta1
     schema:

--- a/cluster/crds/pkg.crossplane.io_functions.yaml
+++ b/cluster/crds/pkg.crossplane.io_functions.yaml
@@ -18,16 +18,16 @@ spec:
   versions:
   - additionalPrinterColumns:
     - jsonPath: .status.conditions[?(@.type=='Installed')].status
-      name: INSTALLED
+      name: Installed
       type: string
     - jsonPath: .status.conditions[?(@.type=='Healthy')].status
-      name: HEALTHY
+      name: Healthy
       type: string
     - jsonPath: .spec.package
-      name: PACKAGE
+      name: Package
       type: string
     - jsonPath: .metadata.creationTimestamp
-      name: AGE
+      name: Age
       type: date
     name: v1beta1
     schema:

--- a/cluster/crds/pkg.crossplane.io_locks.yaml
+++ b/cluster/crds/pkg.crossplane.io_locks.yaml
@@ -15,7 +15,7 @@ spec:
   versions:
   - additionalPrinterColumns:
     - jsonPath: .metadata.creationTimestamp
-      name: AGE
+      name: Age
       type: date
     name: v1beta1
     schema:

--- a/cluster/crds/pkg.crossplane.io_providerrevisions.yaml
+++ b/cluster/crds/pkg.crossplane.io_providerrevisions.yaml
@@ -18,25 +18,25 @@ spec:
   versions:
   - additionalPrinterColumns:
     - jsonPath: .status.conditions[?(@.type=='Healthy')].status
-      name: HEALTHY
+      name: Healthy
       type: string
     - jsonPath: .spec.revision
-      name: REVISION
+      name: Revision
       type: string
     - jsonPath: .spec.image
-      name: IMAGE
+      name: Image
       type: string
     - jsonPath: .spec.desiredState
-      name: STATE
+      name: State
       type: string
     - jsonPath: .status.foundDependencies
-      name: DEP-FOUND
+      name: Dep-Found
       type: string
     - jsonPath: .status.installedDependencies
-      name: DEP-INSTALLED
+      name: Dep-Installed
       type: string
     - jsonPath: .metadata.creationTimestamp
-      name: AGE
+      name: Age
       type: date
     name: v1
     schema:

--- a/cluster/crds/pkg.crossplane.io_providers.yaml
+++ b/cluster/crds/pkg.crossplane.io_providers.yaml
@@ -18,16 +18,16 @@ spec:
   versions:
   - additionalPrinterColumns:
     - jsonPath: .status.conditions[?(@.type=='Installed')].status
-      name: INSTALLED
+      name: Installed
       type: string
     - jsonPath: .status.conditions[?(@.type=='Healthy')].status
-      name: HEALTHY
+      name: Healthy
       type: string
     - jsonPath: .spec.package
-      name: PACKAGE
+      name: Package
       type: string
     - jsonPath: .metadata.creationTimestamp
-      name: AGE
+      name: Age
       type: date
     name: v1
     schema:

--- a/cluster/crds/secrets.crossplane.io_storeconfigs.yaml
+++ b/cluster/crds/secrets.crossplane.io_storeconfigs.yaml
@@ -18,13 +18,13 @@ spec:
   versions:
   - additionalPrinterColumns:
     - jsonPath: .metadata.creationTimestamp
-      name: AGE
+      name: Age
       type: date
     - jsonPath: .spec.type
-      name: TYPE
+      name: Type
       type: string
     - jsonPath: .spec.defaultScope
-      name: DEFAULT-SCOPE
+      name: Default-Scope
       type: string
     name: v1alpha1
     schema:

--- a/design/design-doc-packages-v2.md
+++ b/design/design-doc-packages-v2.md
@@ -247,11 +247,11 @@ The current `ClusterPackageInstall` will serve as the basis for the new
 // ClusterPackageInstall is the CRD type for a request to add a package to Crossplane.
 // +kubebuilder:resource:categories=crossplane
 // +kubebuilder:subresource:status
-// +kubebuilder:printcolumn:name="READY",type="string",JSONPath=".status.conditionedStatus.conditions[?(@.type=='Ready')].status"
-// +kubebuilder:printcolumn:name="SOURCE",type="string",JSONPath=".spec.source"
-// +kubebuilder:printcolumn:name="PACKAGE",type="string",JSONPath=".spec.package"
+// +kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.conditionedStatus.conditions[?(@.type=='Ready')].status"
+// +kubebuilder:printcolumn:name="Source",type="string",JSONPath=".spec.source"
+// +kubebuilder:printcolumn:name="Package",type="string",JSONPath=".spec.package"
 // +kubebuilder:printcolumn:name="CRD",type="string",JSONPath=".spec.crd"
-// +kubebuilder:printcolumn:name="AGE",type="date",JSONPath=".metadata.creationTimestamp"
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 type ClusterPackageInstall struct {
   metav1.TypeMeta   `json:",inline"`
   metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -358,11 +358,11 @@ The full schema for the `Package` will be as follows:
 // Package is the CRD type for a request to add a package to Crossplane.
 // +kubebuilder:resource:categories=crossplane
 // +kubebuilder:subresource:status
-// +kubebuilder:printcolumn:name="READY",type="string",JSONPath=".status.conditionedStatus.conditions[?(@.type=='Ready')].status"
-// +kubebuilder:printcolumn:name="SOURCE",type="string",JSONPath=".spec.source"
-// +kubebuilder:printcolumn:name="PACKAGE",type="string",JSONPath=".spec.package"
+// +kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.conditionedStatus.conditions[?(@.type=='Ready')].status"
+// +kubebuilder:printcolumn:name="Source",type="string",JSONPath=".spec.source"
+// +kubebuilder:printcolumn:name="Package",type="string",JSONPath=".spec.package"
 // +kubebuilder:printcolumn:name="CRD",type="string",JSONPath=".spec.crd"
-// +kubebuilder:printcolumn:name="AGE",type="date",JSONPath=".metadata.creationTimestamp"
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 type Package struct {
   metav1.TypeMeta   `json:",inline"`
   metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -436,9 +436,9 @@ type. The current `Package` schema is as follows:
 // A Package that has been added to Crossplane.
 // +kubebuilder:resource:categories=crossplane
 // +kubebuilder:subresource:status
-// +kubebuilder:printcolumn:name="READY",type="string",JSONPath=".status.conditionedStatus.conditions[?(@.type=='Ready')].status"
-// +kubebuilder:printcolumn:name="VERSION",type="string",JSONPath=".spec.version"
-// +kubebuilder:printcolumn:name="AGE",type="date",JSONPath=".metadata.creationTimestamp"
+// +kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.conditionedStatus.conditions[?(@.type=='Ready')].status"
+// +kubebuilder:printcolumn:name="Version",type="string",JSONPath=".spec.version"
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 type Package struct {
   metav1.TypeMeta   `json:",inline"`
   metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -631,9 +631,9 @@ const (
 // A PackageRevision that has been added to Crossplane.
 // +kubebuilder:resource:categories=crossplane
 // +kubebuilder:subresource:status
-// +kubebuilder:printcolumn:name="READY",type="string",JSONPath=".status.conditionedStatus.conditions[?(@.type=='Ready')].status"
-// +kubebuilder:printcolumn:name="VERSION",type="string",JSONPath=".spec.version"
-// +kubebuilder:printcolumn:name="AGE",type="date",JSONPath=".metadata.creationTimestamp"
+// +kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.conditionedStatus.conditions[?(@.type=='Ready')].status"
+// +kubebuilder:printcolumn:name="Version",type="string",JSONPath=".spec.version"
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 type PackageRevision struct {
   metav1.TypeMeta   `json:",inline"`
   metav1.ObjectMeta `json:"metadata,omitempty"`


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane! Please read the contribution docs
(linked below) if this is your first Crossplane pull request.
-->

### Description of your changes

As pointed out in #5406, this PR adjust the printcolumn names from UPPERCASE to Kebab-Case. In this way resources like Providers will not get highlighted green in k9s every time the `AGE` column changes its value. @ValentinGerlach an I, we changed the capitalization for every column name in the CRDs.

When applying the CRD with the new capitalization of the printcolumns the result will look like this:

![Screenshot 2024-02-19 at 13 30 59](https://github.com/crossplane/crossplane/assets/74709975/d648af60-8062-4536-a9d5-5c06b11e3b29)

The printcolumns will stay the same, since the capitalization to UPPERCASE is a client-side feature from kubectl and k9s.

Fixes #5406

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [X] Read and followed Crossplane's [contribution process].
- [X] Run `make reviewable` to ensure this PR is ready for review.
- [ ] ~Added or updated unit tests.~
- [ ] ~Added or updated e2e tests.~
- [X] Linked a PR or a [docs tracking issue] to [document this change].
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/master/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/master/contributing#checklist-cheat-sheet
