### PR TITLE
Bump golangci-lint to v1.56.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ on:
 env:
   # Common versions
   GO_VERSION: '1.22.0'
-  GOLANGCI_VERSION: 'v1.55.2'
+  GOLANGCI_VERSION: 'v1.56.2'
   DOCKER_BUILDX_VERSION: 'v0.10.0'
 
   # Common users. We can't run a step 'if secrets.AWS_USR != ""' but we can run

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ GO_TEST_PACKAGES = $(GO_PROJECT)/test/e2e
 GO_LDFLAGS += -X $(GO_PROJECT)/internal/version.version=$(VERSION)
 GO_SUBDIRS += cmd internal apis
 GO111MODULE = on
-GOLANGCILINT_VERSION = 1.55.2
+GOLANGCILINT_VERSION = 1.56.2
 GO_LINT_ARGS ?= "--fix"
 
 -include build/makelib/golang.mk

--- a/cmd/crank/beta/render/render_test.go
+++ b/cmd/crank/beta/render/render_test.go
@@ -546,7 +546,7 @@ func TestRender(t *testing.T) {
 					Functions: []pkgv1beta1.Function{
 						func() pkgv1beta1.Function {
 							i := 0
-							lis := NewFunctionWithRunFunc(t, func(ctx context.Context, request *fnv1beta1.RunFunctionRequest) (*fnv1beta1.RunFunctionResponse, error) {
+							lis := NewFunctionWithRunFunc(t, func(_ context.Context, request *fnv1beta1.RunFunctionRequest) (*fnv1beta1.RunFunctionResponse, error) {
 								defer func() { i++ }()
 								switch i {
 								case 0:

--- a/cmd/crank/beta/render/runtime_docker_test.go
+++ b/cmd/crank/beta/render/runtime_docker_test.go
@@ -33,7 +33,7 @@ import (
 )
 
 type mockPullClient struct {
-	MockPullImage func(ctx context.Context, ref string, options types.ImagePullOptions) (io.ReadCloser, error)
+	MockPullImage func(_ context.Context, ref string, options types.ImagePullOptions) (io.ReadCloser, error)
 }
 
 func (m *mockPullClient) ImagePull(ctx context.Context, ref string, options types.ImagePullOptions) (io.ReadCloser, error) {

--- a/cmd/crank/beta/trace/internal/resource/xpkg/client_test.go
+++ b/cmd/crank/beta/trace/internal/resource/xpkg/client_test.go
@@ -145,7 +145,7 @@ func TestGetDependencyRef(t *testing.T) {
 				pkgType: v1beta1.FunctionPackageType,
 				pkg:     "example.com/function-1:v1.0.0",
 				client: &test.MockClient{
-					MockGet: test.NewMockGetFn(nil, func(obj client.Object) error {
+					MockGet: test.NewMockGetFn(nil, func(_ client.Object) error {
 						return kerrors.NewNotFound(schema.GroupResource{}, "whatever")
 					}),
 				},

--- a/internal/controller/apiextensions/claim/fuzz_test.go
+++ b/internal/controller/apiextensions/claim/fuzz_test.go
@@ -31,7 +31,7 @@ import (
 )
 
 func FuzzPropagateConnection(f *testing.F) {
-	f.Fuzz(func(t *testing.T, data []byte) {
+	f.Fuzz(func(_ *testing.T, data []byte) {
 		f := fuzz.NewConsumer(data)
 		cp := &fake.Composite{}
 		cm := &fake.CompositeClaim{}
@@ -62,7 +62,7 @@ func FuzzPropagateConnection(f *testing.F) {
 					return nil
 				}),
 			},
-			Applicator: resource.ApplyFn(func(_ context.Context, o client.Object, _ ...resource.ApplyOption) error {
+			Applicator: resource.ApplyFn(func(_ context.Context, _ client.Object, _ ...resource.ApplyOption) error {
 				return nil
 			}),
 		}

--- a/internal/controller/apiextensions/claim/reconciler_test.go
+++ b/internal/controller/apiextensions/claim/reconciler_test.go
@@ -132,10 +132,10 @@ func TestReconcile(t *testing.T) {
 						})),
 					}),
 					WithClaimFinalizer(resource.FinalizerFns{
-						AddFinalizerFn: func(ctx context.Context, obj resource.Object) error { return nil },
+						AddFinalizerFn: func(_ context.Context, _ resource.Object) error { return nil },
 					}),
-					WithCompositeSyncer(CompositeSyncerFn(func(ctx context.Context, cm *claim.Unstructured, xr *composite.Unstructured) error { return nil })),
-					WithConnectionPropagator(ConnectionPropagatorFn(func(ctx context.Context, to resource.LocalConnectionSecretOwner, from resource.ConnectionSecretOwner) (propagated bool, err error) {
+					WithCompositeSyncer(CompositeSyncerFn(func(_ context.Context, _ *claim.Unstructured, _ *composite.Unstructured) error { return nil })),
+					WithConnectionPropagator(ConnectionPropagatorFn(func(_ context.Context, _ resource.LocalConnectionSecretOwner, _ resource.ConnectionSecretOwner) (propagated bool, err error) {
 						return true, nil
 					})),
 				},
@@ -235,7 +235,7 @@ func TestReconcile(t *testing.T) {
 						})),
 					}),
 					WithClaimFinalizer(resource.FinalizerFns{
-						RemoveFinalizerFn: func(ctx context.Context, obj resource.Object) error { return nil },
+						RemoveFinalizerFn: func(_ context.Context, _ resource.Object) error { return nil },
 					}),
 				},
 			},
@@ -261,7 +261,7 @@ func TestReconcile(t *testing.T) {
 							cm.SetConditions(xpv1.ReconcileError(errors.Wrap(errBoom, errDeleteCDs)))
 						})),
 					}),
-					WithConnectionUnpublisher(ConnectionUnpublisherFn(func(ctx context.Context, so resource.LocalConnectionSecretOwner, c managed.ConnectionDetails) error {
+					WithConnectionUnpublisher(ConnectionUnpublisherFn(func(_ context.Context, _ resource.LocalConnectionSecretOwner, _ managed.ConnectionDetails) error {
 						return errBoom
 					})),
 				},
@@ -289,7 +289,7 @@ func TestReconcile(t *testing.T) {
 						})),
 					}),
 					WithClaimFinalizer(resource.FinalizerFns{
-						RemoveFinalizerFn: func(ctx context.Context, obj resource.Object) error { return errBoom },
+						RemoveFinalizerFn: func(_ context.Context, _ resource.Object) error { return errBoom },
 					}),
 				},
 			},
@@ -316,7 +316,7 @@ func TestReconcile(t *testing.T) {
 						})),
 					}),
 					WithClaimFinalizer(resource.FinalizerFns{
-						RemoveFinalizerFn: func(ctx context.Context, obj resource.Object) error { return nil },
+						RemoveFinalizerFn: func(_ context.Context, _ resource.Object) error { return nil },
 					}),
 				},
 			},
@@ -350,7 +350,7 @@ func TestReconcile(t *testing.T) {
 						MockDelete: test.NewMockDeleteFn(nil),
 					}),
 					WithClaimFinalizer(resource.FinalizerFns{
-						RemoveFinalizerFn: func(ctx context.Context, obj resource.Object) error { return nil },
+						RemoveFinalizerFn: func(_ context.Context, _ resource.Object) error { return nil },
 					}),
 				},
 			},
@@ -385,7 +385,7 @@ func TestReconcile(t *testing.T) {
 						}),
 					}),
 					WithClaimFinalizer(resource.FinalizerFns{
-						RemoveFinalizerFn: func(ctx context.Context, obj resource.Object) error { return nil },
+						RemoveFinalizerFn: func(_ context.Context, _ resource.Object) error { return nil },
 					}),
 				},
 			},
@@ -406,7 +406,7 @@ func TestReconcile(t *testing.T) {
 						})),
 					}),
 					WithClaimFinalizer(resource.FinalizerFns{
-						AddFinalizerFn: func(ctx context.Context, obj resource.Object) error { return errBoom },
+						AddFinalizerFn: func(_ context.Context, _ resource.Object) error { return errBoom },
 					}),
 				},
 			},
@@ -427,9 +427,9 @@ func TestReconcile(t *testing.T) {
 						})),
 					}),
 					WithClaimFinalizer(resource.FinalizerFns{
-						AddFinalizerFn: func(ctx context.Context, obj resource.Object) error { return nil },
+						AddFinalizerFn: func(_ context.Context, _ resource.Object) error { return nil },
 					}),
-					WithCompositeSyncer(CompositeSyncerFn(func(ctx context.Context, cm *claim.Unstructured, xr *composite.Unstructured) error { return errBoom })),
+					WithCompositeSyncer(CompositeSyncerFn(func(_ context.Context, _ *claim.Unstructured, _ *composite.Unstructured) error { return errBoom })),
 				},
 			},
 			want: want{
@@ -465,9 +465,9 @@ func TestReconcile(t *testing.T) {
 						})),
 					}),
 					WithClaimFinalizer(resource.FinalizerFns{
-						AddFinalizerFn: func(ctx context.Context, obj resource.Object) error { return nil },
+						AddFinalizerFn: func(_ context.Context, _ resource.Object) error { return nil },
 					}),
-					WithCompositeSyncer(CompositeSyncerFn(func(ctx context.Context, cm *claim.Unstructured, xr *composite.Unstructured) error { return nil })),
+					WithCompositeSyncer(CompositeSyncerFn(func(_ context.Context, _ *claim.Unstructured, _ *composite.Unstructured) error { return nil })),
 				},
 			},
 			want: want{
@@ -501,10 +501,10 @@ func TestReconcile(t *testing.T) {
 						})),
 					}),
 					WithClaimFinalizer(resource.FinalizerFns{
-						AddFinalizerFn: func(ctx context.Context, obj resource.Object) error { return nil },
+						AddFinalizerFn: func(_ context.Context, _ resource.Object) error { return nil },
 					}),
-					WithCompositeSyncer(CompositeSyncerFn(func(ctx context.Context, cm *claim.Unstructured, xr *composite.Unstructured) error { return nil })),
-					WithConnectionPropagator(ConnectionPropagatorFn(func(ctx context.Context, to resource.LocalConnectionSecretOwner, from resource.ConnectionSecretOwner) (propagated bool, err error) {
+					WithCompositeSyncer(CompositeSyncerFn(func(_ context.Context, _ *claim.Unstructured, _ *composite.Unstructured) error { return nil })),
+					WithConnectionPropagator(ConnectionPropagatorFn(func(_ context.Context, _ resource.LocalConnectionSecretOwner, _ resource.ConnectionSecretOwner) (propagated bool, err error) {
 						return false, errBoom
 					})),
 				},
@@ -542,10 +542,10 @@ func TestReconcile(t *testing.T) {
 						})),
 					}),
 					WithClaimFinalizer(resource.FinalizerFns{
-						AddFinalizerFn: func(ctx context.Context, obj resource.Object) error { return nil },
+						AddFinalizerFn: func(_ context.Context, _ resource.Object) error { return nil },
 					}),
-					WithCompositeSyncer(CompositeSyncerFn(func(ctx context.Context, cm *claim.Unstructured, xr *composite.Unstructured) error { return nil })),
-					WithConnectionPropagator(ConnectionPropagatorFn(func(ctx context.Context, to resource.LocalConnectionSecretOwner, from resource.ConnectionSecretOwner) (propagated bool, err error) {
+					WithCompositeSyncer(CompositeSyncerFn(func(_ context.Context, _ *claim.Unstructured, _ *composite.Unstructured) error { return nil })),
+					WithConnectionPropagator(ConnectionPropagatorFn(func(_ context.Context, _ resource.LocalConnectionSecretOwner, _ resource.ConnectionSecretOwner) (propagated bool, err error) {
 						return true, nil
 					})),
 				},
@@ -582,8 +582,8 @@ func NewClaim(m ...ClaimModifier) *claim.Unstructured {
 }
 
 // A status update function that ensures the supplied object is the claim we want.
-func WantClaim(t *testing.T, want *claim.Unstructured) func(ctx context.Context, obj client.Object, _ ...client.SubResourceUpdateOption) error {
-	return func(ctx context.Context, got client.Object, _ ...client.SubResourceUpdateOption) error {
+func WantClaim(t *testing.T, want *claim.Unstructured) func(_ context.Context, obj client.Object, _ ...client.SubResourceUpdateOption) error {
+	return func(_ context.Context, got client.Object, _ ...client.SubResourceUpdateOption) error {
 		// Normally we use a custom Equal method on conditions to ignore the
 		// lastTransitionTime, but we're using unstructured types here where
 		// the conditions are just a map[string]any.

--- a/internal/controller/apiextensions/claim/syncer_csa_test.go
+++ b/internal/controller/apiextensions/claim/syncer_csa_test.go
@@ -88,7 +88,7 @@ func TestClientSideSync(t *testing.T) {
 		"GenerateXRNameError": {
 			reason: "We should return an error if we can't generate an XR name.",
 			params: params{
-				ng: names.NameGeneratorFn(func(ctx context.Context, cd resource.Object) error {
+				ng: names.NameGeneratorFn(func(_ context.Context, _ resource.Object) error {
 					return errBoom
 				}),
 			},
@@ -132,7 +132,7 @@ func TestClientSideSync(t *testing.T) {
 		"UpdateClaimResourceRefError": {
 			reason: "We should return an error if we can't update the claim to persist its resourceRef.",
 			params: params{
-				ng: names.NameGeneratorFn(func(ctx context.Context, cd resource.Object) error {
+				ng: names.NameGeneratorFn(func(_ context.Context, cd resource.Object) error {
 					cd.SetName("cool-claim-random")
 					return nil
 				}),
@@ -184,7 +184,7 @@ func TestClientSideSync(t *testing.T) {
 		"ApplyXRError": {
 			reason: "We should return an error if we can't apply the XR.",
 			params: params{
-				ng: names.NameGeneratorFn(func(ctx context.Context, cd resource.Object) error {
+				ng: names.NameGeneratorFn(func(_ context.Context, cd resource.Object) error {
 					cd.SetName("cool-claim-random")
 					return nil
 				}),
@@ -239,7 +239,7 @@ func TestClientSideSync(t *testing.T) {
 		"UpdateClaimStatusError": {
 			reason: "We should return an error if we can't update the claim's status.",
 			params: params{
-				ng: names.NameGeneratorFn(func(ctx context.Context, cd resource.Object) error {
+				ng: names.NameGeneratorFn(func(_ context.Context, cd resource.Object) error {
 					cd.SetName("cool-claim-random")
 					return nil
 				}),
@@ -296,7 +296,7 @@ func TestClientSideSync(t *testing.T) {
 		"XRDoesNotExist": {
 			reason: "We should create, bind, and sync with an XR when none exists.",
 			params: params{
-				ng: names.NameGeneratorFn(func(ctx context.Context, cd resource.Object) error {
+				ng: names.NameGeneratorFn(func(_ context.Context, cd resource.Object) error {
 					cd.SetName("cool-claim-random")
 					return nil
 				}),

--- a/internal/controller/apiextensions/claim/syncer_ssa_test.go
+++ b/internal/controller/apiextensions/claim/syncer_ssa_test.go
@@ -65,7 +65,7 @@ func TestServerSideSync(t *testing.T) {
 		"GenerateXRNameError": {
 			reason: "We should return an error if we can't generate an XR name.",
 			params: params{
-				ng: names.NameGeneratorFn(func(ctx context.Context, cd resource.Object) error {
+				ng: names.NameGeneratorFn(func(_ context.Context, _ resource.Object) error {
 					return errBoom
 				}),
 			},
@@ -88,7 +88,7 @@ func TestServerSideSync(t *testing.T) {
 		"WeirdClaimSpec": {
 			reason: "We should return an error if the claim spec is not an object.",
 			params: params{
-				ng: names.NameGeneratorFn(func(ctx context.Context, cd resource.Object) error {
+				ng: names.NameGeneratorFn(func(_ context.Context, _ resource.Object) error {
 					return nil
 				}),
 			},
@@ -117,7 +117,7 @@ func TestServerSideSync(t *testing.T) {
 					// Fail to update the claim.
 					MockUpdate: test.NewMockUpdateFn(errBoom),
 				},
-				ng: names.NameGeneratorFn(func(ctx context.Context, cd resource.Object) error {
+				ng: names.NameGeneratorFn(func(_ context.Context, _ resource.Object) error {
 					return nil
 				}),
 			},
@@ -170,7 +170,7 @@ func TestServerSideSync(t *testing.T) {
 					// Fail to patch the XR.
 					MockPatch: test.NewMockPatchFn(errBoom),
 				},
-				ng: names.NameGeneratorFn(func(ctx context.Context, cd resource.Object) error {
+				ng: names.NameGeneratorFn(func(_ context.Context, _ resource.Object) error {
 					return nil
 				}),
 			},
@@ -228,7 +228,7 @@ func TestServerSideSync(t *testing.T) {
 						return nil
 					}),
 				},
-				ng: names.NameGeneratorFn(func(ctx context.Context, cd resource.Object) error {
+				ng: names.NameGeneratorFn(func(_ context.Context, _ resource.Object) error {
 					return nil
 				}),
 			},
@@ -285,7 +285,7 @@ func TestServerSideSync(t *testing.T) {
 					// Fail to update the claim's status.
 					MockStatusUpdate: test.NewMockSubResourceUpdateFn(errBoom),
 				},
-				ng: names.NameGeneratorFn(func(ctx context.Context, cd resource.Object) error {
+				ng: names.NameGeneratorFn(func(_ context.Context, _ resource.Object) error {
 					return nil
 				}),
 			},
@@ -345,7 +345,7 @@ func TestServerSideSync(t *testing.T) {
 					// Update the claim's status.
 					MockStatusUpdate: test.NewMockSubResourceUpdateFn(nil),
 				},
-				ng: names.NameGeneratorFn(func(ctx context.Context, cd resource.Object) error {
+				ng: names.NameGeneratorFn(func(_ context.Context, cd resource.Object) error {
 					// Generate a name for the XR.
 					cd.SetName("cool-claim-random")
 					return nil

--- a/internal/controller/apiextensions/composite/api_test.go
+++ b/internal/controller/apiextensions/composite/api_test.go
@@ -323,7 +323,7 @@ func TestFetchRevision(t *testing.T) {
 					}),
 				},
 				// This should not be called.
-				Applicator: resource.ApplyFn(func(c context.Context, o client.Object, ao ...resource.ApplyOption) error { return errBoom }),
+				Applicator: resource.ApplyFn(func(_ context.Context, _ client.Object, _ ...resource.ApplyOption) error { return errBoom }),
 			},
 			args: args{
 				cr: &fake.Composite{
@@ -359,7 +359,7 @@ func TestFetchRevision(t *testing.T) {
 						return nil
 					}),
 				},
-				Applicator: resource.ApplyFn(func(c context.Context, o client.Object, ao ...resource.ApplyOption) error {
+				Applicator: resource.ApplyFn(func(_ context.Context, o client.Object, _ ...resource.ApplyOption) error {
 					// Ensure we were updated to reference the latest CompositionRevision.
 					want := &fake.Composite{
 						CompositionReferencer: fake.CompositionReferencer{
@@ -416,7 +416,7 @@ func TestFetchRevision(t *testing.T) {
 						return nil
 					}),
 				},
-				Applicator: resource.ApplyFn(func(c context.Context, o client.Object, ao ...resource.ApplyOption) error {
+				Applicator: resource.ApplyFn(func(_ context.Context, o client.Object, _ ...resource.ApplyOption) error {
 					// Ensure we were updated to reference the latest CompositionRevision.
 					want := &fake.Composite{
 						CompositionReferencer: fake.CompositionReferencer{
@@ -474,7 +474,7 @@ func TestFetchRevision(t *testing.T) {
 						return nil
 					}),
 				},
-				Applicator: resource.ApplyFn(func(c context.Context, o client.Object, ao ...resource.ApplyOption) error {
+				Applicator: resource.ApplyFn(func(_ context.Context, _ client.Object, _ ...resource.ApplyOption) error {
 					return errBoom
 				}),
 			},

--- a/internal/controller/apiextensions/composite/composition_functions_test.go
+++ b/internal/controller/apiextensions/composite/composition_functions_test.go
@@ -80,10 +80,10 @@ func TestFunctionCompose(t *testing.T) {
 			reason: "We should return any error encountered while fetching the XR's connection details.",
 			params: params{
 				o: []FunctionComposerOption{
-					WithComposedResourceObserver(ComposedResourceObserverFn(func(ctx context.Context, xr resource.Composite) (ComposedResourceStates, error) {
+					WithComposedResourceObserver(ComposedResourceObserverFn(func(_ context.Context, _ resource.Composite) (ComposedResourceStates, error) {
 						return ComposedResourceStates{}, nil
 					})),
-					WithCompositeConnectionDetailsFetcher(ConnectionDetailsFetcherFn(func(ctx context.Context, o resource.ConnectionSecretOwner) (managed.ConnectionDetails, error) {
+					WithCompositeConnectionDetailsFetcher(ConnectionDetailsFetcherFn(func(_ context.Context, _ resource.ConnectionSecretOwner) (managed.ConnectionDetails, error) {
 						return nil, errBoom
 					})),
 				},
@@ -100,10 +100,10 @@ func TestFunctionCompose(t *testing.T) {
 			reason: "We should return any error encountered while getting the XR's existing composed resources.",
 			params: params{
 				o: []FunctionComposerOption{
-					WithCompositeConnectionDetailsFetcher(ConnectionDetailsFetcherFn(func(ctx context.Context, o resource.ConnectionSecretOwner) (managed.ConnectionDetails, error) {
+					WithCompositeConnectionDetailsFetcher(ConnectionDetailsFetcherFn(func(_ context.Context, _ resource.ConnectionSecretOwner) (managed.ConnectionDetails, error) {
 						return nil, nil
 					})),
-					WithComposedResourceObserver(ComposedResourceObserverFn(func(ctx context.Context, xr resource.Composite) (ComposedResourceStates, error) {
+					WithComposedResourceObserver(ComposedResourceObserverFn(func(_ context.Context, _ resource.Composite) (ComposedResourceStates, error) {
 						return nil, errBoom
 					})),
 				},
@@ -120,10 +120,10 @@ func TestFunctionCompose(t *testing.T) {
 			reason: "We should return any error encountered while unmarshalling a Composition Function input",
 			params: params{
 				o: []FunctionComposerOption{
-					WithCompositeConnectionDetailsFetcher(ConnectionDetailsFetcherFn(func(ctx context.Context, o resource.ConnectionSecretOwner) (managed.ConnectionDetails, error) {
+					WithCompositeConnectionDetailsFetcher(ConnectionDetailsFetcherFn(func(_ context.Context, _ resource.ConnectionSecretOwner) (managed.ConnectionDetails, error) {
 						return nil, nil
 					})),
-					WithComposedResourceObserver(ComposedResourceObserverFn(func(ctx context.Context, xr resource.Composite) (ComposedResourceStates, error) {
+					WithComposedResourceObserver(ComposedResourceObserverFn(func(_ context.Context, _ resource.Composite) (ComposedResourceStates, error) {
 						return nil, nil
 					})),
 				},
@@ -151,14 +151,14 @@ func TestFunctionCompose(t *testing.T) {
 		"RunFunctionError": {
 			reason: "We should return any error encountered while running a Composition Function",
 			params: params{
-				r: FunctionRunnerFn(func(ctx context.Context, name string, req *v1beta1.RunFunctionRequest) (rsp *v1beta1.RunFunctionResponse, err error) {
+				r: FunctionRunnerFn(func(_ context.Context, _ string, _ *v1beta1.RunFunctionRequest) (rsp *v1beta1.RunFunctionResponse, err error) {
 					return nil, errBoom
 				}),
 				o: []FunctionComposerOption{
-					WithCompositeConnectionDetailsFetcher(ConnectionDetailsFetcherFn(func(ctx context.Context, o resource.ConnectionSecretOwner) (managed.ConnectionDetails, error) {
+					WithCompositeConnectionDetailsFetcher(ConnectionDetailsFetcherFn(func(_ context.Context, _ resource.ConnectionSecretOwner) (managed.ConnectionDetails, error) {
 						return nil, nil
 					})),
-					WithComposedResourceObserver(ComposedResourceObserverFn(func(ctx context.Context, xr resource.Composite) (ComposedResourceStates, error) {
+					WithComposedResourceObserver(ComposedResourceObserverFn(func(_ context.Context, _ resource.Composite) (ComposedResourceStates, error) {
 						return nil, nil
 					})),
 				},
@@ -185,7 +185,7 @@ func TestFunctionCompose(t *testing.T) {
 		"FatalFunctionResultError": {
 			reason: "We should return any fatal function results as an error",
 			params: params{
-				r: FunctionRunnerFn(func(ctx context.Context, name string, req *v1beta1.RunFunctionRequest) (rsp *v1beta1.RunFunctionResponse, err error) {
+				r: FunctionRunnerFn(func(_ context.Context, _ string, _ *v1beta1.RunFunctionRequest) (rsp *v1beta1.RunFunctionResponse, err error) {
 					r := &v1beta1.Result{
 						Severity: v1beta1.Severity_SEVERITY_FATAL,
 						Message:  "oh no",
@@ -193,10 +193,10 @@ func TestFunctionCompose(t *testing.T) {
 					return &v1beta1.RunFunctionResponse{Results: []*v1beta1.Result{r}}, nil
 				}),
 				o: []FunctionComposerOption{
-					WithCompositeConnectionDetailsFetcher(ConnectionDetailsFetcherFn(func(ctx context.Context, o resource.ConnectionSecretOwner) (managed.ConnectionDetails, error) {
+					WithCompositeConnectionDetailsFetcher(ConnectionDetailsFetcherFn(func(_ context.Context, _ resource.ConnectionSecretOwner) (managed.ConnectionDetails, error) {
 						return nil, nil
 					})),
-					WithComposedResourceObserver(ComposedResourceObserverFn(func(ctx context.Context, xr resource.Composite) (ComposedResourceStates, error) {
+					WithComposedResourceObserver(ComposedResourceObserverFn(func(_ context.Context, _ resource.Composite) (ComposedResourceStates, error) {
 						return nil, nil
 					})),
 				},
@@ -223,7 +223,7 @@ func TestFunctionCompose(t *testing.T) {
 		"RenderComposedResourceMetadataError": {
 			reason: "We should return any error we encounter when rendering composed resource metadata",
 			params: params{
-				r: FunctionRunnerFn(func(ctx context.Context, name string, req *v1beta1.RunFunctionRequest) (rsp *v1beta1.RunFunctionResponse, err error) {
+				r: FunctionRunnerFn(func(_ context.Context, _ string, _ *v1beta1.RunFunctionRequest) (rsp *v1beta1.RunFunctionResponse, err error) {
 					d := &v1beta1.State{
 						Resources: map[string]*v1beta1.Resource{
 							"cool-resource": {
@@ -237,10 +237,10 @@ func TestFunctionCompose(t *testing.T) {
 					return &v1beta1.RunFunctionResponse{Desired: d}, nil
 				}),
 				o: []FunctionComposerOption{
-					WithCompositeConnectionDetailsFetcher(ConnectionDetailsFetcherFn(func(ctx context.Context, o resource.ConnectionSecretOwner) (managed.ConnectionDetails, error) {
+					WithCompositeConnectionDetailsFetcher(ConnectionDetailsFetcherFn(func(_ context.Context, _ resource.ConnectionSecretOwner) (managed.ConnectionDetails, error) {
 						return nil, nil
 					})),
-					WithComposedResourceObserver(ComposedResourceObserverFn(func(ctx context.Context, xr resource.Composite) (ComposedResourceStates, error) {
+					WithComposedResourceObserver(ComposedResourceObserverFn(func(_ context.Context, _ resource.Composite) (ComposedResourceStates, error) {
 						return nil, nil
 					})),
 				},
@@ -271,7 +271,7 @@ func TestFunctionCompose(t *testing.T) {
 				kube: &test.MockClient{
 					MockGet: test.NewMockGetFn(errBoom),
 				},
-				r: FunctionRunnerFn(func(ctx context.Context, name string, req *v1beta1.RunFunctionRequest) (rsp *v1beta1.RunFunctionResponse, err error) {
+				r: FunctionRunnerFn(func(_ context.Context, _ string, _ *v1beta1.RunFunctionRequest) (rsp *v1beta1.RunFunctionResponse, err error) {
 					d := &v1beta1.State{
 						Resources: map[string]*v1beta1.Resource{
 							"cool-resource": {
@@ -287,10 +287,10 @@ func TestFunctionCompose(t *testing.T) {
 					return &v1beta1.RunFunctionResponse{Desired: d}, nil
 				}),
 				o: []FunctionComposerOption{
-					WithCompositeConnectionDetailsFetcher(ConnectionDetailsFetcherFn(func(ctx context.Context, o resource.ConnectionSecretOwner) (managed.ConnectionDetails, error) {
+					WithCompositeConnectionDetailsFetcher(ConnectionDetailsFetcherFn(func(_ context.Context, _ resource.ConnectionSecretOwner) (managed.ConnectionDetails, error) {
 						return nil, nil
 					})),
-					WithComposedResourceObserver(ComposedResourceObserverFn(func(ctx context.Context, xr resource.Composite) (ComposedResourceStates, error) {
+					WithComposedResourceObserver(ComposedResourceObserverFn(func(_ context.Context, _ resource.Composite) (ComposedResourceStates, error) {
 						return nil, nil
 					})),
 				},
@@ -320,17 +320,17 @@ func TestFunctionCompose(t *testing.T) {
 				kube: &test.MockClient{
 					MockPatch: test.NewMockPatchFn(nil),
 				},
-				r: FunctionRunnerFn(func(ctx context.Context, name string, req *v1beta1.RunFunctionRequest) (rsp *v1beta1.RunFunctionResponse, err error) {
+				r: FunctionRunnerFn(func(_ context.Context, _ string, _ *v1beta1.RunFunctionRequest) (rsp *v1beta1.RunFunctionResponse, err error) {
 					return &v1beta1.RunFunctionResponse{}, nil
 				}),
 				o: []FunctionComposerOption{
-					WithCompositeConnectionDetailsFetcher(ConnectionDetailsFetcherFn(func(ctx context.Context, o resource.ConnectionSecretOwner) (managed.ConnectionDetails, error) {
+					WithCompositeConnectionDetailsFetcher(ConnectionDetailsFetcherFn(func(_ context.Context, _ resource.ConnectionSecretOwner) (managed.ConnectionDetails, error) {
 						return nil, nil
 					})),
-					WithComposedResourceObserver(ComposedResourceObserverFn(func(ctx context.Context, xr resource.Composite) (ComposedResourceStates, error) {
+					WithComposedResourceObserver(ComposedResourceObserverFn(func(_ context.Context, _ resource.Composite) (ComposedResourceStates, error) {
 						return nil, nil
 					})),
-					WithComposedResourceGarbageCollector(ComposedResourceGarbageCollectorFn(func(ctx context.Context, owner metav1.Object, observed, desired ComposedResourceStates) error {
+					WithComposedResourceGarbageCollector(ComposedResourceGarbageCollectorFn(func(_ context.Context, _ metav1.Object, _, _ ComposedResourceStates) error {
 						return errBoom
 					})),
 				},
@@ -367,17 +367,17 @@ func TestFunctionCompose(t *testing.T) {
 						return errBoom
 					}),
 				},
-				r: FunctionRunnerFn(func(ctx context.Context, name string, req *v1beta1.RunFunctionRequest) (rsp *v1beta1.RunFunctionResponse, err error) {
+				r: FunctionRunnerFn(func(_ context.Context, _ string, _ *v1beta1.RunFunctionRequest) (rsp *v1beta1.RunFunctionResponse, err error) {
 					return &v1beta1.RunFunctionResponse{}, nil
 				}),
 				o: []FunctionComposerOption{
-					WithCompositeConnectionDetailsFetcher(ConnectionDetailsFetcherFn(func(ctx context.Context, o resource.ConnectionSecretOwner) (managed.ConnectionDetails, error) {
+					WithCompositeConnectionDetailsFetcher(ConnectionDetailsFetcherFn(func(_ context.Context, _ resource.ConnectionSecretOwner) (managed.ConnectionDetails, error) {
 						return nil, nil
 					})),
-					WithComposedResourceObserver(ComposedResourceObserverFn(func(ctx context.Context, xr resource.Composite) (ComposedResourceStates, error) {
+					WithComposedResourceObserver(ComposedResourceObserverFn(func(_ context.Context, _ resource.Composite) (ComposedResourceStates, error) {
 						return nil, nil
 					})),
-					WithComposedResourceGarbageCollector(ComposedResourceGarbageCollectorFn(func(ctx context.Context, owner metav1.Object, observed, desired ComposedResourceStates) error {
+					WithComposedResourceGarbageCollector(ComposedResourceGarbageCollectorFn(func(_ context.Context, _ metav1.Object, _, _ ComposedResourceStates) error {
 						return nil
 					})),
 				},
@@ -408,7 +408,7 @@ func TestFunctionCompose(t *testing.T) {
 					MockPatch:       test.NewMockPatchFn(nil),
 					MockStatusPatch: test.NewMockSubResourcePatchFn(errBoom),
 				},
-				r: FunctionRunnerFn(func(ctx context.Context, name string, req *v1beta1.RunFunctionRequest) (rsp *v1beta1.RunFunctionResponse, err error) {
+				r: FunctionRunnerFn(func(_ context.Context, _ string, _ *v1beta1.RunFunctionRequest) (rsp *v1beta1.RunFunctionResponse, err error) {
 					d := &v1beta1.State{
 						Composite: &v1beta1.Resource{
 							Resource: MustStruct(map[string]any{
@@ -420,13 +420,13 @@ func TestFunctionCompose(t *testing.T) {
 					return &v1beta1.RunFunctionResponse{Desired: d}, nil
 				}),
 				o: []FunctionComposerOption{
-					WithCompositeConnectionDetailsFetcher(ConnectionDetailsFetcherFn(func(ctx context.Context, o resource.ConnectionSecretOwner) (managed.ConnectionDetails, error) {
+					WithCompositeConnectionDetailsFetcher(ConnectionDetailsFetcherFn(func(_ context.Context, _ resource.ConnectionSecretOwner) (managed.ConnectionDetails, error) {
 						return nil, nil
 					})),
-					WithComposedResourceObserver(ComposedResourceObserverFn(func(ctx context.Context, xr resource.Composite) (ComposedResourceStates, error) {
+					WithComposedResourceObserver(ComposedResourceObserverFn(func(_ context.Context, _ resource.Composite) (ComposedResourceStates, error) {
 						return nil, nil
 					})),
-					WithComposedResourceGarbageCollector(ComposedResourceGarbageCollectorFn(func(ctx context.Context, owner metav1.Object, observed, desired ComposedResourceStates) error {
+					WithComposedResourceGarbageCollector(ComposedResourceGarbageCollectorFn(func(_ context.Context, _ metav1.Object, _, _ ComposedResourceStates) error {
 						return nil
 					})),
 				},
@@ -466,7 +466,7 @@ func TestFunctionCompose(t *testing.T) {
 					}),
 					MockStatusPatch: test.NewMockSubResourcePatchFn(nil),
 				},
-				r: FunctionRunnerFn(func(ctx context.Context, name string, req *v1beta1.RunFunctionRequest) (rsp *v1beta1.RunFunctionResponse, err error) {
+				r: FunctionRunnerFn(func(_ context.Context, _ string, _ *v1beta1.RunFunctionRequest) (rsp *v1beta1.RunFunctionResponse, err error) {
 					d := &v1beta1.State{
 						Resources: map[string]*v1beta1.Resource{
 							"uncool-resource": {
@@ -480,13 +480,13 @@ func TestFunctionCompose(t *testing.T) {
 					return &v1beta1.RunFunctionResponse{Desired: d}, nil
 				}),
 				o: []FunctionComposerOption{
-					WithCompositeConnectionDetailsFetcher(ConnectionDetailsFetcherFn(func(ctx context.Context, o resource.ConnectionSecretOwner) (managed.ConnectionDetails, error) {
+					WithCompositeConnectionDetailsFetcher(ConnectionDetailsFetcherFn(func(_ context.Context, _ resource.ConnectionSecretOwner) (managed.ConnectionDetails, error) {
 						return nil, nil
 					})),
-					WithComposedResourceObserver(ComposedResourceObserverFn(func(ctx context.Context, xr resource.Composite) (ComposedResourceStates, error) {
+					WithComposedResourceObserver(ComposedResourceObserverFn(func(_ context.Context, _ resource.Composite) (ComposedResourceStates, error) {
 						return nil, nil
 					})),
-					WithComposedResourceGarbageCollector(ComposedResourceGarbageCollectorFn(func(ctx context.Context, owner metav1.Object, observed, desired ComposedResourceStates) error {
+					WithComposedResourceGarbageCollector(ComposedResourceGarbageCollectorFn(func(_ context.Context, _ metav1.Object, _, _ ComposedResourceStates) error {
 						return nil
 					})),
 				},
@@ -518,7 +518,7 @@ func TestFunctionCompose(t *testing.T) {
 					MockPatch:       test.NewMockPatchFn(nil),
 					MockStatusPatch: test.NewMockSubResourcePatchFn(nil),
 				},
-				r: FunctionRunnerFn(func(ctx context.Context, name string, req *v1beta1.RunFunctionRequest) (*v1beta1.RunFunctionResponse, error) {
+				r: FunctionRunnerFn(func(_ context.Context, _ string, _ *v1beta1.RunFunctionRequest) (*v1beta1.RunFunctionResponse, error) {
 					rsp := &v1beta1.RunFunctionResponse{
 						Desired: &v1beta1.State{
 							Composite: &v1beta1.Resource{
@@ -563,10 +563,10 @@ func TestFunctionCompose(t *testing.T) {
 					return rsp, nil
 				}),
 				o: []FunctionComposerOption{
-					WithCompositeConnectionDetailsFetcher(ConnectionDetailsFetcherFn(func(ctx context.Context, o resource.ConnectionSecretOwner) (managed.ConnectionDetails, error) {
+					WithCompositeConnectionDetailsFetcher(ConnectionDetailsFetcherFn(func(_ context.Context, _ resource.ConnectionSecretOwner) (managed.ConnectionDetails, error) {
 						return nil, nil
 					})),
-					WithComposedResourceObserver(ComposedResourceObserverFn(func(ctx context.Context, xr resource.Composite) (ComposedResourceStates, error) {
+					WithComposedResourceObserver(ComposedResourceObserverFn(func(_ context.Context, _ resource.Composite) (ComposedResourceStates, error) {
 						// We only try to extract connection details for
 						// observed resources.
 						r := ComposedResourceStates{
@@ -578,7 +578,7 @@ func TestFunctionCompose(t *testing.T) {
 						}
 						return r, nil
 					})),
-					WithComposedResourceGarbageCollector(ComposedResourceGarbageCollectorFn(func(ctx context.Context, owner metav1.Object, observed, desired ComposedResourceStates) error {
+					WithComposedResourceGarbageCollector(ComposedResourceGarbageCollectorFn(func(_ context.Context, _ metav1.Object, _, _ ComposedResourceStates) error {
 						return nil
 					})),
 				},
@@ -651,7 +651,7 @@ func TestFunctionCompose(t *testing.T) {
 				},
 				r: func() FunctionRunner {
 					var nrCalls int
-					return FunctionRunnerFn(func(ctx context.Context, name string, req *v1beta1.RunFunctionRequest) (*v1beta1.RunFunctionResponse, error) {
+					return FunctionRunnerFn(func(_ context.Context, _ string, req *v1beta1.RunFunctionRequest) (*v1beta1.RunFunctionResponse, error) {
 						defer func() { nrCalls++ }()
 						requirements := &v1beta1.Requirements{
 							ExtraResources: map[string]*v1beta1.ResourceSelector{
@@ -738,10 +738,10 @@ func TestFunctionCompose(t *testing.T) {
 					})
 				}(),
 				o: []FunctionComposerOption{
-					WithCompositeConnectionDetailsFetcher(ConnectionDetailsFetcherFn(func(ctx context.Context, o resource.ConnectionSecretOwner) (managed.ConnectionDetails, error) {
+					WithCompositeConnectionDetailsFetcher(ConnectionDetailsFetcherFn(func(_ context.Context, _ resource.ConnectionSecretOwner) (managed.ConnectionDetails, error) {
 						return nil, nil
 					})),
-					WithComposedResourceObserver(ComposedResourceObserverFn(func(ctx context.Context, xr resource.Composite) (ComposedResourceStates, error) {
+					WithComposedResourceObserver(ComposedResourceObserverFn(func(_ context.Context, _ resource.Composite) (ComposedResourceStates, error) {
 						// We only try to extract connection details for
 						// observed resources.
 						r := ComposedResourceStates{
@@ -753,10 +753,10 @@ func TestFunctionCompose(t *testing.T) {
 						}
 						return r, nil
 					})),
-					WithComposedResourceGarbageCollector(ComposedResourceGarbageCollectorFn(func(ctx context.Context, owner metav1.Object, observed, desired ComposedResourceStates) error {
+					WithComposedResourceGarbageCollector(ComposedResourceGarbageCollectorFn(func(_ context.Context, _ metav1.Object, _, _ ComposedResourceStates) error {
 						return nil
 					})),
-					WithExtraResourcesFetcher(ExtraResourcesFetcherFn(func(ctx context.Context, rs *v1beta1.ResourceSelector) (*v1beta1.Resources, error) {
+					WithExtraResourcesFetcher(ExtraResourcesFetcherFn(func(_ context.Context, rs *v1beta1.ResourceSelector) (*v1beta1.Resources, error) {
 						if rs.GetMatchName() == "existing" {
 							return &v1beta1.Resources{
 								Items: []*v1beta1.Resource{
@@ -1019,7 +1019,7 @@ func TestGetComposedResources(t *testing.T) {
 						return nil
 					}),
 				},
-				f: ConnectionDetailsFetcherFn(func(ctx context.Context, o resource.ConnectionSecretOwner) (managed.ConnectionDetails, error) {
+				f: ConnectionDetailsFetcherFn(func(_ context.Context, _ resource.ConnectionSecretOwner) (managed.ConnectionDetails, error) {
 					return nil, errBoom
 				}),
 			},
@@ -1049,7 +1049,7 @@ func TestGetComposedResources(t *testing.T) {
 						return nil
 					}),
 				},
-				f: ConnectionDetailsFetcherFn(func(ctx context.Context, o resource.ConnectionSecretOwner) (managed.ConnectionDetails, error) {
+				f: ConnectionDetailsFetcherFn(func(_ context.Context, _ resource.ConnectionSecretOwner) (managed.ConnectionDetails, error) {
 					return details, nil
 				}),
 			},

--- a/internal/controller/apiextensions/composite/composition_pt_test.go
+++ b/internal/controller/apiextensions/composite/composition_pt_test.go
@@ -94,7 +94,7 @@ func TestPTCompose(t *testing.T) {
 			reason: "We should return any error encountered while associating Composition templates with composed resources.",
 			params: params{
 				o: []PTComposerOption{
-					WithTemplateAssociator(CompositionTemplateAssociatorFn(func(ctx context.Context, c resource.Composite, ct []v1.ComposedTemplate) ([]TemplateAssociation, error) {
+					WithTemplateAssociator(CompositionTemplateAssociatorFn(func(_ context.Context, _ resource.Composite, _ []v1.ComposedTemplate) ([]TemplateAssociation, error) {
 						return nil, errBoom
 					})),
 				},
@@ -112,7 +112,7 @@ func TestPTCompose(t *testing.T) {
 			reason: "We should return any error encountered while parsing a composed resource base template",
 			params: params{
 				o: []PTComposerOption{
-					WithTemplateAssociator(CompositionTemplateAssociatorFn(func(ctx context.Context, c resource.Composite, ct []v1.ComposedTemplate) ([]TemplateAssociation, error) {
+					WithTemplateAssociator(CompositionTemplateAssociatorFn(func(_ context.Context, _ resource.Composite, _ []v1.ComposedTemplate) ([]TemplateAssociation, error) {
 						tas := []TemplateAssociation{
 							{
 								Template: v1.ComposedTemplate{
@@ -123,14 +123,14 @@ func TestPTCompose(t *testing.T) {
 						}
 						return tas, nil
 					})),
-					WithComposedNameGenerator(names.NameGeneratorFn(func(ctx context.Context, cd resource.Object) error { return nil })),
-					WithComposedConnectionDetailsFetcher(ConnectionDetailsFetcherFn(func(ctx context.Context, o resource.ConnectionSecretOwner) (managed.ConnectionDetails, error) {
+					WithComposedNameGenerator(names.NameGeneratorFn(func(_ context.Context, _ resource.Object) error { return nil })),
+					WithComposedConnectionDetailsFetcher(ConnectionDetailsFetcherFn(func(_ context.Context, _ resource.ConnectionSecretOwner) (managed.ConnectionDetails, error) {
 						return nil, nil
 					})),
-					WithComposedConnectionDetailsExtractor(ConnectionDetailsExtractorFn(func(cd resource.Composed, conn managed.ConnectionDetails, cfg ...ConnectionDetailExtractConfig) (managed.ConnectionDetails, error) {
+					WithComposedConnectionDetailsExtractor(ConnectionDetailsExtractorFn(func(_ resource.Composed, _ managed.ConnectionDetails, _ ...ConnectionDetailExtractConfig) (managed.ConnectionDetails, error) {
 						return details, nil
 					})),
-					WithComposedReadinessChecker(ReadinessCheckerFn(func(ctx context.Context, o ConditionedObject, rc ...ReadinessCheck) (ready bool, err error) {
+					WithComposedReadinessChecker(ReadinessCheckerFn(func(_ context.Context, _ ConditionedObject, _ ...ReadinessCheck) (ready bool, err error) {
 						return true, nil
 					})),
 				},
@@ -152,7 +152,7 @@ func TestPTCompose(t *testing.T) {
 					MockUpdate: test.NewMockUpdateFn(errBoom),
 				},
 				o: []PTComposerOption{
-					WithTemplateAssociator(CompositionTemplateAssociatorFn(func(ctx context.Context, c resource.Composite, ct []v1.ComposedTemplate) ([]TemplateAssociation, error) {
+					WithTemplateAssociator(CompositionTemplateAssociatorFn(func(_ context.Context, _ resource.Composite, _ []v1.ComposedTemplate) ([]TemplateAssociation, error) {
 						tas := []TemplateAssociation{{
 							Template: v1.ComposedTemplate{
 								Name: ptr.To("cool-resource"),
@@ -161,7 +161,7 @@ func TestPTCompose(t *testing.T) {
 						}}
 						return tas, nil
 					})),
-					WithComposedNameGenerator(names.NameGeneratorFn(func(ctx context.Context, cd resource.Object) error { return nil })),
+					WithComposedNameGenerator(names.NameGeneratorFn(func(_ context.Context, _ resource.Object) error { return nil })),
 				},
 			},
 			args: args{
@@ -184,7 +184,7 @@ func TestPTCompose(t *testing.T) {
 					MockCreate: test.NewMockCreateFn(errBoom),
 				},
 				o: []PTComposerOption{
-					WithTemplateAssociator(CompositionTemplateAssociatorFn(func(ctx context.Context, c resource.Composite, ct []v1.ComposedTemplate) ([]TemplateAssociation, error) {
+					WithTemplateAssociator(CompositionTemplateAssociatorFn(func(_ context.Context, _ resource.Composite, _ []v1.ComposedTemplate) ([]TemplateAssociation, error) {
 						tas := []TemplateAssociation{{
 							Template: v1.ComposedTemplate{
 								Name: ptr.To("cool-resource"),
@@ -193,7 +193,7 @@ func TestPTCompose(t *testing.T) {
 						}}
 						return tas, nil
 					})),
-					WithComposedNameGenerator(names.NameGeneratorFn(func(ctx context.Context, cd resource.Object) error { return nil })),
+					WithComposedNameGenerator(names.NameGeneratorFn(func(_ context.Context, _ resource.Object) error { return nil })),
 				},
 			},
 			args: args{
@@ -216,7 +216,7 @@ func TestPTCompose(t *testing.T) {
 					MockCreate: test.NewMockCreateFn(nil),
 				},
 				o: []PTComposerOption{
-					WithTemplateAssociator(CompositionTemplateAssociatorFn(func(ctx context.Context, c resource.Composite, ct []v1.ComposedTemplate) ([]TemplateAssociation, error) {
+					WithTemplateAssociator(CompositionTemplateAssociatorFn(func(_ context.Context, _ resource.Composite, _ []v1.ComposedTemplate) ([]TemplateAssociation, error) {
 						tas := []TemplateAssociation{{
 							Template: v1.ComposedTemplate{
 								Name: ptr.To("cool-resource"),
@@ -225,8 +225,8 @@ func TestPTCompose(t *testing.T) {
 						}}
 						return tas, nil
 					})),
-					WithComposedNameGenerator(names.NameGeneratorFn(func(ctx context.Context, cd resource.Object) error { return nil })),
-					WithComposedConnectionDetailsFetcher(ConnectionDetailsFetcherFn(func(ctx context.Context, o resource.ConnectionSecretOwner) (managed.ConnectionDetails, error) {
+					WithComposedNameGenerator(names.NameGeneratorFn(func(_ context.Context, _ resource.Object) error { return nil })),
+					WithComposedConnectionDetailsFetcher(ConnectionDetailsFetcherFn(func(_ context.Context, _ resource.ConnectionSecretOwner) (managed.ConnectionDetails, error) {
 						return nil, errBoom
 					})),
 				},
@@ -251,7 +251,7 @@ func TestPTCompose(t *testing.T) {
 					MockCreate: test.NewMockCreateFn(nil),
 				},
 				o: []PTComposerOption{
-					WithTemplateAssociator(CompositionTemplateAssociatorFn(func(ctx context.Context, c resource.Composite, ct []v1.ComposedTemplate) ([]TemplateAssociation, error) {
+					WithTemplateAssociator(CompositionTemplateAssociatorFn(func(_ context.Context, _ resource.Composite, _ []v1.ComposedTemplate) ([]TemplateAssociation, error) {
 						tas := []TemplateAssociation{{
 							Template: v1.ComposedTemplate{
 								Name: ptr.To("cool-resource"),
@@ -260,11 +260,11 @@ func TestPTCompose(t *testing.T) {
 						}}
 						return tas, nil
 					})),
-					WithComposedNameGenerator(names.NameGeneratorFn(func(ctx context.Context, cd resource.Object) error { return nil })),
-					WithComposedConnectionDetailsFetcher(ConnectionDetailsFetcherFn(func(ctx context.Context, o resource.ConnectionSecretOwner) (managed.ConnectionDetails, error) {
+					WithComposedNameGenerator(names.NameGeneratorFn(func(_ context.Context, _ resource.Object) error { return nil })),
+					WithComposedConnectionDetailsFetcher(ConnectionDetailsFetcherFn(func(_ context.Context, _ resource.ConnectionSecretOwner) (managed.ConnectionDetails, error) {
 						return nil, nil
 					})),
-					WithComposedConnectionDetailsExtractor(ConnectionDetailsExtractorFn(func(cd resource.Composed, conn managed.ConnectionDetails, cfg ...ConnectionDetailExtractConfig) (managed.ConnectionDetails, error) {
+					WithComposedConnectionDetailsExtractor(ConnectionDetailsExtractorFn(func(_ resource.Composed, _ managed.ConnectionDetails, _ ...ConnectionDetailExtractConfig) (managed.ConnectionDetails, error) {
 						return nil, errBoom
 					})),
 				},
@@ -289,7 +289,7 @@ func TestPTCompose(t *testing.T) {
 					MockCreate: test.NewMockCreateFn(nil),
 				},
 				o: []PTComposerOption{
-					WithTemplateAssociator(CompositionTemplateAssociatorFn(func(ctx context.Context, c resource.Composite, ct []v1.ComposedTemplate) ([]TemplateAssociation, error) {
+					WithTemplateAssociator(CompositionTemplateAssociatorFn(func(_ context.Context, _ resource.Composite, _ []v1.ComposedTemplate) ([]TemplateAssociation, error) {
 						tas := []TemplateAssociation{{
 							Template: v1.ComposedTemplate{
 								Name: ptr.To("cool-resource"),
@@ -298,14 +298,14 @@ func TestPTCompose(t *testing.T) {
 						}}
 						return tas, nil
 					})),
-					WithComposedNameGenerator(names.NameGeneratorFn(func(ctx context.Context, cd resource.Object) error { return nil })),
-					WithComposedConnectionDetailsFetcher(ConnectionDetailsFetcherFn(func(ctx context.Context, o resource.ConnectionSecretOwner) (managed.ConnectionDetails, error) {
+					WithComposedNameGenerator(names.NameGeneratorFn(func(_ context.Context, _ resource.Object) error { return nil })),
+					WithComposedConnectionDetailsFetcher(ConnectionDetailsFetcherFn(func(_ context.Context, _ resource.ConnectionSecretOwner) (managed.ConnectionDetails, error) {
 						return nil, nil
 					})),
-					WithComposedConnectionDetailsFetcher(ConnectionDetailsFetcherFn(func(ctx context.Context, cd resource.ConnectionSecretOwner) (managed.ConnectionDetails, error) {
+					WithComposedConnectionDetailsFetcher(ConnectionDetailsFetcherFn(func(_ context.Context, _ resource.ConnectionSecretOwner) (managed.ConnectionDetails, error) {
 						return nil, nil
 					})),
-					WithComposedReadinessChecker(ReadinessCheckerFn(func(ctx context.Context, o ConditionedObject, rc ...ReadinessCheck) (ready bool, err error) {
+					WithComposedReadinessChecker(ReadinessCheckerFn(func(_ context.Context, _ ConditionedObject, _ ...ReadinessCheck) (ready bool, err error) {
 						return false, errBoom
 					})),
 				},
@@ -333,7 +333,7 @@ func TestPTCompose(t *testing.T) {
 					MockPatch: test.NewMockPatchFn(nil),
 				},
 				o: []PTComposerOption{
-					WithTemplateAssociator(CompositionTemplateAssociatorFn(func(ctx context.Context, c resource.Composite, ct []v1.ComposedTemplate) ([]TemplateAssociation, error) {
+					WithTemplateAssociator(CompositionTemplateAssociatorFn(func(_ context.Context, _ resource.Composite, _ []v1.ComposedTemplate) ([]TemplateAssociation, error) {
 						return nil, nil
 					})),
 				},
@@ -360,7 +360,7 @@ func TestPTCompose(t *testing.T) {
 					MockPatch:  test.NewMockPatchFn(nil),
 				},
 				o: []PTComposerOption{
-					WithTemplateAssociator(CompositionTemplateAssociatorFn(func(ctx context.Context, c resource.Composite, ct []v1.ComposedTemplate) ([]TemplateAssociation, error) {
+					WithTemplateAssociator(CompositionTemplateAssociatorFn(func(_ context.Context, _ resource.Composite, _ []v1.ComposedTemplate) ([]TemplateAssociation, error) {
 						tas := []TemplateAssociation{{
 							Template: v1.ComposedTemplate{
 								Name: ptr.To("cool-resource"),
@@ -369,14 +369,14 @@ func TestPTCompose(t *testing.T) {
 						}}
 						return tas, nil
 					})),
-					WithComposedNameGenerator(names.NameGeneratorFn(func(ctx context.Context, cd resource.Object) error { return nil })),
-					WithComposedConnectionDetailsFetcher(ConnectionDetailsFetcherFn(func(ctx context.Context, o resource.ConnectionSecretOwner) (managed.ConnectionDetails, error) {
+					WithComposedNameGenerator(names.NameGeneratorFn(func(_ context.Context, _ resource.Object) error { return nil })),
+					WithComposedConnectionDetailsFetcher(ConnectionDetailsFetcherFn(func(_ context.Context, _ resource.ConnectionSecretOwner) (managed.ConnectionDetails, error) {
 						return nil, nil
 					})),
-					WithComposedConnectionDetailsExtractor(ConnectionDetailsExtractorFn(func(cd resource.Composed, conn managed.ConnectionDetails, cfg ...ConnectionDetailExtractConfig) (managed.ConnectionDetails, error) {
+					WithComposedConnectionDetailsExtractor(ConnectionDetailsExtractorFn(func(_ resource.Composed, _ managed.ConnectionDetails, _ ...ConnectionDetailExtractConfig) (managed.ConnectionDetails, error) {
 						return details, nil
 					})),
-					WithComposedReadinessChecker(ReadinessCheckerFn(func(ctx context.Context, o ConditionedObject, rc ...ReadinessCheck) (ready bool, err error) {
+					WithComposedReadinessChecker(ReadinessCheckerFn(func(_ context.Context, _ ConditionedObject, _ ...ReadinessCheck) (ready bool, err error) {
 						return true, nil
 					})),
 				},
@@ -409,7 +409,7 @@ func TestPTCompose(t *testing.T) {
 					MockPatch:  test.NewMockPatchFn(nil),
 				},
 				o: []PTComposerOption{
-					WithTemplateAssociator(CompositionTemplateAssociatorFn(func(ctx context.Context, c resource.Composite, ct []v1.ComposedTemplate) ([]TemplateAssociation, error) {
+					WithTemplateAssociator(CompositionTemplateAssociatorFn(func(_ context.Context, _ resource.Composite, _ []v1.ComposedTemplate) ([]TemplateAssociation, error) {
 						tas := []TemplateAssociation{
 							{
 								Template: v1.ComposedTemplate{
@@ -428,19 +428,19 @@ func TestPTCompose(t *testing.T) {
 						}
 						return tas, nil
 					})),
-					WithComposedNameGenerator(names.NameGeneratorFn(func(ctx context.Context, cd resource.Object) error {
+					WithComposedNameGenerator(names.NameGeneratorFn(func(_ context.Context, cd resource.Object) error {
 						if cd.GetObjectKind().GroupVersionKind().Kind == "BrokenResource" {
 							return errBoom
 						}
 						return nil
 					})),
-					WithComposedConnectionDetailsFetcher(ConnectionDetailsFetcherFn(func(ctx context.Context, o resource.ConnectionSecretOwner) (managed.ConnectionDetails, error) {
+					WithComposedConnectionDetailsFetcher(ConnectionDetailsFetcherFn(func(_ context.Context, _ resource.ConnectionSecretOwner) (managed.ConnectionDetails, error) {
 						return nil, nil
 					})),
-					WithComposedConnectionDetailsExtractor(ConnectionDetailsExtractorFn(func(cd resource.Composed, conn managed.ConnectionDetails, cfg ...ConnectionDetailExtractConfig) (managed.ConnectionDetails, error) {
+					WithComposedConnectionDetailsExtractor(ConnectionDetailsExtractorFn(func(_ resource.Composed, _ managed.ConnectionDetails, _ ...ConnectionDetailExtractConfig) (managed.ConnectionDetails, error) {
 						return details, nil
 					})),
-					WithComposedReadinessChecker(ReadinessCheckerFn(func(ctx context.Context, o ConditionedObject, rc ...ReadinessCheck) (ready bool, err error) {
+					WithComposedReadinessChecker(ReadinessCheckerFn(func(_ context.Context, _ ConditionedObject, _ ...ReadinessCheck) (ready bool, err error) {
 						return true, nil
 					})),
 				},
@@ -645,7 +645,7 @@ func TestGarbageCollectingAssociator(t *testing.T) {
 			},
 		},
 		"ResourceControlledBySomeoneElse": {
-			reason: "We should not garbage collect a resource that is controlled by another resource.",
+			reason: "We should not garbage colle_ a resource that is controlled by another resource.",
 			c: &test.MockClient{
 				MockGet: test.NewMockGetFn(nil, func(obj client.Object) error {
 					// The template used to create this resource is no longer known to us.
@@ -673,7 +673,7 @@ func TestGarbageCollectingAssociator(t *testing.T) {
 			},
 		},
 		"ResourceNotControlled": {
-			reason: "We should not garbage collect a resource that has no controller reference.",
+			reason: "We should not garbage colle_ a resource that has no controller reference.",
 			c: &test.MockClient{
 				MockGet: test.NewMockGetFn(nil, func(obj client.Object) error {
 					// The template used to create this resource is no longer known to us.

--- a/internal/controller/apiextensions/composite/composition_render_test.go
+++ b/internal/controller/apiextensions/composite/composition_render_test.go
@@ -36,7 +36,7 @@ import (
 )
 
 func TestRenderFromJSON(t *testing.T) {
-	errInvalidChar := json.Unmarshal([]byte("olala"), &fake.Composed{})
+	errInvalidChar := json.Unmarshal([]byte("olala"), &fake.Composed{}) //nolint:musttag // Not an issue in this test.
 
 	type args struct {
 		o    resource.Object

--- a/internal/controller/apiextensions/composite/connection_test.go
+++ b/internal/controller/apiextensions/composite/connection_test.go
@@ -177,7 +177,7 @@ func TestConnectionDetailsFetcherChain(t *testing.T) {
 		"SingleFetcherChain": {
 			reason: "A chain of one fetcher should return only its connection details.",
 			c: ConnectionDetailsFetcherChain{
-				ConnectionDetailsFetcherFn(func(ctx context.Context, o resource.ConnectionSecretOwner) (managed.ConnectionDetails, error) {
+				ConnectionDetailsFetcherFn(func(_ context.Context, _ resource.ConnectionSecretOwner) (managed.ConnectionDetails, error) {
 					return managed.ConnectionDetails{"a": []byte("b")}, nil
 				}),
 			},
@@ -191,7 +191,7 @@ func TestConnectionDetailsFetcherChain(t *testing.T) {
 		"FetcherError": {
 			reason: "We should return errors from a chained fetcher.",
 			c: ConnectionDetailsFetcherChain{
-				ConnectionDetailsFetcherFn(func(ctx context.Context, o resource.ConnectionSecretOwner) (managed.ConnectionDetails, error) {
+				ConnectionDetailsFetcherFn(func(_ context.Context, _ resource.ConnectionSecretOwner) (managed.ConnectionDetails, error) {
 					return nil, errBoom
 				}),
 			},
@@ -205,14 +205,14 @@ func TestConnectionDetailsFetcherChain(t *testing.T) {
 		"MultipleFetcherChain": {
 			reason: "A chain of multiple fetchers should return all of their connection details, with later fetchers winning if there are duplicates.",
 			c: ConnectionDetailsFetcherChain{
-				ConnectionDetailsFetcherFn(func(ctx context.Context, o resource.ConnectionSecretOwner) (managed.ConnectionDetails, error) {
+				ConnectionDetailsFetcherFn(func(_ context.Context, _ resource.ConnectionSecretOwner) (managed.ConnectionDetails, error) {
 					return managed.ConnectionDetails{
 						"a": []byte("a"),
 						"b": []byte("b"),
 						"c": []byte("c"),
 					}, nil
 				}),
-				ConnectionDetailsFetcherFn(func(ctx context.Context, o resource.ConnectionSecretOwner) (managed.ConnectionDetails, error) {
+				ConnectionDetailsFetcherFn(func(_ context.Context, _ resource.ConnectionSecretOwner) (managed.ConnectionDetails, error) {
 					return managed.ConnectionDetails{
 						"a": []byte("A"),
 					}, nil

--- a/internal/controller/apiextensions/composite/environment_fetcher_test.go
+++ b/internal/controller/apiextensions/composite/environment_fetcher_test.go
@@ -212,7 +212,7 @@ func TestFetch(t *testing.T) {
 			reason: "It should merge the data of multiple EnvironmentConfigs in the order they are listed.",
 			args: args{
 				kube: &test.MockClient{
-					MockGet: func(ctx context.Context, key client.ObjectKey, o client.Object) error {
+					MockGet: func(_ context.Context, key client.ObjectKey, o client.Object) error {
 						cs := o.(*v1alpha1.EnvironmentConfig)
 						switch key.Name {
 						case "a":

--- a/internal/controller/apiextensions/composite/environment_selector_test.go
+++ b/internal/controller/apiextensions/composite/environment_selector_test.go
@@ -227,7 +227,7 @@ func TestSelect(t *testing.T) {
 			reason: "It should create a name reference for the first selected EnvironmentConfig that matches the labels.",
 			args: args{
 				kube: &test.MockClient{
-					MockList: func(ctx context.Context, obj client.ObjectList, opts ...client.ListOption) error {
+					MockList: func(_ context.Context, obj client.ObjectList, opts ...client.ListOption) error {
 						list := obj.(*v1alpha1.EnvironmentConfigList)
 						match := opts[0].(client.MatchingLabels)
 						if match["foo"] != "test-composite" {

--- a/internal/controller/apiextensions/composite/fuzz_test.go
+++ b/internal/controller/apiextensions/composite/fuzz_test.go
@@ -66,7 +66,7 @@ func addType(p *v1.Patch, i int) {
 }
 
 func FuzzPatchApply(f *testing.F) {
-	f.Fuzz(func(t *testing.T, data []byte) {
+	f.Fuzz(func(_ *testing.T, data []byte) {
 		f := fuzz.NewConsumer(data)
 
 		cp := &fake.Composite{}
@@ -122,7 +122,7 @@ func addTransformType(t *v1.Transform, i int) error {
 }
 
 func FuzzTransform(f *testing.F) {
-	f.Fuzz(func(tt *testing.T, data []byte) {
+	f.Fuzz(func(_ *testing.T, data []byte) {
 		f := fuzz.NewConsumer(data)
 
 		t := &v1.Transform{}

--- a/internal/controller/apiextensions/composite/reconciler_test.go
+++ b/internal/controller/apiextensions/composite/reconciler_test.go
@@ -50,7 +50,7 @@ import (
 	v1 "github.com/crossplane/crossplane/apis/apiextensions/v1"
 )
 
-var _ Composer = ComposerSelectorFn(func(cm *v1.CompositionMode) Composer { return nil })
+var _ Composer = ComposerSelectorFn(func(_ *v1.CompositionMode) Composer { return nil })
 
 func TestReconcile(t *testing.T) {
 	errBoom := errors.New("boom")
@@ -117,7 +117,7 @@ func TestReconcile(t *testing.T) {
 					}),
 					WithCompositeFinalizer(resource.NewNopFinalizer()),
 					WithConnectionPublishers(managed.ConnectionPublisherFns{
-						UnpublishConnectionFn: func(ctx context.Context, o resource.ConnectionSecretOwner, c managed.ConnectionDetails) error {
+						UnpublishConnectionFn: func(_ context.Context, _ resource.ConnectionSecretOwner, _ managed.ConnectionDetails) error {
 							return errBoom
 						},
 					}),
@@ -142,12 +142,12 @@ func TestReconcile(t *testing.T) {
 						})),
 					}),
 					WithCompositeFinalizer(resource.FinalizerFns{
-						RemoveFinalizerFn: func(ctx context.Context, obj resource.Object) error {
+						RemoveFinalizerFn: func(_ context.Context, _ resource.Object) error {
 							return errBoom
 						},
 					}),
 					WithConnectionPublishers(managed.ConnectionPublisherFns{
-						UnpublishConnectionFn: func(ctx context.Context, o resource.ConnectionSecretOwner, c managed.ConnectionDetails) error {
+						UnpublishConnectionFn: func(_ context.Context, _ resource.ConnectionSecretOwner, _ managed.ConnectionDetails) error {
 							return nil
 						},
 					}),
@@ -172,12 +172,12 @@ func TestReconcile(t *testing.T) {
 						})),
 					}),
 					WithCompositeFinalizer(resource.FinalizerFns{
-						RemoveFinalizerFn: func(ctx context.Context, obj resource.Object) error {
+						RemoveFinalizerFn: func(_ context.Context, _ resource.Object) error {
 							return nil
 						},
 					}),
 					WithConnectionPublishers(managed.ConnectionPublisherFns{
-						UnpublishConnectionFn: func(ctx context.Context, o resource.ConnectionSecretOwner, c managed.ConnectionDetails) error {
+						UnpublishConnectionFn: func(_ context.Context, _ resource.ConnectionSecretOwner, _ managed.ConnectionDetails) error {
 							return nil
 						},
 					}),
@@ -199,7 +199,7 @@ func TestReconcile(t *testing.T) {
 						})),
 					}),
 					WithCompositeFinalizer(resource.FinalizerFns{
-						AddFinalizerFn: func(ctx context.Context, obj resource.Object) error {
+						AddFinalizerFn: func(_ context.Context, _ resource.Object) error {
 							return errBoom
 						},
 					}),
@@ -325,7 +325,7 @@ func TestReconcile(t *testing.T) {
 						MockStatusUpdate: test.NewMockSubResourceUpdateFn(nil),
 					}),
 					WithCompositeFinalizer(resource.NewNopFinalizer()),
-					WithCompositionSelector(CompositionSelectorFn(func(_ context.Context, cr resource.Composite) error {
+					WithCompositionSelector(CompositionSelectorFn(func(_ context.Context, _ resource.Composite) error {
 						return nil
 					})),
 					WithCompositionRevisionFetcher(CompositionRevisionFetcherFn(func(_ context.Context, _ resource.Composite) (*v1.CompositionRevision, error) {
@@ -333,8 +333,8 @@ func TestReconcile(t *testing.T) {
 						return c, nil
 					})),
 					WithCompositionRevisionValidator(CompositionRevisionValidatorFn(func(_ *v1.CompositionRevision) error { return nil })),
-					WithConfigurator(ConfiguratorFn(func(ctx context.Context, cr resource.Composite, rev *v1.CompositionRevision) error { return nil })),
-					WithEnvironmentSelector(EnvironmentSelectorFn(func(ctx context.Context, cr resource.Composite, rev *v1.CompositionRevision) error {
+					WithConfigurator(ConfiguratorFn(func(_ context.Context, _ resource.Composite, _ *v1.CompositionRevision) error { return nil })),
+					WithEnvironmentSelector(EnvironmentSelectorFn(func(_ context.Context, _ resource.Composite, _ *v1.CompositionRevision) error {
 						return errBoom
 					})),
 				},
@@ -353,7 +353,7 @@ func TestReconcile(t *testing.T) {
 						MockStatusUpdate: test.NewMockSubResourceUpdateFn(nil),
 					}),
 					WithCompositeFinalizer(resource.NewNopFinalizer()),
-					WithCompositionSelector(CompositionSelectorFn(func(_ context.Context, cr resource.Composite) error {
+					WithCompositionSelector(CompositionSelectorFn(func(_ context.Context, _ resource.Composite) error {
 						return nil
 					})),
 					WithCompositionRevisionFetcher(CompositionRevisionFetcherFn(func(_ context.Context, _ resource.Composite) (*v1.CompositionRevision, error) {
@@ -361,8 +361,8 @@ func TestReconcile(t *testing.T) {
 						return c, nil
 					})),
 					WithCompositionRevisionValidator(CompositionRevisionValidatorFn(func(_ *v1.CompositionRevision) error { return nil })),
-					WithConfigurator(ConfiguratorFn(func(ctx context.Context, cr resource.Composite, rev *v1.CompositionRevision) error { return nil })),
-					WithEnvironmentFetcher(EnvironmentFetcherFn(func(ctx context.Context, req EnvironmentFetcherRequest) (*Environment, error) {
+					WithConfigurator(ConfiguratorFn(func(_ context.Context, _ resource.Composite, _ *v1.CompositionRevision) error { return nil })),
+					WithEnvironmentFetcher(EnvironmentFetcherFn(func(_ context.Context, _ EnvironmentFetcherRequest) (*Environment, error) {
 						return nil, errBoom
 					})),
 				},
@@ -395,7 +395,7 @@ func TestReconcile(t *testing.T) {
 					WithConfigurator(ConfiguratorFn(func(_ context.Context, _ resource.Composite, _ *v1.CompositionRevision) error {
 						return nil
 					})),
-					WithComposer(ComposerFn(func(ctx context.Context, xr *composite.Unstructured, req CompositionRequest) (CompositionResult, error) {
+					WithComposer(ComposerFn(func(_ context.Context, _ *composite.Unstructured, _ CompositionRequest) (CompositionResult, error) {
 						return CompositionResult{}, errBoom
 					})),
 				},
@@ -428,11 +428,11 @@ func TestReconcile(t *testing.T) {
 					WithConfigurator(ConfiguratorFn(func(_ context.Context, _ resource.Composite, _ *v1.CompositionRevision) error {
 						return nil
 					})),
-					WithComposer(ComposerFn(func(ctx context.Context, xr *composite.Unstructured, req CompositionRequest) (CompositionResult, error) {
+					WithComposer(ComposerFn(func(_ context.Context, _ *composite.Unstructured, _ CompositionRequest) (CompositionResult, error) {
 						return CompositionResult{}, nil
 					})),
 					WithConnectionPublishers(managed.ConnectionPublisherFns{
-						PublishConnectionFn: func(ctx context.Context, o resource.ConnectionSecretOwner, c managed.ConnectionDetails) (published bool, err error) {
+						PublishConnectionFn: func(_ context.Context, _ resource.ConnectionSecretOwner, _ managed.ConnectionDetails) (published bool, err error) {
 							return false, errBoom
 						},
 					}),
@@ -449,9 +449,9 @@ func TestReconcile(t *testing.T) {
 				opts: []ReconcilerOption{
 					WithClient(&test.MockClient{
 						MockGet: test.NewMockGetFn(nil),
-						MockStatusUpdate: WantComposite(t, NewComposite(func(cr resource.Composite) {
-							cr.SetCompositionReference(&corev1.ObjectReference{})
-							cr.SetConditions(xpv1.ReconcileSuccess(), xpv1.Available())
+						MockStatusUpdate: WantComposite(t, NewComposite(func(xr resource.Composite) {
+							xr.SetCompositionReference(&corev1.ObjectReference{})
+							xr.SetConditions(xpv1.ReconcileSuccess(), xpv1.Available())
 						})),
 					}),
 					WithCompositeFinalizer(resource.NewNopFinalizer()),
@@ -469,13 +469,13 @@ func TestReconcile(t *testing.T) {
 					WithConfigurator(ConfiguratorFn(func(_ context.Context, _ resource.Composite, _ *v1.CompositionRevision) error {
 						return nil
 					})),
-					WithComposer(ComposerFn(func(ctx context.Context, xr *composite.Unstructured, req CompositionRequest) (CompositionResult, error) {
+					WithComposer(ComposerFn(func(_ context.Context, _ *composite.Unstructured, _ CompositionRequest) (CompositionResult, error) {
 						return CompositionResult{
 							Events: []event.Event{event.Warning("Warning", errBoom)},
 						}, nil
 					})),
 					WithConnectionPublishers(managed.ConnectionPublisherFns{
-						PublishConnectionFn: func(ctx context.Context, o resource.ConnectionSecretOwner, c managed.ConnectionDetails) (published bool, err error) {
+						PublishConnectionFn: func(_ context.Context, _ resource.ConnectionSecretOwner, _ managed.ConnectionDetails) (published bool, err error) {
 							return false, nil
 						},
 					}),
@@ -512,7 +512,7 @@ func TestReconcile(t *testing.T) {
 					WithConfigurator(ConfiguratorFn(func(_ context.Context, _ resource.Composite, _ *v1.CompositionRevision) error {
 						return nil
 					})),
-					WithComposer(ComposerFn(func(ctx context.Context, xr *composite.Unstructured, req CompositionRequest) (CompositionResult, error) {
+					WithComposer(ComposerFn(func(_ context.Context, _ *composite.Unstructured, _ CompositionRequest) (CompositionResult, error) {
 						return CompositionResult{
 							Composed: []ComposedResource{{
 								ResourceName: "elephant",
@@ -536,7 +536,7 @@ func TestReconcile(t *testing.T) {
 						}, nil
 					})),
 					WithConnectionPublishers(managed.ConnectionPublisherFns{
-						PublishConnectionFn: func(ctx context.Context, o resource.ConnectionSecretOwner, c managed.ConnectionDetails) (published bool, err error) {
+						PublishConnectionFn: func(_ context.Context, _ resource.ConnectionSecretOwner, _ managed.ConnectionDetails) (published bool, err error) {
 							return false, nil
 						},
 					}),
@@ -574,11 +574,11 @@ func TestReconcile(t *testing.T) {
 					WithConfigurator(ConfiguratorFn(func(_ context.Context, _ resource.Composite, _ *v1.CompositionRevision) error {
 						return nil
 					})),
-					WithComposer(ComposerFn(func(ctx context.Context, xr *composite.Unstructured, req CompositionRequest) (CompositionResult, error) {
+					WithComposer(ComposerFn(func(_ context.Context, _ *composite.Unstructured, _ CompositionRequest) (CompositionResult, error) {
 						return CompositionResult{ConnectionDetails: cd}, nil
 					})),
 					WithConnectionPublishers(managed.ConnectionPublisherFns{
-						PublishConnectionFn: func(ctx context.Context, o resource.ConnectionSecretOwner, got managed.ConnectionDetails) (published bool, err error) {
+						PublishConnectionFn: func(_ context.Context, _ resource.ConnectionSecretOwner, got managed.ConnectionDetails) (published bool, err error) {
 							want := cd
 							if diff := cmp.Diff(want, got); diff != "" {
 								t.Errorf("PublishConnection(...): -want, +got:\n%s", diff)
@@ -661,11 +661,11 @@ func TestReconcile(t *testing.T) {
 					WithConfigurator(ConfiguratorFn(func(_ context.Context, _ resource.Composite, _ *v1.CompositionRevision) error {
 						return nil
 					})),
-					WithComposer(ComposerFn(func(ctx context.Context, xr *composite.Unstructured, req CompositionRequest) (CompositionResult, error) {
+					WithComposer(ComposerFn(func(_ context.Context, _ *composite.Unstructured, _ CompositionRequest) (CompositionResult, error) {
 						return CompositionResult{}, nil
 					})),
 					WithConnectionPublishers(managed.ConnectionPublisherFns{
-						PublishConnectionFn: func(ctx context.Context, o resource.ConnectionSecretOwner, got managed.ConnectionDetails) (published bool, err error) {
+						PublishConnectionFn: func(_ context.Context, _ resource.ConnectionSecretOwner, _ managed.ConnectionDetails) (published bool, err error) {
 							return true, nil
 						},
 					}),
@@ -707,11 +707,11 @@ func TestReconcile(t *testing.T) {
 					WithConfigurator(ConfiguratorFn(func(_ context.Context, _ resource.Composite, _ *v1.CompositionRevision) error {
 						return nil
 					})),
-					WithComposer(ComposerFn(func(ctx context.Context, xr *composite.Unstructured, req CompositionRequest) (CompositionResult, error) {
+					WithComposer(ComposerFn(func(_ context.Context, _ *composite.Unstructured, _ CompositionRequest) (CompositionResult, error) {
 						return CompositionResult{}, nil
 					})),
 					WithConnectionPublishers(managed.ConnectionPublisherFns{
-						PublishConnectionFn: func(ctx context.Context, o resource.ConnectionSecretOwner, got managed.ConnectionDetails) (published bool, err error) {
+						PublishConnectionFn: func(_ context.Context, _ resource.ConnectionSecretOwner, _ managed.ConnectionDetails) (published bool, err error) {
 							return true, nil
 						},
 					}),
@@ -759,8 +759,8 @@ func WithComposite(_ *testing.T, cr *composite.Unstructured) func(_ context.Cont
 }
 
 // A status update function that ensures the supplied object is the XR we want.
-func WantComposite(t *testing.T, want resource.Composite) func(ctx context.Context, obj client.Object, _ ...client.SubResourceUpdateOption) error {
-	return func(ctx context.Context, got client.Object, _ ...client.SubResourceUpdateOption) error {
+func WantComposite(t *testing.T, want resource.Composite) func(_ context.Context, obj client.Object, _ ...client.SubResourceUpdateOption) error {
+	return func(_ context.Context, got client.Object, _ ...client.SubResourceUpdateOption) error {
 		// Normally we use a custom Equal method on conditions to ignore the
 		// lastTransitionTime, but we may be using unstructured types here where
 		// the conditions are just a map[string]any.
@@ -839,7 +839,7 @@ func TestFilterToXRPatches(t *testing.T) {
 func TestEnqueueForCompositionRevisionFunc(t *testing.T) {
 	type args struct {
 		of    schema.GroupVersionKind
-		list  func(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error
+		list  func(_ context.Context, list client.ObjectList, opts ...client.ListOption) error
 		event runtimeevent.CreateEvent
 	}
 	type want struct {
@@ -858,7 +858,7 @@ func TestEnqueueForCompositionRevisionFunc(t *testing.T) {
 			name: "empty",
 			args: args{
 				of: dog,
-				list: func(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
+				list: func(_ context.Context, list client.ObjectList, opts ...client.ListOption) error {
 					// test parameters only here, not in the later tests for brevity.
 					u, ok := list.(*kunstructured.UnstructuredList)
 					if !ok {
@@ -877,7 +877,7 @@ func TestEnqueueForCompositionRevisionFunc(t *testing.T) {
 			name: "automatic management policy",
 			args: args{
 				of: dog,
-				list: func(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
+				list: func(_ context.Context, list client.ObjectList, _ ...client.ListOption) error {
 					var obj1 composite.Unstructured
 					obj1.SetNamespace("ns")
 					obj1.SetName("obj1")
@@ -911,7 +911,7 @@ func TestEnqueueForCompositionRevisionFunc(t *testing.T) {
 			name: "manual management policy",
 			args: args{
 				of: dog,
-				list: func(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
+				list: func(_ context.Context, list client.ObjectList, _ ...client.ListOption) error {
 					var obj1 composite.Unstructured
 					obj1.SetNamespace("ns")
 					obj1.SetName("obj1")
@@ -940,7 +940,7 @@ func TestEnqueueForCompositionRevisionFunc(t *testing.T) {
 			name: "other composition",
 			args: args{
 				of: dog,
-				list: func(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
+				list: func(_ context.Context, list client.ObjectList, _ ...client.ListOption) error {
 					var obj1 composite.Unstructured
 					obj1.SetNamespace("ns")
 					obj1.SetName("obj1")
@@ -969,7 +969,7 @@ func TestEnqueueForCompositionRevisionFunc(t *testing.T) {
 			name: "multiple",
 			args: args{
 				of: dog,
-				list: func(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
+				list: func(_ context.Context, list client.ObjectList, _ ...client.ListOption) error {
 					var obj1 composite.Unstructured
 					obj1.SetNamespace("ns")
 					obj1.SetName("obj1")

--- a/internal/controller/apiextensions/composition/fuzz_test.go
+++ b/internal/controller/apiextensions/composition/fuzz_test.go
@@ -25,7 +25,7 @@ import (
 )
 
 func FuzzNewCompositionRevision(f *testing.F) {
-	f.Fuzz(func(t *testing.T, data []byte) {
+	f.Fuzz(func(_ *testing.T, data []byte) {
 		f := fuzz.NewConsumer(data)
 		c := &v1.Composition{}
 		f.GenerateStruct(c)

--- a/internal/controller/apiextensions/composition/reconciler_test.go
+++ b/internal/controller/apiextensions/composition/reconciler_test.go
@@ -249,7 +249,7 @@ func TestReconcile(t *testing.T) {
 							*obj.(*v1.Composition) = *compDev
 							return nil
 						}),
-						MockList: func(ctx context.Context, obj client.ObjectList, opts ...client.ListOption) error {
+						MockList: func(_ context.Context, obj client.ObjectList, opts ...client.ListOption) error {
 							if len(opts) < 1 || opts[0].(client.MatchingLabels)[v1.LabelCompositionName] != compDev.Name {
 								t.Errorf("unexpected list options: %v", opts)
 							}
@@ -287,7 +287,7 @@ func TestReconcile(t *testing.T) {
 							*obj.(*v1.Composition) = *compDev
 							return nil
 						}),
-						MockList: func(ctx context.Context, obj client.ObjectList, opts ...client.ListOption) error {
+						MockList: func(_ context.Context, obj client.ObjectList, opts ...client.ListOption) error {
 							if len(opts) < 1 || opts[0].(client.MatchingLabels)[v1.LabelCompositionName] != compDev.Name {
 								t.Errorf("unexpected list options: %v", opts)
 							}

--- a/internal/controller/apiextensions/definition/reconciler_test.go
+++ b/internal/controller/apiextensions/definition/reconciler_test.go
@@ -534,7 +534,7 @@ func TestReconcile(t *testing.T) {
 				mgr: &mockManager{
 					GetCacheFn: func() cache.Cache {
 						return &mockCache{
-							ListFn: func(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error { return nil },
+							ListFn: func(_ context.Context, _ client.ObjectList, _ ...client.ListOption) error { return nil },
 						}
 					},
 					GetClientFn: func() client.Client {
@@ -585,7 +585,7 @@ func TestReconcile(t *testing.T) {
 				mgr: &mockManager{
 					GetCacheFn: func() cache.Cache {
 						return &mockCache{
-							ListFn: func(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error { return nil },
+							ListFn: func(_ context.Context, _ client.ObjectList, _ ...client.ListOption) error { return nil },
 						}
 					},
 					GetClientFn: func() client.Client {
@@ -627,16 +627,16 @@ func TestReconcile(t *testing.T) {
 						return nil
 					}}),
 					WithControllerEngine(&MockEngine{
-						MockErr: func(name string) error { return errBoom }, // This error should only be logged.
+						MockErr: func(_ string) error { return errBoom }, // This error should only be logged.
 						MockCreate: func(_ string, _ kcontroller.Options, _ ...controller.Watch) (controller.NamedController, error) {
 							return mockNamedController{
-								MockStart: func(ctx context.Context) error { return nil },
+								MockStart: func(_ context.Context) error { return nil },
 								MockGetCache: func() cache.Cache {
 									return &mockCache{
-										IndexFieldFn: func(ctx context.Context, obj client.Object, field string, extractValue client.IndexerFunc) error {
+										IndexFieldFn: func(_ context.Context, _ client.Object, _ string, _ client.IndexerFunc) error {
 											return nil
 										},
-										WaitForCacheSyncFn: func(ctx context.Context) bool {
+										WaitForCacheSyncFn: func(_ context.Context) bool {
 											return true
 										},
 									}
@@ -656,7 +656,7 @@ func TestReconcile(t *testing.T) {
 				mgr: &mockManager{
 					GetCacheFn: func() cache.Cache {
 						return &mockCache{
-							ListFn: func(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error { return nil },
+							ListFn: func(_ context.Context, _ client.ObjectList, _ ...client.ListOption) error { return nil },
 						}
 					},
 					GetClientFn: func() client.Client {
@@ -711,16 +711,16 @@ func TestReconcile(t *testing.T) {
 						return nil
 					}}),
 					WithControllerEngine(&MockEngine{
-						MockErr: func(name string) error { return nil },
+						MockErr: func(_ string) error { return nil },
 						MockCreate: func(_ string, _ kcontroller.Options, _ ...controller.Watch) (controller.NamedController, error) {
 							return mockNamedController{
-								MockStart: func(ctx context.Context) error { return nil },
+								MockStart: func(_ context.Context) error { return nil },
 								MockGetCache: func() cache.Cache {
 									return &mockCache{
-										IndexFieldFn: func(ctx context.Context, obj client.Object, field string, extractValue client.IndexerFunc) error {
+										IndexFieldFn: func(_ context.Context, _ client.Object, _ string, _ client.IndexerFunc) error {
 											return nil
 										},
-										WaitForCacheSyncFn: func(ctx context.Context) bool {
+										WaitForCacheSyncFn: func(_ context.Context) bool {
 											return true
 										},
 									}
@@ -768,7 +768,7 @@ func TestReconcile(t *testing.T) {
 }
 
 type mockNamedController struct {
-	MockStart    func(ctx context.Context) error
+	MockStart    func(_ context.Context) error
 	MockGetCache func() cache.Cache
 }
 
@@ -823,9 +823,9 @@ func (m *mockManager) GetControllerOptions() ctrlconfig.Controller {
 type mockCache struct {
 	cache.Cache
 
-	ListFn             func(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error
-	IndexFieldFn       func(ctx context.Context, obj client.Object, field string, extractValue client.IndexerFunc) error
-	WaitForCacheSyncFn func(ctx context.Context) bool
+	ListFn             func(_ context.Context, list client.ObjectList, opts ...client.ListOption) error
+	IndexFieldFn       func(_ context.Context, obj client.Object, field string, extractValue client.IndexerFunc) error
+	WaitForCacheSyncFn func(_ context.Context) bool
 }
 
 func (m *mockCache) List(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {

--- a/internal/controller/apiextensions/offered/reconciler_test.go
+++ b/internal/controller/apiextensions/offered/reconciler_test.go
@@ -595,7 +595,7 @@ func TestReconcile(t *testing.T) {
 						return nil
 					}}),
 					WithControllerEngine(&MockEngine{
-						MockErr:   func(name string) error { return errBoom }, // This error should only be logged.
+						MockErr:   func(_ string) error { return errBoom }, // This error should only be logged.
 						MockStart: func(_ string, _ kcontroller.Options, _ ...controller.Watch) error { return nil }},
 					),
 				},
@@ -654,7 +654,7 @@ func TestReconcile(t *testing.T) {
 						return nil
 					}}),
 					WithControllerEngine(&MockEngine{
-						MockErr:   func(name string) error { return nil },
+						MockErr:   func(_ string) error { return nil },
 						MockStart: func(_ string, _ kcontroller.Options, _ ...controller.Watch) error { return nil },
 						MockStop:  func(_ string) {},
 					}),

--- a/internal/controller/apiextensions/usage/reconciler.go
+++ b/internal/controller/apiextensions/usage/reconciler.go
@@ -444,7 +444,7 @@ func detailsAnnotation(u *v1alpha1.Usage) string {
 // composite controller since otherwise we lose the owner reference this
 // controller puts on the Usage.
 func RespectOwnerRefs() xpresource.ApplyOption {
-	return func(ctx context.Context, current, desired runtime.Object) error {
+	return func(_ context.Context, current, desired runtime.Object) error {
 		cu, ok := current.(*composed.Unstructured)
 		if !ok || cu.GetObjectKind().GroupVersionKind() != v1alpha1.UsageGroupVersionKind {
 			return nil

--- a/internal/controller/apiextensions/usage/reconciler_test.go
+++ b/internal/controller/apiextensions/usage/reconciler_test.go
@@ -42,7 +42,7 @@ import (
 )
 
 type fakeSelectorResolver struct {
-	resourceSelectorFn func(ctx context.Context, u *v1alpha1.Usage) error
+	resourceSelectorFn func(_ context.Context, _ *v1alpha1.Usage) error
 }
 
 func (f fakeSelectorResolver) resolveSelectors(ctx context.Context, u *v1alpha1.Usage) error {
@@ -118,7 +118,7 @@ func TestReconcile(t *testing.T) {
 						},
 					}),
 					WithSelectorResolver(fakeSelectorResolver{
-						resourceSelectorFn: func(ctx context.Context, u *v1alpha1.Usage) error {
+						resourceSelectorFn: func(_ context.Context, _ *v1alpha1.Usage) error {
 							return errBoom
 						},
 					}),
@@ -143,7 +143,7 @@ func TestReconcile(t *testing.T) {
 						},
 					}),
 					WithSelectorResolver(fakeSelectorResolver{
-						resourceSelectorFn: func(ctx context.Context, u *v1alpha1.Usage) error {
+						resourceSelectorFn: func(_ context.Context, _ *v1alpha1.Usage) error {
 							return nil
 						},
 					}),
@@ -172,7 +172,7 @@ func TestReconcile(t *testing.T) {
 						},
 					}),
 					WithSelectorResolver(fakeSelectorResolver{
-						resourceSelectorFn: func(ctx context.Context, u *v1alpha1.Usage) error {
+						resourceSelectorFn: func(_ context.Context, _ *v1alpha1.Usage) error {
 							return nil
 						},
 					}),
@@ -201,13 +201,13 @@ func TestReconcile(t *testing.T) {
 								}
 								return nil
 							}),
-							MockUpdate: test.NewMockUpdateFn(nil, func(obj client.Object) error {
+							MockUpdate: test.NewMockUpdateFn(nil, func(_ client.Object) error {
 								return nil
 							}),
 						},
 					}),
 					WithSelectorResolver(fakeSelectorResolver{
-						resourceSelectorFn: func(ctx context.Context, u *v1alpha1.Usage) error {
+						resourceSelectorFn: func(_ context.Context, _ *v1alpha1.Usage) error {
 							return nil
 						},
 					}),
@@ -245,7 +245,7 @@ func TestReconcile(t *testing.T) {
 						},
 					}),
 					WithSelectorResolver(fakeSelectorResolver{
-						resourceSelectorFn: func(ctx context.Context, u *v1alpha1.Usage) error {
+						resourceSelectorFn: func(_ context.Context, _ *v1alpha1.Usage) error {
 							return nil
 						},
 					}),
@@ -283,7 +283,7 @@ func TestReconcile(t *testing.T) {
 						},
 					}),
 					WithSelectorResolver(fakeSelectorResolver{
-						resourceSelectorFn: func(ctx context.Context, u *v1alpha1.Usage) error {
+						resourceSelectorFn: func(_ context.Context, _ *v1alpha1.Usage) error {
 							return nil
 						},
 					}),
@@ -332,7 +332,7 @@ func TestReconcile(t *testing.T) {
 						},
 					}),
 					WithSelectorResolver(fakeSelectorResolver{
-						resourceSelectorFn: func(ctx context.Context, u *v1alpha1.Usage) error {
+						resourceSelectorFn: func(_ context.Context, _ *v1alpha1.Usage) error {
 							return nil
 						},
 					}),
@@ -391,7 +391,7 @@ func TestReconcile(t *testing.T) {
 						},
 					}),
 					WithSelectorResolver(fakeSelectorResolver{
-						resourceSelectorFn: func(ctx context.Context, u *v1alpha1.Usage) error {
+						resourceSelectorFn: func(_ context.Context, _ *v1alpha1.Usage) error {
 							return nil
 						},
 					}),
@@ -440,7 +440,7 @@ func TestReconcile(t *testing.T) {
 						},
 					}),
 					WithSelectorResolver(fakeSelectorResolver{
-						resourceSelectorFn: func(ctx context.Context, u *v1alpha1.Usage) error {
+						resourceSelectorFn: func(_ context.Context, _ *v1alpha1.Usage) error {
 							return nil
 						},
 					}),
@@ -474,7 +474,7 @@ func TestReconcile(t *testing.T) {
 						},
 					}),
 					WithSelectorResolver(fakeSelectorResolver{
-						resourceSelectorFn: func(ctx context.Context, u *v1alpha1.Usage) error {
+						resourceSelectorFn: func(_ context.Context, _ *v1alpha1.Usage) error {
 							return nil
 						},
 					}),
@@ -508,7 +508,7 @@ func TestReconcile(t *testing.T) {
 						},
 					}),
 					WithSelectorResolver(fakeSelectorResolver{
-						resourceSelectorFn: func(ctx context.Context, u *v1alpha1.Usage) error {
+						resourceSelectorFn: func(_ context.Context, _ *v1alpha1.Usage) error {
 							return nil
 						},
 					}),
@@ -550,7 +550,7 @@ func TestReconcile(t *testing.T) {
 						},
 					}),
 					WithSelectorResolver(fakeSelectorResolver{
-						resourceSelectorFn: func(ctx context.Context, u *v1alpha1.Usage) error {
+						resourceSelectorFn: func(_ context.Context, _ *v1alpha1.Usage) error {
 							return nil
 						},
 					}),
@@ -582,13 +582,13 @@ func TestReconcile(t *testing.T) {
 								}
 								return errors.New("unexpected object type")
 							}),
-							MockList: test.NewMockListFn(nil, func(obj client.ObjectList) error {
+							MockList: test.NewMockListFn(nil, func(_ client.ObjectList) error {
 								return errBoom
 							}),
 						},
 					}),
 					WithSelectorResolver(fakeSelectorResolver{
-						resourceSelectorFn: func(ctx context.Context, u *v1alpha1.Usage) error {
+						resourceSelectorFn: func(_ context.Context, _ *v1alpha1.Usage) error {
 							return nil
 						},
 					}),
@@ -620,16 +620,16 @@ func TestReconcile(t *testing.T) {
 								}
 								return errors.New("unexpected object type")
 							}),
-							MockList: test.NewMockListFn(nil, func(obj client.ObjectList) error {
+							MockList: test.NewMockListFn(nil, func(_ client.ObjectList) error {
 								return nil
 							}),
-							MockUpdate: test.NewMockUpdateFn(nil, func(obj client.Object) error {
+							MockUpdate: test.NewMockUpdateFn(nil, func(_ client.Object) error {
 								return errBoom
 							}),
 						},
 					}),
 					WithSelectorResolver(fakeSelectorResolver{
-						resourceSelectorFn: func(ctx context.Context, u *v1alpha1.Usage) error {
+						resourceSelectorFn: func(_ context.Context, _ *v1alpha1.Usage) error {
 							return nil
 						},
 					}),
@@ -663,7 +663,7 @@ func TestReconcile(t *testing.T) {
 						},
 					}),
 					WithSelectorResolver(fakeSelectorResolver{
-						resourceSelectorFn: func(ctx context.Context, u *v1alpha1.Usage) error {
+						resourceSelectorFn: func(_ context.Context, _ *v1alpha1.Usage) error {
 							return nil
 						},
 					}),
@@ -695,7 +695,7 @@ func TestReconcile(t *testing.T) {
 								}
 								return errors.New("unexpected object type")
 							}),
-							MockList: test.NewMockListFn(nil, func(obj client.ObjectList) error {
+							MockList: test.NewMockListFn(nil, func(_ client.ObjectList) error {
 								return nil
 							}),
 							MockUpdate: test.NewMockUpdateFn(nil, func(obj client.Object) error {
@@ -710,7 +710,7 @@ func TestReconcile(t *testing.T) {
 						},
 					}),
 					WithSelectorResolver(fakeSelectorResolver{
-						resourceSelectorFn: func(ctx context.Context, u *v1alpha1.Usage) error {
+						resourceSelectorFn: func(_ context.Context, _ *v1alpha1.Usage) error {
 							return nil
 						},
 					}),
@@ -753,7 +753,7 @@ func TestReconcile(t *testing.T) {
 								}
 								return errors.New("unexpected object type")
 							}),
-							MockList: test.NewMockListFn(nil, func(obj client.ObjectList) error {
+							MockList: test.NewMockListFn(nil, func(_ client.ObjectList) error {
 								return nil
 							}),
 							MockUpdate: test.NewMockUpdateFn(nil, func(obj client.Object) error {
@@ -768,7 +768,7 @@ func TestReconcile(t *testing.T) {
 						},
 					}),
 					WithSelectorResolver(fakeSelectorResolver{
-						resourceSelectorFn: func(ctx context.Context, u *v1alpha1.Usage) error {
+						resourceSelectorFn: func(_ context.Context, _ *v1alpha1.Usage) error {
 							return nil
 						},
 					}),

--- a/internal/controller/apiextensions/usage/selector_test.go
+++ b/internal/controller/apiextensions/usage/selector_test.go
@@ -155,7 +155,7 @@ func TestResolveSelectors(t *testing.T) {
 			reason: "We should return error if we cannot list the used resources.",
 			args: args{
 				client: &test.MockClient{
-					MockList: func(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
+					MockList: func(_ context.Context, _ client.ObjectList, _ ...client.ListOption) error {
 						return errBoom
 					},
 				},
@@ -181,7 +181,7 @@ func TestResolveSelectors(t *testing.T) {
 			reason: "We should return error if we cannot list the using resources.",
 			args: args{
 				client: &test.MockClient{
-					MockList: func(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
+					MockList: func(_ context.Context, _ client.ObjectList, _ ...client.ListOption) error {
 						return errBoom
 					},
 				},
@@ -214,7 +214,7 @@ func TestResolveSelectors(t *testing.T) {
 			reason: "We should return error if we cannot update the usage after resolving used resource.",
 			args: args{
 				client: &test.MockClient{
-					MockList: func(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
+					MockList: func(_ context.Context, list client.ObjectList, _ ...client.ListOption) error {
 						l := list.(*composed.UnstructuredList)
 						switch l.GetKind() {
 						case "SomeKindList":
@@ -234,7 +234,7 @@ func TestResolveSelectors(t *testing.T) {
 						}
 						return nil
 					},
-					MockUpdate: func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
+					MockUpdate: func(_ context.Context, _ client.Object, _ ...client.UpdateOption) error {
 						return errBoom
 					},
 				},
@@ -260,7 +260,7 @@ func TestResolveSelectors(t *testing.T) {
 			reason: "We should return error if we cannot update the usage after resolving using resource.",
 			args: args{
 				client: &test.MockClient{
-					MockList: func(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
+					MockList: func(_ context.Context, list client.ObjectList, _ ...client.ListOption) error {
 						l := list.(*composed.UnstructuredList)
 						switch l.GetKind() {
 						case "AnotherKindList":
@@ -280,7 +280,7 @@ func TestResolveSelectors(t *testing.T) {
 						}
 						return nil
 					},
-					MockUpdate: func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
+					MockUpdate: func(_ context.Context, _ client.Object, _ ...client.UpdateOption) error {
 						return errBoom
 					},
 				},
@@ -313,7 +313,7 @@ func TestResolveSelectors(t *testing.T) {
 			reason: "We should return error if there are no matching resources.",
 			args: args{
 				client: &test.MockClient{
-					MockList: func(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
+					MockList: func(_ context.Context, _ client.ObjectList, _ ...client.ListOption) error {
 						return nil
 					},
 				},
@@ -340,7 +340,7 @@ func TestResolveSelectors(t *testing.T) {
 			reason: "We should return error if there are no matching resources with controller ref.",
 			args: args{
 				client: &test.MockClient{
-					MockList: func(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
+					MockList: func(_ context.Context, list client.ObjectList, _ ...client.ListOption) error {
 						l := list.(*composed.UnstructuredList)
 						switch l.GetKind() {
 						case "SomeKindList":
@@ -360,7 +360,7 @@ func TestResolveSelectors(t *testing.T) {
 						}
 						return nil
 					},
-					MockUpdate: func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
+					MockUpdate: func(_ context.Context, _ client.Object, _ ...client.UpdateOption) error {
 						return nil
 					},
 				},
@@ -387,7 +387,7 @@ func TestResolveSelectors(t *testing.T) {
 			reason: "If selectors defined for both \"of\" and \"by\", both should be resolved.",
 			args: args{
 				client: &test.MockClient{
-					MockList: func(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
+					MockList: func(_ context.Context, list client.ObjectList, opts ...client.ListOption) error {
 						l := list.(*composed.UnstructuredList)
 						if v := l.GroupVersionKind().Version; v != "v1" {
 							t.Errorf("unexpected list version: %s", v)
@@ -437,7 +437,7 @@ func TestResolveSelectors(t *testing.T) {
 						}
 						return nil
 					},
-					MockUpdate: func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
+					MockUpdate: func(_ context.Context, _ client.Object, _ ...client.UpdateOption) error {
 						return nil
 					},
 				},

--- a/internal/controller/pkg/manager/reconciler_test.go
+++ b/internal/controller/pkg/manager/reconciler_test.go
@@ -489,7 +489,7 @@ func TestReconcile(t *testing.T) {
 								return nil
 							}),
 						},
-						Applicator: resource.ApplyFn(func(_ context.Context, o client.Object, _ ...resource.ApplyOption) error {
+						Applicator: resource.ApplyFn(func(_ context.Context, _ client.Object, _ ...resource.ApplyOption) error {
 							return errBoom
 						}),
 					},

--- a/internal/controller/pkg/resolver/reconciler_test.go
+++ b/internal/controller/pkg/resolver/reconciler_test.go
@@ -165,7 +165,7 @@ func TestReconcile(t *testing.T) {
 				rec: []ReconcilerOption{
 					WithNewDagFn(func() dag.DAG {
 						return &fakedag.MockDag{
-							MockInit: func(nodes []dag.Node) ([]dag.Node, error) {
+							MockInit: func(_ []dag.Node) ([]dag.Node, error) {
 								return nil, errBoom
 							},
 						}
@@ -201,7 +201,7 @@ func TestReconcile(t *testing.T) {
 				rec: []ReconcilerOption{
 					WithNewDagFn(func() dag.DAG {
 						return &fakedag.MockDag{
-							MockInit: func(nodes []dag.Node) ([]dag.Node, error) {
+							MockInit: func(_ []dag.Node) ([]dag.Node, error) {
 								return nil, nil
 							},
 							MockSort: func() ([]string, error) {
@@ -240,7 +240,7 @@ func TestReconcile(t *testing.T) {
 				rec: []ReconcilerOption{
 					WithNewDagFn(func() dag.DAG {
 						return &fakedag.MockDag{
-							MockInit: func(nodes []dag.Node) ([]dag.Node, error) {
+							MockInit: func(_ []dag.Node) ([]dag.Node, error) {
 								return nil, nil
 							},
 							MockSort: func() ([]string, error) {
@@ -279,7 +279,7 @@ func TestReconcile(t *testing.T) {
 				rec: []ReconcilerOption{
 					WithNewDagFn(func() dag.DAG {
 						return &fakedag.MockDag{
-							MockInit: func(nodes []dag.Node) ([]dag.Node, error) {
+							MockInit: func(_ []dag.Node) ([]dag.Node, error) {
 								return []dag.Node{
 									&v1beta1.Dependency{
 										Package: "not.a.valid.package",
@@ -322,7 +322,7 @@ func TestReconcile(t *testing.T) {
 				rec: []ReconcilerOption{
 					WithNewDagFn(func() dag.DAG {
 						return &fakedag.MockDag{
-							MockInit: func(nodes []dag.Node) ([]dag.Node, error) {
+							MockInit: func(_ []dag.Node) ([]dag.Node, error) {
 								return []dag.Node{
 									&v1beta1.Dependency{
 										Package:     "hasheddan/config-nop-b",
@@ -369,7 +369,7 @@ func TestReconcile(t *testing.T) {
 				rec: []ReconcilerOption{
 					WithNewDagFn(func() dag.DAG {
 						return &fakedag.MockDag{
-							MockInit: func(nodes []dag.Node) ([]dag.Node, error) {
+							MockInit: func(_ []dag.Node) ([]dag.Node, error) {
 								return []dag.Node{
 									&v1beta1.Dependency{
 										Package:     "hasheddan/config-nop-b",
@@ -417,7 +417,7 @@ func TestReconcile(t *testing.T) {
 				rec: []ReconcilerOption{
 					WithNewDagFn(func() dag.DAG {
 						return &fakedag.MockDag{
-							MockInit: func(nodes []dag.Node) ([]dag.Node, error) {
+							MockInit: func(_ []dag.Node) ([]dag.Node, error) {
 								return []dag.Node{
 									&v1beta1.Dependency{
 										Package:     "hasheddan/config-nop-c",
@@ -466,7 +466,7 @@ func TestReconcile(t *testing.T) {
 				rec: []ReconcilerOption{
 					WithNewDagFn(func() dag.DAG {
 						return &fakedag.MockDag{
-							MockInit: func(nodes []dag.Node) ([]dag.Node, error) {
+							MockInit: func(_ []dag.Node) ([]dag.Node, error) {
 								return []dag.Node{
 									&v1beta1.Dependency{
 										Package:     "hasheddan/config-nop-c",

--- a/internal/controller/pkg/revision/dependency_test.go
+++ b/internal/controller/pkg/revision/dependency_test.go
@@ -173,7 +173,7 @@ func TestResolve(t *testing.T) {
 					},
 					newDag: func() dag.DAG {
 						return &dagfake.MockDag{
-							MockInit: func(nodes []dag.Node) ([]dag.Node, error) {
+							MockInit: func(_ []dag.Node) ([]dag.Node, error) {
 								return nil, nil
 							},
 							MockTraceNode: func(_ string) (map[string]dag.Node, error) {
@@ -200,14 +200,14 @@ func TestResolve(t *testing.T) {
 			args: args{
 				dep: &PackageDependencyManager{
 					client: &test.MockClient{
-						MockGet: test.NewMockGetFn(nil, func(obj client.Object) error {
+						MockGet: test.NewMockGetFn(nil, func(_ client.Object) error {
 							return nil
 						}),
 						MockUpdate: test.NewMockUpdateFn(nil),
 					},
 					newDag: func() dag.DAG {
 						return &dagfake.MockDag{
-							MockInit: func(nodes []dag.Node) ([]dag.Node, error) {
+							MockInit: func(_ []dag.Node) ([]dag.Node, error) {
 								return nil, nil
 							},
 							MockNodeExists: func(_ string) bool {
@@ -287,7 +287,7 @@ func TestResolve(t *testing.T) {
 					},
 					newDag: func() dag.DAG {
 						return &dagfake.MockDag{
-							MockInit: func(nodes []dag.Node) ([]dag.Node, error) {
+							MockInit: func(_ []dag.Node) ([]dag.Node, error) {
 								return []dag.Node{
 									&v1beta1.Dependency{
 										Package: "not-here-2",
@@ -375,7 +375,7 @@ func TestResolve(t *testing.T) {
 					},
 					newDag: func() dag.DAG {
 						return &dagfake.MockDag{
-							MockInit: func(nodes []dag.Node) ([]dag.Node, error) {
+							MockInit: func(_ []dag.Node) ([]dag.Node, error) {
 								return nil, nil
 							},
 							MockTraceNode: func(_ string) (map[string]dag.Node, error) {
@@ -478,10 +478,10 @@ func TestResolve(t *testing.T) {
 					},
 					newDag: func() dag.DAG {
 						return &dagfake.MockDag{
-							MockInit: func(nodes []dag.Node) ([]dag.Node, error) {
+							MockInit: func(_ []dag.Node) ([]dag.Node, error) {
 								return nil, nil
 							},
-							MockNodeExists: func(identifier string) bool {
+							MockNodeExists: func(_ string) bool {
 								return true
 							},
 							MockTraceNode: func(_ string) (map[string]dag.Node, error) {

--- a/internal/controller/pkg/revision/establisher_test.go
+++ b/internal/controller/pkg/revision/establisher_test.go
@@ -141,7 +141,7 @@ func TestAPIEstablisherEstablish(t *testing.T) {
 			args: args{
 				est: &APIEstablisher{
 					client: &test.MockClient{
-						MockGet: func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
+						MockGet: func(_ context.Context, _ client.ObjectKey, obj client.Object) error {
 							if s, ok := obj.(*corev1.Secret); ok {
 								(&corev1.Secret{
 									Data: map[string][]byte{
@@ -353,7 +353,7 @@ func TestAPIEstablisherEstablish(t *testing.T) {
 			args: args{
 				est: &APIEstablisher{
 					client: &test.MockClient{
-						MockGet: func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
+						MockGet: func(_ context.Context, _ client.ObjectKey, obj client.Object) error {
 							s := &corev1.Secret{}
 							s.DeepCopyInto(obj.(*corev1.Secret))
 							return nil
@@ -378,7 +378,7 @@ func TestAPIEstablisherEstablish(t *testing.T) {
 			args: args{
 				est: &APIEstablisher{
 					client: &test.MockClient{
-						MockGet: func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
+						MockGet: func(_ context.Context, _ client.ObjectKey, obj client.Object) error {
 							s := &corev1.Secret{}
 							s.DeepCopyInto(obj.(*corev1.Secret))
 							return nil
@@ -495,7 +495,7 @@ func TestAPIEstablisherReleaseObjects(t *testing.T) {
 			args: args{
 				est: &APIEstablisher{
 					client: &test.MockClient{
-						MockGet: func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
+						MockGet: func(_ context.Context, _ client.ObjectKey, _ client.Object) error {
 							return errBoom
 						},
 					},
@@ -524,7 +524,7 @@ func TestAPIEstablisherReleaseObjects(t *testing.T) {
 			args: args{
 				est: &APIEstablisher{
 					client: &test.MockClient{
-						MockGet: func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
+						MockGet: func(_ context.Context, _ client.ObjectKey, _ client.Object) error {
 							return kerrors.NewNotFound(schema.GroupResource{}, "")
 						},
 					},
@@ -553,7 +553,7 @@ func TestAPIEstablisherReleaseObjects(t *testing.T) {
 			args: args{
 				est: &APIEstablisher{
 					client: &test.MockClient{
-						MockGet: func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
+						MockGet: func(_ context.Context, _ client.ObjectKey, obj client.Object) error {
 							o := obj.(*unstructured.Unstructured)
 							o.SetOwnerReferences([]metav1.OwnerReference{
 								{
@@ -573,7 +573,7 @@ func TestAPIEstablisherReleaseObjects(t *testing.T) {
 							})
 							return nil
 						},
-						MockUpdate: func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
+						MockUpdate: func(_ context.Context, _ client.Object, _ ...client.UpdateOption) error {
 							return errBoom
 						},
 					},
@@ -602,10 +602,10 @@ func TestAPIEstablisherReleaseObjects(t *testing.T) {
 			args: args{
 				est: &APIEstablisher{
 					client: &test.MockClient{
-						MockGet: func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
+						MockGet: func(_ context.Context, _ client.ObjectKey, _ client.Object) error {
 							return nil
 						},
-						MockUpdate: func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
+						MockUpdate: func(_ context.Context, _ client.Object, _ ...client.UpdateOption) error {
 							return nil
 						},
 					},
@@ -625,7 +625,7 @@ func TestAPIEstablisherReleaseObjects(t *testing.T) {
 			args: args{
 				est: &APIEstablisher{
 					client: &test.MockClient{
-						MockGet: func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
+						MockGet: func(_ context.Context, _ client.ObjectKey, obj client.Object) error {
 							o := obj.(*unstructured.Unstructured)
 							o.SetOwnerReferences([]metav1.OwnerReference{
 								{
@@ -645,7 +645,7 @@ func TestAPIEstablisherReleaseObjects(t *testing.T) {
 							})
 							return nil
 						},
-						MockUpdate: func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
+						MockUpdate: func(_ context.Context, _ client.Object, _ ...client.UpdateOption) error {
 							t.Errorf("should not have called update")
 							return nil
 						},
@@ -675,7 +675,7 @@ func TestAPIEstablisherReleaseObjects(t *testing.T) {
 			args: args{
 				est: &APIEstablisher{
 					client: &test.MockClient{
-						MockGet: func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
+						MockGet: func(_ context.Context, _ client.ObjectKey, obj client.Object) error {
 							o := obj.(*unstructured.Unstructured)
 							o.SetOwnerReferences([]metav1.OwnerReference{
 								{
@@ -688,7 +688,7 @@ func TestAPIEstablisherReleaseObjects(t *testing.T) {
 							})
 							return nil
 						},
-						MockUpdate: func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
+						MockUpdate: func(_ context.Context, obj client.Object, _ ...client.UpdateOption) error {
 							o := obj.(*unstructured.Unstructured)
 							if len(o.GetOwnerReferences()) != 2 {
 								t.Errorf("expected 2 owner references, got %d", len(o.GetOwnerReferences()))
@@ -736,7 +736,7 @@ func TestAPIEstablisherReleaseObjects(t *testing.T) {
 			args: args{
 				est: &APIEstablisher{
 					client: &test.MockClient{
-						MockGet: func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
+						MockGet: func(_ context.Context, _ client.ObjectKey, obj client.Object) error {
 							o := obj.(*unstructured.Unstructured)
 							o.SetOwnerReferences([]metav1.OwnerReference{
 								{
@@ -756,7 +756,7 @@ func TestAPIEstablisherReleaseObjects(t *testing.T) {
 							})
 							return nil
 						},
-						MockUpdate: func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
+						MockUpdate: func(_ context.Context, obj client.Object, _ ...client.UpdateOption) error {
 							o := obj.(*unstructured.Unstructured)
 							if len(o.GetOwnerReferences()) != 2 {
 								t.Errorf("expected 2 owner references, got %d", len(o.GetOwnerReferences()))

--- a/internal/controller/pkg/revision/fuzz_test.go
+++ b/internal/controller/pkg/revision/fuzz_test.go
@@ -69,16 +69,16 @@ func newFuzzDag(ff *fuzz.ConsumeFuzzer) (func() dag.DAG, error) {
 	}
 	return func() dag.DAG {
 		return &dagfake.MockDag{
-			MockInit: func(nodes []dag.Node) ([]dag.Node, error) {
+			MockInit: func(_ []dag.Node) ([]dag.Node, error) {
 				return nil, nil
 			},
-			MockNodeExists: func(identifier string) bool {
+			MockNodeExists: func(_ string) bool {
 				return true
 			},
 			MockTraceNode: func(_ string) (map[string]dag.Node, error) {
 				return traceNodeMap, nil
 			},
-			MockGetNode: func(s string) (dag.Node, error) {
+			MockGetNode: func(_ string) (dag.Node, error) {
 				return lp, nil
 			},
 		}
@@ -102,7 +102,7 @@ func getFuzzMockClient(ff *fuzz.ConsumeFuzzer) (*test.MockClient, error) {
 }
 
 func FuzzRevisionControllerPackageHandling(f *testing.F) {
-	f.Fuzz(func(t *testing.T, data, revisionData []byte) {
+	f.Fuzz(func(_ *testing.T, data, revisionData []byte) {
 		ff := fuzz.NewConsumer(revisionData)
 		p := parser.New(metaScheme, objScheme)
 		r := io.NopCloser(bytes.NewReader(data))

--- a/internal/controller/pkg/revision/reconciler_test.go
+++ b/internal/controller/pkg/revision/reconciler_test.go
@@ -274,7 +274,7 @@ func TestReconcile(t *testing.T) {
 								pr.SetDeletionTimestamp(&now)
 								return nil
 							}),
-							MockStatusUpdate: test.NewMockSubResourceUpdateFn(nil, func(o client.Object) error {
+							MockStatusUpdate: test.NewMockSubResourceUpdateFn(nil, func(_ client.Object) error {
 								t.Errorf("StatusUpdate should not be called")
 								return nil
 							}),
@@ -380,7 +380,7 @@ func TestReconcile(t *testing.T) {
 								pr.SetDesiredState(v1.PackageRevisionActive)
 								return nil
 							}),
-							MockStatusUpdate: test.NewMockSubResourceUpdateFn(nil, func(o client.Object) error {
+							MockStatusUpdate: test.NewMockSubResourceUpdateFn(nil, func(_ client.Object) error {
 								t.Errorf("StatusUpdate should not be called")
 								return nil
 							}),
@@ -415,7 +415,7 @@ func TestReconcile(t *testing.T) {
 								pr.SetDesiredState(v1.PackageRevisionActive)
 								return nil
 							}),
-							MockStatusUpdate: test.NewMockSubResourceUpdateFn(nil, func(o client.Object) error {
+							MockStatusUpdate: test.NewMockSubResourceUpdateFn(nil, func(_ client.Object) error {
 								t.Errorf("StatusUpdate should not be called")
 								return nil
 							}),
@@ -732,7 +732,7 @@ func TestReconcile(t *testing.T) {
 					WithLinter(&MockLinter{MockLint: NewMockLintFn(errBoom)}),
 					WithCache(&xpkgfake.MockCache{
 						MockHas: xpkgfake.NewMockCacheHasFn(false),
-						MockStore: func(s string, rc io.ReadCloser) error {
+						MockStore: func(_ string, rc io.ReadCloser) error {
 							_, err := io.ReadAll(rc)
 							return err
 						},
@@ -789,7 +789,7 @@ func TestReconcile(t *testing.T) {
 					WithParserBackend(parser.NewEchoBackend(string(providerBytes))),
 					WithCache(&xpkgfake.MockCache{
 						MockHas: xpkgfake.NewMockCacheHasFn(false),
-						MockStore: func(s string, rc io.ReadCloser) error {
+						MockStore: func(_ string, rc io.ReadCloser) error {
 							_, err := io.ReadAll(rc)
 							return err
 						},
@@ -886,7 +886,7 @@ func TestReconcile(t *testing.T) {
 					WithParserBackend(parser.NewEchoBackend(string(providerBytes))),
 					WithCache(&xpkgfake.MockCache{
 						MockHas: xpkgfake.NewMockCacheHasFn(false),
-						MockStore: func(s string, rc io.ReadCloser) error {
+						MockStore: func(_ string, rc io.ReadCloser) error {
 							_, err := io.ReadAll(rc)
 							return err
 						},
@@ -950,7 +950,7 @@ func TestReconcile(t *testing.T) {
 					WithParserBackend(parser.NewEchoBackend(string(providerBytes))),
 					WithCache(&xpkgfake.MockCache{
 						MockHas: xpkgfake.NewMockCacheHasFn(false),
-						MockStore: func(s string, rc io.ReadCloser) error {
+						MockStore: func(_ string, rc io.ReadCloser) error {
 							_, err := io.ReadAll(rc)
 							return err
 						},
@@ -1016,7 +1016,7 @@ func TestReconcile(t *testing.T) {
 					WithParserBackend(parser.NewEchoBackend(string(providerBytes))),
 					WithCache(&xpkgfake.MockCache{
 						MockHas: xpkgfake.NewMockCacheHasFn(false),
-						MockStore: func(s string, rc io.ReadCloser) error {
+						MockStore: func(_ string, rc io.ReadCloser) error {
 							_, err := io.ReadAll(rc)
 							return err
 						},
@@ -1084,7 +1084,7 @@ func TestReconcile(t *testing.T) {
 					WithParserBackend(parser.NewEchoBackend(string(providerBytes))),
 					WithCache(&xpkgfake.MockCache{
 						MockHas: xpkgfake.NewMockCacheHasFn(false),
-						MockStore: func(s string, rc io.ReadCloser) error {
+						MockStore: func(_ string, rc io.ReadCloser) error {
 							_, err := io.ReadAll(rc)
 							return err
 						},
@@ -1146,7 +1146,7 @@ func TestReconcile(t *testing.T) {
 					WithParserBackend(parser.NewEchoBackend(string(providerBytes))),
 					WithCache(&xpkgfake.MockCache{
 						MockHas: xpkgfake.NewMockCacheHasFn(false),
-						MockStore: func(s string, rc io.ReadCloser) error {
+						MockStore: func(_ string, rc io.ReadCloser) error {
 							_, err := io.ReadAll(rc)
 							return err
 						},
@@ -1212,7 +1212,7 @@ func TestReconcile(t *testing.T) {
 					WithParserBackend(parser.NewEchoBackend(string(providerBytes))),
 					WithCache(&xpkgfake.MockCache{
 						MockHas: xpkgfake.NewMockCacheHasFn(false),
-						MockStore: func(s string, rc io.ReadCloser) error {
+						MockStore: func(_ string, rc io.ReadCloser) error {
 							_, err := io.ReadAll(rc)
 							return err
 						},
@@ -1275,7 +1275,7 @@ func TestReconcile(t *testing.T) {
 					WithParserBackend(parser.NewEchoBackend(string(providerBytes))),
 					WithCache(&xpkgfake.MockCache{
 						MockHas: xpkgfake.NewMockCacheHasFn(false),
-						MockStore: func(s string, rc io.ReadCloser) error {
+						MockStore: func(_ string, rc io.ReadCloser) error {
 							_, err := io.ReadAll(rc)
 							return err
 						},
@@ -1407,7 +1407,7 @@ func TestReconcile(t *testing.T) {
 					WithParserBackend(parser.NewEchoBackend(string(providerBytes))),
 					WithCache(&xpkgfake.MockCache{
 						MockHas: xpkgfake.NewMockCacheHasFn(false),
-						MockStore: func(s string, rc io.ReadCloser) error {
+						MockStore: func(_ string, rc io.ReadCloser) error {
 							_, err := io.ReadAll(rc)
 							return err
 						},
@@ -1525,7 +1525,7 @@ func TestReconcile(t *testing.T) {
 					WithParserBackend(parser.NewEchoBackend(string(providerBytes))),
 					WithCache(&xpkgfake.MockCache{
 						MockHas: xpkgfake.NewMockCacheHasFn(false),
-						MockStore: func(s string, rc io.ReadCloser) error {
+						MockStore: func(_ string, rc io.ReadCloser) error {
 							_, err := io.ReadAll(rc)
 							return err
 						},
@@ -1589,7 +1589,7 @@ func TestReconcile(t *testing.T) {
 					WithParserBackend(parser.NewEchoBackend(string(providerBytes))),
 					WithCache(&xpkgfake.MockCache{
 						MockHas: xpkgfake.NewMockCacheHasFn(false),
-						MockStore: func(s string, rc io.ReadCloser) error {
+						MockStore: func(_ string, rc io.ReadCloser) error {
 							_, err := io.ReadAll(rc)
 							return err
 						},

--- a/internal/controller/pkg/revision/runtime_function_test.go
+++ b/internal/controller/pkg/revision/runtime_function_test.go
@@ -74,7 +74,7 @@ func TestFunctionPreHook(t *testing.T) {
 					},
 				},
 				manifests: &MockManifestBuilder{
-					ServiceFn: func(overrides ...ServiceOverride) *corev1.Service {
+					ServiceFn: func(_ ...ServiceOverride) *corev1.Service {
 						return &corev1.Service{}
 					},
 					TLSServerSecretFn: func() *corev1.Secret {
@@ -82,17 +82,17 @@ func TestFunctionPreHook(t *testing.T) {
 					},
 				},
 				client: &test.MockClient{
-					MockGet: func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
+					MockGet: func(_ context.Context, _ client.ObjectKey, obj client.Object) error {
 						if svc, ok := obj.(*corev1.Service); ok {
 							svc.Name = "some-service"
 							svc.Namespace = "some-namespace"
 						}
 						return nil
 					},
-					MockPatch: func(ctx context.Context, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+					MockPatch: func(_ context.Context, _ client.Object, _ client.Patch, _ ...client.PatchOption) error {
 						return nil
 					},
-					MockUpdate: func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
+					MockUpdate: func(_ context.Context, _ client.Object, _ ...client.UpdateOption) error {
 						return nil
 					},
 				},
@@ -189,18 +189,18 @@ func TestFunctionPostHook(t *testing.T) {
 					},
 				},
 				manifests: &MockManifestBuilder{
-					ServiceAccountFn: func(overrides ...ServiceAccountOverride) *corev1.ServiceAccount {
+					ServiceAccountFn: func(_ ...ServiceAccountOverride) *corev1.ServiceAccount {
 						return &corev1.ServiceAccount{}
 					},
-					DeploymentFn: func(serviceAccount string, overrides ...DeploymentOverride) *appsv1.Deployment {
+					DeploymentFn: func(_ string, _ ...DeploymentOverride) *appsv1.Deployment {
 						return &appsv1.Deployment{}
 					},
 				},
 				client: &test.MockClient{
-					MockGet: func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
+					MockGet: func(_ context.Context, _ client.ObjectKey, _ client.Object) error {
 						return nil
 					},
-					MockPatch: func(ctx context.Context, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+					MockPatch: func(_ context.Context, _ client.Object, _ client.Patch, _ ...client.PatchOption) error {
 						return errBoom
 					},
 				},
@@ -230,18 +230,18 @@ func TestFunctionPostHook(t *testing.T) {
 					},
 				},
 				manifests: &MockManifestBuilder{
-					ServiceAccountFn: func(overrides ...ServiceAccountOverride) *corev1.ServiceAccount {
+					ServiceAccountFn: func(_ ...ServiceAccountOverride) *corev1.ServiceAccount {
 						return &corev1.ServiceAccount{}
 					},
-					DeploymentFn: func(serviceAccount string, overrides ...DeploymentOverride) *appsv1.Deployment {
+					DeploymentFn: func(_ string, _ ...DeploymentOverride) *appsv1.Deployment {
 						return &appsv1.Deployment{}
 					},
 				},
 				client: &test.MockClient{
-					MockGet: func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
+					MockGet: func(_ context.Context, _ client.ObjectKey, _ client.Object) error {
 						return nil
 					},
-					MockPatch: func(ctx context.Context, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+					MockPatch: func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) error {
 						if _, ok := obj.(*appsv1.Deployment); ok {
 							return errBoom
 						}
@@ -274,18 +274,18 @@ func TestFunctionPostHook(t *testing.T) {
 					},
 				},
 				manifests: &MockManifestBuilder{
-					ServiceAccountFn: func(overrides ...ServiceAccountOverride) *corev1.ServiceAccount {
+					ServiceAccountFn: func(_ ...ServiceAccountOverride) *corev1.ServiceAccount {
 						return &corev1.ServiceAccount{}
 					},
-					DeploymentFn: func(serviceAccount string, overrides ...DeploymentOverride) *appsv1.Deployment {
+					DeploymentFn: func(_ string, _ ...DeploymentOverride) *appsv1.Deployment {
 						return &appsv1.Deployment{}
 					},
 				},
 				client: &test.MockClient{
-					MockGet: func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
+					MockGet: func(_ context.Context, _ client.ObjectKey, _ client.Object) error {
 						return nil
 					},
-					MockPatch: func(ctx context.Context, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+					MockPatch: func(_ context.Context, _ client.Object, _ client.Patch, _ ...client.PatchOption) error {
 						return nil
 					},
 				},
@@ -315,18 +315,18 @@ func TestFunctionPostHook(t *testing.T) {
 					},
 				},
 				manifests: &MockManifestBuilder{
-					ServiceAccountFn: func(overrides ...ServiceAccountOverride) *corev1.ServiceAccount {
+					ServiceAccountFn: func(_ ...ServiceAccountOverride) *corev1.ServiceAccount {
 						return &corev1.ServiceAccount{}
 					},
-					DeploymentFn: func(serviceAccount string, overrides ...DeploymentOverride) *appsv1.Deployment {
+					DeploymentFn: func(_ string, _ ...DeploymentOverride) *appsv1.Deployment {
 						return &appsv1.Deployment{}
 					},
 				},
 				client: &test.MockClient{
-					MockGet: func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
+					MockGet: func(_ context.Context, _ client.ObjectKey, _ client.Object) error {
 						return nil
 					},
-					MockPatch: func(ctx context.Context, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+					MockPatch: func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) error {
 						if d, ok := obj.(*appsv1.Deployment); ok {
 							d.Status.Conditions = []appsv1.DeploymentCondition{{
 								Type:    appsv1.DeploymentAvailable,
@@ -364,18 +364,18 @@ func TestFunctionPostHook(t *testing.T) {
 					},
 				},
 				manifests: &MockManifestBuilder{
-					ServiceAccountFn: func(overrides ...ServiceAccountOverride) *corev1.ServiceAccount {
+					ServiceAccountFn: func(_ ...ServiceAccountOverride) *corev1.ServiceAccount {
 						return &corev1.ServiceAccount{}
 					},
-					DeploymentFn: func(serviceAccount string, overrides ...DeploymentOverride) *appsv1.Deployment {
+					DeploymentFn: func(_ string, _ ...DeploymentOverride) *appsv1.Deployment {
 						return &appsv1.Deployment{}
 					},
 				},
 				client: &test.MockClient{
-					MockGet: func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
+					MockGet: func(_ context.Context, _ client.ObjectKey, _ client.Object) error {
 						return nil
 					},
-					MockPatch: func(ctx context.Context, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+					MockPatch: func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) error {
 						if d, ok := obj.(*appsv1.Deployment); ok {
 							d.Status.Conditions = []appsv1.DeploymentCondition{{
 								Type:   appsv1.DeploymentAvailable,
@@ -411,15 +411,15 @@ func TestFunctionPostHook(t *testing.T) {
 					},
 				},
 				manifests: &MockManifestBuilder{
-					ServiceAccountFn: func(overrides ...ServiceAccountOverride) *corev1.ServiceAccount {
+					ServiceAccountFn: func(_ ...ServiceAccountOverride) *corev1.ServiceAccount {
 						return &corev1.ServiceAccount{}
 					},
-					DeploymentFn: func(serviceAccount string, overrides ...DeploymentOverride) *appsv1.Deployment {
+					DeploymentFn: func(_ string, _ ...DeploymentOverride) *appsv1.Deployment {
 						return &appsv1.Deployment{}
 					},
 				},
 				client: &test.MockClient{
-					MockGet: func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
+					MockGet: func(_ context.Context, _ client.ObjectKey, obj client.Object) error {
 						if sa, ok := obj.(*corev1.ServiceAccount); ok {
 							if sa.GetName() == xpManagedSA {
 								return kerrors.NewNotFound(corev1.Resource("serviceaccount"), xpManagedSA)
@@ -427,7 +427,7 @@ func TestFunctionPostHook(t *testing.T) {
 						}
 						return nil
 					},
-					MockCreate: func(ctx context.Context, obj client.Object, opts ...client.CreateOption) error {
+					MockCreate: func(_ context.Context, obj client.Object, _ ...client.CreateOption) error {
 						if sa, ok := obj.(*corev1.ServiceAccount); ok {
 							if sa.GetName() == xpManagedSA {
 								t.Error("unexpected call to create SA when SA is managed externally")
@@ -435,7 +435,7 @@ func TestFunctionPostHook(t *testing.T) {
 						}
 						return nil
 					},
-					MockPatch: func(ctx context.Context, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+					MockPatch: func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) error {
 						if d, ok := obj.(*appsv1.Deployment); ok {
 							d.Status.Conditions = []appsv1.DeploymentCondition{{
 								Type:   appsv1.DeploymentAvailable,
@@ -501,15 +501,15 @@ func TestFunctionDeactivateHook(t *testing.T) {
 			reason: "Should return error if we fail to delete deployment.",
 			args: args{
 				manifests: &MockManifestBuilder{
-					ServiceAccountFn: func(overrides ...ServiceAccountOverride) *corev1.ServiceAccount {
+					ServiceAccountFn: func(_ ...ServiceAccountOverride) *corev1.ServiceAccount {
 						return &corev1.ServiceAccount{}
 					},
-					DeploymentFn: func(serviceAccount string, overrides ...DeploymentOverride) *appsv1.Deployment {
+					DeploymentFn: func(_ string, _ ...DeploymentOverride) *appsv1.Deployment {
 						return &appsv1.Deployment{}
 					},
 				},
 				client: &test.MockClient{
-					MockDelete: func(ctx context.Context, obj client.Object, opts ...client.DeleteOption) error {
+					MockDelete: func(_ context.Context, obj client.Object, _ ...client.DeleteOption) error {
 						if _, ok := obj.(*appsv1.Deployment); ok {
 							return errBoom
 						}
@@ -525,14 +525,14 @@ func TestFunctionDeactivateHook(t *testing.T) {
 			reason: "Should not return error if successfully deleted service account and deployment.",
 			args: args{
 				manifests: &MockManifestBuilder{
-					ServiceAccountFn: func(overrides ...ServiceAccountOverride) *corev1.ServiceAccount {
+					ServiceAccountFn: func(_ ...ServiceAccountOverride) *corev1.ServiceAccount {
 						return &corev1.ServiceAccount{
 							ObjectMeta: metav1.ObjectMeta{
 								Name: "some-sa",
 							},
 						}
 					},
-					DeploymentFn: func(serviceAccount string, overrides ...DeploymentOverride) *appsv1.Deployment {
+					DeploymentFn: func(_ string, _ ...DeploymentOverride) *appsv1.Deployment {
 						return &appsv1.Deployment{
 							ObjectMeta: metav1.ObjectMeta{
 								Name: "some-deployment",
@@ -552,7 +552,7 @@ func TestFunctionDeactivateHook(t *testing.T) {
 					},
 				},
 				client: &test.MockClient{
-					MockDelete: func(ctx context.Context, obj client.Object, opts ...client.DeleteOption) error {
+					MockDelete: func(_ context.Context, obj client.Object, _ ...client.DeleteOption) error {
 						switch obj.(type) {
 						case *corev1.ServiceAccount:
 							return errors.New("service account should not be deleted during deactivation")

--- a/internal/controller/pkg/revision/runtime_provider_test.go
+++ b/internal/controller/pkg/revision/runtime_provider_test.go
@@ -149,7 +149,7 @@ func TestProviderPreHook(t *testing.T) {
 					},
 				},
 				manifests: &MockManifestBuilder{
-					ServiceFn: func(overrides ...ServiceOverride) *corev1.Service {
+					ServiceFn: func(_ ...ServiceOverride) *corev1.Service {
 						return &corev1.Service{}
 					},
 					TLSClientSecretFn: func() *corev1.Secret {
@@ -160,13 +160,13 @@ func TestProviderPreHook(t *testing.T) {
 					},
 				},
 				client: &test.MockClient{
-					MockGet: func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
+					MockGet: func(_ context.Context, _ client.ObjectKey, _ client.Object) error {
 						return nil
 					},
-					MockPatch: func(ctx context.Context, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+					MockPatch: func(_ context.Context, _ client.Object, _ client.Patch, _ ...client.PatchOption) error {
 						return nil
 					},
-					MockUpdate: func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
+					MockUpdate: func(_ context.Context, _ client.Object, _ ...client.UpdateOption) error {
 						return nil
 					},
 				},
@@ -261,18 +261,18 @@ func TestProviderPostHook(t *testing.T) {
 					},
 				},
 				manifests: &MockManifestBuilder{
-					ServiceAccountFn: func(overrides ...ServiceAccountOverride) *corev1.ServiceAccount {
+					ServiceAccountFn: func(_ ...ServiceAccountOverride) *corev1.ServiceAccount {
 						return &corev1.ServiceAccount{}
 					},
-					DeploymentFn: func(serviceAccount string, overrides ...DeploymentOverride) *appsv1.Deployment {
+					DeploymentFn: func(_ string, _ ...DeploymentOverride) *appsv1.Deployment {
 						return &appsv1.Deployment{}
 					},
 				},
 				client: &test.MockClient{
-					MockGet: func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
+					MockGet: func(_ context.Context, _ client.ObjectKey, _ client.Object) error {
 						return nil
 					},
-					MockPatch: func(ctx context.Context, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+					MockPatch: func(_ context.Context, _ client.Object, _ client.Patch, _ ...client.PatchOption) error {
 						return errBoom
 					},
 				},
@@ -302,18 +302,18 @@ func TestProviderPostHook(t *testing.T) {
 					},
 				},
 				manifests: &MockManifestBuilder{
-					ServiceAccountFn: func(overrides ...ServiceAccountOverride) *corev1.ServiceAccount {
+					ServiceAccountFn: func(_ ...ServiceAccountOverride) *corev1.ServiceAccount {
 						return &corev1.ServiceAccount{}
 					},
-					DeploymentFn: func(serviceAccount string, overrides ...DeploymentOverride) *appsv1.Deployment {
+					DeploymentFn: func(_ string, _ ...DeploymentOverride) *appsv1.Deployment {
 						return &appsv1.Deployment{}
 					},
 				},
 				client: &test.MockClient{
-					MockGet: func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
+					MockGet: func(_ context.Context, _ client.ObjectKey, _ client.Object) error {
 						return nil
 					},
-					MockPatch: func(ctx context.Context, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+					MockPatch: func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) error {
 						if _, ok := obj.(*appsv1.Deployment); ok {
 							return errBoom
 						}
@@ -346,18 +346,18 @@ func TestProviderPostHook(t *testing.T) {
 					},
 				},
 				manifests: &MockManifestBuilder{
-					ServiceAccountFn: func(overrides ...ServiceAccountOverride) *corev1.ServiceAccount {
+					ServiceAccountFn: func(_ ...ServiceAccountOverride) *corev1.ServiceAccount {
 						return &corev1.ServiceAccount{}
 					},
-					DeploymentFn: func(serviceAccount string, overrides ...DeploymentOverride) *appsv1.Deployment {
+					DeploymentFn: func(_ string, _ ...DeploymentOverride) *appsv1.Deployment {
 						return &appsv1.Deployment{}
 					},
 				},
 				client: &test.MockClient{
-					MockGet: func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
+					MockGet: func(_ context.Context, _ client.ObjectKey, _ client.Object) error {
 						return nil
 					},
-					MockPatch: func(ctx context.Context, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+					MockPatch: func(_ context.Context, _ client.Object, _ client.Patch, _ ...client.PatchOption) error {
 						return nil
 					},
 				},
@@ -387,18 +387,18 @@ func TestProviderPostHook(t *testing.T) {
 					},
 				},
 				manifests: &MockManifestBuilder{
-					ServiceAccountFn: func(overrides ...ServiceAccountOverride) *corev1.ServiceAccount {
+					ServiceAccountFn: func(_ ...ServiceAccountOverride) *corev1.ServiceAccount {
 						return &corev1.ServiceAccount{}
 					},
-					DeploymentFn: func(serviceAccount string, overrides ...DeploymentOverride) *appsv1.Deployment {
+					DeploymentFn: func(_ string, _ ...DeploymentOverride) *appsv1.Deployment {
 						return &appsv1.Deployment{}
 					},
 				},
 				client: &test.MockClient{
-					MockGet: func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
+					MockGet: func(_ context.Context, _ client.ObjectKey, _ client.Object) error {
 						return nil
 					},
-					MockPatch: func(ctx context.Context, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+					MockPatch: func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) error {
 						if d, ok := obj.(*appsv1.Deployment); ok {
 							d.Status.Conditions = []appsv1.DeploymentCondition{{
 								Type:    appsv1.DeploymentAvailable,
@@ -436,18 +436,18 @@ func TestProviderPostHook(t *testing.T) {
 					},
 				},
 				manifests: &MockManifestBuilder{
-					ServiceAccountFn: func(overrides ...ServiceAccountOverride) *corev1.ServiceAccount {
+					ServiceAccountFn: func(_ ...ServiceAccountOverride) *corev1.ServiceAccount {
 						return &corev1.ServiceAccount{}
 					},
-					DeploymentFn: func(serviceAccount string, overrides ...DeploymentOverride) *appsv1.Deployment {
+					DeploymentFn: func(_ string, _ ...DeploymentOverride) *appsv1.Deployment {
 						return &appsv1.Deployment{}
 					},
 				},
 				client: &test.MockClient{
-					MockGet: func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
+					MockGet: func(_ context.Context, _ client.ObjectKey, _ client.Object) error {
 						return nil
 					},
-					MockPatch: func(ctx context.Context, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+					MockPatch: func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) error {
 						if d, ok := obj.(*appsv1.Deployment); ok {
 							d.Status.Conditions = []appsv1.DeploymentCondition{{
 								Type:   appsv1.DeploymentAvailable,
@@ -483,14 +483,14 @@ func TestProviderPostHook(t *testing.T) {
 					},
 				},
 				manifests: &MockManifestBuilder{
-					ServiceAccountFn: func(overrides ...ServiceAccountOverride) *corev1.ServiceAccount {
+					ServiceAccountFn: func(_ ...ServiceAccountOverride) *corev1.ServiceAccount {
 						return &corev1.ServiceAccount{
 							ObjectMeta: metav1.ObjectMeta{
 								Name: "xp-managed-sa",
 							},
 						}
 					},
-					DeploymentFn: func(serviceAccount string, overrides ...DeploymentOverride) *appsv1.Deployment {
+					DeploymentFn: func(_ string, _ ...DeploymentOverride) *appsv1.Deployment {
 						return &appsv1.Deployment{
 							Spec: appsv1.DeploymentSpec{
 								Template: corev1.PodTemplateSpec{
@@ -503,7 +503,7 @@ func TestProviderPostHook(t *testing.T) {
 					},
 				},
 				client: &test.MockClient{
-					MockGet: func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
+					MockGet: func(_ context.Context, _ client.ObjectKey, obj client.Object) error {
 						if sa, ok := obj.(*corev1.ServiceAccount); ok {
 							if sa.GetName() == "xp-managed-sa" {
 								return kerrors.NewNotFound(corev1.Resource("serviceaccount"), "xp-managed-sa")
@@ -511,7 +511,7 @@ func TestProviderPostHook(t *testing.T) {
 						}
 						return nil
 					},
-					MockCreate: func(ctx context.Context, obj client.Object, opts ...client.CreateOption) error {
+					MockCreate: func(_ context.Context, obj client.Object, _ ...client.CreateOption) error {
 						if sa, ok := obj.(*corev1.ServiceAccount); ok {
 							if sa.GetName() == "xp-managed-sa" {
 								t.Error("unexpected call to create SA when SA is managed externally")
@@ -519,7 +519,7 @@ func TestProviderPostHook(t *testing.T) {
 						}
 						return nil
 					},
-					MockPatch: func(ctx context.Context, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+					MockPatch: func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) error {
 						if d, ok := obj.(*appsv1.Deployment); ok {
 							d.Status.Conditions = []appsv1.DeploymentCondition{{
 								Type:   appsv1.DeploymentAvailable,
@@ -585,15 +585,15 @@ func TestProviderDeactivateHook(t *testing.T) {
 			reason: "Should return error if we fail to delete deployment.",
 			args: args{
 				manifests: &MockManifestBuilder{
-					ServiceAccountFn: func(overrides ...ServiceAccountOverride) *corev1.ServiceAccount {
+					ServiceAccountFn: func(_ ...ServiceAccountOverride) *corev1.ServiceAccount {
 						return &corev1.ServiceAccount{}
 					},
-					DeploymentFn: func(serviceAccount string, overrides ...DeploymentOverride) *appsv1.Deployment {
+					DeploymentFn: func(_ string, _ ...DeploymentOverride) *appsv1.Deployment {
 						return &appsv1.Deployment{}
 					},
 				},
 				client: &test.MockClient{
-					MockDelete: func(ctx context.Context, obj client.Object, opts ...client.DeleteOption) error {
+					MockDelete: func(_ context.Context, obj client.Object, _ ...client.DeleteOption) error {
 						if _, ok := obj.(*appsv1.Deployment); ok {
 							return errBoom
 						}
@@ -614,14 +614,14 @@ func TestProviderDeactivateHook(t *testing.T) {
 					},
 				},
 				manifests: &MockManifestBuilder{
-					ServiceAccountFn: func(overrides ...ServiceAccountOverride) *corev1.ServiceAccount {
+					ServiceAccountFn: func(_ ...ServiceAccountOverride) *corev1.ServiceAccount {
 						return &corev1.ServiceAccount{
 							ObjectMeta: metav1.ObjectMeta{
 								Name: "some-sa",
 							},
 						}
 					},
-					DeploymentFn: func(serviceAccount string, overrides ...DeploymentOverride) *appsv1.Deployment {
+					DeploymentFn: func(_ string, _ ...DeploymentOverride) *appsv1.Deployment {
 						return &appsv1.Deployment{
 							ObjectMeta: metav1.ObjectMeta{
 								Name: "some-deployment",
@@ -641,7 +641,7 @@ func TestProviderDeactivateHook(t *testing.T) {
 					},
 				},
 				client: &test.MockClient{
-					MockDelete: func(ctx context.Context, obj client.Object, opts ...client.DeleteOption) error {
+					MockDelete: func(_ context.Context, obj client.Object, _ ...client.DeleteOption) error {
 						switch obj.(type) {
 						case *corev1.ServiceAccount:
 							return errors.New("service account should not be deleted during deactivation")

--- a/internal/controller/rbac/definition/reconciler_test.go
+++ b/internal/controller/rbac/definition/reconciler_test.go
@@ -143,7 +143,7 @@ func TestReconcile(t *testing.T) {
 						Client: &test.MockClient{
 							MockGet: test.NewMockGetFn(nil),
 						},
-						Applicator: resource.ApplyFn(func(ctx context.Context, o client.Object, ao ...resource.ApplyOption) error {
+						Applicator: resource.ApplyFn(func(ctx context.Context, o client.Object, _ ...resource.ApplyOption) error {
 							// Simulate a no-op change by not allowing the update.
 							return resource.AllowUpdateIf(func(_, _ runtime.Object) bool { return false })(ctx, o, o)
 						}),

--- a/internal/controller/rbac/namespace/fuzz_test.go
+++ b/internal/controller/rbac/namespace/fuzz_test.go
@@ -25,7 +25,7 @@ import (
 )
 
 func FuzzRenderRoles(f *testing.F) {
-	f.Fuzz(func(t *testing.T, data []byte) {
+	f.Fuzz(func(_ *testing.T, data []byte) {
 		ff := fuzz.NewConsumer(data)
 		ns := &corev1.Namespace{}
 		ff.GenerateStruct(ns)

--- a/internal/controller/rbac/namespace/reconciler_test.go
+++ b/internal/controller/rbac/namespace/reconciler_test.go
@@ -161,7 +161,7 @@ func TestReconcile(t *testing.T) {
 							MockGet:  test.NewMockGetFn(nil),
 							MockList: test.NewMockListFn(nil),
 						},
-						Applicator: resource.ApplyFn(func(ctx context.Context, o client.Object, ao ...resource.ApplyOption) error {
+						Applicator: resource.ApplyFn(func(ctx context.Context, o client.Object, _ ...resource.ApplyOption) error {
 							// Simulate a no-op change by not allowing the update.
 							return resource.AllowUpdateIf(func(_, _ runtime.Object) bool { return false })(ctx, o, o)
 						}),

--- a/internal/controller/rbac/provider/roles/fuzz_test.go
+++ b/internal/controller/rbac/provider/roles/fuzz_test.go
@@ -25,7 +25,7 @@ import (
 )
 
 func FuzzRenderClusterRoles(f *testing.F) {
-	f.Fuzz(func(t *testing.T, data []byte) {
+	f.Fuzz(func(_ *testing.T, data []byte) {
 		ff := fuzz.NewConsumer(data)
 		pr := &v1.ProviderRevision{}
 		ff.GenerateStruct(pr)

--- a/internal/controller/rbac/provider/roles/reconciler_test.go
+++ b/internal/controller/rbac/provider/roles/reconciler_test.go
@@ -152,7 +152,7 @@ func TestReconcile(t *testing.T) {
 							MockList: test.NewMockListFn(nil),
 						},
 					}),
-					WithPermissionRequestsValidator(PermissionRequestsValidatorFn(func(ctx context.Context, requested ...rbacv1.PolicyRule) ([]Rule, error) {
+					WithPermissionRequestsValidator(PermissionRequestsValidatorFn(func(_ context.Context, _ ...rbacv1.PolicyRule) ([]Rule, error) {
 						return nil, errBoom
 					})),
 				},
@@ -172,7 +172,7 @@ func TestReconcile(t *testing.T) {
 							MockList: test.NewMockListFn(nil),
 						},
 					}),
-					WithPermissionRequestsValidator(PermissionRequestsValidatorFn(func(ctx context.Context, requested ...rbacv1.PolicyRule) ([]Rule, error) {
+					WithPermissionRequestsValidator(PermissionRequestsValidatorFn(func(_ context.Context, _ ...rbacv1.PolicyRule) ([]Rule, error) {
 						return []Rule{{}}, nil
 					})),
 				},
@@ -214,7 +214,7 @@ func TestReconcile(t *testing.T) {
 							MockGet:  test.NewMockGetFn(nil),
 							MockList: test.NewMockListFn(nil),
 						},
-						Applicator: resource.ApplyFn(func(ctx context.Context, o client.Object, ao ...resource.ApplyOption) error {
+						Applicator: resource.ApplyFn(func(ctx context.Context, o client.Object, _ ...resource.ApplyOption) error {
 							// Simulate a no-op change by not allowing the update.
 							return resource.AllowUpdateIf(func(_, _ runtime.Object) bool { return false })(ctx, o, o)
 						}),

--- a/internal/dag/fuzz_test.go
+++ b/internal/dag/fuzz_test.go
@@ -67,7 +67,7 @@ func (s *SimpleFuzzNode) Neighbors() []Node {
 }
 
 func FuzzDag(f *testing.F) {
-	f.Fuzz(func(t *testing.T, data []byte) {
+	f.Fuzz(func(_ *testing.T, data []byte) {
 		c := fuzz.NewConsumer(data)
 		nodes := make([]SimpleFuzzNode, 0)
 		err := c.CreateSlice(&nodes)

--- a/internal/initializer/deployment_runtime_config_test.go
+++ b/internal/initializer/deployment_runtime_config_test.go
@@ -43,7 +43,7 @@ func TestDeploymentRuntimeConfigObject(t *testing.T) {
 		"FailedToCreate": {
 			args: args{
 				kube: &test.MockClient{
-					MockCreate: func(ctx context.Context, obj client.Object, opts ...client.CreateOption) error {
+					MockCreate: func(_ context.Context, _ client.Object, _ ...client.CreateOption) error {
 						return errBoom
 					},
 				},
@@ -55,7 +55,7 @@ func TestDeploymentRuntimeConfigObject(t *testing.T) {
 		"SuccessCreated": {
 			args: args{
 				kube: &test.MockClient{
-					MockCreate: func(ctx context.Context, obj client.Object, opts ...client.CreateOption) error {
+					MockCreate: func(_ context.Context, _ client.Object, _ ...client.CreateOption) error {
 						return nil
 					},
 				},
@@ -64,7 +64,7 @@ func TestDeploymentRuntimeConfigObject(t *testing.T) {
 		"SuccessAlreadyExists": {
 			args: args{
 				kube: &test.MockClient{
-					MockCreate: func(ctx context.Context, obj client.Object, opts ...client.CreateOption) error {
+					MockCreate: func(_ context.Context, _ client.Object, _ ...client.CreateOption) error {
 						return kerrors.NewAlreadyExists(schema.GroupResource{}, "default")
 					},
 				},

--- a/internal/initializer/installer_test.go
+++ b/internal/initializer/installer_test.go
@@ -226,7 +226,7 @@ func TestInstaller(t *testing.T) {
 				p: []string{p1},
 				c: []string{c1},
 				kube: &test.MockClient{
-					MockList: func(_ context.Context, list client.ObjectList, _ ...client.ListOption) error {
+					MockList: func(_ context.Context, _ client.ObjectList, _ ...client.ListOption) error {
 						return nil
 					},
 					MockGet: func(_ context.Context, key client.ObjectKey, obj client.Object) error {
@@ -244,7 +244,7 @@ func TestInstaller(t *testing.T) {
 						}
 						return kerrors.NewNotFound(schema.GroupResource{}, key.Name)
 					},
-					MockCreate: func(_ context.Context, obj client.Object, _ ...client.CreateOption) error {
+					MockCreate: func(_ context.Context, _ client.Object, _ ...client.CreateOption) error {
 						return nil
 					},
 				},
@@ -304,7 +304,7 @@ func TestInstaller(t *testing.T) {
 						}
 						return kerrors.NewNotFound(schema.GroupResource{}, key.Name)
 					},
-					MockCreate: func(_ context.Context, obj client.Object, _ ...client.CreateOption) error {
+					MockCreate: func(_ context.Context, _ client.Object, _ ...client.CreateOption) error {
 						return nil
 					},
 				},
@@ -316,7 +316,7 @@ func TestInstaller(t *testing.T) {
 			args: args{
 				c: []string{c1},
 				kube: &test.MockClient{
-					MockList: func(_ context.Context, list client.ObjectList, _ ...client.ListOption) error {
+					MockList: func(_ context.Context, _ client.ObjectList, _ ...client.ListOption) error {
 						return nil
 					},
 					MockGet: func(_ context.Context, key client.ObjectKey, obj client.Object) error {
@@ -332,7 +332,7 @@ func TestInstaller(t *testing.T) {
 						}
 						return kerrors.NewNotFound(schema.GroupResource{}, key.Name)
 					},
-					MockCreate: func(_ context.Context, obj client.Object, _ ...client.CreateOption) error {
+					MockCreate: func(_ context.Context, _ client.Object, _ ...client.CreateOption) error {
 						return nil
 					},
 				},
@@ -343,10 +343,10 @@ func TestInstaller(t *testing.T) {
 				p: []string{p1},
 				c: []string{c1},
 				kube: &test.MockClient{
-					MockList: func(_ context.Context, list client.ObjectList, _ ...client.ListOption) error {
+					MockList: func(_ context.Context, _ client.ObjectList, _ ...client.ListOption) error {
 						return nil
 					},
-					MockGet: func(_ context.Context, key client.ObjectKey, obj client.Object) error {
+					MockGet: func(_ context.Context, _ client.ObjectKey, _ client.Object) error {
 						return errBoom
 					},
 				},

--- a/internal/initializer/lock_test.go
+++ b/internal/initializer/lock_test.go
@@ -53,7 +53,7 @@ func TestLockObject(t *testing.T) {
 		"FailApply": {
 			args: args{
 				kube: &test.MockClient{
-					MockGet: func(_ context.Context, key client.ObjectKey, obj client.Object) error {
+					MockGet: func(_ context.Context, _ client.ObjectKey, _ client.Object) error {
 						return errBoom
 					},
 				},

--- a/internal/initializer/store_config_test.go
+++ b/internal/initializer/store_config_test.go
@@ -43,7 +43,7 @@ func TestStoreConfigObject(t *testing.T) {
 		"FailedToCreate": {
 			args: args{
 				kube: &test.MockClient{
-					MockCreate: func(ctx context.Context, obj client.Object, opts ...client.CreateOption) error {
+					MockCreate: func(_ context.Context, _ client.Object, _ ...client.CreateOption) error {
 						return errBoom
 					},
 				},
@@ -55,7 +55,7 @@ func TestStoreConfigObject(t *testing.T) {
 		"SuccessCreated": {
 			args: args{
 				kube: &test.MockClient{
-					MockCreate: func(ctx context.Context, obj client.Object, opts ...client.CreateOption) error {
+					MockCreate: func(_ context.Context, _ client.Object, _ ...client.CreateOption) error {
 						return nil
 					},
 				},
@@ -64,7 +64,7 @@ func TestStoreConfigObject(t *testing.T) {
 		"SuccessAlreadyExists": {
 			args: args{
 				kube: &test.MockClient{
-					MockCreate: func(ctx context.Context, obj client.Object, opts ...client.CreateOption) error {
+					MockCreate: func(_ context.Context, _ client.Object, _ ...client.CreateOption) error {
 						return kerrors.NewAlreadyExists(schema.GroupResource{}, "default")
 					},
 				},

--- a/internal/initializer/tls_test.go
+++ b/internal/initializer/tls_test.go
@@ -108,7 +108,7 @@ func TestTLSCertificateGeneratorRun(t *testing.T) {
 			reason: "It should return error if the CA secret cannot be retrieved.",
 			args: args{
 				kube: &test.MockClient{
-					MockGet: func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
+					MockGet: func(_ context.Context, key client.ObjectKey, _ client.Object) error {
 						if key.Name != caCertSecretName || key.Namespace != secretNS {
 							return errors.New("unexpected secret name or namespace")
 						}
@@ -129,7 +129,7 @@ func TestTLSCertificateGeneratorRun(t *testing.T) {
 			reason: "It should return error if the CA secret cannot be updated.",
 			args: args{
 				kube: &test.MockClient{
-					MockGet: func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
+					MockGet: func(_ context.Context, key client.ObjectKey, obj client.Object) error {
 						if key.Name != caCertSecretName || key.Namespace != secretNS {
 							return errors.New("unexpected secret name or namespace")
 						}
@@ -161,7 +161,7 @@ func TestTLSCertificateGeneratorRun(t *testing.T) {
 			reason: "It should return no error after loading the CA from the Secret.",
 			args: args{
 				kube: &test.MockClient{
-					MockGet: func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
+					MockGet: func(_ context.Context, key client.ObjectKey, obj client.Object) error {
 						if key.Name != caCertSecretName {
 							return nil
 						}
@@ -177,7 +177,7 @@ func TestTLSCertificateGeneratorRun(t *testing.T) {
 					MockUpdate: test.NewMockUpdateFn(nil),
 				},
 				certificate: &MockCertificateGenerator{
-					MockGenerate: func(cert *x509.Certificate, signer *CertificateSigner) ([]byte, []byte, error) {
+					MockGenerate: func(_ *x509.Certificate, _ *CertificateSigner) ([]byte, []byte, error) {
 						return []byte("test-key"), []byte("test-cert"), nil
 					},
 				},
@@ -191,7 +191,7 @@ func TestTLSCertificateGeneratorRun(t *testing.T) {
 			reason: "It should return error if the CA secret cannot be parsed.",
 			args: args{
 				kube: &test.MockClient{
-					MockGet: func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
+					MockGet: func(_ context.Context, key client.ObjectKey, obj client.Object) error {
 						if key.Name != caCertSecretName || key.Namespace != secretNS {
 							return errors.New("unexpected secret name or namespace")
 						}
@@ -228,7 +228,7 @@ func TestTLSCertificateGeneratorRun(t *testing.T) {
 			reason: "It should return error if the server secret cannot be retrieved.",
 			args: args{
 				kube: &test.MockClient{
-					MockGet: func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
+					MockGet: func(_ context.Context, key client.ObjectKey, obj client.Object) error {
 						if key.Name == caCertSecretName && key.Namespace == secretNS {
 							s := &corev1.Secret{
 								Data: map[string][]byte{
@@ -260,7 +260,7 @@ func TestTLSCertificateGeneratorRun(t *testing.T) {
 			reason: "It should return error if the client secret cannot be retrieved.",
 			args: args{
 				kube: &test.MockClient{
-					MockGet: func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
+					MockGet: func(_ context.Context, key client.ObjectKey, obj client.Object) error {
 						if key.Name == caCertSecretName && key.Namespace == secretNS {
 							s := &corev1.Secret{
 								Data: map[string][]byte{
@@ -301,7 +301,7 @@ func TestTLSCertificateGeneratorRun(t *testing.T) {
 			reason: "It should be successful if the CA and TLS certificates are generated and put into the Secret.",
 			args: args{
 				kube: &test.MockClient{
-					MockGet: func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
+					MockGet: func(_ context.Context, key client.ObjectKey, obj client.Object) error {
 						if key.Name == caCertSecretName && key.Namespace == secretNS {
 							s := &corev1.Secret{
 								Data: map[string][]byte{
@@ -337,7 +337,7 @@ func TestTLSCertificateGeneratorRun(t *testing.T) {
 
 						return errors.New("unexpected secret name or namespace")
 					},
-					MockUpdate: func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
+					MockUpdate: func(_ context.Context, obj client.Object, _ ...client.UpdateOption) error {
 						if obj.GetName() == tlsServerSecretName && obj.GetNamespace() == secretNS {
 							s := &corev1.Secret{
 								Data: map[string][]byte{
@@ -366,7 +366,7 @@ func TestTLSCertificateGeneratorRun(t *testing.T) {
 					},
 				},
 				certificate: &MockCertificateGenerator{
-					MockGenerate: func(cert *x509.Certificate, signer *CertificateSigner) ([]byte, []byte, error) {
+					MockGenerate: func(_ *x509.Certificate, _ *CertificateSigner) ([]byte, []byte, error) {
 						return []byte(caKey), []byte(caCert), nil
 					},
 				},
@@ -380,7 +380,7 @@ func TestTLSCertificateGeneratorRun(t *testing.T) {
 			reason: "It should be successful if the CA and TLS certificates are already in the Secret.",
 			args: args{
 				kube: &test.MockClient{
-					MockGet: func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
+					MockGet: func(_ context.Context, key client.ObjectKey, obj client.Object) error {
 						if key.Name == caCertSecretName && key.Namespace == secretNS {
 							s := &corev1.Secret{
 								Data: map[string][]byte{
@@ -428,7 +428,7 @@ func TestTLSCertificateGeneratorRun(t *testing.T) {
 					MockGet: test.NewMockGetFn(nil),
 				},
 				certificate: &MockCertificateGenerator{
-					MockGenerate: func(cert *x509.Certificate, signer *CertificateSigner) ([]byte, []byte, error) {
+					MockGenerate: func(_ *x509.Certificate, _ *CertificateSigner) ([]byte, []byte, error) {
 						return nil, nil, errBoom
 					},
 				},
@@ -445,7 +445,7 @@ func TestTLSCertificateGeneratorRun(t *testing.T) {
 			reason: "It should return error if the CA and TLS certificates cannot be generated.",
 			args: args{
 				kube: &test.MockClient{
-					MockGet: func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
+					MockGet: func(_ context.Context, key client.ObjectKey, obj client.Object) error {
 						if key.Name == caCertSecretName && key.Namespace == secretNS {
 							s := &corev1.Secret{
 								Data: map[string][]byte{
@@ -460,7 +460,7 @@ func TestTLSCertificateGeneratorRun(t *testing.T) {
 					},
 				},
 				certificate: &MockCertificateGenerator{
-					MockGenerate: func(cert *x509.Certificate, signer *CertificateSigner) ([]byte, []byte, error) {
+					MockGenerate: func(_ *x509.Certificate, _ *CertificateSigner) ([]byte, []byte, error) {
 						return nil, nil, errBoom
 					},
 				},
@@ -479,7 +479,7 @@ func TestTLSCertificateGeneratorRun(t *testing.T) {
 			reason: "It should return error if the CA secret cannot be retrieved.",
 			args: args{
 				kube: &test.MockClient{
-					MockGet: func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
+					MockGet: func(_ context.Context, key client.ObjectKey, _ client.Object) error {
 						if key.Name != caCertSecretName || key.Namespace != secretNS {
 							return errors.New("unexpected secret name or namespace")
 						}
@@ -499,7 +499,7 @@ func TestTLSCertificateGeneratorRun(t *testing.T) {
 			reason: "It should return error if the server secret cannot be retrieved.",
 			args: args{
 				kube: &test.MockClient{
-					MockGet: func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
+					MockGet: func(_ context.Context, key client.ObjectKey, obj client.Object) error {
 						if key.Name == caCertSecretName && key.Namespace == secretNS {
 							s := &corev1.Secret{
 								Data: map[string][]byte{
@@ -530,7 +530,7 @@ func TestTLSCertificateGeneratorRun(t *testing.T) {
 			reason: "It should be successful if the server certificates are already in the Secret.",
 			args: args{
 				kube: &test.MockClient{
-					MockGet: func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
+					MockGet: func(_ context.Context, key client.ObjectKey, obj client.Object) error {
 						if key.Name == caCertSecretName && key.Namespace == secretNS {
 							s := &corev1.Secret{
 								Data: map[string][]byte{
@@ -567,7 +567,7 @@ func TestTLSCertificateGeneratorRun(t *testing.T) {
 			args: args{
 
 				kube: &test.MockClient{
-					MockGet: func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
+					MockGet: func(_ context.Context, key client.ObjectKey, obj client.Object) error {
 						if key.Name == caCertSecretName && key.Namespace == secretNS {
 							s := &corev1.Secret{
 								Data: map[string][]byte{
@@ -592,7 +592,7 @@ func TestTLSCertificateGeneratorRun(t *testing.T) {
 
 						return errors.New("unexpected secret name or namespace")
 					},
-					MockUpdate: func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
+					MockUpdate: func(_ context.Context, obj client.Object, _ ...client.UpdateOption) error {
 						if obj.GetName() == tlsServerSecretName && obj.GetNamespace() == secretNS {
 							s := &corev1.Secret{
 								Data: map[string][]byte{
@@ -609,7 +609,7 @@ func TestTLSCertificateGeneratorRun(t *testing.T) {
 				},
 
 				certificate: &MockCertificateGenerator{
-					MockGenerate: func(cert *x509.Certificate, signer *CertificateSigner) ([]byte, []byte, error) {
+					MockGenerate: func(_ *x509.Certificate, _ *CertificateSigner) ([]byte, []byte, error) {
 						return []byte(caKey), []byte(caCert), nil
 					},
 				},
@@ -623,7 +623,7 @@ func TestTLSCertificateGeneratorRun(t *testing.T) {
 			reason: "It should return error if the CA secret cannot be retrieved.",
 			args: args{
 				kube: &test.MockClient{
-					MockGet: func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
+					MockGet: func(_ context.Context, key client.ObjectKey, _ client.Object) error {
 						if key.Name != caCertSecretName || key.Namespace != secretNS {
 							return errors.New("unexpected secret name or namespace")
 						}
@@ -643,7 +643,7 @@ func TestTLSCertificateGeneratorRun(t *testing.T) {
 			reason: "It should return error if the client secret cannot be retrieved.",
 			args: args{
 				kube: &test.MockClient{
-					MockGet: func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
+					MockGet: func(_ context.Context, key client.ObjectKey, obj client.Object) error {
 						if key.Name == caCertSecretName && key.Namespace == secretNS {
 							s := &corev1.Secret{
 								Data: map[string][]byte{
@@ -674,7 +674,7 @@ func TestTLSCertificateGeneratorRun(t *testing.T) {
 			reason: "It should be successful if the client certificates are already in the Secret.",
 			args: args{
 				kube: &test.MockClient{
-					MockGet: func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
+					MockGet: func(_ context.Context, key client.ObjectKey, obj client.Object) error {
 						if key.Name == caCertSecretName && key.Namespace == secretNS {
 							s := &corev1.Secret{
 								Data: map[string][]byte{
@@ -711,7 +711,7 @@ func TestTLSCertificateGeneratorRun(t *testing.T) {
 			args: args{
 
 				kube: &test.MockClient{
-					MockGet: func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
+					MockGet: func(_ context.Context, key client.ObjectKey, obj client.Object) error {
 						if key.Name == caCertSecretName && key.Namespace == secretNS {
 							s := &corev1.Secret{
 								Data: map[string][]byte{
@@ -736,7 +736,7 @@ func TestTLSCertificateGeneratorRun(t *testing.T) {
 
 						return errors.New("unexpected secret name or namespace")
 					},
-					MockUpdate: func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
+					MockUpdate: func(_ context.Context, obj client.Object, _ ...client.UpdateOption) error {
 						if obj.GetName() == tlsClientSecretName && obj.GetNamespace() == secretNS {
 							s := &corev1.Secret{
 								Data: map[string][]byte{
@@ -753,7 +753,7 @@ func TestTLSCertificateGeneratorRun(t *testing.T) {
 				},
 
 				certificate: &MockCertificateGenerator{
-					MockGenerate: func(cert *x509.Certificate, signer *CertificateSigner) ([]byte, []byte, error) {
+					MockGenerate: func(_ *x509.Certificate, _ *CertificateSigner) ([]byte, []byte, error) {
 						return []byte(caKey), []byte(caCert), nil
 					},
 				},

--- a/internal/initializer/waiter_test.go
+++ b/internal/initializer/waiter_test.go
@@ -51,7 +51,7 @@ func TestCRDWaiter(t *testing.T) {
 				period:  1 * time.Second,
 				timeout: 2 * time.Second,
 				kube: &test.MockClient{
-					MockGet: func(_ context.Context, key client.ObjectKey, obj client.Object) error {
+					MockGet: func(_ context.Context, _ client.ObjectKey, _ client.Object) error {
 						return nil
 					},
 				},
@@ -63,7 +63,7 @@ func TestCRDWaiter(t *testing.T) {
 				timeout: 2 * time.Millisecond,
 				period:  1 * time.Millisecond,
 				kube: &test.MockClient{
-					MockGet: func(_ context.Context, key client.ObjectKey, obj client.Object) error {
+					MockGet: func(_ context.Context, key client.ObjectKey, _ client.Object) error {
 						return kerrors.NewNotFound(schema.GroupResource{}, key.Name)
 					},
 				},
@@ -78,7 +78,7 @@ func TestCRDWaiter(t *testing.T) {
 				period:  1 * time.Millisecond,
 				timeout: 1 * time.Second,
 				kube: &test.MockClient{
-					MockGet: func(_ context.Context, key client.ObjectKey, obj client.Object) error {
+					MockGet: func(_ context.Context, _ client.ObjectKey, _ client.Object) error {
 						return errBoom
 					},
 				},

--- a/internal/names/generate_test.go
+++ b/internal/names/generate_test.go
@@ -110,7 +110,7 @@ func TestGenerateName(t *testing.T) {
 		},
 		"SuccessAfterConflict": {
 			reason: "Name is found on second try",
-			client: &test.MockClient{MockGet: func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
+			client: &test.MockClient{MockGet: func(_ context.Context, key client.ObjectKey, _ client.Object) error {
 				if key.Name == "cool-resource-42" {
 					return nil
 				}

--- a/internal/usage/handler_test.go
+++ b/internal/usage/handler_test.go
@@ -122,7 +122,7 @@ func TestHandle(t *testing.T) {
 			reason: "We should allow a delete request if there is no usages for the given object.",
 			args: args{
 				reader: &test.MockClient{
-					MockList: func(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
+					MockList: func(_ context.Context, _ client.ObjectList, _ ...client.ListOption) error {
 						return nil
 					},
 				},
@@ -148,7 +148,7 @@ func TestHandle(t *testing.T) {
 			reason: "We should reject a delete request if we cannot list usages.",
 			args: args{
 				reader: &test.MockClient{
-					MockList: func(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
+					MockList: func(_ context.Context, _ client.ObjectList, _ ...client.ListOption) error {
 						return errBoom
 					},
 				},
@@ -174,7 +174,7 @@ func TestHandle(t *testing.T) {
 			reason: "We should reject a delete request if there are usages for the given object with \"by\" defined.",
 			args: args{
 				reader: &test.MockClient{
-					MockList: func(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
+					MockList: func(_ context.Context, list client.ObjectList, _ ...client.ListOption) error {
 						l := list.(*v1alpha1.UsageList)
 						l.Items = []v1alpha1.Usage{
 							{
@@ -232,7 +232,7 @@ func TestHandle(t *testing.T) {
 			reason: "We should reject a delete request if there are usages for the given object with \"reason\" defined.",
 			args: args{
 				reader: &test.MockClient{
-					MockList: func(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
+					MockList: func(_ context.Context, list client.ObjectList, _ ...client.ListOption) error {
 						l := list.(*v1alpha1.UsageList)
 						l.Items = []v1alpha1.Usage{
 							{
@@ -284,7 +284,7 @@ func TestHandle(t *testing.T) {
 			reason: "We should reject a delete request if there are usages for the given object without \"reason\" or \"by\" defined.",
 			args: args{
 				reader: &test.MockClient{
-					MockList: func(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
+					MockList: func(_ context.Context, list client.ObjectList, _ ...client.ListOption) error {
 						l := list.(*v1alpha1.UsageList)
 						l.Items = []v1alpha1.Usage{
 							{

--- a/internal/xcrd/fuzz_test.go
+++ b/internal/xcrd/fuzz_test.go
@@ -25,7 +25,7 @@ import (
 )
 
 func FuzzForCompositeResourceXcrd(f *testing.F) {
-	f.Fuzz(func(t *testing.T, data []byte) {
+	f.Fuzz(func(_ *testing.T, data []byte) {
 		ff := fuzz.NewConsumer(data)
 		xrd := &v1.CompositeResourceDefinition{}
 		err := ff.GenerateStruct(xrd)
@@ -37,7 +37,7 @@ func FuzzForCompositeResourceXcrd(f *testing.F) {
 }
 
 func FuzzForCompositeResourceClaim(f *testing.F) {
-	f.Fuzz(func(t *testing.T, data []byte) {
+	f.Fuzz(func(_ *testing.T, data []byte) {
 		ff := fuzz.NewConsumer(data)
 		xrd := &v1.CompositeResourceDefinition{}
 		err := ff.GenerateStruct(xrd)

--- a/internal/xpkg/build.go
+++ b/internal/xpkg/build.go
@@ -252,7 +252,7 @@ func encode(pkg parser.Lintable) (*bytes.Buffer, error) {
 
 // SkipContains supplies a FilterFn that skips paths that contain the give pattern.
 func SkipContains(pattern string) parser.FilterFn {
-	return func(path string, info os.FileInfo) (bool, error) {
+	return func(path string, _ os.FileInfo) (bool, error) {
 		return strings.Contains(path, pattern), nil
 	}
 }

--- a/internal/xpkg/fake/mocks.go
+++ b/internal/xpkg/fake/mocks.go
@@ -49,7 +49,7 @@ func NewMockCacheGetFn(rc io.ReadCloser, err error) func() (io.ReadCloser, error
 
 // NewMockCacheStoreFn creates a new MockStore function for MockCache.
 func NewMockCacheStoreFn(err error) func(s string, rc io.ReadCloser) error {
-	return func(s string, rc io.ReadCloser) error { return err }
+	return func(_ string, _ io.ReadCloser) error { return err }
 }
 
 // NewMockCacheDeleteFn creates a new MockDelete function for MockCache.

--- a/internal/xpkg/upbound/resolver.go
+++ b/internal/xpkg/upbound/resolver.go
@@ -39,7 +39,7 @@ func JSON(base, overlay io.Reader) (kong.Resolver, error) {
 		return nil, err
 	}
 
-	var f kong.ResolverFunc = func(context *kong.Context, parent *kong.Path, flag *kong.Flag) (interface{}, error) {
+	var f kong.ResolverFunc = func(_ *kong.Context, _ *kong.Path, flag *kong.Flag) (interface{}, error) {
 		name := strings.ReplaceAll(flag.Name, "-", "_")
 		bRaw, bOk := resolveValue(name, flag.Envs, baseValues)
 		oRaw, oOk := resolveValue(name, flag.Envs, overlayValues)

--- a/test/e2e/funcs/env.go
+++ b/test/e2e/funcs/env.go
@@ -119,7 +119,7 @@ func EnvFuncs(fns ...env.Func) env.Func {
 func CreateKindClusterWithConfig(clusterName, configFilePath string) env.Func {
 	return EnvFuncs(
 		envfuncs.CreateClusterWithConfig(kind.NewProvider(), clusterName, configFilePath),
-		func(ctx context.Context, config *envconf.Config) (context.Context, error) {
+		func(ctx context.Context, _ *envconf.Config) (context.Context, error) {
 			b, err := os.ReadFile(filepath.Clean(configFilePath))
 			if err != nil {
 				return ctx, err

--- a/test/e2e/funcs/feature.go
+++ b/test/e2e/funcs/feature.go
@@ -157,7 +157,7 @@ func ResourceCreatedWithin(d time.Duration, o k8s.Object) features.Func {
 		t.Logf("Waiting %s for %s to be created...", d, identifier(o))
 
 		start := time.Now()
-		if err := wait.For(conditions.New(c.Client().Resources()).ResourceMatch(o, func(object k8s.Object) bool { return true }), wait.WithTimeout(d), wait.WithInterval(DefaultPollInterval)); err != nil {
+		if err := wait.For(conditions.New(c.Client().Resources()).ResourceMatch(o, func(_ k8s.Object) bool { return true }), wait.WithTimeout(d), wait.WithInterval(DefaultPollInterval)); err != nil {
 			t.Errorf("resource %s did not exist: %v", identifier(o), err)
 			return ctx
 		}


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane! Please read the contribution docs
(linked below) if this is your first Crossplane pull request.
-->

### Description of your changes

<!--
Briefly describe what this pull request does, and how it is covered by tests.
Be proactive - direct your reviewers' attention to anything that needs special
consideration.

We love pull requests that fix an open issue. If yours does, use the below line
to indicate which issue it fixes, for example "Fixes #500".
-->

Closes https://github.com/crossplane/crossplane/pull/5358

Most of this diff is just renaming unused arguments to `_`. I don't think there's much need to review anything other than `Makefile` and `ci.yaml`.

I believe golint used to enforce this. It was then abandoned, and we ended up with a mix of using _ and not using it. The revive linter now catches this, so we can be consistent.


I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added or updated unit tests.
- [x] Added or updated e2e tests.
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/master/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/master/contributing#checklist-cheat-sheet
