### PR TITLE
WIP: Fix several issues in realtime-compositions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -246,6 +246,7 @@ jobs:
           - environment-configs
           - usage
           - ssa-claims
+          - realtime-compositions
 
     steps:
       - name: Setup QEMU

--- a/internal/controller/apiextensions/definition/composed.go
+++ b/internal/controller/apiextensions/definition/composed.go
@@ -70,7 +70,9 @@ type composedResourceInformers struct {
 	// composites referencing a certain composed resource GVK. If no composite
 	// is left doing so, a composed resource informer is stopped.
 	xrCaches map[schema.GroupVersionKind]cache.Cache
-	sinks    map[string]func(ev runtimeevent.UpdateEvent) // by some uid
+	// xrCachesSynced holds the composite resource informers sync state.
+	xrCachesSynced map[schema.GroupVersionKind]bool
+	sinks          map[string]func(ev runtimeevent.UpdateEvent) // by some uid
 }
 
 type cdCache struct {
@@ -113,23 +115,51 @@ func (i *composedResourceInformers) Start(ctx context.Context, h handler.EventHa
 
 // RegisterComposite registers a composite resource cache with its GVK.
 // Instances of this GVK will be considered to keep composed resource informers
-// alive.
-func (i *composedResourceInformers) RegisterComposite(gvk schema.GroupVersionKind, ca cache.Cache) {
+// alive as soon as the cache syncs. This method does not block.
+func (i *composedResourceInformers) RegisterComposite(gvk schema.GroupVersionKind, xrCache cache.Cache) {
+	i.log.Debug("Registering composite resource cache. Waiting for sync", "gvk", gvk.String())
+
 	i.lock.Lock()
 	defer i.lock.Unlock()
+
+	startAt := time.Now()
 
 	if i.xrCaches == nil {
 		i.xrCaches = make(map[schema.GroupVersionKind]cache.Cache)
 	}
-	i.xrCaches[gvk] = ca
+	i.xrCaches[gvk] = xrCache
+	if i.xrCachesSynced[gvk] {
+		i.log.Debug("Unmatched RegisterComposite call. Should be unregistred first", "gvk", gvk.String())
+		delete(i.xrCachesSynced, gvk)
+	}
+
+	// Asynchronously mark the cache as synced. We won't list XRs before this
+	// happens. We delay composite informer deletion by at least
+	// minTimeToKeepAlive such that there is time to sync.
+	go func() {
+		if xrCache.WaitForCacheSync(context.Background()) {
+			i.lock.Lock()
+			defer i.lock.Unlock()
+			if ca, ok := i.xrCaches[gvk]; ok && ca == xrCache {
+				i.log.Debug("Composite resource cache seen synced", "gvk", gvk.String(), "after", time.Since(startAt))
+				if i.xrCachesSynced == nil {
+					i.xrCachesSynced = make(map[schema.GroupVersionKind]bool)
+				}
+				i.xrCachesSynced[gvk] = true
+			}
+		}
+	}()
 }
 
 // UnregisterComposite removes a composite resource cache from being considered
 // to keep composed resource informers alive.
 func (i *composedResourceInformers) UnregisterComposite(gvk schema.GroupVersionKind) {
+	i.log.Debug("Unregistering composite resource cache", "gvk", gvk.String())
+
 	i.lock.Lock()
 	defer i.lock.Unlock()
 	delete(i.xrCaches, gvk)
+	delete(i.xrCachesSynced, gvk)
 }
 
 // WatchComposedResources starts informers for the given composed resource GVKs.
@@ -236,7 +266,9 @@ func (i *composedResourceInformers) cleanupComposedResourceInformers(ctx context
 	xrCaches := make(map[schema.GroupVersionKind]cache.Cache, len(i.xrCaches))
 	i.lock.RLock()
 	for gvk, ca := range i.xrCaches {
-		xrCaches[gvk] = ca
+		if i.xrCachesSynced[gvk] {
+			xrCaches[gvk] = ca
+		}
 	}
 	i.lock.RUnlock()
 


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane! Please read the contribution docs
(linked below) if this is your first Crossplane pull request.
-->

### Description of your changes

In collaboration with @haarchri, fixing a number of issues in realtime-compositions. In particular, ensure the right life-cycle of watches and informers to match that of the composite controller:

- ~~apiextensions/definition: don't attempt to start multiple composite controllers~~ merged through https://github.com/crossplane/crossplane/pull/5437
- apiextensions/definition: fix life-cycle of composite informers to be that of the composite controller
- ~~apiextensions/definition: fix leak of watch on composition revisions due to wrong referenced cache~~ moved to https://github.com/crossplane/crossplane/pull/5463
- ~~apiextensions/definition: unregister composite gvk from composedResourceInformers everywhere~~ merged through https://github.com/crossplane/crossplane/pull/5437
- apiextensions/definition: wait for sync in composedResourceInformers and delay cd informer deletion
- revert https://github.com/crossplane/crossplane/pull/5296.

~~Depends on https://github.com/crossplane/crossplane-runtime/pull/672.~~
<!--
Briefly describe what this pull request does, and how it is covered by tests.
Be proactive - direct your reviewers' attention to anything that needs special
consideration.

We love pull requests that fix an open issue. If yours does, use the below line
to indicate which issue it fixes, for example "Fixes #500".
-->

Fixes https://github.com/crossplane/crossplane/issues/5400

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- ~~[ ] Added or updated unit tests.~~
- [x] Added or updated e2e tests.
- ~~[ ] Linked a PR or a [docs tracking issue] to [document this change].~~
- ~~[ ] Added `backport release-x.y` labels to auto-backport this PR.~~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/master/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/master/contributing#checklist-cheat-sheet