### PR TITLE
Update claim status to Deleting while waiting for foreground deletion

### DIFF
--- a/internal/controller/apiextensions/claim/reconciler.go
+++ b/internal/controller/apiextensions/claim/reconciler.go
@@ -411,7 +411,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 			}
 			if meta.WasDeleted(xr) && requiresForegroundDeletion {
 				log.Debug("Waiting for the XR to finish deleting (foreground deletion)")
-				return reconcile.Result{Requeue: true}, nil
+				return reconcile.Result{Requeue: true}, errors.Wrap(r.client.Status().Update(ctx, cm), errUpdateClaimStatus)
 			}
 			do := &client.DeleteOptions{}
 			if requiresForegroundDeletion {

--- a/internal/controller/apiextensions/claim/reconciler_test.go
+++ b/internal/controller/apiextensions/claim/reconciler_test.go
@@ -383,7 +383,18 @@ func TestReconcile(t *testing.T) {
 							}
 							return nil
 						}),
-					}),
+						MockStatusUpdate: WantClaim(t, NewClaim(func(cm *claim.Unstructured) {
+							cm.SetResourceReference(&corev1.ObjectReference{Name: "cool-composite"})
+							// We want to foreground delete.
+							fg := xpv1.CompositeDeleteForeground
+							cm.SetCompositeDeletePolicy(&fg)
+
+							// Check that we set our status condition.
+							cm.SetDeletionTimestamp(&now)
+							cm.SetConditions(xpv1.Deleting())
+						})),
+					},
+					),
 					WithClaimFinalizer(resource.FinalizerFns{
 						RemoveFinalizerFn: func(_ context.Context, _ resource.Object) error { return nil },
 					}),


### PR DESCRIPTION
### Description of your changes

Update the Claim status to Deleting while it is waiting for foreground deletion to finish.

Fixes #5416

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [X] Read and followed Crossplane's [contribution process].
- [X] Run `make reviewable` to ensure this PR is ready for review.
- [X ] Added or updated unit tests.
- ~[ ] Added or updated e2e tests.~
- ~[ ] Linked a PR or a [docs tracking issue] to [document this change].~
- ~[ ] Added `backport release-x.y` labels to auto-backport this PR.~

Need help with this checklist? See the [cheat sheet].

Prior to this change when a Claim was deleted and uses foreground cascading deletion, the `Ready` condition remained set to `True` while it was waiting for it's composite and other resources to finish deleting.  After this change the `Ready` condition changes to `False` with reason `Deleting` immediately and remains that way while the foreground deletion is running.
