### PR TITLE
apiextension/definition: don't attempt to start composite controllers multiple times

### DIFF
--- a/internal/controller/apiextensions/definition/reconciler.go
+++ b/internal/controller/apiextensions/definition/reconciler.go
@@ -446,7 +446,8 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 
 	observed := d.Status.Controllers.CompositeResourceTypeRef
 	desired := v1.TypeReferenceTo(d.GetCompositeGroupVersionKind())
-	if observed.APIVersion != "" && observed != desired {
+	switch {
+	case observed.APIVersion != "" && observed != desired:
 		r.composite.Stop(composite.ControllerName(d.GetName()))
 		if r.options.Features.Enabled(features.EnableAlphaRealtimeCompositions) {
 			r.xrInformers.UnregisterComposite(d.GetCompositeGroupVersionKind())
@@ -454,6 +455,16 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 		log.Debug("Referenceable version changed; stopped composite resource controller",
 			"observed-version", observed.APIVersion,
 			"desired-version", desired.APIVersion)
+	case r.composite.IsRunning(composite.ControllerName(d.GetName())):
+		log.Debug("Composite resource controller is running")
+		d.Status.SetConditions(v1.WatchingComposite())
+		return reconcile.Result{Requeue: false}, errors.Wrap(r.client.Status().Update(ctx, d), errUpdateStatus)
+	default:
+		if err := r.composite.Err(composite.ControllerName(d.GetName())); err != nil {
+			log.Debug("Composite resource controller encountered an error. Going to restart it", "error", err)
+		} else {
+			log.Debug("Composite resource controller is not running. Going to start it")
+		}
 	}
 
 	ro := CompositeReconcilerOptions(r.options, d, r.client, r.log, r.record)


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane! Please read the contribution docs
(linked below) if this is your first Crossplane pull request.
-->

### Description of your changes

The old code dependended on controller engine's idem-potency of `Run(...)`. This PR makes this logic explicit in the XRD reconciler, skipping everything around controller start too.

Fixes parts of #5400, more is coming in https://github.com/crossplane/crossplane/pull/5422.

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added or updated unit tests.
- ~~[ ] Added or updated e2e tests.~~
- ~~[ ] Linked a PR or a [docs tracking issue] to [document this change].~~
- ~~[ ] Added `backport release-x.y` labels to auto-backport this PR.~~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/master/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/master/contributing#checklist-cheat-sheet