### PR TITLE
apiextensions/definition: fix leak of watch on composition revisions due to wrong referenced cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -246,6 +246,7 @@ jobs:
           - environment-configs
           - usage
           - ssa-claims
+          - realtime-compositions
 
     steps:
       - name: Setup QEMU

--- a/internal/controller/apiextensions/composite/reconciler.go
+++ b/internal/controller/apiextensions/composite/reconciler.go
@@ -736,7 +736,7 @@ func getComposerResourcesNames(cds []ComposedResource) []string {
 // related) XRs when a new CompositionRevision is created. This speeds up
 // reconciliation of XRs on changes to the Composition by not having to wait for
 // the 60s sync period, but be instant.
-func EnqueueForCompositionRevisionFunc(of resource.CompositeKind, list func(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error, log logging.Logger) func(ctx context.Context, createEvent runtimeevent.CreateEvent, q workqueue.RateLimitingInterface) {
+func EnqueueForCompositionRevisionFunc(of resource.CompositeKind, c client.Reader, log logging.Logger) func(ctx context.Context, createEvent runtimeevent.CreateEvent, q workqueue.RateLimitingInterface) {
 	return func(ctx context.Context, createEvent runtimeevent.CreateEvent, q workqueue.RateLimitingInterface) {
 		rev, ok := createEvent.Object.(*v1.CompositionRevision)
 		if !ok {
@@ -748,7 +748,7 @@ func EnqueueForCompositionRevisionFunc(of resource.CompositeKind, list func(ctx 
 		xrs := kunstructured.UnstructuredList{}
 		xrs.SetGroupVersionKind(schema.GroupVersionKind(of))
 		xrs.SetKind(schema.GroupVersionKind(of).Kind + "List")
-		if err := list(ctx, &xrs); err != nil {
+		if err := c.List(ctx, &xrs); err != nil {
 			// logging is most we can do here. This is a programming error if it happens.
 			log.Info("cannot list in CompositionRevision handler", "type", schema.GroupVersionKind(of).String(), "error", err)
 			return

--- a/internal/controller/apiextensions/composite/reconciler.go
+++ b/internal/controller/apiextensions/composite/reconciler.go
@@ -750,9 +750,10 @@ func EnqueueForCompositionRevisionFunc(of resource.CompositeKind, c client.Reade
 		xrs.SetKind(schema.GroupVersionKind(of).Kind + "List")
 		if err := c.List(ctx, &xrs); err != nil {
 			// logging is most we can do here. This is a programming error if it happens.
-			log.Info("cannot list in CompositionRevision handler", "type", schema.GroupVersionKind(of).String(), "error", err)
+			log.Info("cannot list in CompositionRevision handler", "gvk", schema.GroupVersionKind(of).String(), "error", err)
 			return
 		}
+		log.Debug("Enqueueing composite resources because a new CompositionRevision was created", "gvk", schema.GroupVersionKind(of), "count", len(xrs.Items))
 
 		// enqueue all those that reference the Composition of this revision
 		compName := rev.Labels[v1.LabelCompositionName]


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane! Please read the contribution docs
(linked below) if this is your first Crossplane pull request.
-->

### Description of your changes

This PR changes the triggering cache for `CompositionRevisions` to `xrCache`, i.e. the informer watching `CompositionRevisions` as long as the XR controller is running. Before this PR both life-cycles did not match and a trigger is never removing its event handler. Hence, this was leaking event handlers on the global manager cache.

<!--
Briefly describe what this pull request does, and how it is covered by tests.
Be proactive - direct your reviewers' attention to anything that needs special
consideration.

We love pull requests that fix an open issue. If yours does, use the below line
to indicate which issue it fixes, for example "Fixes #500".
-->

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- ~~[ ] Added or updated unit tests.~~
- ~~[ ] Added or updated e2e tests.~~
- ~~[ ] Linked a PR or a [docs tracking issue] to [document this change].~~
- ~~[ ] Added `backport release-x.y` labels to auto-backport this PR.~~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/master/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/master/contributing#checklist-cheat-sheet