### PR TITLE
Migrate from Policy MergeOptions to ToFieldPath in `beta convert pipeline-composition`

### DIFF
--- a/cmd/crank/beta/convert/pipelinecomposition/converter.go
+++ b/cmd/crank/beta/convert/pipelinecomposition/converter.go
@@ -214,16 +214,16 @@ func patchPolicy(policy *v1.PatchPolicy) *PatchPolicy {
 	}
 
 	mo := policy.MergeOptions
-	if mo.KeepMapValues == nil && mo.AppendSlice == nil {
+	switch {
+	case mo.KeepMapValues == nil && mo.AppendSlice == nil:
 		pp.ToFieldPath = ptr.To(ToFieldPathPolicyForceMergeObjects)
-	} else if mo.AppendSlice == nil {
+	case mo.AppendSlice == nil:
 		pp.ToFieldPath = ptr.To(ToFieldPathPolicyMergeObjects)
-	} else if mo.KeepMapValues == nil {
+	case mo.KeepMapValues == nil:
 		pp.ToFieldPath = ptr.To(ToFieldPathPolicyForceMergeObjectsAppendArrays)
-	} else {
+	default:
 		pp.ToFieldPath = ptr.To(ToFieldPathPolicyMergeObjectsAppendArrays)
 	}
-
 	return pp
 }
 

--- a/cmd/crank/beta/convert/pipelinecomposition/converter_test.go
+++ b/cmd/crank/beta/convert/pipelinecomposition/converter_test.go
@@ -291,40 +291,44 @@ func TestConvertPnTToPipeline(t *testing.T) {
 													},
 												},
 											},
-											"patchSets": []v1.PatchSet{
+											"patchSets": []NewPatchSet{
 												{
 													Name: "test-patchset",
-													Patches: []v1.Patch{
+													Patch: []Patch{
 														{
-															Type:          v1.PatchTypeFromCompositeFieldPath,
-															FromFieldPath: &fieldPath,
-															ToFieldPath:   &fieldPath,
-															Transforms: []v1.Transform{
-																{
-																	Type: v1.TransformTypeString,
-																	String: &v1.StringTransform{
-																		Format: &stringFmt,
-																		Type:   v1.StringTransformTypeFormat,
+															Patch: v1.Patch{
+																Type:          v1.PatchTypeFromCompositeFieldPath,
+																FromFieldPath: &fieldPath,
+																ToFieldPath:   &fieldPath,
+																Transforms: []v1.Transform{
+																	{
+																		Type: v1.TransformTypeString,
+																		String: &v1.StringTransform{
+																			Format: &stringFmt,
+																			Type:   v1.StringTransformTypeFormat,
+																		},
 																	},
-																},
-																{
-																	Type: v1.TransformTypeMath,
-																	Math: &v1.MathTransform{
-																		Multiply: &intp,
-																		Type:     v1.MathTransformTypeMultiply,
+																	{
+																		Type: v1.TransformTypeMath,
+																		Math: &v1.MathTransform{
+																			Multiply: &intp,
+																			Type:     v1.MathTransformTypeMultiply,
+																		},
 																	},
 																},
 															},
 														},
 														{
-															Type:          v1.PatchTypeCombineFromComposite,
-															FromFieldPath: &fieldPath,
-															ToFieldPath:   &fieldPath,
+															Patch: v1.Patch{
+																Type:          v1.PatchTypeCombineFromComposite,
+																FromFieldPath: &fieldPath,
+																ToFieldPath:   &fieldPath,
+															},
 														},
 													},
 												},
 											},
-											"resources": []v1.ComposedTemplate{},
+											"resources": []ComposedTemplate{},
 										},
 									},
 								},
@@ -494,8 +498,8 @@ func TestProcessFunctionInput(t *testing.T) {
 						"apiVersion":  "pt.fn.crossplane.io/v1beta1",
 						"kind":        "Resources",
 						"environment": (*v1.EnvironmentConfiguration)(nil),
-						"patchSets":   []v1.PatchSet{},
-						"resources":   []v1.ComposedTemplate{},
+						"patchSets":   []NewPatchSet{},
+						"resources":   []ComposedTemplate{},
 					},
 				},
 			},
@@ -559,40 +563,44 @@ func TestProcessFunctionInput(t *testing.T) {
 								},
 							},
 						},
-						"patchSets": []v1.PatchSet{
+						"patchSets": []NewPatchSet{
 							{
 								Name: "test-patchset",
-								Patches: []v1.Patch{
+								Patch: []Patch{
 									{
-										Type:          v1.PatchTypeFromCompositeFieldPath,
-										FromFieldPath: &fieldPath,
-										ToFieldPath:   &fieldPath,
-										Transforms: []v1.Transform{
-											{
-												Type: v1.TransformTypeString,
-												String: &v1.StringTransform{
-													Format: &stringFmt,
-													Type:   v1.StringTransformTypeFormat,
+										Patch: v1.Patch{
+											Type:          v1.PatchTypeFromCompositeFieldPath,
+											FromFieldPath: &fieldPath,
+											ToFieldPath:   &fieldPath,
+											Transforms: []v1.Transform{
+												{
+													Type: v1.TransformTypeString,
+													String: &v1.StringTransform{
+														Format: &stringFmt,
+														Type:   v1.StringTransformTypeFormat,
+													},
 												},
-											},
-											{
-												Type: v1.TransformTypeMath,
-												Math: &v1.MathTransform{
-													Multiply: &intp,
-													Type:     v1.MathTransformTypeMultiply,
+												{
+													Type: v1.TransformTypeMath,
+													Math: &v1.MathTransform{
+														Multiply: &intp,
+														Type:     v1.MathTransformTypeMultiply,
+													},
 												},
 											},
 										},
 									},
 									{
-										Type:          v1.PatchTypeCombineFromComposite,
-										FromFieldPath: &fieldPath,
-										ToFieldPath:   &fieldPath,
+										Patch: v1.Patch{
+											Type:          v1.PatchTypeCombineFromComposite,
+											FromFieldPath: &fieldPath,
+											ToFieldPath:   &fieldPath,
+										},
 									},
 								},
 							},
 						},
-						"resources": []v1.ComposedTemplate{},
+						"resources": []ComposedTemplate{},
 					},
 				},
 			},

--- a/cmd/crank/beta/convert/pipelinecomposition/converter_test.go
+++ b/cmd/crank/beta/convert/pipelinecomposition/converter_test.go
@@ -1017,6 +1017,17 @@ func TestPatchPolicy(t *testing.T) {
 				ToFieldPath:   ptr.To(ToFieldPathPolicyReplace),
 			},
 		},
+		"PatchPolicyWithNilFromFieldPath": { // case 1
+			reason: "MergeOptions is nil",
+			args: &v1.PatchPolicy{
+				FromFieldPath: nil,
+				MergeOptions:  nil,
+			},
+			want: &PatchPolicy{
+				FromFieldPath: nil,
+				ToFieldPath:   ptr.To(ToFieldPathPolicyReplace),
+			},
+		},
 		"PatchPolicyWithKeepMapValuesTrueAppendSliceNil": {
 			reason: "AppendSlice is nil && KeepMapValues is true", // case 2
 			args: &v1.PatchPolicy{
@@ -1111,14 +1122,14 @@ func TestPatchPolicy(t *testing.T) {
 		"PatchPolicyWithBothKeepMapValuesAndAppendSliceFalse": {
 			reason: "Both KeepMapValues and AppendSlice is false",
 			args: &v1.PatchPolicy{
-				FromFieldPath: ptr.To(v1.FromFieldPathPolicyRequired),
+				FromFieldPath: nil,
 				MergeOptions: &commonv1.MergeOptions{
 					KeepMapValues: ptr.To(false),
 					AppendSlice:   ptr.To(false),
 				},
 			},
 			want: &PatchPolicy{
-				FromFieldPath: ptr.To(v1.FromFieldPathPolicyRequired),
+				FromFieldPath: nil,
 				ToFieldPath:   ptr.To(ToFieldPathPolicyForceMergeObjects),
 			},
 		},

--- a/cmd/crank/beta/convert/pipelinecomposition/converter_test.go
+++ b/cmd/crank/beta/convert/pipelinecomposition/converter_test.go
@@ -295,7 +295,7 @@ func TestConvertPnTToPipeline(t *testing.T) {
 											"patchSets": []PatchSet{
 												{
 													Name: "test-patchset",
-													Patch: []Patch{
+													Patches: []Patch{
 														{
 															Patch: v1.Patch{
 																Type:          v1.PatchTypeFromCompositeFieldPath,
@@ -567,7 +567,7 @@ func TestProcessFunctionInput(t *testing.T) {
 						"patchSets": []PatchSet{
 							{
 								Name: "test-patchset",
-								Patch: []Patch{
+								Patches: []Patch{
 									{
 										Patch: v1.Patch{
 											Type:          v1.PatchTypeFromCompositeFieldPath,
@@ -1148,7 +1148,7 @@ func TestPatchPolicy(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			got := patchPolicy(tc.args)
+			got := migratePatchPolicy(tc.args)
 			if diff := cmp.Diff(tc.want, got); diff != "" {
 				t.Errorf("%s\npatchPolicy(...): -want i, +got i:\n%s", tc.reason, diff)
 			}

--- a/cmd/crank/beta/convert/pipelinecomposition/converter_test.go
+++ b/cmd/crank/beta/convert/pipelinecomposition/converter_test.go
@@ -992,14 +992,12 @@ func TestSetMissingResourceFields(t *testing.T) {
 }
 
 /*
-#	MergeOptions  appendSlice	keepMapValues	policy.toFieldPath
-1	nil	          N/A	        N/A*	        Replace
-2	non-nil	      nil or false	true	        MergeObjects
-3	non-nil	      true	        nil or false	ForceMergeObjectsAppendArrays
-4	non-nil	      nil or false	nil or false	ForceMergeObjects
-5	non-nil	      true	        true*	        MergeObjectsAppendArrays
-
-	* keeps dupword linter happy
+#	MergeOptions    appendSlice     keepMapValues   policy.toFieldPath
+1	nil             N/A             N/A             nil (defaults to Replace)
+2	non-nil         nil or false    true            MergeObjects
+3	non-nil         true            nil or false    ForceMergeObjectsAppendArrays
+4	non-nil         nil or false    nil or false    ForceMergeObjects
+5	non-nil         true            true            MergeObjectsAppendArrays
 */
 
 func TestPatchPolicy(t *testing.T) {
@@ -1008,6 +1006,14 @@ func TestPatchPolicy(t *testing.T) {
 		args   *v1.PatchPolicy
 		want   *PatchPolicy
 	}{
+		"PatchPolicyWithNilMergeOptionsAndFromFieldPath": { // case 1
+			reason: "MergeOptions and FromFieldPath are nil",
+			args: &v1.PatchPolicy{
+				FromFieldPath: nil,
+				MergeOptions:  nil,
+			},
+			want: nil,
+		},
 		"PatchPolicyWithNilMergeOptions": { // case 1
 			reason: "MergeOptions is nil",
 			args: &v1.PatchPolicy{
@@ -1016,18 +1022,7 @@ func TestPatchPolicy(t *testing.T) {
 			},
 			want: &PatchPolicy{
 				FromFieldPath: ptr.To(v1.FromFieldPathPolicyOptional),
-				ToFieldPath:   ptr.To(ToFieldPathPolicyReplace),
-			},
-		},
-		"PatchPolicyWithNilFromFieldPath": { // case 1
-			reason: "MergeOptions is nil",
-			args: &v1.PatchPolicy{
-				FromFieldPath: nil,
-				MergeOptions:  nil,
-			},
-			want: &PatchPolicy{
-				FromFieldPath: nil,
-				ToFieldPath:   ptr.To(ToFieldPathPolicyReplace),
+				ToFieldPath:   nil,
 			},
 		},
 		"PatchPolicyWithKeepMapValuesTrueAppendSliceNil": {
@@ -1108,7 +1103,7 @@ func TestPatchPolicy(t *testing.T) {
 				ToFieldPath:   ptr.To(ToFieldPathPolicyForceMergeObjects),
 			},
 		},
-		"PatchPolicyWithNilAppendSliceInMergeOptions": {
+		"PatchPolicyWithNilAppendSliceInMergeOptions": { // case 4
 			reason: "AppendSlice is nil and KeepMapValues is false",
 			args: &v1.PatchPolicy{
 				FromFieldPath: ptr.To(v1.FromFieldPathPolicyOptional),
@@ -1121,7 +1116,7 @@ func TestPatchPolicy(t *testing.T) {
 				ToFieldPath:   ptr.To(ToFieldPathPolicyForceMergeObjects),
 			},
 		},
-		"PatchPolicyWithBothKeepMapValuesAndAppendSliceFalse": {
+		"PatchPolicyWithBothKeepMapValuesAndAppendSliceFalse": { // case 4
 			reason: "Both KeepMapValues and AppendSlice is false",
 			args: &v1.PatchPolicy{
 				FromFieldPath: nil,

--- a/cmd/crank/beta/convert/pipelinecomposition/converter_test.go
+++ b/cmd/crank/beta/convert/pipelinecomposition/converter_test.go
@@ -993,11 +993,11 @@ func TestSetMissingResourceFields(t *testing.T) {
 
 /*
 #	MergeOptions    appendSlice     keepMapValues   policy.toFieldPath
-1	nil             N/A             N/A             nil (defaults to Replace)
+1	nil             N/A             n/A             nil (defaults to Replace)
 2	non-nil         nil or false    true            MergeObjects
 3	non-nil         true            nil or false    ForceMergeObjectsAppendArrays
 4	non-nil         nil or false    nil or false    ForceMergeObjects
-5	non-nil         true            true            MergeObjectsAppendArrays
+5	non-nil         true            True            MergeObjectsAppendArrays
 */
 
 func TestPatchPolicy(t *testing.T) {

--- a/cmd/crank/beta/convert/pipelinecomposition/converter_test.go
+++ b/cmd/crank/beta/convert/pipelinecomposition/converter_test.go
@@ -992,12 +992,14 @@ func TestSetMissingResourceFields(t *testing.T) {
 }
 
 /*
-#	MergeOptions	appendSlice	  keepMapValues	policy.toFieldPath
-1	nil	          N/A	          N/A	          Replace
+#	MergeOptions  appendSlice	keepMapValues	policy.toFieldPath
+1	nil	          N/A	        N/A*	        Replace
 2	non-nil	      nil or false	true	        MergeObjects
 3	non-nil	      true	        nil or false	ForceMergeObjectsAppendArrays
 4	non-nil	      nil or false	nil or false	ForceMergeObjects
-5	non-nil	      true	        true	        MergeObjectsAppendArrays
+5	non-nil	      true	        true*	        MergeObjectsAppendArrays
+
+	* keeps dupword linter happy
 */
 
 func TestPatchPolicy(t *testing.T) {

--- a/cmd/crank/beta/convert/pipelinecomposition/types.go
+++ b/cmd/crank/beta/convert/pipelinecomposition/types.go
@@ -47,3 +47,31 @@ type Input struct {
 	// +optional
 	Resources []v1.ComposedTemplate `json:"resources,omitempty"`
 }
+
+// PatchSet wrapper around v1.PatchSet with custom Patch.
+type PatchSet struct {
+	// Name of this PatchSet.
+	Name string `json:"name"`
+
+	Patch []Patch `json:"patches"`
+}
+
+// ComposedTemplate wrapper around v1.ComposedTemplate with custom Patch.
+type ComposedTemplate struct {
+	v1.ComposedTemplate
+
+	Patches []Patch `json:"patches,omitempty"`
+}
+
+// Patch wrapper around v1.Patch with custom PatchPolicy.
+type Patch struct {
+	v1.Patch
+
+	Policy *PatchPolicy `json:"policy,omitempty"`
+}
+
+// PatchPolicy defines the policy for a patch.
+type PatchPolicy struct {
+	FromFieldPath *v1.FromFieldPathPolicy `json:"fromFieldPath,omitempty"`
+	ToFieldPath   *ToFieldPathPolicy      `json:"toFieldPath,omitempty"`
+}

--- a/cmd/crank/beta/convert/pipelinecomposition/types.go
+++ b/cmd/crank/beta/convert/pipelinecomposition/types.go
@@ -70,6 +70,18 @@ type Patch struct {
 	Policy *PatchPolicy `json:"policy,omitempty"`
 }
 
+// A ToFieldPathPolicy determines how to patch to a field path.
+type ToFieldPathPolicy string
+
+// ToFieldPathPatchPolicy defines the policy for the ToFieldPath in a Patch.
+const (
+	ToFieldPathPolicyReplace                       ToFieldPathPolicy = "Replace"
+	ToFieldPathPolicyMergeObjects                  ToFieldPathPolicy = "MergeObjects"
+	ToFieldPathPolicyMergeObjectsAppendArrays      ToFieldPathPolicy = "MergeObjectsAppendArrays"
+	ToFieldPathPolicyForceMergeObjects             ToFieldPathPolicy = "ForceMergeObjects"
+	ToFieldPathPolicyForceMergeObjectsAppendArrays ToFieldPathPolicy = "ForceMergeObjectsAppendArrays"
+)
+
 // PatchPolicy defines the policy for a patch.
 type PatchPolicy struct {
 	FromFieldPath *v1.FromFieldPathPolicy `json:"fromFieldPath,omitempty"`

--- a/cmd/crank/beta/convert/pipelinecomposition/types.go
+++ b/cmd/crank/beta/convert/pipelinecomposition/types.go
@@ -53,7 +53,7 @@ type PatchSet struct {
 	// Name of this PatchSet.
 	Name string `json:"name"`
 
-	Patch []Patch `json:"patches"`
+	Patches []Patch `json:"patches"`
 }
 
 // ComposedTemplate wrapper around v1.ComposedTemplate with custom Patch.

--- a/cmd/crank/beta/convert/pipelinecomposition/types.go
+++ b/cmd/crank/beta/convert/pipelinecomposition/types.go
@@ -18,9 +18,13 @@ package pipelinecomposition
 
 import v1 "github.com/crossplane/crossplane/apis/apiextensions/v1"
 
-// Input represents the input to the patch-and-transform function
-// This struct is copied from function patch and transform, as we can't import it directly
+// Input represents the input to the patch-and-transform function. This struct
+// originates from function patch and transform, as we can't import it directly
 // https://github.com/crossplane-contrib/function-patch-and-transform/blob/main/input/v1beta1/resources.go
+// Note that it does not exactly match the target type with full fidelity.
+// This type is used during the processing and conversion of the given input,
+// but the final converted output is written in an unstructured manner without a
+// static type definition for more flexibility.
 type Input struct {
 	// PatchSets define a named set of patches that may be included by any
 	// resource in this Composition. PatchSets cannot themselves refer to other
@@ -66,6 +70,18 @@ type ComposedTemplate struct {
 // Patch wrapper around v1.Patch with custom PatchPolicy.
 type Patch struct {
 	v1.Patch
+
+	Policy *PatchPolicy `json:"policy,omitempty"`
+}
+
+// Environment represents the Composition environment.
+type Environment struct {
+	Patches []EnvironmentPatch `json:"patches,omitempty"`
+}
+
+// EnvironmentPatch wrapper around v1.EnvironmentPatch with custom PatchPolicy.
+type EnvironmentPatch struct {
+	v1.EnvironmentPatch
 
 	Policy *PatchPolicy `json:"policy,omitempty"`
 }


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane! Please read the contribution docs
(linked below) if this is your first Crossplane pull request.
-->

### Description of your changes

<!--
Briefly describe what this pull request does, and how it is covered by tests.
Be proactive - direct your reviewers' attention to anything that needs special
consideration.

We love pull requests that fix an open issue. If yours does, use the below line
to indicate which issue it fixes, for example "Fixes #500".
-->

Fixes #5421 

ℹ️  **Key implementation note**: The types in this PR follow a consistent pattern of a struct that embeds the underlying `Patch` type (that contains the old policy format) while also inserting a new `Policy` field at the same level of this embedded `Patch` struct. When the converted data is serialized to the final converted output manifest, this has the effect of essentially overriding the deprecated policy format with our new policy format.

### Useful resources for reviewers:

* Definition of what function-p-and-t supports and how it differs: https://github.com/crossplane-contrib/function-patch-and-transform/?tab=readme-ov-file#differences-from-the-native-implementation
* @negz suggested design for this implementation: https://github.com/crossplane-contrib/function-patch-and-transform/issues/101#issuecomment-2024155035
* PR that updated function-p-and-t: https://github.com/crossplane-contrib/function-patch-and-transform/pull/102/files

Here is a logic table that captures the conversion rules we need to codify in this function. I've kept the case ordering @negz used in his linked comments above for consistency:

| # | `MergeOptions` | `appendSlice`   | `keepMapValues` | `policy.toFieldPath` |
| -----------  | -----------  | ------------- | -----------  | ------------- |
| 1 | `nil`  | N/A | N/A | `nil` which defaults to `Replace` |
| 2 | `non-nil` | `nil` or `false` | `true` | `MergeObjects` | 
| 3 | `non-nil` | `true` | `nil` or `false` | `ForceMergeObjectsAppendArrays` |
| 4 | `non-nil` | `nil` or `false` |  `nil` or `false` |  `ForceMergeObjects`   |
| 5 | `non-nil` | `true` | `true` | `MergeObjectsAppendArrays` |

### Manual testing

A gist containing test manifests and expected output can be found at https://gist.github.com/jbw976/1c06224c0edc4cf9ca9a3765539a1e7f

In its source composition file, it contains patches for all the possible `mergeOptions` combinations in all the possible locations (environment, patchsets, resources). The converted composition has been verified to contain properly converted policies in their correct locations. As a further validation step, the converted composition has been used with the `render` command to sanity test its structure and content.

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added or updated unit tests.
- [ ] ~Added or updated e2e tests.~
- [x] Linked a PR or a [docs tracking issue] to [document this change].
  - https://github.com/crossplane-contrib/function-patch-and-transform/pull/112 
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/master/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/master/contributing#checklist-cheat-sheet
