### PR TITLE
apiextensions/definition: wait for sync in composedResourceInformers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -246,6 +246,7 @@ jobs:
           - environment-configs
           - usage
           - ssa-claims
+          - realtime-compositions
 
     steps:
       - name: Setup QEMU


### PR DESCRIPTION
Pulled out from https://github.com/crossplane/crossplane/pull/5422.

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- ~~[ ] Added or updated unit tests.~~
- [x] Added or updated e2e tests.
- ~~[ ] Linked a PR or a [docs tracking issue] to [document this change].~~
- ~~[ ] Added `backport release-x.y` labels to auto-backport this PR.~~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/master/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/master/contributing#checklist-cheat-sheet