### PR TITLE
Allow kubernetes service annotations

### DIFF
--- a/cluster/charts/crossplane/README.md
+++ b/cluster/charts/crossplane/README.md
@@ -119,6 +119,7 @@ and their default values.
 | `securityContextRBACManager.readOnlyRootFilesystem` | Set the RBAC Manager pod root file system as read-only. | `true` |
 | `securityContextRBACManager.runAsGroup` | The group ID used by the RBAC Manager pod. | `65532` |
 | `securityContextRBACManager.runAsUser` | The user ID used by the RBAC Manager pod. | `65532` |
+| `service.annotations` | Configure annotations on the service object. Only enabled when webhooks.enabled = true | `{}` |
 | `serviceAccount.customAnnotations` | Add custom `annotations` to the Crossplane ServiceAccount. | `{}` |
 | `tolerations` | Add `tolerations` to the Crossplane pod deployment. | `[]` |
 | `webhooks.enabled` | Enable webhooks for Crossplane and installed Provider packages. | `true` |

--- a/cluster/charts/crossplane/README.md
+++ b/cluster/charts/crossplane/README.md
@@ -119,7 +119,7 @@ and their default values.
 | `securityContextRBACManager.readOnlyRootFilesystem` | Set the RBAC Manager pod root file system as read-only. | `true` |
 | `securityContextRBACManager.runAsGroup` | The group ID used by the RBAC Manager pod. | `65532` |
 | `securityContextRBACManager.runAsUser` | The user ID used by the RBAC Manager pod. | `65532` |
-| `service.annotations` | Configure annotations on the service object. Only enabled when webhooks.enabled = true | `{}` |
+| `service.customAnnotations` | Configure annotations on the service object. Only enabled when webhooks.enabled = true | `{}` |
 | `serviceAccount.customAnnotations` | Add custom `annotations` to the Crossplane ServiceAccount. | `{}` |
 | `tolerations` | Add `tolerations` to the Crossplane pod deployment. | `[]` |
 | `webhooks.enabled` | Enable webhooks for Crossplane and installed Provider packages. | `true` |

--- a/cluster/charts/crossplane/templates/service.yaml
+++ b/cluster/charts/crossplane/templates/service.yaml
@@ -8,6 +8,11 @@ metadata:
     app: {{ template "crossplane.name" . }}
     release: {{ .Release.Name }}
     {{- include "crossplane.labels" . | indent 4 }}
+  annotations:
+    {{- with .Values.service.annotations }}
+    {{- range $key, $value := . }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
 spec:
   selector:
     app: {{ template "crossplane.name" . }}

--- a/cluster/charts/crossplane/templates/service.yaml
+++ b/cluster/charts/crossplane/templates/service.yaml
@@ -9,9 +9,10 @@ metadata:
     release: {{ .Release.Name }}
     {{- include "crossplane.labels" . | indent 4 }}
   annotations:
-    {{- with .Values.service.annotations }}
+    {{- with .Values.service.customAnnotations }}
     {{- range $key, $value := . }}
     {{ $key }}: {{ $value | quote }}
+    {{- end }}
     {{- end }}
 spec:
   selector:

--- a/cluster/charts/crossplane/values.yaml
+++ b/cluster/charts/crossplane/values.yaml
@@ -59,7 +59,7 @@ registryCaBundleConfig:
 
 service:
   # -- Configure annotations on the service object. Only enabled when webhooks.enabled = true
-  annotations: {}
+  customAnnotations: {}
 
 webhooks:
   # -- Enable webhooks for Crossplane and installed Provider packages.

--- a/cluster/charts/crossplane/values.yaml
+++ b/cluster/charts/crossplane/values.yaml
@@ -57,6 +57,10 @@ registryCaBundleConfig:
   # -- The ConfigMap key containing a custom CA bundle to enable fetching packages from registries with unknown or untrusted certificates.
   key: ""
 
+service:
+  # -- Configure annotations on the service object. Only enabled when webhooks.enabled = true
+  annotations: {}
+
 webhooks:
   # -- Enable webhooks for Crossplane and installed Provider packages.
   enabled: true


### PR DESCRIPTION
### Description of your changes

Allow setting custom annotations on the service object. For GCP we require a
NEG when using webhooks. Setting up the NEG requires annotations on the
service object. 

I cannot add labels, but prefer backport to 1.13

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] ~Added or updated unit tests.~
- [ ] ~Added or updated e2e tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [x] Added `backport release-x.y` labels to auto-backport this PR.


[contribution process]: https://github.com/crossplane/crossplane/tree/master/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/master/contributing#checklist-cheat-sheet
