### PR TITLE
Allow group changes in composed templates

### DIFF
--- a/internal/controller/apiextensions/composite/composition_render_test.go
+++ b/internal/controller/apiextensions/composite/composition_render_test.go
@@ -62,23 +62,6 @@ func TestRenderFromJSON(t *testing.T) {
 				err: errors.Wrap(errInvalidChar, errUnmarshalJSON),
 			},
 		},
-		"ExistingGroupChanged": {
-			reason: "We should return an error if unmarshalling the base template changed the composed resource's group.",
-			args: args{
-				o: composed.New(composed.FromReference(corev1.ObjectReference{
-					APIVersion: "example.org/v1",
-					Kind:       "Potato",
-				})),
-				data: []byte(`{"apiVersion": "foo.io/v1", "kind": "Potato"}`),
-			},
-			want: want{
-				o: composed.New(composed.FromReference(corev1.ObjectReference{
-					APIVersion: "foo.io/v1",
-					Kind:       "Potato",
-				})),
-				err: errors.Errorf(errFmtKindOrGroupChanged, "example.org/v1, Kind=Potato", "foo.io/v1, Kind=Potato"),
-			},
-		},
 		"ExistingKindChanged": {
 			reason: "We should return an error if unmarshalling the base template changed the composed resource's kind.",
 			args: args{
@@ -93,7 +76,23 @@ func TestRenderFromJSON(t *testing.T) {
 					APIVersion: "example.org/v1",
 					Kind:       "Different",
 				})),
-				err: errors.Errorf(errFmtKindOrGroupChanged, "example.org/v1, Kind=Potato", "example.org/v1, Kind=Different"),
+				err: errors.Errorf(errFmtKindChanged, "example.org/v1, Kind=Potato", "example.org/v1, Kind=Different"),
+			},
+		},
+		"GroupCanChange": {
+			reason: "We should accept group changes in the base template.",
+			args: args{
+				o: composed.New(composed.FromReference(corev1.ObjectReference{
+					APIVersion: "example.org/v1",
+					Kind:       "Potato",
+				})),
+				data: []byte(`{"apiVersion": "foo.io/v1", "kind": "Potato"}`),
+			},
+			want: want{
+				o: composed.New(composed.FromReference(corev1.ObjectReference{
+					APIVersion: "foo.io/v1",
+					Kind:       "Potato",
+				})),
 			},
 		},
 		"VersionCanChange": {


### PR DESCRIPTION
### Description of your changes

As @phisco successfully foresaw in [this comment](https://github.com/crossplane/crossplane/pull/5369#discussion_r1486019598) 🙌 , checking the group backfired during migrations. This PR reverts the check introduced in [this PR ](https://github.com/crossplane/crossplane/pull/4500) and only leaves [checking the kind](https://github.com/crossplane/crossplane/blob/cb232d32a595876a98ab3a7f5125e3fa26e2f2ac/internal/controller/apiextensions/composite/composition_pt.go#L512) as in prior to v1.13.

Fixes #5473

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added or updated unit tests.
- [ ] ~Added or updated e2e tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [x] Added `backport release-x.y` labels to auto-backport this PR.

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/master/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/master/contributing#checklist-cheat-sheet
