### PR TITLE
[Backport release-1.14]  fix: ignore invalid resources when composing

### DIFF
--- a/internal/controller/apiextensions/composite/composed.go
+++ b/internal/controller/apiextensions/composite/composed.go
@@ -35,8 +35,14 @@ type ComposedResource struct {
 	ResourceName ResourceName
 
 	// Ready indicates whether this composed resource is ready - i.e. whether
-	// all of its readiness checks passed.
+	// all of its readiness checks passed. Setting it to false will cause the
+	// XR to be marked as not ready.
 	Ready bool
+
+	// Synced indicates whether the composition process was able to sync the
+	// composed resource with its desired state. Setting it to false will cause
+	// the XR to be marked as not synced.
+	Synced bool
 }
 
 // ComposedResourceState represents a composed resource (either desired or

--- a/internal/controller/apiextensions/composite/composition_functions.go
+++ b/internal/controller/apiextensions/composite/composition_functions.go
@@ -372,6 +372,46 @@ func (c *FunctionComposer) Compose(ctx context.Context, xr *composite.Unstructur
 		return CompositionResult{}, errors.Wrap(err, errApplyXRRefs)
 	}
 
+	// Produce our array of resources to return to the Reconciler. The
+	// Reconciler uses this array to determine whether the XR is ready.
+	resources := make([]ComposedResource, 0, len(desired))
+
+	// We apply all of our desired resources before we observe them in the loop
+	// below. This ensures that issues observing and processing one composed
+	// resource won't block the application of another.
+	for name, cd := range desired {
+		// We don't need any crossplane-runtime resource.Applicator style apply
+		// options here because server-side apply takes care of everything.
+		// Specifically it will merge rather than replace owner references (e.g.
+		// for Usages), and will fail if we try to add a controller reference to
+		// a resource that already has a different one.
+		// NOTE(phisco): We need to set a field owner unique for each XR here,
+		// this prevents multiple XRs composing the same resource to be
+		// continuously alternated as controllers.
+		if err := c.client.Patch(ctx, cd.Resource, client.Apply, client.ForceOwnership, client.FieldOwner(ComposedFieldOwnerName(xr))); err != nil {
+			if kerrors.IsInvalid(err) {
+				// We tried applying an invalid resource, we can't tell whether
+				// this means the resource will never be valid or it will if we
+				// run again the composition after some other resource is
+				// created or updated successfully. So, we emit a warning event
+				// and move on.
+				// We mark the resource as not synced, so that once we get to
+				// decide the XR's Synced condition, we can set it to false if
+				// any of the resources didn't sync successfully.
+				events = append(events, event.Warning(reasonCompose, errors.Wrapf(err, errFmtApplyCD, name)))
+				// NOTE(phisco): here we behave differently w.r.t. the native
+				// p&t composer, as we respect the readiness reported by
+				// functions, while there we defaulted to also set ready false
+				// in case of apply errors.
+				resources = append(resources, ComposedResource{ResourceName: name, Ready: cd.Ready, Synced: false})
+				continue
+			}
+			return CompositionResult{}, errors.Wrapf(err, errFmtApplyCD, name)
+		}
+
+		resources = append(resources, ComposedResource{ResourceName: name, Ready: cd.Ready, Synced: true})
+	}
+
 	// Our goal here is to patch our XR's status using server-side apply. We
 	// want the resulting, patched object loaded into uxr. We need to pass in
 	// only our "fully specified intent" - i.e. only the fields that we actually
@@ -391,27 +431,10 @@ func (c *FunctionComposer) Compose(ctx context.Context, xr *composite.Unstructur
 	xr.SetUID(u)
 
 	if err := c.client.Status().Patch(ctx, xr, client.Apply, client.ForceOwnership, client.FieldOwner(FieldOwnerXR)); err != nil {
+		// Note(phisco): here we are fine with this error being terminal, as
+		// there is no other resource to apply that might eventually resolve
+		// this issue.
 		return CompositionResult{}, errors.Wrap(err, errApplyXRStatus)
-	}
-
-	// Produce our array of resources to return to the Reconciler. The
-	// Reconciler uses this array to determine whether the XR is ready.
-	resources := make([]ComposedResource, 0, len(desired))
-
-	// We apply all of our desired resources before we observe them in the loop
-	// below. This ensures that issues observing and processing one composed
-	// resource won't block the application of another.
-	for name, cd := range desired {
-		// We don't need any crossplane-runtime resource.Applicator style apply
-		// options here because server-side apply takes care of everything.
-		// Specifically it will merge rather than replace owner references (e.g.
-		// for Usages), and will fail if we try to add a controller reference to
-		// a resource that already has a different one.
-		if err := c.client.Patch(ctx, cd.Resource, client.Apply, client.ForceOwnership, client.FieldOwner(FieldOwnerComposed)); err != nil {
-			return CompositionResult{}, errors.Wrapf(err, errFmtApplyCD, name)
-		}
-
-		resources = append(resources, ComposedResource{ResourceName: name, Ready: cd.Ready})
 	}
 
 	return CompositionResult{ConnectionDetails: d.GetComposite().GetConnectionDetails(), Composed: resources, Events: events}, nil

--- a/internal/controller/apiextensions/composite/composition_functions.go
+++ b/internal/controller/apiextensions/composite/composition_functions.go
@@ -388,7 +388,7 @@ func (c *FunctionComposer) Compose(ctx context.Context, xr *composite.Unstructur
 		// NOTE(phisco): We need to set a field owner unique for each XR here,
 		// this prevents multiple XRs composing the same resource to be
 		// continuously alternated as controllers.
-		if err := c.client.Patch(ctx, cd.Resource, client.Apply, client.ForceOwnership, client.FieldOwner(ComposedFieldOwnerName(xr))); err != nil {
+		if err := c.client.Patch(ctx, cd.Resource, client.Apply, client.ForceOwnership, client.FieldOwner(FieldOwnerXR)); err != nil {
 			if kerrors.IsInvalid(err) {
 				// We tried applying an invalid resource, we can't tell whether
 				// this means the resource will never be valid or it will if we

--- a/internal/controller/apiextensions/composite/composition_functions_test.go
+++ b/internal/controller/apiextensions/composite/composition_functions_test.go
@@ -614,8 +614,8 @@ func TestFunctionCompose(t *testing.T) {
 			want: want{
 				res: CompositionResult{
 					Composed: []ComposedResource{
-						{ResourceName: "desired-resource-a"},
-						{ResourceName: "observed-resource-a", Ready: true},
+						{ResourceName: "desired-resource-a", Synced: true},
+						{ResourceName: "observed-resource-a", Ready: true, Synced: true},
 					},
 					ConnectionDetails: managed.ConnectionDetails{
 						"from": []byte("function-pipeline"),

--- a/internal/controller/apiextensions/composite/composition_pt_test.go
+++ b/internal/controller/apiextensions/composite/composition_pt_test.go
@@ -391,6 +391,7 @@ func TestPTCompose(t *testing.T) {
 					Composed: []ComposedResource{{
 						ResourceName: "cool-resource",
 						Ready:        true,
+						Synced:       true,
 					}},
 					ConnectionDetails: details,
 				},
@@ -456,10 +457,12 @@ func TestPTCompose(t *testing.T) {
 						{
 							ResourceName: "cool-resource",
 							Ready:        true,
+							Synced:       true,
 						},
 						{
 							ResourceName: "uncool-resource",
 							Ready:        false,
+							Synced:       false,
 						},
 					},
 					ConnectionDetails: details,

--- a/internal/controller/apiextensions/composite/reconciler.go
+++ b/internal/controller/apiextensions/composite/reconciler.go
@@ -685,14 +685,12 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 			log.Debug("Composed resource is not yet valid", "id", id)
 			unsynced = append(unsynced, cd)
 			r.record.Event(xr, event.Normal(reasonCompose, fmt.Sprintf("Composed resource %q is not yet valid", id)))
-			continue
 		}
 
 		if !cd.Ready {
 			log.Debug("Composed resource is not yet ready", "id", id)
 			unready = append(unready, cd)
 			r.record.Event(xr, event.Normal(reasonCompose, fmt.Sprintf("Composed resource %q is not yet ready", id)))
-			continue
 		}
 	}
 

--- a/internal/controller/apiextensions/composite/reconciler.go
+++ b/internal/controller/apiextensions/composite/reconciler.go
@@ -72,6 +72,7 @@ const (
 	errSelectEnvironment      = "cannot select environment"
 	errCompose                = "cannot compose resources"
 	errRenderCD               = "cannot render composed resource"
+	errSyncResources          = "cannot sync composed resources"
 
 	reconcilePausedMsg = "Reconciliation (including deletion) is paused via the pause annotation"
 )
@@ -671,12 +672,20 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 	}
 
 	var unready []ComposedResource
+	var unsynced []ComposedResource
 	for i, cd := range res.Composed {
 		// Specifying a name for P&T templates is optional but encouraged.
 		// If there was no name, fall back to using the index.
 		id := string(cd.ResourceName)
 		if id == "" {
 			id = strconv.Itoa(i)
+		}
+
+		if !cd.Synced {
+			log.Debug("Composed resource is not yet synced", "id", id)
+			unsynced = append(unsynced, cd)
+			r.record.Event(xr, event.Normal(reasonCompose, fmt.Sprintf("Composed resource %q is not yet synced", id)))
+			continue
 		}
 
 		if !cd.Ready {
@@ -687,28 +696,47 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 		}
 	}
 
-	xr.SetConditions(xpv1.ReconcileSuccess())
-
-	// TODO(muvaf): If a resource becomes Unavailable at some point, should we
-	// still report it as Creating?
-	if len(unready) > 0 {
-		// We want to requeue to wait for our composed resources to
-		// become ready, since we can't watch them.
-		names := make([]string, len(unready))
-		for i, cd := range unready {
-			names[i] = string(cd.ResourceName)
-		}
-		// sort for stable condition messages. With functions, we don't have a
-		// stable order otherwise.
-		xr.SetConditions(xpv1.Creating().WithMessage(fmt.Sprintf("Unready resources: %s", resource.StableNAndSomeMore(resource.DefaultFirstN, names))))
+	if updateXRConditions(xr, unsynced, unready) {
+		// This requeue is subject to rate limiting. Requeues will exponentially
+		// backoff from 1 to 30 seconds. See the 'definition' (XRD) reconciler
+		// that sets up the ratelimiter.
 		return reconcile.Result{Requeue: true}, errors.Wrap(r.client.Status().Update(ctx, xr), errUpdateStatus)
 	}
 
 	// We requeue after our poll interval because we can't watch composed
 	// resources - we can't know what type of resources we might compose
 	// when this controller is started.
-	xr.SetConditions(xpv1.Available())
 	return reconcile.Result{RequeueAfter: r.pollInterval}, errors.Wrap(r.client.Status().Update(ctx, xr), errUpdateStatus)
+}
+
+// updateXRConditions updates the conditions of the supplied composite resource
+// based on the supplied composed resources. It returns true if the XR should be
+// requeued immediately.
+func updateXRConditions(xr *composite.Unstructured, unsynced, unready []ComposedResource) (requeueImmediately bool) {
+	readyCond := xpv1.Available()
+	syncedCond := xpv1.ReconcileSuccess()
+	if len(unsynced) > 0 {
+		// We want to requeue to wait for our composed resources to
+		// become ready, since we can't watch them.
+		syncedCond = xpv1.ReconcileError(errors.New(errSyncResources)).WithMessage(fmt.Sprintf("Unsynced resources: %s", resource.StableNAndSomeMore(resource.DefaultFirstN, getComposerResourcesNames(unsynced))))
+		requeueImmediately = true
+	}
+	if len(unready) > 0 {
+		// We want to requeue to wait for our composed resources to
+		// become ready, since we can't watch them.
+		readyCond = xpv1.Creating().WithMessage(fmt.Sprintf("Unready resources: %s", resource.StableNAndSomeMore(resource.DefaultFirstN, getComposerResourcesNames(unready))))
+		requeueImmediately = true
+	}
+	xr.SetConditions(syncedCond, readyCond)
+	return requeueImmediately
+}
+
+func getComposerResourcesNames(cds []ComposedResource) []string {
+	names := make([]string, len(cds))
+	for i, cd := range cds {
+		names[i] = string(cd.ResourceName)
+	}
+	return names
 }
 
 // EnqueueForCompositionRevisionFunc returns a function that enqueues (the

--- a/internal/controller/apiextensions/composite/reconciler.go
+++ b/internal/controller/apiextensions/composite/reconciler.go
@@ -716,7 +716,7 @@ func updateXRConditions(xr *composite.Unstructured, unsynced, unready []Composed
 	if len(unsynced) > 0 {
 		// We want to requeue to wait for our composed resources to
 		// become ready, since we can't watch them.
-		syncedCond = xpv1.ReconcileError(errors.New(errSyncResources)).WithMessage(fmt.Sprintf("Unsynced resources: %s", resource.StableNAndSomeMore(resource.DefaultFirstN, getComposerResourcesNames(unsynced))))
+		syncedCond = xpv1.ReconcileError(errors.New(errSyncResources)).WithMessage(fmt.Sprintf("Invalid resources: %s", resource.StableNAndSomeMore(resource.DefaultFirstN, getComposerResourcesNames(unsynced))))
 		requeueImmediately = true
 	}
 	if len(unready) > 0 {

--- a/internal/controller/apiextensions/composite/reconciler.go
+++ b/internal/controller/apiextensions/composite/reconciler.go
@@ -682,9 +682,9 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 		}
 
 		if !cd.Synced {
-			log.Debug("Composed resource is not yet synced", "id", id)
+			log.Debug("Composed resource is not yet valid", "id", id)
 			unsynced = append(unsynced, cd)
-			r.record.Event(xr, event.Normal(reasonCompose, fmt.Sprintf("Composed resource %q is not yet synced", id)))
+			r.record.Event(xr, event.Normal(reasonCompose, fmt.Sprintf("Composed resource %q is not yet valid", id)))
 			continue
 		}
 

--- a/internal/controller/apiextensions/composite/reconciler_test.go
+++ b/internal/controller/apiextensions/composite/reconciler_test.go
@@ -547,21 +547,27 @@ func TestReconcile(t *testing.T) {
 							Composed: []ComposedResource{{
 								ResourceName: "elephant",
 								Ready:        false,
+								Synced:       true,
 							}, {
 								ResourceName: "cow",
 								Ready:        false,
+								Synced:       true,
 							}, {
 								ResourceName: "pig",
 								Ready:        true,
+								Synced:       true,
 							}, {
 								ResourceName: "cat",
 								Ready:        false,
+								Synced:       true,
 							}, {
 								ResourceName: "dog",
 								Ready:        true,
+								Synced:       true,
 							}, {
 								ResourceName: "snake",
 								Ready:        false,
+								Synced:       true,
 							}},
 						}, nil
 					})),

--- a/test/e2e/manifests/apiextensions/composition/invalid-composed/setup/composition.yaml
+++ b/test/e2e/manifests/apiextensions/composition/invalid-composed/setup/composition.yaml
@@ -1,0 +1,75 @@
+---
+apiVersion: apiextensions.crossplane.io/v1
+kind: Composition
+metadata:
+  name: parent
+spec:
+  compositeTypeRef:
+    apiVersion: example.org/v1alpha1
+    kind: XParent
+  resources:
+    - name: child
+      base:
+        apiVersion: example.org/v1alpha1
+        kind: XChild
+        spec: {}
+      patches:
+        - type: FromCompositeFieldPath
+          # this is going to be 1
+          fromFieldPath: spec.someField
+          # this will fail because it's supposed to be > 1
+          toFieldPath: spec.someField
+    - name: nop-resource-1
+      base:
+        apiVersion: nop.crossplane.io/v1alpha1
+        kind: NopResource
+        metadata:
+          annotations:
+            exampleVal: "foo"
+        spec:
+          forProvider:
+            conditionAfter:
+              - conditionType: Ready
+                conditionStatus: "False"
+                time: 0s
+              - conditionType: Ready
+                conditionStatus: "True"
+                time: 1s
+      patches:
+        - type: FromCompositeFieldPath
+          fromFieldPath: metadata.name
+          # we should still see this in the child
+          toFieldPath: metadata.annotations[something]
+        - type: ToCompositeFieldPath
+          fromFieldPath: metadata.annotations[exampleVal]
+          # we should still see this in the composite
+          toFieldPath: metadata.annotations[exampleVal]
+---
+apiVersion: apiextensions.crossplane.io/v1
+kind: Composition
+metadata:
+  name: child
+spec:
+  compositeTypeRef:
+    apiVersion: example.org/v1alpha1
+    kind: XChild
+  resources:
+    # we don't really care about what happens here, it's not going to work
+    # because the composite resource will be invalid
+    - name: nop-resource-1
+      base:
+        apiVersion: nop.crossplane.io/v1alpha1
+        kind: NopResource
+        spec:
+          forProvider:
+            conditionAfter:
+              - conditionType: Ready
+                conditionStatus: "False"
+                time: 0s
+              - conditionType: Ready
+                conditionStatus: "True"
+                time: 1s
+      patches:
+        - type: FromCompositeFieldPath
+          fromFieldPath: metadata.name
+          toFieldPath: metadata.annotations[something]

--- a/test/e2e/manifests/apiextensions/composition/invalid-composed/setup/definition.yaml
+++ b/test/e2e/manifests/apiextensions/composition/invalid-composed/setup/definition.yaml
@@ -1,0 +1,51 @@
+apiVersion: apiextensions.crossplane.io/v1
+kind: CompositeResourceDefinition
+metadata:
+  name: xparents.example.org
+spec:
+  defaultCompositionRef:
+    name: parent
+  group: example.org
+  names:
+    kind: XParent
+    plural: xparents
+  versions:
+    - name: v1alpha1
+      served: true
+      referenceable: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                someField:
+                  # no limits on its value
+                  type: integer
+---
+apiVersion: apiextensions.crossplane.io/v1
+kind: CompositeResourceDefinition
+metadata:
+  name: xchildren.example.org
+spec:
+  defaultCompositionRef:
+    name: child
+  group: example.org
+  names:
+    kind: XChild
+    plural: xchildren
+  versions:
+    - name: v1alpha1
+      served: true
+      referenceable: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                someField:
+                  minimum: 2
+                  type: integer

--- a/test/e2e/manifests/apiextensions/composition/invalid-composed/setup/provider.yaml
+++ b/test/e2e/manifests/apiextensions/composition/invalid-composed/setup/provider.yaml
@@ -1,0 +1,7 @@
+apiVersion: pkg.crossplane.io/v1
+kind: Provider
+metadata:
+  name: provider-nop
+spec:
+  package: xpkg.upbound.io/crossplane-contrib/provider-nop:v0.2.1
+  ignoreCrossplaneConstraints: true

--- a/test/e2e/manifests/apiextensions/composition/invalid-composed/xr.yaml
+++ b/test/e2e/manifests/apiextensions/composition/invalid-composed/xr.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: example.org/v1alpha1
+kind: XParent
+metadata:
+  name: test
+#  Expected:
+#  annotations:
+#    exampleVal: "foo"
+spec:
+  # this should be > 1 in the XChild composed resource, so it will fail applying it
+  someField: 1


### PR DESCRIPTION
Description of your changes

Fixes https://github.com/crossplane/crossplane/issues/5292.
Fixes https://github.com/crossplane/crossplane/issues/5114.

This PR fixes the stated issues by implementing a change in the resource application approach. Even in cases where one of the composed resources is invalid, we will proceed to apply other resources. This adjustment ensures that eventually consistent Compositions work as intended, while still emitting Warnings events and setting the XR's Sync Condition to false to signal the issue to consumers.

`Sync` and `Ready` conditions will adhere to the following logic:

* for both `Resources` and `Pipeline` compositions: if any of the composed resources fails to apply, the XR's `Sync` condition is set to false.
* only for `Resources` compositions, in the above scenario, also the XR's `Ready` condition is set to false.

While at it, we decided to revise the execution order of the XR status update for `Pipeline` Compositions, ensuring it occurs after the application of composed resources. This modification serves two key purposes: firstly, it ensures the process aligns with the execution order in the PTComposer. Secondly, it prevents an invalid XR status from obstructing the application of composed resources, thereby enabling eventually consistent compositions to subsequently yield a valid XR status.

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [X] Read and followed Crossplane's [contribution process].
- [X] Run `make reviewable` to ensure this PR is ready for review.
- [X] Added or updated unit tests.
- ~[ ] Added or updated e2e tests.~
- ~[ ] Linked a PR or a [docs tracking issue] to [document this change].~
- ~[ ] Added `backport release-x.y` labels to auto-backport this PR.~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/master/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/master/contributing#checklist-cheat-sheet
