### PR TITLE
fix: include generatName field in default metadata property

### DIFF
--- a/pkg/validation/apiextensions/v1/composition/patches_test.go
+++ b/pkg/validation/apiextensions/v1/composition/patches_test.go
@@ -492,6 +492,14 @@ func TestValidateFieldPath(t *testing.T) {
 				schema:    &apiextensions.JSONSchemaProps{Properties: map[string]apiextensions.JSONSchemaProps{"metadata": {Type: "object"}}},
 			},
 		},
+		"AcceptMetadataGenerateName": {
+			reason: "Should accept metadata.generateName",
+			want:   want{err: nil, fieldType: "string"},
+			args: args{
+				fieldPath: "metadata.generateName",
+				schema:    &apiextensions.JSONSchemaProps{Properties: map[string]apiextensions.JSONSchemaProps{"metadata": {Type: "object"}}},
+			},
+		},
 		"AcceptXPreserveUnknownFieldsInAdditionalProperties": {
 			reason: "Should properly handle x-preserve-unknown-fields even if defined in a nested schema",
 			want:   want{err: nil, fieldType: ""},

--- a/pkg/validation/apiextensions/v1/composition/schema.go
+++ b/pkg/validation/apiextensions/v1/composition/schema.go
@@ -32,6 +32,7 @@ func defaultMetadataOnly(metadata *apiextensions.JSONSchemaProps) *apiextensions
 	setDefaultProperty(metadata, "name", string(schema.KnownJSONTypeString))
 	setDefaultProperty(metadata, "namespace", string(schema.KnownJSONTypeString))
 	setDefaultProperty(metadata, "uid", string(schema.KnownJSONTypeString))
+	setDefaultProperty(metadata, "generateName", string(schema.KnownJSONTypeString))
 	setDefaultLabels(metadata)
 	setDefaultAnnotations(metadata)
 	return metadata


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane! Please read the contribution docs
(linked below) if this is your first Crossplane pull request.
-->

### Description of your changes

<!--
Briefly describe what this pull request does, and how it is covered by tests.
Be proactive - direct your reviewers' attention to anything that needs special
consideration.

We love pull requests that fix an open issue. If yours does, use the below line
to indicate which issue it fixes, for example "Fixes #500".
-->

Fixes # 
- include generatName field in default metadata property

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added or updated unit tests.
- [x] Added or updated e2e tests.
- [ ] Linked a PR or a [docs tracking issue] to [document this change].
- [ ] Added `backport release-x.y` labels to auto-backport this PR.

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/master/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/master/contributing#checklist-cheat-sheet
