### PR TITLE
Add missing scrape annotations to provider pods

### DIFF
--- a/internal/controller/pkg/revision/runtime_override_options.go
+++ b/internal/controller/pkg/revision/runtime_override_options.go
@@ -92,6 +92,21 @@ func DeploymentWithNamespace(namespace string) DeploymentOverride {
 	}
 }
 
+// DeploymentWithOptionalPodScrapeAnnotations adds Prometheus scrape annotations
+// to a Deployment pod template if they are not already set.
+func DeploymentWithOptionalPodScrapeAnnotations() DeploymentOverride {
+	return func(d *appsv1.Deployment) {
+		if d.Spec.Template.Annotations == nil {
+			d.Spec.Template.Annotations = map[string]string{}
+		}
+		if _, ok := d.Spec.Template.Annotations["prometheus.io/scrape"]; !ok {
+			d.Spec.Template.Annotations["prometheus.io/scrape"] = "true"
+			d.Spec.Template.Annotations["prometheus.io/port"] = "8080"
+			d.Spec.Template.Annotations["prometheus.io/path"] = "/metrics"
+		}
+	}
+}
+
 // DeploymentWithOwnerReferences overrides the owner references of a Deployment.
 func DeploymentWithOwnerReferences(owners []metav1.OwnerReference) DeploymentOverride {
 	return func(d *appsv1.Deployment) {

--- a/internal/controller/pkg/revision/runtime_provider.go
+++ b/internal/controller/pkg/revision/runtime_provider.go
@@ -229,6 +229,11 @@ func providerDeploymentOverrides(pm *pkgmetav1.Provider, pr v1.PackageRevisionWi
 		// and plan to remove this after implementing a migration in a future
 		// release.
 		DeploymentWithSelectors(providerSelectors(pm, pr)),
+
+		// Add optional scrape annotations to the deployment. It is possible to
+		// disable the scraping by setting the annotation "prometheus.io/scrape"
+		// as "false" in the DeploymentRuntimeConfig.
+		DeploymentWithOptionalPodScrapeAnnotations(),
 	}
 
 	do = append(do, DeploymentRuntimeWithOptionalImage(image))

--- a/internal/controller/pkg/revision/runtime_test.go
+++ b/internal/controller/pkg/revision/runtime_test.go
@@ -159,6 +159,7 @@ func TestRuntimeManifestBuilderDeployment(t *testing.T) {
 					"pkg.crossplane.io/revision": providerRevisionName,
 				}), func(deployment *appsv1.Deployment) {
 					deployment.Spec.Replicas = ptr.To[int32](3)
+					deployment.Spec.Template.Annotations = nil
 					deployment.Spec.Template.Labels["k"] = "v"
 					deployment.Spec.Template.Spec.Containers[0].Image = "crossplane/provider-foo:v1.2.4"
 					deployment.Spec.Template.Spec.Volumes = append(deployment.Spec.Template.Spec.Volumes, corev1.Volume{Name: "vol-a"}, corev1.Volume{Name: "vol-b"})
@@ -218,6 +219,43 @@ func TestRuntimeManifestBuilderDeployment(t *testing.T) {
 					deployment.Spec.Template.Spec.Containers[0].Image = "crossplane/provider-foo:v1.2.4"
 					deployment.Spec.Template.Spec.Volumes = append([]corev1.Volume{{Name: "vol-a"}, {Name: "vol-b"}}, deployment.Spec.Template.Spec.Volumes...)
 					deployment.Spec.Template.Spec.Containers[0].VolumeMounts = append([]corev1.VolumeMount{{Name: "vm-a"}, {Name: "vm-b"}}, deployment.Spec.Template.Spec.Containers[0].VolumeMounts...)
+				}),
+			},
+		},
+		"ProviderDeploymentNoScrapeAnnotation": {
+			reason: "It should be possible to disable default scrape annotations",
+			args: args{
+				builder: &RuntimeManifestBuilder{
+					revision:  providerRevision,
+					namespace: namespace,
+					runtimeConfig: &v1beta1.DeploymentRuntimeConfig{
+						Spec: v1beta1.DeploymentRuntimeConfigSpec{
+							DeploymentTemplate: &v1beta1.DeploymentTemplate{
+								Spec: &appsv1.DeploymentSpec{
+									Template: corev1.PodTemplateSpec{
+										ObjectMeta: metav1.ObjectMeta{
+											Annotations: map[string]string{
+												"prometheus.io/scrape": "false",
+											},
+										},
+										Spec: corev1.PodSpec{},
+									},
+								},
+							},
+						},
+					},
+				},
+				serviceAccountName: providerRevisionName,
+				overrides:          providerDeploymentOverrides(&pkgmetav1.Provider{ObjectMeta: metav1.ObjectMeta{Name: providerMetaName}}, providerRevision, providerImage),
+			},
+			want: want{
+				want: deploymentProvider(providerName, providerRevisionName, providerImage, DeploymentWithSelectors(map[string]string{
+					"pkg.crossplane.io/provider": providerMetaName,
+					"pkg.crossplane.io/revision": providerRevisionName,
+				}), func(deployment *appsv1.Deployment) {
+					deployment.Spec.Template.Annotations = map[string]string{
+						"prometheus.io/scrape": "false",
+					}
 				}),
 			},
 		},
@@ -391,6 +429,11 @@ func deploymentProvider(provider string, revision string, image string, override
 			},
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"prometheus.io/scrape": "true",
+						"prometheus.io/port":   "8080",
+						"prometheus.io/path":   "/metrics",
+					},
 					Labels: map[string]string{
 						"pkg.crossplane.io/revision": revision,
 						"pkg.crossplane.io/provider": provider,


### PR DESCRIPTION
### Description of your changes

All crossplane providers expose metrics by default, [the ones](https://github.com/kubernetes-sigs/controller-runtime/blob/main/pkg/internal/controller/metrics/metrics.go) inherited from controller runtime at minimum.  In provider pods, the package manager added the `metrics` pods already but didn't add the Prometheus scrape annotations, which would be convenient for observing providers without additional configuration.  

This PR adds the following annotations to all provider pods by default:

```yaml
"prometheus.io/scrape": "true"
"prometheus.io/port":   "8080"
"prometheus.io/path":   "/metrics"
```

It is possible to disable this behavior with a `DeploymentRuntimeConfig` as below:

```yaml
apiVersion: pkg.crossplane.io/v1beta1
kind: DeploymentRuntimeConfig
metadata:
  name: no-scrape
spec:
  deploymentTemplate:
    spec:
      selector: {}
      template:
        metadata:
          annotations:
            prometheus.io/scrape: "false"
``` 

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added or updated unit tests.
- [ ] ~Added or updated e2e tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [x] Added `backport release-x.y` labels to auto-backport this PR.

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/master/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/master/contributing#checklist-cheat-sheet
