### PR TITLE
[Backport release-1.14] Add missing scrape annotations to provider pods

### DIFF
--- a/internal/controller/pkg/revision/runtime_override_options.go
+++ b/internal/controller/pkg/revision/runtime_override_options.go
@@ -92,6 +92,21 @@ func DeploymentWithNamespace(namespace string) DeploymentOverride {
 	}
 }
 
+// DeploymentWithOptionalPodScrapeAnnotations adds Prometheus scrape annotations
+// to a Deployment pod template if they are not already set.
+func DeploymentWithOptionalPodScrapeAnnotations() DeploymentOverride {
+	return func(d *appsv1.Deployment) {
+		if d.Spec.Template.Annotations == nil {
+			d.Spec.Template.Annotations = map[string]string{}
+		}
+		if _, ok := d.Spec.Template.Annotations["prometheus.io/scrape"]; !ok {
+			d.Spec.Template.Annotations["prometheus.io/scrape"] = "true"
+			d.Spec.Template.Annotations["prometheus.io/port"] = "8080"
+			d.Spec.Template.Annotations["prometheus.io/path"] = "/metrics"
+		}
+	}
+}
+
 // DeploymentWithOwnerReferences overrides the owner references of a Deployment.
 func DeploymentWithOwnerReferences(owners []metav1.OwnerReference) DeploymentOverride {
 	return func(d *appsv1.Deployment) {

--- a/internal/controller/pkg/revision/runtime_provider.go
+++ b/internal/controller/pkg/revision/runtime_provider.go
@@ -218,6 +218,11 @@ func providerDeploymentOverrides(providerMeta *pkgmetav1.Provider, pr v1.Package
 		// and plan to remove this after implementing a migration in a future
 		// release.
 		DeploymentWithSelectors(providerSelectors(providerMeta, pr)),
+
+		// Add optional scrape annotations to the deployment. It is possible to
+		// disable the scraping by setting the annotation "prometheus.io/scrape"
+		// as "false" in the DeploymentRuntimeConfig.
+		DeploymentWithOptionalPodScrapeAnnotations(),
 	}
 
 	image := pr.GetSource()


### PR DESCRIPTION
# Description
(Manual) Backport of #5529 to `release-1.14`.

- [x] workaround for checklist. 