### PR TITLE
feat/configurable ports

### DIFF
--- a/cluster/charts/crossplane/README.md
+++ b/cluster/charts/crossplane/README.md
@@ -85,6 +85,7 @@ and their default values.
 | `imagePullSecrets` | The imagePullSecret names to add to the Crossplane ServiceAccount. | `[]` |
 | `leaderElection` | Enable [leader election](https://docs.crossplane.io/latest/concepts/pods/#leader-election) for the Crossplane pod. | `true` |
 | `metrics.enabled` | Enable Prometheus path, port and scrape annotations and expose port 8080 for both the Crossplane and RBAC Manager pods. | `false` |
+| `metrics.port` | The port the metrics server listens on. | `""` |
 | `nodeSelector` | Add `nodeSelectors` to the Crossplane pod deployment. | `{}` |
 | `packageCache.configMap` | The name of a ConfigMap to use as the package cache. Disables the default package cache `emptyDir` Volume. | `""` |
 | `packageCache.medium` | Set to `Memory` to hold the package cache in a RAM backed file system. Useful for Crossplane development. | `""` |
@@ -105,6 +106,7 @@ and their default values.
 | `rbacManager.skipAggregatedClusterRoles` | Don't install aggregated Crossplane ClusterRoles. | `false` |
 | `rbacManager.tolerations` | Add `tolerations` to the RBAC Manager pod deployment. | `[]` |
 | `rbacManager.topologySpreadConstraints` | Add `topologySpreadConstraints` to the RBAC Manager pod deployment. | `[]` |
+| `readiness.port` | The port the readyz server listens on. | `""` |
 | `registryCaBundleConfig.key` | The ConfigMap key containing a custom CA bundle to enable fetching packages from registries with unknown or untrusted certificates. | `""` |
 | `registryCaBundleConfig.name` | The ConfigMap name containing a custom CA bundle to enable fetching packages from registries with unknown or untrusted certificates. | `""` |
 | `replicas` | The number of Crossplane pod `replicas` to deploy. | `1` |
@@ -132,6 +134,7 @@ and their default values.
 | `tolerations` | Add `tolerations` to the Crossplane pod deployment. | `[]` |
 | `topologySpreadConstraints` | Add `topologySpreadConstraints` to the Crossplane pod deployment. | `[]` |
 | `webhooks.enabled` | Enable webhooks for Crossplane and installed Provider packages. | `true` |
+| `webhooks.port` | The port the webhook server listens on. | `""` |
 
 ### Command Line
 

--- a/cluster/charts/crossplane/templates/deployment.yaml
+++ b/cluster/charts/crossplane/templates/deployment.yaml
@@ -141,14 +141,14 @@ spec:
             port: readyz
         ports:
         - name: readyz
-          containerPort: 8081
+          containerPort: {{ .Values.readiness.port | default 8081 }}
         {{- if .Values.metrics.enabled }}
         - name: metrics
-          containerPort: 8080
+          containerPort: {{ .Values.metrics.port | default 8080 }}
         {{- end }}
         {{- if .Values.webhooks.enabled }}
         - name: webhooks
-          containerPort: 9443
+          containerPort: {{ .Values.webhooks.port | default 9443 }}
         {{- end }}
         {{- with .Values.securityContextCrossplane }}
         securityContext:
@@ -185,6 +185,18 @@ spec:
           - name: "WEBHOOK_ENABLED"
             value: "false"
           {{- end }}
+          {{- if and .Values.webhooks.enabled .Values.webhooks.port }}
+          - name: "WEBHOOK_PORT"
+            value: "{{ .Values.webhooks.port }}"
+          {{- end}}
+          {{- if and .Values.metrics.enabled .Values.metrics.port }}
+          - name: "METRICS_PORT"
+            value: "{{ .Values.metrics.port }}"
+          {{- end}}
+          {{- if .Values.readiness.port }}
+          - name: "HEALTH_PROBE_PORT"
+            value: "{{ .Values.readiness.port }}"
+          {{- end}}
           - name: "TLS_SERVER_SECRET_NAME"
             value: crossplane-tls-server
           - name: "TLS_SERVER_CERTS_DIR"

--- a/cluster/charts/crossplane/templates/service.yaml
+++ b/cluster/charts/crossplane/templates/service.yaml
@@ -21,5 +21,5 @@ spec:
   ports:
   - protocol: TCP
     port: 9443
-    targetPort: 9443
+    targetPort: {{ .Values.webhooks.port | default 9443 }}
 {{- end }}

--- a/cluster/charts/crossplane/values.yaml
+++ b/cluster/charts/crossplane/values.yaml
@@ -80,6 +80,8 @@ service:
 webhooks:
   # -- Enable webhooks for Crossplane and installed Provider packages.
   enabled: true
+  # -- The port the webhook server listens on.
+  port: ""
 
 rbacManager:
   # -- Deploy the RBAC Manager pod and its required roles.
@@ -167,6 +169,12 @@ securityContextRBACManager:
 metrics:
   # -- Enable Prometheus path, port and scrape annotations and expose port 8080 for both the Crossplane and RBAC Manager pods.
   enabled: false
+  # -- The port the metrics server listens on.
+  port: ""
+
+readiness:
+  # -- The port the readyz server listens on.
+  port: ""
 
 # -- Add custom environmental variables to the Crossplane pod deployment.
 # Replaces any `.` in a variable name with `_`. For example, `SAMPLE.KEY=value1` becomes `SAMPLE_KEY=value1`.

--- a/cmd/crossplane/core/core.go
+++ b/cmd/crossplane/core/core.go
@@ -103,11 +103,11 @@ type startCommand struct {
 	MaxReconcileRate                 int           `default:"100" help:"The global maximum rate per second at which resources may checked for drift from the desired state."`
 	MaxConcurrentPackageEstablishers int           `default:"10"  help:"The the maximum number of goroutines to use for establishing Providers, Configurations and Functions."`
 
-	WebhookEnabled                      bool `default:"true" env:"WEBHOOK_ENABLED" help:"Enable webhook configuration."`
+	WebhookEnabled                      bool `default:"true"  env:"WEBHOOK_ENABLED"                        help:"Enable webhook configuration."`
 	AutomaticDependencyDowngradeEnabled bool `default:"false" env:"AUTOMATIC_DEPENDENCY_DOWNGRADE_ENABLED" help:"Enable automatic dependency version downgrades. This configuration requires the 'EnableDependencyVersionUpgrades' feature flag to be enabled."`
 
-	WebhookPort     int `default:"9443" env:"WEBHOOK_PORT"    help:"The port the webhook server listens on."`
-	MetricsPort     int `default:"8080" env:"METRICS_PORT" help:"The port the metrics server listens on."`
+	WebhookPort     int `default:"9443" env:"WEBHOOK_PORT"      help:"The port the webhook server listens on."`
+	MetricsPort     int `default:"8080" env:"METRICS_PORT"      help:"The port the metrics server listens on."`
 	HealthProbePort int `default:"8081" env:"HEALTH_PROBE_PORT" help:"The port the health probe endpoint listens on."`
 
 	TLSServerSecretName string `env:"TLS_SERVER_SECRET_NAME" help:"The name of the TLS Secret that will store Crossplane's server certificate."`

--- a/internal/controller/pkg/revision/runtime.go
+++ b/internal/controller/pkg/revision/runtime.go
@@ -22,7 +22,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/util/intstr"
 
 	"github.com/crossplane/crossplane-runtime/pkg/meta"
 
@@ -44,6 +43,7 @@ const (
 
 	// See https://github.com/grpc/grpc/blob/v1.58.0/doc/naming.md
 	grpcPortName       = "grpc"
+	grpcPort           = 9443
 	servicePort        = 9443
 	serviceEndpointFmt = "dns:///%s.%s:%d"
 
@@ -283,14 +283,7 @@ func (b *RuntimeManifestBuilder) Service(overrides ...ServiceOverride) *corev1.S
 		// Overrides that we are opinionated about.
 		ServiceWithNamespace(b.namespace),
 		ServiceWithOwnerReferences([]metav1.OwnerReference{meta.AsController(meta.TypedReferenceTo(b.revision, b.revision.GetObjectKind().GroupVersionKind()))}),
-		ServiceWithSelectors(b.podSelectors()),
-		ServiceWithAdditionalPorts([]corev1.ServicePort{
-			{
-				Protocol:   corev1.ProtocolTCP,
-				Port:       servicePort,
-				TargetPort: intstr.FromInt32(servicePort),
-			},
-		}))
+		ServiceWithSelectors(b.podSelectors()))
 
 	// We append the overrides passed to the function last so that they can
 	// override the above ones.

--- a/internal/controller/pkg/revision/runtime_defaults.go
+++ b/internal/controller/pkg/revision/runtime_defaults.go
@@ -65,16 +65,18 @@ func deploymentFromRuntimeConfig(tmpl *v1beta1.DeploymentTemplate) *appsv1.Deplo
 func serviceFromRuntimeConfig(tmpl *v1beta1.ServiceTemplate) *corev1.Service {
 	svc := &corev1.Service{}
 
-	if tmpl == nil || tmpl.Metadata == nil {
+	if tmpl == nil {
 		return svc
 	}
 
-	if tmpl.Metadata.Name != nil {
-		svc.Name = *tmpl.Metadata.Name
-	}
+	if meta := tmpl.Metadata; meta != nil {
+		if meta.Name != nil {
+			svc.Name = *meta.Name
+		}
 
-	svc.Annotations = tmpl.Metadata.Annotations
-	svc.Labels = tmpl.Metadata.Labels
+		svc.Annotations = meta.Annotations
+		svc.Labels = meta.Labels
+	}
 
 	return svc
 }

--- a/internal/controller/pkg/revision/runtime_defaults.go
+++ b/internal/controller/pkg/revision/runtime_defaults.go
@@ -65,18 +65,16 @@ func deploymentFromRuntimeConfig(tmpl *v1beta1.DeploymentTemplate) *appsv1.Deplo
 func serviceFromRuntimeConfig(tmpl *v1beta1.ServiceTemplate) *corev1.Service {
 	svc := &corev1.Service{}
 
-	if tmpl == nil {
+	if tmpl == nil || tmpl.Metadata == nil {
 		return svc
 	}
 
-	if meta := tmpl.Metadata; meta != nil {
-		if meta.Name != nil {
-			svc.Name = *meta.Name
-		}
-
-		svc.Annotations = meta.Annotations
-		svc.Labels = meta.Labels
+	if tmpl.Metadata.Name != nil {
+		svc.Name = *tmpl.Metadata.Name
 	}
+
+	svc.Annotations = tmpl.Metadata.Annotations
+	svc.Labels = tmpl.Metadata.Labels
 
 	return svc
 }

--- a/internal/controller/pkg/revision/runtime_provider.go
+++ b/internal/controller/pkg/revision/runtime_provider.go
@@ -25,6 +25,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/crossplane/crossplane-runtime/pkg/errors"
@@ -98,7 +99,18 @@ func (h *ProviderHooks) Pre(ctx context.Context, pkg runtime.Object, pr v1.Packa
 	// post establish.
 	// As a rule of thumb, we create objects named after the package in the
 	// pre hook and objects named after the package revision in the post hook.
-	svc := build.Service(ServiceWithSelectors(providerSelectors(providerMeta, pr)))
+	svc := build.Service(
+		ServiceWithSelectors(providerSelectors(providerMeta, pr)),
+		ServiceWithAdditionalPorts([]corev1.ServicePort{
+			{
+				Name:       webhookPortName,
+				Protocol:   corev1.ProtocolTCP,
+				Port:       servicePort,
+				TargetPort: intstr.FromString(webhookPortName),
+			},
+		}),
+	)
+
 	if err := h.client.Apply(ctx, svc); err != nil {
 		return errors.Wrap(err, errApplyProviderService)
 	}

--- a/internal/controller/pkg/revision/runtime_test.go
+++ b/internal/controller/pkg/revision/runtime_test.go
@@ -24,6 +24,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/ptr"
 
 	pkgmetav1 "github.com/crossplane/crossplane/apis/pkg/meta/v1"
@@ -197,6 +198,9 @@ func TestRuntimeManifestBuilderDeployment(t *testing.T) {
 														{Name: "vm-a"},
 														{Name: "vm-b"},
 													},
+													Ports: []corev1.ContainerPort{
+														{ContainerPort: 7070, Name: metricsPortName},
+													},
 												},
 											},
 										},
@@ -219,6 +223,8 @@ func TestRuntimeManifestBuilderDeployment(t *testing.T) {
 					deployment.Spec.Template.Spec.Containers[0].Image = "crossplane/provider-foo:v1.2.4"
 					deployment.Spec.Template.Spec.Volumes = append([]corev1.Volume{{Name: "vol-a"}, {Name: "vol-b"}}, deployment.Spec.Template.Spec.Volumes...)
 					deployment.Spec.Template.Spec.Containers[0].VolumeMounts = append([]corev1.VolumeMount{{Name: "vm-a"}, {Name: "vm-b"}}, deployment.Spec.Template.Spec.Containers[0].VolumeMounts...)
+					deployment.Spec.Template.Spec.Containers[0].Ports[0].ContainerPort = 7070
+					deployment.Spec.Template.Annotations["prometheus.io/port"] = "7070"
 				}),
 			},
 		},
@@ -393,12 +399,137 @@ func TestRuntimeManifestBuilderDeployment(t *testing.T) {
 				}),
 			},
 		},
+		"FunctionDeploymentWithRuntimeConfig": {
+			reason: "Overrides from the runtime config should be applied to the deployment",
+			args: args{
+				builder: &RuntimeManifestBuilder{
+					revision:  functionRevision,
+					namespace: namespace,
+					runtimeConfig: &v1beta1.DeploymentRuntimeConfig{
+						Spec: v1beta1.DeploymentRuntimeConfigSpec{
+							DeploymentTemplate: &v1beta1.DeploymentTemplate{
+								Spec: &appsv1.DeploymentSpec{
+									Replicas: ptr.To[int32](3),
+									Template: corev1.PodTemplateSpec{
+										Spec: corev1.PodSpec{
+											Containers: []corev1.Container{
+												{
+													Name: runtimeContainerName,
+													Ports: []corev1.ContainerPort{
+														{
+															Name:          grpcPortName,
+															ContainerPort: 7070,
+														},
+														{
+															Name:          metricsPortName,
+															ContainerPort: 7071,
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				serviceAccountName: functionRevisionName,
+				overrides:          functionDeploymentOverrides(functionImage),
+			},
+			want: want{
+				want: deploymentFunction(functionName, functionRevisionName, functionImage, func(deployment *appsv1.Deployment) {
+					deployment.Spec.Replicas = ptr.To[int32](3)
+					deployment.Spec.Template.Spec.Containers[0].Ports[0].Name = grpcPortName
+					deployment.Spec.Template.Spec.Containers[0].Ports[0].ContainerPort = 7070
+					deployment.Spec.Template.Spec.Containers[0].Ports[1].Name = metricsPortName
+					deployment.Spec.Template.Spec.Containers[0].Ports[1].ContainerPort = 7071
+				}),
+			},
+		},
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			got := tc.args.builder.Deployment(tc.args.serviceAccountName, tc.args.overrides...)
 			if diff := cmp.Diff(tc.want.want, got); diff != "" {
 				t.Errorf("\n%s\nDeployment(...): -want, +got:\n%s\n", tc.reason, diff)
+			}
+		})
+	}
+}
+
+func TestRuntimeManifestBuilderService(t *testing.T) {
+	type args struct {
+		builder            ManifestBuilder
+		overrides          []ServiceOverride
+		serviceAccountName string
+	}
+	type want struct {
+		want *corev1.Service
+	}
+	cases := map[string]struct {
+		reason string
+		args   args
+		want   want
+	}{
+		"ProviderServiceNoRuntimeConfig": {
+			reason: "No overrides should result in a deployment with default values",
+			args: args{
+				builder: &RuntimeManifestBuilder{
+					revision:  providerRevision,
+					namespace: namespace,
+				},
+				serviceAccountName: providerRevisionName,
+				overrides: []ServiceOverride{
+					ServiceWithSelectors(providerSelectors(&pkgmetav1.Provider{ObjectMeta: metav1.ObjectMeta{Name: providerMetaName}}, providerRevision)),
+					ServiceWithAdditionalPorts([]corev1.ServicePort{
+						{
+							Name:       grpcPortName,
+							Protocol:   corev1.ProtocolTCP,
+							Port:       servicePort,
+							TargetPort: intstr.FromString(grpcPortName),
+						},
+					}),
+				},
+			},
+			want: want{
+				want: &corev1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      providerName,
+						Namespace: namespace,
+						OwnerReferences: []metav1.OwnerReference{
+							{
+								APIVersion:         "pkg.crossplane.io/v1",
+								Kind:               "ProviderRevision",
+								Name:               providerRevisionName,
+								Controller:         ptr.To(true),
+								BlockOwnerDeletion: ptr.To(true),
+							},
+						},
+					},
+					Spec: corev1.ServiceSpec{
+						Selector: map[string]string{
+							"pkg.crossplane.io/provider": providerMetaName,
+							"pkg.crossplane.io/revision": providerRevisionName,
+						},
+						Ports: []corev1.ServicePort{
+							{
+								Name:       grpcPortName,
+								Port:       int32(servicePort),
+								TargetPort: intstr.FromString(grpcPortName),
+								Protocol:   corev1.ProtocolTCP,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got := tc.args.builder.Service(tc.args.overrides...)
+			if diff := cmp.Diff(tc.want.want, got); diff != "" {
+				t.Errorf("\n%s\nService(...): -want, +got:\n%s\n", tc.reason, diff)
 			}
 		})
 	}

--- a/internal/controller/pkg/revision/runtime_test.go
+++ b/internal/controller/pkg/revision/runtime_test.go
@@ -473,7 +473,7 @@ func TestRuntimeManifestBuilderService(t *testing.T) {
 		want   want
 	}{
 		"ProviderServiceNoRuntimeConfig": {
-			reason: "No overrides should result in a deployment with default values",
+			reason: "No runtime config on the builder should result in a service with default values",
 			args: args{
 				builder: &RuntimeManifestBuilder{
 					revision:  providerRevision,
@@ -484,10 +484,10 @@ func TestRuntimeManifestBuilderService(t *testing.T) {
 					ServiceWithSelectors(providerSelectors(&pkgmetav1.Provider{ObjectMeta: metav1.ObjectMeta{Name: providerMetaName}}, providerRevision)),
 					ServiceWithAdditionalPorts([]corev1.ServicePort{
 						{
-							Name:       grpcPortName,
+							Name:       webhookPortName,
 							Protocol:   corev1.ProtocolTCP,
 							Port:       servicePort,
-							TargetPort: intstr.FromString(grpcPortName),
+							TargetPort: intstr.FromString(webhookPortName),
 						},
 					}),
 				},
@@ -514,9 +514,9 @@ func TestRuntimeManifestBuilderService(t *testing.T) {
 						},
 						Ports: []corev1.ServicePort{
 							{
-								Name:       grpcPortName,
+								Name:       webhookPortName,
 								Port:       int32(servicePort),
-								TargetPort: intstr.FromString(grpcPortName),
+								TargetPort: intstr.FromString(webhookPortName),
 								Protocol:   corev1.ProtocolTCP,
 							},
 						},


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane! Please read the contribution docs
(linked below) if this is your first Crossplane pull request.
-->

### Description of your changes

When running crossplane (and providers/functions) in the host network the need to configure ports arises.

This MR has two parts:

1. Make crossplane ports (service/webhook, health probe, metrics) configurable
2. Allow `DeploymentRuntimeConfig` to override the default ports (`metrics`, `webhook`, `grpc`) in both `Deployment` and `Service`.

Additional merge requests would be necessary to

- Adjust the documentation
- Adjust the provider and function templates (to introduce configuration options for their ports)
- Providers / Functions (to introduce configuration options for their ports)

Putting this on draft to gather your feedback. Please let me know what you think about it and how to proceed with the follow ups.

Contributes to #5520

#### Crossplane Ports

The following configuration options (flags / environment variables) where added, with their defaults set to the current values:

- `--webhook-port=9443`
- `--metrics-bind-address=:8080`
- `--health-probe-bind-address=:8081`

Additionally these options were added to the values of the helm charts defaulting to unset:

- `webhooks.port`
- `metrics.port`
- `readiness.port`

Note that for the configuration options I chose to stick as close as possible to the underlying API for increased flexibility (thus the bind-address choice), while the helm chart is more oriented towards a consistent user experience (thus ports for all 3 options). Let me know what you think about it!

#### Provider, Functions, Service Ports

The core idea is to allow the user to specify the ports in the DeploymentRuntimeConfig (DRC), by setting `spec.deploymentTemplate.spec.template.spec.containers[0].ports` and passing `args` to the container to tell the provider which ports to bind to. An example DRC can be found at https://github.com/jbw976/crossplane/blob/configurable-ports-review/provider-k8s.yaml.

Here's a brief summary of the changes:

- `DeploymentWithOptionalPodScrapeAnnotations` uses the port number of a given `metrics` port if set in the DRC deployment template.
- `DeploymentRuntimeWithAdditionalPorts` only adds ports not contained in the DRC deployment template (based on comparing their names).
- `ServiceWithAdditionalPorts` only adds ports not contained in the DRC service template (based on comparing their names).
- Set the `Name` attribute of webhook ports in services to `webhook` (to facilitate the name comparison).

Unit tests were added.
<!--
Briefly describe what this pull request does, and how it is covered by tests.
Be proactive - direct your reviewers' attention to anything that needs special
consideration.

We love pull requests that fix an open issue. If yours does, use the below line
to indicate which issue it fixes, for example "Fixes #500".
-->

### Housekeeping

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added or updated unit tests.
- [ ] ~Added or updated e2e tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/master/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/master/contributing#checklist-cheat-sheet
