### PR TITLE
[Backport release-1.15] tests(e2e): allow passing options when decoding files

### DIFF
--- a/test/e2e/funcs/feature.go
+++ b/test/e2e/funcs/feature.go
@@ -123,10 +123,10 @@ func DeploymentBecomesAvailableWithin(d time.Duration, namespace, name string) f
 
 // ResourcesCreatedWithin fails a test if the supplied resources are not found
 // to exist within the supplied duration.
-func ResourcesCreatedWithin(d time.Duration, dir, pattern string) features.Func {
+func ResourcesCreatedWithin(d time.Duration, dir, pattern string, options ...decoder.DecodeOption) features.Func {
 	return func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
 
-		rs, err := decoder.DecodeAllFiles(ctx, os.DirFS(dir), pattern)
+		rs, err := decoder.DecodeAllFiles(ctx, os.DirFS(dir), pattern, options...)
 		if err != nil {
 			t.Error(err)
 			return ctx
@@ -169,10 +169,10 @@ func ResourceCreatedWithin(d time.Duration, o k8s.Object) features.Func {
 
 // ResourcesDeletedWithin fails a test if the supplied resources are not deleted
 // within the supplied duration.
-func ResourcesDeletedWithin(d time.Duration, dir, pattern string) features.Func {
+func ResourcesDeletedWithin(d time.Duration, dir, pattern string, options ...decoder.DecodeOption) features.Func {
 	return func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
 
-		rs, err := decoder.DecodeAllFiles(ctx, os.DirFS(dir), pattern)
+		rs, err := decoder.DecodeAllFiles(ctx, os.DirFS(dir), pattern, options...)
 		if err != nil {
 			t.Error(err)
 			return ctx
@@ -313,10 +313,10 @@ var NotFound = notFound{}
 // ResourcesHaveFieldValueWithin fails a test if the supplied resources do not
 // have the supplied value at the supplied field path within the supplied
 // duration. The supplied 'want' value must cmp.Equal the actual value.
-func ResourcesHaveFieldValueWithin(d time.Duration, dir, pattern, path string, want any) features.Func {
+func ResourcesHaveFieldValueWithin(d time.Duration, dir, pattern, path string, want any, options ...decoder.DecodeOption) features.Func {
 	return func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
 
-		rs, err := decoder.DecodeAllFiles(ctx, os.DirFS(dir), pattern)
+		rs, err := decoder.DecodeAllFiles(ctx, os.DirFS(dir), pattern, options...)
 		if err != nil {
 			t.Error(err)
 			return ctx
@@ -433,7 +433,7 @@ type claimCtxKey struct{}
 
 // ApplyClaim applies the claim stored in the given folder and file
 // and stores it in the test context for later retrival if needed
-func ApplyClaim(manager, dir, cm string) features.Func {
+func ApplyClaim(manager, dir, cm string, options ...decoder.DecodeOption) features.Func {
 	return func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
 		dfs := os.DirFS(dir)
 
@@ -443,7 +443,7 @@ func ApplyClaim(manager, dir, cm string) features.Func {
 			return ctx
 		}
 
-		objs, err := decoder.DecodeAllFiles(ctx, dfs, cm)
+		objs, err := decoder.DecodeAllFiles(ctx, dfs, cm, options...)
 		if err != nil {
 			t.Error(err)
 			return ctx
@@ -469,15 +469,7 @@ func ApplyClaim(manager, dir, cm string) features.Func {
 // SetAnnotationMutateOption returns a DecodeOption that sets the supplied
 // annotation on the decoded object.
 func SetAnnotationMutateOption(key, value string) decoder.DecodeOption {
-	return decoder.MutateOption(func(o k8s.Object) error {
-		a := o.GetAnnotations()
-		if a == nil {
-			a = map[string]string{}
-		}
-		a[key] = value
-		o.SetAnnotations(a)
-		return nil
-	})
+	return decoder.MutateAnnotations(map[string]string{key: value})
 }
 
 // ResourcesFailToApply applies all manifests under the supplied directory that
@@ -485,11 +477,11 @@ func SetAnnotationMutateOption(key, value string) decoder.DecodeOption {
 // fields are managed by the supplied field manager. It fails the test if any
 // supplied resource _can_ be applied successfully - use it to test that the API
 // server should reject a resource.
-func ResourcesFailToApply(manager, dir, pattern string) features.Func {
+func ResourcesFailToApply(manager, dir, pattern string, options ...decoder.DecodeOption) features.Func {
 	return func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
 		dfs := os.DirFS(dir)
 
-		if err := decoder.DecodeEachFile(ctx, dfs, pattern, ApplyHandler(c.Client().Resources(), manager)); err == nil {
+		if err := decoder.DecodeEachFile(ctx, dfs, pattern, ApplyHandler(c.Client().Resources(), manager), options...); err == nil {
 			// TODO(negz): Ideally we'd say which one.
 			t.Error("Resource applied successfully, but should have failed")
 			return ctx
@@ -525,11 +517,11 @@ func ApplyHandler(r *resources.Resources, manager string, osh ...onSuccessHandle
 // DeleteResources deletes (from the environment) all resources defined by the
 // manifests under the supplied directory that match the supplied glob pattern
 // (e.g. *.yaml).
-func DeleteResources(dir, pattern string) features.Func {
+func DeleteResources(dir, pattern string, options ...decoder.DecodeOption) features.Func {
 	return func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
 		dfs := os.DirFS(dir)
 
-		if err := decoder.DecodeEachFile(ctx, dfs, pattern, decoder.DeleteHandler(c.Client().Resources())); err != nil {
+		if err := decoder.DecodeEachFile(ctx, dfs, pattern, decoder.DeleteHandler(c.Client().Resources()), options...); err != nil {
 			t.Fatal(err)
 			return ctx
 		}
@@ -620,11 +612,11 @@ func CompositeUnderTestMustNotChangeWithin(d time.Duration) features.Func {
 
 // CompositeResourceMustMatchWithin assert that a composite referred by the given file
 // must be matched by the given function within the given timeout
-func CompositeResourceMustMatchWithin(d time.Duration, dir, claimFile string, match func(xr *composite.Unstructured) bool) features.Func {
+func CompositeResourceMustMatchWithin(d time.Duration, dir, claimFile string, match func(xr *composite.Unstructured) bool, options ...decoder.DecodeOption) features.Func {
 	return func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
 		cm := &claim.Unstructured{}
 
-		if err := decoder.DecodeFile(os.DirFS(dir), claimFile, cm); err != nil {
+		if err := decoder.DecodeFile(os.DirFS(dir), claimFile, cm, options...); err != nil {
 			t.Error(err)
 			return ctx
 		}
@@ -670,11 +662,11 @@ func CompositeResourceMustMatchWithin(d time.Duration, dir, claimFile string, ma
 // CompositeResourceHasFieldValueWithin asserts that the XR referred to by the
 // claim in the given file has the specified value at the specified path within
 // the specified time.
-func CompositeResourceHasFieldValueWithin(d time.Duration, dir, claimFile, path string, want any) features.Func {
+func CompositeResourceHasFieldValueWithin(d time.Duration, dir, claimFile, path string, want any, options ...decoder.DecodeOption) features.Func {
 	return func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
 		cm := &claim.Unstructured{}
 
-		if err := decoder.DecodeFile(os.DirFS(dir), claimFile, cm); err != nil {
+		if err := decoder.DecodeFile(os.DirFS(dir), claimFile, cm, options...); err != nil {
 			t.Error(err)
 			return ctx
 		}
@@ -739,10 +731,10 @@ func CompositeResourceHasFieldValueWithin(d time.Duration, dir, claimFile, path 
 // ComposedResourcesHaveFieldValueWithin fails a test if the composed
 // resources created by the claim does not have the supplied value at the
 // supplied path within the supplied duration.
-func ComposedResourcesHaveFieldValueWithin(d time.Duration, dir, file, path string, want any, filter func(object k8s.Object) bool) features.Func { //nolint:gocyclo // Not too much over.
+func ComposedResourcesHaveFieldValueWithin(d time.Duration, dir, file, path string, want any, filter func(object k8s.Object) bool, options ...decoder.DecodeOption) features.Func { //nolint:gocyclo // Not too much over.
 	return func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
 		cm := &claim.Unstructured{}
-		if err := decoder.DecodeFile(os.DirFS(dir), file, cm); err != nil {
+		if err := decoder.DecodeFile(os.DirFS(dir), file, cm, options...); err != nil {
 			t.Error(err)
 			return ctx
 		}
@@ -965,11 +957,11 @@ func LogResources(list k8s.ObjectList, listOptions ...resources.ListOption) feat
 // defined by the manifests under the supplied directory that match the supplied
 // glob pattern (e.g. *.yaml) and verifies that they are blocked by the usage
 // webhook.
-func DeletionBlockedByUsageWebhook(dir, pattern string) features.Func {
+func DeletionBlockedByUsageWebhook(dir, pattern string, options ...decoder.DecodeOption) features.Func {
 	return func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
 		dfs := os.DirFS(dir)
 
-		err := decoder.DecodeEachFile(ctx, dfs, pattern, decoder.DeleteHandler(c.Client().Resources()))
+		err := decoder.DecodeEachFile(ctx, dfs, pattern, decoder.DeleteHandler(c.Client().Resources()), options...)
 		if err == nil {
 			t.Fatal("expected the usage webhook to deny the request but deletion succeeded")
 			return ctx


### PR DESCRIPTION
Signed-off-by: Philippe Scorsolini <p.scorsolini@gmail.com>
(cherry picked from commit 3a401f8abc7ae6fff7ef310654a9fda9fc347fac)

<!--
Thank you for helping to improve Crossplane! Please read the contribution docs
(linked below) if this is your first Crossplane pull request.
-->

### Description of your changes

<!--
Briefly describe what this pull request does, and how it is covered by tests.
Be proactive - direct your reviewers' attention to anything that needs special
consideration.

We love pull requests that fix an open issue. If yours does, use the below line
to indicate which issue it fixes, for example "Fixes #500".
-->

Backport of https://github.com/crossplane/crossplane/pull/5517.

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] ~Added or updated unit tests.~
- [ ] ~Added or updated e2e tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/master/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/master/contributing#checklist-cheat-sheet
