### PR TITLE
Update community meeting schedule

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,10 +62,13 @@ for more information on how you can help.
 * Join our regular community meetings.
 * Provide feedback on our [roadmap and releases board].
 
-The Crossplane community meeting takes place every other [Thursday at 10:00am
-Pacific Time][community meeting time]. Anyone who wants to discuss the direction
-of the project, design and implementation reviews, or raise general questions
-with the broader community is encouraged to join.
+The Crossplane community meeting takes place every 4 weeks on [Thursday at
+10:00am Pacific Time][community meeting time]. You can find the up to date
+meeting schedule on the [Community Calendar][community calendar].
+
+Anyone who wants to discuss the direction of the project, design and
+implementation reviews, or raise general questions with the broader community is
+encouraged to join.
 
 * Meeting link: <https://zoom.us/j/425148449?pwd=NEk4N0tHWGpEazhuam1yR28yWHY5QT09>
 * [Current agenda and past meeting notes]


### PR DESCRIPTION
### Description of your changes

This PR simply updates the README.md to clearly state the community meeting will be once every 4 weeks. This change in schedule was discussed at the last community meeting on [Apr 4, 2024](https://docs.google.com/document/d/1q_sp2jLQsDEOX7Yug6TPOv7Fwrys6EwcF5Itxjkno7Y/edit#heading=h.68i5rn95ne93).

The [community calendar](https://calendar.google.com/calendar/u/0/embed?src=c_2cdn0hs9e2m05rrv1233cjoj1k@group.calendar.google.com) and [agenda doc](https://docs.google.com/document/d/1q_sp2jLQsDEOX7Yug6TPOv7Fwrys6EwcF5Itxjkno7Y/edit?usp=sharing) have also been updated.

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [ ] ~Run `make reviewable` to ensure this PR is ready for review.~
- [ ] ~Added or updated unit tests.~
- [ ] ~Added or updated e2e tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/master/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/master/contributing#checklist-cheat-sheet
