### PR TITLE
[Backport release-1.14] fix(sa): Merge image pull secrets created by other controllers 

### DIFF
--- a/internal/controller/pkg/revision/runtime_function.go
+++ b/internal/controller/pkg/revision/runtime_function.go
@@ -123,7 +123,7 @@ func (h *FunctionHooks) Post(ctx context.Context, pkg runtime.Object, pr v1.Pack
 	// `deploymentTemplate.spec.template.spec.serviceAccountName` in the
 	// DeploymentRuntimeConfig.
 	if sa.Name == d.Spec.Template.Spec.ServiceAccountName {
-		if err := h.client.Apply(ctx, sa); err != nil {
+		if err := applySA(ctx, h.client, sa); err != nil {
 			return errors.Wrap(err, errApplyFunctionSA)
 		}
 	}

--- a/internal/controller/pkg/revision/runtime_provider_test.go
+++ b/internal/controller/pkg/revision/runtime_provider_test.go
@@ -459,6 +459,56 @@ func TestProviderPostHook(t *testing.T) {
 				},
 			},
 		},
+		"SuccessWithExtraSecret": {
+			reason: "Should not return error if successfully applied service account with additional secret.",
+			args: args{
+				pkg: &pkgmetav1.Provider{},
+				rev: &v1.ProviderRevision{
+					Spec: v1.ProviderRevisionSpec{
+						PackageRevisionSpec: v1.PackageRevisionSpec{
+							Package:      providerImage,
+							DesiredState: v1.PackageRevisionActive,
+						},
+					},
+				},
+				manifests: &MockManifestBuilder{
+					ServiceAccountFn: func(_ ...ServiceAccountOverride) *corev1.ServiceAccount {
+						return &corev1.ServiceAccount{}
+					},
+					DeploymentFn: func(_ string, _ ...DeploymentOverride) *appsv1.Deployment {
+						return &appsv1.Deployment{}
+					},
+				},
+				client: &test.MockClient{
+					MockGet: func(_ context.Context, _ client.ObjectKey, obj client.Object) error {
+						if sa, ok := obj.(*corev1.ServiceAccount); ok {
+							sa.ImagePullSecrets = []corev1.LocalObjectReference{{Name: "test_secret"}}
+						}
+						return nil
+					},
+					MockPatch: func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) error {
+						if d, ok := obj.(*appsv1.Deployment); ok {
+							d.Status.Conditions = []appsv1.DeploymentCondition{{
+								Type:   appsv1.DeploymentAvailable,
+								Status: corev1.ConditionTrue,
+							}}
+							return nil
+						}
+						return nil
+					},
+				},
+			},
+			want: want{
+				rev: &v1.ProviderRevision{
+					Spec: v1.ProviderRevisionSpec{
+						PackageRevisionSpec: v1.PackageRevisionSpec{
+							Package:      providerImage,
+							DesiredState: v1.PackageRevisionActive,
+						},
+					},
+				},
+			},
+		},
 		"SuccessfulWithExternallyManagedSA": {
 			reason: "Should be successful without creating an SA, when the SA is managed externally",
 			args: args{


### PR DESCRIPTION
Signed-off-by: Bob Haddleton <bob.haddleton@nokia.com>
(cherry picked from commit 36f0c56268d9b9da2c4dfb586d6c348899311be7)

Backport #5558 to release-1.14

I have:
- [X] Read and followed Crossplane's [contribution process](https://github.com/crossplane/crossplane/tree/master/contributing).
- [X] Run make reviewable to ensure this PR is ready for review.
- [X] Added or updated unit tests.
- ~[] Added or updated e2e tests.~
- ~[] Linked a PR or a [docs tracking issue](https://github.com/crossplane/docs/issues/new) to [document this change](https://docs.crossplane.io/contribute/contribute).~
- ~[] Added backport release-x.y labels to auto-backport this PR.~