### PR TITLE
cli: tilde expansion for validate command

### DIFF
--- a/cmd/crank/beta/validate/cmd.go
+++ b/cmd/crank/beta/validate/cmd.go
@@ -20,6 +20,7 @@ package validate
 import (
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/alecthomas/kong"
 	"github.com/spf13/afero"
@@ -115,6 +116,11 @@ func (c *Cmd) Run(k *kong.Context, _ logging.Logger) error {
 			return errors.Wrapf(err, "cannot get current path")
 		}
 		c.CacheDir = filepath.Join(currentPath, c.CacheDir)
+	}
+
+	if strings.HasPrefix(c.CacheDir, "~/") {
+		homeDir, _ := os.UserHomeDir()
+		c.CacheDir = filepath.Join(homeDir, c.CacheDir[2:])
 	}
 
 	m := NewManager(c.CacheDir, c.fs, k.Stdout)


### PR DESCRIPTION
### Description of your changes

The crossplane validate command has an arg names cacheDir that receives an path to the directory where the cache files for the validate process is stored. When the argument contains a value with tilde (~) that refers to the user's home directory, the tilde expansion doesn't happen implicitly by the shell. This has to be handled programmatically.

Fixes #5487 

I have: 

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.


