### PR TITLE
governance: include steering committee contact info

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -72,6 +72,17 @@ Here are the members of the initial steering committee (listed in alphabetical o
 | <img width="30px" src="https://github.com/jbw976.png">    | [Jared Watts](https://github.com/jbw976)       | Upbound      | jared@upbound.io            | 2024-02-06 | 2026-02-06 |
 | <img width="30px" src="https://github.com/negz.png">      | [Nic Cope](https://github.com/negz)            | Upbound      | negz@upbound.io             | 2024-02-06 | 2026-02-06 |
 
+### Contact Info
+
+The steering committee can be reached at the following locations:
+
+* [`#steering-committee`](https://crossplane.slack.com/archives/C032WMA459S)
+  channel on the [Crossplane Slack](https://slack.crossplane.io/) workspace
+* [`steering@crossplane.io`](mailto:steering@crossplane.io) public email address
+
+Members of the community as well as the broader ecosystem are welcome to contact
+the steering committee for any issues or concerns they can assist with.
+
 ### Election Process
 
 #### Eligibility for Voting


### PR DESCRIPTION
### Description of your changes

This PR adds contact information for the steering committee to the project governance.  It intends to make the steering committee discoverable and available for all that can benefit from their assistance.

As this PR touches GOVERNANCE.md, a super majority (2/3 vote) of the steering committee is required to approve and update, as per existing project governance: https://github.com/crossplane/crossplane/blob/master/GOVERNANCE.md#updating-the-governance 

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] ~Added or updated unit tests.~
- [ ] ~Added or updated e2e tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/master/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/master/contributing#checklist-cheat-sheet
