### PR TITLE
feat(Makefile): Add checksums and tarballs for crank

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -143,6 +143,14 @@ e2e.init: build e2e-tag-images
 
 e2e.run: $(KIND) $(HELM3) e2e-run-tests
 
+build.artifacts.platform: build.artifacts.bundle.platform
+
+build.artifacts.bundle.platform:
+	@mkdir -p $(abspath $(OUTPUT_DIR)/bundle/$(PLATFORM))
+	@$(SHA256SUM) $(GO_OUT_DIR)/crank$(GO_OUT_EXT) | head -c 64 > $(GO_OUT_DIR)/crank$(GO_OUT_EXT).sha256
+	@tar -czvf $(abspath $(OUTPUT_DIR)/bundle/$(PLATFORM)/crank).tar.gz -C $(GO_BIN_DIR) $(PLATFORM)/crank$(GO_OUT_EXT) $(PLATFORM)/crank$(GO_OUT_EXT).sha256
+	@$(SHA256SUM) $(OUTPUT_DIR)/bundle/$(PLATFORM)/crank.tar.gz | head -c 64 > $(OUTPUT_DIR)/bundle/$(PLATFORM)/crank.tar.gz.sha256
+
 # Update the submodules, such as the common build scripts.
 submodules:
 	@git submodule sync


### PR DESCRIPTION
- The checksums will help people to verify that their downloaded binary is not corrupted
- The tarballs provide faster downloads, plus they can be useful for creating distro and brew packages, see #4899

<!--
Thank you for helping to improve Crossplane! Please read the contribution docs
(linked below) if this is your first Crossplane pull request.
-->

### Description of your changes

<!--
Briefly describe what this pull request does, and how it is covered by tests.
Be proactive - direct your reviewers' attention to anything that needs special
consideration.

We love pull requests that fix an open issue. If yours does, use the below line
to indicate which issue it fixes, for example "Fixes #500".
-->

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [X] Read and followed Crossplane's [contribution process].
- [X] Run `make reviewable` to ensure this PR is ready for review.
- [ ] ~Added or updated unit tests.~
- [ ] ~Added or updated e2e tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change]~.
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/master/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/master/contributing#checklist-cheat-sheet
