### PR TITLE
Deploy providers in a different namespace other than core

### DIFF
--- a/internal/controller/pkg/revision/reconciler.go
+++ b/internal/controller/pkg/revision/reconciler.go
@@ -20,6 +20,7 @@ package revision
 import (
 	"context"
 	"io"
+	"os"
 	"sort"
 	"strings"
 	"time"
@@ -928,7 +929,7 @@ func (r *Reconciler) runtimeManifestBuilderOptions(ctx context.Context, pwr v1.P
 	// Fetch XP ServiceAccount to get the ImagePullSecrets defined there.
 	// We will append them to the list of ImagePullSecrets for the runtime
 	// ServiceAccount.
-	if err := r.client.Get(ctx, types.NamespacedName{Namespace: r.namespace, Name: r.serviceAccount}, sa); err != nil {
+	if err := r.client.Get(ctx, types.NamespacedName{Namespace: os.Getenv("POD_NAMESPACE"), Name: os.Getenv("POD_SERVICE_ACCOUNT")}, sa); err != nil {
 		return nil, errors.Wrap(err, errGetServiceAccount)
 	}
 	if len(sa.ImagePullSecrets) > 0 {


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane! Please read the contribution docs
(linked below) if this is your first Crossplane pull request.
-->

### Description of your changes

Use the namespace and service account of the core crossplane components to pull the ImagePullSecret.
Fixes #5576 

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added or updated unit tests.
- [ ] Added or updated e2e tests.
- [ ] Linked a PR or a [docs tracking issue] to [document this change].
- [ ] Added `backport release-x.y` labels to auto-backport this PR.

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/master/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/master/contributing#checklist-cheat-sheet

Followed the steps jotted down here https://github.com/crossplane/crossplane/discussions/5449#discussioncomment-8669511.
```
crossplane on  issue-5576 [$!?] via 🐹 v1.22.2
❯ k get providers
NAME                          INSTALLED   HEALTHY   PACKAGE                                              AGE
provider-aws-s3               True        True      xpkg.upbound.io/upbound/provider-aws-s3:v1.3.1       6m52s
upbound-provider-family-aws   True        True      xpkg.upbound.io/upbound/provider-family-aws:v1.4.0   14m

crossplane on  issue-5576 [$!?] via 🐹 v1.22.2
❯ k get pods -A
NAMESPACE              NAME                                                        READY   STATUS    RESTARTS   AGE
crossplane-providers   provider-aws-s3-80f883595f8c-67ccffcbc8-jxj2q               1/1     Running   0          6m50s
crossplane-providers   upbound-provider-family-aws-bac5d48bd353-869c456d7c-flpw9   1/1     Running   0          7m26s
crossplane-system      crossplane-6bd9f5f75d-r7l2g                                 1/1     Running   0          10m
crossplane-system      crossplane-rbac-manager-796fdb775d-szttc                    1/1     Running   0          14m
crossplane-system      upbound-provider-family-aws-bac5d48bd353-869c456d7c-sv522   1/1     Running   0          14m
kube-system            coredns-5d78c9869d-8nw7j                                    1/1     Running   0          43m
```