### PR TITLE
Bump crossplane-runtime dependency to v1.16.0-rc.2

### DIFF
--- a/cluster/crds/apiextensions.crossplane.io_compositeresourcedefinitions.yaml
+++ b/cluster/crds/apiextensions.crossplane.io_compositeresourcedefinitions.yaml
@@ -483,6 +483,13 @@ spec:
                         A Message containing details about this condition's last transition from
                         one status to another, if any.
                       type: string
+                    observedGeneration:
+                      description: |-
+                        ObservedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      type: integer
                     reason:
                       description: A Reason for this condition's last transition from
                         one status to another.

--- a/cluster/crds/apiextensions.crossplane.io_compositionrevisions.yaml
+++ b/cluster/crds/apiextensions.crossplane.io_compositionrevisions.yaml
@@ -287,7 +287,7 @@ spec:
                               type: string
                             mergeOptions:
                               description: MergeOptions Specifies merge options on
-                                a field path
+                                a field path.
                               properties:
                                 appendSlice:
                                   description: Specifies that already existing elements
@@ -701,7 +701,7 @@ spec:
                                 type: string
                               mergeOptions:
                                 description: MergeOptions Specifies merge options
-                                  on a field path
+                                  on a field path.
                                 properties:
                                   appendSlice:
                                     description: Specifies that already existing elements
@@ -1239,7 +1239,7 @@ spec:
                                 type: string
                               mergeOptions:
                                 description: MergeOptions Specifies merge options
-                                  on a field path
+                                  on a field path.
                                 properties:
                                   appendSlice:
                                     description: Specifies that already existing elements
@@ -1614,6 +1614,13 @@ spec:
                         A Message containing details about this condition's last transition from
                         one status to another, if any.
                       type: string
+                    observedGeneration:
+                      description: |-
+                        ObservedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      type: integer
                     reason:
                       description: A Reason for this condition's last transition from
                         one status to another.
@@ -1913,7 +1920,7 @@ spec:
                               type: string
                             mergeOptions:
                               description: MergeOptions Specifies merge options on
-                                a field path
+                                a field path.
                               properties:
                                 appendSlice:
                                   description: Specifies that already existing elements
@@ -2327,7 +2334,7 @@ spec:
                                 type: string
                               mergeOptions:
                                 description: MergeOptions Specifies merge options
-                                  on a field path
+                                  on a field path.
                                 properties:
                                   appendSlice:
                                     description: Specifies that already existing elements
@@ -2865,7 +2872,7 @@ spec:
                                 type: string
                               mergeOptions:
                                 description: MergeOptions Specifies merge options
-                                  on a field path
+                                  on a field path.
                                 properties:
                                   appendSlice:
                                     description: Specifies that already existing elements
@@ -3240,6 +3247,13 @@ spec:
                         A Message containing details about this condition's last transition from
                         one status to another, if any.
                       type: string
+                    observedGeneration:
+                      description: |-
+                        ObservedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      type: integer
                     reason:
                       description: A Reason for this condition's last transition from
                         one status to another.

--- a/cluster/crds/apiextensions.crossplane.io_compositions.yaml
+++ b/cluster/crds/apiextensions.crossplane.io_compositions.yaml
@@ -282,7 +282,7 @@ spec:
                               type: string
                             mergeOptions:
                               description: MergeOptions Specifies merge options on
-                                a field path
+                                a field path.
                               properties:
                                 appendSlice:
                                   description: Specifies that already existing elements
@@ -696,7 +696,7 @@ spec:
                                 type: string
                               mergeOptions:
                                 description: MergeOptions Specifies merge options
-                                  on a field path
+                                  on a field path.
                                 properties:
                                   appendSlice:
                                     description: Specifies that already existing elements
@@ -1237,7 +1237,7 @@ spec:
                                 type: string
                               mergeOptions:
                                 description: MergeOptions Specifies merge options
-                                  on a field path
+                                  on a field path.
                                 properties:
                                   appendSlice:
                                     description: Specifies that already existing elements

--- a/cluster/crds/apiextensions.crossplane.io_usages.yaml
+++ b/cluster/crds/apiextensions.crossplane.io_usages.yaml
@@ -176,6 +176,13 @@ spec:
                         A Message containing details about this condition's last transition from
                         one status to another, if any.
                       type: string
+                    observedGeneration:
+                      description: |-
+                        ObservedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      type: integer
                     reason:
                       description: A Reason for this condition's last transition from
                         one status to another.

--- a/cluster/crds/pkg.crossplane.io_configurationrevisions.yaml
+++ b/cluster/crds/pkg.crossplane.io_configurationrevisions.yaml
@@ -159,6 +159,13 @@ spec:
                         A Message containing details about this condition's last transition from
                         one status to another, if any.
                       type: string
+                    observedGeneration:
+                      description: |-
+                        ObservedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      type: integer
                     reason:
                       description: A Reason for this condition's last transition from
                         one status to another.

--- a/cluster/crds/pkg.crossplane.io_configurations.yaml
+++ b/cluster/crds/pkg.crossplane.io_configurations.yaml
@@ -151,6 +151,13 @@ spec:
                         A Message containing details about this condition's last transition from
                         one status to another, if any.
                       type: string
+                    observedGeneration:
+                      description: |-
+                        ObservedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      type: integer
                     reason:
                       description: A Reason for this condition's last transition from
                         one status to another.

--- a/cluster/crds/pkg.crossplane.io_functionrevisions.yaml
+++ b/cluster/crds/pkg.crossplane.io_functionrevisions.yaml
@@ -202,6 +202,13 @@ spec:
                         A Message containing details about this condition's last transition from
                         one status to another, if any.
                       type: string
+                    observedGeneration:
+                      description: |-
+                        ObservedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      type: integer
                     reason:
                       description: A Reason for this condition's last transition from
                         one status to another.

--- a/cluster/crds/pkg.crossplane.io_functions.yaml
+++ b/cluster/crds/pkg.crossplane.io_functions.yaml
@@ -181,6 +181,13 @@ spec:
                         A Message containing details about this condition's last transition from
                         one status to another, if any.
                       type: string
+                    observedGeneration:
+                      description: |-
+                        ObservedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      type: integer
                     reason:
                       description: A Reason for this condition's last transition from
                         one status to another.

--- a/cluster/crds/pkg.crossplane.io_providerrevisions.yaml
+++ b/cluster/crds/pkg.crossplane.io_providerrevisions.yaml
@@ -202,6 +202,13 @@ spec:
                         A Message containing details about this condition's last transition from
                         one status to another, if any.
                       type: string
+                    observedGeneration:
+                      description: |-
+                        ObservedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      type: integer
                     reason:
                       description: A Reason for this condition's last transition from
                         one status to another.

--- a/cluster/crds/pkg.crossplane.io_providers.yaml
+++ b/cluster/crds/pkg.crossplane.io_providers.yaml
@@ -183,6 +183,13 @@ spec:
                         A Message containing details about this condition's last transition from
                         one status to another, if any.
                       type: string
+                    observedGeneration:
+                      description: |-
+                        ObservedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      type: integer
                     reason:
                       description: A Reason for this condition's last transition from
                         one status to another.

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/AdaLogics/go-fuzz-headers v0.0.0-20230811130428-ced1acdcaa24
 	github.com/Masterminds/semver v1.5.0
 	github.com/alecthomas/kong v0.8.1
-	github.com/crossplane/crossplane-runtime v1.16.0-rc.1.0.20240226223305-2c81cc6326e5
+	github.com/crossplane/crossplane-runtime v1.16.0-rc.2
 	github.com/docker/docker v25.0.5+incompatible
 	github.com/docker/go-connections v0.5.0
 	github.com/emicklei/dot v1.6.1

--- a/go.sum
+++ b/go.sum
@@ -125,8 +125,8 @@ github.com/cpuguy83/go-md2man/v2 v2.0.3/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46t
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/creack/pty v1.1.18 h1:n56/Zwd5o6whRC5PMGretI4IdRLlmBXYNjScPaBgsbY=
 github.com/creack/pty v1.1.18/go.mod h1:MOBLtS5ELjhRRrroQr9kyvTxUAFNvYEK993ew/Vr4O4=
-github.com/crossplane/crossplane-runtime v1.16.0-rc.1.0.20240226223305-2c81cc6326e5 h1:Jiqj9j43gUX/goitNa86/ociah8G74C3pIGwIPSZsks=
-github.com/crossplane/crossplane-runtime v1.16.0-rc.1.0.20240226223305-2c81cc6326e5/go.mod h1:rG/KJwyA4iGMCubZ1EXs39Ow7XvOcWEfb1u3jkNekfw=
+github.com/crossplane/crossplane-runtime v1.16.0-rc.2 h1:jjOx1uJdllLA+z9qeYMx7EtXL74pCEb1XFHOHf2WWIY=
+github.com/crossplane/crossplane-runtime v1.16.0-rc.2/go.mod h1:Pz2tdGVMF6KDGzHZOkvKro0nKc8EzK0sb/nSA7pH4Dc=
 github.com/cyphar/filepath-securejoin v0.2.4 h1:Ugdm7cg7i6ZK6x3xDF1oEu1nfkyfH53EtKeQYTC3kyg=
 github.com/cyphar/filepath-securejoin v0.2.4/go.mod h1:aPGpWjXOXUn2NCNjFvBE6aRxGGx79pTxQpKOJNYHHl4=
 github.com/danieljoos/wincred v1.1.2/go.mod h1:GijpziifJoIBfYh+S7BbkdUTU4LfM+QnGqR5Vl2tAx0=


### PR DESCRIPTION
### Description of your changes

This PR simply bumps the crossplane-runtime dependency in the `release-1.16` branch to [v1.16.0-rc.2](https://github.com/crossplane/crossplane-runtime/releases/tag/v1.16.0-rc.2), as per the code freeze steps in https://github.com/crossplane/release/issues/9, specifically:

>   (On the Release Branch) created and merged a PR bumping the Crossplane Runtime dependency to the release candidate tag on the release branch, vX.Y.0-rc.2.

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] ~Added or updated unit tests.~
- [ ] ~Added or updated e2e tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/master/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/master/contributing#checklist-cheat-sheet
