### PR TITLE
Enhance permissions for Crossplane managed-roles by allowing access to the status subresource for Claims/Composites

### DIFF
--- a/internal/controller/rbac/definition/roles.go
+++ b/internal/controller/rbac/definition/roles.go
@@ -111,8 +111,11 @@ func RenderClusterRoles(d *v1.CompositeResourceDefinition) []rbacv1.ClusterRole 
 		Rules: []rbacv1.PolicyRule{
 			{
 				APIGroups: []string{d.Spec.Group},
-				Resources: []string{d.Spec.Names.Plural},
-				Verbs:     verbsEdit,
+				Resources: []string{
+					d.Spec.Names.Plural,
+					d.Spec.Names.Plural + suffixStatus,
+				},
+				Verbs: verbsEdit,
 			},
 		},
 	}
@@ -130,8 +133,11 @@ func RenderClusterRoles(d *v1.CompositeResourceDefinition) []rbacv1.ClusterRole 
 		Rules: []rbacv1.PolicyRule{
 			{
 				APIGroups: []string{d.Spec.Group},
-				Resources: []string{d.Spec.Names.Plural},
-				Verbs:     verbsView,
+				Resources: []string{
+					d.Spec.Names.Plural,
+					d.Spec.Names.Plural + suffixStatus,
+				},
+				Verbs: verbsView,
 			},
 		},
 	}
@@ -148,8 +154,11 @@ func RenderClusterRoles(d *v1.CompositeResourceDefinition) []rbacv1.ClusterRole 
 		Rules: []rbacv1.PolicyRule{
 			{
 				APIGroups: []string{d.Spec.Group},
-				Resources: []string{d.Spec.Names.Plural},
-				Verbs:     verbsBrowse,
+				Resources: []string{
+					d.Spec.Names.Plural,
+					d.Spec.Names.Plural + suffixStatus,
+				},
+				Verbs: verbsBrowse,
 			},
 		},
 	}
@@ -176,14 +185,20 @@ func RenderClusterRoles(d *v1.CompositeResourceDefinition) []rbacv1.ClusterRole 
 
 		edit.Rules = append(edit.Rules, rbacv1.PolicyRule{
 			APIGroups: []string{d.Spec.Group},
-			Resources: []string{d.Spec.ClaimNames.Plural},
-			Verbs:     verbsEdit,
+			Resources: []string{
+				d.Spec.ClaimNames.Plural,
+				d.Spec.ClaimNames.Plural + suffixStatus,
+			},
+			Verbs: verbsEdit,
 		})
 
 		view.Rules = append(view.Rules, rbacv1.PolicyRule{
 			APIGroups: []string{d.Spec.Group},
-			Resources: []string{d.Spec.ClaimNames.Plural},
-			Verbs:     verbsView,
+			Resources: []string{
+				d.Spec.ClaimNames.Plural,
+				d.Spec.ClaimNames.Plural + suffixStatus,
+			},
+			Verbs: verbsView,
 		})
 
 		// The browse role only includes composite resources; not claims.

--- a/internal/controller/rbac/definition/roles_test.go
+++ b/internal/controller/rbac/definition/roles_test.go
@@ -96,7 +96,7 @@ func TestRenderClusterRoles(t *testing.T) {
 					Rules: []rbacv1.PolicyRule{
 						{
 							APIGroups: []string{group},
-							Resources: []string{pluralXR},
+							Resources: []string{pluralXR, pluralXR + suffixStatus},
 							Verbs:     verbsEdit,
 						},
 					},
@@ -114,7 +114,7 @@ func TestRenderClusterRoles(t *testing.T) {
 					Rules: []rbacv1.PolicyRule{
 						{
 							APIGroups: []string{group},
-							Resources: []string{pluralXR},
+							Resources: []string{pluralXR, pluralXR + suffixStatus},
 							Verbs:     verbsView,
 						},
 					},
@@ -131,7 +131,7 @@ func TestRenderClusterRoles(t *testing.T) {
 					Rules: []rbacv1.PolicyRule{
 						{
 							APIGroups: []string{group},
-							Resources: []string{pluralXR},
+							Resources: []string{pluralXR, pluralXR + suffixStatus},
 							Verbs:     verbsBrowse,
 						},
 					},
@@ -195,12 +195,12 @@ func TestRenderClusterRoles(t *testing.T) {
 					Rules: []rbacv1.PolicyRule{
 						{
 							APIGroups: []string{group},
-							Resources: []string{pluralXR},
+							Resources: []string{pluralXR, pluralXR + suffixStatus},
 							Verbs:     verbsEdit,
 						},
 						{
 							APIGroups: []string{group},
-							Resources: []string{pluralXRC},
+							Resources: []string{pluralXRC, pluralXRC + suffixStatus},
 							Verbs:     verbsEdit,
 						},
 					},
@@ -218,12 +218,12 @@ func TestRenderClusterRoles(t *testing.T) {
 					Rules: []rbacv1.PolicyRule{
 						{
 							APIGroups: []string{group},
-							Resources: []string{pluralXR},
+							Resources: []string{pluralXR, pluralXR + suffixStatus},
 							Verbs:     verbsView,
 						},
 						{
 							APIGroups: []string{group},
-							Resources: []string{pluralXRC},
+							Resources: []string{pluralXRC, pluralXRC + suffixStatus},
 							Verbs:     verbsView,
 						},
 					},
@@ -241,7 +241,7 @@ func TestRenderClusterRoles(t *testing.T) {
 					Rules: []rbacv1.PolicyRule{
 						{
 							APIGroups: []string{group},
-							Resources: []string{pluralXR},
+							Resources: []string{pluralXR, pluralXR + suffixStatus},
 							Verbs:     verbsBrowse,
 						},
 					},


### PR DESCRIPTION
### Description of your changes

This PR enchances permissions for Crossplane managed-roles, namely `crossplane-admin`, `crossplane-edit` and `crossplane-view` (which has no impact I believe since get -o yaml already returns status, but to be consistent) to operate on status subresources of Claims and Composites. This was already the case for managed resources but not Claims/Composites. As a Crossplane admin/editor, I should be able to update/patch the status of composites/claims for any resource for whatever reason (debugging / testing / restoration). 

Fixes #5262

Before/After for Crossplane Admin:

<img width="1704" alt="Screenshot 2024-05-09 at 12 47 52" src="https://github.com/crossplane/crossplane/assets/9900707/7215e9e8-45cc-4ee2-bf52-9be728a40d36">


I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added or updated unit tests.
- [ ] ~Added or updated e2e tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [x] Added `backport release-x.y` labels to auto-backport this PR.

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/master/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/master/contributing#checklist-cheat-sheet
