### PR TITLE
Fix unit test coverage reports, add E2E flake reports

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -312,6 +312,16 @@ jobs:
           path: ./logs-kind
           if-no-files-found: error
           retention-days: 7
+      
+      - name: Publish E2E Test Flakes
+        if: '!cancelled()'
+        uses: buildpulse/buildpulse-action@v0.11.0
+        with:
+          account: 45158470
+          repository: 147886080
+          path: _output/tests/linux_amd64/e2e-tests.xml
+          key: ${{ secrets.BUILDPULSE_ACCESS_KEY_ID }}
+          secret: ${{ secrets.BUILDPULSE_SECRET_ACCESS_KEY }}
 
   publish-artifacts:
     runs-on: ubuntu-22.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -233,6 +233,7 @@ jobs:
         with:
           flags: unittests
           file: _output/tests/linux_amd64/coverage.txt
+          token: ${{ secrets.CODECOV_TOKEN }}
 
   e2e-tests:
     runs-on: ubuntu-22.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -229,7 +229,7 @@ jobs:
         run: make -j2 test
 
       - name: Publish Unit Test Coverage
-        uses: codecov/codecov-action@ab904c41d6ece82784817410c45d8b8c02684457 # v3
+        uses: codecov/codecov-action@v4
         with:
           flags: unittests
           file: _output/tests/linux_amd64/coverage.txt
@@ -320,9 +320,9 @@ jobs:
         with:
           account: 45158470
           repository: 147886080
-          path: _output/tests/linux_amd64/e2e-tests.xml
           key: ${{ secrets.BUILDPULSE_ACCESS_KEY_ID }}
           secret: ${{ secrets.BUILDPULSE_SECRET_ACCESS_KEY }}
+          path: _output/tests/linux_amd64/e2e-tests.xml
 
   publish-artifacts:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane! Please read the contribution docs
(linked below) if this is your first Crossplane pull request.
-->

### Description of your changes

<!--
Briefly describe what this pull request does, and how it is covered by tests.
Be proactive - direct your reviewers' attention to anything that needs special
consideration.

We love pull requests that fix an open issue. If yours does, use the below line
to indicate which issue it fixes, for example "Fixes #500".
-->

This PR:

* Adds a https://codecov.io token, to fix uploading code coverage.
* Sets up https://buildpulse.io, to upload E2E tests results in order to track flakes

As part of setting up Buildpulse I've configured our E2E tests to be less verbose when everything is going well. I believe they'll still give us plenty of context for failed tests.

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] ~Added or updated unit tests.~
- [ ] ~Added or updated e2e tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/master/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/master/contributing#checklist-cheat-sheet
