### PR TITLE
tests: AllOf failing immediately if fail-fast

### DIFF
--- a/test/e2e/funcs/feature.go
+++ b/test/e2e/funcs/feature.go
@@ -66,13 +66,18 @@ const DefaultPollInterval = time.Millisecond * 500
 
 type onSuccessHandler func(o k8s.Object)
 
-// AllOf runs the supplied functions in order.
+// AllOf runs the supplied functions in order. If a function fails the test and
+// the environment is configured to fail fast (e2e-framework's -fail-fast flag)
+// the remaining functions will not be run.
 func AllOf(fns ...features.Func) features.Func {
 	return func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
 		t.Helper()
 
 		for _, fn := range fns {
 			ctx = fn(ctx, t, c)
+			if t.Failed() && c.FailFast() {
+				break
+			}
 		}
 		return ctx
 	}


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane! Please read the contribution docs
(linked below) if this is your first Crossplane pull request.
-->

### Description of your changes

<!--
Briefly describe what this pull request does, and how it is covered by tests.
Be proactive - direct your reviewers' attention to anything that needs special
consideration.

We love pull requests that fix an open issue. If yours does, use the below line
to indicate which issue it fixes, for example "Fixes #500".
-->

e2e-framework has its own fail-fast flag, see [docs](https://github.com/kubernetes-sigs/e2e-framework/tree/2135435d7f19b812bcce7963a6176a41ccc82755/examples/fail_fast). 

This makes `funcs.AllOf` aware of it, skipping the rest of the provided functions in fail-fast mode.

Fixes #5672.

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] ~Added or updated unit tests.~
- [ ] ~Added or updated e2e tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/master/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/master/contributing#checklist-cheat-sheet
