### PR TITLE
correcting help tag

### DIFF
--- a/cmd/crossplane/core/core.go
+++ b/cmd/crossplane/core/core.go
@@ -91,7 +91,7 @@ type startCommand struct {
 	CABundlePath   string `env:"CA_BUNDLE_PATH"            help:"Additional CA bundle to use when fetching packages from registry."`
 	UserAgent      string `default:"${default_user_agent}" env:"USER_AGENT"                                                         help:"The User-Agent header that will be set on all package requests."`
 
-	PackageRuntime string `default:"Deployment" env:"PACKAGE_RUNTIME" helm:"The package runtime to use for packages with a runtime (e.g. Providers and Functions)"`
+	PackageRuntime string `default:"Deployment" env:"PACKAGE_RUNTIME" help:"The package runtime to use for packages with a runtime (e.g. Providers and Functions)"`
 
 	SyncInterval     time.Duration `default:"1h"  help:"How often all resources will be double-checked for drift from the desired state."                    short:"s"`
 	PollInterval     time.Duration `default:"1m"  help:"How often individual resources will be checked for drift from the desired state."`


### PR DESCRIPTION
### Description of your changes

A typo on PackageRuntime field tag that supposed to be a help tag.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [ ] ~Run `make reviewable` to ensure this PR is ready for review.~
- [ ] ~Added or updated unit tests.~
- [ ] ~Added or updated e2e tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~