### PR TITLE
Don't check for buf breaking changes on release branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -482,24 +482,18 @@ jobs:
         with:
           input: apis
 
-      - name: Detect Breaking Changes in Protocol Buffers (Master Branch)
+      # buf-breaking-action doesn't support branches
+      # https://github.com/bufbuild/buf-push-action/issues/34
+      - name: Detect Breaking Changes in Protocol Buffers
         uses: bufbuild/buf-breaking-action@a074e988ee34efcd4927079e79c611f428354c01 # v1
-        # We want to run this for the master branch, and PRs.
-        if: ${{ ! startsWith(github.ref, 'refs/heads/release-') }}
+        # We want to run this for the master branch, and PRs against master.
+        if: ${{ github.ref == 'refs/heads/master' || github.base_ref == 'master' }}
         with:
           input: apis
           against: "https://github.com/${GITHUB_REPOSITORY}.git#branch=master,subdir=apis"
-
-      - name: Detect Breaking Changes in Protocol Buffers (Release Branch)
-        uses: bufbuild/buf-breaking-action@a074e988ee34efcd4927079e79c611f428354c01 # v1
-        # We want to run this only on release branches.
-        if: ${{ startsWith(github.ref, 'refs/heads/release-') }}
-        with:
-          input: apis
-          against: "https://github.com/${GITHUB_REPOSITORY}.git#branch=${GITHUB_REF_NAME},subdir=apis"
         
       - name: Push Protocol Buffers to Buf Schema Registry
-        if: ${{ github.repository == 'crossplane/crossplane' && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/release-')) }}
+        if: ${{ github.repository == 'crossplane/crossplane' && github.ref == 'refs/heads/master' }}
         uses: bufbuild/buf-push-action@v1
         with:
           input: apis


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane! Please read the contribution docs
(linked below) if this is your first Crossplane pull request.
-->

### Description of your changes

<!--
Briefly describe what this pull request does, and how it is covered by tests.
Be proactive - direct your reviewers' attention to anything that needs special
consideration.

We love pull requests that fix an open issue. If yours does, use the below line
to indicate which issue it fixes, for example "Fixes #500".
-->

Fixes https://github.com/crossplane/crossplane/issues/5382

The action we use to do this doesn't yet understand branches. For now let's just not run on release branches.

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] ~Added or updated unit tests.~
- [ ] ~Added or updated e2e tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/master/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/master/contributing#checklist-cheat-sheet
