### PR TITLE
build: add release-1.16 to Renovate baseBranches

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -12,7 +12,7 @@
   "prConcurrentLimit": 5,
 // The branches renovate should target
 // PLEASE UPDATE THIS WHEN RELEASING.
-  "baseBranches": ["master","release-1.13","release-1.14","release-1.15"],
+  "baseBranches": ["master","release-1.13","release-1.14","release-1.15", "release-1.16"],
   "ignorePaths": [
     "design/**",
     // We test upgrades, so leave it on an older version on purpose.


### PR DESCRIPTION
### Description of your changes

This PR adds the new(ish) `release-1.16` branch to the `baseBranches` list that Renovate manages, as discussed in https://github.com/crossplane/crossplane/issues/5681#issuecomment-2113017812. 

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] ~Added or updated unit tests.~
- [ ] ~Added or updated e2e tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/master/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/master/contributing#checklist-cheat-sheet
