### PR TITLE
chore(deps): update golang version to v1.22.3 (release-1.16)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
 
 env:
   # Common versions
-  GO_VERSION: '1.22.2'
+  GO_VERSION: '1.22.3'
   GOLANGCI_VERSION: 'v1.57.2'
   DOCKER_BUILDX_VERSION: 'v0.10.0'
 

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -21,7 +21,7 @@ on:
 
 env:
   # Common versions
-  GO_VERSION: '1.22.2'
+  GO_VERSION: '1.22.3'
 
   # Common users. We can't run a step 'if secrets.AWS_USR != ""' but we can run
   # a step 'if env.AWS_USR' != ""', so we copy these to succinctly test whether

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/crossplane/crossplane
 
 go 1.21
 
-toolchain go1.22.2
+toolchain go1.22.3
 
 require (
 	dario.cat/mergo v1.0.0


### PR DESCRIPTION
### Description of your changes

This PR manually backports https://github.com/crossplane/crossplane/pull/5684 to the `release-1.16` branch. This is being performed manually because:

* Renovate is configured to only update security related dependencies in release branches, but it is not considering https://github.com/crossplane/crossplane/pull/5684 as security related
* [Backport action](https://github.com/crossplane/crossplane/actions/runs/9062385378/job/25016846893) fails to backport https://github.com/crossplane/crossplane/pull/5684 because it touches `.github/workflows/ci.yml`: 
```
 ! [remote rejected]   backport-5684-to-release-1.16 -> backport-5684-to-release-1.16 (refusing to allow a GitHub App to create or update workflow `.github/workflows/ci.yml` without `workflows` permission)
```

Fixes #5681 

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] ~Added or updated unit tests.~
- [ ] ~Added or updated e2e tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/master/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/master/contributing#checklist-cheat-sheet
