### PR TITLE
Update releases table and renovate branches post 1.16

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -12,7 +12,7 @@
   "prConcurrentLimit": 5,
 // The branches renovate should target
 // PLEASE UPDATE THIS WHEN RELEASING.
-  "baseBranches": ["master","release-1.13","release-1.14","release-1.15", "release-1.16"],
+  "baseBranches": ["master","release-1.14","release-1.15", "release-1.16"],
   "ignorePaths": [
     "design/**",
     // We test upgrades, so leave it on an older version on purpose.

--- a/README.md
+++ b/README.md
@@ -24,12 +24,12 @@ documentation].
 
 | Release | Release Date  |   EOL    |
 |:-------:|:-------------:|:--------:|
-|  v1.13  | Jul 27, 2023  | May 2024 |
 |  v1.14  | Nov 1, 2023   | Aug 2024 |
 |  v1.15  | Feb 15, 2024  | Nov 2024 |
-|  v1.16  | Early May '24 | Feb 2025 |
+|  v1.16  | May 15, 2024  | Feb 2025 |
 |  v1.17  | Early Aug '24 | May 2025 |
 |  v1.18  | Early Nov '24 | Aug 2025 |
+|  v1.19  | Early Feb '25 | Nov 2025 |
 
 You can subscribe to the [community calendar] to track all release dates, and
 find the most recent releases on the [releases] page.


### PR DESCRIPTION
### Description of your changes

This PR updates both the releases table in the README and the Renovate config now that v1.16.0 has been released to remove the now unsupported v1.13.

From https://github.com/crossplane/release/issues/9:

> Updated, in a single PR, the following on master:
 The [releases table](https://github.com/crossplane/crossplane#releases) in the README.md, removing the now old unsupported release and adding the new one.
 The baseBranches list in .github/renovate.json5, removing the now old unsupported release.

Note that 1.16 was already added to the Renovate config in https://github.com/crossplane/crossplane/pull/5694.

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [ ] ~Run `make reviewable` to ensure this PR is ready for review.~
- [ ] ~Added or updated unit tests.~
- [ ] ~Added or updated e2e tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/master/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/master/contributing#checklist-cheat-sheet
