### PR TITLE
Update Claim CRD and XR CRD Reconciliation Filters

### DIFF
--- a/internal/controller/apiextensions/definition/reconciler.go
+++ b/internal/controller/apiextensions/definition/reconciler.go
@@ -146,6 +146,7 @@ func Setup(mgr ctrl.Manager, o apiextensionscontroller.Options) error {
 		Named(name).
 		For(&v1.CompositeResourceDefinition{}).
 		Owns(&extv1.CustomResourceDefinition{}).
+		WithEventFilter(resource.NewPredicates(OffersCompositeResource())).
 		WithOptions(o.ForControllerRuntime()).
 		Complete(ratelimiter.NewReconciler(name, errors.WithSilentRequeueOnConflict(r), o.GlobalRateLimiter))
 }

--- a/internal/controller/apiextensions/definition/reconciler.go
+++ b/internal/controller/apiextensions/definition/reconciler.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/util/workqueue"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	kcontroller "sigs.k8s.io/controller-runtime/pkg/controller"
@@ -145,8 +146,7 @@ func Setup(mgr ctrl.Manager, o apiextensionscontroller.Options) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		Named(name).
 		For(&v1.CompositeResourceDefinition{}).
-		Owns(&extv1.CustomResourceDefinition{}).
-		WithEventFilter(resource.NewPredicates(OffersCompositeResource())).
+		Owns(&extv1.CustomResourceDefinition{}, builder.WithPredicates(resource.NewPredicates(IsCompositeResourceCRD()))).
 		WithOptions(o.ForControllerRuntime()).
 		Complete(ratelimiter.NewReconciler(name, errors.WithSilentRequeueOnConflict(r), o.GlobalRateLimiter))
 }

--- a/internal/controller/apiextensions/definition/watch.go
+++ b/internal/controller/apiextensions/definition/watch.go
@@ -6,18 +6,13 @@ import (
 
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
 
-	v1 "github.com/crossplane/crossplane/apis/apiextensions/v1"
 	"github.com/crossplane/crossplane/internal/xcrd"
 )
 
-// OffersCompositeResource accepts any CompositeResourceDefinition or a
-// CustomResourceDefinition that represents a composite.
-func OffersCompositeResource() resource.PredicateFn {
+// IsCompositeResourceCRD accepts any CustomResourceDefinition that represents a
+// Composite Resource.
+func IsCompositeResourceCRD() resource.PredicateFn {
 	return func(obj runtime.Object) bool {
-		if _, ok := obj.(*v1.CompositeResourceDefinition); ok {
-			return true
-		}
-
 		crd, ok := obj.(*extv1.CustomResourceDefinition)
 		if !ok {
 			return false

--- a/internal/controller/apiextensions/definition/watch.go
+++ b/internal/controller/apiextensions/definition/watch.go
@@ -1,0 +1,32 @@
+package definition
+
+import (
+	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/crossplane/crossplane-runtime/pkg/resource"
+
+	v1 "github.com/crossplane/crossplane/apis/apiextensions/v1"
+	"github.com/crossplane/crossplane/internal/xcrd"
+)
+
+// OffersCompositeResource accepts any CompositeResourceDefinition or a
+// CustomResourceDefinition that represents a composite.
+func OffersCompositeResource() resource.PredicateFn {
+	return func(obj runtime.Object) bool {
+		if _, ok := obj.(*v1.CompositeResourceDefinition); ok {
+			return true
+		}
+
+		crd, ok := obj.(*extv1.CustomResourceDefinition)
+		if !ok {
+			return false
+		}
+		for _, c := range crd.Spec.Names.Categories {
+			if c == xcrd.CategoryComposite {
+				return true
+			}
+		}
+		return false
+	}
+}

--- a/internal/controller/apiextensions/definition/watch_test.go
+++ b/internal/controller/apiextensions/definition/watch_test.go
@@ -26,17 +26,17 @@ import (
 	v1 "github.com/crossplane/crossplane/apis/apiextensions/v1"
 )
 
-func TestOffersCompositeResource(t *testing.T) {
+func TestIsCompositeResourceCRD(t *testing.T) {
 	cases := map[string]struct {
 		obj  runtime.Object
 		want bool
 	}{
-		"NotAnXRD": {
+		"NotCRD": {
 			want: false,
 		},
 		"XRD": {
 			obj:  &v1.CompositeResourceDefinition{},
-			want: true,
+			want: false,
 		},
 		"ClaimCRD": {
 			obj: &extv1.CustomResourceDefinition{
@@ -76,9 +76,9 @@ func TestOffersCompositeResource(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			got := OffersCompositeResource()(tc.obj)
+			got := IsCompositeResourceCRD()(tc.obj)
 			if diff := cmp.Diff(tc.want, got); diff != "" {
-				t.Errorf("\n%s\nOffersCompositeResource(...): -want, +got:\n%s", name, diff)
+				t.Errorf("\n%s\nIsCompositeResourceCRD(...): -want, +got:\n%s", name, diff)
 			}
 		})
 	}

--- a/internal/controller/apiextensions/definition/watch_test.go
+++ b/internal/controller/apiextensions/definition/watch_test.go
@@ -1,0 +1,85 @@
+/*
+Copyright 2024 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package definition
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	v1 "github.com/crossplane/crossplane/apis/apiextensions/v1"
+)
+
+func TestOffersCompositeResource(t *testing.T) {
+	cases := map[string]struct {
+		obj  runtime.Object
+		want bool
+	}{
+		"NotAnXRD": {
+			want: false,
+		},
+		"XRD": {
+			obj:  &v1.CompositeResourceDefinition{},
+			want: true,
+		},
+		"ClaimCRD": {
+			obj: &extv1.CustomResourceDefinition{
+				Spec: extv1.CustomResourceDefinitionSpec{
+					Names: extv1.CustomResourceDefinitionNames{
+						Categories: []string{
+							"claim",
+						},
+					},
+				},
+			},
+			want: false,
+		},
+		"CompositeCRD": {
+			obj: &extv1.CustomResourceDefinition{
+				Spec: extv1.CustomResourceDefinitionSpec{
+					Names: extv1.CustomResourceDefinitionNames{
+						Categories: []string{
+							"composite",
+						},
+					},
+				},
+			},
+			want: true,
+		},
+		"OtherCRD": {
+			obj: &extv1.CustomResourceDefinition{
+				Spec: extv1.CustomResourceDefinitionSpec{
+					Names: extv1.CustomResourceDefinitionNames{
+						Categories: []string{},
+					},
+				},
+			},
+			want: false,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got := OffersCompositeResource()(tc.obj)
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("\n%s\nOffersCompositeResource(...): -want, +got:\n%s", name, diff)
+			}
+		})
+	}
+}

--- a/internal/controller/apiextensions/offered/reconciler.go
+++ b/internal/controller/apiextensions/offered/reconciler.go
@@ -30,6 +30,7 @@ import (
 	kunstructured "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	kcontroller "sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -124,9 +125,8 @@ func Setup(mgr ctrl.Manager, o apiextensionscontroller.Options) error {
 
 	return ctrl.NewControllerManagedBy(mgr).
 		Named(name).
-		For(&v1.CompositeResourceDefinition{}).
-		Owns(&extv1.CustomResourceDefinition{}).
-		WithEventFilter(resource.NewPredicates(OffersClaim())).
+		For(&v1.CompositeResourceDefinition{}, builder.WithPredicates(resource.NewPredicates(OffersClaim()))).
+		Owns(&extv1.CustomResourceDefinition{}, builder.WithPredicates(resource.NewPredicates(IsClaimCRD()))).
 		WithOptions(o.ForControllerRuntime()).
 		Complete(ratelimiter.NewReconciler(name, errors.WithSilentRequeueOnConflict(r), o.GlobalRateLimiter))
 }

--- a/internal/controller/apiextensions/offered/watch.go
+++ b/internal/controller/apiextensions/offered/watch.go
@@ -34,20 +34,25 @@ import (
 	"github.com/crossplane/crossplane/internal/xcrd"
 )
 
-// OffersClaim accepts a CompositeResourceDefinition that has a claim or a
-// CustomResourceDefinition that represents a claim.
+// OffersClaim accepts any CompositeResourceDefinition that offers a claim.
 func OffersClaim() resource.PredicateFn {
 	return func(obj runtime.Object) bool {
-		xrd, ok := obj.(*v1.CompositeResourceDefinition)
-		if ok {
-			return xrd.OffersClaim()
-		}
-
-		crd, ok := obj.(*extv1.CustomResourceDefinition)
+		d, ok := obj.(*v1.CompositeResourceDefinition)
 		if !ok {
 			return false
 		}
-		for _, c := range crd.Spec.Names.Categories {
+		return d.OffersClaim()
+	}
+}
+
+// IsClaimCRD accepts any CustomResourceDefinition that represents a Claim.
+func IsClaimCRD() resource.PredicateFn {
+	return func(obj runtime.Object) bool {
+		d, ok := obj.(*extv1.CustomResourceDefinition)
+		if !ok {
+			return false
+		}
+		for _, c := range d.Spec.Names.Categories {
 			if c == xcrd.CategoryClaim {
 				return true
 			}

--- a/internal/controller/apiextensions/offered/watch_test.go
+++ b/internal/controller/apiextensions/offered/watch_test.go
@@ -55,13 +55,47 @@ func TestOffersClaim(t *testing.T) {
 			},
 			want: true,
 		},
+		"ClaimCRD": {
+			obj: &extv1.CustomResourceDefinition{
+				Spec: extv1.CustomResourceDefinitionSpec{
+					Names: extv1.CustomResourceDefinitionNames{
+						Categories: []string{
+							"claim",
+						},
+					},
+				},
+			},
+			want: true,
+		},
+		"CompositeCRD": {
+			obj: &extv1.CustomResourceDefinition{
+				Spec: extv1.CustomResourceDefinitionSpec{
+					Names: extv1.CustomResourceDefinitionNames{
+						Categories: []string{
+							"composite",
+						},
+					},
+				},
+			},
+			want: false,
+		},
+		"OtherCRD": {
+			obj: &extv1.CustomResourceDefinition{
+				Spec: extv1.CustomResourceDefinitionSpec{
+					Names: extv1.CustomResourceDefinitionNames{
+						Categories: []string{},
+					},
+				},
+			},
+			want: false,
+		},
 	}
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			got := OffersClaim()(tc.obj)
 			if diff := cmp.Diff(tc.want, got); diff != "" {
-				t.Errorf("OffersClaim(...): -want, +got:\n%s", diff)
+				t.Errorf("\n%s\nOffersClaim(...): -want, +got:\n%s", name, diff)
 			}
 		})
 	}

--- a/internal/controller/apiextensions/offered/watch_test.go
+++ b/internal/controller/apiextensions/offered/watch_test.go
@@ -42,6 +42,10 @@ func TestOffersClaim(t *testing.T) {
 		"NotAnXRD": {
 			want: false,
 		},
+		"CRD": {
+			obj:  &extv1.CustomResourceDefinition{},
+			want: false,
+		},
 		"DoesNotOfferClaim": {
 			obj:  &v1.CompositeResourceDefinition{},
 			want: false,
@@ -54,6 +58,30 @@ func TestOffersClaim(t *testing.T) {
 				},
 			},
 			want: true,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got := OffersClaim()(tc.obj)
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("\n%s\nOffersClaim(...): -want, +got:\n%s", name, diff)
+			}
+		})
+	}
+}
+
+func TestIsClaimCRD(t *testing.T) {
+	cases := map[string]struct {
+		obj  runtime.Object
+		want bool
+	}{
+		"NotCRD": {
+			want: false,
+		},
+		"XRD": {
+			obj:  &v1.CompositeResourceDefinition{},
+			want: false,
 		},
 		"ClaimCRD": {
 			obj: &extv1.CustomResourceDefinition{
@@ -80,22 +108,16 @@ func TestOffersClaim(t *testing.T) {
 			want: false,
 		},
 		"OtherCRD": {
-			obj: &extv1.CustomResourceDefinition{
-				Spec: extv1.CustomResourceDefinitionSpec{
-					Names: extv1.CustomResourceDefinitionNames{
-						Categories: []string{},
-					},
-				},
-			},
+			obj:  &extv1.CustomResourceDefinition{},
 			want: false,
 		},
 	}
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			got := OffersClaim()(tc.obj)
+			got := IsClaimCRD()(tc.obj)
 			if diff := cmp.Diff(tc.want, got); diff != "" {
-				t.Errorf("\n%s\nOffersClaim(...): -want, +got:\n%s", name, diff)
+				t.Errorf("\n%s\nIsClaimCRD(...): -want, +got:\n%s", name, diff)
 			}
 		})
 	}


### PR DESCRIPTION
### Description of your changes
Fixes #5715 

Problem summary: Claim CRD changes are reconciled by the XR CRD reconciler (`definition/reconciler.go`) instead of the Claim CRD reconciler (`offered/reconciler.go`).

---
#### Existing behavior
Claim CRD reconciler reconciles on:
  - changes to the XRD (if it serves claims)

XR CRD reconciler reconciles on:
  - changes to the XRD
  - changes to the XR CRD
  - changes to the Claim CRD

---
#### Proposed Behavior
Claim CRD reconciler reconciles on:
  - changes to the XRD (if it serves claims)
  - changes to the Claim CRD

XR CRD reconciler reconciles on:
  - changes to the XRD
  - changes to the XR CRD

---
### Checklist

I have:
- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added or updated unit tests.
- [ ] ~Added or updated e2e tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~
