### PR TITLE
fix: crossplane xpkg init doesn't close file

### DIFF
--- a/cmd/crank/beta/xpkg/init.go
+++ b/cmd/crank/beta/xpkg/init.go
@@ -235,6 +235,7 @@ func printFile(w io.Writer, path string) error {
 	if _, err := fmt.Fprintf(w, "\n%s\n", content); err != nil {
 		return errors.Wrap(err, "failed to write to stdout")
 	}
+	defer func() { _ = f.Close() }()
 	return nil
 }
 

--- a/cmd/crank/beta/xpkg/init.go
+++ b/cmd/crank/beta/xpkg/init.go
@@ -228,7 +228,7 @@ func printFile(w io.Writer, path string) error {
 	if err != nil {
 		return errors.Wrapf(err, "failed to open file %s", path)
 	}
-	defer f.Close() //nolint:errcheck // It's safe to ingore the error here.
+	defer f.Close() //nolint:errcheck // It's safe to ignore the error because it only do read operation.
 	content, err := io.ReadAll(f)
 	if err != nil {
 		return errors.Wrapf(err, "failed to read file %s", path)

--- a/cmd/crank/beta/xpkg/init.go
+++ b/cmd/crank/beta/xpkg/init.go
@@ -235,7 +235,7 @@ func printFile(w io.Writer, path string) error {
 	if _, err := fmt.Fprintf(w, "\n%s\n", content); err != nil {
 		return errors.Wrap(err, "failed to write to stdout")
 	}
-	defer func() { _ = f.Close() }()
+	defer f.Close() //nolint:errcheck // It's safe to ingore the error here.
 	return nil
 }
 

--- a/cmd/crank/beta/xpkg/init.go
+++ b/cmd/crank/beta/xpkg/init.go
@@ -228,6 +228,7 @@ func printFile(w io.Writer, path string) error {
 	if err != nil {
 		return errors.Wrapf(err, "failed to open file %s", path)
 	}
+	defer f.Close() //nolint:errcheck // It's safe to ingore the error here.
 	content, err := io.ReadAll(f)
 	if err != nil {
 		return errors.Wrapf(err, "failed to read file %s", path)
@@ -235,7 +236,6 @@ func printFile(w io.Writer, path string) error {
 	if _, err := fmt.Fprintf(w, "\n%s\n", content); err != nil {
 		return errors.Wrap(err, "failed to write to stdout")
 	}
-	defer f.Close() //nolint:errcheck // It's safe to ingore the error here.
 	return nil
 }
 


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane! Please read the contribution docs
(linked below) if this is your first Crossplane pull request.
-->

### Description of your changes
Based on the previous #5632 with the fix for linting.

I believe it's safe to not handle the error. The whole function is doing read only, and not doing any write operation.

<!--
Briefly describe what this pull request does, and how it is covered by tests.
Be proactive - direct your reviewers' attention to anything that needs special
consideration.

We love pull requests that fix an open issue. If yours does, use the below line
to indicate which issue it fixes, for example "Fixes #500".
-->

Fixes #5717

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added or updated unit tests.
- [ ] Added or updated e2e tests.
- [x] Linked a PR or a [docs tracking issue] to [document this change].
- [ ] Added `backport release-x.y` labels to auto-backport this PR.

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/master/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/master/contributing#checklist-cheat-sheet
