### PR TITLE
Unset some UP env vars to avoid unexpect test behaviour.

### DIFF
--- a/internal/xpkg/upbound/context_test.go
+++ b/internal/xpkg/upbound/context_test.go
@@ -19,6 +19,7 @@ package upbound
 import (
 	"fmt"
 	"net/url"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -274,6 +275,11 @@ func TestNewFromFlags(t *testing.T) {
 	}
 
 	for name, tc := range cases {
+		// Unset common UP env vars used by the test to avoid unexpect behaviours describe in #5721
+		os.Unsetenv("UP_ACCOUNT")
+		os.Unsetenv("UP_DOMAIN")
+		os.Unsetenv("UP_PROFILE")
+		os.Unsetenv("UP_INSECURE_SKIP_TLS_VERIFY")
 		t.Run(name, func(t *testing.T) {
 			flags := Flags{}
 			parser, _ := kong.New(&flags)


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane! Please read the contribution docs
(linked below) if this is your first Crossplane pull request.
-->

### Description of your changes

<!--
Briefly describe what this pull request does, and how it is covered by tests.
Be proactive - direct your reviewers' attention to anything that needs special
consideration.

We love pull requests that fix an open issue. If yours does, use the below line
to indicate which issue it fixes, for example "Fixes #500".
-->
Unset common UP environment variables before tests to avoid unexpected behaviour.

Fixes #5721 

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added or updated unit tests.
- [ ] ~Added or updated e2e tests.~
- [x] Linked a PR or a [docs tracking issue] to [document this change].
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/master/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/master/contributing#checklist-cheat-sheet
