### PR TITLE
Allow Externally Managed CRD Fields

### DIFF
--- a/cmd/crank/beta/validate/validate_test.go
+++ b/cmd/crank/beta/validate/validate_test.go
@@ -262,6 +262,10 @@ func TestConvertToCRDs(t *testing.T) {
 			want: want{
 				crd: []*extv1.CustomResourceDefinition{
 					{
+						TypeMeta: metav1.TypeMeta{
+							Kind:       "CustomResourceDefinition",
+							APIVersion: "apiextensions.k8s.io/v1",
+						},
 						ObjectMeta: metav1.ObjectMeta{
 							Name: "test",
 							OwnerReferences: []metav1.OwnerReference{
@@ -605,6 +609,10 @@ func TestConvertToCRDs(t *testing.T) {
 			want: want{
 				crd: []*extv1.CustomResourceDefinition{
 					{
+						TypeMeta: metav1.TypeMeta{
+							Kind:       "CustomResourceDefinition",
+							APIVersion: "apiextensions.k8s.io/v1",
+						},
 						ObjectMeta: metav1.ObjectMeta{
 							Name: "test",
 							OwnerReferences: []metav1.OwnerReference{
@@ -885,6 +893,10 @@ func TestConvertToCRDs(t *testing.T) {
 						},
 					},
 					{
+						TypeMeta: metav1.TypeMeta{
+							Kind:       "CustomResourceDefinition",
+							APIVersion: "apiextensions.k8s.io/v1",
+						},
 						ObjectMeta: metav1.ObjectMeta{
 							Name: "testclaims.test.org",
 							OwnerReferences: []metav1.OwnerReference{

--- a/internal/controller/apiextensions/definition/reconciler_test.go
+++ b/internal/controller/apiextensions/definition/reconciler_test.go
@@ -550,11 +550,9 @@ func TestReconcile(t *testing.T) {
 			args: args{
 				ca: resource.ClientApplicator{
 					Client: &test.MockClient{
-						MockGet: test.NewMockGetFn(nil),
+						MockGet:   test.NewMockGetFn(nil),
+						MockPatch: test.NewMockPatchFn(errBoom),
 					},
-					Applicator: resource.ApplyFn(func(_ context.Context, _ client.Object, _ ...resource.ApplyOption) error {
-						return errBoom
-					}),
 				},
 				opts: []ReconcilerOption{
 					WithCRDRenderer(CRDRenderFn(func(_ *v1.CompositeResourceDefinition) (*extv1.CustomResourceDefinition, error) {
@@ -574,11 +572,9 @@ func TestReconcile(t *testing.T) {
 			args: args{
 				ca: resource.ClientApplicator{
 					Client: &test.MockClient{
-						MockGet: test.NewMockGetFn(nil),
+						MockGet:   test.NewMockGetFn(nil),
+						MockPatch: test.NewMockPatchFn(nil),
 					},
-					Applicator: resource.ApplyFn(func(_ context.Context, _ client.Object, _ ...resource.ApplyOption) error {
-						return nil
-					}),
 				},
 				opts: []ReconcilerOption{
 					WithCRDRenderer(CRDRenderFn(func(_ *v1.CompositeResourceDefinition) (*extv1.CustomResourceDefinition, error) {
@@ -628,10 +624,8 @@ func TestReconcile(t *testing.T) {
 							*obj.(*v1.CompositeResourceDefinition) = *xrd
 							return nil
 						}),
+						MockPatch: test.NewMockPatchFn(nil),
 					},
-					Applicator: resource.ApplyFn(func(_ context.Context, _ client.Object, _ ...resource.ApplyOption) error {
-						return nil
-					}),
 				},
 				opts: []ReconcilerOption{
 					WithCRDRenderer(CRDRenderFn(func(_ *v1.CompositeResourceDefinition) (*extv1.CustomResourceDefinition, error) {
@@ -664,11 +658,9 @@ func TestReconcile(t *testing.T) {
 			args: args{
 				ca: resource.ClientApplicator{
 					Client: &test.MockClient{
-						MockGet: test.NewMockGetFn(nil),
+						MockGet:   test.NewMockGetFn(nil),
+						MockPatch: test.NewMockPatchFn(nil),
 					},
-					Applicator: resource.ApplyFn(func(_ context.Context, _ client.Object, _ ...resource.ApplyOption) error {
-						return nil
-					}),
 				},
 				opts: []ReconcilerOption{
 					WithCRDRenderer(CRDRenderFn(func(_ *v1.CompositeResourceDefinition) (*extv1.CustomResourceDefinition, error) {
@@ -702,11 +694,9 @@ func TestReconcile(t *testing.T) {
 			args: args{
 				ca: resource.ClientApplicator{
 					Client: &test.MockClient{
-						MockGet: test.NewMockGetFn(nil),
+						MockGet:   test.NewMockGetFn(nil),
+						MockPatch: test.NewMockPatchFn(nil),
 					},
-					Applicator: resource.ApplyFn(func(_ context.Context, _ client.Object, _ ...resource.ApplyOption) error {
-						return nil
-					}),
 				},
 				opts: []ReconcilerOption{
 					WithCRDRenderer(CRDRenderFn(func(_ *v1.CompositeResourceDefinition) (*extv1.CustomResourceDefinition, error) {
@@ -753,10 +743,8 @@ func TestReconcile(t *testing.T) {
 							}
 							return nil
 						}),
+						MockPatch: test.NewMockPatchFn(nil),
 					},
-					Applicator: resource.ApplyFn(func(_ context.Context, _ client.Object, _ ...resource.ApplyOption) error {
-						return nil
-					}),
 				},
 				opts: []ReconcilerOption{
 					WithCRDRenderer(CRDRenderFn(func(_ *v1.CompositeResourceDefinition) (*extv1.CustomResourceDefinition, error) {
@@ -811,10 +799,8 @@ func TestReconcile(t *testing.T) {
 							}
 							return nil
 						}),
+						MockPatch: test.NewMockPatchFn(nil),
 					},
-					Applicator: resource.ApplyFn(func(_ context.Context, _ client.Object, _ ...resource.ApplyOption) error {
-						return nil
-					}),
 				},
 				opts: []ReconcilerOption{
 					WithCRDRenderer(CRDRenderFn(func(_ *v1.CompositeResourceDefinition) (*extv1.CustomResourceDefinition, error) {
@@ -857,10 +843,8 @@ func TestReconcile(t *testing.T) {
 							}
 							return nil
 						}),
+						MockPatch: test.NewMockPatchFn(nil),
 					},
-					Applicator: resource.ApplyFn(func(_ context.Context, _ client.Object, _ ...resource.ApplyOption) error {
-						return nil
-					}),
 				},
 				opts: []ReconcilerOption{
 					WithCRDRenderer(CRDRenderFn(func(_ *v1.CompositeResourceDefinition) (*extv1.CustomResourceDefinition, error) {

--- a/internal/controller/apiextensions/offered/reconciler.go
+++ b/internal/controller/apiextensions/offered/reconciler.go
@@ -57,6 +57,10 @@ import (
 const (
 	timeout   = 1 * time.Minute
 	finalizer = "offered.apiextensions.crossplane.io"
+
+	// FieldOwner owns the fields this controller mutates on
+	// CustomResourceDefinitions (CRDs).
+	FieldOwner = "apiextensions.crossplane.io/offered"
 )
 
 // Error strings.
@@ -408,17 +412,17 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 		return reconcile.Result{}, err
 	}
 
-	origRV := ""
-	if err := r.client.Apply(ctx, crd, resource.MustBeControllableBy(d.GetUID()), resource.StoreCurrentRV(&origRV)); err != nil {
+	// We are aware that using controller-runtime server-side apply will result in
+	// some zero-value fields, however, this should not affect the way CRDs are
+	// implemented in this controller. For a discussion on the runtime issue, see
+	// https://github.com/kubernetes-sigs/controller-runtime/issues/347.
+	if err := r.client.Patch(ctx, crd, client.Apply, client.ForceOwnership, client.FieldOwner(FieldOwner)); err != nil {
 		if kerrors.IsConflict(err) {
 			return reconcile.Result{Requeue: true}, nil
 		}
 		err = errors.Wrap(err, errApplyCRD)
 		r.record.Event(d, event.Warning(reasonOfferXRC, err))
 		return reconcile.Result{}, err
-	}
-	if crd.GetResourceVersion() != origRV {
-		r.record.Event(d, event.Normal(reasonOfferXRC, fmt.Sprintf("Applied composite resource claim CustomResourceDefinition: %s", crd.GetName())))
 	}
 
 	if !xcrd.IsEstablished(crd.Status) {

--- a/internal/controller/apiextensions/offered/reconciler_test.go
+++ b/internal/controller/apiextensions/offered/reconciler_test.go
@@ -557,11 +557,9 @@ func TestReconcile(t *testing.T) {
 			args: args{
 				ca: resource.ClientApplicator{
 					Client: &test.MockClient{
-						MockGet: test.NewMockGetFn(nil),
+						MockGet:   test.NewMockGetFn(nil),
+						MockPatch: test.NewMockPatchFn(errBoom),
 					},
-					Applicator: resource.ApplyFn(func(_ context.Context, _ client.Object, _ ...resource.ApplyOption) error {
-						return errBoom
-					}),
 				},
 				opts: []ReconcilerOption{
 					WithCRDRenderer(CRDRenderFn(func(_ *v1.CompositeResourceDefinition) (*extv1.CustomResourceDefinition, error) {
@@ -581,11 +579,9 @@ func TestReconcile(t *testing.T) {
 			args: args{
 				ca: resource.ClientApplicator{
 					Client: &test.MockClient{
-						MockGet: test.NewMockGetFn(nil),
+						MockGet:   test.NewMockGetFn(nil),
+						MockPatch: test.NewMockPatchFn(nil),
 					},
-					Applicator: resource.ApplyFn(func(_ context.Context, _ client.Object, _ ...resource.ApplyOption) error {
-						return nil
-					}),
 				},
 				opts: []ReconcilerOption{
 					WithCRDRenderer(CRDRenderFn(func(_ *v1.CompositeResourceDefinition) (*extv1.CustomResourceDefinition, error) {
@@ -635,10 +631,8 @@ func TestReconcile(t *testing.T) {
 							*obj.(*v1.CompositeResourceDefinition) = *xrd
 							return nil
 						}),
+						MockPatch: test.NewMockPatchFn(nil),
 					},
-					Applicator: resource.ApplyFn(func(_ context.Context, _ client.Object, _ ...resource.ApplyOption) error {
-						return nil
-					}),
 				},
 				opts: []ReconcilerOption{
 					WithCRDRenderer(CRDRenderFn(func(_ *v1.CompositeResourceDefinition) (*extv1.CustomResourceDefinition, error) {
@@ -671,11 +665,9 @@ func TestReconcile(t *testing.T) {
 			args: args{
 				ca: resource.ClientApplicator{
 					Client: &test.MockClient{
-						MockGet: test.NewMockGetFn(nil),
+						MockGet:   test.NewMockGetFn(nil),
+						MockPatch: test.NewMockPatchFn(nil),
 					},
-					Applicator: resource.ApplyFn(func(_ context.Context, _ client.Object, _ ...resource.ApplyOption) error {
-						return nil
-					}),
 				},
 				opts: []ReconcilerOption{
 					WithCRDRenderer(CRDRenderFn(func(_ *v1.CompositeResourceDefinition) (*extv1.CustomResourceDefinition, error) {
@@ -706,11 +698,9 @@ func TestReconcile(t *testing.T) {
 			args: args{
 				ca: resource.ClientApplicator{
 					Client: &test.MockClient{
-						MockGet: test.NewMockGetFn(nil),
+						MockGet:   test.NewMockGetFn(nil),
+						MockPatch: test.NewMockPatchFn(nil),
 					},
-					Applicator: resource.ApplyFn(func(_ context.Context, _ client.Object, _ ...resource.ApplyOption) error {
-						return nil
-					}),
 				},
 				opts: []ReconcilerOption{
 					WithCRDRenderer(CRDRenderFn(func(_ *v1.CompositeResourceDefinition) (*extv1.CustomResourceDefinition, error) {
@@ -757,10 +747,8 @@ func TestReconcile(t *testing.T) {
 							}
 							return nil
 						}),
+						MockPatch: test.NewMockPatchFn(nil),
 					},
-					Applicator: resource.ApplyFn(func(_ context.Context, _ client.Object, _ ...resource.ApplyOption) error {
-						return nil
-					}),
 				},
 				opts: []ReconcilerOption{
 					WithCRDRenderer(CRDRenderFn(func(_ *v1.CompositeResourceDefinition) (*extv1.CustomResourceDefinition, error) {
@@ -818,10 +806,8 @@ func TestReconcile(t *testing.T) {
 							}
 							return nil
 						}),
+						MockPatch: test.NewMockPatchFn(nil),
 					},
-					Applicator: resource.ApplyFn(func(_ context.Context, _ client.Object, _ ...resource.ApplyOption) error {
-						return nil
-					}),
 				},
 				opts: []ReconcilerOption{
 					WithCRDRenderer(CRDRenderFn(func(_ *v1.CompositeResourceDefinition) (*extv1.CustomResourceDefinition, error) {
@@ -864,10 +850,8 @@ func TestReconcile(t *testing.T) {
 							}
 							return nil
 						}),
+						MockPatch: test.NewMockPatchFn(nil),
 					},
-					Applicator: resource.ApplyFn(func(_ context.Context, _ client.Object, _ ...resource.ApplyOption) error {
-						return nil
-					}),
 				},
 				opts: []ReconcilerOption{
 					WithCRDRenderer(CRDRenderFn(func(_ *v1.CompositeResourceDefinition) (*extv1.CustomResourceDefinition, error) {

--- a/internal/xcrd/crd.go
+++ b/internal/xcrd/crd.go
@@ -55,6 +55,10 @@ const (
 // resource from the supplied CompositeResourceDefinition.
 func ForCompositeResource(xrd *v1.CompositeResourceDefinition) (*extv1.CustomResourceDefinition, error) {
 	crd := &extv1.CustomResourceDefinition{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "CustomResourceDefinition",
+			APIVersion: extv1.SchemeGroupVersion.String(),
+		},
 		Spec: extv1.CustomResourceDefinitionSpec{
 			Scope:      extv1.ClusterScoped,
 			Group:      xrd.Spec.Group,
@@ -105,6 +109,10 @@ func ForCompositeResourceClaim(xrd *v1.CompositeResourceDefinition) (*extv1.Cust
 	}
 
 	crd := &extv1.CustomResourceDefinition{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "CustomResourceDefinition",
+			APIVersion: extv1.SchemeGroupVersion.String(),
+		},
 		Spec: extv1.CustomResourceDefinitionSpec{
 			Scope:      extv1.NamespaceScoped,
 			Group:      xrd.Spec.Group,

--- a/internal/xcrd/crd_test.go
+++ b/internal/xcrd/crd_test.go
@@ -208,6 +208,10 @@ func TestForCompositeResource(t *testing.T) {
 			},
 			want: want{
 				c: &extv1.CustomResourceDefinition{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "CustomResourceDefinition",
+						APIVersion: "apiextensions.k8s.io/v1",
+					},
 					ObjectMeta: metav1.ObjectMeta{
 						Name:   name,
 						Labels: labels,
@@ -524,6 +528,10 @@ func TestForCompositeResource(t *testing.T) {
 			},
 			want: want{
 				c: &extv1.CustomResourceDefinition{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "CustomResourceDefinition",
+						APIVersion: "apiextensions.k8s.io/v1",
+					},
 					ObjectMeta: metav1.ObjectMeta{
 						Name:   name,
 						Labels: labels,
@@ -818,6 +826,10 @@ func TestForCompositeResource(t *testing.T) {
 			},
 			want: want{
 				c: &extv1.CustomResourceDefinition{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "CustomResourceDefinition",
+						APIVersion: "apiextensions.k8s.io/v1",
+					},
 					ObjectMeta: metav1.ObjectMeta{
 						Name:   name,
 						Labels: labels,
@@ -1075,6 +1087,10 @@ func TestForCompositeResource(t *testing.T) {
 			},
 			want: want{
 				c: &extv1.CustomResourceDefinition{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "CustomResourceDefinition",
+						APIVersion: "apiextensions.k8s.io/v1",
+					},
 					ObjectMeta: metav1.ObjectMeta{
 						Name:   name,
 						Labels: labels,
@@ -1368,6 +1384,10 @@ func TestForCompositeResource(t *testing.T) {
 			},
 			want: want{
 				c: &extv1.CustomResourceDefinition{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "CustomResourceDefinition",
+						APIVersion: "apiextensions.k8s.io/v1",
+					},
 					ObjectMeta: metav1.ObjectMeta{
 						Name:   name,
 						Labels: labels,
@@ -1892,6 +1912,10 @@ func TestForCompositeResourceClaim(t *testing.T) {
 			},
 
 			want: &extv1.CustomResourceDefinition{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "CustomResourceDefinition",
+					APIVersion: "apiextensions.k8s.io/v1",
+				},
 				ObjectMeta: metav1.ObjectMeta{
 					Name:   claimPlural + "." + group,
 					Labels: labels,
@@ -2177,6 +2201,10 @@ func TestForCompositeResourceClaim(t *testing.T) {
 			},
 
 			want: &extv1.CustomResourceDefinition{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "CustomResourceDefinition",
+					APIVersion: "apiextensions.k8s.io/v1",
+				},
 				ObjectMeta: metav1.ObjectMeta{
 					Name:   claimPlural + "." + group,
 					Labels: labels,
@@ -2496,6 +2524,10 @@ func TestForCompositeResourceClaimEmptyXrd(t *testing.T) {
 	}
 
 	want := &extv1.CustomResourceDefinition{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "CustomResourceDefinition",
+			APIVersion: "apiextensions.k8s.io/v1",
+		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   claimPlural + "." + group,
 			Labels: labels,


### PR DESCRIPTION
### Description of your changes
Use server-side apply for reconciling CRDs for composite resources and claims. This will allow for other processes (e.g., CertManager) to control fields on the CRD that are not owned by the reconciler.

*Note: The current implementation only fixes composite resource CRDs. If this approach is desired, I will implement for Claims as well.*

Fixes #5723 

I have:

- [X] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added or updated unit tests.
- [ ] ~Added or updated e2e tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~