### PR TITLE
build: allow CRD patch dir to already exist

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,7 @@ CRD_PATCH_DIR = cluster/crd-patches
 # See patch files for details.
 crds.patch: $(KUBECTL)
 	@$(INFO) patching generated CRDs
-	@mkdir $(WORK_DIR)/patch
+	@mkdir -p $(WORK_DIR)/patch
 	@$(KUBECTL) patch --local --type=json -f $(CRD_DIR)/pkg.crossplane.io_deploymentruntimeconfigs.yaml --patch-file $(CRD_PATCH_DIR)/pkg.crossplane.io_deploymentruntimeconfigs.yaml -o yaml > $(WORK_DIR)/patch/pkg.crossplane.io_deploymentruntimeconfigs.yaml
 	@mv $(WORK_DIR)/patch/pkg.crossplane.io_deploymentruntimeconfigs.yaml $(CRD_DIR)/pkg.crossplane.io_deploymentruntimeconfigs.yaml
 	@$(OK) patched generated CRDs


### PR DESCRIPTION
### Description of your changes

As described in https://github.com/crossplane/crossplane/pull/5734#issuecomment-2131300291 and #5738, this PR attempts to allow `make generate` to be run more than once by dealing with an existing `$(WORK_DIR)/patch` directory from previous runs.

Fixes #5738 

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] ~Added or updated unit tests.~
- [ ] ~Added or updated e2e tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/master/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/master/contributing#checklist-cheat-sheet
