### PR TITLE
Enable Earthly remote caching, pass AWS credentials explicitly

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -33,6 +33,18 @@
   "customManagers": [
     {
       "customType": "regex",
+      "description": "Bump Earthly version in GitHub workflows",
+      "fileMatch": [
+        "^\\.github\\/workflows\\/[^/]+\\.ya?ml$"
+      ],
+      "matchStrings": [
+        "EARTHLY_VERSION '(?<currentValue>.*?)'\\n"
+      ],
+      "datasourceTemplate": "github-tags",
+      "depNameTemplate": "earthly/earthly"
+    },
+    {
+      "customType": "regex",
       "description": "Bump Go version in Earthfile",
       "fileMatch": [
         "^Earthfile$"

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -94,6 +94,18 @@
     },
     {
       "customType": "regex",
+      "description": "Bump kubectl version in the Earthfile",
+      "fileMatch": [
+        "^Earthfile$"
+      ],
+      "matchStrings": [
+        "ARG KUBECTL_VERSION=v(?<currentValue>.*?)\\n"
+      ],
+      "datasourceTemplate": "github-tags",
+      "depNameTemplate": "kubernetes/kubernetes",
+    },
+    {
+      "customType": "regex",
       "description": "Bump gotestsum version in the Earthfile",
       "fileMatch": [
         "^Earthfile$"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,8 +44,21 @@ jobs:
           username: ${{ secrets.DOCKER_USR }}
           password: ${{ secrets.DOCKER_PSW }}
 
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Configure Earthly to Push Cache to GitHub Container Registry 
+        if: github.ref == 'refs/heads/master'
+        run: |
+          echo "EARTHLY_PUSH=true" > $GITHUB_ENV
+          echo "EARTHLY_MAX_REMOTE_CACHE=true" > $GITHUB_ENV
+
       - name: Generate Files
-        run: earthly --strict +generate
+        run: earthly --strict --remote-cache ghcr.io/crossplane/earthly-cache:${{ github.job }} +generate
 
       - name: Count Changed Files
         id: changed_files
@@ -77,8 +90,21 @@ jobs:
           username: ${{ secrets.DOCKER_USR }}
           password: ${{ secrets.DOCKER_PSW }}
 
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Configure Earthly to Push Cache to GitHub Container Registry 
+        if: github.ref == 'refs/heads/master'
+        run: |
+          echo "EARTHLY_PUSH=true" > $GITHUB_ENV
+          echo "EARTHLY_MAX_REMOTE_CACHE=true" > $GITHUB_ENV
+
       - name: Lint
-        run: earthly --strict +lint
+        run: earthly --strict --remote-cache ghcr.io/crossplane/earthly-cache:${{ github.job }} +lint
 
   codeql:
     runs-on: ubuntu-22.04
@@ -100,8 +126,21 @@ jobs:
           username: ${{ secrets.DOCKER_USR }}
           password: ${{ secrets.DOCKER_PSW }}
 
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Configure Earthly to Push Cache to GitHub Container Registry 
+        if: github.ref == 'refs/heads/master'
+        run: |
+          echo "EARTHLY_PUSH=true" > $GITHUB_ENV
+          echo "EARTHLY_MAX_REMOTE_CACHE=true" > $GITHUB_ENV
+
       - name: Run CodeQL
-        run: earthly --strict +ci-codeql
+        run: earthly --strict --remote-cache ghcr.io/crossplane/earthly-cache:${{ github.job }} +ci-codeql
 
       - name: Upload CodeQL Results to GitHub
         uses: github/codeql-action/upload-sarif@v3
@@ -151,8 +190,21 @@ jobs:
           username: ${{ secrets.DOCKER_USR }}
           password: ${{ secrets.DOCKER_PSW }}
 
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Configure Earthly to Push Cache to GitHub Container Registry 
+        if: github.ref == 'refs/heads/master'
+        run: |
+          echo "EARTHLY_PUSH=true" > $GITHUB_ENV
+          echo "EARTHLY_MAX_REMOTE_CACHE=true" > $GITHUB_ENV
+
       - name: Run Unit Tests
-        run: earthly --strict +test
+        run: earthly --strict --remote-cache ghcr.io/crossplane/earthly-cache:${{ github.job }} +test
 
       - name: Publish Unit Test Coverage
         uses: codecov/codecov-action@125fc84a9a348dbcf27191600683ec096ec9021c # v4
@@ -190,8 +242,23 @@ jobs:
           username: ${{ secrets.DOCKER_USR }}
           password: ${{ secrets.DOCKER_PSW }}
 
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Configure Earthly to Push Cache to GitHub Container Registry 
+        if: github.ref == 'refs/heads/master'
+        run: |
+          echo "EARTHLY_PUSH=true" > $GITHUB_ENV
+          echo "EARTHLY_MAX_REMOTE_CACHE=true" > $GITHUB_ENV
+
       - name: Run E2E Tests
-        run: earthly --strict --allow-privileged +e2e --FLAGS="-test.failfast -fail-fast --test-suite ${{ matrix.test-suite }}"
+        run: |
+          earthly --strict --allow-privileged --remote-cache ghcr.io/crossplane/earthly-cache:${{ github.job }}-${{ matrix.test-suite}} \
+            +e2e --FLAGS="-test.failfast -fail-fast --test-suite ${{ matrix.test-suite }}"
 
       - name: Publish E2E Test Flakes
         if: '!cancelled()'
@@ -247,7 +314,18 @@ jobs:
           username: ${{ secrets.UPBOUND_MARKETPLACE_PUSH_ROBOT_USR }}
           password: ${{ secrets.UPBOUND_MARKETPLACE_PUSH_ROBOT_PSW }}
 
-      - name: Enable Earthly to Push Artifacts
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Configure Earthly to Push Cache to GitHub Container Registry 
+        if: github.ref == 'refs/heads/master'
+        run: echo "EARTHLY_MAX_REMOTE_CACHE=true" > $GITHUB_ENV
+
+      - name: Configure Earthly to Push Artifacts
         if: env.DOCKER_USR != '' && env.UPBOUND_MARKETPLACE_PUSH_ROBOT_USR != '' && env.AWS_USR != ''
         run: echo "EARTHLY_PUSH=true" > $GITHUB_ENV
 
@@ -255,7 +333,7 @@ jobs:
         run: earthly +ci-version
 
       - name: Build and Push Artifacts
-        run: earthly --strict +ci-artifacts --CROSSPLANE_VERSION=${CROSSPLANE_VERSION}
+        run: earthly --strict --remote-cache ghcr.io/crossplane/earthly-cache:${{ github.job }} +ci-artifacts --CROSSPLANE_VERSION=${CROSSPLANE_VERSION}
 
       - name: Push Artifacts to https://releases.crossplane.io/build/
         if: env.AWS_USR != ''

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -259,19 +259,19 @@ jobs:
 
       - name: Push Artifacts to https://releases.crossplane.io/build/
         if: env.AWS_USR != ''
-        run: earthly --strict +ci-push-build-artifacts --CROSSPLANE_VERSION=${CROSSPLANE_VERSION}
-        env:
-          AWS_DEFAULT_REGION: us-east-1
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_USR }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_PSW }}
+        run: |
+          earthly --strict \
+            --secret=AWS_ACCESS_KEY_ID=${{ secrets.AWS_USR }} \
+            --secret=AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_PSW }} \
+            +ci-push-build-artifacts --AWS_DEFAULT_REGION=us-east-1 --CROSSPLANE_VERSION=${CROSSPLANE_VERSION}
 
       - name: Push Artifacts to https://releases.crossplane.io/master/ and https://charts.crossplane.io/master
         if: env.AWS_USR != '' && github.ref == 'refs/heads/master'
-        run: earthly --strict +ci-promote-build-artifacts --CROSSPLANE_VERSION=${CROSSPLANE_VERSION} --CHANNEL=master
-        env:
-          AWS_DEFAULT_REGION: us-east-1
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_USR }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_PSW }}
+        run: |
+          earthly --strict \
+            --secret=AWS_ACCESS_KEY_ID=${{ secrets.AWS_USR }} \
+            --secret=AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_PSW }} \
+            +ci-promote-build-artifacts --AWS_DEFAULT_REGION=us-east-1 --CROSSPLANE_VERSION=${CROSSPLANE_VERSION} --CHANNEL=master
 
       - name: Upload Artifacts to GitHub
         uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -61,8 +61,8 @@ jobs:
 
       - name: Promote Build Artifacts to https://releases.crossplane.io/${{ inputs.channel }}
         if: env.AWS_USR != ''
-        run: earthly --strict +ci-promote-build-artifacts --CHANNEL=${{ inputs.channel }} --PRERELEASE=${{ inputs.pre-release }} --CROSSPLANE_VERSION=${{ inputs.version }}
-        env:
-          AWS_DEFAULT_REGION: us-east-1
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_USR }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_PSW }}
+        run: |
+          earthly --strict \
+            --secret=AWS_ACCESS_KEY_ID=${{ secrets.AWS_USR }} \
+            --secret=AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_PSW }} \
+            +ci-promote-build-artifacts --AWS_DEFAULT_REGION=us-east-1 --CHANNEL=${{ inputs.channel }} --PRERELEASE=${{ inputs.pre-release }} --CROSSPLANE_VERSION=${{ inputs.version }}

--- a/Earthfile
+++ b/Earthfile
@@ -1,5 +1,5 @@
 # See https://docs.earthly.dev/docs/earthfile/features
-VERSION --try --raw-output --run-with-aws 0.8
+VERSION --try --raw-output 0.8
 
 PROJECT crossplane/crossplane
 
@@ -396,9 +396,10 @@ ci-push-build-artifacts:
   ARG ARTIFACTS_DIR=_output
   ARG EARTHLY_GIT_BRANCH
   ARG BUCKET_RELEASES=crossplane.releases
+  ARG AWS_DEFAULT_REGION
   FROM amazon/aws-cli:2.15.57
   COPY --dir ${ARTIFACTS_DIR} artifacts
-  RUN --push --aws aws s3 sync --delete artifacts s3://${BUCKET_RELEASES}/build/${EARTHLY_GIT_BRANCH}/${CROSSPLANE_VERSION}
+  RUN --push --secret=AWS_ACCESS_KEY_ID --secret=AWS_SECRET_ACCESS_KEY aws s3 sync --delete artifacts s3://${BUCKET_RELEASES}/build/${EARTHLY_GIT_BRANCH}/${CROSSPLANE_VERSION}
 
 # ci-promote-build-artifacts is used by CI to promote binary artifacts and Helm
 # charts to a channel. In practice, this means copying them from one S3
@@ -411,14 +412,15 @@ ci-promote-build-artifacts:
   ARG BUCKET_RELEASES=crossplane.releases
   ARG BUCKET_CHARTS=crossplane.charts
   ARG PRERELEASE=false
+  ARG AWS_DEFAULT_REGION
   FROM amazon/aws-cli:2.15.57
   COPY +helm-setup/helm /usr/local/bin/helm
-  RUN --aws aws s3 sync s3://${BUCKET_CHARTS}/${CHANNEL} repo
-  RUN --aws aws s3 sync s3://${BUCKET_RELEASES}/build/${EARTHLY_GIT_BRANCH}/${CROSSPLANE_VERSION}/charts repo
+  RUN --secret=AWS_ACCESS_KEY_ID --secret=AWS_SECRET_ACCESS_KEY aws s3 sync s3://${BUCKET_CHARTS}/${CHANNEL} repo
+  RUN --secret=AWS_ACCESS_KEY_ID --secret=AWS_SECRET_ACCESS_KEY aws s3 sync s3://${BUCKET_RELEASES}/build/${EARTHLY_GIT_BRANCH}/${CROSSPLANE_VERSION}/charts repo
   RUN helm repo index --url ${HELM_REPO_URL} repo
-  RUN --push --aws aws s3 sync --delete repo s3://${BUCKET_CHARTS}/${CHANNEL}
-  RUN --push --aws aws s3 cp "private, max-age=0, no-transform" repo/index.yaml s3://${BUCKET_CHARTS}/${CHANNEL}/index.yaml
-  RUN --push --aws aws s3 sync --delete s3://${BUCKET_RELEASES}/build/${EARTHLY_GIT_BRANCH}/${CROSSPLANE_VERSION} s3://${BUCKET_RELEASES}/${CHANNEL}/${CROSSPLANE_VERSION}
+  RUN --push --secret=AWS_ACCESS_KEY_ID --secret=AWS_SECRET_ACCESS_KEY aws s3 sync --delete repo s3://${BUCKET_CHARTS}/${CHANNEL}
+  RUN --push --secret=AWS_ACCESS_KEY_ID --secret=AWS_SECRET_ACCESS_KEY aws s3 cp "private, max-age=0, no-transform" repo/index.yaml s3://${BUCKET_CHARTS}/${CHANNEL}/index.yaml
+  RUN --push --secret=AWS_ACCESS_KEY_ID --secret=AWS_SECRET_ACCESS_KEY aws s3 sync --delete s3://${BUCKET_RELEASES}/build/${EARTHLY_GIT_BRANCH}/${CROSSPLANE_VERSION} s3://${BUCKET_RELEASES}/${CHANNEL}/${CROSSPLANE_VERSION}
   IF [ "${PRERELEASE}" = "false" ]
-    RUN --push --aws aws s3 sync --delete s3://${BUCKET_RELEASES}/build/${EARTHLY_GIT_BRANCH}/${CROSSPLANE_VERSION} s3://${BUCKET_RELEASES}/${CHANNEL}/current
+    RUN --push --secret=AWS_ACCESS_KEY_ID --secret=AWS_SECRET_ACCESS_KEY aws s3 sync --delete s3://${BUCKET_RELEASES}/build/${EARTHLY_GIT_BRANCH}/${CROSSPLANE_VERSION} s3://${BUCKET_RELEASES}/${CHANNEL}/current
   END


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane! Please read the contribution docs
(linked below) if this is your first Crossplane pull request.
-->

### Description of your changes

<!--
Briefly describe what this pull request does, and how it is covered by tests.
Be proactive - direct your reviewers' attention to anything that needs special
consideration.

We love pull requests that fix an open issue. If yours does, use the below line
to indicate which issue it fixes, for example "Fixes #500".
-->

Follow up to https://github.com/crossplane/crossplane/pull/5711.

See the AWS credential related commit in particular - I noticed `+ci-push-build-artifacts` failed in master

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `earthly +reviewable` to ensure this PR is ready for review.
- [ ] ~Added or updated unit tests.~
- [ ] ~Added or updated e2e tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/master/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/master/contributing#checklist-cheat-sheet
