### PR TITLE
Make Renovate play nice with Earthly

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -172,9 +172,7 @@
       postUpgradeTasks: {
         // Post-upgrade tasks that are executed before a commit is made by Renovate.
         "commands": [
-          "git submodule update --init",
-          "install-tool golang $(grep -oP \"^toolchain go\\K.+\" go.mod)",
-          "make generate",
+          "earthly --strict +go-generate",
         ],
         fileFilters: [
           "**/*"
@@ -190,8 +188,7 @@
       postUpgradeTasks: {
         // Post-upgrade tasks that are executed before a commit is made by Renovate.
         "commands": [
-          "install-tool golang $(grep -oP \"^toolchain go\\K.+\" go.mod)",
-          "make go.lint",
+          "earthly --strict +go-lint",
         ],
         fileFilters: [
           "**/*"

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -41,7 +41,8 @@
         "EARTHLY_VERSION '(?<currentValue>.*?)'\\n"
       ],
       "datasourceTemplate": "github-tags",
-      "depNameTemplate": "earthly/earthly"
+      "depNameTemplate": "earthly/earthly",
+      "extractVersionTemplate": "^v(?<version>.*)$"
     },
     {
       "customType": "regex",
@@ -62,11 +63,10 @@
         "^Earthfile$"
       ],
       "matchStrings": [
-        "ARG GOLANGCI_LINT_VERSION=v(?<currentValue>.*?)\\n"
+        "ARG GOLANGCI_LINT_VERSION=(?<currentValue>.*?)\\n"
       ],
       "datasourceTemplate": "github-tags",
-      "depNameTemplate": "golangci/golangci-lint",
-      "extractVersionTemplate": "^v(?<version>.*)$"
+      "depNameTemplate": "golangci/golangci-lint"
     },
     {
       "customType": "regex",
@@ -75,7 +75,7 @@
         "^Earthfile$"
       ],
       "matchStrings": [
-        "ARG HELM_VERSION=v(?<currentValue>.*?)\\n"
+        "ARG HELM_VERSION=(?<currentValue>.*?)\\n"
       ],
       "datasourceTemplate": "github-tags",
       "depNameTemplate": "helm/helm",
@@ -91,6 +91,7 @@
       ],
       "datasourceTemplate": "github-tags",
       "depNameTemplate": "norwoodj/helm-docs",
+      "extractVersionTemplate": "^v(?<version>.*)$"
     },
     {
       "customType": "regex",
@@ -99,7 +100,7 @@
         "^Earthfile$"
       ],
       "matchStrings": [
-        "ARG KIND_VERSION=v(?<currentValue>.*?)\\n"
+        "ARG KIND_VERSION=(?<currentValue>.*?)\\n"
       ],
       "datasourceTemplate": "github-tags",
       "depNameTemplate": "kubernetes-sigs/kind",
@@ -111,7 +112,7 @@
         "^Earthfile$"
       ],
       "matchStrings": [
-        "ARG KUBECTL_VERSION=v(?<currentValue>.*?)\\n"
+        "ARG KUBECTL_VERSION=(?<currentValue>.*?)\\n"
       ],
       "datasourceTemplate": "github-tags",
       "depNameTemplate": "kubernetes/kubernetes",
@@ -127,6 +128,7 @@
       ],
       "datasourceTemplate": "github-tags",
       "depNameTemplate": "gotestyourself/gotestsum",
+      "extractVersionTemplate": "^v(?<version>.*)$"
     },
     {
       "customType": "regex",
@@ -135,7 +137,7 @@
         "^Earthfile$"
       ],
       "matchStrings": [
-        "ARG CODEQL_VERSION=v(?<currentValue>.*?)\\n"
+        "ARG CODEQL_VERSION=(?<currentValue>.*?)\\n"
       ],
       "datasourceTemplate": "github-tags",
       "depNameTemplate": "github/codeql-action",

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -12,6 +12,9 @@ on:
     - cron: '0 8 * * *'
 
 env:
+  # Common versions
+  EARTHLY_VERSION: '0.8.11'
+
   LOG_LEVEL: "info"
 
 jobs:
@@ -23,8 +26,12 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
+
+      - name: Setup Earthly
+        uses: earthly/actions-setup@v1
         with:
-          submodules: true
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          version: ${{ env.EARTHLY_VERSION }}
 
       # Don't waste time starting Renovate if JSON is invalid
       - name: Validate Renovate JSON
@@ -44,7 +51,7 @@ jobs:
           # Use GitHub API to create commits
           RENOVATE_PLATFORM_COMMIT: "true"
           LOG_LEVEL: ${{ github.event.inputs.logLevel || env.LOG_LEVEL }}
-          RENOVATE_ALLOWED_POST_UPGRADE_COMMANDS: '["^git submodule update --init$", "^make generate$", "^install-tool golang \\$\\(grep -oP \"\\^toolchain go\\\\K\\.\\+\" go\\.mod\\)$", "^make go.lint$"]'
+          RENOVATE_ALLOWED_POST_UPGRADE_COMMANDS: '["^earthly .+"]'
         with:
           configurationFile: .github/renovate.json5
           token: '${{ steps.get-github-app-token.outputs.token }}'


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane! Please read the contribution docs
(linked below) if this is your first Crossplane pull request.
-->

### Description of your changes

<!--
Briefly describe what this pull request does, and how it is covered by tests.
Be proactive - direct your reviewers' attention to anything that needs special
consideration.

We love pull requests that fix an open issue. If yours does, use the below line
to indicate which issue it fixes, for example "Fixes #500".
-->

This PR contains two fixes.

First, it runs `earthly` rather than `make` after bumping Go or golangci-lint. Second, it (hopefully) fixes the version matching logic for the versioned tools in Earthfile.

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `earthly +reviewable` to ensure this PR is ready for review.
- [ ] ~Added or updated unit tests.~
- [ ] ~Added or updated e2e tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/master/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/master/contributing#checklist-cheat-sheet
