### PR TITLE
Don't re-run CodeQL or E2E tests if nothing but the git commit changes

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -53,7 +53,10 @@ e2e:
   COPY +gotestsum-setup/gotestsum /usr/local/bin/gotestsum
   COPY +go-build-e2e/e2e .
   COPY --dir cluster test .
-  WITH DOCKER --load crossplane-e2e/crossplane:latest=+image
+  # Using a static CROSSPLANE_VERSION allows Earthly to cache E2E runs as long
+  # as no code changed. If the version contains a git commit (the default) the
+  # build layer cache is invalidated on every commit.
+  WITH DOCKER --load crossplane-e2e/crossplane:latest=(+image --CROSSPLANE_VERSION=v0.0.0-e2e)
     TRY
       # TODO(negz:) Set GITHUB_ACTIONS=true and use RUN --raw-output when
       # https://github.com/earthly/earthly/issues/4143 is fixed.
@@ -357,7 +360,10 @@ ci-codeql:
   ARG CGO_ENABLED=0
   ARG TARGETOS
   ARG TARGETARCH
-  FROM +go-modules
+  # Using a static CROSSPLANE_VERSION allows Earthly to cache E2E runs as long
+  # as no code changed. If the version contains a git commit (the default) the
+  # build layer cache is invalidated on every commit.
+  FROM +go-modules --CROSSPLANE_VERSION=v0.0.0-codeql
   IF [ "${TARGETARCH}" = "arm64" ] && [ "${TARGETOS}" = "linux" ]
     RUN --no-cache echo "CodeQL doesn't support Linux on Apple Silicon" && false
   END


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane! Please read the contribution docs
(linked below) if this is your first Crossplane pull request.
-->

### Description of your changes

<!--
Briefly describe what this pull request does, and how it is covered by tests.
Be proactive - direct your reviewers' attention to anything that needs special
consideration.

We love pull requests that fix an open issue. If yours does, use the below line
to indicate which issue it fixes, for example "Fixes #500".
-->

CodeQL and the E2E tests were running on every PR, even if the PR didn't touch any (code) inputs. This was because `CROSSPLANE_VERSION` was being derived from a git commit hash. Since `CROSSPLANE_VERSION` is an input to the build, every new git commit would cause Crossplane to be rebuilt and thus cause CodeQL and the E2E tests to re-run.

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `earthly +reviewable` to ensure this PR is ready for review.
- [ ] ~Added or updated unit tests.~
- [ ] ~Added or updated e2e tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/master/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/master/contributing#checklist-cheat-sheet
