### PR TITLE
Fix earthly E2E test results, CodeQL Renovate version

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -141,6 +141,7 @@
       ],
       "datasourceTemplate": "github-tags",
       "depNameTemplate": "github/codeql-action",
+      "extractVersionTemplate": "^codeql-bundle-(?<version>.*)$"
     },
   ],
   // Renovate doesn't have native Earthfile support, but because Earthfile

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,7 @@ jobs:
         if: steps.changed_files.outputs.count != 0
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7
         with:
-          script: core.setFailed('Found changed files after running earthly +generate.'')
+          script: core.setFailed('Found changed files after running earthly +generate.')
 
   lint:
     runs-on: ubuntu-22.04

--- a/Earthfile
+++ b/Earthfile
@@ -53,17 +53,17 @@ e2e:
   COPY +gotestsum-setup/gotestsum /usr/local/bin/gotestsum
   COPY +go-build-e2e/e2e .
   COPY --dir cluster test .
-  # Using a static CROSSPLANE_VERSION allows Earthly to cache E2E runs as long
-  # as no code changed. If the version contains a git commit (the default) the
-  # build layer cache is invalidated on every commit.
-  WITH DOCKER --load crossplane-e2e/crossplane:latest=(+image --CROSSPLANE_VERSION=v0.0.0-e2e)
-    TRY
+  TRY
+    # Using a static CROSSPLANE_VERSION allows Earthly to cache E2E runs as long
+    # as no code changed. If the version contains a git commit (the default) the
+    # build layer cache is invalidated on every commit.
+    WITH DOCKER --load crossplane-e2e/crossplane:latest=(+image --CROSSPLANE_VERSION=v0.0.0-e2e)
       # TODO(negz:) Set GITHUB_ACTIONS=true and use RUN --raw-output when
       # https://github.com/earthly/earthly/issues/4143 is fixed.
       RUN gotestsum --no-color=false --format testname --junitfile e2e-tests.xml --raw-command go tool test2json -t -p E2E ./e2e -test.v ${FLAGS}
-    FINALLY
-      SAVE ARTIFACT --if-exists e2e-tests.xml AS LOCAL _output/tests/e2e-tests.xml
     END
+  FINALLY
+    SAVE ARTIFACT --if-exists e2e-tests.xml AS LOCAL _output/tests/e2e-tests.xml
   END
 
 # hack builds Crossplane, and deploys it to a kind cluster. It runs in your


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane! Please read the contribution docs
(linked below) if this is your first Crossplane pull request.
-->

### Description of your changes

<!--
Briefly describe what this pull request does, and how it is covered by tests.
Be proactive - direct your reviewers' attention to anything that needs special
consideration.

We love pull requests that fix an open issue. If yours does, use the below line
to indicate which issue it fixes, for example "Fixes #500".
-->

Closes https://github.com/crossplane/crossplane/pull/5752

Two more fixes for the new build system:

* Makes sure E2E tests write output (for https://app.buildpulse.io/@crossplane) even when they fail.
* Hopefully, makes Renovate ignore github/codeql-action tags that aren't the CodeQL bundle. 

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `earthly +reviewable` to ensure this PR is ready for review.
- [ ] ~Added or updated unit tests.~
- [ ] ~Added or updated e2e tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/master/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/master/contributing#checklist-cheat-sheet
