### PR TITLE
Fix Renovate running `earthly`

### DIFF
--- a/.github/renovate-entrypoint.sh
+++ b/.github/renovate-entrypoint.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+curl -fsSLo /usr/local/bin/earthly https://github.com/earthly/earthly/releases/latest/download/earthly-linux-amd64
+chmod +x /usr/local/bin/earthly
+/usr/local/bin/earthly bootstrap
+
+renovate

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -166,10 +166,12 @@
   // be at the beginning, high priority at the end
   "packageRules": [
     {
-      "description": "Generate code after upgrading go dependencies",
+      "description": "Generate code after upgrading go dependencies (master)",
       "matchDatasources": [
         "go"
       ],
+      // Currently we only have an Earthfile on master.
+      matchBaseBranches: ["master"],
       postUpgradeTasks: {
         // Post-upgrade tasks that are executed before a commit is made by Renovate.
         "commands": [
@@ -182,14 +184,52 @@
       },
     },
     {
-      "description": "Lint code after upgrading golangci-lint",
+      "description": "Generate code after upgrading go dependencies (release branch)",
+      "matchDatasources": [
+        "go"
+      ],
+      // Currently we only have an Earthfile on master.
+      matchBaseBranches: ["release-.+"],
+      postUpgradeTasks: {
+        // Post-upgrade tasks that are executed before a commit is made by Renovate.
+        "commands": [
+          "make go.generate",
+        ],
+        fileFilters: [
+          "**/*"
+        ],
+        executionMode: "update",
+      },
+    },
+    {
+      "description": "Lint code after upgrading golangci-lint (master)",
       "matchDepNames": [
         "golangci/golangci-lint"
       ],
+      // Currently we only have an Earthfile on master.
+      matchBaseBranches: ["master"],
       postUpgradeTasks: {
         // Post-upgrade tasks that are executed before a commit is made by Renovate.
         "commands": [
           "earthly --strict +go-lint",
+        ],
+        fileFilters: [
+          "**/*"
+        ],
+        executionMode: "update",
+      },
+    },
+    {
+      "description": "Lint code after upgrading golangci-lint (release branch)",
+      "matchDepNames": [
+        "golangci/golangci-lint"
+      ],
+      // Currently we only have an Earthfile on master.
+      matchBaseBranches: ["release-.+"],
+      postUpgradeTasks: {
+        // Post-upgrade tasks that are executed before a commit is made by Renovate.
+        "commands": [
+          "make go.lint",
         ],
         fileFilters: [
           "**/*"

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -40,7 +40,7 @@
       "matchStrings": [
         "EARTHLY_VERSION: '(?<currentValue>.*?)'\\n"
       ],
-      "datasourceTemplate": "github-tags",
+      "datasourceTemplate": "github-releases",
       "depNameTemplate": "earthly/earthly",
       "extractVersionTemplate": "^v(?<version>.*)$"
     },
@@ -65,7 +65,7 @@
       "matchStrings": [
         "ARG GOLANGCI_LINT_VERSION=(?<currentValue>.*?)\\n"
       ],
-      "datasourceTemplate": "github-tags",
+      "datasourceTemplate": "github-releases",
       "depNameTemplate": "golangci/golangci-lint"
     },
     {
@@ -77,7 +77,7 @@
       "matchStrings": [
         "ARG HELM_VERSION=(?<currentValue>.*?)\\n"
       ],
-      "datasourceTemplate": "github-tags",
+      "datasourceTemplate": "github-releases",
       "depNameTemplate": "helm/helm",
     },
     {
@@ -89,7 +89,7 @@
       "matchStrings": [
         "ARG HELM_DOCS_VERSION=(?<currentValue>.*?)\\n"
       ],
-      "datasourceTemplate": "github-tags",
+      "datasourceTemplate": "github-releases",
       "depNameTemplate": "norwoodj/helm-docs",
       "extractVersionTemplate": "^v(?<version>.*)$"
     },
@@ -102,7 +102,7 @@
       "matchStrings": [
         "ARG KIND_VERSION=(?<currentValue>.*?)\\n"
       ],
-      "datasourceTemplate": "github-tags",
+      "datasourceTemplate": "github-releases",
       "depNameTemplate": "kubernetes-sigs/kind",
     },
     {
@@ -114,7 +114,7 @@
       "matchStrings": [
         "ARG KUBECTL_VERSION=(?<currentValue>.*?)\\n"
       ],
-      "datasourceTemplate": "github-tags",
+      "datasourceTemplate": "github-releases",
       "depNameTemplate": "kubernetes/kubernetes",
     },
     {
@@ -126,7 +126,7 @@
       "matchStrings": [
         "ARG GOTESTSUM_VERSION=(?<currentValue>.*?)\\n"
       ],
-      "datasourceTemplate": "github-tags",
+      "datasourceTemplate": "github-releases",
       "depNameTemplate": "gotestyourself/gotestsum",
       "extractVersionTemplate": "^v(?<version>.*)$"
     },
@@ -139,7 +139,7 @@
       "matchStrings": [
         "ARG CODEQL_VERSION=(?<currentValue>.*?)\\n"
       ],
-      "datasourceTemplate": "github-tags",
+      "datasourceTemplate": "github-releases",
       "depNameTemplate": "github/codeql-action",
       "extractVersionTemplate": "^codeql-bundle-(?<version>.*)$"
     },

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -27,12 +27,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
 
-      - name: Setup Earthly
-        uses: earthly/actions-setup@v1
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          version: ${{ env.EARTHLY_VERSION }}
-
       # Don't waste time starting Renovate if JSON is invalid
       - name: Validate Renovate JSON
         run:  npx --yes --package renovate -- renovate-config-validator
@@ -55,3 +49,6 @@ jobs:
         with:
           configurationFile: .github/renovate.json5
           token: '${{ steps.get-github-app-token.outputs.token }}'
+          mount-docker-socket: true
+          docker-user: root
+          docker-cmd-file: .github/renovate-entrypoint.sh


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane! Please read the contribution docs
(linked below) if this is your first Crossplane pull request.
-->

### Description of your changes

<!--
Briefly describe what this pull request does, and how it is covered by tests.
Be proactive - direct your reviewers' attention to anything that needs special
consideration.

We love pull requests that fix an open issue. If yours does, use the below line
to indicate which issue it fixes, for example "Fixes #500".
-->

Actually make `earthly` available to Renovate, and only run it on master branches.

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [ ] ~Run `earthly +reviewable` to ensure this PR is ready for review.~
- [ ] ~Added or updated unit tests.~
- [ ] ~Added or updated e2e tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/master/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/master/contributing#checklist-cheat-sheet
