### PR TITLE
Reported the status as deleted for the deleted resources in crossplane beta trace

### DIFF
--- a/cmd/crank/beta/trace/internal/printer/default.go
+++ b/cmd/crank/beta/trace/internal/printer/default.go
@@ -216,6 +216,9 @@ func getResourceStatus(r *resource.Resource, name string, wide bool) fmt.Stringe
 	syncedCond := r.GetCondition(xpv1.TypeSynced)
 	var status, m string
 	switch {
+	case r.Unstructured.GetDeletionTimestamp() != nil:
+		// Report the status as deleted if the resource is being deleted
+		status = "Deleted"
 	case r.Error != nil:
 		// if there is an error we want to show it
 		status = "Error"

--- a/cmd/crank/beta/trace/internal/printer/default.go
+++ b/cmd/crank/beta/trace/internal/printer/default.go
@@ -218,7 +218,7 @@ func getResourceStatus(r *resource.Resource, name string, wide bool) fmt.Stringe
 	switch {
 	case r.Unstructured.GetDeletionTimestamp() != nil:
 		// Report the status as deleted if the resource is being deleted
-		status = "Deleted"
+		status = "Deleting"
 	case r.Error != nil:
 		// if there is an error we want to show it
 		status = "Error"


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane! Please read the contribution docs
(linked below) if this is your first Crossplane pull request.
-->

### Description of your changes
When running `crossplane beta trace` on a claim/composite that is in the process if being deleted, the resource status for all of the "missing" resources is now reported as "Deleted"
<!--
Briefly describe what this pull request does, and how it is covered by tests.
Be proactive - direct your reviewers' attention to anything that needs special
consideration.

We love pull requests that fix an open issue. If yours does, use the below line
to indicate which issue it fixes, for example "Fixes #500".
-->

Fixes #5363 

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `earthly +reviewable` to ensure this PR is ready for review.
- [ ] ~Added or updated unit tests.~
- [ ] ~Added or updated e2e tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/master/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/master/contributing#checklist-cheat-sheet
