### PR TITLE
fix(Earthfile): Add .exe extension in the windows binaries

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -154,12 +154,16 @@ go-build:
   ARG GOFLAGS="-ldflags=-X=github.com/crossplane/crossplane/internal/version.version=${CROSSPLANE_VERSION}"
   ARG CGO_ENABLED=0
   FROM +go-modules
+  LET ext = ""
+  IF [ "$GOOS" = "windows" ]
+    SET ext = ".exe"
+  END
   CACHE --id go-build --sharing shared /root/.cache/go-build
   COPY --dir apis/ cmd/ internal/ pkg/ .
-  RUN go build -o crossplane ./cmd/crossplane
-  RUN go build -o crank ./cmd/crank
-  SAVE ARTIFACT crossplane AS LOCAL _output/bin/${GOOS}_${GOARCH}/crossplane
-  SAVE ARTIFACT crank AS LOCAL _output/bin/${GOOS}_${GOARCH}/crank
+  RUN go build -o crossplane${ext} ./cmd/crossplane
+  RUN go build -o crank${ext} ./cmd/crank
+  SAVE ARTIFACT crossplane${ext} AS LOCAL _output/bin/${GOOS}_${GOARCH}/crossplane${ext}
+  SAVE ARTIFACT crank${ext} AS LOCAL _output/bin/${GOOS}_${GOARCH}/crank${ext}
 
 # go-multiplatform-build builds Crossplane binaries for all supported OS
 # and architectures.


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane! Please read the contribution docs
(linked below) if this is your first Crossplane pull request.
-->

### Description of your changes

This is a regression compared to the Makefile era, see for example
https://releases.crossplane.io/stable/v1.16.0/bin/windows_amd64/ and
also what install.sh expects.

<!--
Briefly describe what this pull request does, and how it is covered by tests.
Be proactive - direct your reviewers' attention to anything that needs special
consideration.

We love pull requests that fix an open issue. If yours does, use the below line
to indicate which issue it fixes, for example "Fixes #500".
-->

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [X] Read and followed Crossplane's [contribution process].
- [X] Run `earthly +reviewable` to ensure this PR is ready for review.
- [ ] ~Added or updated unit tests.~
- [ ] ~Added or updated e2e tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/master/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/master/contributing#checklist-cheat-sheet