### PR TITLE
fix(runtime): remove container after run

### DIFF
--- a/cmd/crank/beta/render/runtime_docker_test.go
+++ b/cmd/crank/beta/render/runtime_docker_test.go
@@ -77,7 +77,7 @@ func TestGetRuntimeDocker(t *testing.T) {
 			want: want{
 				rd: &RuntimeDocker{
 					Image:      "test-image-from-annotation",
-					Stop:       false,
+					Cleanup:    AnnotationValueRuntimeDockerCleanupOrphan,
 					PullPolicy: AnnotationValueRuntimeDockerPullPolicyAlways,
 				},
 			},
@@ -99,7 +99,7 @@ func TestGetRuntimeDocker(t *testing.T) {
 			want: want{
 				rd: &RuntimeDocker{
 					Image:      "test-package",
-					Stop:       true,
+					Cleanup:    AnnotationValueRuntimeDockerCleanupRemove,
 					PullPolicy: AnnotationValueRuntimeDockerPullPolicyIfNotPresent,
 				},
 			},
@@ -142,6 +142,30 @@ func TestGetRuntimeDocker(t *testing.T) {
 			},
 			want: want{
 				err: cmpopts.AnyError,
+			},
+		},
+		"AnnotationsCleanupSetToStop": {
+			reason: "should return a RuntimeDocker with all fields set according to the supplied Function's annotations",
+			args: args{
+				fn: v1beta1.Function{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							AnnotationKeyRuntimeDockerCleanup: string(AnnotationValueRuntimeDockerCleanupStop),
+						},
+					},
+					Spec: v1beta1.FunctionSpec{
+						PackageSpec: v1.PackageSpec{
+							Package: "test-package",
+						},
+					},
+				},
+			},
+			want: want{
+				rd: &RuntimeDocker{
+					Image:      "test-package",
+					Cleanup:    AnnotationValueRuntimeDockerCleanupStop,
+					PullPolicy: AnnotationValueRuntimeDockerPullPolicyIfNotPresent,
+				},
 			},
 		},
 	}


### PR DESCRIPTION
### Description of your changes

This pull request includes a change to the `Start` method in the `RuntimeDocker` struct within the `cmd/crank/beta/render/runtime_docker.go` file. The change enhances the stop functionality of a Docker container. Now, in addition to stopping the container, the container is also removed along with its volumes. This is a crucial change as it ensures proper cleanup of resources when a Docker container is stopped.

Reason for this change when running `crossplane beta render` commands the docker containers do not remove



I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `earthly +reviewable` to ensure this PR is ready for review.
- [ ] ~Added or updated unit tests.~
- [ ] ~Added or updated e2e tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~

Unsure on how to unit test or e2e test this, suggestions would be appreciated.

From my manual testing, I compiled the binary and ran it locally to confirm the containers do get removed. 
