### PR TITLE
download/cache full graph of dependencies at `beta validate`

### DIFF
--- a/cmd/crank/beta/validate/manager.go
+++ b/cmd/crank/beta/validate/manager.go
@@ -216,6 +216,10 @@ func (m *Manager) addDependencies() error {
 			if len(image) > 0 {
 				image = fmt.Sprintf(imageFmt, image, dep.Version)
 				m.deps[image] = true
+
+				if _, ok := m.confs[image]; !ok && dep.Configuration != nil {
+					m.confs[image] = true
+				}
 			}
 		}
 	}

--- a/cmd/crank/beta/validate/manager.go
+++ b/cmd/crank/beta/validate/manager.go
@@ -181,13 +181,12 @@ func (m *Manager) CacheAndLoad(cleanCache bool) error {
 	return m.PrepExtensions(schemas)
 }
 
-// TODO(enesonus): update function to be inline with https://github.com/crossplane/crossplane/pull/5815 confs type
-func (m *Manager) addDependencies(confs map[string]bool) error {
+func (m *Manager) addDependencies(confs map[string]*metav1.Configuration) error {
 	if len(confs) == 0 {
 		return nil
 	}
 
-	deepConfs := make(map[string]bool)
+	deepConfs := make(map[string]*metav1.Configuration)
 	for image := range confs {
 		cfg := m.confs[image]
 
@@ -224,8 +223,8 @@ func (m *Manager) addDependencies(confs map[string]bool) error {
 				m.deps[image] = true
 
 				if _, ok := m.confs[image]; !ok && dep.Configuration != nil {
-					deepConfs[image] = true
-					m.confs[image] = true
+					deepConfs[image] = nil
+					m.confs[image] = nil
 				}
 			}
 		}

--- a/cmd/crank/beta/validate/manager_test.go
+++ b/cmd/crank/beta/validate/manager_test.go
@@ -330,7 +330,7 @@ func TestAddDependencies(t *testing.T) {
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			m.fetcher = &MockFetcher{tc.args.fetchMock}
-			err := m.addDependencies()
+			err := m.addDependencies(m.confs)
 
 			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\naddDependencies(...): -want error, +got error:\n%s", tc.reason, diff)

--- a/cmd/crank/beta/validate/manager_test.go
+++ b/cmd/crank/beta/validate/manager_test.go
@@ -296,9 +296,8 @@ func TestAddDependencies(t *testing.T) {
 		"SuccessfulDependenciesAddition": {
 			// config-dep-1
 			//└─►config-dep-2
-			//config-dep-2
-			//├─►provider-dep-1
-			//└─►function-dep-1
+			//   ├─►provider-dep-1
+			//   └─►function-dep-1
 			reason: "All dependencies should be successfully fetched and added",
 			args: args{
 				fetchMock: fetchMockFunc,

--- a/cmd/crank/beta/validate/manager_test.go
+++ b/cmd/crank/beta/validate/manager_test.go
@@ -126,7 +126,7 @@ func TestConfigurationTypeSupport(t *testing.T) {
 	}{
 		"SuccessfulConfigPkg": {
 			// config-pkg
-			//└─►provider-dep-1
+			// └─►provider-dep-1
 			reason: "All dependencies should be successfully added from Configuration.pkg",
 			args: args{
 				extensions: []*unstructured.Unstructured{
@@ -153,7 +153,7 @@ func TestConfigurationTypeSupport(t *testing.T) {
 		},
 		"SuccessfulConfigMeta": {
 			// config-meta
-			//└─►function-dep-1
+			// └─►function-dep-1
 			reason: "All dependencies should be successfully added from Configuration.meta",
 			args: args{
 				extensions: []*unstructured.Unstructured{
@@ -185,7 +185,7 @@ func TestConfigurationTypeSupport(t *testing.T) {
 		},
 		"SuccessfulConfigMetaAndPkg": {
 			// config-meta
-			//└─►function-dep-1
+			// └─►function-dep-1
 			//config-pkg
 			//└─►provider-dep-1
 			reason: "All dependencies should be successfully added from both Configuration.meta and Configuration.pkg",
@@ -234,7 +234,7 @@ func TestConfigurationTypeSupport(t *testing.T) {
 		fs := afero.NewMemMapFs()
 		w := &bytes.Buffer{}
 
-		m := NewManager(".crossplane/cache", fs, w)
+		m := NewManager("", fs, w)
 		t.Run(name, func(t *testing.T) {
 			m.fetcher = &MockFetcher{tc.args.fetchMock}
 			err := m.PrepExtensions(tc.args.extensions)
@@ -295,7 +295,7 @@ func TestAddDependencies(t *testing.T) {
 	}{
 		"SuccessfulDependenciesAddition": {
 			// config-dep-1
-			//└─►config-dep-2
+			// └─►config-dep-2
 			//   ├─►provider-dep-1
 			//   └─►function-dep-1
 			reason: "All dependencies should be successfully fetched and added",
@@ -317,8 +317,8 @@ func TestAddDependencies(t *testing.T) {
 				},
 			},
 			want: want{
-				confs: 2, // 1 Base Configuration, 1 Child Configuration
-				deps:  4, // 2 Configurations, 1 provider, 1 function
+				confs: 2, // 1 Base configuration (config-dep-1), 1 child configuration (config-dep-2)
+				deps:  4, // 2 configurations (config-dep-1, config-dep-2), 1 provider (provider-dep-1), 1 function (function-dep-1)
 				err:   nil,
 			},
 		},
@@ -328,7 +328,7 @@ func TestAddDependencies(t *testing.T) {
 			fs := afero.NewMemMapFs()
 			w := &bytes.Buffer{}
 
-			m := NewManager(".crossplane/cache", fs, w)
+			m := NewManager("", fs, w)
 			_ = m.PrepExtensions(tc.args.extensions)
 
 			m.fetcher = &MockFetcher{tc.args.fetchMock}


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane! Please read the contribution docs
(linked below) if this is your first Crossplane pull request.
-->

### Description of your changes

<!--
Briefly describe what this pull request does, and how it is covered by tests.
Be proactive - direct your reviewers' attention to anything that needs special
consideration.

We love pull requests that fix an open issue. If yours does, use the below line
to indicate which issue it fixes, for example "Fixes #500".
-->
This PR enables 'beta validate' command to calculate all dependencies of the provided configurations and therefore the full graph of dependencies is downloaded/cached. Previously we were only downloading/caching the level-1 dependencies of a configuration which are the dependencies of the provided configuration.. 

Fixes https://github.com/crossplane/crossplane/issues/5803

Here are some examples with this functionality:

1. `configuration-aws-database:v0.10.0`
Dependency graph is: 
    - `provider-aws-rds`
    - `configuration-aws-network:v0.12.0`
        - `provider-aws-ec2:v1.2.0`
        - `function-patch-and-transform:v0.4.0`


    Current behavior:
    ```
    crossplane beta validate .work/xfn/config-aws-db.yaml .work/xfn/
                                                                                                   
    package schemas does not exist, downloading:  xpkg.upbound.io/upbound/configuration-aws-database:v0.10.0
    package schemas does not exist, downloading:  xpkg.upbound.io/upbound/provider-aws-rds:v1.2.0
    package schemas does not exist, downloading:  xpkg.upbound.io/upbound/configuration-aws-network:v0.12.0
    ```
        
    New behavior:
    ```
    go run cmd/crank/main.go beta validate .work/xfn/config-aws-db.yaml .work/xfn/

    package schemas does not exist, downloading:  xpkg.upbound.io/upbound/configuration-aws-database:v0.10.0
    package schemas does not exist, downloading:  xpkg.upbound.io/upbound/provider-aws-rds:v1.2.0
    package schemas does not exist, downloading:  xpkg.upbound.io/upbound/configuration-aws-network:v0.12.0
    package schemas does not exist, downloading:  xpkg.upbound.io/upbound/provider-aws-ec2:v1.2.0
    package schemas does not exist, downloading:  xpkg.upbound.io/crossplane-contrib/function-patch-and-transform:v0.4.0
    ```

2. `platform-ref-azure:v0.11.0`:
Dependency graph is: 
    - `provider-azure-containerservice:v0.42.1`
    - `configuration-azure-network:v0.8.0`
        - `provider-azure-network:v0.42.1`
        - `function-patch-and-transform:v0.4.0`
    - `configuration-azure-aks:v0.7.0`
        - `provider-azure-containerservice:v0.42.1`
        - `configuration-azure-network:v0.8.0`
            - `provider-azure-network:v0.42.1`
            - `function-patch-and-transform:v0.4.0`
        - `provider-helm:v0.17.0`
        - `provider-kubernetes:v0.12.1`
    - `configuration-azure-database:v0.11.1`
        - `provider-azure-dbformariadb:v0.42.1`
        - `provider-azure-dbforpostgresql:v0.42.1`
        - `configuration-azure-network:v0.8.0`
            - `provider-azure-network:v0.42.1`
            - `function-patch-and-transform:v0.4.0`
        - `function-patch-and-transform:v0.4.0`
    - `configuration-app:v0.5.0`
        - `provider-helm:v0.17.0`
        - `function-patch-and-transform:v0.4.0`
    - `configuration-observability-oss:v0.5.0`
        - `provider-helm:v0.17.0`
        - `provider-kubernetes:v0.12.1`
        - `provider-grafana:v0.8.0`
        - `function-patch-and-transform:v0.4.0`
    - `configuration-gitops-flux:v0.6.0`
        - `provider-helm:v0.17.0`
        - `function-patch-and-transform:v0.4.0`

    `This configuration has 14 distinct dependencies. We need to download it's own yaml plus 14 other yamls`

    Current behavior:
    ```
    crossplane beta validate .work/xfn/config-plat-ref-azure.yaml .work/xfn/
    
    package schemas does not exist, downloading:  xpkg.upbound.io/upbound/configuration-gitops-flux:v0.6.0
    package schemas does not exist, downloading:  xpkg.upbound.io/upbound/platform-ref-azure:v0.11.0
    package schemas does not exist, downloading:  xpkg.upbound.io/upbound/provider-azure-containerservice:v0.42.1
    package schemas does not exist, downloading:  xpkg.upbound.io/upbound/configuration-azure-network:v0.8.0
    package schemas does not exist, downloading:  xpkg.upbound.io/upbound/configuration-azure-aks:v0.7.0
    package schemas does not exist, downloading:  xpkg.upbound.io/upbound/configuration-azure-database:v0.11.1
    package schemas does not exist, downloading:  xpkg.upbound.io/upbound/configuration-app:v0.5.0
    package schemas does not exist, downloading:  xpkg.upbound.io/upbound/configuration-observability-oss:v0.5.0
    ```
        
    New behavior:
    ```
    go run cmd/crank/main.go beta validate .work/xfn/config-plat-ref-azure.yaml .work/xfn/
    
    package schemas does not exist, downloading:  xpkg.upbound.io/upbound/platform-ref-azure:v0.11.0
    package schemas does not exist, downloading:  xpkg.upbound.io/upbound/configuration-azure-network:v0.8.0
    package schemas does not exist, downloading:  xpkg.upbound.io/upbound/configuration-gitops-flux:v0.6.0
    package schemas does not exist, downloading:  xpkg.upbound.io/crossplane-contrib/provider-kubernetes:v0.12.1
    package schemas does not exist, downloading:  xpkg.upbound.io/upbound/configuration-azure-database:v0.11.1
    package schemas does not exist, downloading:  xpkg.upbound.io/upbound/configuration-app:v0.5.0
    package schemas does not exist, downloading:  xpkg.upbound.io/crossplane-contrib/function-patch-and-transform:v0.4.0
    package schemas does not exist, downloading:  xpkg.upbound.io/crossplane-contrib/provider-helm:v0.17.0
    package schemas does not exist, downloading:  xpkg.upbound.io/upbound/configuration-azure-aks:v0.7.0
    package schemas does not exist, downloading:  xpkg.upbound.io/upbound/provider-azure-network:v0.42.1
    package schemas does not exist, downloading:  xpkg.upbound.io/upbound/provider-azure-dbformariadb:v0.42.1
    package schemas does not exist, downloading:  xpkg.upbound.io/grafana/provider-grafana:v0.8.0
    package schemas does not exist, downloading:  xpkg.upbound.io/upbound/provider-azure-containerservice:v0.42.1
    package schemas does not exist, downloading:  xpkg.upbound.io/upbound/configuration-observability-oss:v0.5.0
    package schemas does not exist, downloading:  xpkg.upbound.io/upbound/provider-azure-dbforpostgresql:v0.42.1
    ```


I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `earthly +reviewable` to ensure this PR is ready for review.
- [x] Added or updated unit tests.
- [ ] ~Added or updated e2e tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/master/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/master/contributing#checklist-cheat-sheet
