### PR TITLE
README: add SIG-docs to the list of SIGs

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ find the meetings in the [Community Calendar][community calendar].
 - [#sig-composition-functions][sig-composition-functions-slack]
 - [#sig-deletion-ordering][sig-deletion-ordering-slack]
 - [#sig-devex][sig-devex-slack]
+- [#sig-docs][sig-docs-slack]
 - [#sig-e2e-testing][sig-e2e-testing-slack]
 - [#sig-observability][sig-observability-slack]
 - [#sig-observe-only][sig-observe-only-slack]
@@ -128,6 +129,7 @@ Crossplane is under the Apache 2.0 license.
 [sig-composition-functions-slack]: https://crossplane.slack.com/archives/C031Y29CSAE
 [sig-deletion-ordering-slack]: https://crossplane.slack.com/archives/C05BP8W5ALW
 [sig-devex-slack]: https://crossplane.slack.com/archives/C05U1LLM3B2
+[sig-docs-slack]: https://crossplane.slack.com/archives/C02CAQ52DPU
 [sig-e2e-testing-slack]: https://crossplane.slack.com/archives/C05C8CCTVNV
 [sig-observability-slack]: https://crossplane.slack.com/archives/C061GNH3LA0
 [sig-observe-only-slack]: https://crossplane.slack.com/archives/C04D5988QEA


### PR DESCRIPTION
### Description of your changes

SIG-docs has gotten a small shot in the arm today with a bit of prioritization/organization shared with the rest of the SIG in the #SIG-docs slack channel: https://crossplane.slack.com/archives/C02CAQ52DPU

Therefore, it's time to officially add SIG-docs to the list in the main README 🥳 

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `earthly +reviewable` to ensure this PR is ready for review.
- [x] Added or updated unit tests.
- [x] Added or updated e2e tests.
- [x] Linked a PR or a [docs tracking issue] to [document this change].
- [x] Added `backport release-x.y` labels to auto-backport this PR.

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/master/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/master/contributing#checklist-cheat-sheet
