### PR TITLE
Add configuration.meta/crossplane.yaml support for dependencies to beta validate

### DIFF
--- a/cmd/crank/beta/validate/manager_test.go
+++ b/cmd/crank/beta/validate/manager_test.go
@@ -19,11 +19,11 @@ package validate
 import (
 	"bytes"
 	"fmt"
-	"github.com/google/go-containerregistry/pkg/v1/static"
-	"github.com/google/go-containerregistry/pkg/v1/types"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-containerregistry/pkg/v1/static"
+	"github.com/google/go-containerregistry/pkg/v1/types"
 	conregv1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/spf13/afero"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"

--- a/cmd/crank/beta/validate/manager_test.go
+++ b/cmd/crank/beta/validate/manager_test.go
@@ -44,7 +44,7 @@ spec:
 
 `)
 
-	providerYaml = []byte(`apiVersion: pkg.crossplane.io/v1
+	providerYaml = []byte(`apiVersion: meta.pkg.crossplane.io/v1
 kind: Provider
 metadata:
   name: provider-dep-1
@@ -54,7 +54,7 @@ spec:
 
 `)
 
-	funcYaml = []byte(`apiVersion: pkg.crossplane.io/v1beta1
+	funcYaml = []byte(`apiVersion: meta.pkg.crossplane.io/v1beta1
 kind: Function
 metadata:
   name: function-dep-1

--- a/cmd/crank/beta/validate/manager_test.go
+++ b/cmd/crank/beta/validate/manager_test.go
@@ -1,0 +1,176 @@
+/*
+Copyright 2024 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package validate
+
+import (
+	"bytes"
+	"fmt"
+	"github.com/google/go-containerregistry/pkg/v1/static"
+	"github.com/google/go-containerregistry/pkg/v1/types"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	conregv1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/spf13/afero"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/crossplane/crossplane-runtime/pkg/test"
+)
+
+var (
+	configDep2Yaml = []byte(`apiVersion: meta.pkg.crossplane.io/v1alpha1
+kind: Configuration
+metadata:
+  name: config-dep-2
+spec:
+  dependsOn:
+    - provider: provider-dep-1
+      version: "v1.3.0"
+    - function: function-dep-1
+      version: "v1.3.0"
+---
+
+`)
+
+	providerYaml = []byte(`apiVersion: pkg.crossplane.io/v1
+kind: Provider
+metadata:
+  name: provider-dep-1
+spec:
+  package: provider-dep-1:v1.3.0
+---
+
+`)
+
+	funcYaml = []byte(`apiVersion: pkg.crossplane.io/v1beta1
+kind: Function
+metadata:
+  name: function-dep-1
+spec:
+  package: function-dep-1:v1.3.0
+---
+
+`)
+)
+
+func TestConfigurationTypeSupport(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	w := &bytes.Buffer{}
+
+	m := NewManager(".crossplane/cache", fs, w)
+	confpkg := static.NewLayer(configDep2Yaml, types.OCILayer)
+	pd := static.NewLayer(providerYaml, types.OCILayer)
+	fd := static.NewLayer(funcYaml, types.OCILayer)
+
+	type args struct {
+		extensions []*unstructured.Unstructured
+		fetchMock  func(image string) (*conregv1.Layer, error)
+	}
+	type want struct {
+		err   error
+		confs int
+		deps  int
+	}
+	cases := map[string]struct {
+		reason string
+		args   args
+		want   want
+	}{
+		"SuccessfulDependenciesAddition": {
+			reason: "All dependencies should be successfully added from both Configuration.pkg and Configuration.meta",
+			args: args{
+				extensions: []*unstructured.Unstructured{
+					{
+						Object: map[string]interface{}{
+							"apiVersion": "meta.pkg.crossplane.io/v1alpha1",
+							"kind":       "Configuration",
+							"metadata": map[string]interface{}{
+								"name": "config-meta",
+							},
+							"spec": map[string]interface{}{
+								"dependsOn": []map[string]interface{}{
+									{
+										"provider": "provider-dep-1",
+										"version":  "v1.3.0",
+									},
+								},
+							},
+						},
+					},
+					{
+						Object: map[string]interface{}{
+							"apiVersion": "pkg.crossplane.io/v1alpha1",
+							"kind":       "Configuration",
+							"metadata": map[string]interface{}{
+								"name": "config-pkg",
+							},
+							"spec": map[string]interface{}{
+								"package": "config-dep-2:v1.3.0",
+							},
+						},
+					},
+				}, fetchMock: func(image string) (*conregv1.Layer, error) {
+					switch image {
+					case "config-dep-2:v1.3.0":
+						return &confpkg, nil
+					case "provider-dep-1:v1.3.0":
+						return &pd, nil
+					case "function-dep-1:v1.3.0":
+						return &fd, nil
+					default:
+						return nil, fmt.Errorf("unknown image: %s", image)
+					}
+				},
+			},
+			want: want{
+				err:   nil,
+				confs: 2,
+				deps:  3,
+			},
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			m.fetcher = &MockFetcher{tc.args.fetchMock}
+			err := m.PrepExtensions(tc.args.extensions)
+
+			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
+				t.Errorf("\n%s\nPrepExtensions(...): -want error, +got error:\n%s", tc.reason, diff)
+			}
+
+			err = m.addDependencies()
+			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
+				t.Errorf("\n%s\naddDependencies(...): -want error, +got error:\n%s", tc.reason, diff)
+			}
+
+			if diff := cmp.Diff(tc.want.confs, len(m.confs)); diff != "" {
+				t.Errorf("\n%s\naddDependencies(...): -want confs, +got confs:\n%s", tc.reason, diff)
+			}
+			if diff := cmp.Diff(tc.want.deps, len(m.deps)); diff != "" {
+				t.Errorf("\n%s\naddDependencies(...): -want deps, +got deps:\n%s", tc.reason, diff)
+			}
+		})
+	}
+}
+
+type MockFetcher struct {
+	fetch func(image string) (*conregv1.Layer, error)
+}
+
+func (m *MockFetcher) FetchBaseLayer(image string) (*conregv1.Layer, error) {
+	return m.fetch(image)
+}

--- a/cmd/crank/beta/validate/manager_test.go
+++ b/cmd/crank/beta/validate/manager_test.go
@@ -32,6 +32,7 @@ import (
 )
 
 var (
+	// config-pkg:v1.3.0
 	configPkg = []byte(`apiVersion: meta.pkg.crossplane.io/v1alpha1
 kind: Configuration
 metadata:
@@ -44,22 +45,20 @@ spec:
 
 `)
 
+	// provider-dep-1:v1.3.0
 	providerYaml = []byte(`apiVersion: meta.pkg.crossplane.io/v1
 kind: Provider
 metadata:
   name: provider-dep-1
-spec:
-  package: provider-dep-1:v1.3.0
 ---
 
 `)
 
+	// function-dep-1:v1.3.0
 	funcYaml = []byte(`apiVersion: meta.pkg.crossplane.io/v1beta1
 kind: Function
 metadata:
   name: function-dep-1
-spec:
-  package: function-dep-1:v1.3.0
 ---
 
 `)


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane! Please read the contribution docs
(linked below) if this is your first Crossplane pull request.
-->

### Description of your changes

<!--
Briefly describe what this pull request does, and how it is covered by tests.
Be proactive - direct your reviewers' attention to anything that needs special
consideration.

We love pull requests that fix an open issue. If yours does, use the below line
to indicate which issue it fixes, for example "Fixes #500".
-->
This PR enables `crossplane beta validate` command to use `Configuration.meta/crossplane.yaml` for pulling dependencies. With this PR `beta validate` command can validate the correctness of the Configurations using their `crossplane.yaml` file before the build, without an already published `Configuration.pkg`. 

Here is what this PR does:

**Current usage** (with https://github.com/enesonus/configuration-aws-eks/tree/config-meta-validate):

_We need an already built and published Configuration.pkg specified at examples/configuration.yaml_
```
crossplane beta render examples/eks-xr.yaml apis/composition.yaml examples/functions.yaml --include-full-xr | crossplane beta validate examples/configuration.yaml -
 
package schemas does not exist, downloading:  xpkg.upbound.io/crossplane-contrib/provider-kubernetes:v0.12.1
package schemas does not exist, downloading:  xpkg.upbound.io/upbound/provider-aws-ec2:v1.2.0
package schemas does not exist, downloading:  xpkg.upbound.io/upbound/provider-aws-eks:v1.2.0
package schemas does not exist, downloading:  xpkg.upbound.io/upbound/provider-aws-iam:v1.2.0
package schemas does not exist, downloading:  xpkg.upbound.io/crossplane-contrib/function-patch-and-transform:v0.4.0
package schemas does not exist, downloading:  xpkg.upbound.io/upbound/configuration-aws-eks:v0.11.0
package schemas does not exist, downloading:  xpkg.upbound.io/upbound/configuration-aws-network:v0.12.0
package schemas does not exist, downloading:  xpkg.upbound.io/crossplane-contrib/provider-helm:v0.17.0
[x] schema validation error aws.platform.upbound.io/v1alpha1, Kind=XEKS, configuration-aws-eks : spec.parameters.deletionPolicy: Required value
[x] schema validation error aws.platform.upbound.io/v1alpha1, Kind=XEKS, configuration-aws-eks : spec.parameters.providerConfigName: Required value
[✓] kubernetes.crossplane.io/v1alpha2, Kind=Object, configuration-aws-eks-aws-auth validated successfully
[✓] iam.aws.upbound.io/v1beta1, Kind=RolePolicyAttachment, clusterRolePolicyAttachment validated successfully
[✓] iam.aws.upbound.io/v1beta1, Kind=RolePolicyAttachment, cniRolePolicyAttachment validated successfully
[✓] iam.aws.upbound.io/v1beta1, Kind=RolePolicyAttachment, containerRegistryRolePolicyAttachment validated successfully
[✓] iam.aws.upbound.io/v1beta1, Kind=Role, controlplaneRole validated successfully
[✓] iam.aws.upbound.io/v1beta1, Kind=RolePolicyAttachment, ebsCsiRolePolicyAttachment validated successfully
[✓] kubernetes.crossplane.io/v1alpha2, Kind=Object, configuration-aws-eks-irsa-settings validated successfully
[✓] eks.aws.upbound.io/v1beta1, Kind=Cluster, kubernetesCluster validated successfully
[x] schema validation error eks.aws.upbound.io/v1beta1, Kind=ClusterAuth, kubernetesClusterAuth : spec.writeConnectionSecretToRef.name: Required value
[✓] iam.aws.upbound.io/v1beta1, Kind=Role, nodegroupRole validated successfully
[x] schema validation error helm.crossplane.io/v1beta1, Kind=ProviderConfig, configuration-aws-eks : spec.credentials.secretRef.name: Required value
[x] schema validation error kubernetes.crossplane.io/v1alpha1, Kind=ProviderConfig, configuration-aws-eks : spec.credentials.secretRef.name: Required value
[✓] iam.aws.upbound.io/v1beta1, Kind=RolePolicyAttachment, workerNodeRolePolicyAttachment validated successfully
Total 14 resources: 0 missing schemas, 10 success cases, 4 failure cases
crossplane: error: cannot validate resources: could not validate all resources

```

**New usage** (with https://github.com/enesonus/configuration-aws-eks/tree/config-meta-validate):

_No need for building and publishing the package. Pulls dependencies from `Configuration.meta/crossplane.yaml`_
```
crossplane beta render examples/eks-xr.yaml apis/composition.yaml examples/functions.yaml --include-full-xr | go run cmd/crank/main.go beta validate crossplane.yaml -

package schemas does not exist, downloading:  xpkg.upbound.io/crossplane-contrib/provider-kubernetes:v0.12.1
package schemas does not exist, downloading:  xpkg.upbound.io/upbound/provider-aws-ec2:v1.2.0
package schemas does not exist, downloading:  xpkg.upbound.io/crossplane-contrib/function-patch-and-transform:v0.4.0
package schemas does not exist, downloading:  xpkg.upbound.io/crossplane-contrib/function-kcl:v0.6.0
package schemas does not exist, downloading:  xpkg.upbound.io/crossplane-contrib/function-auto-ready:v0.2.1
package schemas does not exist, downloading:  xpkg.upbound.io/crossplane-contrib/function-sequencer:v0.1.2
package schemas does not exist, downloading:  xpkg.upbound.io/upbound/configuration-aws-network:v0.12.0
package schemas does not exist, downloading:  xpkg.upbound.io/crossplane-contrib/provider-helm:v0.17.0
package schemas does not exist, downloading:  xpkg.upbound.io/upbound/provider-aws-eks:v1.2.0
package schemas does not exist, downloading:  xpkg.upbound.io/upbound/provider-aws-iam:v1.2.0
[!] could not find CRD/XRD for: aws.platform.upbound.io/v1alpha1, Kind=XEKS
[✓] kubernetes.crossplane.io/v1alpha2, Kind=Object, configuration-aws-eks-aws-auth validated successfully
[✓] iam.aws.upbound.io/v1beta1, Kind=RolePolicyAttachment, clusterRolePolicyAttachment validated successfully
[✓] iam.aws.upbound.io/v1beta1, Kind=RolePolicyAttachment, cniRolePolicyAttachment validated successfully
[✓] iam.aws.upbound.io/v1beta1, Kind=RolePolicyAttachment, containerRegistryRolePolicyAttachment validated successfully
[✓] iam.aws.upbound.io/v1beta1, Kind=Role, controlplaneRole validated successfully
[✓] iam.aws.upbound.io/v1beta1, Kind=RolePolicyAttachment, ebsCsiRolePolicyAttachment validated successfully
[✓] kubernetes.crossplane.io/v1alpha2, Kind=Object, configuration-aws-eks-irsa-settings validated successfully
[✓] eks.aws.upbound.io/v1beta1, Kind=Cluster, kubernetesCluster validated successfully
[x] schema validation error eks.aws.upbound.io/v1beta1, Kind=ClusterAuth, kubernetesClusterAuth : spec.writeConnectionSecretToRef.name: Required value
[✓] iam.aws.upbound.io/v1beta1, Kind=Role, nodegroupRole validated successfully
[x] schema validation error helm.crossplane.io/v1beta1, Kind=ProviderConfig, configuration-aws-eks : spec.credentials.secretRef.name: Required value
[x] schema validation error kubernetes.crossplane.io/v1alpha1, Kind=ProviderConfig, configuration-aws-eks : spec.credentials.secretRef.name: Required value
[✓] iam.aws.upbound.io/v1beta1, Kind=RolePolicyAttachment, workerNodeRolePolicyAttachment validated successfully
Total 14 resources: 1 missing schemas, 10 success cases, 3 failure cases
crossplane: error: cannot validate resources: could not validate all resources
```

Fixes https://github.com/crossplane/crossplane/issues/5728

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `earthly +reviewable` to ensure this PR is ready for review.
- [x] Added or updated unit tests.
- [ ] ~Added or updated e2e tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/master/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/master/contributing#checklist-cheat-sheet
