### PR TITLE
fix(rbac): fix rbac manager org differ for local packages

### DIFF
--- a/internal/controller/rbac/provider/roles/reconciler.go
+++ b/internal/controller/rbac/provider/roles/reconciler.go
@@ -419,6 +419,12 @@ type OrgDiffer struct {
 // Differs returns true if the supplied references are not part of the same OCI
 // registry and org.
 func (d OrgDiffer) Differs(a, b string) bool {
+	if isLocalBuild(a) && isLocalBuild(b) {
+		oa := extractLocalOrg(a)
+		ob := extractLocalOrg(b)
+		return oa != ob
+	}
+
 	// If we can't parse either reference we can't compare them. Safest thing to
 	// do is to assume they're not part of the same org.
 	ra, err := name.ParseReference(a, name.WithDefaultRegistry(d.DefaultRegistry))
@@ -443,4 +449,18 @@ func (d OrgDiffer) Differs(a, b string) bool {
 	ob := strings.Split(cb.RepositoryStr(), "/")[0]
 
 	return oa != ob
+}
+
+// isLocalBuild checks if the reference is a local build without registry info
+func isLocalBuild(ref string) bool {
+	return !strings.Contains(ref, "/")
+}
+
+// extractLocalOrg extracts the organization part from a local build reference
+func extractLocalOrg(ref string) string {
+	parts := strings.Split(ref, "-")
+	if len(parts) > 2 {
+		return parts[1]
+	}
+	return ref
 }

--- a/internal/controller/rbac/provider/roles/reconciler_test.go
+++ b/internal/controller/rbac/provider/roles/reconciler_test.go
@@ -464,6 +464,24 @@ func TestOrgDiffer(t *testing.T) {
 			b:        "cool/other-provider:v1.0.0",
 			want:     true,
 		},
+		"SameLocalOrg": {
+			registry: "xpkg.example.org",
+			a:        "provider-aws-config-v1.9.0-rc.0.2.g596f83b66.dirty.gz",
+			b:        "provider-aws-ec2-v1.9.0-rc.0.2.g596f83b66.dirty.gz",
+			want:     false,
+		},
+		"DifferentLocalOrgs": {
+			registry: "xpkg.example.org",
+			a:        "provider-aws-config-v1.9.0-rc.0.2.g596f83b66.dirty.gz",
+			b:        "provider-azure-config-v1.9.0-rc.0.2.g596f83b66.dirty.gz",
+			want:     true,
+		},
+		"OneLocalOneRemote": {
+			registry: "xpkg.example.org",
+			a:        "provider-aws-config-v1.9.0-rc.0.2.g596f83b66.dirty.gz",
+			b:        "xpkg.example.org/provider-aws-ec2:v1.9.0-rc.0.2.g596f83b66.dirty.gz",
+			want:     true,
+		},
 	}
 
 	for name, tc := range cases {


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane! Please read the contribution docs
(linked below) if this is your first Crossplane pull request.
-->

### Description of your changes
since crossplane release 1.15 its not possible anymore to use up2date crossplane version to run family provider tests - it turns out that the OrgDiffer is the problem - and the rbac rights for providerconfigs will not be added

This will fix https://github.com/crossplane-contrib/provider-upjet-aws/pull/1330

```
kubectl get providers
NAME                  INSTALLED   HEALTHY   PACKAGE                                                 AGE
provider-aws-config   True        True      provider-aws-config-v1.9.0-rc.0.2.g596f83b66.dirty.gz   39m
provider-aws-ec2      True        True      provider-aws-ec2-v1.9.0-rc.0.2.g596f83b66.dirty.gz      39m
```

before this PR:
```
- apiGroups:
  - ec2.aws.upbound.io
  resources:
  - amicopies
  - amicopies/status
  - amilaunchpermissions
  - amilaunchpermissions/status
  - amis
  - amis/status
  - availabilityzonegroups
  - availabilityzonegroups/status
  - capacityreservations
  - capacityreservations/status
  - carriergateways
  - carriergateways/status
  - customergateways
  - customergateways/status
  - defaultnetworkacls
  - defaultnetworkacls/status
  - defaultroutetables
  - defaultroutetables/status
  - defaultsecuritygroups
  - defaultsecuritygroups/status
  - defaultsubnets
  - defaultsubnets/status
  - defaultvpcdhcpoptions
  - defaultvpcdhcpoptions/status
  - defaultvpcs
  - defaultvpcs/status
  - ebsdefaultkmskeys
  - ebsdefaultkmskeys/status
  - ebsencryptionbydefaults
  - ebsencryptionbydefaults/status
  - ebssnapshotcopies
  - ebssnapshotcopies/status
  - ebssnapshotimports
  - ebssnapshotimports/status
  - ebssnapshots
  - ebssnapshots/status
  - ebsvolumes
  - ebsvolumes/status
  - egressonlyinternetgateways
  - egressonlyinternetgateways/status
  - eipassociations
  - eipassociations/status
  - eips
  - eips/status
  - flowlogs
  - flowlogs/status
  - hosts
  - hosts/status
  - instances
  - instances/status
  - instancestates
  - instancestates/status
  - internetgateways
  - internetgateways/status
  - keypairs
  - keypairs/status
  - launchtemplates
  - launchtemplates/status
  - mainroutetableassociations
  - mainroutetableassociations/status
  - managedprefixlistentries
  - managedprefixlistentries/status
  - managedprefixlists
  - managedprefixlists/status
  - natgateways
  - natgateways/status
  - networkaclrules
  - networkaclrules/status
  - networkacls
  - networkacls/status
  - networkinsightsanalyses
  - networkinsightsanalyses/status
  - networkinsightspaths
  - networkinsightspaths/status
  - networkinterfaceattachments
  - networkinterfaceattachments/status
  - networkinterfaces
  - networkinterfaces/status
  - networkinterfacesgattachments
  - networkinterfacesgattachments/status
  - placementgroups
  - placementgroups/status
  - routes
  - routes/status
  - routetableassociations
  - routetableassociations/status
  - routetables
  - routetables/status
  - securitygroupegressrules
  - securitygroupegressrules/status
  - securitygroupingressrules
  - securitygroupingressrules/status
  - securitygrouprules
  - securitygrouprules/status
  - securitygroups
  - securitygroups/status
  - serialconsoleaccesses
  - serialconsoleaccesses/status
  - snapshotcreatevolumepermissions
  - snapshotcreatevolumepermissions/status
  - spotdatafeedsubscriptions
  - spotdatafeedsubscriptions/status
  - spotfleetrequests
  - spotfleetrequests/status
  - spotinstancerequests
  - spotinstancerequests/status
  - subnetcidrreservations
  - subnetcidrreservations/status
  - subnets
  - subnets/status
  - tags
  - tags/status
  - trafficmirrorfilterrules
  - trafficmirrorfilterrules/status
  - trafficmirrorfilters
  - trafficmirrorfilters/status
  - transitgatewayconnectpeers
  - transitgatewayconnectpeers/status
  - transitgatewayconnects
  - transitgatewayconnects/status
  - transitgatewaymulticastdomainassociations
  - transitgatewaymulticastdomainassociations/status
  - transitgatewaymulticastdomains
  - transitgatewaymulticastdomains/status
  - transitgatewaymulticastgroupmembers
  - transitgatewaymulticastgroupmembers/status
  - transitgatewaymulticastgroupsources
  - transitgatewaymulticastgroupsources/status
  - transitgatewaypeeringattachmentaccepters
  - transitgatewaypeeringattachmentaccepters/status
  - transitgatewaypeeringattachments
  - transitgatewaypeeringattachments/status
  - transitgatewaypolicytables
  - transitgatewaypolicytables/status
  - transitgatewayprefixlistreferences
  - transitgatewayprefixlistreferences/status
  - transitgatewayroutes
  - transitgatewayroutes/status
  - transitgatewayroutetableassociations
  - transitgatewayroutetableassociations/status
  - transitgatewayroutetablepropagations
  - transitgatewayroutetablepropagations/status
  - transitgatewayroutetables
  - transitgatewayroutetables/status
  - transitgateways
  - transitgateways/status
  - transitgatewayvpcattachmentaccepters
  - transitgatewayvpcattachmentaccepters/status
  - transitgatewayvpcattachments
  - transitgatewayvpcattachments/status
  - volumeattachments
  - volumeattachments/status
  - vpcdhcpoptionsassociations
  - vpcdhcpoptionsassociations/status
  - vpcdhcpoptions
  - vpcdhcpoptions/status
  - vpcendpointconnectionnotifications
  - vpcendpointconnectionnotifications/status
  - vpcendpointroutetableassociations
  - vpcendpointroutetableassociations/status
  - vpcendpoints
  - vpcendpoints/status
  - vpcendpointsecuritygroupassociations
  - vpcendpointsecuritygroupassociations/status
  - vpcendpointserviceallowedprincipals
  - vpcendpointserviceallowedprincipals/status
  - vpcendpointservices
  - vpcendpointservices/status
  - vpcendpointsubnetassociations
  - vpcendpointsubnetassociations/status
  - vpcipampoolcidrallocations
  - vpcipampoolcidrallocations/status
  - vpcipampoolcidrs
  - vpcipampoolcidrs/status
  - vpcipampools
  - vpcipampools/status
  - vpcipamscopes
  - vpcipamscopes/status
  - vpcipams
  - vpcipams/status
  - vpcipv4cidrblockassociations
  - vpcipv4cidrblockassociations/status
  - vpcpeeringconnectionaccepters
  - vpcpeeringconnectionaccepters/status
  - vpcpeeringconnectionoptions
  - vpcpeeringconnectionoptions/status
  - vpcpeeringconnections
  - vpcpeeringconnections/status
  - vpcs
  - vpcs/status
  - vpnconnectionroutes
  - vpnconnectionroutes/status
  - vpnconnections
  - vpnconnections/status
  - vpngatewayattachments
  - vpngatewayattachments/status
  - vpngatewayroutepropagations
  - vpngatewayroutepropagations/status
  - vpngateways
  - vpngateways/status
  verbs:
  - get
  - list
  - watch
```

after this PR:
```
- apiGroups:
  - ec2.aws.upbound.io
  resources:
  - amicopies
  - amicopies/status
  - amilaunchpermissions
  - amilaunchpermissions/status
  - amis
  - amis/status
  - availabilityzonegroups
  - availabilityzonegroups/status
  - capacityreservations
  - capacityreservations/status
  - carriergateways
  - carriergateways/status
  - customergateways
  - customergateways/status
  - defaultnetworkacls
  - defaultnetworkacls/status
  - defaultroutetables
  - defaultroutetables/status
  - defaultsecuritygroups
  - defaultsecuritygroups/status
  - defaultsubnets
  - defaultsubnets/status
  - defaultvpcdhcpoptions
  - defaultvpcdhcpoptions/status
  - defaultvpcs
  - defaultvpcs/status
  - ebsdefaultkmskeys
  - ebsdefaultkmskeys/status
  - ebsencryptionbydefaults
  - ebsencryptionbydefaults/status
  - ebssnapshotcopies
  - ebssnapshotcopies/status
  - ebssnapshotimports
  - ebssnapshotimports/status
  - ebssnapshots
  - ebssnapshots/status
  - ebsvolumes
  - ebsvolumes/status
  - egressonlyinternetgateways
  - egressonlyinternetgateways/status
  - eipassociations
  - eipassociations/status
  - eips
  - eips/status
  - flowlogs
  - flowlogs/status
  - hosts
  - hosts/status
  - instances
  - instances/status
  - instancestates
  - instancestates/status
  - internetgateways
  - internetgateways/status
  - keypairs
  - keypairs/status
  - launchtemplates
  - launchtemplates/status
  - mainroutetableassociations
  - mainroutetableassociations/status
  - managedprefixlistentries
  - managedprefixlistentries/status
  - managedprefixlists
  - managedprefixlists/status
  - natgateways
  - natgateways/status
  - networkaclrules
  - networkaclrules/status
  - networkacls
  - networkacls/status
  - networkinsightsanalyses
  - networkinsightsanalyses/status
  - networkinsightspaths
  - networkinsightspaths/status
  - networkinterfaceattachments
  - networkinterfaceattachments/status
  - networkinterfaces
  - networkinterfaces/status
  - networkinterfacesgattachments
  - networkinterfacesgattachments/status
  - placementgroups
  - placementgroups/status
  - routes
  - routes/status
  - routetableassociations
  - routetableassociations/status
  - routetables
  - routetables/status
  - securitygroupegressrules
  - securitygroupegressrules/status
  - securitygroupingressrules
  - securitygroupingressrules/status
  - securitygrouprules
  - securitygrouprules/status
  - securitygroups
  - securitygroups/status
  - serialconsoleaccesses
  - serialconsoleaccesses/status
  - snapshotcreatevolumepermissions
  - snapshotcreatevolumepermissions/status
  - spotdatafeedsubscriptions
  - spotdatafeedsubscriptions/status
  - spotfleetrequests
  - spotfleetrequests/status
  - spotinstancerequests
  - spotinstancerequests/status
  - subnetcidrreservations
  - subnetcidrreservations/status
  - subnets
  - subnets/status
  - tags
  - tags/status
  - trafficmirrorfilterrules
  - trafficmirrorfilterrules/status
  - trafficmirrorfilters
  - trafficmirrorfilters/status
  - transitgatewayconnectpeers
  - transitgatewayconnectpeers/status
  - transitgatewayconnects
  - transitgatewayconnects/status
  - transitgatewaymulticastdomainassociations
  - transitgatewaymulticastdomainassociations/status
  - transitgatewaymulticastdomains
  - transitgatewaymulticastdomains/status
  - transitgatewaymulticastgroupmembers
  - transitgatewaymulticastgroupmembers/status
  - transitgatewaymulticastgroupsources
  - transitgatewaymulticastgroupsources/status
  - transitgatewaypeeringattachmentaccepters
  - transitgatewaypeeringattachmentaccepters/status
  - transitgatewaypeeringattachments
  - transitgatewaypeeringattachments/status
  - transitgatewaypolicytables
  - transitgatewaypolicytables/status
  - transitgatewayprefixlistreferences
  - transitgatewayprefixlistreferences/status
  - transitgatewayroutes
  - transitgatewayroutes/status
  - transitgatewayroutetableassociations
  - transitgatewayroutetableassociations/status
  - transitgatewayroutetablepropagations
  - transitgatewayroutetablepropagations/status
  - transitgatewayroutetables
  - transitgatewayroutetables/status
  - transitgateways
  - transitgateways/status
  - transitgatewayvpcattachmentaccepters
  - transitgatewayvpcattachmentaccepters/status
  - transitgatewayvpcattachments
  - transitgatewayvpcattachments/status
  - volumeattachments
  - volumeattachments/status
  - vpcdhcpoptionsassociations
  - vpcdhcpoptionsassociations/status
  - vpcdhcpoptions
  - vpcdhcpoptions/status
  - vpcendpointconnectionnotifications
  - vpcendpointconnectionnotifications/status
  - vpcendpointroutetableassociations
  - vpcendpointroutetableassociations/status
  - vpcendpoints
  - vpcendpoints/status
  - vpcendpointsecuritygroupassociations
  - vpcendpointsecuritygroupassociations/status
  - vpcendpointserviceallowedprincipals
  - vpcendpointserviceallowedprincipals/status
  - vpcendpointservices
  - vpcendpointservices/status
  - vpcendpointsubnetassociations
  - vpcendpointsubnetassociations/status
  - vpcipampoolcidrallocations
  - vpcipampoolcidrallocations/status
  - vpcipampoolcidrs
  - vpcipampoolcidrs/status
  - vpcipampools
  - vpcipampools/status
  - vpcipamscopes
  - vpcipamscopes/status
  - vpcipams
  - vpcipams/status
  - vpcipv4cidrblockassociations
  - vpcipv4cidrblockassociations/status
  - vpcpeeringconnectionaccepters
  - vpcpeeringconnectionaccepters/status
  - vpcpeeringconnectionoptions
  - vpcpeeringconnectionoptions/status
  - vpcpeeringconnections
  - vpcpeeringconnections/status
  - vpcs
  - vpcs/status
  - vpnconnectionroutes
  - vpnconnectionroutes/status
  - vpnconnections
  - vpnconnections/status
  - vpngatewayattachments
  - vpngatewayattachments/status
  - vpngatewayroutepropagations
  - vpngatewayroutepropagations/status
  - vpngateways
  - vpngateways/status
  verbs:
  - get
  - list
  - watch
- apiGroups:
  - aws.upbound.io
  resources:
  - providerconfigs
  - providerconfigs/status
  - providerconfigusages
  - providerconfigusages/status
  - storeconfigs
  - storeconfigs/status
  verbs:
  - get
  - list
  - watch
```

<!--
Briefly describe what this pull request does, and how it is covered by tests.
Be proactive - direct your reviewers' attention to anything that needs special
consideration.

We love pull requests that fix an open issue. If yours does, use the below line
to indicate which issue it fixes, for example "Fixes #500".
-->

Fixes # 

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `earthly +reviewable` to ensure this PR is ready for review.
- [x] Added or updated unit tests.
- [x] Added or updated e2e tests.
- [x] Linked a PR or a [docs tracking issue] to [document this change].
- [x] Added `backport release-x.y` labels to auto-backport this PR.

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/master/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/master/contributing#checklist-cheat-sheet
