### PR TITLE
Adds assert command to make assertions against crossplane resources

### DIFF
--- a/cmd/crank/beta/assert/assert.go
+++ b/cmd/crank/beta/assert/assert.go
@@ -1,0 +1,122 @@
+package assert
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"reflect"
+	"sort"
+	"strings"
+
+	"github.com/crossplane/crossplane-runtime/pkg/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+const (
+	errWriteOutput = "cannot write output"
+)
+
+// Assert compares expected resources against actual resources and reports any differences.
+// It returns an error if there's an issue writing output.
+func Assert(expectedResources, actualResources []*unstructured.Unstructured, skipSuccessLogs bool, w io.Writer) error {
+
+	failure, missing := 0, 0
+	for _, exp := range expectedResources {
+		id := resourceID(exp)
+		actualResource, exists := findMatchingResource(exp, actualResources)
+		if !exists {
+			missing++
+			if _, err := fmt.Fprintf(w, "[x] %s\n - resource is missing\n", id); err != nil {
+				return errors.Wrap(err, errWriteOutput)
+			}
+			continue
+		}
+
+		if _, err := isSubset(exp, actualResource); err != nil {
+			failure++
+			if _, err := fmt.Fprintf(w, "[x] %s\n%s\n", id, err); err != nil {
+				return errors.Wrap(err, errWriteOutput)
+			}
+			continue
+		}
+
+		if skipSuccessLogs {
+			continue
+		}
+
+		if _, err := fmt.Fprintf(w, "[✓] %s asserted successfully\n", id); err != nil {
+			return errors.Wrap(err, errWriteOutput)
+		}
+	}
+
+	fmt.Fprintf(os.Stdout, "\nTotal %d resources: %d missing resources, %d success cases, %d failure cases\n", len(expectedResources), missing, len(expectedResources)-failure-missing, failure)
+
+	return nil
+}
+
+// findMatchingResource finds a matching resource based on GVK and labels in a slice of unstructured.Unstructured.
+// It returns the matching resource and a boolean indicating if a match was found.
+func findMatchingResource(expected *unstructured.Unstructured, actuals []*unstructured.Unstructured) (*unstructured.Unstructured, bool) {
+	expGVK := expected.GroupVersionKind()
+	expName := expected.GetName()
+	expectedLabels, labelsExists, _ := unstructured.NestedStringMap(expected.Object, "metadata", "labels")
+
+	for _, act := range actuals {
+		actGVK := act.GroupVersionKind()
+		actName := act.GetName()
+		actLabels, _, _ := unstructured.NestedStringMap(act.Object, "metadata", "labels")
+
+		if !reflect.DeepEqual(expGVK, actGVK) {
+			continue
+		}
+
+		if expName != "" && expName != actName {
+			continue
+		}
+
+		if labelsExists && !labelsAreSubset(expectedLabels, actLabels) {
+			continue
+		}
+
+		return act, true
+	}
+	return nil, false
+}
+
+// labelsAreSubset checks if expectedLabels is a subset of actualLabels.
+func labelsAreSubset(expectedLabels, actualLabels map[string]string) bool {
+	for key, expValue := range expectedLabels {
+		if actValue, found := actualLabels[key]; !found || actValue != expValue {
+			return false
+		}
+	}
+	return true
+}
+
+// resourceID generates a unique identifier string for a resource.
+// It includes the GroupVersionKind, Name, and Labels of the resource.
+func resourceID(resource *unstructured.Unstructured) string {
+	id := resource.GroupVersionKind().String()
+
+	labels := make(map[string]string)
+	if labelMap, found, err := unstructured.NestedStringMap(resource.Object, "metadata", "labels"); found && err == nil {
+		labels = labelMap
+	}
+
+	// Add the resource name
+	if name, found, _ := unstructured.NestedString(resource.Object, "metadata", "name"); found {
+		id += fmt.Sprintf(", Name=%s", name)
+	}
+
+	// If labels are not empty, concatenate them to gvk string.
+	if len(labels) > 0 {
+		labelStrings := make([]string, 0, len(labels))
+		for key, value := range labels {
+			labelStrings = append(labelStrings, fmt.Sprintf("%s: %s", key, value))
+		}
+		sort.Strings(labelStrings) // Sort for consistent output
+		id += fmt.Sprintf(", Labels=[%s]", strings.Join(labelStrings, ", "))
+	}
+
+	return id
+}

--- a/cmd/crank/beta/assert/assert_test.go
+++ b/cmd/crank/beta/assert/assert_test.go
@@ -1,0 +1,520 @@
+package assert
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/crossplane/crossplane-runtime/pkg/test"
+	"github.com/google/go-cmp/cmp"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func TestAssert(t *testing.T) {
+	type args struct {
+		expectedResources []*unstructured.Unstructured
+		actualResources   []*unstructured.Unstructured
+		skipSuccessLogs   bool
+	}
+	type want struct {
+		output string
+		err    error
+	}
+	cases := map[string]struct {
+		reason string
+		args   args
+		want   want
+	}{
+		"MatchOnName": {
+			reason: "Should match resources based on name",
+			args: args{
+				expectedResources: []*unstructured.Unstructured{
+					{
+						Object: map[string]interface{}{
+							"apiVersion": "test.org/v1",
+							"kind":       "Test",
+							"metadata": map[string]interface{}{
+								"name": "match",
+							},
+							"spec": map[string]interface{}{
+								"replicas": 3,
+								"config": map[string]interface{}{
+									"key": "value",
+								},
+							},
+						},
+					},
+				},
+				actualResources: []*unstructured.Unstructured{
+					{
+						Object: map[string]interface{}{
+							"apiVersion": "test.org/v1",
+							"kind":       "Test",
+							"metadata": map[string]interface{}{
+								"name": "not-match-1",
+							},
+						},
+					},
+					{
+						Object: map[string]interface{}{
+							"apiVersion": "test.org/v1",
+							"kind":       "Test",
+							"metadata": map[string]interface{}{
+								"name": "match",
+							},
+							"spec": map[string]interface{}{
+								"replicas": 3,
+								"config": map[string]interface{}{
+									"key": "value",
+								},
+							},
+						},
+					},
+					{
+						Object: map[string]interface{}{
+							"apiVersion": "test.org/v1",
+							"kind":       "Test",
+							"metadata": map[string]interface{}{
+								"name": "not-match-2",
+							},
+						},
+					},
+				},
+				skipSuccessLogs: false,
+			},
+			want: want{
+				output: "[✓] test.org/v1, Kind=Test, Name=match asserted successfully\n",
+				err:    nil,
+			},
+		},
+		"MatchOnLabels": {
+			reason: "Should match resources based on labels when name is not provided",
+			args: args{
+				expectedResources: []*unstructured.Unstructured{
+					{
+						Object: map[string]interface{}{
+							"apiVersion": "test.org/v1",
+							"kind":       "Test",
+							"metadata": map[string]interface{}{
+								"labels": map[string]interface{}{
+									"app": "myapp",
+									"env": "prod",
+								},
+							},
+							"spec": map[string]interface{}{
+								"replicas": 3,
+							},
+						},
+					},
+				},
+				actualResources: []*unstructured.Unstructured{
+					{
+						Object: map[string]interface{}{
+							"apiVersion": "test.org/v1",
+							"kind":       "Test",
+							"metadata": map[string]interface{}{
+								"name": "test1",
+								"labels": map[string]interface{}{
+									"app":     "myapp",
+									"env":     "prod",
+									"version": "v1",
+								},
+							},
+							"spec": map[string]interface{}{
+								"replicas": 3,
+							},
+						},
+					},
+					{
+						Object: map[string]interface{}{
+							"apiVersion": "test.org/v1",
+							"kind":       "Test",
+							"metadata": map[string]interface{}{
+								"name": "test2",
+								"labels": map[string]interface{}{
+									"app": "otherapp",
+									"env": "prod",
+								},
+							},
+							"spec": map[string]interface{}{
+								"replicas": 2,
+							},
+						},
+					},
+				},
+				skipSuccessLogs: false,
+			},
+			want: want{
+				output: "[✓] test.org/v1, Kind=Test, Labels=[app: myapp, env: prod] asserted successfully\n",
+				err:    nil,
+			},
+		},
+		"MatchOnGVK": {
+			reason: "Should match resources based on GVK when name and labels are not provided",
+			args: args{
+				expectedResources: []*unstructured.Unstructured{
+					{
+						Object: map[string]interface{}{
+							"apiVersion": "test.org/v1",
+							"kind":       "Test",
+							"spec": map[string]interface{}{
+								"replicas": 3,
+							},
+						},
+					},
+				},
+				actualResources: []*unstructured.Unstructured{
+					{
+						Object: map[string]interface{}{
+							"apiVersion": "test.org/v1",
+							"kind":       "Test",
+							"metadata": map[string]interface{}{
+								"name": "test1",
+							},
+							"spec": map[string]interface{}{
+								"replicas": 3,
+							},
+						},
+					},
+					{
+						Object: map[string]interface{}{
+							"apiVersion": "test.org/v1",
+							"kind":       "OtherTest",
+							"metadata": map[string]interface{}{
+								"name": "test2",
+							},
+							"spec": map[string]interface{}{
+								"replicas": 2,
+							},
+						},
+					},
+				},
+				skipSuccessLogs: false,
+			},
+			want: want{
+				output: "[✓] test.org/v1, Kind=Test asserted successfully\n",
+				err:    nil,
+			},
+		},
+		"MatchingResources": {
+			reason: "Should match resources with complex spec data",
+			args: args{
+				expectedResources: []*unstructured.Unstructured{
+					{
+						Object: map[string]interface{}{
+							"apiVersion": "test.org/v1",
+							"kind":       "ComplexTest",
+							"metadata": map[string]interface{}{
+								"name": "complex1",
+							},
+							"spec": map[string]interface{}{
+								"replicas": 3,
+								"config": map[string]interface{}{
+									"key1": "value1",
+									"key2": 42,
+								},
+								"ports": []interface{}{
+									map[string]interface{}{
+										"name": "http",
+										"port": 80,
+									},
+									map[string]interface{}{
+										"name": "https",
+										"port": 443,
+									},
+								},
+							},
+						},
+					},
+				},
+				actualResources: []*unstructured.Unstructured{
+					{
+						Object: map[string]interface{}{
+							"apiVersion": "test.org/v1",
+							"kind":       "ComplexTest",
+							"metadata": map[string]interface{}{
+								"name": "complex1",
+							},
+							"spec": map[string]interface{}{
+								"replicas": 3,
+								"config": map[string]interface{}{
+									"key1": "value1",
+									"key2": 42,
+								},
+								"ports": []interface{}{
+									map[string]interface{}{
+										"name": "http",
+										"port": 80,
+									},
+									map[string]interface{}{
+										"name": "https",
+										"port": 443,
+									},
+								},
+							},
+						},
+					},
+				},
+				skipSuccessLogs: false,
+			},
+			want: want{
+				output: "[✓] test.org/v1, Kind=ComplexTest, Name=complex1 asserted successfully\n",
+				err:    nil,
+			},
+		},
+		"ValueMismatch": {
+			reason: "Should report value mismatches",
+			args: args{
+				expectedResources: []*unstructured.Unstructured{{
+					Object: map[string]interface{}{
+						"apiVersion": "test.org/v1",
+						"kind":       "Test",
+						"metadata": map[string]interface{}{
+							"name": "test1",
+						},
+						"spec": map[string]interface{}{
+							"replicas": 3,
+							"config": map[string]interface{}{
+								"key": "value",
+							},
+							"ports": []interface{}{
+								map[string]interface{}{
+									"name": "http",
+									"port": 80,
+								},
+								map[string]interface{}{
+									"name": "https",
+									"port": 443,
+								},
+							},
+						},
+					},
+				}},
+				actualResources: []*unstructured.Unstructured{{
+					Object: map[string]interface{}{
+						"apiVersion": "test.org/v1",
+						"kind":       "Test",
+						"metadata": map[string]interface{}{
+							"name": "test1",
+						},
+						"spec": map[string]interface{}{
+							"replicas": 2,
+							"config": map[string]interface{}{
+								"key": "different",
+							},
+							"ports": []interface{}{
+								map[string]interface{}{
+									"name": "http",
+									"port": 8080,
+								},
+								map[string]interface{}{
+									"name": "https",
+									"port": 443,
+								},
+							},
+						},
+					},
+				}},
+			},
+			want: want{
+				output: "[x] test.org/v1, Kind=Test, Name=test1\n" +
+					" - spec.config.key: value mismatch: expected value, got different\n" +
+					" - spec.ports.[0].port: value mismatch: expected 80, got 8080\n" +
+					" - spec.replicas: value mismatch: expected 3, got 2\n",
+				err: nil,
+			},
+		},
+		"TypeMismatch": {
+			reason: "Should report type mismatches",
+			args: args{
+				expectedResources: []*unstructured.Unstructured{{
+					Object: map[string]interface{}{
+						"apiVersion": "test.org/v1",
+						"kind":       "Test",
+						"metadata": map[string]interface{}{
+							"name": "test1",
+						},
+						"spec": map[string]interface{}{
+							"replicas": 3,
+						},
+					},
+				}},
+				actualResources: []*unstructured.Unstructured{{
+					Object: map[string]interface{}{
+						"apiVersion": "test.org/v1",
+						"kind":       "Test",
+						"metadata": map[string]interface{}{
+							"name": "test1",
+						},
+						"spec": map[string]interface{}{
+							"replicas": "3",
+						},
+					},
+				}},
+			},
+			want: want{
+				output: "[x] test.org/v1, Kind=Test, Name=test1\n" +
+					" - spec.replicas: type mismatch: expected int, got string\n",
+				err: nil,
+			},
+		},
+		"ArrayLengthMismatch": {
+			reason: "Should report array length mismatches",
+			args: args{
+				expectedResources: []*unstructured.Unstructured{{
+					Object: map[string]interface{}{
+						"apiVersion": "test.org/v1",
+						"kind":       "Test",
+						"metadata": map[string]interface{}{
+							"name": "test1",
+						},
+						"spec": map[string]interface{}{
+							"ports": []interface{}{80, 443},
+						},
+					},
+				}},
+				actualResources: []*unstructured.Unstructured{{
+					Object: map[string]interface{}{
+						"apiVersion": "test.org/v1",
+						"kind":       "Test",
+						"metadata": map[string]interface{}{
+							"name": "test1",
+						},
+						"spec": map[string]interface{}{
+							"ports": []interface{}{80},
+						},
+					},
+				}},
+			},
+			want: want{
+				output: "[x] test.org/v1, Kind=Test, Name=test1\n" +
+					" - spec.ports: expected an array of length 2, but got an array of length 1\n",
+				err: nil,
+			},
+		},
+		"MissingKey": {
+			reason: "Should report missing key",
+			args: args{
+				expectedResources: []*unstructured.Unstructured{{
+					Object: map[string]interface{}{
+						"apiVersion": "test.org/v1",
+						"kind":       "Test",
+						"spec": map[string]interface{}{
+							"replicas": 3,
+						},
+					},
+				}},
+				actualResources: []*unstructured.Unstructured{{
+					Object: map[string]interface{}{
+						"apiVersion": "test.org/v1",
+						"kind":       "Test",
+						"spec":       map[string]interface{}{},
+					},
+				},
+				}},
+			want: want{
+				output: "[x] test.org/v1, Kind=Test\n" +
+					" - spec.replicas: key is missing from map\n",
+				err: nil,
+			},
+		},
+		"MissingResource": {
+			reason: "Should report missing resources",
+			args: args{
+				expectedResources: []*unstructured.Unstructured{{
+					Object: map[string]interface{}{
+						"apiVersion": "test.org/v1",
+						"kind":       "Test",
+						"metadata": map[string]interface{}{
+							"name": "test1",
+						},
+					},
+				}},
+				actualResources: []*unstructured.Unstructured{},
+			},
+			want: want{
+				output: "[x] test.org/v1, Kind=Test, Name=test1\n" +
+					" - resource is missing\n",
+				err: nil,
+			},
+		},
+		"SkipSuccessLogs": {
+			reason: "Should skip success logs but report mismatches when skipSuccessLogs is true",
+			args: args{
+				expectedResources: []*unstructured.Unstructured{
+					{
+						Object: map[string]interface{}{
+							"apiVersion": "test.org/v1",
+							"kind":       "Test",
+							"metadata": map[string]interface{}{
+								"name": "test1",
+							},
+							"spec": map[string]interface{}{
+								"replicas": 3,
+							},
+						},
+					},
+					{
+						Object: map[string]interface{}{
+							"apiVersion": "test.org/v1",
+							"kind":       "Test",
+							"metadata": map[string]interface{}{
+								"name": "test2",
+							},
+							"spec": map[string]interface{}{
+								"replicas": 2,
+							},
+						},
+					},
+				},
+				actualResources: []*unstructured.Unstructured{
+					{
+						Object: map[string]interface{}{
+							"apiVersion": "test.org/v1",
+							"kind":       "Test",
+							"metadata": map[string]interface{}{
+								"name": "test1",
+							},
+							"spec": map[string]interface{}{
+								"replicas": 3,
+							},
+						},
+					},
+					{
+						Object: map[string]interface{}{
+							"apiVersion": "test.org/v1",
+							"kind":       "Test",
+							"metadata": map[string]interface{}{
+								"name": "test2",
+							},
+							"spec": map[string]interface{}{
+								"replicas": 4,
+							},
+						},
+					},
+				},
+				skipSuccessLogs: true,
+			},
+			want: want{
+				output: "[x] test.org/v1, Kind=Test, Name=test2\n" +
+					" - spec.replicas: value mismatch: expected 2, got 4\n",
+				err: nil,
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			w := &bytes.Buffer{}
+			err := Assert(tc.args.expectedResources, tc.args.actualResources, tc.args.skipSuccessLogs, w)
+
+			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
+				t.Errorf("%s\nAssert(...): -want error, +got error:\n%s", tc.reason, diff)
+			}
+
+			got := w.String()
+			if diff := cmp.Diff(tc.want.output, got); diff != "" {
+				t.Errorf("%s\nAssert(...): -want output, +got output:\n%s", tc.reason, diff)
+			}
+		})
+	}
+}

--- a/cmd/crank/beta/assert/cmd.go
+++ b/cmd/crank/beta/assert/cmd.go
@@ -1,0 +1,93 @@
+/*
+Copyright 2023 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package assert
+
+import (
+	"github.com/alecthomas/kong"
+	"github.com/crossplane/crossplane-runtime/pkg/errors"
+	"github.com/crossplane/crossplane-runtime/pkg/logging"
+	"github.com/crossplane/crossplane/cmd/crank/beta/validate"
+	"github.com/spf13/afero"
+)
+
+// Cmd arguments and flags for render subcommand.
+type Cmd struct {
+	// Arguments
+	ExpectedResources string `arg:"" help:"A YAML file or directory of YAML files specifying the expected resources."`
+	ActualResources   string `arg:"" help:"A YAML file or directory of YAML files specifying the actual resources to compare against the expected resources, or '-' for standard input." `
+
+	// Flags. Keep them in alphabetical order.
+	SkipSuccessResults bool `help:"Skip printing success results, showing only failures."`
+
+	fs afero.Fs
+}
+
+func (c *Cmd) Help() string {
+	return `
+	This command compares expected resources against actual resources and reports
+	any differences or failures. The output of the "crossplane beta render" command can be 
+	piped to this assert command in order to rapidly assert on the outputs of the composition
+	development experience.
+	
+	Examples:
+	
+      # Assert all resources in the actual.yaml file against the resources in the expected.yaml file
+	  crossplane beta assert expected.yaml actual.yaml
+	
+      # Assert all resources in the actual.yaml file against the resources in the expected.yaml file
+      skipping success logs
+	  crossplane beta assert  expected.yaml actual.yaml --skip-success-results
+	
+	  # Assert the output of the render command against the resources in expected.yaml
+	  crossplane beta render xr.yaml composition.yaml func.yaml | crossplane beta assert expected.yaml -
+`
+}
+
+// AfterApply implements kong.AfterApply.
+func (c *Cmd) AfterApply() error {
+	c.fs = afero.NewOsFs()
+	return nil
+}
+
+// Run assert.
+func (c *Cmd) Run(k *kong.Context, log logging.Logger) error {
+	// Load all resources
+	expectedLoader, err := validate.NewLoader(c.ExpectedResources)
+	if err != nil {
+		return errors.Wrapf(err, "cannot load resources from %q", c.ExpectedResources)
+	}
+
+	expectedResources, err := expectedLoader.Load()
+	if err != nil {
+		return errors.Wrapf(err, "cannot load resources from %q", c.ExpectedResources)
+	}
+
+	actualLoader, err := validate.NewLoader(c.ActualResources)
+	if err != nil {
+		return errors.Wrapf(err, "cannot load resources from %q", c.ActualResources)
+	}
+
+	actualResources, err := actualLoader.Load()
+	if err != nil {
+		return errors.Wrapf(err, "cannot load resources from %q", c.ActualResources)
+	}
+
+	if err := Assert(expectedResources, actualResources, c.SkipSuccessResults, k.Stdout); err != nil {
+		return errors.Wrap(err, "error occurred during assertion")
+	}
+
+	return nil
+}

--- a/cmd/crank/beta/assert/cmd.go
+++ b/cmd/crank/beta/assert/cmd.go
@@ -23,7 +23,7 @@ import (
 	"github.com/spf13/afero"
 )
 
-// Cmd arguments and flags for render subcommand.
+// Cmd arguments and flags for assert subcommand.
 type Cmd struct {
 	// Arguments
 	ExpectedResources string `arg:"" help:"A YAML file or directory of YAML files specifying the expected resources."`

--- a/cmd/crank/beta/assert/subset.go
+++ b/cmd/crank/beta/assert/subset.go
@@ -1,0 +1,132 @@
+package assert
+
+import (
+	"fmt"
+	"reflect"
+	"sort"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+// SubsetError struct modified to hold multiple errors
+type SubsetError struct {
+	path    []string
+	message string
+	errors  []*SubsetError // Store nested errors
+}
+
+// Error method to format the error message, including nested errors
+func (e *SubsetError) Error() string {
+	if len(e.errors) > 0 {
+		var nestedErrors []string
+		for _, err := range e.errors {
+			nestedErrors = append(nestedErrors, fmt.Sprintf(" - %s", err.Error()))
+		}
+		return fmt.Sprintf("\n%s", strings.Join(nestedErrors, "\n"))
+	}
+
+	return fmt.Sprintf("%s: %s", e.pathString(), e.message)
+}
+
+// isSubset checks if 'actual' is a subset of 'expected'. Both parameters are interface{} to handle both structured and unstructured data.
+func isSubset(expected, actual interface{}) (bool, error) {
+	var errors []*SubsetError
+
+	expected, actual = normalizeData(expected), normalizeData(actual)
+
+	compare(expected, actual, nil, &errors)
+	if len(errors) > 0 {
+		// Sort errors by path
+		sort.Slice(errors, func(i, j int) bool {
+			return errors[i].pathString() < errors[j].pathString()
+		})
+
+		var errMsg []string
+		for _, err := range errors {
+			errMsg = append(errMsg, fmt.Sprintf(" - %s", err.Error()))
+		}
+		return false, fmt.Errorf(strings.Join(errMsg, "\n"))
+	}
+	return true, nil
+}
+
+// compare recursively compares data between expected and actual.
+func compare(expected, actual interface{}, path []string, errors *[]*SubsetError) {
+
+	if reflect.DeepEqual(expected, actual) {
+		return
+	}
+
+	if reflect.TypeOf(expected) != reflect.TypeOf(actual) {
+		*errors = append(*errors, &SubsetError{
+			path:    path,
+			message: fmt.Sprintf("type mismatch: expected %T, got %T", expected, actual),
+		})
+		return
+	}
+
+	switch exp := expected.(type) {
+	case map[string]interface{}:
+		act, ok := actual.(map[string]interface{})
+		if !ok {
+			*errors = append(*errors, &SubsetError{
+				path:    path,
+				message: "expected a map but found a different type",
+			})
+			return
+		}
+
+		for k, vExp := range exp {
+			vAct, exists := act[k]
+			if !exists {
+				*errors = append(*errors, &SubsetError{
+					path:    append(path, k),
+					message: "key is missing from map",
+				})
+				continue
+			}
+			compare(vExp, vAct, append(path, k), errors)
+		}
+	case []interface{}:
+		act, ok := actual.([]interface{})
+		if !ok || len(exp) != len(act) {
+			*errors = append(*errors, &SubsetError{
+				path:    path,
+				message: fmt.Sprintf("expected an array of length %d, but got an array of length %d", len(exp), len(act)),
+			})
+			return
+		}
+
+		for i, vExp := range exp {
+			compare(vExp, act[i], append(path, fmt.Sprintf("[%d]", i)), errors)
+		}
+	default:
+		*errors = append(*errors, &SubsetError{
+			path:    path,
+			message: fmt.Sprintf("value mismatch: expected %v, got %v", expected, actual),
+		})
+
+	}
+}
+
+// normalizeData converts *unstructured.Unstructured to their underlying map[string]interface{} if necessary
+func normalizeData(obj interface{}) interface{} {
+	if uns, ok := obj.(*unstructured.Unstructured); ok {
+		return uns.Object
+	}
+	return obj
+}
+
+// pathString formats the path for the error message
+func (e *SubsetError) pathString() string {
+	if len(e.path) == 0 {
+		return ""
+	}
+
+	path := e.path[0]
+	for i := 1; i < len(e.path); i++ {
+		path = fmt.Sprintf("%s.%s", path, e.path[i])
+	}
+	return path
+}

--- a/cmd/crank/beta/beta.go
+++ b/cmd/crank/beta/beta.go
@@ -20,6 +20,7 @@ limitations under the License.
 package beta
 
 import (
+	"github.com/crossplane/crossplane/cmd/crank/beta/assert"
 	"github.com/crossplane/crossplane/cmd/crank/beta/convert"
 	"github.com/crossplane/crossplane/cmd/crank/beta/render"
 	"github.com/crossplane/crossplane/cmd/crank/beta/top"
@@ -32,6 +33,7 @@ import (
 type Cmd struct {
 	// Subcommands and flags will appear in the CLI help output in the same
 	// order they're specified here. Keep them in alphabetical order.
+	Assert   assert.Cmd   `cmd:"" help:"Assert Crossplane resources."`
 	Convert  convert.Cmd  `cmd:"" help:"Convert a Crossplane resource to a newer version or kind."`
 	Render   render.Cmd   `cmd:"" help:"Render a composite resource (XR)."`
 	Top      top.Cmd      `cmd:"" help:"Display resource (CPU/memory) usage by Crossplane related pods."`


### PR DESCRIPTION
### Description of your changes

This pull request introduces a new beta command 'assert' that allows us to assert the correctness of rendered resources by asserting them against 'expected' resources. This enables quick verification of rendered output without the need to create and deploy resources to a cluster. The primary advantage of this approach is the significant reduction in time and resources required for validation, as it bypasses the need for actual deployment.

example output:
```bash
→ crossplane beta render xr.yaml ... | crossplane beta assert expected.yaml -
[x] storage.azure.upbound.io/v1beta1, Kind=Account, Labels=[crossplane.io/claim-namespace: test-stage-us]
 - spec.forProvider.allowNestedItemsToBePublic: key is missing from map
 - spec.forProvider.blobProperties.[0].containerDeleteRetentionPolicy.[0].days: value mismatch: expected 60, got 30
 - spec.providerConfigRef.name: value mismatch: expected test-stage-us-azure, got test-stage-eu-azure
[x] storage.azure.upbound.io/v1beta1, Kind=Container, Labels=[crossplane.io/claim-namespace: test-stage-us, external-name: storage1]
- resource is missing
[✓] storage.azure.upbound.io/v1beta1, Kind=Container, Labels=[external-name: storage2] asserted successfully
[✓] storage.azure.upbound.io/v1beta1, Kind=Container, Labels=[external-name: storage3] asserted successfully

Total 4 resources: 1 missing resources, 2 success cases, 1 failure case
```

Problem Statement:
Current tools require the deployment of resources into a cluster to validate their creation and configuration. This process is time-consuming and resource-intensive, as it necessitates the creation of cluster along with actual resources in a live environment.

Solution:
The new command addresses this problem by using the output of the Crossplane beta render command to perform assertions against expected resources. This method allows for rapid verification of resource configurations, ensuring that the managed resources are being created as intended without the need for actual deployment. By asserting the rendered output against 'expected' files, we can quickly identify discrepancies and ensure correctness in a fraction of the time.

When used alongside the beta validate command, this approach enables a tighter feedback loop when developing compositions. This combined usage ensures that any issues in resource configurations are caught early, facilitating a smoother and faster development process.

Related to #5710 

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [ ] Read and followed Crossplane's [contribution process].
- [ ] Run `earthly +reviewable` to ensure this PR is ready for review.
- [x] Added or updated unit tests.
- [ ] Added or updated e2e tests.
- [ ] Linked a PR or a [docs tracking issue] to [document this change].
- [ ] Added `backport release-x.y` labels to auto-backport this PR.

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/master/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/master/contributing#checklist-cheat-sheet
