### PR TITLE
Use more global cache directory at validate

### DIFF
--- a/cmd/crank/beta/validate/cmd.go
+++ b/cmd/crank/beta/validate/cmd.go
@@ -36,7 +36,7 @@ type Cmd struct {
 	Resources  string `arg:"" help:"Resources source which can be a file, directory, or '-' for standard input."`
 
 	// Flags. Keep them in alphabetical order.
-	CacheDir           string `default:".crossplane/cache"                                          help:"Absolute path to the cache directory where downloaded schemas are stored."`
+	CacheDir           string `default:"~/.crossplane/cache"                                        help:"Absolute path to the cache directory where downloaded schemas are stored."`
 	CleanCache         bool   `help:"Clean the cache directory before downloading package schemas."`
 	SkipSuccessResults bool   `help:"Skip printing success results."`
 
@@ -51,7 +51,7 @@ CRDs, providers, and configurations. The output of the "crossplane beta render" 
 piped to this validate command in order to rapidly validate on the outputs of the composition development experience.
 
 If providers or configurations are provided as extensions, they will be downloaded and loaded as CRDs before performing
-validation. If the cache directory is not provided, it will default to ".crossplane/cache" in the current workspace. 
+validation. If the cache directory is not provided, it will default to "~/.crossplane/cache" in the current workspace. 
 Cache directory can be cleaned before downloading schemas by setting the "clean-cache" flag.
 
 All validation is performed offline locally using the Kubernetes API server's validation library, so it does not require 
@@ -107,15 +107,6 @@ func (c *Cmd) Run(k *kong.Context, _ logging.Logger) error {
 	resources, err := resourceLoader.Load()
 	if err != nil {
 		return errors.Wrapf(err, "cannot load resources from %q", c.Resources)
-	}
-
-	// Update default cache directory to absolute path based on the current working directory
-	if c.CacheDir == defaultCacheDir {
-		currentPath, err := os.Getwd()
-		if err != nil {
-			return errors.Wrapf(err, "cannot get current path")
-		}
-		c.CacheDir = filepath.Join(currentPath, c.CacheDir)
 	}
 
 	if strings.HasPrefix(c.CacheDir, "~/") {

--- a/cmd/crank/beta/validate/cmd.go
+++ b/cmd/crank/beta/validate/cmd.go
@@ -51,7 +51,7 @@ CRDs, providers, and configurations. The output of the "crossplane beta render" 
 piped to this validate command in order to rapidly validate on the outputs of the composition development experience.
 
 If providers or configurations are provided as extensions, they will be downloaded and loaded as CRDs before performing
-validation. If the cache directory is not provided, it will default to "~/.crossplane/cache" in the current workspace. 
+validation. If the cache directory is not provided, it will default to "~/.crossplane/cache". 
 Cache directory can be cleaned before downloading schemas by setting the "clean-cache" flag.
 
 All validation is performed offline locally using the Kubernetes API server's validation library, so it does not require 

--- a/cmd/crank/beta/validate/manager.go
+++ b/cmd/crank/beta/validate/manager.go
@@ -35,7 +35,6 @@ import (
 )
 
 const (
-	defaultCacheDir = ".crossplane/cache"
 	packageFileName = "package.yaml"
 	baseLayerLabel  = "base"
 


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane! Please read the contribution docs
(linked below) if this is your first Crossplane pull request.
-->

### Description of your changes

This PR changes the default caching directory from `{CURRENT_PATH}/.crossplane/cache` to `{HOME_DIR}/.crossplane/cache` so that we have a global cache and we dont get a new cache every time we run the command from a different directory.
<!--
Briefly describe what this pull request does, and how it is covered by tests.
Be proactive - direct your reviewers' attention to anything that needs special
consideration.

We love pull requests that fix an open issue. If yours does, use the below line
to indicate which issue it fixes, for example "Fixes #500".
-->

Fixes https://github.com/crossplane/crossplane/issues/5823

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `earthly +reviewable` to ensure this PR is ready for review.
- [ ] ~Added or updated unit tests.~
- [ ] ~Added or updated e2e tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/master/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/master/contributing#checklist-cheat-sheet
