### PR TITLE
Crossplane Helm chart service account creation flag

### DIFF
--- a/cluster/charts/crossplane/README.md
+++ b/cluster/charts/crossplane/README.md
@@ -123,8 +123,9 @@ and their default values.
 | `securityContextRBACManager.runAsGroup` | The group ID used by the RBAC Manager pod. | `65532` |
 | `securityContextRBACManager.runAsUser` | The user ID used by the RBAC Manager pod. | `65532` |
 | `service.customAnnotations` | Configure annotations on the service object. Only enabled when webhooks.enabled = true | `{}` |
-| `serviceAccount.create` | Specifies whether a ServiceAccount should be created | `true` |
+| `serviceAccount.create` | Specifies whether Crossplane ServiceAccount should be created | `true` |
 | `serviceAccount.customAnnotations` | Add custom `annotations` to the Crossplane ServiceAccount. | `{}` |
+| `serviceAccount.name` | Provide the name of an already created Crossplane ServiceAccount. Required when `create: false` | `""` |
 | `tolerations` | Add `tolerations` to the Crossplane pod deployment. | `[]` |
 | `topologySpreadConstraints` | Add `topologySpreadConstraints` to the Crossplane pod deployment. | `[]` |
 | `webhooks.enabled` | Enable webhooks for Crossplane and installed Provider packages. | `true` |

--- a/cluster/charts/crossplane/README.md
+++ b/cluster/charts/crossplane/README.md
@@ -123,6 +123,7 @@ and their default values.
 | `securityContextRBACManager.runAsGroup` | The group ID used by the RBAC Manager pod. | `65532` |
 | `securityContextRBACManager.runAsUser` | The user ID used by the RBAC Manager pod. | `65532` |
 | `service.customAnnotations` | Configure annotations on the service object. Only enabled when webhooks.enabled = true | `{}` |
+| `serviceAccount.create` | Specifies whether a ServiceAccount should be created | `true` |
 | `serviceAccount.customAnnotations` | Add custom `annotations` to the Crossplane ServiceAccount. | `{}` |
 | `tolerations` | Add `tolerations` to the Crossplane pod deployment. | `[]` |
 | `topologySpreadConstraints` | Add `topologySpreadConstraints` to the Crossplane pod deployment. | `[]` |

--- a/cluster/charts/crossplane/README.md
+++ b/cluster/charts/crossplane/README.md
@@ -125,7 +125,7 @@ and their default values.
 | `service.customAnnotations` | Configure annotations on the service object. Only enabled when webhooks.enabled = true | `{}` |
 | `serviceAccount.create` | Specifies whether Crossplane ServiceAccount should be created | `true` |
 | `serviceAccount.customAnnotations` | Add custom `annotations` to the Crossplane ServiceAccount. | `{}` |
-| `serviceAccount.name` | Provide the name of an already created Crossplane ServiceAccount. Required when `create: false` | `""` |
+| `serviceAccount.name` | Provide the name of an already created Crossplane ServiceAccount. Required when `serviceAccount.create` is `false` | `""` |
 | `tolerations` | Add `tolerations` to the Crossplane pod deployment. | `[]` |
 | `topologySpreadConstraints` | Add `topologySpreadConstraints` to the Crossplane pod deployment. | `[]` |
 | `webhooks.enabled` | Enable webhooks for Crossplane and installed Provider packages. | `true` |

--- a/cluster/charts/crossplane/templates/clusterrolebinding.yaml
+++ b/cluster/charts/crossplane/templates/clusterrolebinding.yaml
@@ -11,5 +11,9 @@ roleRef:
   name: {{ template "crossplane.name" . }}
 subjects:
 - kind: ServiceAccount
+  {{- if not .Values.serviceAccount.create }}
+  name: {{ .Values.serviceAccount.name }}
+  {{- else }}
   name: {{ template "crossplane.name" . }}
+  {{- end }}
   namespace: {{ .Release.Namespace }}

--- a/cluster/charts/crossplane/templates/deployment.yaml
+++ b/cluster/charts/crossplane/templates/deployment.yaml
@@ -44,7 +44,11 @@ spec:
       {{- if .Values.priorityClassName }}
       priorityClassName: {{ .Values.priorityClassName  | quote }}
       {{- end }}
+      {{- if not .Values.serviceAccount.create }}
+      serviceAccountName: {{ .Values.serviceAccount.name }}
+      {{- else }}
       serviceAccountName: {{ template "crossplane.name" . }}
+      {{- end }}
       hostNetwork: {{ .Values.hostNetwork }}
       initContainers:
         - image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default (printf "v%s" .Chart.AppVersion) }}"

--- a/cluster/charts/crossplane/templates/serviceaccount.yaml
+++ b/cluster/charts/crossplane/templates/serviceaccount.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.serviceAccount.create }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -15,3 +16,4 @@ imagePullSecrets:
 - name: {{ $secret }}
 {{- end }}
 {{ end }}
+{{- end }}

--- a/cluster/charts/crossplane/values.yaml
+++ b/cluster/charts/crossplane/values.yaml
@@ -37,8 +37,10 @@ customLabels: {}
 customAnnotations: {}
 
 serviceAccount:
-  # -- Specifies whether a ServiceAccount should be created
+  # -- Specifies whether Crossplane ServiceAccount should be created
   create: true
+  # -- Provide the name of an already created Crossplane ServiceAccount. Required when `create: false`
+  name: ""
   # -- Add custom `annotations` to the Crossplane ServiceAccount.
   customAnnotations: {}
 

--- a/cluster/charts/crossplane/values.yaml
+++ b/cluster/charts/crossplane/values.yaml
@@ -39,7 +39,7 @@ customAnnotations: {}
 serviceAccount:
   # -- Specifies whether Crossplane ServiceAccount should be created
   create: true
-  # -- Provide the name of an already created Crossplane ServiceAccount. Required when `create: false`
+  # -- Provide the name of an already created Crossplane ServiceAccount. Required when `serviceAccount.create` is `false`
   name: ""
   # -- Add custom `annotations` to the Crossplane ServiceAccount.
   customAnnotations: {}

--- a/cluster/charts/crossplane/values.yaml
+++ b/cluster/charts/crossplane/values.yaml
@@ -37,6 +37,8 @@ customLabels: {}
 customAnnotations: {}
 
 serviceAccount:
+  # -- Specifies whether a ServiceAccount should be created
+  create: true
   # -- Add custom `annotations` to the Crossplane ServiceAccount.
   customAnnotations: {}
 


### PR DESCRIPTION
### Description of your changes

This PR adds a support in the Helm chart, in order to control the creation of Crossplane service account.

Currently there's no option to avoid the creation of Crossplane service account.
Having the ability to control its creation can be useful in cases, where we already have a service account that was created outside Crossplane's chart that we would like to use.

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [X] Read and followed Crossplane's [contribution process].
- [X] Run `earthly +reviewable` to ensure this PR is ready for review.
- [ ] ~Added or updated unit tests.~
- [ ] ~Added or updated e2e tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/master/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/master/contributing#checklist-cheat-sheet
