### PR TITLE
Add secrets.crossplane.io grant rules to RBAC manager roles, even though the feature is alpha.

### DIFF
--- a/cluster/charts/crossplane/templates/rbac-manager-managed-clusterroles.yaml
+++ b/cluster/charts/crossplane/templates/rbac-manager-managed-clusterroles.yaml
@@ -103,6 +103,10 @@ rules:
   - pkg.crossplane.io
   resources: ["*"]
   verbs: ["*"]
+- apiGroups:
+  - secrets.crossplane.io
+  resources: ["*"]
+  verbs: ["*"]
 # Crossplane administrators have access to view CRDs in order to debug XRDs.
 - apiGroups: [apiextensions.k8s.io]
   resources: [customresourcedefinitions]
@@ -139,6 +143,10 @@ rules:
   - pkg.crossplane.io
   resources: ["*"]
   verbs: ["*"]
+- apiGroups:
+  - secrets.crossplane.io
+  resources: ["*"]
+  verbs: ["*"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -164,6 +172,10 @@ rules:
   verbs: [get, list, watch]
 - apiGroups:
   - pkg.crossplane.io
+  resources: ["*"]
+  verbs: [get, list, watch]
+- apiGroups:
+  - secrets.crossplane.io
   resources: ["*"]
   verbs: [get, list, watch]
 ---


### PR DESCRIPTION

<!--
Thank you for helping to improve Crossplane! Please read the contribution docs
(linked below) if this is your first Crossplane pull request.
-->

### Description of your changes

Hi folks! 👋 Noticed that `secrets.crossplane.io` isn't part of the RBAC manager-managed roles, is this intentional (the feature is indeed alpha, and maybe slated for removal?) or shall we add the grant to admin/editor/viewer roles?

Happy to go either way, but just wanted to open this PR to discuss.

Not sure if there were an open issue for this.

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `earthly +reviewable` to ensure this PR is ready for review.
- [x] Added or updated unit tests.
- [x] Added or updated e2e tests.
- [x] Linked a PR or a [docs tracking issue] to [document this change].
- [x] Added `backport release-x.y` labels to auto-backport this PR.

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/master/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/master/contributing#checklist-cheat-sheet
