### PR TITLE
feat(crank): beta validate, get crossplane schemas, extract function pipeline step input

### DIFF
--- a/cmd/crank/beta/validate/cmd.go
+++ b/cmd/crank/beta/validate/cmd.go
@@ -18,6 +18,7 @@ limitations under the License.
 package validate
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -27,6 +28,9 @@ import (
 
 	"github.com/crossplane/crossplane-runtime/pkg/errors"
 	"github.com/crossplane/crossplane-runtime/pkg/logging"
+
+	"github.com/crossplane/crossplane/internal/version"
+	"github.com/crossplane/crossplane/internal/xpkg"
 )
 
 // Cmd arguments and flags for render subcommand.
@@ -36,9 +40,10 @@ type Cmd struct {
 	Resources  string `arg:"" help:"Resources source which can be a file, directory, or '-' for standard input."`
 
 	// Flags. Keep them in alphabetical order.
-	CacheDir           string `default:"~/.crossplane/cache"                                        help:"Absolute path to the cache directory where downloaded schemas are stored."`
+	CacheDir           string `default:"~/.crossplane/cache"                                                       help:"Absolute path to the cache directory where downloaded schemas are stored."`
 	CleanCache         bool   `help:"Clean the cache directory before downloading package schemas."`
 	SkipSuccessResults bool   `help:"Skip printing success results."`
+	CrossplaneImage    string `help:"Specify the Crossplane image to be used for validating the built-in schemas."`
 
 	fs afero.Fs
 }
@@ -46,15 +51,15 @@ type Cmd struct {
 // Help prints out the help for the validate command.
 func (c *Cmd) Help() string {
 	return `
-This command validates the provided Crossplane resources against the schemas of the provided extensions like XRDs, 
-CRDs, providers, and configurations. The output of the "crossplane render" command can be 
+This command validates the provided Crossplane resources against the schemas of the provided extensions like XRDs,
+CRDs, providers, and configurations. The output of the "crossplane render" command can be
 piped to this validate command in order to rapidly validate on the outputs of the composition development experience.
 
 If providers or configurations are provided as extensions, they will be downloaded and loaded as CRDs before performing
-validation. If the cache directory is not provided, it will default to "~/.crossplane/cache". 
+validation. If the cache directory is not provided, it will default to "~/.crossplane/cache".
 Cache directory can be cleaned before downloading schemas by setting the "clean-cache" flag.
 
-All validation is performed offline locally using the Kubernetes API server's validation library, so it does not require 
+All validation is performed offline locally using the Kubernetes API server's validation library, so it does not require
 any Crossplane instance or control plane to be running or configured.
 
 Examples:
@@ -62,10 +67,13 @@ Examples:
   # Validate all resources in the resources.yaml file against the extensions in the extensions.yaml file
   crossplane beta validate extensions.yaml resources.yaml
 
-  # Validate all resources in the resourceDir folder against the extensions in the extensionsDir folder and skip 
+  # Validate all resources in the resources.yaml file against the extensions in the extensions.yaml file using a specific Crossplane image version
+  crossplane beta validate extensions.yaml resources.yaml --crossplane-image=xpkg.upbound.io/crossplane/crossplane:v1.16.0
+
+  # Validate all resources in the resourceDir folder against the extensions in the extensionsDir folder and skip
   # success logs
   crossplane beta validate extensionsDir/ resourceDir/ --skip-success-results
- 
+
   # Validate the output of the render command against the extensions in the extensionsDir folder
   crossplane render xr.yaml composition.yaml func.yaml --include-full-xr | crossplane beta validate extensionsDir/ -
 
@@ -85,6 +93,10 @@ func (c *Cmd) AfterApply() error {
 func (c *Cmd) Run(k *kong.Context, _ logging.Logger) error {
 	if c.Resources == "-" && c.Extensions == "-" {
 		return errors.New("cannot use stdin for both extensions and resources")
+	}
+
+	if len(c.CrossplaneImage) < 1 {
+		c.CrossplaneImage = fmt.Sprintf("%s/crossplane/crossplane:%s", xpkg.DefaultRegistry, version.New().GetVersionString())
 	}
 
 	// Load all extensions
@@ -122,7 +134,7 @@ func (c *Cmd) Run(k *kong.Context, _ logging.Logger) error {
 	}
 
 	// Download package base layers to cache and load them as CRDs
-	if err := m.CacheAndLoad(c.CleanCache); err != nil {
+	if err := m.CacheAndLoad(c.CleanCache, c.CrossplaneImage); err != nil {
 		return errors.Wrapf(err, "cannot download and load cache")
 	}
 

--- a/cmd/crank/beta/validate/image.go
+++ b/cmd/crank/beta/validate/image.go
@@ -17,7 +17,12 @@ limitations under the License.
 package validate
 
 import (
+	"archive/tar"
 	"fmt"
+	"io"
+	"log"
+	"os"
+	"path/filepath"
 	"sort"
 	"strings"
 
@@ -29,25 +34,83 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/errors"
 )
 
+const maxDecompressedSize = 200 * 1024 * 1024 // 200 MB
+
 // ImageFetcher defines an interface for fetching images.
 type ImageFetcher interface {
 	FetchBaseLayer(image string) (*conregv1.Layer, error)
+	FetchImage(image string) ([][]byte, error)
 }
 
 // Fetcher implements the ImageFetcher interface.
 type Fetcher struct{}
 
+// FetchImage pulls the full image and extracts the CRDs folder to fetch .yaml files.
+func (f *Fetcher) FetchImage(image string) ([][]byte, error) {
+	image, err := prepareImageReference(image)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to prepare image reference")
+	}
+
+	// Pull the image
+	img, err := crane.Pull(image)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to pull image")
+	}
+
+	// Create a temporary directory to extract the files
+	tmpDir, err := os.MkdirTemp("", "image-extract")
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to create temporary directory")
+	}
+	defer func() {
+		if err := os.RemoveAll(tmpDir); err != nil {
+			log.Printf("Failed to remove temporary directory: %v", err)
+		}
+	}()
+
+	// Extract the layers of the image into the temporary directory
+	layers, err := img.Layers()
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to get image layers")
+	}
+
+	for _, layer := range layers {
+		if err := extractLayer(layer, tmpDir); err != nil {
+			return nil, errors.Wrapf(err, "failed to extract layer")
+		}
+	}
+
+	// Search for .yaml files in the "crds" directory
+	var yamlFiles [][]byte
+	err = filepath.Walk(tmpDir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		// Check if the file is in the "crds" directory and has a .yaml extension
+		if strings.Contains(path, "/crds/") && strings.HasSuffix(info.Name(), ".yaml") {
+			content, err := os.ReadFile(filepath.Clean(path))
+			if err != nil {
+				return errors.Wrapf(err, "failed to read file: %s", path)
+			}
+			yamlFiles = append(yamlFiles, content)
+		}
+
+		return nil
+	})
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to walk through extracted files")
+	}
+
+	return yamlFiles, nil
+}
+
 // FetchBaseLayer fetches the base layer of the image which contains the 'package.yaml' file.
 func (f *Fetcher) FetchBaseLayer(image string) (*conregv1.Layer, error) {
-	if strings.Contains(image, "@") {
-		// Strip the digest before fetching the image
-		image = strings.SplitN(image, "@", 2)[0]
-	} else if strings.Contains(image, ":") {
-		var err error
-		image, err = findImageTagForVersionConstraint(image)
-		if err != nil {
-			return nil, errors.Wrapf(err, "cannot find image tag for version constraint")
-		}
+	image, err := prepareImageReference(image)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to prepare image reference")
 	}
 
 	cBytes, err := crane.Config(image)
@@ -164,4 +227,87 @@ func extractPackageContent(layer conregv1.Layer) ([][]byte, []byte, error) {
 
 	// the last obj is not yaml, so we need to remove it
 	return objs[1 : len(objs)-1], []byte(metaStr), nil
+}
+
+// extractLayer extracts the contents of a layer to the specified directory.
+func extractLayer(layer conregv1.Layer, destDir string) error { //nolint:gocognit // no extra func
+	r, err := layer.Uncompressed()
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if err := r.Close(); err != nil {
+			log.Printf("Failed to close reader: %v", err)
+		}
+	}()
+
+	tr := tar.NewReader(r)
+
+	for {
+		hdr, err := tr.Next()
+		if errors.Is(err, io.EOF) {
+			break // End of tar archive
+		}
+		if err != nil {
+			return err
+		}
+
+		// Resolve the target path
+		target := filepath.Join(destDir, filepath.Clean(hdr.Name))
+		targetPath, err := filepath.Abs(target)
+		if err != nil {
+			return errors.Wrap(err, "failed to get absolute path")
+		}
+
+		// Skip entries that are the same as the destination directory or just "./"
+		if targetPath == filepath.Clean(destDir) || hdr.Name == "./" {
+			continue
+		}
+
+		// Ensure the target path is within the destination directory
+		if !strings.HasPrefix(targetPath, filepath.Clean(destDir)+string(os.PathSeparator)) {
+			return errors.Errorf("invalid file path: %s", targetPath)
+		}
+
+		// Create the file or directory
+		switch hdr.Typeflag {
+		case tar.TypeDir:
+			if err := os.MkdirAll(targetPath, 0o750); err != nil {
+				return errors.Wrapf(err, "cannot create directory: %s", targetPath)
+			}
+		case tar.TypeReg:
+			dir := filepath.Dir(targetPath)
+			if err := os.MkdirAll(dir, 0o750); err != nil {
+				return errors.Wrapf(err, "cannot create directory: %s", dir)
+			}
+			file, err := os.Create(filepath.Clean(targetPath))
+			if err != nil {
+				return errors.Wrapf(err, "cannot create file: %s", targetPath)
+			}
+			defer func() {
+				if err := file.Close(); err != nil {
+					log.Printf("Failed to close file: %v", err)
+				}
+			}()
+
+			// Limit the decompression size to avoid DoS attacks
+			limitedReader := io.LimitReader(tr, maxDecompressedSize)
+			if _, err := io.Copy(file, limitedReader); err != nil {
+				return errors.Wrapf(err, "cannot decompress file: %s", targetPath)
+			}
+		}
+	}
+
+	return nil
+}
+
+// prepareImageReference prepares the image reference by stripping the digest or resolving the tag if necessary.
+func prepareImageReference(image string) (string, error) {
+	if strings.Contains(image, "@") {
+		return strings.SplitN(image, "@", 2)[0], nil
+	}
+	if strings.Contains(image, ":") {
+		return findImageTagForVersionConstraint(image)
+	}
+	return image, nil
 }


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane! Please read the contribution docs
(linked below) if this is your first Crossplane pull request.
-->

### Description of your changes
crank cli local build via: `go build -ldflags="-X 'github.com/crossplane/crossplane/internal/version.version=v1.16.0'"`

In `crossplane beta validate`, a new default option was introduced to validate against built-in CRDs (Compositions, EnvironmentConfigs, StoreConfig etc) directly from the Crossplane image.
By default, the Crossplane image corresponding to the version used to build the binary is utilized. However, you can override this by specifying a different image location. 

```bash
crossplane beta validate crossplane.yaml composition.yaml --crossplane-image=xpkg.upbound.io/upbound/crossplane:v1.16.0-up.1
```

```bash
crossplane beta validate crossplane.yaml composition.yaml --crossplane-image=xpkg.upbound.io/crossplane/crossplane:v1.14.0
```

When a Composition is included in the Resources input parameter, we will verify if it is set to pipeline mode. If it is, we will extract the input for each pipeline step as an additional resource and append it to the Resources list. This allows for validation against the function's input schema if a function is specified (in Extensions input parameter like crossplane.yaml)


#### before this PR

```
crossplane beta validate crossplane.yaml composition.yaml

[!] could not find CRD/XRD for: apiextensions.crossplane.io/v1, Kind=Composition
Total 1 resources: 1 missing schemas, 0 success cases, 0 failure cases
```

```
crossplane beta render xr.yaml composition.yaml functions.yaml | crossplane beta validate crossplane.yaml -

[!] could not find CRD/XRD for: aws.platform.upbound.io/v1alpha1, Kind=XKarpenter
[!] could not find CRD/XRD for: apiextensions.crossplane.io/v1alpha1, Kind=EnvironmentConfig
Total 2 resources: 2 missing schemas, 0 success cases, 0 failure cases

```

#### with this PR
here is a repo with test-cases: https://github.com/haarchri/xp-validate-test-cases

```
crossplane beta validate crossplane.yaml composition.yaml

schemas does not exist, downloading:  xpkg.upbound.io/crossplane/crossplane:v1.16.0
schemas does not exist, downloading:  xpkg.upbound.io/crossplane-contrib/function-patch-and-transform:v0.7.0
[✓] pt.fn.crossplane.io/v1beta1, Kind=Resources,  validated successfully
[✓] apiextensions.crossplane.io/v1, Kind=Composition, pat.xkarpenters.aws.platform.upbound.io validated successfully
Total 2 resources: 0 missing schemas, 2 success cases, 0 failure cases
```


```
crossplane beta render xr.yaml composition.yaml functions.yaml  | crossplane beta validate crossplane.yaml -

[!] could not find CRD/XRD for: aws.platform.upbound.io/v1alpha1, Kind=XKarpenter
[✓] apiextensions.crossplane.io/v1alpha1, Kind=EnvironmentConfig, example-environment validated successfully
Total 2 resources: 1 missing schemas, 1 success cases, 0 failure cases
```

lets validate a bad composition.yaml with patch-and-transform function step:

```
crossplane beta validate crossplane.yaml composition.yaml

schemas does not exist, downloading:  xpkg.upbound.io/crossplane/crossplane:v1.16.0
schemas does not exist, downloading:  xpkg.upbound.io/crossplane-contrib/function-patch-and-transform:v0.7.0
[x] schema validation error pt.fn.crossplane.io/v1beta1, Kind=Resources,  : resources[0].name: Required value
[x] schema validation error pt.fn.crossplane.io/v1beta1, Kind=Resources,  : patches: Invalid value: "patches": unknown field: "patches"
[✓] apiextensions.crossplane.io/v1, Kind=Composition, pat.xkarpenters.aws.platform.upbound.io validated successfully
Total 2 resources: 0 missing schemas, 1 success cases, 1 failure cases
crossplane: error: cannot validate resources: could not validate all resources
```


<!--
Briefly describe what this pull request does, and how it is covered by tests.
Be proactive - direct your reviewers' attention to anything that needs special
consideration.

We love pull requests that fix an open issue. If yours does, use the below line
to indicate which issue it fixes, for example "Fixes #500".
-->

Implementes parts of #5861
Fixes: #5859 #5094

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `earthly +reviewable` to ensure this PR is ready for review.
- [x] Added or updated unit tests.
- [x] Added or updated e2e tests.
- [x] Linked a PR or a [docs tracking issue] to [document this change].
- [x] Added `backport release-x.y` labels to auto-backport this PR.

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/master/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/master/contributing#checklist-cheat-sheet
