### PR TITLE
Omit docker login registry arg when promoting tag in Docker Hub

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -389,7 +389,13 @@ ci-promote-image:
   ARG --required CHANNEL
   FROM alpine:3.20
   RUN apk add docker
-  RUN --secret DOCKER_USER --secret DOCKER_PASSWORD docker login -u ${DOCKER_USER} -p ${DOCKER_PASSWORD} ${CROSSPLANE_REPO}
+  # We need to omit the registry argument when we're logging into Docker Hub.
+  # Otherwise login will appear to succeed, but buildx will fail on auth.
+  IF [[ "${CROSSPLANE_REPO}" == *docker.io/* ]]
+    RUN --secret DOCKER_USER --secret DOCKER_PASSWORD docker login -u ${DOCKER_USER} -p ${DOCKER_PASSWORD}
+  ELSE
+    RUN --secret DOCKER_USER --secret DOCKER_PASSWORD docker login -u ${DOCKER_USER} -p ${DOCKER_PASSWORD} ${CROSSPLANE_REPO}
+  END
   RUN --push docker buildx imagetools create \
     --tag ${CROSSPLANE_REPO}:${CHANNEL} \
     --tag ${CROSSPLANE_REPO}:${CROSSPLANE_VERSION}-${CHANNEL} \


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane! Please read the contribution docs
(linked below) if this is your first Crossplane pull request.
-->

### Description of your changes

<!--
Briefly describe what this pull request does, and how it is covered by tests.
Be proactive - direct your reviewers' attention to anything that needs special
consideration.

We love pull requests that fix an open issue. If yours does, use the below line
to indicate which issue it fixes, for example "Fixes #500".
-->

Apparently you get a magic URL in your Docker config file when you omit the registry. It seems to be needed to successfully push.

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `earthly +reviewable` to ensure this PR is ready for review.
- [ ] ~Added or updated unit tests.~
- [ ] ~Added or updated e2e tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/master/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/master/contributing#checklist-cheat-sheet
