### PR TITLE
Implement bring-your-own ServiceAccount in helm chart

### DIFF
--- a/cluster/charts/crossplane/README.md
+++ b/cluster/charts/crossplane/README.md
@@ -123,7 +123,9 @@ and their default values.
 | `securityContextRBACManager.runAsGroup` | The group ID used by the RBAC Manager pod. | `65532` |
 | `securityContextRBACManager.runAsUser` | The user ID used by the RBAC Manager pod. | `65532` |
 | `service.customAnnotations` | Configure annotations on the service object. Only enabled when webhooks.enabled = true | `{}` |
+| `serviceAccount.create` | Create the Crossplane ServiceAccount automatically. | `true` |
 | `serviceAccount.customAnnotations` | Add custom `annotations` to the Crossplane ServiceAccount. | `{}` |
+| `serviceAccount.name` | Define the Crossplane ServiceAccount name. | `""` |
 | `tolerations` | Add `tolerations` to the Crossplane pod deployment. | `[]` |
 | `topologySpreadConstraints` | Add `topologySpreadConstraints` to the Crossplane pod deployment. | `[]` |
 | `webhooks.enabled` | Enable webhooks for Crossplane and installed Provider packages. | `true` |

--- a/cluster/charts/crossplane/templates/_helpers.tpl
+++ b/cluster/charts/crossplane/templates/_helpers.tpl
@@ -41,3 +41,12 @@ true
 false
 {{- end -}}
 {{- end -}}
+
+{{/* Create the name of service account to use */}}
+{{- define "crossplane.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "crossplane.name" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}

--- a/cluster/charts/crossplane/templates/clusterrolebinding.yaml
+++ b/cluster/charts/crossplane/templates/clusterrolebinding.yaml
@@ -11,5 +11,5 @@ roleRef:
   name: {{ template "crossplane.name" . }}
 subjects:
 - kind: ServiceAccount
-  name: {{ template "crossplane.name" . }}
+  name: {{ template "crossplane.serviceAccountName". }}
   namespace: {{ .Release.Namespace }}

--- a/cluster/charts/crossplane/templates/deployment.yaml
+++ b/cluster/charts/crossplane/templates/deployment.yaml
@@ -44,7 +44,7 @@ spec:
       {{- if .Values.priorityClassName }}
       priorityClassName: {{ .Values.priorityClassName  | quote }}
       {{- end }}
-      serviceAccountName: {{ template "crossplane.name" . }}
+      serviceAccountName: {{ include "crossplane.serviceAccountName" . }}
       hostNetwork: {{ .Values.hostNetwork }}
       initContainers:
         - image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default (printf "v%s" .Chart.AppVersion) }}"

--- a/cluster/charts/crossplane/templates/serviceaccount.yaml
+++ b/cluster/charts/crossplane/templates/serviceaccount.yaml
@@ -1,7 +1,8 @@
+{{- if .Values.serviceAccount.create }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ template "crossplane.name" . }}
+  name: {{ include "crossplane.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "crossplane.name" . }}
@@ -15,3 +16,4 @@ imagePullSecrets:
 - name: {{ $secret }}
 {{- end }}
 {{ end }}
+{{- end }}

--- a/cluster/charts/crossplane/values.yaml
+++ b/cluster/charts/crossplane/values.yaml
@@ -39,6 +39,10 @@ customAnnotations: {}
 serviceAccount:
   # -- Add custom `annotations` to the Crossplane ServiceAccount.
   customAnnotations: {}
+  # -- Create the Crossplane ServiceAccount automatically.
+  create: true
+  # -- Define the Crossplane ServiceAccount name.
+  name: ""
 
 # -- Enable [leader election](https://docs.crossplane.io/latest/concepts/pods/#leader-election) for the Crossplane pod.
 leaderElection: true


### PR DESCRIPTION
### Description of your changes

This change is another implementation for the helm chart which allows setting custom service accounts. 
There have been PRs (#2756, #3374) which only contain a simple create flag and it has been discussed that it would make sense to also pass a custom serviceAccount name that is compliant with the crossplane name override. This PR implements both. 

There's also another one (#5870) with an implementation but lacks the defaulting mechanism.

In general this is also a well-known pattern in helm charts ([example](https://github.com/prometheus-community/helm-charts/blob/71845c4d5795ec552e3ea96036c39dcfb97132ad/charts/alertmanager/values.yaml#L40-L47), [another example](https://github.com/argoproj/argo-helm/blob/a5dc0350b9c9834a3c691aa6ed5c6be408b72e5c/charts/argo-cd/values.yaml#L804-L814)).

A use case for that is utilizing workload identities in GKE/AKS with the [Control Plane of Control Planes](https://docs.crossplane.io/latest/guides/multi-tenant/#control-plane-of-control-planes) pattern. When a cluster is provisioned from a composition a service account with the corresponding identity can be provisoned aswell and used by crossplane.

Fixes #2755  

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `earthly +reviewable` to ensure this PR is ready for review.
- [ ] Added or updated unit tests.
- [ ] Added or updated e2e tests.
- [ ] Linked a PR or a [docs tracking issue] to [document this change].
- [ ] Added `backport release-x.y` labels to auto-backport this PR.

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
