### PR TITLE
Make composition revision numbers mutable

### DIFF
--- a/apis/apiextensions/v1/composition_revision_types.go
+++ b/apis/apiextensions/v1/composition_revision_types.go
@@ -126,7 +126,11 @@ type CompositionRevisionSpec struct {
 	PublishConnectionDetailsWithStoreConfigRef *StoreConfigReference `json:"publishConnectionDetailsWithStoreConfigRef,omitempty"`
 
 	// Revision number. Newer revisions have larger numbers.
-	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="Value is immutable"
+	//
+	// This number can change. When a Composition transitions from state A
+	// -> B -> A there will be only two CompositionRevisions. Crossplane will
+	// edit the original CompositionRevision to change its revision number from
+	// 0 to 2.
 	Revision int64 `json:"revision"`
 }
 

--- a/apis/apiextensions/v1beta1/zz_generated.composition_revision_types.go
+++ b/apis/apiextensions/v1beta1/zz_generated.composition_revision_types.go
@@ -128,7 +128,11 @@ type CompositionRevisionSpec struct {
 	PublishConnectionDetailsWithStoreConfigRef *StoreConfigReference `json:"publishConnectionDetailsWithStoreConfigRef,omitempty"`
 
 	// Revision number. Newer revisions have larger numbers.
-	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="Value is immutable"
+	//
+	// This number can change. When a Composition transitions from state A
+	// -> B -> A there will be only two CompositionRevisions. Crossplane will
+	// edit the original CompositionRevision to change its revision number from
+	// 0 to 2.
 	Revision int64 `json:"revision"`
 }
 

--- a/cluster/crds/apiextensions.crossplane.io_compositionrevisions.yaml
+++ b/cluster/crds/apiextensions.crossplane.io_compositionrevisions.yaml
@@ -1587,12 +1587,16 @@ spec:
                   type: object
                 type: array
               revision:
-                description: Revision number. Newer revisions have larger numbers.
+                description: |-
+                  Revision number. Newer revisions have larger numbers.
+
+
+                  This number can change. When a Composition transitions from state A
+                  -> B -> A there will be only two CompositionRevisions. Crossplane will
+                  edit the original CompositionRevision to change its revision number from
+                  0 to 2.
                 format: int64
                 type: integer
-                x-kubernetes-validations:
-                - message: Value is immutable
-                  rule: self == oldSelf
               writeConnectionSecretsToNamespace:
                 description: |-
                   WriteConnectionSecretsToNamespace specifies the namespace in which the
@@ -3234,12 +3238,16 @@ spec:
                   type: object
                 type: array
               revision:
-                description: Revision number. Newer revisions have larger numbers.
+                description: |-
+                  Revision number. Newer revisions have larger numbers.
+
+
+                  This number can change. When a Composition transitions from state A
+                  -> B -> A there will be only two CompositionRevisions. Crossplane will
+                  edit the original CompositionRevision to change its revision number from
+                  0 to 2.
                 format: int64
                 type: integer
-                x-kubernetes-validations:
-                - message: Value is immutable
-                  rule: self == oldSelf
               writeConnectionSecretsToNamespace:
                 description: |-
                   WriteConnectionSecretsToNamespace specifies the namespace in which the


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane! Please read the contribution docs
(linked below) if this is your first Crossplane pull request.
-->

### Description of your changes

<!--
Briefly describe what this pull request does, and how it is covered by tests.
Be proactive - direct your reviewers' attention to anything that needs special
consideration.

We love pull requests that fix an open issue. If yours does, use the below line
to indicate which issue it fixes, for example "Fixes #500".
-->

Fixes #5928 

Revision numbers were made immutable by mistake. See https://github.com/crossplane/crossplane/issues/5928#issuecomment-2332894884 for context.


I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `earthly +reviewable` to ensure this PR is ready for review.
- [ ] ~Added or updated unit tests.~
- [ ] ~Added or updated e2e tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [x] Added `backport release-x.y` labels to auto-backport this PR.

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
