### PR TITLE
Fix "Missing node in tree error" after updating a package source

### DIFF
--- a/internal/controller/pkg/revision/dependency.go
+++ b/internal/controller/pkg/revision/dependency.go
@@ -137,6 +137,24 @@ func (m *PackageDependencyManager) Resolve(ctx context.Context, pkg runtime.Obje
 		Dependencies: sources,
 	}
 
+	// Delete packages in lock with same name and distinct source
+	// This is a corner case when source is updated but image SHA is not (i.e. relocate same image
+	// to another registry)
+	for _, lp := range lock.Packages {
+		if self.Name == lp.Name &&
+			self.Type == lp.Type &&
+			self.Source != lp.Identifier() {
+			if err := m.RemoveSelf(ctx, pr); err != nil {
+				return found, installed, invalid, err
+			}
+			// refresh the lock to be in sync with the contents
+			if err = m.client.Get(ctx, types.NamespacedName{Name: lockName}, lock); err != nil {
+				return found, installed, invalid, err
+			}
+			break
+		}
+	}
+
 	prExists := false
 	for _, lp := range lock.Packages {
 		if lp.Name == pr.GetName() {

--- a/internal/controller/pkg/revision/dependency.go
+++ b/internal/controller/pkg/revision/dependency.go
@@ -141,9 +141,7 @@ func (m *PackageDependencyManager) Resolve(ctx context.Context, pkg runtime.Obje
 	// This is a corner case when source is updated but image SHA is not (i.e. relocate same image
 	// to another registry)
 	for _, lp := range lock.Packages {
-		if self.Name == lp.Name &&
-			self.Type == lp.Type &&
-			self.Source != lp.Identifier() {
+		if self.Name == lp.Name && self.Type == lp.Type && self.Source != lp.Identifier() {
 			if err := m.RemoveSelf(ctx, pr); err != nil {
 				return found, installed, invalid, err
 			}

--- a/internal/controller/pkg/revision/dependency_test.go
+++ b/internal/controller/pkg/revision/dependency_test.go
@@ -42,6 +42,7 @@ var _ DependencyManager = &PackageDependencyManager{}
 
 func TestResolve(t *testing.T) {
 	errBoom := errors.New("boom")
+	mockUpdateCallCount := 0
 
 	type args struct {
 		dep  *PackageDependencyManager
@@ -553,9 +554,68 @@ func TestResolve(t *testing.T) {
 				invalid:   0,
 			},
 		},
+		"SuccessfulLockPackageSourceMismatch": {
+			reason: "Should not return error if source in packages does not match provider revision package.",
+			args: args{
+				dep: &PackageDependencyManager{
+					client: &test.MockClient{
+						MockGet: test.NewMockGetFn(nil, func(obj client.Object) error {
+							l := obj.(*v1beta1.Lock)
+							if mockUpdateCallCount < 1 {
+								l.Packages = []v1beta1.LockPackage{
+									{
+										Name: "config-nop-a-abc123",
+										// Source mistmatch provider revision package
+										Source: "hasheddan/config-nop-b",
+									},
+								}
+							} else {
+								l.Packages = []v1beta1.LockPackage{}
+							}
+							return nil
+						}),
+						MockUpdate: func(_ context.Context, _ client.Object, _ ...client.UpdateOption) error {
+							mockUpdateCallCount++
+							return nil
+						},
+					},
+					newDag: func() dag.DAG {
+						return &dagfake.MockDag{
+							MockInit: func(_ []dag.Node) ([]dag.Node, error) {
+								return []dag.Node{}, nil
+							},
+							MockTraceNode: func(s string) (map[string]dag.Node, error) {
+								if s == "hasheddan/config-nop-a" {
+									return map[string]dag.Node{
+										s: &v1beta1.Dependency{},
+									}, nil
+								}
+								return nil, errors.New("missing node in tree")
+							},
+							MockAddOrUpdateNodes: func(_ ...dag.Node) {},
+						}
+					},
+				},
+				meta: &pkgmetav1.Configuration{},
+				pr: &v1.ConfigurationRevision{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "config-nop-a-abc123",
+					},
+					Spec: v1.PackageRevisionSpec{
+						Package:      "hasheddan/config-nop-a:v0.0.1",
+						DesiredState: v1.PackageRevisionActive,
+					},
+				},
+			},
+			want: want{
+				total:     1,
+				installed: 1,
+			},
+		},
 	}
 
 	for name, tc := range cases {
+		mockUpdateCallCount = 0
 		t.Run(name, func(t *testing.T) {
 			total, installed, invalid, err := tc.args.dep.Resolve(context.TODO(), tc.args.meta, tc.args.pr)
 


### PR DESCRIPTION
### Description of your changes
This PR fixes "Missing node in tree error" after updating a package source when image is not updated.
The issue happens because package in lock is updated with new source, but providerrevision is not updated because image SHA is not changed (providerrevision name is created from provider name + image SHA).
This causes "Missing node in tree error" when installing the package because of the mismatch between old source and new source for the same provider (or function).

The PR:
- deletes a package from the lock when there is a source mismatch. This allows the reconciler to install the package from updated source.
- adds a unit test.

Fixes #3985 

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `earthly +reviewable` to ensure this PR is ready for review.
- [x] Added or updated unit tests.
- [ ] ~Added or updated e2e tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [x] Added `backport release-x.y` labels to auto-backport this PR.

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
