### PR TITLE
feat(pkg-mgr): Support package installation with digests

### DIFF
--- a/apis/pkg/v1beta1/lock.go
+++ b/apis/pkg/v1beta1/lock.go
@@ -94,7 +94,7 @@ type Dependency struct {
 	// Type is the type of package. Can be either Configuration or Provider.
 	Type PackageType `json:"type"`
 
-	// Constraints is a valid semver range, which will be used to select a valid
+	// Constraints is a valid semver range or a digest, which will be used to select a valid
 	// dependency version.
 	Constraints string `json:"constraints"`
 }

--- a/cluster/crds/pkg.crossplane.io_locks.yaml
+++ b/cluster/crds/pkg.crossplane.io_locks.yaml
@@ -54,7 +54,7 @@ spec:
                     properties:
                       constraints:
                         description: |-
-                          Constraints is a valid semver range, which will be used to select a valid
+                          Constraints is a valid semver range or a digest, which will be used to select a valid
                           dependency version.
                         type: string
                       package:

--- a/internal/controller/pkg/manager/revisioner_test.go
+++ b/internal/controller/pkg/manager/revisioner_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	conregv1 "github.com/google/go-containerregistry/pkg/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -94,6 +95,33 @@ func TestPackageRevisioner(t *testing.T) {
 			},
 			want: want{
 				digest: "return-me",
+			},
+		},
+		"SuccessfulDigest": {
+			reason: "Should return the digest of the package source image.",
+			args: args{
+				pkg: &v1.Provider{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "provider-nop",
+					},
+					Spec: v1.ProviderSpec{
+						PackageSpec: v1.PackageSpec{
+							Package:           "crossplane-contrib/provider-nop@sha256:ecc25c121431dfc7058754427f97c034ecde26d4aafa0da16d258090e0443904",
+							PackagePullPolicy: &pullIfNotPresent,
+						},
+					},
+				},
+				f: &fake.MockFetcher{
+					MockHead: fake.NewMockHeadFn(&conregv1.Descriptor{
+						Digest: conregv1.Hash{
+							Algorithm: "sha256",
+							Hex:       "ecc25c121431dfc7058754427f97c034ecde26d4aafa0da16d258090e0443904",
+						},
+					}, nil),
+				},
+			},
+			want: want{
+				digest: "provider-nop-ecc25c121431",
 			},
 		},
 		"ErrParseRef": {


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane! Please read the contribution docs
(linked below) if this is your first Crossplane pull request.
-->

### Description of your changes
With this change, we'll be able to install packages with digests instead of tags.

Installation of a package with digest:
```
Every 2,0s: kubectl get pkg                                                                                                                                                                Ezgis-MacBook-Pro.local: Tue Sep 17 15:30:27 2024

NAME                                                            INSTALLED   HEALTHY   PACKAGE                                                                                                                         AGE
configuration.pkg.crossplane.io/configuration-getting-started   True        False     xpkg.upbound.io/upbound/configuration-getting-started@sha256:869bca254eb12f2d5d9681ac7186f13e67e2984e68f18e6195492d37e4fb42a2   29s

NAME                                                                         INSTALLED   HEALTHY   PACKAGE                                                                  AGE
function.pkg.crossplane.io/crossplane-contrib-function-patch-and-transform   True        True      xpkg.upbound.io/crossplane-contrib/function-patch-and-transform:v0.6.0   20s

NAME                                                         INSTALLED   HEALTHY   PACKAGE                                                  AGE
provider.pkg.crossplane.io/crossplane-contrib-provider-nop   True        True      xpkg.upbound.io/crossplane-contrib/provider-nop:v0.2.1   25s
```

Installation of a package with a dependency with digest:
```
Every 2,0s: kubectl get pkg                                                                                                                                                                Ezgis-MacBook-Pro.local: Tue Sep 17 15:33:29 2024

NAME                                                            INSTALLED   HEALTHY   PACKAGE                                                             AGE
configuration.pkg.crossplane.io/configuration-getting-started   True        Unknown   xpkg.upbound.io/ezgiorg/ezgi-configuration-getting-started:v0.2.0   31s

NAME                                                                INSTALLED   HEALTHY   PACKAGE                                                         AGE
function.pkg.crossplane.io/crossplane-contrib-function-auto-ready   True        True      xpkg.upbound.io/crossplane-contrib/function-auto-ready:v0.2.1   17s
function.pkg.crossplane.io/crossplane-contrib-function-kcl          True        True      xpkg.upbound.io/crossplane-contrib/function-kcl:v0.8.0          22s

NAME                                                         INSTALLED   HEALTHY   PACKAGE                                                                                                                   AGE
provider.pkg.crossplane.io/crossplane-contrib-provider-nop   True        True      xpkg.upbound.io/crossplane-contrib/provider-nop@sha256:ecc25c121431dfc7058754427f97c034ecde26d4aafa0da16d258090e0443904   27s

```
<!--
Briefly describe what this pull request does, and how it is covered by tests.
Be proactive - direct your reviewers' attention to anything that needs special
consideration.

We love pull requests that fix an open issue. If yours does, use the below line
to indicate which issue it fixes, for example "Fixes #500".
-->

Fixes #5920 

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `earthly +reviewable` to ensure this PR is ready for review.
- [x] Added or updated unit tests.
- [ ] ~Added or updated e2e tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
