### PR TITLE
feat: make package installation concurrency configurable

### DIFF
--- a/cmd/crossplane/core/core.go
+++ b/cmd/crossplane/core/core.go
@@ -97,9 +97,10 @@ type startCommand struct {
 
 	PackageRuntime string `default:"Deployment" env:"PACKAGE_RUNTIME" help:"The package runtime to use for packages with a runtime (e.g. Providers and Functions)"`
 
-	SyncInterval     time.Duration `default:"1h"  help:"How often all resources will be double-checked for drift from the desired state."                    short:"s"`
-	PollInterval     time.Duration `default:"1m"  help:"How often individual resources will be checked for drift from the desired state."`
-	MaxReconcileRate int           `default:"100" help:"The global maximum rate per second at which resources may checked for drift from the desired state."`
+	SyncInterval                     time.Duration `default:"1h"  help:"How often all resources will be double-checked for drift from the desired state."                      short:"s"`
+	PollInterval                     time.Duration `default:"1m"  help:"How often individual resources will be checked for drift from the desired state."`
+	MaxReconcileRate                 int           `default:"100" help:"The global maximum rate per second at which resources may checked for drift from the desired state."`
+	MaxConcurrentPackageEstablishers int           `default:"10"  help:"The the maximum number of goroutines to use for establishing Providers, Configurations and Functions."`
 
 	WebhookEnabled bool `default:"true" env:"WEBHOOK_ENABLED" help:"Enable webhook configuration."`
 
@@ -374,13 +375,14 @@ func (c *startCommand) Run(s *runtime.Scheme, log logging.Logger) error { //noli
 	}
 
 	po := pkgcontroller.Options{
-		Options:         o,
-		Cache:           xpkg.NewFsPackageCache(c.CacheDir, afero.NewOsFs()),
-		Namespace:       c.Namespace,
-		ServiceAccount:  c.ServiceAccount,
-		DefaultRegistry: c.Registry,
-		FetcherOptions:  []xpkg.FetcherOpt{xpkg.WithUserAgent(c.UserAgent)},
-		PackageRuntime:  pr,
+		Options:                          o,
+		Cache:                            xpkg.NewFsPackageCache(c.CacheDir, afero.NewOsFs()),
+		Namespace:                        c.Namespace,
+		ServiceAccount:                   c.ServiceAccount,
+		DefaultRegistry:                  c.Registry,
+		FetcherOptions:                   []xpkg.FetcherOpt{xpkg.WithUserAgent(c.UserAgent)},
+		PackageRuntime:                   pr,
+		MaxConcurrentPackageEstablishers: c.MaxConcurrentPackageEstablishers,
 	}
 
 	if c.CABundlePath != "" {

--- a/internal/controller/pkg/controller/options.go
+++ b/internal/controller/pkg/controller/options.go
@@ -45,4 +45,8 @@ type Options struct {
 
 	// PackageRuntime specifies the runtime to use for package runtime.
 	PackageRuntime PackageRuntime
+
+	// MaxConcurrentPackageEstablishers is the maximum number of goroutines to use
+	// for establishing Providers, Configurations and Functions.
+	MaxConcurrentPackageEstablishers int
 }

--- a/internal/controller/pkg/revision/establisher.go
+++ b/internal/controller/pkg/revision/establisher.go
@@ -42,12 +42,6 @@ import (
 )
 
 const (
-	// maxConcurrentEstablishers specifies the maximum number of goroutines to use
-	// for establishing resources.
-	maxConcurrentEstablishers = 10
-)
-
-const (
 	errAssertResourceObj            = "cannot assert object to resource.Object"
 	errAssertClientObj              = "cannot assert object to client.Object"
 	errConversionWithNoWebhookCA    = "cannot deploy a CRD with webhook conversion strategy without having a TLS bundle"
@@ -86,15 +80,17 @@ func (*NopEstablisher) ReleaseObjects(_ context.Context, _ v1.PackageRevision) e
 // APIEstablisher establishes control or ownership of resources in the API
 // server for a parent.
 type APIEstablisher struct {
-	client    client.Client
-	namespace string
+	client                           client.Client
+	namespace                        string
+	MaxConcurrentPackageEstablishers int
 }
 
 // NewAPIEstablisher creates a new APIEstablisher.
-func NewAPIEstablisher(client client.Client, namespace string) *APIEstablisher {
+func NewAPIEstablisher(client client.Client, namespace string, maxConcurrentPackageEstablishers int) *APIEstablisher {
 	return &APIEstablisher{
-		client:    client,
-		namespace: namespace,
+		client:                           client,
+		namespace:                        namespace,
+		MaxConcurrentPackageEstablishers: maxConcurrentPackageEstablishers,
 	}
 }
 
@@ -143,7 +139,7 @@ func (e *APIEstablisher) ReleaseObjects(ctx context.Context, parent v1.PackageRe
 	}
 
 	g, ctx := errgroup.WithContext(ctx)
-	g.SetLimit(maxConcurrentEstablishers)
+	g.SetLimit(e.MaxConcurrentPackageEstablishers)
 	for _, ref := range allObjs {
 		g.Go(func() error {
 			select {
@@ -231,7 +227,7 @@ func (e *APIEstablisher) validate(ctx context.Context, objs []runtime.Object, pa
 	}
 
 	g, ctx := errgroup.WithContext(ctx)
-	g.SetLimit(maxConcurrentEstablishers)
+	g.SetLimit(e.MaxConcurrentPackageEstablishers)
 	out := make(chan currentDesired, len(objs))
 	for _, res := range objs {
 		g.Go(func() error {
@@ -388,7 +384,7 @@ func (e *APIEstablisher) getWebhookTLSCert(ctx context.Context, parentWithRuntim
 
 func (e *APIEstablisher) establish(ctx context.Context, allObjs []currentDesired, parent client.Object, control bool) ([]xpv1.TypedReference, error) {
 	g, ctx := errgroup.WithContext(ctx)
-	g.SetLimit(maxConcurrentEstablishers)
+	g.SetLimit(e.MaxConcurrentPackageEstablishers)
 	out := make(chan xpv1.TypedReference, len(allObjs))
 	for _, cd := range allObjs {
 		g.Go(func() error {

--- a/internal/controller/pkg/revision/establisher_test.go
+++ b/internal/controller/pkg/revision/establisher_test.go
@@ -69,12 +69,10 @@ func TestAPIEstablisherEstablish(t *testing.T) {
 		"SuccessfulExistsEstablishControl": {
 			reason: "Establishment should be successful if we can establish control for a parent of existing objects.",
 			args: args{
-				est: &APIEstablisher{
-					client: &test.MockClient{
-						MockGet:    test.NewMockGetFn(nil),
-						MockUpdate: test.NewMockUpdateFn(nil),
-					},
-				},
+				est: newAPIEstablisher(&test.MockClient{
+					MockGet:    test.NewMockGetFn(nil),
+					MockUpdate: test.NewMockUpdateFn(nil),
+				}),
 				objs: []runtime.Object{
 					&extv1.CustomResourceDefinition{
 						ObjectMeta: metav1.ObjectMeta{
@@ -104,12 +102,10 @@ func TestAPIEstablisherEstablish(t *testing.T) {
 		"SuccessfulNotExistsEstablishControl": {
 			reason: "Establishment should be successful if we can establish control for a parent of new objects.",
 			args: args{
-				est: &APIEstablisher{
-					client: &test.MockClient{
-						MockGet:    test.NewMockGetFn(kerrors.NewNotFound(schema.GroupResource{}, "")),
-						MockCreate: test.NewMockCreateFn(nil),
-					},
-				},
+				est: newAPIEstablisher(&test.MockClient{
+					MockGet:    test.NewMockGetFn(kerrors.NewNotFound(schema.GroupResource{}, "")),
+					MockCreate: test.NewMockCreateFn(nil),
+				}),
 				objs: []runtime.Object{
 					&extv1.CustomResourceDefinition{
 						ObjectMeta: metav1.ObjectMeta{
@@ -139,22 +135,20 @@ func TestAPIEstablisherEstablish(t *testing.T) {
 		"SuccessfulNotExistsEstablishControlWebhookEnabledActiveRevision": {
 			reason: "Establishment should be successful if we can establish control for a parent of new objects in case webhooks are enabled.",
 			args: args{
-				est: &APIEstablisher{
-					client: &test.MockClient{
-						MockGet: func(_ context.Context, _ client.ObjectKey, obj client.Object) error {
-							if s, ok := obj.(*corev1.Secret); ok {
-								(&corev1.Secret{
-									Data: map[string][]byte{
-										"tls.crt": caBundle,
-									},
-								}).DeepCopyInto(s)
-								return nil
-							}
-							return kerrors.NewNotFound(schema.GroupResource{}, "")
-						},
-						MockCreate: test.NewMockCreateFn(nil),
+				est: newAPIEstablisher(&test.MockClient{
+					MockGet: func(_ context.Context, _ client.ObjectKey, obj client.Object) error {
+						if s, ok := obj.(*corev1.Secret); ok {
+							(&corev1.Secret{
+								Data: map[string][]byte{
+									"tls.crt": caBundle,
+								},
+							}).DeepCopyInto(s)
+							return nil
+						}
+						return kerrors.NewNotFound(schema.GroupResource{}, "")
 					},
-				},
+					MockCreate: test.NewMockCreateFn(nil),
+				}),
 				objs: []runtime.Object{
 					&extv1.CustomResourceDefinition{
 						ObjectMeta: metav1.ObjectMeta{
@@ -223,12 +217,10 @@ func TestAPIEstablisherEstablish(t *testing.T) {
 		"SuccessfulExistsEstablishOwnership": {
 			reason: "Establishment should be successful if we can establish ownership for a parent of existing objects.",
 			args: args{
-				est: &APIEstablisher{
-					client: &test.MockClient{
-						MockGet:    test.NewMockGetFn(nil),
-						MockUpdate: test.NewMockUpdateFn(nil),
-					},
-				},
+				est: newAPIEstablisher(&test.MockClient{
+					MockGet:    test.NewMockGetFn(nil),
+					MockUpdate: test.NewMockUpdateFn(nil),
+				}),
 				objs: []runtime.Object{
 					&extv1.CustomResourceDefinition{
 						ObjectMeta: metav1.ObjectMeta{
@@ -246,12 +238,10 @@ func TestAPIEstablisherEstablish(t *testing.T) {
 		"SuccessfulNotExistsDoNotCreate": {
 			reason: "Establishment should be successful if we skip creating a resource we do not want to control.",
 			args: args{
-				est: &APIEstablisher{
-					client: &test.MockClient{
-						MockGet:    test.NewMockGetFn(kerrors.NewNotFound(schema.GroupResource{}, "")),
-						MockCreate: test.NewMockCreateFn(errBoom),
-					},
-				},
+				est: newAPIEstablisher(&test.MockClient{
+					MockGet:    test.NewMockGetFn(kerrors.NewNotFound(schema.GroupResource{}, "")),
+					MockCreate: test.NewMockCreateFn(errBoom),
+				}),
 				objs: []runtime.Object{
 					&extv1.CustomResourceDefinition{
 						ObjectMeta: metav1.ObjectMeta{
@@ -269,12 +259,10 @@ func TestAPIEstablisherEstablish(t *testing.T) {
 		"FailedCreationWebhookDisabledConversionRequested": {
 			reason: "Establishment should fail if the CRD requires conversion webhook and Crossplane does not have the webhooks enabled.",
 			args: args{
-				est: &APIEstablisher{
-					client: &test.MockClient{
-						MockGet:    test.NewMockGetFn(kerrors.NewNotFound(schema.GroupResource{}, "")),
-						MockCreate: test.NewMockCreateFn(nil),
-					},
-				},
+				est: newAPIEstablisher(&test.MockClient{
+					MockGet:    test.NewMockGetFn(kerrors.NewNotFound(schema.GroupResource{}, "")),
+					MockCreate: test.NewMockCreateFn(nil),
+				}),
 				objs: []runtime.Object{
 					&extv1.CustomResourceDefinition{
 						ObjectMeta: metav1.ObjectMeta{
@@ -309,11 +297,9 @@ func TestAPIEstablisherEstablish(t *testing.T) {
 		"FailedGettingWebhookTLSSecretControl": {
 			reason: "Establishment of a controlling revision should fail if a webhook TLS secret is given but cannot be fetched",
 			args: args{
-				est: &APIEstablisher{
-					client: &test.MockClient{
-						MockGet: test.NewMockGetFn(errBoom),
-					},
-				},
+				est: newAPIEstablisher(&test.MockClient{
+					MockGet: test.NewMockGetFn(errBoom),
+				}),
 				parent: &v1.ProviderRevision{
 					Spec: v1.ProviderRevisionSpec{
 						PackageRevisionRuntimeSpec: v1.PackageRevisionRuntimeSpec{
@@ -330,11 +316,9 @@ func TestAPIEstablisherEstablish(t *testing.T) {
 		"NoErrGettingWebhookTLSSecretNoControl": {
 			reason: "Establishment of a revision should not fail if a webhook TLS secret is given but cannot be fetched if we don't want to control resources",
 			args: args{
-				est: &APIEstablisher{
-					client: &test.MockClient{
-						MockGet: test.NewMockGetFn(errBoom),
-					},
-				},
+				est: newAPIEstablisher(&test.MockClient{
+					MockGet: test.NewMockGetFn(errBoom),
+				}),
 				parent: &v1.ProviderRevision{
 					Spec: v1.ProviderRevisionSpec{
 						PackageRevisionRuntimeSpec: v1.PackageRevisionRuntimeSpec{
@@ -351,15 +335,13 @@ func TestAPIEstablisherEstablish(t *testing.T) {
 		"FailedEmptyWebhookTLSSecretControl": {
 			reason: "Establishment should fail for a controlling revision if a webhook TLS secret is given but empty if we want to control resources",
 			args: args{
-				est: &APIEstablisher{
-					client: &test.MockClient{
-						MockGet: func(_ context.Context, _ client.ObjectKey, obj client.Object) error {
-							s := &corev1.Secret{}
-							s.DeepCopyInto(obj.(*corev1.Secret))
-							return nil
-						},
+				est: newAPIEstablisher(&test.MockClient{
+					MockGet: func(_ context.Context, _ client.ObjectKey, obj client.Object) error {
+						s := &corev1.Secret{}
+						s.DeepCopyInto(obj.(*corev1.Secret))
+						return nil
 					},
-				},
+				}),
 				parent: &v1.ProviderRevision{
 					Spec: v1.ProviderRevisionSpec{
 						PackageRevisionRuntimeSpec: v1.PackageRevisionRuntimeSpec{
@@ -376,15 +358,13 @@ func TestAPIEstablisherEstablish(t *testing.T) {
 		"NoErrEmptyWebhookTLSSecretNoControl": {
 			reason: "Establishment should not fail for an revision if a webhook TLS secret is given but empty if we don't want to control resources",
 			args: args{
-				est: &APIEstablisher{
-					client: &test.MockClient{
-						MockGet: func(_ context.Context, _ client.ObjectKey, obj client.Object) error {
-							s := &corev1.Secret{}
-							s.DeepCopyInto(obj.(*corev1.Secret))
-							return nil
-						},
+				est: newAPIEstablisher(&test.MockClient{
+					MockGet: func(_ context.Context, _ client.ObjectKey, obj client.Object) error {
+						s := &corev1.Secret{}
+						s.DeepCopyInto(obj.(*corev1.Secret))
+						return nil
 					},
-				},
+				}),
 				parent: &v1.ProviderRevision{
 					Spec: v1.ProviderRevisionSpec{
 						PackageRevisionRuntimeSpec: v1.PackageRevisionRuntimeSpec{
@@ -401,12 +381,10 @@ func TestAPIEstablisherEstablish(t *testing.T) {
 		"FailedCreate": {
 			reason: "Cannot establish control of object if we cannot create it.",
 			args: args{
-				est: &APIEstablisher{
-					client: &test.MockClient{
-						MockGet:    test.NewMockGetFn(kerrors.NewNotFound(schema.GroupResource{}, "")),
-						MockCreate: test.NewMockCreateFn(errBoom),
-					},
-				},
+				est: newAPIEstablisher(&test.MockClient{
+					MockGet:    test.NewMockGetFn(kerrors.NewNotFound(schema.GroupResource{}, "")),
+					MockCreate: test.NewMockCreateFn(errBoom),
+				}),
 				objs: []runtime.Object{
 					&extv1.CustomResourceDefinition{
 						ObjectMeta: metav1.ObjectMeta{
@@ -428,12 +406,10 @@ func TestAPIEstablisherEstablish(t *testing.T) {
 		"FailedUpdate": {
 			reason: "Cannot establish control of object if we cannot update it.",
 			args: args{
-				est: &APIEstablisher{
-					client: &test.MockClient{
-						MockGet:    test.NewMockGetFn(nil),
-						MockUpdate: test.NewMockUpdateFn(errBoom),
-					},
-				},
+				est: newAPIEstablisher(&test.MockClient{
+					MockGet:    test.NewMockGetFn(nil),
+					MockUpdate: test.NewMockUpdateFn(errBoom),
+				}),
 				objs: []runtime.Object{
 					&extv1.CustomResourceDefinition{
 						ObjectMeta: metav1.ObjectMeta{
@@ -493,13 +469,11 @@ func TestAPIEstablisherReleaseObjects(t *testing.T) {
 		"CannotGetObject": {
 			reason: "Should return an error if we cannot get the owned object.",
 			args: args{
-				est: &APIEstablisher{
-					client: &test.MockClient{
-						MockGet: func(_ context.Context, _ client.ObjectKey, _ client.Object) error {
-							return errBoom
-						},
+				est: newAPIEstablisher(&test.MockClient{
+					MockGet: func(_ context.Context, _ client.ObjectKey, _ client.Object) error {
+						return errBoom
 					},
-				},
+				}),
 				parent: &v1.ProviderRevision{
 					ObjectMeta: metav1.ObjectMeta{
 						UID: "some-unique-uid-2312",
@@ -522,13 +496,11 @@ func TestAPIEstablisherReleaseObjects(t *testing.T) {
 		"IgnoreOwnedObjectNotFound": {
 			reason: "Should ignore if we the owned object does not exist.",
 			args: args{
-				est: &APIEstablisher{
-					client: &test.MockClient{
-						MockGet: func(_ context.Context, _ client.ObjectKey, _ client.Object) error {
-							return kerrors.NewNotFound(schema.GroupResource{}, "")
-						},
+				est: newAPIEstablisher(&test.MockClient{
+					MockGet: func(_ context.Context, _ client.ObjectKey, _ client.Object) error {
+						return kerrors.NewNotFound(schema.GroupResource{}, "")
 					},
-				},
+				}),
 				parent: &v1.ProviderRevision{
 					ObjectMeta: metav1.ObjectMeta{
 						UID: "some-unique-uid-2312",
@@ -551,33 +523,31 @@ func TestAPIEstablisherReleaseObjects(t *testing.T) {
 		"CannotUpdate": {
 			reason: "Should return an error if we cannot update the owned object.",
 			args: args{
-				est: &APIEstablisher{
-					client: &test.MockClient{
-						MockGet: func(_ context.Context, _ client.ObjectKey, obj client.Object) error {
-							o := obj.(*unstructured.Unstructured)
-							o.SetOwnerReferences([]metav1.OwnerReference{
-								{
-									APIVersion: "pkg.crossplane.io/v1",
-									Kind:       "Provider",
-									Name:       "provider-helm",
-									UID:        "some-other-uid-1234",
-									Controller: &noControl,
-								},
-								{
-									APIVersion: "pkg.crossplane.io/v1",
-									Kind:       "ProviderRevision",
-									Name:       "provider-helm-ce18dd03e6e4",
-									UID:        "some-unique-uid-2312",
-									Controller: &controls,
-								},
-							})
-							return nil
-						},
-						MockUpdate: func(_ context.Context, _ client.Object, _ ...client.UpdateOption) error {
-							return errBoom
-						},
+				est: newAPIEstablisher(&test.MockClient{
+					MockGet: func(_ context.Context, _ client.ObjectKey, obj client.Object) error {
+						o := obj.(*unstructured.Unstructured)
+						o.SetOwnerReferences([]metav1.OwnerReference{
+							{
+								APIVersion: "pkg.crossplane.io/v1",
+								Kind:       "Provider",
+								Name:       "provider-helm",
+								UID:        "some-other-uid-1234",
+								Controller: &noControl,
+							},
+							{
+								APIVersion: "pkg.crossplane.io/v1",
+								Kind:       "ProviderRevision",
+								Name:       "provider-helm-ce18dd03e6e4",
+								UID:        "some-unique-uid-2312",
+								Controller: &controls,
+							},
+						})
+						return nil
 					},
-				},
+					MockUpdate: func(_ context.Context, _ client.Object, _ ...client.UpdateOption) error {
+						return errBoom
+					},
+				}),
 				parent: &v1.ProviderRevision{
 					ObjectMeta: metav1.ObjectMeta{
 						UID: "some-unique-uid-2312",
@@ -600,16 +570,14 @@ func TestAPIEstablisherReleaseObjects(t *testing.T) {
 		"NoObjectsInStatus": {
 			reason: "Should not return an error if there are no objects in the status.",
 			args: args{
-				est: &APIEstablisher{
-					client: &test.MockClient{
-						MockGet: func(_ context.Context, _ client.ObjectKey, _ client.Object) error {
-							return nil
-						},
-						MockUpdate: func(_ context.Context, _ client.Object, _ ...client.UpdateOption) error {
-							return nil
-						},
+				est: newAPIEstablisher(&test.MockClient{
+					MockGet: func(_ context.Context, _ client.ObjectKey, _ client.Object) error {
+						return nil
 					},
-				},
+					MockUpdate: func(_ context.Context, _ client.Object, _ ...client.UpdateOption) error {
+						return nil
+					},
+				}),
 				parent: &v1.ProviderRevision{
 					ObjectMeta: metav1.ObjectMeta{
 						UID: "some-unique-uid-2312",
@@ -623,34 +591,32 @@ func TestAPIEstablisherReleaseObjects(t *testing.T) {
 		"AlreadyReleased": {
 			reason: "ReleaseObjects should make no updates if the object is already released.",
 			args: args{
-				est: &APIEstablisher{
-					client: &test.MockClient{
-						MockGet: func(_ context.Context, _ client.ObjectKey, obj client.Object) error {
-							o := obj.(*unstructured.Unstructured)
-							o.SetOwnerReferences([]metav1.OwnerReference{
-								{
-									APIVersion: "pkg.crossplane.io/v1",
-									Kind:       "Provider",
-									Name:       "provider-helm",
-									UID:        "some-other-uid-1234",
-									Controller: &noControl,
-								},
-								{
-									APIVersion: "pkg.crossplane.io/v1",
-									Kind:       "ProviderRevision",
-									Name:       "provider-helm-ce18dd03e6e4",
-									UID:        "some-unique-uid-2312",
-									Controller: &noControl,
-								},
-							})
-							return nil
-						},
-						MockUpdate: func(_ context.Context, _ client.Object, _ ...client.UpdateOption) error {
-							t.Errorf("should not have called update")
-							return nil
-						},
+				est: newAPIEstablisher(&test.MockClient{
+					MockGet: func(_ context.Context, _ client.ObjectKey, obj client.Object) error {
+						o := obj.(*unstructured.Unstructured)
+						o.SetOwnerReferences([]metav1.OwnerReference{
+							{
+								APIVersion: "pkg.crossplane.io/v1",
+								Kind:       "Provider",
+								Name:       "provider-helm",
+								UID:        "some-other-uid-1234",
+								Controller: &noControl,
+							},
+							{
+								APIVersion: "pkg.crossplane.io/v1",
+								Kind:       "ProviderRevision",
+								Name:       "provider-helm-ce18dd03e6e4",
+								UID:        "some-unique-uid-2312",
+								Controller: &noControl,
+							},
+						})
+						return nil
 					},
-				},
+					MockUpdate: func(_ context.Context, _ client.Object, _ ...client.UpdateOption) error {
+						t.Errorf("should not have called update")
+						return nil
+					},
+				}),
 				parent: &v1.ProviderRevision{
 					ObjectMeta: metav1.ObjectMeta{
 						UID: "some-unique-uid-2312",
@@ -673,42 +639,40 @@ func TestAPIEstablisherReleaseObjects(t *testing.T) {
 		"OwnedIfNotAlready": {
 			reason: "ReleaseObjects should put owner reference back if we are not already the owner.",
 			args: args{
-				est: &APIEstablisher{
-					client: &test.MockClient{
-						MockGet: func(_ context.Context, _ client.ObjectKey, obj client.Object) error {
-							o := obj.(*unstructured.Unstructured)
-							o.SetOwnerReferences([]metav1.OwnerReference{
-								{
-									APIVersion: "pkg.crossplane.io/v1",
-									Kind:       "Provider",
-									Name:       "provider-helm",
-									UID:        "some-other-uid-1234",
-									Controller: &noControl,
-								},
-							})
-							return nil
-						},
-						MockUpdate: func(_ context.Context, obj client.Object, _ ...client.UpdateOption) error {
-							o := obj.(*unstructured.Unstructured)
-							if len(o.GetOwnerReferences()) != 2 {
-								t.Errorf("expected 2 owner references, got %d", len(o.GetOwnerReferences()))
-							}
-							found := false
-							for _, ref := range o.GetOwnerReferences() {
-								if ref.Kind == "ProviderRevision" && ref.UID == "some-unique-uid-2312" {
-									found = true
-									if ptr.Deref(ref.Controller, false) {
-										t.Errorf("expected controller to be false, got %t", *ref.Controller)
-									}
+				est: newAPIEstablisher(&test.MockClient{
+					MockGet: func(_ context.Context, _ client.ObjectKey, obj client.Object) error {
+						o := obj.(*unstructured.Unstructured)
+						o.SetOwnerReferences([]metav1.OwnerReference{
+							{
+								APIVersion: "pkg.crossplane.io/v1",
+								Kind:       "Provider",
+								Name:       "provider-helm",
+								UID:        "some-other-uid-1234",
+								Controller: &noControl,
+							},
+						})
+						return nil
+					},
+					MockUpdate: func(_ context.Context, obj client.Object, _ ...client.UpdateOption) error {
+						o := obj.(*unstructured.Unstructured)
+						if len(o.GetOwnerReferences()) != 2 {
+							t.Errorf("expected 2 owner references, got %d", len(o.GetOwnerReferences()))
+						}
+						found := false
+						for _, ref := range o.GetOwnerReferences() {
+							if ref.Kind == "ProviderRevision" && ref.UID == "some-unique-uid-2312" {
+								found = true
+								if ptr.Deref(ref.Controller, false) {
+									t.Errorf("expected controller to be false, got %t", *ref.Controller)
 								}
 							}
-							if !found {
-								t.Errorf("expected to find owner reference for revision with uid some-unique-uid-2312")
-							}
-							return nil
-						},
+						}
+						if !found {
+							t.Errorf("expected to find owner reference for revision with uid some-unique-uid-2312")
+						}
+						return nil
 					},
-				},
+				}),
 				parent: &v1.ProviderRevision{
 					TypeMeta: metav1.TypeMeta{
 						Kind: "ProviderRevision",
@@ -734,42 +698,40 @@ func TestAPIEstablisherReleaseObjects(t *testing.T) {
 		"SuccessfulRelease": {
 			reason: "ReleaseObjects should be successful if we can release control of existing objects",
 			args: args{
-				est: &APIEstablisher{
-					client: &test.MockClient{
-						MockGet: func(_ context.Context, _ client.ObjectKey, obj client.Object) error {
-							o := obj.(*unstructured.Unstructured)
-							o.SetOwnerReferences([]metav1.OwnerReference{
-								{
-									APIVersion: "pkg.crossplane.io/v1",
-									Kind:       "Provider",
-									Name:       "provider-helm",
-									UID:        "some-other-uid-1234",
-									Controller: &noControl,
-								},
-								{
-									APIVersion: "pkg.crossplane.io/v1",
-									Kind:       "ProviderRevision",
-									Name:       "provider-helm-ce18dd03e6e4",
-									UID:        "some-unique-uid-2312",
-									Controller: &controls,
-								},
-							})
-							return nil
-						},
-						MockUpdate: func(_ context.Context, obj client.Object, _ ...client.UpdateOption) error {
-							o := obj.(*unstructured.Unstructured)
-							if len(o.GetOwnerReferences()) != 2 {
-								t.Errorf("expected 2 owner references, got %d", len(o.GetOwnerReferences()))
-							}
-							for _, ref := range o.GetOwnerReferences() {
-								if ref.UID == "some-unique-uid-2312" && *ref.Controller {
-									t.Errorf("expected controller to be false, got %t", *ref.Controller)
-								}
-							}
-							return nil
-						},
+				est: newAPIEstablisher(&test.MockClient{
+					MockGet: func(_ context.Context, _ client.ObjectKey, obj client.Object) error {
+						o := obj.(*unstructured.Unstructured)
+						o.SetOwnerReferences([]metav1.OwnerReference{
+							{
+								APIVersion: "pkg.crossplane.io/v1",
+								Kind:       "Provider",
+								Name:       "provider-helm",
+								UID:        "some-other-uid-1234",
+								Controller: &noControl,
+							},
+							{
+								APIVersion: "pkg.crossplane.io/v1",
+								Kind:       "ProviderRevision",
+								Name:       "provider-helm-ce18dd03e6e4",
+								UID:        "some-unique-uid-2312",
+								Controller: &controls,
+							},
+						})
+						return nil
 					},
-				},
+					MockUpdate: func(_ context.Context, obj client.Object, _ ...client.UpdateOption) error {
+						o := obj.(*unstructured.Unstructured)
+						if len(o.GetOwnerReferences()) != 2 {
+							t.Errorf("expected 2 owner references, got %d", len(o.GetOwnerReferences()))
+						}
+						for _, ref := range o.GetOwnerReferences() {
+							if ref.UID == "some-unique-uid-2312" && *ref.Controller {
+								t.Errorf("expected controller to be false, got %t", *ref.Controller)
+							}
+						}
+						return nil
+					},
+				}),
 				parent: &v1.ProviderRevision{
 					ObjectMeta: metav1.ObjectMeta{
 						UID: "some-unique-uid-2312",
@@ -862,5 +824,12 @@ func TestGetPackageOwnerReference(t *testing.T) {
 				t.Errorf("\n%s\ne.GetPackageOwnerReference(...): -want, +got:\n%s", tc.reason, diff)
 			}
 		})
+	}
+}
+
+func newAPIEstablisher(client client.Client) *APIEstablisher {
+	return &APIEstablisher{
+		client:                           client,
+		MaxConcurrentPackageEstablishers: 10, // Use the current default
 	}
 }

--- a/internal/controller/pkg/revision/reconciler.go
+++ b/internal/controller/pkg/revision/reconciler.go
@@ -307,7 +307,7 @@ func SetupProviderRevision(mgr ctrl.Manager, o controller.Options) error {
 	ro := []ReconcilerOption{
 		WithCache(o.Cache),
 		WithDependencyManager(NewPackageDependencyManager(mgr.GetClient(), dag.NewMapDag, v1beta1.ProviderPackageType)),
-		WithEstablisher(NewAPIEstablisher(mgr.GetClient(), o.Namespace)),
+		WithEstablisher(NewAPIEstablisher(mgr.GetClient(), o.Namespace, o.MaxConcurrentPackageEstablishers)),
 		WithNewPackageRevisionFn(nr),
 		WithParser(parser.New(metaScheme, objScheme)),
 		WithParserBackend(NewImageBackend(fetcher, WithDefaultRegistry(o.DefaultRegistry))),
@@ -360,7 +360,7 @@ func SetupConfigurationRevision(mgr ctrl.Manager, o controller.Options) error {
 		WithCache(o.Cache),
 		WithDependencyManager(NewPackageDependencyManager(mgr.GetClient(), dag.NewMapDag, v1beta1.ConfigurationPackageType)),
 		WithNewPackageRevisionFn(nr),
-		WithEstablisher(NewAPIEstablisher(mgr.GetClient(), o.Namespace)),
+		WithEstablisher(NewAPIEstablisher(mgr.GetClient(), o.Namespace, o.MaxConcurrentPackageEstablishers)),
 		WithParser(parser.New(metaScheme, objScheme)),
 		WithParserBackend(NewImageBackend(f, WithDefaultRegistry(o.DefaultRegistry))),
 		WithLinter(xpkg.NewConfigurationLinter()),
@@ -415,7 +415,7 @@ func SetupFunctionRevision(mgr ctrl.Manager, o controller.Options) error {
 	ro := []ReconcilerOption{
 		WithCache(o.Cache),
 		WithDependencyManager(NewPackageDependencyManager(mgr.GetClient(), dag.NewMapDag, v1beta1.FunctionPackageType)),
-		WithEstablisher(NewAPIEstablisher(mgr.GetClient(), o.Namespace)),
+		WithEstablisher(NewAPIEstablisher(mgr.GetClient(), o.Namespace, o.MaxConcurrentPackageEstablishers)),
 		WithNewPackageRevisionFn(nr),
 		WithParser(parser.New(metaScheme, objScheme)),
 		WithParserBackend(NewImageBackend(fetcher, WithDefaultRegistry(o.DefaultRegistry))),


### PR DESCRIPTION
Previously, the concurrency for package installation was hardcoded to 10 goroutines per package establisher. 

This made it difficult to adjust performance settings without rebuilding Crossplane.

This introduces a new flag **--max-concurrent-package-establishers**

 to allow configuration of this value at runtime.


<!--
Thank you for helping to improve Crossplane! Please read the contribution docs
(linked below) if this is your first Crossplane pull request.
-->

### Description of your changes

<!--
Briefly describe what this pull request does, and how it is covered by tests.
Be proactive - direct your reviewers' attention to anything that needs special
consideration.

We love pull requests that fix an open issue. If yours does, use the below line
to indicate which issue it fixes, for example "Fixes #500".
-->

Fixes #3598

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `earthly +reviewable` to ensure this PR is ready for review.
- [x] Added or updated unit tests.
- [x] Added or updated e2e tests.
- [ ] Linked a PR or a [docs tracking issue] to [document this change].
- [ ] Added `backport release-x.y` labels to auto-backport this PR.
