### PR TITLE
feat: support pass credentials to functions in `render` function

### DIFF
--- a/cmd/crank/render/cmd.go
+++ b/cmd/crank/render/cmd.go
@@ -23,10 +23,9 @@ import (
 	"os"
 	"time"
 
-	corev1 "k8s.io/api/core/v1"
-
 	"github.com/alecthomas/kong"
 	"github.com/spf13/afero"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/serializer/json"
 
@@ -50,10 +49,10 @@ type Cmd struct {
 	ContextValues          map[string]string `help:"Comma-separated context key-value pairs to pass to the Function pipeline. Values must be JSON. Keys take precedence over --context-files." mapsep:""`
 	IncludeFunctionResults bool              `help:"Include informational and warning messages from Functions in the rendered output as resources of kind: Result."                            short:"r"`
 	IncludeFullXR          bool              `help:"Include a direct copy of the input XR's spec and metadata fields in the rendered output."                                                  short:"x"`
-	ObservedResources      string            `help:"A YAML file or directory of YAML files specifying the observed state of composed resources."                                               placeholder:"PATH" short:"o" type:"path"`
-	ExtraResources         string            `help:"A YAML file or directory of YAML files specifying extra resources to pass to the Function pipeline."                                       placeholder:"PATH" short:"e" type:"path"`
+	ObservedResources      string            `help:"A YAML file or directory of YAML files specifying the observed state of composed resources."                                               placeholder:"PATH" short:"o"   type:"path"`
+	ExtraResources         string            `help:"A YAML file or directory of YAML files specifying extra resources to pass to the Function pipeline."                                       placeholder:"PATH" short:"e"   type:"path"`
 	IncludeContext         bool              `help:"Include the context in the rendered output as a resource of kind: Context."                                                                short:"c"`
-	FunctionCredentials    string            `help:"A YAML file or directory of YAML files specifying credentials to use for Functions to render the XR."                                      placeholder:"PATH" short:"s" type:"path"`
+	FunctionCredentials    string            `help:"A YAML file or directory of YAML files specifying credentials to use for Functions to render the XR."                                      placeholder:"PATH" type:"path"`
 
 	Timeout time.Duration `default:"1m" help:"How long to run before timing out."`
 
@@ -112,6 +111,10 @@ Examples:
   # Pass extra resources Functions in the pipeline can request.
   crossplane render xr.yaml composition.yaml functions.yaml \
 	--extra-resources=extra-resources.yaml
+
+  # Pass credentials to Functions in the pipeline that need them.
+  crossplane render xr.yaml composition.yaml functions.yaml \
+	--function-credentials=credentials.yaml
 `
 }
 

--- a/cmd/crank/render/cmd.go
+++ b/cmd/crank/render/cmd.go
@@ -20,6 +20,7 @@ package render
 import (
 	"context"
 	"fmt"
+	corev1 "k8s.io/api/core/v1"
 	"os"
 	"time"
 
@@ -150,9 +151,12 @@ func (c *Cmd) Run(k *kong.Context, log logging.Logger) error { //nolint:gocognit
 		return errors.Wrapf(err, "cannot load functions from %q", c.Functions)
 	}
 
-	fcreds, err := LoadCredentials(c.fs, c.FunctionCredentials)
-	if err != nil {
-		return errors.Wrapf(err, "cannot load secrets from %q", c.FunctionCredentials)
+	fcreds := []corev1.Secret{}
+	if c.FunctionCredentials != "" {
+		fcreds, err = LoadCredentials(c.fs, c.FunctionCredentials)
+		if err != nil {
+			return errors.Wrapf(err, "cannot load secrets from %q", c.FunctionCredentials)
+		}
 	}
 
 	ors := []composed.Unstructured{}

--- a/cmd/crank/render/cmd.go
+++ b/cmd/crank/render/cmd.go
@@ -20,9 +20,10 @@ package render
 import (
 	"context"
 	"fmt"
-	corev1 "k8s.io/api/core/v1"
 	"os"
 	"time"
+
+	corev1 "k8s.io/api/core/v1"
 
 	"github.com/alecthomas/kong"
 	"github.com/spf13/afero"

--- a/cmd/crank/render/cmd.go
+++ b/cmd/crank/render/cmd.go
@@ -42,6 +42,7 @@ type Cmd struct {
 	CompositeResource string `arg:"" help:"A YAML file specifying the composite resource (XR) to render."                                        type:"existingfile"`
 	Composition       string `arg:"" help:"A YAML file specifying the Composition to use to render the XR. Must be mode: Pipeline."              type:"existingfile"`
 	Functions         string `arg:"" help:"A YAML file or directory of YAML files specifying the Composition Functions to use to render the XR." type:"path"`
+	FunctionSecrets   string `arg:"" help:"A YAML file or directory of YAML files specifying the Secrets to use for Functions to render the XR." type:"secrets"`
 
 	// Flags. Keep them in alphabetical order.
 	ContextFiles           map[string]string `help:"Comma-separated context key-value pairs to pass to the Function pipeline. Values must be files containing JSON."                           mapsep:""`
@@ -149,6 +150,11 @@ func (c *Cmd) Run(k *kong.Context, log logging.Logger) error { //nolint:gocognit
 		return errors.Wrapf(err, "cannot load functions from %q", c.Functions)
 	}
 
+	fsecrets, err := LoadSecrets(c.fs, c.FunctionSecrets)
+	if err != nil {
+		return errors.Wrapf(err, "cannot load secrets from %q", c.FunctionSecrets)
+	}
+
 	ors := []composed.Unstructured{}
 	if c.ObservedResources != "" {
 		ors, err = LoadObservedResources(c.fs, c.ObservedResources)
@@ -184,6 +190,7 @@ func (c *Cmd) Run(k *kong.Context, log logging.Logger) error { //nolint:gocognit
 		CompositeResource: xr,
 		Composition:       comp,
 		Functions:         fns,
+		FunctionSecrets:   fsecrets,
 		ObservedResources: ors,
 		ExtraResources:    ers,
 		Context:           fctx,

--- a/cmd/crank/render/load.go
+++ b/cmd/crank/render/load.go
@@ -22,6 +22,7 @@ import (
 	"path/filepath"
 
 	"github.com/spf13/afero"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/util/yaml"
 
@@ -92,6 +93,25 @@ func LoadFunctions(filesys afero.Fs, file string) ([]pkgv1.Function, error) {
 	}
 
 	return functions, nil
+}
+
+// LoadSecrets from a stream of YAML manifests.
+func LoadSecrets(fs afero.Fs, file string) ([]corev1.Secret, error) {
+	stream, err := LoadYAMLStream(fs, file)
+	if err != nil {
+		return nil, errors.Wrap(err, "cannot load YAML stream from file")
+	}
+
+	secrets := make([]corev1.Secret, 0, len(stream))
+	for _, y := range stream {
+		s := &corev1.Secret{}
+		if err := yaml.Unmarshal(y, s); err != nil {
+			return nil, errors.Wrap(err, "cannot parse YAML secret manifest")
+		}
+		secrets = append(secrets, *s)
+	}
+
+	return secrets, nil
 }
 
 // LoadExtraResources from a stream of YAML manifests.

--- a/cmd/crank/render/load.go
+++ b/cmd/crank/render/load.go
@@ -95,8 +95,8 @@ func LoadFunctions(filesys afero.Fs, file string) ([]pkgv1.Function, error) {
 	return functions, nil
 }
 
-// LoadSecrets from a stream of YAML manifests.
-func LoadSecrets(fs afero.Fs, file string) ([]corev1.Secret, error) {
+// LoadCredentials from a stream of YAML manifests.
+func LoadCredentials(fs afero.Fs, file string) ([]corev1.Secret, error) {
 	stream, err := LoadYAMLStream(fs, file)
 	if err != nil {
 		return nil, errors.Wrap(err, "cannot load YAML stream from file")

--- a/cmd/crank/render/render.go
+++ b/cmd/crank/render/render.go
@@ -20,16 +20,16 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"sort"
-	"sync"
-	"time"
-
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/protobuf/types/known/structpb"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
+	"sort"
+	"sync"
+	"time"
 
 	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
 	"github.com/crossplane/crossplane-runtime/pkg/errors"
@@ -69,6 +69,7 @@ type Inputs struct {
 	CompositeResource *ucomposite.Unstructured
 	Composition       *apiextensionsv1.Composition
 	Functions         []pkgv1.Function
+	FunctionSecrets   []corev1.Secret
 	ObservedResources []composed.Unstructured
 	ExtraResources    []unstructured.Unstructured
 	Context           map[string][]byte
@@ -159,6 +160,16 @@ func (r *RuntimeFunctionRunner) Stop(ctx context.Context) error {
 	return nil
 }
 
+// getSecret retrieves the secret with the specified name and namespace from the provided list of secrets.
+func getSecret(name string, nameSpace string, secrets []corev1.Secret) (*corev1.Secret, error) {
+	for _, s := range secrets {
+		if s.GetName() == name && s.GetNamespace() == nameSpace {
+			return &s, nil
+		}
+	}
+	return nil, errors.Errorf("secret %q not found", name)
+}
+
 // Render the desired XR and composed resources, sorted by resource name, given the supplied inputs.
 func Render(ctx context.Context, log logging.Logger, in Inputs) (Outputs, error) { //nolint:gocognit // TODO(negz): Should we refactor to break this up a bit?
 	runtimes, err := NewRuntimeFunctionRunner(ctx, log, in.Functions)
@@ -225,6 +236,26 @@ func Render(ctx context.Context, log logging.Logger, in Inputs) (Outputs, error)
 				return Outputs{}, errors.Wrapf(err, "cannot unmarshal input for Composition pipeline step %q", fn.Step)
 			}
 			req.Input = in
+		}
+
+		req.Credentials = map[string]*fnv1.Credentials{}
+		for _, cs := range fn.Credentials {
+			// For now we only support loading credentials from secrets.
+			if cs.Source != apiextensionsv1.FunctionCredentialsSourceSecret || cs.SecretRef == nil {
+				continue
+			}
+
+			s, err := getSecret(cs.SecretRef.Name, cs.SecretRef.Namespace, in.FunctionSecrets)
+			if err != nil {
+				return Outputs{}, errors.Wrapf(err, "cannot get credentials from secret %q", cs.SecretRef.Name)
+			}
+			req.Credentials[cs.Name] = &fnv1.Credentials{
+				Source: &fnv1.Credentials_CredentialData{
+					CredentialData: &fnv1.CredentialData{
+						Data: s.Data,
+					},
+				},
+			}
 		}
 
 		rsp, err := runner.RunFunction(ctx, fn.FunctionRef.Name, req)

--- a/cmd/crank/render/render.go
+++ b/cmd/crank/render/render.go
@@ -20,6 +20,10 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"sort"
+	"sync"
+	"time"
+
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/protobuf/types/known/structpb"
@@ -27,9 +31,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
-	"sort"
-	"sync"
-	"time"
 
 	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
 	"github.com/crossplane/crossplane-runtime/pkg/errors"

--- a/cmd/crank/render/render.go
+++ b/cmd/crank/render/render.go
@@ -67,13 +67,13 @@ const (
 
 // Inputs contains all inputs to the render process.
 type Inputs struct {
-	CompositeResource *ucomposite.Unstructured
-	Composition       *apiextensionsv1.Composition
-	Functions         []pkgv1.Function
-	FunctionSecrets   []corev1.Secret
-	ObservedResources []composed.Unstructured
-	ExtraResources    []unstructured.Unstructured
-	Context           map[string][]byte
+	CompositeResource   *ucomposite.Unstructured
+	Composition         *apiextensionsv1.Composition
+	Functions           []pkgv1.Function
+	FunctionCredentials []corev1.Secret
+	ObservedResources   []composed.Unstructured
+	ExtraResources      []unstructured.Unstructured
+	Context             map[string][]byte
 
 	// TODO(negz): Allow supplying observed XR and composed resource connection
 	// details. Maybe as Secrets? What if secret stores are in use?
@@ -246,7 +246,7 @@ func Render(ctx context.Context, log logging.Logger, in Inputs) (Outputs, error)
 				continue
 			}
 
-			s, err := getSecret(cs.SecretRef.Name, cs.SecretRef.Namespace, in.FunctionSecrets)
+			s, err := getSecret(cs.SecretRef.Name, cs.SecretRef.Namespace, in.FunctionCredentials)
 			if err != nil {
 				return Outputs{}, errors.Wrapf(err, "cannot get credentials from secret %q", cs.SecretRef.Name)
 			}

--- a/cmd/crank/render/render_test.go
+++ b/cmd/crank/render/render_test.go
@@ -22,6 +22,8 @@ import (
 	"net"
 	"testing"
 
+	corev1 "k8s.io/api/core/v1"
+
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"google.golang.org/grpc"
@@ -1041,6 +1043,58 @@ func TestFilterExtraResources(t *testing.T) {
 			}
 			if diff := cmp.Diff(tc.want.err, err, cmpopts.EquateErrors()); diff != "" {
 				t.Errorf("%s\nfilterExtraResources(...): -want error, +got error:\n%s", tc.reason, diff)
+			}
+		})
+	}
+}
+
+func TestGetSecret(t *testing.T) {
+	secrets := []corev1.Secret{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "secret1",
+				Namespace: "namespace1",
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "secret2",
+				Namespace: "namespace2",
+			},
+		},
+	}
+
+	tests := map[string]struct {
+		name      string
+		namespace string
+		secrets   []corev1.Secret
+		wantErr   bool
+	}{
+		"SecretFound": {
+			name:      "secret1",
+			namespace: "namespace1",
+			secrets:   secrets,
+			wantErr:   false,
+		},
+		"SecretNotFound": {
+			name:      "secret3",
+			namespace: "namespace3",
+			secrets:   secrets,
+			wantErr:   true,
+		},
+		"SecretWrongNamespace": {
+			name:      "secret1",
+			namespace: "namespace2",
+			secrets:   secrets,
+			wantErr:   true,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			_, err := getSecret(tc.name, tc.namespace, tc.secrets)
+			if (err != nil) != tc.wantErr {
+				t.Errorf("getSecret() error = %v, wantErr %v", err, tc.wantErr)
 			}
 		})
 	}

--- a/cmd/crank/render/render_test.go
+++ b/cmd/crank/render/render_test.go
@@ -22,14 +22,13 @@ import (
 	"net"
 	"testing"
 
-	corev1 "k8s.io/api/core/v1"
-
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/types/known/structpb"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane! Please read the contribution docs
(linked below) if this is your first Crossplane pull request.
-->

### Description of your changes

<!--
Briefly describe what this pull request does, and how it is covered by tests.
Be proactive - direct your reviewers' attention to anything that needs special
consideration.

We love pull requests that fix an open issue. If yours does, use the below line
to indicate which issue it fixes, for example "Fixes #500".
-->

Fixes #5975 

This PR is trying to pass credentials to functions, and introduce a new flag `function-credentials` to pass a folder or a secret yaml file. [Here](https://github.com/cychiang/function-print-secrets/tree/main/example) is the example, and function for my local tests.

```bash
# Use -s flag to include credentials
crossplane beta render example/xr.yaml example/composition.yaml example/functions.yaml -s example/secrets
```

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `earthly +reviewable` to ensure this PR is ready for review.
- [ ] ~~Added or updated unit tests.~~
- [ ] ~~Added or updated e2e tests.~~
- [x] Linked a PR or a [docs tracking issue] to [document this change].
- [ ] ~~Added `backport release-x.y` labels to auto-backport this PR.~~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
