### PR TITLE
crank render - add support for observed connectionDetails

### DIFF
--- a/cmd/crank/render/render.go
+++ b/cmd/crank/render/render.go
@@ -31,11 +31,14 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
 	"github.com/crossplane/crossplane-runtime/pkg/errors"
 	"github.com/crossplane/crossplane-runtime/pkg/logging"
 	"github.com/crossplane/crossplane-runtime/pkg/meta"
+	"github.com/crossplane/crossplane-runtime/pkg/reconciler/managed"
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
 	"github.com/crossplane/crossplane-runtime/pkg/resource/unstructured/composed"
 	ucomposite "github.com/crossplane/crossplane-runtime/pkg/resource/unstructured/composite"
@@ -74,9 +77,6 @@ type Inputs struct {
 	ObservedResources   []composed.Unstructured
 	ExtraResources      []unstructured.Unstructured
 	Context             map[string][]byte
-
-	// TODO(negz): Allow supplying observed XR and composed resource connection
-	// details. Maybe as Secrets? What if secret stores are in use?
 }
 
 // Outputs contains all outputs from the render process.
@@ -187,18 +187,52 @@ func Render(ctx context.Context, log logging.Logger, in Inputs) (Outputs, error)
 	runner := composite.NewFetchingFunctionRunner(runtimes, &FilteringFetcher{extra: in.ExtraResources})
 
 	observed := composite.ComposedResourceStates{}
+	secretGvk := schema.GroupVersionKind{
+		Group:   "",
+		Version: "v1",
+		Kind:    "Secret",
+	}
+
+	observedConnectionDetails := map[xpv1.SecretReference]managed.ConnectionDetails{}
+
+	for _, cd := range in.ObservedResources {
+		if secretGvk != cd.GroupVersionKind() {
+			continue
+		}
+		secret := &corev1.Secret{}
+		if err := runtime.DefaultUnstructuredConverter.FromUnstructured(cd.Object, secret); err != nil {
+			continue
+		}
+		observedConnectionDetails[xpv1.SecretReference{
+			Name:      secret.GetName(),
+			Namespace: secret.GetNamespace(),
+		}] = secret.Data
+	}
+
 	for i, cd := range in.ObservedResources {
-		name := cd.GetAnnotations()[AnnotationKeyCompositionResourceName]
+		name, ok := cd.GetAnnotations()[AnnotationKeyCompositionResourceName]
+		if !ok {
+			continue
+		}
+		var or resource.Composed = &in.ObservedResources[i]
+		var connectionDetails managed.ConnectionDetails
+		if connectionSecretRef := or.GetWriteConnectionSecretToReference(); connectionSecretRef != nil {
+			connectionDetails = observedConnectionDetails[*connectionSecretRef]
+		}
+
 		observed[composite.ResourceName(name)] = composite.ComposedResourceState{
-			Resource:          &in.ObservedResources[i],
-			ConnectionDetails: nil, // We don't support passing in observed connection details.
+			Resource:          or,
+			ConnectionDetails: connectionDetails, // We don't support passing in observed connection details.
 			Ready:             false,
 		}
 	}
 
-	// TODO(negz): Support passing in optional observed connection details for
-	// both the XR and composed resources.
-	o, err := composite.AsState(in.CompositeResource, nil, observed)
+	var connectionDetails managed.ConnectionDetails
+	if connectionSecretRef := in.CompositeResource.GetWriteConnectionSecretToReference(); connectionSecretRef != nil {
+		connectionDetails = observedConnectionDetails[*connectionSecretRef]
+	}
+
+	o, err := composite.AsState(in.CompositeResource, connectionDetails, observed)
 	if err != nil {
 		return Outputs{}, errors.Wrap(err, "cannot build observed composite and composed resources for RunFunctionRequest")
 	}

--- a/cmd/crank/render/render_test.go
+++ b/cmd/crank/render/render_test.go
@@ -739,6 +739,207 @@ func TestRender(t *testing.T) {
 				},
 			},
 		},
+		"SuccessWithObservedConnectionSecrets": {
+			args: args{
+				ctx: context.Background(),
+				in: Inputs{
+					CompositeResource: &ucomposite.Unstructured{
+						Unstructured: unstructured.Unstructured{
+							Object: MustLoadJSON(`{
+								"apiVersion": "nop.example.org/v1alpha1",
+								"kind": "XNopResource",
+								"metadata": {
+									"name": "test-render"
+								},
+								"spec": {
+									"writeConnectionSecretToRef": {
+										"name": "secret1",
+										"namespace": "default"
+									}
+								}
+							}`),
+						},
+					},
+					Composition: &apiextensionsv1.Composition{
+						Spec: apiextensionsv1.CompositionSpec{
+							Mode: &pipeline,
+							Pipeline: []apiextensionsv1.PipelineStep{
+								{
+									Step:        "test",
+									FunctionRef: apiextensionsv1.FunctionReference{Name: "function-test"},
+								},
+							},
+						},
+					},
+					Functions: []pkgv1.Function{
+						func() pkgv1.Function {
+							lis := NewFunctionWithRunFunc(t, func(_ context.Context, request *fnv1.RunFunctionRequest) (*fnv1.RunFunctionResponse, error) {
+								if request.Observed.Resources["missing-connectionsecret"].ConnectionDetails != nil {
+									t.Fatalf("expected no connectionDetails to be present")
+								}
+
+								coolConnectionDetails := request.Observed.Resources["a-cool-resource"].ConnectionDetails
+								if coolConnectionDetails == nil {
+									t.Fatalf("expected connectiondetails for observed managed resources \"a-cool-resource\"")
+								}
+								compositeConnectionDetails := request.Observed.Composite.ConnectionDetails
+								if compositeConnectionDetails == nil {
+									t.Fatalf("expected connectiondetails for observed composite")
+								}
+
+								return &fnv1.RunFunctionResponse{
+									Desired: &fnv1.State{
+										Composite: &fnv1.Resource{
+											Resource: MustStructJSON(`{
+												"status": {
+													"widgets": 9001
+												}
+											}`),
+											ConnectionDetails: map[string][]byte{
+												"foo": compositeConnectionDetails["foo"],
+												"boo": coolConnectionDetails["boo"],
+											},
+										},
+									},
+								}, nil
+							})
+							listeners = append(listeners, lis)
+
+							return pkgv1.Function{
+								ObjectMeta: metav1.ObjectMeta{
+									Name: "function-test",
+									Annotations: map[string]string{
+										AnnotationKeyRuntime:                  string(AnnotationValueRuntimeDevelopment),
+										AnnotationKeyRuntimeDevelopmentTarget: lis.Addr().String(),
+									},
+								},
+							}
+						}(),
+					},
+					Context: map[string][]byte{
+						"crossplane.io/context-key": []byte(`{}`),
+					},
+					ObservedResources: []composed.Unstructured{
+						{
+							Unstructured: unstructured.Unstructured{
+								Object: MustLoadJSON(`{
+									"apiVersion": "v1",
+									"kind": "Secret",
+									"metadata": {
+										"name": "secret1",
+										"namespace": "default"
+									},
+									"data": {
+										"foo": "Zm9v"
+									}
+								}`),
+							},
+						}, {
+							Unstructured: unstructured.Unstructured{
+								Object: MustLoadJSON(`{
+									"apiVersion": "v1",
+									"kind": "Secret",
+									"metadata": {
+										"name": "secret2",
+										"namespace": "default"
+									},
+									"data": {
+										"boo": "YnV6"
+									}
+								}`),
+							},
+						}, {
+							Unstructured: unstructured.Unstructured{
+								Object: MustLoadJSON(`{
+									"apiVersion": "btest.crossplane.io/v1",
+									"kind": "BComposed",
+									"metadata": {
+										"generateName": "test-render-",
+										"labels": {
+											"crossplane.io/composite": "test-render"
+										},
+										"annotations": {
+											"crossplane.io/composition-resource-name": "a-cool-resource"
+										},
+										"ownerReferences": [{
+											"apiVersion": "nop.example.org/v1alpha1",
+											"kind": "XNopResource",
+											"name": "test-render",
+											"blockOwnerDeletion": true,
+											"controller": true,
+											"uid": ""
+										}]
+									},
+									"spec": {
+										"widgets": 9002,
+										"writeConnectionSecretToRef": {
+											"name": "secret2",
+											"namespace": "default"
+										}
+									}
+								}`),
+							},
+						}, {
+							Unstructured: unstructured.Unstructured{
+								Object: MustLoadJSON(`{
+									"apiVersion": "btest.crossplane.io/v1",
+									"kind": "BComposed",
+									"metadata": {
+										"generateName": "test-render-",
+										"labels": {
+											"crossplane.io/composite": "test-render"
+										},
+										"annotations": {
+											"crossplane.io/composition-resource-name": "missing-connectionsecret"
+										},
+										"ownerReferences": [{
+											"apiVersion": "nop.example.org/v1alpha1",
+											"kind": "XNopResource",
+											"name": "test-render",
+											"blockOwnerDeletion": true,
+											"controller": true,
+											"uid": ""
+										}]
+									},
+									"spec": {
+										"widgets": 9002,
+										"writeConnectionSecretToRef": {
+											"name": "no-secret",
+											"namespace": "default"
+										}
+									}
+								}`),
+							},
+						},
+					},
+				},
+			},
+			want: want{
+				out: Outputs{
+					// TODO: expect connectionDetails in composite when support is added
+					CompositeResource: &ucomposite.Unstructured{
+						Unstructured: unstructured.Unstructured{
+							Object: MustLoadJSON(`{
+								"apiVersion": "nop.example.org/v1alpha1",
+								"kind": "XNopResource",
+								"metadata": {
+									"name": "test-render"
+								},
+								"status": {
+									"widgets": 9001,
+									"conditions": [{
+										"lastTransitionTime": "2024-01-01T00:00:00Z",
+										"type": "Ready",
+										"status": "True",
+										"reason": "Available"
+									}]
+								}
+							}`),
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for name, tc := range cases {


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane! Please read the contribution docs
(linked below) if this is your first Crossplane pull request.
-->

### Description of your changes
Adds support for observed resources to use connectonDetails.

This allows adding kubernetes Secrets to observed resources in the `crossplane render` command. when another observed Resource targets the secret by having a spec.writeConnectionSecretToRef with the name and namespace of the kubernetes secret the secret data is set as the connectionDetails.

e.g.:
observed.yaml:
```yaml
---
apiVersion: test/v1
kind: xResource
metadata:
  annotations:
    crossplane.io/composition-resource-name: my-resource
spec:
  writeConnectionSecretToRef:
    name: foo
    namespace: bar
---
apiVersion: v1
kind: Secret
metadata:
  name: foo
  namespace: bar
data:
  foo: Zm9v
```
during the function run, the observed resource `my-resource` has the connectionDetails set based on the data of the secret.
<!--
Briefly describe what this pull request does, and how it is covered by tests.
Be proactive - direct your reviewers' attention to anything that needs special
consideration.

We love pull requests that fix an open issue. If yours does, use the below line
to indicate which issue it fixes, for example "Fixes #500".
-->


I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `earthly +reviewable` to ensure this PR is ready for review.
- [x] Added or updated unit tests.
- [ ] Added or updated e2e tests.
- [ ] Linked a PR or a [docs tracking issue] to [document this change].
- [ ] Added `backport release-x.y` labels to auto-backport this PR.

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
