### PR TITLE
Add contexts to RuntimeFunctionRunner

### DIFF
--- a/cmd/crank/render/render.go
+++ b/cmd/crank/render/render.go
@@ -126,7 +126,7 @@ func NewRuntimeFunctionRunner(ctx context.Context, log logging.Logger, fns []pkg
 		conns[fn.GetName()] = conn
 	}
 
-	return &RuntimeFunctionRunner{conns: conns}, nil
+	return &RuntimeFunctionRunner{contexts: contexts, conns: conns}, nil
 }
 
 // RunFunction runs the named function.


### PR DESCRIPTION
### Description of your changes
Added the `contexts` parameter to the RuntimeFunctionRunner instance.

This PR fixes the problem with containers not being stopped/removed after `crossplane render` is run on MacOS.

As described in #5994 the `contexts` attribute of the `RuntimeFunctionRunner` was never being set so there was nothing to iterate over to stop the containers.

I tested this change by running `crossplane render` on MacOS and verified that the docker containers are stopped and removed.

Fixes #5926, Fixes #5994

I have:
- [X] Read and followed Crossplane's [contribution process].
- [X] Run `earthly +reviewable` to ensure this PR is ready for review.
~- [ ] Added or updated unit tests.~
~- [ ] Added or updated e2e tests.~
~- [ ] Linked a PR or a [docs tracking issue] to [document this change].~
- [X] Added `backport release-x.y` labels to auto-backport this PR.

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
