### PR TITLE
fix: remove warnings in ci workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -404,7 +404,7 @@ jobs:
       # buf-breaking-action doesn't support branches
       # https://github.com/bufbuild/buf-push-action/issues/34
       - name: Detect Breaking Changes in Protocol Buffers
-        uses: bufbuild/buf-breaking-action@a074e988ee34efcd4927079e79c611f428354c01 # v1
+        uses: bufbuild/buf-breaking-action@c57b3d842a5c3f3b454756ef65305a50a587c5ba # v1
         # We want to run this for the main branch, and PRs against main.
         if: ${{ github.ref == 'refs/heads/main' || github.base_ref == 'main' }}
         with:


### PR DESCRIPTION
### Description of your changes

Removes the warning in the CI workflows, by bumping the action version.
See example https://github.com/crossplane/crossplane/actions/runs/11304939678.

See https://github.com/bufbuild/buf-lint-action/releases for references and particularly https://github.com/bufbuild/buf-lint-action/compare/v1.1.0...v1.1.1