### PR TITLE
feat(crank): convert supporting function-environment-configs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,5 +26,5 @@ gitlab/
 *.xpkg
 
 # go build output (from go build ./cmd/crank etc)
-crank
-crossplane
+/crank
+/crossplane

--- a/cmd/crank/beta/convert/compositionenvironment/cmd.go
+++ b/cmd/crank/beta/convert/compositionenvironment/cmd.go
@@ -50,19 +50,20 @@ func (c *Cmd) Help() string {
 	return `
 This command converts a Crossplane Composition to use function-environment-configs, if needed.
 
-By default it adds a function pipeline step using 
-crossplane-contrib/function-environment-configs, by default it'll reference the function as
-function-environment-configs, but it can be overridden with the -f flag.
+It adds a function pipeline step using crossplane-contrib/function-environment-configs, if needed.
+By default it'll reference the function as function-environment-configs, but it can be overridden
+with the -f flag.
 
 Examples:
 
-  # Convert an existing Composition to use Pipelines
+  # Convert an existing Composition (Pipeline mode) leveraging native
+  # Composition Environment to use function-environment-configs.
   crossplane beta convert composition-environment composition.yaml -o composition-environment.yaml
 
-  # Use a different functionRef and output to stdout
+  # Use a different functionRef and output to stdout.
   crossplane beta convert composition-environment composition.yaml --function-environment-configs-ref local-function-environment-configs
 
-  # Stdin to stdout
+  # Stdin to stdout.
   cat composition.yaml | ./crossplane beta convert composition-environment
 
 `
@@ -81,7 +82,6 @@ func (c *Cmd) Run() error {
 		return err
 	}
 
-	// Set up schemes for our API types
 	u := &unstructured.Unstructured{}
 
 	if err := yaml.Unmarshal(data, u); err != nil {

--- a/cmd/crank/beta/convert/compositionenvironment/cmd.go
+++ b/cmd/crank/beta/convert/compositionenvironment/cmd.go
@@ -1,0 +1,129 @@
+/*
+Copyright 2024 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package compositionenvironment is a package for converting Pipeline Compositions using native Composition Environment
+// capabilities to use function-environment-configs.
+package compositionenvironment
+
+import (
+	"bufio"
+	"io"
+	"os"
+
+	"github.com/spf13/afero"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/yaml"
+
+	"github.com/crossplane/crossplane-runtime/pkg/errors"
+
+	commonIO "github.com/crossplane/crossplane/cmd/crank/beta/convert/io"
+)
+
+// Cmd arguments and flags for converting a Composition to use function-environment-configs.
+type Cmd struct {
+	// Arguments.
+	InputFile string `arg:"" default:"-" help:"The Composition file to be converted. If not specified or '-', stdin will be used." optional:"" type:"path"`
+
+	// Flags.
+	OutputFile string `help:"The file to write the generated Composition to. If not specified, stdout will be used." placeholder:"PATH" short:"o" type:"path"`
+
+	FunctionEnvironmentConfigRef string `default:"function-environment-configs" help:"Name of the existing function-environment-configs Function, to be used to reference it." name:"function-environment-configs-ref"`
+
+	fs afero.Fs
+}
+
+// Help returns help message for the migrate composition-environment command.
+func (c *Cmd) Help() string {
+	return `
+This command converts a Crossplane Composition to use function-environment-configs, if needed.
+
+By default it adds a function pipeline step using 
+crossplane-contrib/function-environment-configs, by default it'll reference the function as
+function-environment-configs, but it can be overridden with the -f flag.
+
+Examples:
+
+  # Convert an existing Composition to use Pipelines
+  crossplane beta convert composition-environment composition.yaml -o composition-environment.yaml
+
+  # Use a different functionRef and output to stdout
+  crossplane beta convert composition-environment composition.yaml --function-environment-configs-ref local-function-environment-configs
+
+  # Stdin to stdout
+  cat composition.yaml | ./crossplane beta convert composition-environment
+
+`
+}
+
+// AfterApply implements kong.AfterApply.
+func (c *Cmd) AfterApply() error {
+	c.fs = afero.NewOsFs()
+	return nil
+}
+
+// Run converts a classic Composition to a function pipeline Composition.
+func (c *Cmd) Run() error {
+	data, err := commonIO.Read(c.fs, c.InputFile)
+	if err != nil {
+		return err
+	}
+
+	// Set up schemes for our API types
+	u := &unstructured.Unstructured{}
+
+	if err := yaml.Unmarshal(data, u); err != nil {
+		return errors.Wrap(err, "Unmarshalling Error")
+	}
+
+	out, err := ConvertToFunctionEnvironmentConfigs(u, c.FunctionEnvironmentConfigRef)
+	if err != nil {
+		return errors.Wrap(err, "Error generating new Composition")
+	}
+	if out == nil {
+		// TODO(phisco): log we didn't do anything maybe
+		return nil
+	}
+
+	b, err := yaml.Marshal(out)
+	if err != nil {
+		return errors.Wrap(err, "Unable to marshal back to yaml")
+	}
+
+	var output io.Writer = os.Stdout
+	if outputFileName := c.OutputFile; outputFileName != "" {
+		f, err := c.fs.OpenFile(outputFileName, os.O_CREATE|os.O_WRONLY, 0o644)
+		if err != nil {
+			return errors.Wrap(err, "Unable to open output file")
+		}
+		defer func() { _ = f.Close() }()
+		output = f
+	}
+
+	outputW := bufio.NewWriter(output)
+	if _, err := outputW.WriteString("---\n"); err != nil {
+		return errors.Wrap(err, "Writing YAML file header")
+	}
+
+	if _, err := outputW.Write(b); err != nil {
+		return errors.Wrap(err, "Writing YAML file content")
+	}
+
+	if err := outputW.Flush(); err != nil {
+		return errors.Wrap(err, "Flushing output")
+	}
+
+	return nil
+}

--- a/cmd/crank/beta/convert/compositionenvironment/cmd.go
+++ b/cmd/crank/beta/convert/compositionenvironment/cmd.go
@@ -20,9 +20,10 @@ package compositionenvironment
 
 import (
 	"bufio"
-	"io"
+	"fmt"
 	"os"
 
+	"github.com/alecthomas/kong"
 	"github.com/spf13/afero"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"sigs.k8s.io/yaml"
@@ -76,7 +77,7 @@ func (c *Cmd) AfterApply() error {
 }
 
 // Run converts a classic Composition to a function pipeline Composition.
-func (c *Cmd) Run() error {
+func (c *Cmd) Run(k *kong.Context) error {
 	data, err := commonIO.Read(c.fs, c.InputFile)
 	if err != nil {
 		return err
@@ -93,8 +94,8 @@ func (c *Cmd) Run() error {
 		return errors.Wrap(err, "Error generating new Composition")
 	}
 	if out == nil {
-		// TODO(phisco): log we didn't do anything maybe
-		return nil
+		_, err = fmt.Fprintf(k.Stderr, "No changes needed.\n")
+		return errors.Wrap(err, "unable to write to stderr")
 	}
 
 	b, err := yaml.Marshal(out)
@@ -102,7 +103,7 @@ func (c *Cmd) Run() error {
 		return errors.Wrap(err, "Unable to marshal back to yaml")
 	}
 
-	var output io.Writer = os.Stdout
+	var output = k.Stdout
 	if outputFileName := c.OutputFile; outputFileName != "" {
 		f, err := c.fs.OpenFile(outputFileName, os.O_CREATE|os.O_WRONLY, 0o644)
 		if err != nil {

--- a/cmd/crank/beta/convert/compositionenvironment/converter.go
+++ b/cmd/crank/beta/convert/compositionenvironment/converter.go
@@ -1,0 +1,113 @@
+package compositionenvironment
+
+import (
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/crossplane/crossplane-runtime/pkg/errors"
+	"github.com/crossplane/crossplane-runtime/pkg/fieldpath"
+
+	v1 "github.com/crossplane/crossplane/apis/apiextensions/v1"
+)
+
+// ConvertToFunctionEnvironmentConfigs converts a Composition to use function-environment-configs.
+func ConvertToFunctionEnvironmentConfigs(in *unstructured.Unstructured, functionName string) (*unstructured.Unstructured, error) {
+	if in == nil {
+		return nil, errors.New("input is nil")
+	}
+
+	gvk := in.GetObjectKind().GroupVersionKind()
+
+	if gvk.Empty() {
+		return nil, errors.New("GroupVersionKind is empty")
+	}
+
+	if gvk.Group != v1.Group {
+		return nil, errors.Errorf("GroupVersionKind Group is not %s", v1.Group)
+	}
+
+	if gvk.Kind != v1.CompositionKind {
+		return nil, errors.Errorf("GroupVersionKind Kind is not %s", v1.CompositionKind)
+	}
+
+	out, err := fieldpath.PaveObject(in)
+	if err != nil {
+		return nil, err
+	}
+
+	if mode, err := out.GetString("spec.mode"); fieldpath.IsNotFound(err) || mode != string(v1.CompositionModePipeline) {
+		return nil, errors.New("Composition is using Resources mode, run pipeline-composition command instead")
+	}
+
+	// Prepare function-environment-configs input
+	inputPaved := fieldpath.Pave(map[string]any{
+		"apiVersion": "environmentconfigs.fn.crossplane.io/v1beta1",
+		"kind":       "Input",
+	})
+
+	var modified bool
+
+	// Copy spec.environment.defaultData to function-environment-configs, if any
+	if dd, err := out.GetValue("spec.environment.defaultData"); err == nil {
+		if err := inputPaved.SetValue("spec.defaultData", dd); err != nil {
+			return nil, errors.Wrap(err, "failed to set defaultData")
+		}
+		modified = true
+	}
+
+	// Copy spec.environment.environmentConfigs to function-environment-configs, if any
+	if ec, err := out.GetValue("spec.environment.environmentConfigs"); err == nil {
+		if err := inputPaved.SetValue("spec.environmentConfigs", ec); err != nil {
+			return nil, errors.Wrap(err, "failed to set environmentConfigs")
+		}
+		modified = true
+	}
+
+	// Copy spec.environment.policy.resolution to function-environment-configs, if any
+	if resolutionPolicy, err := out.GetString("spec.environment.policy.resolution"); err == nil {
+		if err := inputPaved.SetValue("spec.policy.resolution", resolutionPolicy); err != nil {
+			return nil, errors.Wrap(err, "failed to set policy.resolution")
+		}
+		modified = true
+	}
+
+	if !modified {
+		// Nothing to do
+		return nil, nil
+	}
+
+	// Nothing else should be left, we can delete the environment field
+	if err := out.DeleteField("spec.environment"); err != nil {
+		return nil, errors.Wrap(err, "failed to delete environment")
+	}
+
+	// We can drop environmentConfigRefs as well
+	if err := out.DeleteField("spec.environmentConfigRefs"); err != nil && !fieldpath.IsNotFound(err) {
+		return nil, errors.Wrap(err, "failed to delete environmentConfigRefs")
+	}
+
+	// Add function-environment-configs to the pipeline
+	var pipeline []map[string]any
+	if err := out.GetValueInto("spec.pipeline", &pipeline); err != nil {
+		return nil, errors.Wrap(err, "failed to get pipeline")
+	}
+
+	if functionName == "" {
+		functionName = "function-environment-configs"
+	}
+
+	pipeline = append([]map[string]any{
+		{
+			"step": "environment-configs",
+			"functionRef": map[string]any{
+				"name": functionName,
+			},
+			"input": inputPaved.UnstructuredContent(),
+		},
+	}, pipeline...)
+
+	if err := out.SetValue("spec.pipeline", pipeline); err != nil {
+		return nil, errors.Wrap(err, "failed to set pipeline")
+	}
+
+	return &unstructured.Unstructured{Object: out.UnstructuredContent()}, nil
+}

--- a/cmd/crank/beta/convert/compositionenvironment/converter.go
+++ b/cmd/crank/beta/convert/compositionenvironment/converter.go
@@ -80,11 +80,6 @@ func ConvertToFunctionEnvironmentConfigs(in *unstructured.Unstructured, function
 		return nil, errors.Wrap(err, "failed to delete environment")
 	}
 
-	// We can drop environmentConfigRefs as well
-	if err := out.DeleteField("spec.environmentConfigRefs"); err != nil && !fieldpath.IsNotFound(err) {
-		return nil, errors.Wrap(err, "failed to delete environmentConfigRefs")
-	}
-
 	// Add function-environment-configs to the pipeline
 	var pipeline []map[string]any
 	if err := out.GetValueInto("spec.pipeline", &pipeline); err != nil {

--- a/cmd/crank/beta/convert/compositionenvironment/converter_test.go
+++ b/cmd/crank/beta/convert/compositionenvironment/converter_test.go
@@ -1,0 +1,179 @@
+package compositionenvironment
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/yaml"
+)
+
+func TestConvertToFunctionEnvironmentConfigs(t *testing.T) {
+	type args struct {
+		in           *unstructured.Unstructured
+		functionName string
+	}
+
+	type want struct {
+		out *unstructured.Unstructured
+		err error
+	}
+	tests := map[string]struct {
+		reason string
+		args   args
+		want   want
+	}{
+		"Success": {
+			reason: "Should successfully convert a Composition to use function-environment-configs.",
+			args: args{
+				in: fromYAML(t, `
+apiVersion: apiextensions.crossplane.io/v1
+kind: Composition
+metadata:
+   name: foo
+spec:
+  compositeTypeRef:
+    apiVersion: example.crossplane.io/v1
+    kind: XR
+  mode: Pipeline
+  environment:
+    policy:
+      resolution: Required
+      resolve: Always
+    defaultData:
+      foo:
+        bar: baz
+      key: value
+    environmentConfigs:
+    - type: Reference
+      ref:
+        name: example-config
+  pipeline:
+  - step: patch-and-transform
+    functionRef:
+      name: function-patch-and-transform
+    input:
+      apiVersion: pt.fn.crossplane.io/v1beta1
+      kind: Resources
+      environment:
+        patches:
+        - type: ToCompositeFieldPath
+          fromFieldPath: "someFieldInTheEnvironment"
+          toFieldPath: "status.someFieldFromTheEnvironment"
+      resources:
+      - name: bucket
+        base:
+          apiVersion: s3.aws.upbound.io/v1beta1
+          kind: Bucket
+          spec:
+            forProvider:
+              region: us-east-2
+        patches:
+        - type: FromEnvironmentFieldPath
+          fromFieldPath: "someFieldInTheEnvironment"
+          toFieldPath: "spec.forProvider.someFieldFromTheEnvironment"
+        - type: ToEnvironmentFieldPath
+          fromFieldPath: "status.someOtherFieldInTheResource"
+          toFieldPath: "someOtherFieldInTheEnvironment"`),
+			},
+			want: want{
+				out: fromYAML(t, `
+apiVersion: apiextensions.crossplane.io/v1
+kind: Composition
+metadata:
+   name: foo
+spec:
+  compositeTypeRef:
+    apiVersion: example.crossplane.io/v1
+    kind: XR
+  mode: Pipeline
+  pipeline:
+  - step: environment-configs
+    functionRef:
+      name: function-environment-configs
+    input:
+      apiVersion: environmentconfigs.fn.crossplane.io/v1beta1
+      kind: Input
+      spec:
+        policy:
+          resolution: Required
+        defaultData:
+          foo:
+            bar: baz
+          key: value
+        environmentConfigs:
+        - type: Reference
+          ref:
+            name: example-config
+  - step: patch-and-transform
+    functionRef:
+      name: function-patch-and-transform
+    input:
+      apiVersion: pt.fn.crossplane.io/v1beta1
+      kind: Resources
+      environment:
+        patches:
+        - type: ToCompositeFieldPath
+          fromFieldPath: "someFieldInTheEnvironment"
+          toFieldPath: "status.someFieldFromTheEnvironment"
+      resources:
+      - name: bucket
+        base:
+          apiVersion: s3.aws.upbound.io/v1beta1
+          kind: Bucket
+          spec:
+            forProvider:
+              region: us-east-2
+        patches:
+        - type: FromEnvironmentFieldPath
+          fromFieldPath: "someFieldInTheEnvironment"
+          toFieldPath: "spec.forProvider.someFieldFromTheEnvironment"
+        - type: ToEnvironmentFieldPath
+          fromFieldPath: "status.someOtherFieldInTheResource"
+          toFieldPath: "someOtherFieldInTheEnvironment"
+`),
+			},
+		},
+		"FailWithResources": {
+			reason: "Should refuse to convert a Composition that still uses Resources mode.",
+			args: args{
+				in: fromYAML(t, `
+apiVersion: apiextensions.crossplane.io/v1
+kind: Composition
+metadata:
+   name: foo
+spec:
+  compositeTypeRef:
+    apiVersion: example.crossplane.io/v1
+    kind: XR
+  mode: Resources
+`),
+			},
+			want: want{
+				err: cmpopts.AnyError,
+			},
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			got, err := ConvertToFunctionEnvironmentConfigs(tt.args.in, tt.args.functionName)
+			if diff := cmp.Diff(tt.want.err, err, cmpopts.EquateErrors()); diff != "" {
+				t.Errorf("ConvertToFunctionEnvironmentConfigs() %s error -want, +got:\n%s", tt.reason, diff)
+			}
+			if diff := cmp.Diff(tt.want.out, got); diff != "" {
+				t.Errorf("ConvertToFunctionEnvironmentConfigs() %s -want, +got:\n%s", tt.reason, diff)
+			}
+		})
+	}
+}
+
+func fromYAML(t *testing.T, in string) *unstructured.Unstructured {
+	t.Helper()
+	obj := make(map[string]interface{})
+	err := yaml.Unmarshal([]byte(in), &obj)
+	if err != nil {
+		t.Fatalf("fromYAML: %s", err)
+	}
+	return &unstructured.Unstructured{Object: obj}
+}

--- a/cmd/crank/beta/convert/convert.go
+++ b/cmd/crank/beta/convert/convert.go
@@ -19,14 +19,16 @@ limitations under the License.
 package convert
 
 import (
+	"github.com/crossplane/crossplane/cmd/crank/beta/convert/compositionenvironment"
 	"github.com/crossplane/crossplane/cmd/crank/beta/convert/deploymentruntime"
 	"github.com/crossplane/crossplane/cmd/crank/beta/convert/pipelinecomposition"
 )
 
 // Cmd converts a Crossplane resource to a newer version or a different kind.
 type Cmd struct {
-	DeploymentRuntime   deploymentruntime.Cmd   `cmd:"" help:"Convert a ControllerConfig to a DeploymentRuntimeConfig."`
-	PipelineComposition pipelinecomposition.Cmd `cmd:"" help:"Convert a Patch-and-Transform Composition to a Function Pipeline Composition."`
+	DeploymentRuntime      deploymentruntime.Cmd      `cmd:"" help:"Convert a ControllerConfig to a DeploymentRuntimeConfig."`
+	PipelineComposition    pipelinecomposition.Cmd    `cmd:"" help:"Convert a Patch-and-Transform Composition to a Function Pipeline Composition."`
+	CompositionEnvironment compositionenvironment.Cmd `cmd:"" help:"Convert a Pipeline Composition to use function-environment-configs."`
 }
 
 // Help returns help message for the migrate command.
@@ -45,5 +47,8 @@ Examples:
   # Convert an existing Composition to use Pipelines
   crossplane beta convert pipeline-composition composition.yaml -o pipeline-composition.yaml
 
+  # Convert an existing Composition to use function-environment-configs instead of native Composition Environment,
+  # requires the composition to be in pipeline mode already.
+  crossplane beta convert composition-environment composition.yaml -o composition-environment.yaml
 `
 }

--- a/cmd/crank/beta/convert/convert.go
+++ b/cmd/crank/beta/convert/convert.go
@@ -48,7 +48,7 @@ Examples:
   crossplane beta convert pipeline-composition composition.yaml -o pipeline-composition.yaml
 
   # Convert an existing Composition to use function-environment-configs instead of native Composition Environment,
-  # requires the composition to be in pipeline mode already.
+  # requires the composition to be in Pipeline mode already.
   crossplane beta convert composition-environment composition.yaml -o composition-environment.yaml
 `
 }

--- a/cmd/crank/beta/convert/pipelinecomposition/cmd.go
+++ b/cmd/crank/beta/convert/pipelinecomposition/cmd.go
@@ -19,14 +19,17 @@ limitations under the License.
 package pipelinecomposition
 
 import (
+	"bufio"
+	"io"
+	"os"
+
 	"github.com/pkg/errors"
 	"github.com/spf13/afero"
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/serializer"
-	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/yaml"
 
-	v1 "github.com/crossplane/crossplane/apis/apiextensions/v1"
-	"github.com/crossplane/crossplane/cmd/crank/beta/convert/io"
+	"github.com/crossplane/crossplane/cmd/crank/beta/convert/compositionenvironment"
+	commonio "github.com/crossplane/crossplane/cmd/crank/beta/convert/io"
 )
 
 // Cmd arguments and flags for converting a patch-and-transform to a function pipeline composition.
@@ -35,8 +38,10 @@ type Cmd struct {
 	InputFile string `arg:"" default:"-" help:"The Composition file to be converted. If not specified or '-', stdin will be used." optional:"" type:"path"`
 
 	// Flags.
-	OutputFile   string `help:"The file to write the generated Composition to. If not specified, stdout will be used." placeholder:"PATH"   short:"o" type:"path"`
-	FunctionName string `help:"FunctionRefName. Defaults to function-patch-and-transform."                             placeholder:"STRING" short:"f" type:"string"`
+	OutputFile string `help:"The file to write the generated Composition to. If not specified, stdout will be used." placeholder:"PATH" short:"o" type:"path"`
+
+	FunctionPatchAndTransformRef string `default:"function-patch-and-transform" help:"Name of the existing function-patch-and-transform Function, to be used to reference it." name:"function-patch-and-transform-ref"`
+	FunctionEnvironmentConfigRef string `default:"function-environment-configs" help:"Name of the existing function-environment-configs Function, to be used to reference it." name:"function-environment-configs-ref"`
 
 	fs afero.Fs
 }
@@ -48,15 +53,23 @@ This command converts a Crossplane Composition to use a Composition function pip
 
 By default it transforms the Composition using the classic patch-and-transform approach
 to a function pipeline using crossplane-contrib/function-patch-and-transform, but the
-function ref name can be overridden with the -f flag.
+function ref name can be overridden with the --function-patch-and-transform-ref flag.
+
+If native Composition Environment was used it will also convert the Composition to use
+function-environment-configs, by default it'll reference the function as
+function-environment-configs, but it can be overridden with the --function-environment-configs-ref flag.
+
 
 Examples:
 
   # Convert an existing Composition to use Pipelines
   crossplane beta convert pipeline-composition composition.yaml -o pipeline-composition.yaml
 
-  # Use a different functionRef and output to stdout
-  crossplane beta convert pipeline-composition composition.yaml -f local-function-patch-and-transform
+  # Use a different functionRef for function-patch-and-transform and output to stdout
+  crossplane beta convert pipeline-composition composition.yaml --function-patch-and-transform-ref local-function-patch-and-transform
+
+  # Use a different functionRef for function-environment-configs and output to stdout
+  crossplane beta convert pipeline-composition composition.yaml --function-environment-configs-ref local-function-environment-configs
 
   # Stdin to stdout
   cat composition.yaml | ./crossplane beta convert pipeline-composition 
@@ -72,33 +85,61 @@ func (c *Cmd) AfterApply() error {
 
 // Run converts a classic Composition to a function pipeline Composition.
 func (c *Cmd) Run() error {
-	data, err := io.Read(c.fs, c.InputFile)
+	data, err := commonio.Read(c.fs, c.InputFile)
 	if err != nil {
 		return err
 	}
 
 	// Set up schemes for our API types
-	sch := runtime.NewScheme()
-	_ = scheme.AddToScheme(sch)
-	_ = v1.AddToScheme(sch)
+	u := &unstructured.Unstructured{}
 
-	decode := serializer.NewCodecFactory(sch).UniversalDeserializer().Decode
-
-	oc := &v1.Composition{}
-	_, _, err = decode(data, &v1.CompositionGroupVersionKind, oc)
-	if err != nil {
-		return errors.Wrap(err, "Decoding Error")
+	if err := yaml.Unmarshal(data, u); err != nil {
+		return errors.Wrap(err, "Unmarshalling Error")
 	}
 
-	_, errs := oc.Validate()
-	if len(errs) > 0 {
-		return errors.Wrap(errs.ToAggregate(), "Existing Composition Validation error")
-	}
-
-	pc, err := convertPnTToPipeline(oc, c.FunctionName)
+	out, err := convertPnTToPipeline(u, c.FunctionPatchAndTransformRef)
 	if err != nil {
 		return errors.Wrap(err, "Error generating new Composition")
 	}
+	if out == nil {
+		return nil
+	}
 
-	return io.WriteObjectYAML(c.fs, c.OutputFile, pc)
+	outWithEnv, err := compositionenvironment.ConvertToFunctionEnvironmentConfigs(out, c.FunctionEnvironmentConfigRef)
+	if err != nil {
+		return errors.Wrap(err, "Error generating new Composition")
+	}
+	if outWithEnv != nil {
+		out = outWithEnv
+	}
+
+	b, err := yaml.Marshal(out)
+	if err != nil {
+		return errors.Wrap(err, "Unable to marshal back to yaml")
+	}
+
+	var output io.Writer = os.Stdout
+	if outputFileName := c.OutputFile; outputFileName != "" {
+		f, err := c.fs.OpenFile(outputFileName, os.O_CREATE|os.O_WRONLY, 0o644)
+		if err != nil {
+			return errors.Wrap(err, "Unable to open output file")
+		}
+		defer func() { _ = f.Close() }()
+		output = f
+	}
+
+	outputW := bufio.NewWriter(output)
+	if _, err := outputW.WriteString("---\n"); err != nil {
+		return errors.Wrap(err, "Writing YAML file header")
+	}
+
+	if _, err := outputW.Write(b); err != nil {
+		return errors.Wrap(err, "Writing YAML file content")
+	}
+
+	if err := outputW.Flush(); err != nil {
+		return errors.Wrap(err, "Flushing output")
+	}
+
+	return nil
 }

--- a/cmd/crank/beta/convert/pipelinecomposition/cmd.go
+++ b/cmd/crank/beta/convert/pipelinecomposition/cmd.go
@@ -90,7 +90,6 @@ func (c *Cmd) Run() error {
 		return err
 	}
 
-	// Set up schemes for our API types
 	u := &unstructured.Unstructured{}
 
 	if err := yaml.Unmarshal(data, u); err != nil {

--- a/cmd/crank/beta/convert/pipelinecomposition/converter.go
+++ b/cmd/crank/beta/convert/pipelinecomposition/converter.go
@@ -17,186 +17,188 @@ limitations under the License.
 package pipelinecomposition
 
 import (
-	"errors"
 	"fmt"
-	"strings"
-	"time"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/utils/ptr"
 
 	commonv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
+	"github.com/crossplane/crossplane-runtime/pkg/errors"
+	"github.com/crossplane/crossplane-runtime/pkg/fieldpath"
 
 	v1 "github.com/crossplane/crossplane/apis/apiextensions/v1"
 )
 
-const (
-	defaultFunctionRefName = "function-patch-and-transform"
-	errNilComposition      = "provided Composition is empty"
-)
-
-// convertPnTToPipeline takes a patch-and-transform composition and returns
-// a composition where the built-in patch & transform has been moved to a
-// function. If the existing composition has PipelineMode enabled, it will
-// not change anything.
-func convertPnTToPipeline(c *v1.Composition, functionRefName string) (*v1.Composition, error) {
-	if c == nil {
-		return nil, errors.New(errNilComposition)
+func convertPnTToPipeline(in *unstructured.Unstructured, functionRefName string) (*unstructured.Unstructured, error) {
+	if in == nil {
+		return nil, errors.New("input is nil")
 	}
 
-	// If Composition is already set to run in a Pipeline, return immediately
-	if c.Spec.Mode != nil && *c.Spec.Mode == v1.CompositionModePipeline {
-		return c, nil
+	gvk := in.GetObjectKind().GroupVersionKind()
+
+	if gvk.Empty() {
+		return nil, errors.New("GroupVersionKind is empty")
 	}
 
-	// prevent null timestamps in the output. k8s apply ignores this field
-	if c.ObjectMeta.CreationTimestamp.IsZero() {
-		c.ObjectMeta.CreationTimestamp = metav1.NewTime(time.Now())
+	if gvk.Group != v1.Group {
+		return nil, errors.Errorf("GroupVersionKind Group is not %s", v1.Group)
 	}
 
-	cp := &v1.Composition{
-		TypeMeta:   c.TypeMeta,
-		ObjectMeta: c.ObjectMeta,
-		Spec: v1.CompositionSpec{
-			CompositeTypeRef:                           c.Spec.CompositeTypeRef,
-			WriteConnectionSecretsToNamespace:          c.Spec.DeepCopy().WriteConnectionSecretsToNamespace,
-			PublishConnectionDetailsWithStoreConfigRef: c.Spec.PublishConnectionDetailsWithStoreConfigRef.DeepCopy(),
-		},
+	if gvk.Kind != v1.CompositionKind {
+		return nil, errors.Errorf("GroupVersionKind Kind is not %s", v1.CompositionKind)
 	}
 
-	// Migrate existing input
-	input := &Input{
-		PatchSets: []v1.PatchSet{},
-		Resources: []v1.ComposedTemplate{},
+	out, err := fieldpath.PaveObject(in)
+	if err != nil {
+		return nil, err
 	}
 
-	if len(c.Spec.PatchSets) > 0 {
-		input.PatchSets = c.Spec.PatchSets
+	var mode v1.CompositionMode
+	err = out.GetValueInto("spec.mode", &mode)
+	switch {
+	case fieldpath.IsNotFound(err):
+		mode = v1.CompositionModeResources
+	case err != nil:
+		return nil, errors.Wrap(err, "failed to get composition mode")
+	case mode == v1.CompositionModePipeline:
+		// nothing to do
+		return in, nil
 	}
-	if len(c.Spec.Resources) > 0 {
-		input.Resources = c.Spec.Resources
+
+	// Set up the pipeline step
+	if err := out.SetValue("spec.mode", v1.CompositionModePipeline); err != nil {
+		return nil, errors.Wrap(err, "failed to set Composition mode to Pipeline")
+	}
+
+	// Composition Environment settings are now handled by both function-patch-and-transform and function-environment-configs
+	// Prepare function-patch-and-transform input
+	fptInputPaved := fieldpath.Pave(map[string]any{
+		"apiVersion": "pt.fn.crossplane.io/v1beta1",
+		"kind":       "Resources",
+	})
+
+	// Copy spec.environment.patches to function-patch-and-transform, if any
+	if err := migrateEnvironmentPatches(out, fptInputPaved); err != nil {
+		return nil, errors.Wrap(err, "failed to migrate environment")
+	}
+
+	// Copy spec.patchSets, if any, and migrate all patches
+	if err := migratePatchSets(out, fptInputPaved); err != nil {
+		return nil, errors.Wrap(err, "failed to migrate patchSets")
+	}
+
+	// Copy spec.resources, if
+	if err := migrateResources(out, fptInputPaved); err != nil {
+		return nil, errors.Wrap(err, "failed to migrate resources")
 	}
 
 	// Override function name if provided
-	fr := v1.FunctionReference{Name: defaultFunctionRefName}
-	if functionRefName != "" {
-		fr.Name = functionRefName
+	if functionRefName == "" {
+		functionRefName = "function-patch-and-transform"
 	}
 
-	// Set up the pipeline
-	pipelineMode := v1.CompositionModePipeline
-	cp.Spec.Mode = &pipelineMode
-
-	cp.Spec.Pipeline = []v1.PipelineStep{
-		{
-			Step:        "patch-and-transform",
-			FunctionRef: fr,
-			Input:       processFunctionInput(input),
-		},
+	if err := out.SetValue("spec.pipeline[0].step", "patch-and-transform"); err != nil {
+		return nil, errors.Wrap(err, "failed to set pipeline step")
 	}
-	return cp, nil
+
+	if err := out.SetValue("spec.pipeline[0].functionRef.name", functionRefName); err != nil {
+		return nil, errors.Wrap(err, "failed to set pipeline functionRef name")
+	}
+
+	if err := out.SetValue("spec.pipeline[0].input", fptInputPaved.UnstructuredContent()); err != nil {
+		return nil, errors.Wrap(err, "failed to set pipeline input")
+	}
+
+	return &unstructured.Unstructured{Object: out.UnstructuredContent()}, nil
 }
 
-// processFunctionInput populates any missing fields in the input to the function
-// that are required by the function but were optional in the built-in engine.
-func processFunctionInput(input *Input) *runtime.RawExtension {
-	processedInput := &Input{}
-
-	// process PatchSets
-	processedPatchSet := []v1.PatchSet{}
-	for _, patchSet := range input.PatchSets {
-		processedPatchSet = append(processedPatchSet, setMissingPatchSetFields(patchSet))
-	}
-	processedInput.PatchSets = processedPatchSet
-
-	// process Resources
-	processedResources := []v1.ComposedTemplate{}
-	for idx, resource := range input.Resources {
-		processedResources = append(processedResources, setMissingResourceFields(idx, resource))
-	}
-	processedInput.Resources = processedResources
-
-	// Wrap the input in a RawExtension
-	inputType := map[string]any{
-		"apiVersion": "pt.fn.crossplane.io/v1beta1",
-		"kind":       "Resources",
-		"patchSets":  MigratePatchPolicyInPatchSets(processedInput.PatchSets),
-		"resources":  MigratePatchPolicyInResources(processedInput.Resources),
-	}
-
-	return &runtime.RawExtension{
-		Object: &unstructured.Unstructured{Object: inputType},
-	}
-}
-
-// MigratePatchPolicyInResources processes all the patches in the given resources to migrate their patch policies.
-func MigratePatchPolicyInResources(resources []v1.ComposedTemplate) []ComposedTemplate {
-	composedTemplates := []ComposedTemplate{}
-
-	for _, resource := range resources {
-		composedTemplate := ComposedTemplate{}
-		composedTemplate.ComposedTemplate = resource
-		composedTemplate.Patches = migratePatches(resource.Patches)
-		// Conversion function above overrides the patches in the new type,
-		// so after conversion we set the underlying patches to nil to make sure
-		// there's no conflict in the serialized output.
-		composedTemplate.ComposedTemplate.Patches = nil
-		composedTemplates = append(composedTemplates, composedTemplate)
-	}
-	return composedTemplates
-}
-
-// MigratePatchPolicyInPatchSets processes all the patches in the given patch set to migrate their patch policies.
-func MigratePatchPolicyInPatchSets(patchset []v1.PatchSet) []PatchSet {
-	newPatchSets := []PatchSet{}
-
-	for _, patchSet := range patchset {
-		newpatchset := PatchSet{}
-		newpatchset.Name = patchSet.Name
-		newpatchset.Patches = migratePatches(patchSet.Patches)
-
-		newPatchSets = append(newPatchSets, newpatchset)
-	}
-
-	return newPatchSets
-}
-
-func migratePatches(patches []v1.Patch) []Patch {
-	newPatches := []Patch{}
-
-	for _, patch := range patches {
-		newpatch := Patch{}
-		newpatch.Patch = patch
-
-		if patch.Policy != nil {
-			newpatch.Policy = migratePatchPolicy(patch.Policy)
-			// Conversion function above overrides the patch policy in the new type,
-			// so after conversion we set underlying policy to nil to make sure
-			// there's no conflict in the serialized output.
-			newpatch.Patch.Policy = nil
+func migrateResources(out *fieldpath.Paved, fptInputPaved *fieldpath.Paved) error {
+	var resources []map[string]any
+	if err := out.GetValueInto("spec.resources", &resources); err == nil {
+		for idx, resource := range resources {
+			r, err := migrateResource(resource, idx)
+			if err != nil {
+				return errors.Wrap(err, "failed to migrate resource")
+			}
+			resources[idx] = r.UnstructuredContent()
 		}
-
-		newPatches = append(newPatches, newpatch)
+		if err := fptInputPaved.SetValue("resources", resources); err != nil {
+			return errors.Wrap(err, "failed to copy resources")
+		}
 	}
-
-	return newPatches
+	if err := out.DeleteField("spec.resources"); err != nil {
+		return errors.Wrap(err, "failed to delete resources")
+	}
+	return nil
 }
 
-func migratePatchPolicy(policy *v1.PatchPolicy) *PatchPolicy {
-	to := migrateMergeOptions(policy.MergeOptions)
+func migratePatchSets(out *fieldpath.Paved, fptInputPaved *fieldpath.Paved) error {
+	var patchSets []map[string]any
+	if err := out.GetValueInto("spec.patchSets", &patchSets); err == nil {
+		if err := fptInputPaved.SetValue("patchSets", patchSets); err != nil {
+			return errors.Wrap(err, "failed to copy patchSets")
+		}
+		if err := out.DeleteField("spec.patchSets"); err != nil {
+			return errors.Wrap(err, "failed to delete patchSets")
+		}
+		paths, err := fptInputPaved.ExpandWildcards("patchSets[*].patches[*]")
+		if err != nil {
+			return errors.Wrap(err, "failed to expand patchSets")
+		}
+		for _, path := range paths {
+			p := map[string]any{}
+			if err := fptInputPaved.GetValueInto(path, &p); err != nil {
+				return errors.Wrap(err, "failed to get patch")
+			}
+			paved, err := migratePatch(p)
+			if err != nil {
+				return errors.Wrap(err, "failed to migrate patch")
+			}
+			if err := fptInputPaved.SetValue(path, paved.UnstructuredContent()); err != nil {
+				return errors.Wrap(err, "failed to set patch")
+			}
+		}
+	}
+	return nil
+}
 
-	if to == nil && policy.FromFieldPath == nil {
-		// neither To nor From has been set, just return nil to use defaults for
-		// everything
+func migrateEnvironmentPatches(out *fieldpath.Paved, fptInputPaved *fieldpath.Paved) error {
+	var envPatches []map[string]any
+	if err := out.GetValueInto("spec.environment.patches", &envPatches); err == nil {
+		for idx, patch := range envPatches {
+			p, err := migratePatch(patch)
+			if err != nil {
+				return errors.Wrap(err, "failed to set environment patch type")
+			}
+			envPatches[idx] = p.UnstructuredContent()
+		}
+		if err := fptInputPaved.SetValue("environment.patches", envPatches); err != nil {
+			return errors.Wrap(err, "failed to set environment patches")
+		}
+		if err := out.DeleteField("spec.environment.patches"); err != nil {
+			return errors.Wrap(err, "failed to delete environment patches")
+		}
+	}
+
+	if err := out.DeleteField("spec.environment.patches"); err != nil && !fieldpath.IsNotFound(err) {
+		return errors.Wrap(err, "failed to delete environment")
+	}
+
+	env := map[string]any{}
+	if err := out.GetValueInto("spec.environment", &env); err != nil {
+		return errors.Wrap(err, "failed to get environment")
+	}
+
+	if len(env) != 0 {
+		// other fields left in environment, nothing to do
 		return nil
 	}
 
-	return &PatchPolicy{
-		FromFieldPath: policy.FromFieldPath,
-		ToFieldPath:   to,
+	if err := out.DeleteField("spec.environment"); err != nil {
+		return errors.Wrap(err, "failed to delete empty environment")
 	}
+
+	return nil
 }
 
 // migrateMergeOptions implements the conversion of mergeOptions to the new
@@ -208,8 +210,8 @@ func migrateMergeOptions(mo *commonv1.MergeOptions) *ToFieldPathPolicy {
 		return nil
 	}
 
-	if isTrue(mo.KeepMapValues) {
-		if isNilOrFalse(mo.AppendSlice) {
+	if ptr.Deref(mo.KeepMapValues, false) {
+		if !ptr.Deref(mo.AppendSlice, false) {
 			// { appendSlice: nil/false, keepMapValues: true}
 			return ptr.To(ToFieldPathPolicyMergeObjects)
 		}
@@ -218,85 +220,13 @@ func migrateMergeOptions(mo *commonv1.MergeOptions) *ToFieldPathPolicy {
 		return ptr.To(ToFieldPathPolicyMergeObjectsAppendArrays)
 	}
 
-	if isTrue(mo.AppendSlice) {
+	if ptr.Deref(mo.AppendSlice, false) {
 		// { appendSlice: true, keepMapValues: nil/false }
 		return ptr.To(ToFieldPathPolicyForceMergeObjectsAppendArrays)
 	}
 
 	// { appendSlice: nil/false, keepMapValues: nil/false }
 	return ptr.To(ToFieldPathPolicyForceMergeObjects)
-}
-
-func isNilOrFalse(b *bool) bool {
-	return b == nil || !*b
-}
-
-func isTrue(b *bool) bool {
-	return b != nil && *b
-}
-
-func setMissingPatchSetFields(patchSet v1.PatchSet) v1.PatchSet {
-	p := []v1.Patch{}
-	for _, patch := range patchSet.Patches {
-		p = append(p, setMissingPatchFields(patch))
-	}
-	patchSet.Patches = p
-	return patchSet
-}
-
-func setMissingPatchFields(patch v1.Patch) v1.Patch {
-	if patch.Type == "" {
-		patch.Type = v1.PatchTypeFromCompositeFieldPath
-	}
-	if len(patch.Transforms) == 0 {
-		return patch
-	}
-	t := []v1.Transform{}
-	for _, transform := range patch.Transforms {
-		t = append(t, setTransformTypeRequiredFields(transform))
-	}
-	patch.Transforms = t
-	return patch
-}
-
-func setMissingResourceFields(idx int, rs v1.ComposedTemplate) v1.ComposedTemplate {
-	if rs.Name == nil || *rs.Name == "" {
-		rs.Name = ptr.To(strings.ToLower(fmt.Sprintf("resource-%d", idx)))
-	}
-
-	cd := []v1.ConnectionDetail{}
-	for _, detail := range rs.ConnectionDetails {
-		cd = append(cd, setMissingConnectionDetailFields(detail))
-	}
-	rs.ConnectionDetails = cd
-
-	patches := []v1.Patch{}
-	for _, patch := range rs.Patches {
-		patches = append(patches, setMissingPatchFields(patch))
-	}
-	rs.Patches = patches
-	return rs
-}
-
-// setTransformTypeRequiredFields sets fields that are required with
-// function-patch-and-transform but were optional with the built-in engine.
-func setTransformTypeRequiredFields(tt v1.Transform) v1.Transform {
-	if tt.Type == "" {
-		if tt.Math != nil {
-			tt.Type = v1.TransformTypeMath
-		}
-		if tt.String != nil {
-			tt.Type = v1.TransformTypeString
-		}
-	}
-	if tt.Type == v1.TransformTypeMath && tt.Math.Type == "" {
-		tt.Math.Type = getMathTransformType(tt)
-	}
-
-	if tt.Type == v1.TransformTypeString && tt.String.Type == "" {
-		tt.String.Type = getStringTransformType(tt)
-	}
-	return tt
 }
 
 func getMathTransformType(tt v1.Transform) v1.MathTransformType {
@@ -327,6 +257,90 @@ func getStringTransformType(tt v1.Transform) v1.StringTransformType {
 	return ""
 }
 
+// migratePatch will perform all migration steps required to ensure that the
+// given patch is in the correct format for function-patch-and-transform:
+// - default the type to FromCompositeFieldPath if it is not set
+// - migrate the patch policy to the new format
+// - enforce that all transforms have a type set.
+func migratePatch(patch map[string]any) (*fieldpath.Paved, error) {
+	p := fieldpath.Pave(patch)
+	_, err := p.GetString("type")
+	if fieldpath.IsNotFound(err) {
+		if err := p.SetValue("type", v1.PatchTypeFromCompositeFieldPath); err != nil {
+			return nil, errors.Wrap(err, "failed to set patch type")
+		}
+	}
+
+	var mo *commonv1.MergeOptions
+	if err := p.GetValueInto("policy.mergeOptions", &mo); err != nil && !fieldpath.IsNotFound(err) {
+		return nil, errors.Wrap(err, "failed to get mergeOptions")
+	}
+
+	if newPolicy := migrateMergeOptions(mo); newPolicy != nil {
+		if err := p.SetValue("policy.toFieldPath", newPolicy); err != nil {
+			return nil, errors.Wrap(err, "failed to set policy.toFieldPath")
+		}
+	}
+
+	if err := p.DeleteField("policy.mergeOptions"); err != nil && !fieldpath.IsNotFound(err) {
+		return nil, errors.Wrap(err, "failed to delete policy.mergeOptions")
+	}
+
+	var transforms []v1.Transform
+	if err := p.GetValueInto("transforms", &transforms); err == nil {
+		for idx, transform := range transforms {
+			transforms[idx] = setTransformTypeRequiredFields(transform)
+		}
+		if err := p.SetValue("transforms", transforms); err != nil {
+			return nil, errors.Wrap(err, "failed to set transforms")
+		}
+	}
+
+	return p, nil
+}
+
+// migrateResources will perform all migration steps required to ensure that the
+// given resource is in the correct format for function-patch-and-transform:
+// - set a resource name, if not set
+// - defaulting connection details, if needed
+// - migrate all patches, if needed.
+func migrateResource(resource map[string]any, idx int) (*fieldpath.Paved, error) {
+	r := fieldpath.Pave(resource)
+
+	_, err := r.GetString("name")
+	if fieldpath.IsNotFound(err) {
+		if err := r.SetValue("name", fmt.Sprintf("resource-%d", idx)); err != nil {
+			return nil, errors.Wrap(err, "failed to set resource name")
+		}
+	}
+
+	var connectionDetails []v1.ConnectionDetail
+	if err := r.GetValueInto("connectionDetails", &connectionDetails); err == nil {
+		for idx, cd := range connectionDetails {
+			connectionDetails[idx] = setMissingConnectionDetailFields(cd)
+		}
+		if err := r.SetValue("connectionDetails", connectionDetails); err != nil {
+			return nil, errors.Wrap(err, "failed to set connectionDetails")
+		}
+	}
+
+	var patches []map[string]any
+	if err := r.GetValueInto("patches", &patches); err == nil {
+		for idx, patch := range patches {
+			p, err := migratePatch(patch)
+			if err != nil {
+				return nil, errors.Wrap(err, "failed to migrate patch")
+			}
+			patches[idx] = p.UnstructuredContent()
+		}
+		if err := r.SetValue("patches", patches); err != nil {
+			return nil, errors.Wrap(err, "failed to set patches")
+		}
+	}
+
+	return r, nil
+}
+
 func setMissingConnectionDetailFields(sk v1.ConnectionDetail) v1.ConnectionDetail {
 	// Only one of the values should be set, but we are not validating it here
 	nsk := v1.ConnectionDetail{
@@ -355,4 +369,25 @@ func setMissingConnectionDetailFields(sk v1.ConnectionDetail) v1.ConnectionDetai
 		// FromValue and FromFieldPath should have a name, skip implementation for now
 	}
 	return nsk
+}
+
+// setTransformTypeRequiredFields sets fields that are required with
+// function-patch-and-transform but were optional with the built-in engine.
+func setTransformTypeRequiredFields(tt v1.Transform) v1.Transform {
+	if tt.Type == "" {
+		if tt.Math != nil {
+			tt.Type = v1.TransformTypeMath
+		}
+		if tt.String != nil {
+			tt.Type = v1.TransformTypeString
+		}
+	}
+	if tt.Type == v1.TransformTypeMath && tt.Math.Type == "" {
+		tt.Math.Type = getMathTransformType(tt)
+	}
+
+	if tt.Type == v1.TransformTypeString && tt.String.Type == "" {
+		tt.String.Type = getStringTransformType(tt)
+	}
+	return tt
 }

--- a/cmd/crank/beta/convert/pipelinecomposition/converter.go
+++ b/cmd/crank/beta/convert/pipelinecomposition/converter.go
@@ -62,7 +62,7 @@ func convertPnTToPipeline(in *unstructured.Unstructured, functionRefName string)
 		return nil, errors.Wrap(err, "failed to get composition mode")
 	case mode == v1.CompositionModePipeline:
 		// nothing to do
-		return in, nil
+		return nil, nil
 	}
 
 	// Set up the pipeline step

--- a/cmd/crank/beta/convert/pipelinecomposition/converter.go
+++ b/cmd/crank/beta/convert/pipelinecomposition/converter.go
@@ -87,7 +87,7 @@ func convertPnTToPipeline(in *unstructured.Unstructured, functionRefName string)
 		return nil, errors.Wrap(err, "failed to migrate patchSets")
 	}
 
-	// Copy spec.resources, if
+	// Copy spec.resources, if any, and migrate all patches
 	if err := migrateResources(out, fptInputPaved); err != nil {
 		return nil, errors.Wrap(err, "failed to migrate resources")
 	}

--- a/cmd/crank/beta/convert/pipelinecomposition/types.go
+++ b/cmd/crank/beta/convert/pipelinecomposition/types.go
@@ -18,54 +18,6 @@ package pipelinecomposition
 
 import v1 "github.com/crossplane/crossplane/apis/apiextensions/v1"
 
-// Input represents the input to the patch-and-transform function. This struct
-// originates from function patch and transform, as we can't import it directly
-// https://github.com/crossplane-contrib/function-patch-and-transform/blob/main/input/v1beta1/resources.go
-// Note that it does not exactly match the target type with full fidelity.
-// This type is used during the processing and conversion of the given input,
-// but the final converted output is written in an unstructured manner without a
-// static type definition for more flexibility.
-type Input struct {
-	// PatchSets define a named set of patches that may be included by any
-	// resource in this Composition. PatchSets cannot themselves refer to other
-	// PatchSets.
-	//
-	// PatchSets are only used by the "Resources" mode of Composition. They
-	// are ignored by other modes.
-	// +optional
-	PatchSets []v1.PatchSet `json:"patchSets,omitempty"`
-
-	// Resources is a list of resource templates that will be used when a
-	// composite resource referring to this composition is created.
-	//
-	// Resources are only used by the "Resources" mode of Composition. They are
-	// ignored by other modes.
-	// +optional
-	Resources []v1.ComposedTemplate `json:"resources,omitempty"`
-}
-
-// PatchSet wrapper around v1.PatchSet with custom Patch.
-type PatchSet struct {
-	// Name of this PatchSet.
-	Name string `json:"name"`
-
-	Patches []Patch `json:"patches"`
-}
-
-// ComposedTemplate wrapper around v1.ComposedTemplate with custom Patch.
-type ComposedTemplate struct {
-	v1.ComposedTemplate
-
-	Patches []Patch `json:"patches,omitempty"`
-}
-
-// Patch wrapper around v1.Patch with custom PatchPolicy.
-type Patch struct {
-	v1.Patch
-
-	Policy *PatchPolicy `json:"policy,omitempty"`
-}
-
 // A ToFieldPathPolicy determines how to patch to a field path.
 type ToFieldPathPolicy string
 


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane! Please read the contribution docs
(linked below) if this is your first Crossplane pull request.
-->

### Description of your changes

<!--
Briefly describe what this pull request does, and how it is covered by tests.
Be proactive - direct your reviewers' attention to anything that needs special
consideration.

We love pull requests that fix an open issue. If yours does, use the below line
to indicate which issue it fixes, for example "Fixes #500".
-->

Now that https://github.com/crossplane/crossplane/pull/5938 was merged, from Crossplane `v1.18.0` native `Composition Environment` was dropped, in favour of [function-environment-configs](https://github.com/crossplane-contrib/function-environment-configs). Hence documentation and tooling is required to help users migrate.

This patch adds a new subcommand `crossplane beta convert composition-environment`, which allows to convert a Composition already in `Pipeline` mode, but still leveraging native `Composition Environment` support, i.e. `spec.environment`, to use `function-environment-configs`.

To also support users still on `Resources` mode Compositions, wanting to migrate to `Pipeline` based compositions on Crossplane 1.18, we need to go through both steps, `Resources` mode -> `Pipeline` mode using `function-patch-and-transform`, but with native Composition Environment, if any -> full Crossplane 1.18 `Pipeline` mode using `function-patch-and-transform` and `function-environment-configs`.

The first transition was covered already by the existing `crossplane beta convert pipeline-composition` subcommand, but its current implementation wasn't preserving unknown fields, going through the `Composition` type it knew, leading to `spec.environment` being dropped altogether, if present, meaning that we couldn't pipe the two commands to get a full transition as needed.

Therefore, I had to rewrite `crossplane beta convert pipeline-composition` to have a more loose `fieldpath`-based approach. While at it I also switched to plain yaml serialization, instead of the schema based, to avoid the issues with creation timestamps. I should have reached similar test coverage as the original implementation, but obviously it's new code and therefore I plan to add more niche corner cases to be sure it behaves correctly.

`crossplane beta convert pipeline-composition` now also goes through the native Composition Environment migration if needed, in order to streamline the experience for users.

So, to be clear, users will only need to run a single command based on their current condition:
- `crossplane beta convert pipeline-composition`: if the Composition is still in `Resource` mode.
- `crossplane beta convert compositione-environment`: if the Composition is already in `Pipeline` mode, but uses other fields in `spec.environment` than `spec.environment.patches`.

I renamed the flag to pass the ref name to a more unique name, so that both the names of function-patch-and-transform and function-environment-configs can be customized. I don't see it as a breaking change being a one-off migration command, worst case we'll invalidate someone's history.

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `earthly +reviewable` to ensure this PR is ready for review.
- [x] Added or updated unit tests.
- [ ] ~Added or updated e2e tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
