### PR TITLE
feat(xfn): Consider composite ready state in function response

### DIFF
--- a/apis/apiextensions/fn/proto/v1/run_function.pb.go
+++ b/apis/apiextensions/fn/proto/v1/run_function.pb.go
@@ -1066,8 +1066,11 @@ type Resource struct {
 	//   - A Function should set this field to READY_TRUE in a RunFunctionResponse
 	//     to indicate that a desired composed resource is ready.
 	//
-	//   - A Function should not set this field in a RunFunctionResponse to indicate
-	//     that the desired composite resource is ready. This will be ignored.
+	//   - A Function should set this field to READY_TRUE in a RunFunctionResponse
+	//     to indicate that a desired composite resource is ready.
+	//     This overwrites the standard readiness detection that determines the
+	//     ready state of the composite by the ready state of the the
+	//     composed resources.
 	Ready Ready `protobuf:"varint,3,opt,name=ready,proto3,enum=apiextensions.fn.proto.v1.Ready" json:"ready,omitempty"`
 }
 

--- a/apis/apiextensions/fn/proto/v1/run_function.proto
+++ b/apis/apiextensions/fn/proto/v1/run_function.proto
@@ -224,8 +224,11 @@ message Resource {
   // * A Function should set this field to READY_TRUE in a RunFunctionResponse
   //   to indicate that a desired composed resource is ready.
   //
-  // * A Function should not set this field in a RunFunctionResponse to indicate
-  //   that the desired composite resource is ready. This will be ignored.
+  // * A Function should set this field to READY_TRUE in a RunFunctionResponse
+  //   to indicate that a desired composite resource is ready.
+  //   This overwrites the standard readiness detection that determines the
+  //   ready state of the composite by the ready state of the the
+  //   composed resources.
   Ready ready = 3;
 }
 

--- a/apis/apiextensions/fn/proto/v1beta1/zz_generated_run_function.pb.go
+++ b/apis/apiextensions/fn/proto/v1beta1/zz_generated_run_function.pb.go
@@ -1068,8 +1068,11 @@ type Resource struct {
 	//   - A Function should set this field to READY_TRUE in a RunFunctionResponse
 	//     to indicate that a desired composed resource is ready.
 	//
-	//   - A Function should not set this field in a RunFunctionResponse to indicate
-	//     that the desired composite resource is ready. This will be ignored.
+	//   - A Function should set this field to READY_TRUE in a RunFunctionResponse
+	//     to indicate that a desired composite resource is ready.
+	//     This overwrites the standard readiness detection that determines the
+	//     ready state of the composite by the ready state of the the
+	//     composed resources.
 	Ready Ready `protobuf:"varint,3,opt,name=ready,proto3,enum=apiextensions.fn.proto.v1beta1.Ready" json:"ready,omitempty"`
 }
 

--- a/apis/apiextensions/fn/proto/v1beta1/zz_generated_run_function.proto
+++ b/apis/apiextensions/fn/proto/v1beta1/zz_generated_run_function.proto
@@ -226,8 +226,11 @@ message Resource {
   // * A Function should set this field to READY_TRUE in a RunFunctionResponse
   //   to indicate that a desired composed resource is ready.
   //
-  // * A Function should not set this field in a RunFunctionResponse to indicate
-  //   that the desired composite resource is ready. This will be ignored.
+  // * A Function should set this field to READY_TRUE in a RunFunctionResponse
+  //   to indicate that a desired composite resource is ready.
+  //   This overwrites the standard readiness detection that determines the
+  //   ready state of the composite by the ready state of the the
+  //   composed resources.
   Ready ready = 3;
 }
 

--- a/internal/controller/apiextensions/composite/composed.go
+++ b/internal/controller/apiextensions/composite/composed.go
@@ -22,6 +22,15 @@ import (
 	v1 "github.com/crossplane/crossplane/apis/apiextensions/v1"
 )
 
+// A CompositeResource is an output of the composition process.
+type CompositeResource struct { //nolint:revive // stick with CompositeResource
+	// Ready indicated whether the composite resource should be marked as
+	// ready or unready regardless of the state of the composed resoureces.
+	// If it is nil the readiness of the composite is determined by the
+	// readiness of the composed resources.
+	Ready *bool
+}
+
 // A ResourceName uniquely identifies the composed resource within a Composition
 // and within Composition Function gRPC calls. This is not the metadata.name of
 // the actual composed resource instance; rather it is the name of an entry in a


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane! Please read the contribution docs
(linked below) if this is your first Crossplane pull request.
-->

### Description of your changes

Marks the composite as ready or unready if the if `.Desired.Composite.Ready` field is set explicitly.

Fixes https://github.com/crossplane/crossplane/issues/6020

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `earthly +reviewable` to ensure this PR is ready for review.
- ~[ ] Added or updated unit tests.~
- ~[ ] Added or updated e2e tests.~
- ~[ ] Linked a PR or a [docs tracking issue] to [document this change].~
- [x] Added `backport release-x.y` labels to auto-backport this PR.

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
