### PR TITLE
build: bump golang to 1.22.8

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -3,7 +3,7 @@ VERSION --try --raw-output 0.8
 
 PROJECT crossplane/crossplane
 
-ARG --global GO_VERSION=1.22.3
+ARG --global GO_VERSION=1.22.8
 
 # reviewable checks that a branch is ready for review. Run it before opening a
 # pull request. It will catch a lot of the things our CI workflow will catch.

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/crossplane/crossplane
 
-go 1.22.3
-
-toolchain go1.22.5
+go 1.22.8
 
 require (
 	dario.cat/mergo v1.0.0


### PR DESCRIPTION
### Description of your changes

This PR bumps the version of golang used in our builds to 1.22.8 in response to a security vulnerability reported in golang: https://nvd.nist.gov/vuln/detail/CVE-2024-24790#range-13244817.

This PR should be backported to 1.17, but separate PRs will be needed to fix in 1.16 and 1.15 due to those releases not using Earthly for their builds.

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `earthly +reviewable` to ensure this PR is ready for review.
- [ ] ~Added or updated unit tests.~
- [ ] ~Added or updated e2e tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [x] Added `backport release-x.y` labels to auto-backport this PR.

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
