### PR TITLE
build: bump golang to 1.22.8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
 
 env:
   # Common versions
-  GO_VERSION: '1.22.3'
+  GO_VERSION: '1.22.8'
   GOLANGCI_VERSION: 'v1.57.2'
   DOCKER_BUILDX_VERSION: 'v0.10.0'
 

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/crossplane/crossplane
 
-go 1.21
-
-toolchain go1.22.3
+go 1.22.8
 
 require (
 	dario.cat/mergo v1.0.0


### PR DESCRIPTION
### Description of your changes

Similar to #6024, this PR bumps our version of golang 1.22.8, but in the release-1.16 branch that is still using a `make` based build process.

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `earthly +reviewable` to ensure this PR is ready for review.
- [ ] ~Added or updated unit tests.~
- [ ] ~Added or updated e2e tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
