### PR TITLE
fix(crank): convert pipeline-composition skip if no environment defined at all

### DIFF
--- a/cmd/crank/beta/convert/compositionenvironment/cmd.go
+++ b/cmd/crank/beta/convert/compositionenvironment/cmd.go
@@ -103,7 +103,7 @@ func (c *Cmd) Run(k *kong.Context) error {
 		return errors.Wrap(err, "Unable to marshal back to yaml")
 	}
 
-	var output = k.Stdout
+	output := k.Stdout
 	if outputFileName := c.OutputFile; outputFileName != "" {
 		f, err := c.fs.OpenFile(outputFileName, os.O_CREATE|os.O_WRONLY, 0o644)
 		if err != nil {

--- a/cmd/crank/beta/convert/compositionenvironment/converter_test.go
+++ b/cmd/crank/beta/convert/compositionenvironment/converter_test.go
@@ -135,6 +135,51 @@ spec:
 `),
 			},
 		},
+		"SuccessWithNoEnvironment": {
+			reason: "Should do nothing if the Composition has no environment defined.",
+			args: args{
+				in: fromYAML(t, `
+apiVersion: apiextensions.crossplane.io/v1
+kind: Composition
+metadata:
+   name: foo
+spec:
+  compositeTypeRef:
+    apiVersion: example.crossplane.io/v1
+    kind: XR
+  mode: Pipeline
+  pipeline:
+  - step: patch-and-transform
+    functionRef:
+      name: function-patch-and-transform
+    input:
+      apiVersion: pt.fn.crossplane.io/v1beta1
+      kind: Resources
+      environment:
+        patches:
+        - type: ToCompositeFieldPath
+          fromFieldPath: "someFieldInTheEnvironment"
+          toFieldPath: "status.someFieldFromTheEnvironment"
+      resources:
+      - name: bucket
+        base:
+          apiVersion: s3.aws.upbound.io/v1beta1
+          kind: Bucket
+          spec:
+            forProvider:
+              region: us-east-2
+        patches:
+        - type: FromEnvironmentFieldPath
+          fromFieldPath: "someFieldInTheEnvironment"
+          toFieldPath: "spec.forProvider.someFieldFromTheEnvironment"
+        - type: ToEnvironmentFieldPath
+          fromFieldPath: "status.someOtherFieldInTheResource"
+          toFieldPath: "someOtherFieldInTheEnvironment"`),
+			},
+			want: want{
+				out: nil,
+			},
+		},
 		"FailWithResources": {
 			reason: "Should refuse to convert a Composition that still uses Resources mode.",
 			args: args{

--- a/cmd/crank/beta/convert/pipelinecomposition/cmd.go
+++ b/cmd/crank/beta/convert/pipelinecomposition/cmd.go
@@ -119,7 +119,7 @@ func (c *Cmd) Run(k *kong.Context) error {
 		return errors.Wrap(err, "Unable to marshal back to yaml")
 	}
 
-	var output = k.Stdout
+	output := k.Stdout
 	if outputFileName := c.OutputFile; outputFileName != "" {
 		f, err := c.fs.OpenFile(outputFileName, os.O_CREATE|os.O_WRONLY, 0o644)
 		if err != nil {

--- a/cmd/crank/beta/convert/pipelinecomposition/converter.go
+++ b/cmd/crank/beta/convert/pipelinecomposition/converter.go
@@ -78,7 +78,7 @@ func convertPnTToPipeline(in *unstructured.Unstructured, functionRefName string)
 	})
 
 	// Copy spec.environment.patches to function-patch-and-transform, if any
-	if err := migrateEnvironmentPatches(out, fptInputPaved); err != nil {
+	if err := migrateEnvironmentPatches(out, fptInputPaved); err != nil && !fieldpath.IsNotFound(err) {
 		return nil, errors.Wrap(err, "failed to migrate environment")
 	}
 

--- a/cmd/crank/beta/convert/pipelinecomposition/converter.go
+++ b/cmd/crank/beta/convert/pipelinecomposition/converter.go
@@ -83,7 +83,7 @@ func convertPnTToPipeline(in *unstructured.Unstructured, functionRefName string)
 	}
 
 	// Copy spec.patchSets, if any, and migrate all patches
-	if err := migratePatchSets(out, fptInputPaved); err != nil {
+	if err := migratePatchSets(out, fptInputPaved); err != nil && !fieldpath.IsNotFound(err) {
 		return nil, errors.Wrap(err, "failed to migrate patchSets")
 	}
 
@@ -134,29 +134,30 @@ func migrateResources(out *fieldpath.Paved, fptInputPaved *fieldpath.Paved) erro
 
 func migratePatchSets(out *fieldpath.Paved, fptInputPaved *fieldpath.Paved) error {
 	var patchSets []map[string]any
-	if err := out.GetValueInto("spec.patchSets", &patchSets); err == nil {
-		if err := fptInputPaved.SetValue("patchSets", patchSets); err != nil {
-			return errors.Wrap(err, "failed to copy patchSets")
+	if err := out.GetValueInto("spec.patchSets", &patchSets); err != nil {
+		return errors.Wrap(err, "failed to get patchSets")
+	}
+	if err := fptInputPaved.SetValue("patchSets", patchSets); err != nil {
+		return errors.Wrap(err, "failed to copy patchSets")
+	}
+	if err := out.DeleteField("spec.patchSets"); err != nil {
+		return errors.Wrap(err, "failed to delete patchSets")
+	}
+	paths, err := fptInputPaved.ExpandWildcards("patchSets[*].patches[*]")
+	if err != nil {
+		return errors.Wrap(err, "failed to expand patchSets")
+	}
+	for _, path := range paths {
+		p := map[string]any{}
+		if err := fptInputPaved.GetValueInto(path, &p); err != nil {
+			return errors.Wrap(err, "failed to get patch")
 		}
-		if err := out.DeleteField("spec.patchSets"); err != nil {
-			return errors.Wrap(err, "failed to delete patchSets")
-		}
-		paths, err := fptInputPaved.ExpandWildcards("patchSets[*].patches[*]")
+		paved, err := migratePatch(p)
 		if err != nil {
-			return errors.Wrap(err, "failed to expand patchSets")
+			return errors.Wrap(err, "failed to migrate patch")
 		}
-		for _, path := range paths {
-			p := map[string]any{}
-			if err := fptInputPaved.GetValueInto(path, &p); err != nil {
-				return errors.Wrap(err, "failed to get patch")
-			}
-			paved, err := migratePatch(p)
-			if err != nil {
-				return errors.Wrap(err, "failed to migrate patch")
-			}
-			if err := fptInputPaved.SetValue(path, paved.UnstructuredContent()); err != nil {
-				return errors.Wrap(err, "failed to set patch")
-			}
+		if err := fptInputPaved.SetValue(path, paved.UnstructuredContent()); err != nil {
+			return errors.Wrap(err, "failed to set patch")
 		}
 	}
 	return nil


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane! Please read the contribution docs
(linked below) if this is your first Crossplane pull request.
-->

### Description of your changes

<!--
Briefly describe what this pull request does, and how it is covered by tests.
Be proactive - direct your reviewers' attention to anything that needs special
consideration.

We love pull requests that fix an open issue. If yours does, use the below line
to indicate which issue it fixes, for example "Fixes #500".
-->

Fixes a bug reported by @bobh66:
```
I just tried running crossplane CLI convert pipeline-compositionfrom main branch on a composition that didn't have spec.environment set to anything and it failed - crossplane: error: Error generating new Composition: failed to migrate environment: failed to get environment: spec.environment: no such field.   If I add an empty spec.environment block it works. 
```

We should ignore not found errors in that case given that the environment is optional.

Took the chance to refactor the patchsets migration code too for consistency, added test coverage for that too.

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `earthly +reviewable` to ensure this PR is ready for review.
- [x] Added or updated unit tests.
- [ ] ~Added or updated e2e tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
