### PR TITLE
Have the resolver (`Lock`) controller watch package revisions

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -141,6 +141,7 @@ go-generate:
     && mv /tmp/patched.yaml cluster/crds/pkg.crossplane.io_deploymentruntimeconfigs.yaml
   SAVE ARTIFACT apis/ AS LOCAL apis
   SAVE ARTIFACT cluster/crds AS LOCAL cluster/crds
+  SAVE ARTIFACT cluster/meta AS LOCAL cluster/meta
 
 # go-build builds Crossplane binaries for your native OS and architecture.
 go-build:

--- a/cluster/meta/meta.pkg.crossplane.io_configurations.yaml
+++ b/cluster/meta/meta.pkg.crossplane.io_configurations.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.16.5
   name: configurations.meta.pkg.crossplane.io
 spec:
   group: meta.pkg.crossplane.io

--- a/cluster/meta/meta.pkg.crossplane.io_functions.yaml
+++ b/cluster/meta/meta.pkg.crossplane.io_functions.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.16.5
   name: functions.meta.pkg.crossplane.io
 spec:
   group: meta.pkg.crossplane.io

--- a/cluster/meta/meta.pkg.crossplane.io_functions.yaml
+++ b/cluster/meta/meta.pkg.crossplane.io_functions.yaml
@@ -14,7 +14,7 @@ spec:
     singular: function
   scope: Namespaced
   versions:
-  - name: v1beta1
+  - name: v1
     schema:
       openAPIV3Schema:
         description: A Function is the description of a Crossplane Function package.
@@ -83,3 +83,72 @@ spec:
         type: object
     served: true
     storage: true
+  - name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: A Function is the description of a Crossplane Function package.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: FunctionSpec specifies the configuration of a Function.
+            properties:
+              crossplane:
+                description: Semantic version constraints of Crossplane that package
+                  is compatible with.
+                properties:
+                  version:
+                    description: Semantic version constraints of Crossplane that package
+                      is compatible with.
+                    type: string
+                required:
+                - version
+                type: object
+              dependsOn:
+                description: Dependencies on other packages.
+                items:
+                  description: Dependency is a dependency on another package. One
+                    of Provider or Configuration may be supplied.
+                  properties:
+                    configuration:
+                      description: Configuration is the name of a Configuration package
+                        image.
+                      type: string
+                    function:
+                      description: Function is the name of a Function package image.
+                      type: string
+                    provider:
+                      description: Provider is the name of a Provider package image.
+                      type: string
+                    version:
+                      description: Version is the semantic version constraints of
+                        the dependency image.
+                      type: string
+                  required:
+                  - version
+                  type: object
+                type: array
+              image:
+                description: Image is the packaged Function image.
+                type: string
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: false

--- a/cluster/meta/meta.pkg.crossplane.io_providers.yaml
+++ b/cluster/meta/meta.pkg.crossplane.io_providers.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.16.5
   name: providers.meta.pkg.crossplane.io
 spec:
   group: meta.pkg.crossplane.io

--- a/internal/controller/pkg/resolver/reconciler.go
+++ b/internal/controller/pkg/resolver/reconciler.go
@@ -173,25 +173,16 @@ func Setup(mgr ctrl.Manager, o controller.Options) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		Named(name).
 		For(&v1beta1.Lock{}).
-		Owns(&v1.ConfigurationRevision{}).
-		Owns(&v1.ProviderRevision{}).
-		Watches(&v1beta1.ImageConfig{}, handler.EnqueueRequestsFromMapFunc(func(_ context.Context, o client.Object) []reconcile.Request {
-			ic, ok := o.(*v1beta1.ImageConfig)
-			if !ok {
-				return nil
-			}
-			// We only care about ImageConfigs that have a pull secret.
-			if ic.Spec.Registry == nil || ic.Spec.Registry.Authentication == nil || ic.Spec.Registry.Authentication.PullSecretRef.Name == "" {
-				return nil
-			}
-			// Ideally we should enqueue only if the ImageConfig applies to a
-			// package in the Lock which would require getting/parsing the Lock
-			// and checking the source of each package against the prefixes in
-			// the ImageConfig. However, this is a bit more complex than needed,
-			// and we don't expect to have many ImageConfigs so we just enqueue
-			// for all ImageConfigs with a pull secret.
-			return []reconcile.Request{{NamespacedName: client.ObjectKey{Name: lockName}}}
-		})).
+		Watches(&v1.ConfigurationRevision{}, handler.EnqueueRequestsFromMapFunc(ForName(lockName))).
+		Watches(&v1.ProviderRevision{}, handler.EnqueueRequestsFromMapFunc(ForName(lockName))).
+		Watches(&v1.FunctionRevision{}, handler.EnqueueRequestsFromMapFunc(ForName(lockName))).
+		// Ideally we should enqueue only if the ImageConfig applies to a
+		// package in the Lock which would require getting/parsing the Lock and
+		// checking the source of each package against the prefixes in the
+		// ImageConfig. However, this is a bit more complex than needed, and we
+		// don't expect to have many ImageConfigs so we just enqueue for all
+		// ImageConfigs with a pull secret.
+		Watches(&v1beta1.ImageConfig{}, handler.EnqueueRequestsFromMapFunc(ForName(lockName, HasPullSecret()))).
 		WithOptions(o.ForControllerRuntime()).
 		Complete(ratelimiter.NewReconciler(name, errors.WithSilentRequeueOnConflict(NewReconciler(mgr, opts...)), o.GlobalRateLimiter))
 }

--- a/internal/controller/pkg/resolver/watch.go
+++ b/internal/controller/pkg/resolver/watch.go
@@ -1,0 +1,57 @@
+/*
+Copyright 2024 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resolver
+
+import (
+	"context"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"github.com/crossplane/crossplane/apis/pkg/v1beta1"
+)
+
+// A FilterFn returns true if the supplied object should be filtered.
+type FilterFn func(o client.Object) bool
+
+// HasPullSecret returns a FilterFn that filters any object that either isn't an
+// ImageConfig, or is an ImageConfig that doesn't reference a pull secret.
+func HasPullSecret() FilterFn {
+	return func(o client.Object) bool {
+		ic, ok := o.(*v1beta1.ImageConfig)
+		if !ok {
+			// Not an ImageConfig - filter it.
+			return true
+		}
+		// Filter ImageConfigs that don't have a pull secret.
+		return ic.Spec.Registry == nil || ic.Spec.Registry.Authentication == nil || ic.Spec.Registry.Authentication.PullSecretRef.Name == ""
+	}
+}
+
+// ForName enqueues a request for the named object. It only enqueues a request
+// if all supplied filter functions return false.
+func ForName(name string, fns ...FilterFn) handler.MapFunc {
+	return func(_ context.Context, o client.Object) []reconcile.Request {
+		for _, filter := range fns {
+			if filter(o) {
+				return nil
+			}
+		}
+		return []reconcile.Request{{NamespacedName: client.ObjectKey{Name: name}}}
+	}
+}

--- a/internal/controller/pkg/resolver/watch_test.go
+++ b/internal/controller/pkg/resolver/watch_test.go
@@ -1,0 +1,125 @@
+/*
+Copyright 2024 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resolver
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	v1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"github.com/crossplane/crossplane-runtime/pkg/resource/fake"
+
+	"github.com/crossplane/crossplane/apis/pkg/v1beta1"
+)
+
+func TestHasPullSecret(t *testing.T) {
+	cases := map[string]struct {
+		reason string
+		o      client.Object
+		want   bool
+	}{
+		"NotAnImageConfig": {
+			reason: "Objects that aren't an ImageConfig should be filtered.",
+			o:      &fake.Object{},
+			want:   true,
+		},
+		"ImageConfigWithoutPullSecret": {
+			reason: "An ImageConfig without a pull secret should be filtered.",
+			o:      &v1beta1.ImageConfig{},
+			want:   true,
+		},
+		"ImageConfigWithPullSecret": {
+			reason: "An ImageConfig with a pull secret shouldn't be filtered.",
+			o: &v1beta1.ImageConfig{
+				Spec: v1beta1.ImageConfigSpec{
+					Registry: &v1beta1.RegistryConfig{
+						Authentication: &v1beta1.RegistryAuthentication{
+							PullSecretRef: v1.LocalObjectReference{
+								Name: "supersecret",
+							},
+						},
+					},
+				},
+			},
+			want: false,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got := HasPullSecret()(tc.o)
+
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("\n%s\nHasPullsecret(): -want, +got:\n%s", tc.reason, diff)
+			}
+		})
+	}
+}
+
+func TestForName(t *testing.T) {
+	type args struct {
+		name string
+		fns  []FilterFn
+	}
+	cases := map[string]struct {
+		reason string
+		args   args
+		want   []reconcile.Request
+	}{
+		"NoFilters": {
+			reason: "A request should be enqueued for the named object if there are no filter functions.",
+			args: args{
+				name: "cool-object",
+			},
+			want: []reconcile.Request{{NamespacedName: client.ObjectKey{Name: "cool-object"}}},
+		},
+		"AllFiltersReturnFalse": {
+			reason: "A request should be enqueued for the named object if all filter functions return false.",
+			args: args{
+				name: "cool-object",
+				fns:  []FilterFn{func(_ client.Object) bool { return false }},
+			},
+			want: []reconcile.Request{{NamespacedName: client.ObjectKey{Name: "cool-object"}}},
+		},
+		"OneFilterReturnsTrue": {
+			reason: "A request shouldn't be enqueued for the named object if any filter functions return true.",
+			args: args{
+				name: "cool-object",
+				fns: []FilterFn{
+					func(_ client.Object) bool { return false },
+					func(_ client.Object) bool { return true },
+					func(_ client.Object) bool { return false },
+				},
+			},
+			want: nil,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got := ForName(tc.args.name, tc.args.fns...)(context.Background(), &fake.Object{})
+
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("\n%s\nForName(): -want, +got:\n%s", tc.reason, diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane! Please read the contribution docs
(linked below) if this is your first Crossplane pull request.
-->

### Description of your changes

<!--
Briefly describe what this pull request does, and how it is covered by tests.
Be proactive - direct your reviewers' attention to anything that needs special
consideration.

We love pull requests that fix an open issue. If yours does, use the below line
to indicate which issue it fixes, for example "Fixes #500".
-->

Fixes #6004 

We want to enqueue a reconcile of the Lock controller when any package revision changes, but we weren't.

It wasn't watching function revisions at all. It was watching provider and configuration revisions, but using the `Owns()` builder method. This method enqeueus requests for the controller reference of the watched object. The lock isn't the controller reference (or even an owner reference) of any package revision, so we wouldn't be enqueuing reconciles for it.

This PR also includes a commit that fixes saving package metadata CRDs. Nothing really consumes these, so we didn't notice they weren't being saved.

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `earthly +reviewable` to ensure this PR is ready for review.
- [ ] ~Added or updated unit tests.~
- [ ] ~Added or updated e2e tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [x] Added `backport release-x.y` labels to auto-backport this PR.

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
