### PR TITLE
[release-1.18] Backport fix unknown field warnings & bump runtime to v1.18.0

### DIFF
--- a/cmd/crank/beta/trace/internal/resource/xrm/client.go
+++ b/cmd/crank/beta/trace/internal/resource/xrm/client.go
@@ -120,7 +120,6 @@ func getResourceChildrenRefs(r *resource.Resource, getConnectionSecrets bool) []
 				APIVersion: ref.APIVersion,
 				Kind:       ref.Kind,
 				Name:       ref.Name,
-				Namespace:  ref.Namespace,
 			})
 		}
 		if getConnectionSecrets {

--- a/cmd/crank/beta/trace/internal/resource/xrm/client_test.go
+++ b/cmd/crank/beta/trace/internal/resource/xrm/client_test.go
@@ -28,13 +28,14 @@ import (
 	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
 	"github.com/crossplane/crossplane-runtime/pkg/resource/unstructured/claim"
 	"github.com/crossplane/crossplane-runtime/pkg/resource/unstructured/composite"
+	"github.com/crossplane/crossplane-runtime/pkg/resource/unstructured/reference"
 
 	resource2 "github.com/crossplane/crossplane/cmd/crank/beta/trace/internal/resource"
 )
 
 type xrcOpt func(c *claim.Unstructured)
 
-func withXRCRef(ref *v1.ObjectReference) xrcOpt {
+func withXRCRef(ref *reference.Composite) xrcOpt {
 	return func(c *claim.Unstructured) {
 		c.SetResourceReference(ref)
 	}
@@ -96,7 +97,7 @@ func TestGetResourceChildrenRefs(t *testing.T) {
 			reason: "Should return the XR child for an XRC.",
 			args: args{
 				resource: &resource2.Resource{
-					Unstructured: *buildXRC("ns-1", "xrc", withXRCRef(&v1.ObjectReference{
+					Unstructured: *buildXRC("ns-1", "xrc", withXRCRef(&reference.Composite{
 						APIVersion: "example.com/v1",
 						Kind:       "XR",
 						Name:       "xr-1",
@@ -171,7 +172,7 @@ func TestGetResourceChildrenRefs(t *testing.T) {
 				resource: &resource2.Resource{
 					Unstructured: *buildXRC("ns-1", "xrc", withXRCSecretRef(&xpv1.LocalSecretReference{
 						Name: "secret-1",
-					}), withXRCRef(&v1.ObjectReference{
+					}), withXRCRef(&reference.Composite{
 						APIVersion: "example.com/v1",
 						Kind:       "XR",
 						Name:       "xr-1",
@@ -201,7 +202,7 @@ func TestGetResourceChildrenRefs(t *testing.T) {
 				resource: &resource2.Resource{
 					Unstructured: *buildXRC("ns-1", "xrc", withXRCSecretRef(&xpv1.LocalSecretReference{
 						Name: "secret-1",
-					}), withXRCRef(&v1.ObjectReference{
+					}), withXRCRef(&reference.Composite{
 						APIVersion: "example.com/v1",
 						Kind:       "XR",
 						Name:       "xr-1",

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/AdaLogics/go-fuzz-headers v0.0.0-20230811130428-ced1acdcaa24
 	github.com/Masterminds/semver v1.5.0
 	github.com/alecthomas/kong v0.9.0
-	github.com/crossplane/crossplane-runtime v1.18.0-rc.1
+	github.com/crossplane/crossplane-runtime v1.18.0
 	github.com/docker/docker v27.1.1+incompatible
 	github.com/docker/go-connections v0.5.0
 	github.com/emicklei/dot v1.6.2

--- a/go.sum
+++ b/go.sum
@@ -211,8 +211,8 @@ github.com/cpuguy83/go-md2man/v2 v2.0.1/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46t
 github.com/cpuguy83/go-md2man/v2 v2.0.4/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/creack/pty v1.1.18 h1:n56/Zwd5o6whRC5PMGretI4IdRLlmBXYNjScPaBgsbY=
 github.com/creack/pty v1.1.18/go.mod h1:MOBLtS5ELjhRRrroQr9kyvTxUAFNvYEK993ew/Vr4O4=
-github.com/crossplane/crossplane-runtime v1.18.0-rc.1 h1:E4WMn33yM59SbYEH8WaYWAtaIroIISyxELRdqKvs01s=
-github.com/crossplane/crossplane-runtime v1.18.0-rc.1/go.mod h1:p7nVVsLn0CWjsLvLCtr7T40ErbTgNWKRxmYnwFdfXb4=
+github.com/crossplane/crossplane-runtime v1.18.0 h1:aAQIMNOgPbbXaqj9CUSv+gPl3QnVbn33YlzSe145//0=
+github.com/crossplane/crossplane-runtime v1.18.0/go.mod h1:p7nVVsLn0CWjsLvLCtr7T40ErbTgNWKRxmYnwFdfXb4=
 github.com/cyberphone/json-canonicalization v0.0.0-20231011164504-785e29786b46 h1:2Dx4IHfC1yHWI12AxQDJM1QbRCDfk6M+blLzlZCXdrc=
 github.com/cyberphone/json-canonicalization v0.0.0-20231011164504-785e29786b46/go.mod h1:uzvlm1mxhHkdfqitSA92i7Se+S9ksOn3a3qmv/kyOCw=
 github.com/cyphar/filepath-securejoin v0.2.4 h1:Ugdm7cg7i6ZK6x3xDF1oEu1nfkyfH53EtKeQYTC3kyg=

--- a/internal/controller/apiextensions/claim/reconciler.go
+++ b/internal/controller/apiextensions/claim/reconciler.go
@@ -26,6 +26,7 @@ import (
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -348,7 +349,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 		record = record.WithAnnotations("composite-name", cm.GetResourceReference().Name)
 		log = log.WithValues("composite-name", cm.GetResourceReference().Name)
 
-		if err := r.client.Get(ctx, meta.NamespacedNameOf(ref), xr); resource.IgnoreNotFound(err) != nil {
+		if err := r.client.Get(ctx, types.NamespacedName{Name: ref.Name}, xr); resource.IgnoreNotFound(err) != nil {
 			err = errors.Wrap(err, errGetComposite)
 			record.Event(cm, event.Warning(reasonBind, err))
 			cm.SetConditions(xpv1.ReconcileError(err))

--- a/internal/controller/apiextensions/claim/reconciler_test.go
+++ b/internal/controller/apiextensions/claim/reconciler_test.go
@@ -37,6 +37,7 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
 	"github.com/crossplane/crossplane-runtime/pkg/resource/unstructured/claim"
 	"github.com/crossplane/crossplane-runtime/pkg/resource/unstructured/composite"
+	"github.com/crossplane/crossplane-runtime/pkg/resource/unstructured/reference"
 	"github.com/crossplane/crossplane-runtime/pkg/test"
 )
 
@@ -141,7 +142,7 @@ func TestReconcile(t *testing.T) {
 						case *claim.Unstructured:
 							// We won't try to get an XR unless the claim
 							// references one.
-							o.SetResourceReference(&corev1.ObjectReference{Name: "cool-composite"})
+							o.SetResourceReference(&reference.Composite{Name: "cool-composite"})
 						case *composite.Unstructured:
 							// Return an error getting the XR.
 							return errBoom
@@ -150,7 +151,7 @@ func TestReconcile(t *testing.T) {
 					}),
 					MockStatusUpdate: WantClaim(t, NewClaim(func(cm *claim.Unstructured) {
 						// Check that we set our status condition.
-						cm.SetResourceReference(&corev1.ObjectReference{Name: "cool-composite"})
+						cm.SetResourceReference(&reference.Composite{Name: "cool-composite"})
 						cm.SetConditions(xpv1.ReconcileError(errors.Wrap(errBoom, errGetComposite)))
 					})),
 				},
@@ -168,18 +169,18 @@ func TestReconcile(t *testing.T) {
 						case *claim.Unstructured:
 							// We won't try to get an XR unless the claim
 							// references one.
-							o.SetResourceReference(&corev1.ObjectReference{Name: "cool-composite"})
+							o.SetResourceReference(&reference.Composite{Name: "cool-composite"})
 						case *composite.Unstructured:
 							// This XR was created, and references another
 							//  claim.
 							o.SetCreationTimestamp(now)
-							o.SetClaimReference(&claim.Reference{Name: "some-other-claim"})
+							o.SetClaimReference(&reference.Claim{Name: "some-other-claim"})
 						}
 						return nil
 					}),
 					MockStatusUpdate: WantClaim(t, NewClaim(func(cm *claim.Unstructured) {
 						// Check that we set our status condition.
-						cm.SetResourceReference(&corev1.ObjectReference{Name: "cool-composite"})
+						cm.SetResourceReference(&reference.Composite{Name: "cool-composite"})
 						cm.SetConditions(xpv1.ReconcileError(errors.Errorf(errFmtUnbound, "", "some-other-claim")))
 					})),
 				},
@@ -198,7 +199,7 @@ func TestReconcile(t *testing.T) {
 							o.SetDeletionTimestamp(&now)
 							// We won't try to get an XR unless the claim
 							// references one.
-							o.SetResourceReference(&corev1.ObjectReference{Name: "cool-composite"})
+							o.SetResourceReference(&reference.Composite{Name: "cool-composite"})
 						case *composite.Unstructured:
 							// Pretend the XR exists.
 							o.SetCreationTimestamp(now)
@@ -209,7 +210,7 @@ func TestReconcile(t *testing.T) {
 					MockStatusUpdate: WantClaim(t, NewClaim(func(cm *claim.Unstructured) {
 						// Check that we set our status condition.
 						cm.SetDeletionTimestamp(&now)
-						cm.SetResourceReference(&corev1.ObjectReference{Name: "cool-composite"})
+						cm.SetResourceReference(&reference.Composite{Name: "cool-composite"})
 						cm.SetConditions(xpv1.Deleting())
 						cm.SetConditions(xpv1.ReconcileError(errors.Wrap(errBoom, errDeleteComposite)))
 					})),
@@ -312,14 +313,14 @@ func TestReconcile(t *testing.T) {
 							o.SetDeletionTimestamp(&now)
 							// We won't try to get an XR unless the claim
 							// references one.
-							o.SetResourceReference(&corev1.ObjectReference{Name: "cool-composite"})
+							o.SetResourceReference(&reference.Composite{Name: "cool-composite"})
 							// We want to foreground delete.
 							fg := xpv1.CompositeDeleteForeground
 							o.SetCompositeDeletePolicy(&fg)
 						case *composite.Unstructured:
 							// Pretend the XR exists and is bound.
 							o.SetCreationTimestamp(now)
-							o.SetClaimReference(&claim.Reference{})
+							o.SetClaimReference(&reference.Claim{})
 						}
 						return nil
 					}),
@@ -345,7 +346,7 @@ func TestReconcile(t *testing.T) {
 							o.SetDeletionTimestamp(&now)
 							// We won't try to get an XR unless the claim
 							// references one.
-							o.SetResourceReference(&corev1.ObjectReference{Name: "cool-composite"})
+							o.SetResourceReference(&reference.Composite{Name: "cool-composite"})
 							// We want to foreground delete.
 							fg := xpv1.CompositeDeleteForeground
 							o.SetCompositeDeletePolicy(&fg)
@@ -354,12 +355,12 @@ func TestReconcile(t *testing.T) {
 							// being deleted.
 							o.SetCreationTimestamp(now)
 							o.SetDeletionTimestamp(&now)
-							o.SetClaimReference(&claim.Reference{})
+							o.SetClaimReference(&reference.Claim{})
 						}
 						return nil
 					}),
 					MockStatusUpdate: WantClaim(t, NewClaim(func(cm *claim.Unstructured) {
-						cm.SetResourceReference(&corev1.ObjectReference{Name: "cool-composite"})
+						cm.SetResourceReference(&reference.Composite{Name: "cool-composite"})
 						// We want to foreground delete.
 						fg := xpv1.CompositeDeleteForeground
 						cm.SetCompositeDeletePolicy(&fg)
@@ -429,19 +430,19 @@ func TestReconcile(t *testing.T) {
 						case *claim.Unstructured:
 							// We won't try to get an XR unless the claim
 							// references one.
-							o.SetResourceReference(&corev1.ObjectReference{Name: "cool-composite"})
+							o.SetResourceReference(&reference.Composite{Name: "cool-composite"})
 						case *composite.Unstructured:
 							// Pretend the XR exists and is bound, but is
 							// still being created.
 							o.SetCreationTimestamp(now)
-							o.SetClaimReference(&claim.Reference{})
+							o.SetClaimReference(&reference.Claim{})
 							o.SetConditions(xpv1.Creating())
 						}
 						return nil
 					}),
 					MockStatusUpdate: WantClaim(t, NewClaim(func(cm *claim.Unstructured) {
 						// Check that we set our status condition.
-						cm.SetResourceReference(&corev1.ObjectReference{Name: "cool-composite"})
+						cm.SetResourceReference(&reference.Composite{Name: "cool-composite"})
 						cm.SetConditions(xpv1.ReconcileSuccess())
 						cm.SetConditions(Waiting())
 					})),
@@ -466,18 +467,18 @@ func TestReconcile(t *testing.T) {
 						case *claim.Unstructured:
 							// We won't try to get an XR unless the claim
 							// references one.
-							o.SetResourceReference(&corev1.ObjectReference{Name: "cool-composite"})
+							o.SetResourceReference(&reference.Composite{Name: "cool-composite"})
 						case *composite.Unstructured:
 							// Pretend the XR exists and is available.
 							o.SetCreationTimestamp(now)
-							o.SetClaimReference(&claim.Reference{})
+							o.SetClaimReference(&reference.Claim{})
 							o.SetConditions(xpv1.Available())
 						}
 						return nil
 					}),
 					MockStatusUpdate: WantClaim(t, NewClaim(func(cm *claim.Unstructured) {
 						// Check that we set our status condition.
-						cm.SetResourceReference(&corev1.ObjectReference{Name: "cool-composite"})
+						cm.SetResourceReference(&reference.Composite{Name: "cool-composite"})
 						cm.SetConditions(xpv1.ReconcileError(errors.Wrap(errBoom, errPropagateCDs)))
 					})),
 				},
@@ -504,18 +505,18 @@ func TestReconcile(t *testing.T) {
 						case *claim.Unstructured:
 							// We won't try to get an XR unless the claim
 							// references one.
-							o.SetResourceReference(&corev1.ObjectReference{Name: "cool-composite"})
+							o.SetResourceReference(&reference.Composite{Name: "cool-composite"})
 						case *composite.Unstructured:
 							// Pretend the XR exists and is available.
 							o.SetCreationTimestamp(now)
-							o.SetClaimReference(&claim.Reference{})
+							o.SetClaimReference(&reference.Claim{})
 							o.SetConditions(xpv1.Available())
 						}
 						return nil
 					}),
 					MockStatusUpdate: WantClaim(t, NewClaim(func(cm *claim.Unstructured) {
 						// Check that we set our status condition.
-						cm.SetResourceReference(&corev1.ObjectReference{Name: "cool-composite"})
+						cm.SetResourceReference(&reference.Composite{Name: "cool-composite"})
 						cm.SetConnectionDetailsLastPublishedTime(&now)
 						cm.SetConditions(xpv1.ReconcileSuccess())
 						cm.SetConditions(xpv1.Available())
@@ -544,7 +545,7 @@ func TestReconcile(t *testing.T) {
 						case *claim.Unstructured:
 							// We won't try to get an XR unless the claim
 							// references one.
-							o.SetResourceReference(&corev1.ObjectReference{Name: "cool-composite"})
+							o.SetResourceReference(&reference.Composite{Name: "cool-composite"})
 							// The system conditions are already set.
 							o.SetConditions(xpv1.ReconcileSuccess())
 							o.SetConditions(xpv1.Available())
@@ -557,7 +558,7 @@ func TestReconcile(t *testing.T) {
 						case *composite.Unstructured:
 							// Pretend the XR exists and is available.
 							o.SetCreationTimestamp(now)
-							o.SetClaimReference(&claim.Reference{})
+							o.SetClaimReference(&reference.Claim{})
 							o.SetConditions(xpv1.Available())
 							o.SetConditions(
 								// Database has become ready.
@@ -588,7 +589,7 @@ func TestReconcile(t *testing.T) {
 					}),
 					MockStatusUpdate: WantClaim(t, NewClaim(func(cm *claim.Unstructured) {
 						// Check that we set our status condition.
-						cm.SetResourceReference(&corev1.ObjectReference{Name: "cool-composite"})
+						cm.SetResourceReference(&reference.Composite{Name: "cool-composite"})
 						cm.SetConnectionDetailsLastPublishedTime(&now)
 						cm.SetConditions(xpv1.ReconcileSuccess())
 						cm.SetConditions(xpv1.Available())

--- a/internal/controller/apiextensions/claim/syncer_csa.go
+++ b/internal/controller/apiextensions/claim/syncer_csa.go
@@ -150,7 +150,7 @@ func (s *ClientSideCompositeSyncer) Sync(ctx context.Context, cm *claim.Unstruct
 	// then crashed before saving a reference to it. We'd create another XR on
 	// the next reconcile.
 	existing := cm.GetResourceReference()
-	proposed := meta.ReferenceTo(xr, xr.GetObjectKind().GroupVersionKind())
+	proposed := xr.GetReference()
 	if !cmp.Equal(existing, proposed) {
 		cm.SetResourceReference(proposed)
 		if err := s.client.Update(ctx, cm); err != nil {

--- a/internal/controller/apiextensions/claim/syncer_csa_test.go
+++ b/internal/controller/apiextensions/claim/syncer_csa_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
 	"github.com/crossplane/crossplane-runtime/pkg/resource/unstructured/claim"
 	"github.com/crossplane/crossplane-runtime/pkg/resource/unstructured/composite"
+	"github.com/crossplane/crossplane-runtime/pkg/resource/unstructured/reference"
 	"github.com/crossplane/crossplane-runtime/pkg/test"
 
 	"github.com/crossplane/crossplane/internal/names"
@@ -118,7 +119,7 @@ func TestClientSideSync(t *testing.T) {
 						xcrd.LabelKeyClaimNamespace: "default",
 						xcrd.LabelKeyClaimName:      "cool-claim",
 					})
-					xr.SetClaimReference(&claim.Reference{
+					xr.SetClaimReference(&reference.Claim{
 						Namespace: "default",
 						Name:      "cool-claim",
 					})
@@ -159,7 +160,7 @@ func TestClientSideSync(t *testing.T) {
 					cm.SetCompositionReference(&corev1.ObjectReference{
 						Name: "some-composition",
 					})
-					cm.SetResourceReference(&corev1.ObjectReference{
+					cm.SetResourceReference(&reference.Composite{
 						Name: "cool-claim-random",
 					})
 				}),
@@ -170,7 +171,7 @@ func TestClientSideSync(t *testing.T) {
 						xcrd.LabelKeyClaimNamespace: "default",
 						xcrd.LabelKeyClaimName:      "cool-claim",
 					})
-					xr.SetClaimReference(&claim.Reference{
+					xr.SetClaimReference(&reference.Claim{
 						Namespace: "default",
 						Name:      "cool-claim",
 					})
@@ -214,7 +215,7 @@ func TestClientSideSync(t *testing.T) {
 					cm.SetCompositionReference(&corev1.ObjectReference{
 						Name: "some-composition",
 					})
-					cm.SetResourceReference(&corev1.ObjectReference{
+					cm.SetResourceReference(&reference.Composite{
 						Name: "cool-claim-random",
 					})
 				}),
@@ -225,7 +226,7 @@ func TestClientSideSync(t *testing.T) {
 						xcrd.LabelKeyClaimNamespace: "default",
 						xcrd.LabelKeyClaimName:      "cool-claim",
 					})
-					xr.SetClaimReference(&claim.Reference{
+					xr.SetClaimReference(&reference.Claim{
 						Namespace: "default",
 						Name:      "cool-claim",
 					})
@@ -271,7 +272,7 @@ func TestClientSideSync(t *testing.T) {
 					cm.SetCompositionReference(&corev1.ObjectReference{
 						Name: "some-composition",
 					})
-					cm.SetResourceReference(&corev1.ObjectReference{
+					cm.SetResourceReference(&reference.Composite{
 						Name: "cool-claim-random",
 					})
 				}),
@@ -282,7 +283,7 @@ func TestClientSideSync(t *testing.T) {
 						xcrd.LabelKeyClaimNamespace: "default",
 						xcrd.LabelKeyClaimName:      "cool-claim",
 					})
-					xr.SetClaimReference(&claim.Reference{
+					xr.SetClaimReference(&reference.Claim{
 						Namespace: "default",
 						Name:      "cool-claim",
 					})
@@ -358,7 +359,7 @@ func TestClientSideSync(t *testing.T) {
 					cm.SetCompositionReference(&corev1.ObjectReference{
 						Name: "some-composition",
 					})
-					cm.SetResourceReference(&corev1.ObjectReference{
+					cm.SetResourceReference(&reference.Composite{
 						Name: "cool-claim-random",
 					})
 
@@ -377,7 +378,7 @@ func TestClientSideSync(t *testing.T) {
 						"example.org/propagate-me": "true",
 					})
 
-					xr.SetClaimReference(&claim.Reference{
+					xr.SetClaimReference(&reference.Claim{
 						Namespace: "default",
 						Name:      "cool-claim",
 					})

--- a/internal/controller/apiextensions/claim/syncer_ssa.go
+++ b/internal/controller/apiextensions/claim/syncer_ssa.go
@@ -245,7 +245,7 @@ func (s *ServerSideCompositeSyncer) Sync(ctx context.Context, cm *claim.Unstruct
 	// apply the claim before we create it. This ensures we don't leak an XR. We
 	// could leak an XR if we created an XR then crashed before saving a
 	// reference to it. We'd create another XR on the next reconcile.
-	cm.SetResourceReference(meta.ReferenceTo(xrPatch, xrPatch.GroupVersionKind()))
+	cm.SetResourceReference(xrPatch.GetReference())
 
 	// Propagate the actual external name back from the composite to the
 	// claim if it's set. The name we're propagating here will may be a name

--- a/internal/controller/apiextensions/claim/syncer_ssa_test.go
+++ b/internal/controller/apiextensions/claim/syncer_ssa_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
 	"github.com/crossplane/crossplane-runtime/pkg/resource/unstructured/claim"
 	"github.com/crossplane/crossplane-runtime/pkg/resource/unstructured/composite"
+	"github.com/crossplane/crossplane-runtime/pkg/resource/unstructured/reference"
 	"github.com/crossplane/crossplane-runtime/pkg/test"
 
 	"github.com/crossplane/crossplane/internal/names"
@@ -127,7 +128,7 @@ func TestServerSideSync(t *testing.T) {
 					cm.SetName("cool-claim")
 
 					// To make sure the claim spec is an object.
-					cm.SetResourceReference(&corev1.ObjectReference{
+					cm.SetResourceReference(&reference.Composite{
 						Name: "existing-composite",
 					})
 				}),
@@ -142,7 +143,7 @@ func TestServerSideSync(t *testing.T) {
 				cm: NewClaim(func(cm *claim.Unstructured) {
 					cm.SetNamespace("default")
 					cm.SetName("cool-claim")
-					cm.SetResourceReference(&corev1.ObjectReference{
+					cm.SetResourceReference(&reference.Composite{
 						Name: "existing-composite",
 					})
 
@@ -180,7 +181,7 @@ func TestServerSideSync(t *testing.T) {
 					cm.SetName("cool-claim")
 
 					// To make sure the claim spec is an object.
-					cm.SetResourceReference(&corev1.ObjectReference{
+					cm.SetResourceReference(&reference.Composite{
 						Name: "existing-composite",
 					})
 				}),
@@ -195,7 +196,7 @@ func TestServerSideSync(t *testing.T) {
 				cm: NewClaim(func(cm *claim.Unstructured) {
 					cm.SetNamespace("default")
 					cm.SetName("cool-claim")
-					cm.SetResourceReference(&corev1.ObjectReference{
+					cm.SetResourceReference(&reference.Composite{
 						Name: "existing-composite",
 					})
 
@@ -238,7 +239,7 @@ func TestServerSideSync(t *testing.T) {
 					cm.SetName("cool-claim")
 
 					// To make sure the claim spec is an object.
-					cm.SetResourceReference(&corev1.ObjectReference{
+					cm.SetResourceReference(&reference.Composite{
 						Name: "existing-composite",
 					})
 				}),
@@ -250,7 +251,7 @@ func TestServerSideSync(t *testing.T) {
 				cm: NewClaim(func(cm *claim.Unstructured) {
 					cm.SetNamespace("default")
 					cm.SetName("cool-claim")
-					cm.SetResourceReference(&corev1.ObjectReference{
+					cm.SetResourceReference(&reference.Composite{
 						Name: "existing-composite",
 					})
 				}),
@@ -260,7 +261,7 @@ func TestServerSideSync(t *testing.T) {
 						xcrd.LabelKeyClaimNamespace: "default",
 						xcrd.LabelKeyClaimName:      "cool-claim",
 					})
-					xr.SetClaimReference(&claim.Reference{
+					xr.SetClaimReference(&reference.Claim{
 						Namespace: "default",
 						Name:      "cool-claim",
 					})
@@ -295,7 +296,7 @@ func TestServerSideSync(t *testing.T) {
 					cm.SetName("cool-claim")
 
 					// To make sure the claim spec is an object.
-					cm.SetResourceReference(&corev1.ObjectReference{
+					cm.SetResourceReference(&reference.Composite{
 						Name: "existing-composite",
 					})
 				}),
@@ -307,7 +308,7 @@ func TestServerSideSync(t *testing.T) {
 				cm: NewClaim(func(cm *claim.Unstructured) {
 					cm.SetNamespace("default")
 					cm.SetName("cool-claim")
-					cm.SetResourceReference(&corev1.ObjectReference{
+					cm.SetResourceReference(&reference.Composite{
 						Name: "existing-composite",
 					})
 					cm.Object["status"] = map[string]any{}
@@ -318,7 +319,7 @@ func TestServerSideSync(t *testing.T) {
 						xcrd.LabelKeyClaimNamespace: "default",
 						xcrd.LabelKeyClaimName:      "cool-claim",
 					})
-					xr.SetClaimReference(&claim.Reference{
+					xr.SetClaimReference(&reference.Claim{
 						Namespace: "default",
 						Name:      "cool-claim",
 					})
@@ -393,7 +394,7 @@ func TestServerSideSync(t *testing.T) {
 					cm.Object["spec"] = map[string]any{
 						"userDefinedField": "spec",
 					}
-					cm.SetResourceReference(&corev1.ObjectReference{
+					cm.SetResourceReference(&reference.Composite{
 						Name: "cool-claim-random",
 					})
 					cm.Object["status"] = map[string]any{
@@ -416,7 +417,7 @@ func TestServerSideSync(t *testing.T) {
 					xr.Object["spec"] = map[string]any{
 						"userDefinedField": "spec",
 					}
-					xr.SetClaimReference(&claim.Reference{
+					xr.SetClaimReference(&reference.Claim{
 						Namespace: "default",
 						Name:      "cool-claim",
 					})

--- a/internal/controller/apiextensions/composite/api.go
+++ b/internal/controller/apiextensions/composite/api.go
@@ -25,6 +25,7 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
@@ -147,7 +148,7 @@ func (f *APIRevisionFetcher) Fetch(ctx context.Context, cr resource.Composite) (
 	// Just fetch and return the selected revision.
 	if current != nil && pol != nil && *pol == xpv1.UpdateManual {
 		rev := &v1.CompositionRevision{}
-		err := f.ca.Get(ctx, meta.NamespacedNameOf(current), rev)
+		err := f.ca.Get(ctx, types.NamespacedName{Name: current.Name}, rev)
 		return rev, errors.Wrap(err, errGetCompositionRevision)
 	}
 
@@ -170,7 +171,7 @@ func (f *APIRevisionFetcher) Fetch(ctx context.Context, cr resource.Composite) (
 	}
 
 	if current == nil || current.Name != latest.GetName() {
-		cr.SetCompositionRevisionReference(meta.ReferenceTo(latest, v1.CompositionRevisionGroupVersionKind))
+		cr.SetCompositionRevisionReference(&corev1.LocalObjectReference{Name: latest.GetName()})
 		if err := f.ca.Apply(ctx, cr); err != nil {
 			return nil, errors.Wrap(err, errUpdate)
 		}

--- a/internal/controller/apiextensions/composite/api_test.go
+++ b/internal/controller/apiextensions/composite/api_test.go
@@ -224,7 +224,7 @@ func TestFetchRevision(t *testing.T) {
 			}},
 			args: args{
 				cr: &fake.Composite{
-					CompositionRevisionReferencer: fake.CompositionRevisionReferencer{Ref: &corev1.ObjectReference{}},
+					CompositionRevisionReferencer: fake.CompositionRevisionReferencer{Ref: &corev1.LocalObjectReference{}},
 					CompositionUpdater:            fake.CompositionUpdater{Policy: &manual},
 				},
 			},
@@ -243,7 +243,7 @@ func TestFetchRevision(t *testing.T) {
 			}},
 			args: args{
 				cr: &fake.Composite{
-					CompositionRevisionReferencer: fake.CompositionRevisionReferencer{Ref: &corev1.ObjectReference{}},
+					CompositionRevisionReferencer: fake.CompositionRevisionReferencer{Ref: &corev1.LocalObjectReference{}},
 					CompositionUpdater:            fake.CompositionUpdater{Policy: &manual},
 				},
 			},
@@ -332,7 +332,7 @@ func TestFetchRevision(t *testing.T) {
 					},
 					// We're already using the latest revision.
 					CompositionRevisionReferencer: fake.CompositionRevisionReferencer{
-						Ref: &corev1.ObjectReference{Name: rev2.GetName()},
+						Ref: &corev1.LocalObjectReference{Name: rev2.GetName()},
 					},
 				},
 			},
@@ -366,10 +366,8 @@ func TestFetchRevision(t *testing.T) {
 							Ref: &corev1.ObjectReference{Name: comp.GetName()},
 						},
 						CompositionRevisionReferencer: fake.CompositionRevisionReferencer{
-							Ref: &corev1.ObjectReference{
-								APIVersion: v1.SchemeGroupVersion.String(),
-								Kind:       v1.CompositionRevisionKind,
-								Name:       rev2.GetName(),
+							Ref: &corev1.LocalObjectReference{
+								Name: rev2.GetName(),
 							},
 						},
 						CompositionUpdater: fake.CompositionUpdater{Policy: &manual},
@@ -423,10 +421,8 @@ func TestFetchRevision(t *testing.T) {
 							Ref: &corev1.ObjectReference{Name: comp.GetName()},
 						},
 						CompositionRevisionReferencer: fake.CompositionRevisionReferencer{
-							Ref: &corev1.ObjectReference{
-								APIVersion: v1.SchemeGroupVersion.String(),
-								Kind:       v1.CompositionRevisionKind,
-								Name:       rev2.GetName(),
+							Ref: &corev1.LocalObjectReference{
+								Name: rev2.GetName(),
 							},
 						},
 					}
@@ -443,10 +439,8 @@ func TestFetchRevision(t *testing.T) {
 					},
 					// We reference the outdated revision.
 					CompositionRevisionReferencer: fake.CompositionRevisionReferencer{
-						Ref: &corev1.ObjectReference{
-							APIVersion: v1.SchemeGroupVersion.String(),
-							Kind:       v1.CompositionRevisionKind,
-							Name:       rev1.GetName(),
+						Ref: &corev1.LocalObjectReference{
+							Name: rev1.GetName(),
 						},
 					},
 				},

--- a/internal/controller/apiextensions/composite/reconciler_test.go
+++ b/internal/controller/apiextensions/composite/reconciler_test.go
@@ -41,6 +41,7 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/resource/unstructured/claim"
 	"github.com/crossplane/crossplane-runtime/pkg/resource/unstructured/composed"
 	"github.com/crossplane/crossplane-runtime/pkg/resource/unstructured/composite"
+	"github.com/crossplane/crossplane-runtime/pkg/resource/unstructured/reference"
 	"github.com/crossplane/crossplane-runtime/pkg/test"
 
 	v1 "github.com/crossplane/crossplane/apis/apiextensions/v1"
@@ -675,7 +676,7 @@ func TestReconcile(t *testing.T) {
 					MockGet: test.NewMockGetFn(nil, func(obj client.Object) error {
 						if xr, ok := obj.(*composite.Unstructured); ok {
 							// non-nil claim ref to trigger claim Get()
-							xr.SetClaimReference(&claim.Reference{})
+							xr.SetClaimReference(&reference.Claim{})
 							return nil
 						}
 						if cm, ok := obj.(*claim.Unstructured); ok {
@@ -705,7 +706,7 @@ func TestReconcile(t *testing.T) {
 							xpv1.Available(),
 						)
 						cr.(*composite.Unstructured).SetClaimConditionTypes("DatabaseReady")
-						cr.SetClaimReference(&claim.Reference{})
+						cr.SetClaimReference(&reference.Claim{})
 					})),
 				},
 				opts: []ReconcilerOption{
@@ -833,7 +834,7 @@ func TestReconcile(t *testing.T) {
 					MockGet: test.NewMockGetFn(nil, func(obj client.Object) error {
 						if xr, ok := obj.(*composite.Unstructured); ok {
 							// non-nil claim ref to trigger claim Get()
-							xr.SetClaimReference(&claim.Reference{})
+							xr.SetClaimReference(&reference.Claim{})
 							xr.SetConditions(xpv1.Condition{
 								Type:    "DatabaseReady",
 								Status:  corev1.ConditionTrue,
@@ -882,7 +883,7 @@ func TestReconcile(t *testing.T) {
 							"DatabaseReady",
 							"BucketReady",
 						)
-						cr.SetClaimReference(&claim.Reference{})
+						cr.SetClaimReference(&reference.Claim{})
 					})),
 				},
 				opts: []ReconcilerOption{
@@ -1024,7 +1025,7 @@ func TestReconcile(t *testing.T) {
 					MockGet: test.NewMockGetFn(nil, func(obj client.Object) error {
 						if xr, ok := obj.(*composite.Unstructured); ok {
 							// non-nil claim ref to trigger claim Get()
-							xr.SetClaimReference(&claim.Reference{})
+							xr.SetClaimReference(&reference.Claim{})
 							// The database condition already exists on the XR.
 							xr.SetConditions(xpv1.Condition{
 								Type:    "DatabaseReady",
@@ -1087,7 +1088,7 @@ func TestReconcile(t *testing.T) {
 							"DatabaseReady",
 							"BucketReady",
 						)
-						cr.SetClaimReference(&claim.Reference{})
+						cr.SetClaimReference(&reference.Claim{})
 					})),
 				},
 				opts: []ReconcilerOption{
@@ -1169,7 +1170,7 @@ func TestReconcile(t *testing.T) {
 					MockGet: test.NewMockGetFn(nil, func(obj client.Object) error {
 						if xr, ok := obj.(*composite.Unstructured); ok {
 							// non-nil claim ref to trigger claim Get()
-							xr.SetClaimReference(&claim.Reference{})
+							xr.SetClaimReference(&reference.Claim{})
 							return nil
 						}
 						if cm, ok := obj.(*claim.Unstructured); ok {
@@ -1184,7 +1185,7 @@ func TestReconcile(t *testing.T) {
 							xpv1.ReconcileSuccess(),
 							xpv1.Creating().WithMessage("Composite resource was explicitly marked as unready by the composer"),
 						)
-						cr.SetClaimReference(&claim.Reference{})
+						cr.SetClaimReference(&reference.Claim{})
 					})),
 				},
 				opts: []ReconcilerOption{
@@ -1244,7 +1245,7 @@ func TestReconcile(t *testing.T) {
 					MockGet: test.NewMockGetFn(nil, func(obj client.Object) error {
 						if xr, ok := obj.(*composite.Unstructured); ok {
 							// non-nil claim ref to trigger claim Get()
-							xr.SetClaimReference(&claim.Reference{})
+							xr.SetClaimReference(&reference.Claim{})
 							return nil
 						}
 						if _, ok := obj.(*claim.Unstructured); ok {
@@ -1256,7 +1257,7 @@ func TestReconcile(t *testing.T) {
 					MockStatusUpdate: WantComposite(t, NewComposite(func(cr resource.Composite) {
 						cr.SetCompositionReference(&corev1.ObjectReference{})
 						cr.SetConditions(xpv1.ReconcileSuccess(), xpv1.Available())
-						cr.SetClaimReference(&claim.Reference{})
+						cr.SetClaimReference(&reference.Claim{})
 					})),
 				},
 				opts: []ReconcilerOption{

--- a/internal/controller/apiextensions/offered/watch_test.go
+++ b/internal/controller/apiextensions/offered/watch_test.go
@@ -26,8 +26,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	"github.com/crossplane/crossplane-runtime/pkg/resource/unstructured/claim"
 	"github.com/crossplane/crossplane-runtime/pkg/resource/unstructured/composite"
+	"github.com/crossplane/crossplane-runtime/pkg/resource/unstructured/reference"
 
 	v1 "github.com/crossplane/crossplane/apis/apiextensions/v1"
 )
@@ -147,7 +147,7 @@ func TestAddClaim(t *testing.T) {
 		"ObjectHasClaimReference": {
 			obj: func() runtime.Object {
 				cp := composite.New()
-				cp.SetClaimReference(&claim.Reference{Namespace: ns, Name: name})
+				cp.SetClaimReference(&reference.Claim{Namespace: ns, Name: name})
 				return &cp.Unstructured
 			}(),
 			queue: addFn(func(got reconcile.Request) {

--- a/test/e2e/funcs/feature.go
+++ b/test/e2e/funcs/feature.go
@@ -678,7 +678,6 @@ func CompositeResourceMustMatchWithin(d time.Duration, dir, claimFile string, ma
 
 		uxr := unstructured.Unstructured{}
 		uxr.SetName(xrRef.Name)
-		uxr.SetNamespace(xrRef.Namespace)
 		uxr.SetGroupVersionKind(xrRef.GroupVersionKind())
 
 		list.Items = append(list.Items, uxr)
@@ -807,7 +806,7 @@ func ComposedResourcesHaveFieldValueWithin(d time.Duration, dir, file, path stri
 		uxr := &composite.Unstructured{}
 
 		uxr.SetGroupVersionKind(xrRef.GroupVersionKind())
-		if err := c.Client().Resources().Get(ctx, xrRef.Name, xrRef.Namespace, uxr); err != nil {
+		if err := c.Client().Resources().Get(ctx, xrRef.Name, "", uxr); err != nil {
 			t.Errorf("cannot get composite %s: %v", xrRef.Name, err)
 			return ctx
 		}


### PR DESCRIPTION
### Description of your changes

Backports #6064 & bumps runtime to v1.18.0

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `earthly +reviewable` to ensure this PR is ready for review.
- [ ] ~Added or updated unit tests.~
- [ ] ~Added or updated e2e tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
