### PR TITLE
[release-1.18] fix(e2e): install prior version to upgrade fixing lifecycle tests on older branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -256,10 +256,34 @@ jobs:
           echo "EARTHLY_PUSH=true" >> $GITHUB_ENV
           echo "EARTHLY_MAX_REMOTE_CACHE=true" >> $GITHUB_ENV
 
+      - name: Set CROSSPLANE_PRIOR_VERSION GitHub Environment Variable
+        # We want to run this for the release branches, and PRs against release branches.
+        if: startsWith(github.ref, 'refs/heads/release-') || startsWith(github.base_ref, 'release-')
+        run: |
+          # Extract the version part from the branch name
+          if [[ "${GITHUB_REF}" == refs/heads/release-* ]]; then
+            VERSION=${GITHUB_REF#refs/heads/release-}
+          elif [[ "${GITHUB_BASE_REF}" == release-* ]]; then
+            VERSION=${GITHUB_BASE_REF#release-}
+          fi
+          # Extract the major and minor parts of the version
+          MAJOR=$(echo "$VERSION" | cut -d. -f1)
+          MINOR=$(echo "$VERSION" | cut -d. -f2)
+          # Decrement the MINOR version
+          if [[ "$MINOR" -gt 0 ]]; then
+            MINOR=$((MINOR - 1))
+          else
+            echo "Error: Minor version cannot be decremented below 0"
+            exit 1
+          fi
+          
+          echo "CROSSPLANE_PRIOR_VERSION=$MAJOR.$MINOR" >> $GITHUB_ENV
+
+
       - name: Run E2E Tests
         run: |
           earthly --strict --allow-privileged --remote-cache ghcr.io/crossplane/earthly-cache:${{ github.job }}-${{ matrix.test-suite}} \
-            +e2e --FLAGS="-test.failfast -fail-fast --test-suite ${{ matrix.test-suite }}"
+            +e2e --FLAGS="-test.failfast -fail-fast -prior-crossplane-version=${CROSSPLANE_PRIOR_VERSION} --test-suite ${{ matrix.test-suite }}"
 
       - name: Publish E2E Test Flakes
         if: '!cancelled()'

--- a/test/e2e/config/environment.go
+++ b/test/e2e/config/environment.go
@@ -199,7 +199,7 @@ func (e *Environment) HelmInstallPriorCrossplane(namespace, release string) env.
 		helm.WithChart("crossplane-stable/crossplane"),
 		helm.WithArgs("--create-namespace", "--wait"),
 	}
-	if e.priorCrossplaneVersion != nil {
+	if e.priorCrossplaneVersion != nil && *e.priorCrossplaneVersion != "" {
 		opts = append(opts, helm.WithArgs("--version", *e.priorCrossplaneVersion))
 	}
 	return funcs.EnvFuncs(

--- a/test/e2e/config/environment.go
+++ b/test/e2e/config/environment.go
@@ -43,12 +43,13 @@ const testSuiteFlag = "test-suite"
 // Environment is these e2e test configuration, wraps the e2e-framework
 // environment.
 type Environment struct {
-	createKindCluster     *bool
-	destroyKindCluster    *bool
-	preinstallCrossplane  *bool
-	loadImagesKindCluster *bool
-	kindClusterName       *string
-	kindLogsLocation      *string
+	createKindCluster      *bool
+	destroyKindCluster     *bool
+	preinstallCrossplane   *bool
+	loadImagesKindCluster  *bool
+	priorCrossplaneVersion *string
+	kindClusterName        *string
+	kindLogsLocation       *string
 
 	selectedTestSuite *selectedTestSuite
 
@@ -107,6 +108,7 @@ func NewEnvironmentFromFlags() Environment {
 	c.createKindCluster = flag.Bool("create-kind-cluster", true, "create a kind cluster (and deploy Crossplane) before running tests, if the cluster does not already exist with the same name")
 	c.destroyKindCluster = flag.Bool("destroy-kind-cluster", true, "destroy the kind cluster when tests complete")
 	c.preinstallCrossplane = flag.Bool("preinstall-crossplane", true, "install Crossplane before running tests")
+	c.priorCrossplaneVersion = flag.String("prior-crossplane-version", "", "prior Crossplane version to test upgrade from")
 	c.loadImagesKindCluster = flag.Bool("load-images-kind-cluster", true, "load Crossplane images into the kind cluster before running tests")
 	c.selectedTestSuite = &selectedTestSuite{}
 	flag.Var(c.selectedTestSuite, testSuiteFlag, "test suite defining environment setup and tests to run")
@@ -186,6 +188,30 @@ func (e *Environment) HelmUpgradeCrossplaneToBase() env.Func {
 // the default suite's helm install options.
 func (e *Environment) HelmInstallBaseCrossplane() env.Func {
 	return funcs.HelmInstall(e.getSuiteInstallOpts(e.selectedTestSuite.String())...)
+}
+
+// HelmInstallPriorCrossplane returns a features.Func that installs prior
+// Crossplane version from the stable Helm chart repository.
+func (e *Environment) HelmInstallPriorCrossplane(namespace, release string) env.Func {
+	opts := []helm.Option{
+		helm.WithNamespace(namespace),
+		helm.WithName(release),
+		helm.WithChart("crossplane-stable/crossplane"),
+		helm.WithArgs("--create-namespace", "--wait"),
+	}
+	if e.priorCrossplaneVersion != nil {
+		opts = append(opts, helm.WithArgs("--version", *e.priorCrossplaneVersion))
+	}
+	return funcs.EnvFuncs(
+		funcs.HelmRepo(
+			helm.WithArgs("add"),
+			helm.WithArgs("crossplane-stable"),
+			helm.WithArgs("https://charts.crossplane.io/stable"),
+		),
+		funcs.HelmInstall(
+			opts...,
+		),
+	)
 }
 
 // getSuiteInstallOpts returns the helm install options for the specified

--- a/test/e2e/install_test.go
+++ b/test/e2e/install_test.go
@@ -100,17 +100,7 @@ func TestCrossplaneLifecycle(t *testing.T) {
 				funcs.ResourcesDeletedWithin(3*time.Minute, crdsDir, "*.yaml"),
 			)).
 			Assess("InstallStableCrossplane", funcs.AllOf(
-				funcs.AsFeaturesFunc(funcs.HelmRepo(
-					helm.WithArgs("add"),
-					helm.WithArgs("crossplane-stable"),
-					helm.WithArgs("https://charts.crossplane.io/stable"),
-				)),
-				funcs.AsFeaturesFunc(funcs.HelmInstall(
-					helm.WithNamespace(namespace),
-					helm.WithName(helmReleaseName),
-					helm.WithChart("crossplane-stable/crossplane"),
-					helm.WithArgs("--create-namespace", "--wait"),
-				)),
+				funcs.AsFeaturesFunc(environment.HelmInstallPriorCrossplane(namespace, helmReleaseName)),
 				funcs.ReadyToTestWithin(1*time.Minute, namespace))).
 			Assess("CreateClaimPrerequisites", funcs.AllOf(
 				funcs.ApplyResources(FieldManager, manifests, "setup/*.yaml"),


### PR DESCRIPTION
### Description of your changes

Backports #6089 to release-1.18.

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `earthly +reviewable` to ensure this PR is ready for review.
- [ ] ~Added or updated unit tests.~
- [x] Added or updated e2e tests.
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
