### PR TITLE
chore(test): Disable renovate on dependency upgrade test manifests 

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -21,7 +21,9 @@
   ignorePaths: [
     'design/**',
     // We test upgrades, so leave it on an older version on purpose.
-    'test/e2e/manifests/pkg/provider/provider-initial.yaml',
+    "test/e2e/manifests/pkg/provider/provider-initial.yaml",
+    // Manifests must remain unchanged to ensure the test scenario is not broken.
+    "test/e2e/manifests/pkg/dependency-upgrade/**",
   ],
   postUpdateOptions: [
     'gomodTidy',

--- a/test/e2e/pkg_test.go
+++ b/test/e2e/pkg_test.go
@@ -299,6 +299,10 @@ func TestConfigurationWithDigest(t *testing.T) {
 	)
 }
 
+// TestUpgradeDependencyVersion tests that a dependency version is upgraded when the parent configuration is updated.
+// The packages used in this test are built and pushed manually and the manifests must remain unchanged to ensure
+// the test scenario is not broken.Corresponding meta file can be found under
+// test/e2e/manifests/pkg/dependency-upgrade/version/package folder.
 func TestUpgradeDependencyVersion(t *testing.T) {
 	manifests := "test/e2e/manifests/pkg/dependency-upgrade/version"
 
@@ -339,6 +343,10 @@ func TestUpgradeDependencyVersion(t *testing.T) {
 	)
 }
 
+// TestUpgradeDependencyDigest tests that a dependency digest is upgraded when the parent configuration is updated.
+// The packages used in this test are built and pushed manually and the manifests must remain unchanged to ensure
+// the test scenario is not broken. Corresponding meta file can be found under
+// test/e2e/manifests/pkg/dependency-upgrade/digest/package folder.
 func TestUpgradeDependencyDigest(t *testing.T) {
 	manifests := "test/e2e/manifests/pkg/dependency-upgrade/digest"
 
@@ -379,6 +387,10 @@ func TestUpgradeDependencyDigest(t *testing.T) {
 	)
 }
 
+// TestUpgradeAlreadyExistsDependency tests that a previously installed dependency is upgraded to the minimal valid version when the parent configuration is updated.
+// The packages used in this test are built and pushed manually and the manifests must remain unchanged to ensure
+// the test scenario is not broken. Corresponding meta file can be found under
+// test/e2e/manifests/pkg/dependency-upgrade/already-exists/package folder.
 func TestUpgradeAlreadyExistsDependency(t *testing.T) {
 	manifests := "test/e2e/manifests/pkg/dependency-upgrade/already-exists"
 
@@ -428,6 +440,10 @@ func TestUpgradeAlreadyExistsDependency(t *testing.T) {
 	)
 }
 
+// TestNoValidVersion tests that a Configuration will not become healthy if there is no valid version for its dependency.
+// The packages used in this test are built and pushed manually and the manifests must remain unchanged to ensure
+// the test scenario is not broken. Corresponding meta file can be found under
+// test/e2e/manifests/pkg/dependency-upgrade/no-valid/package folder.
 func TestNoValidVersion(t *testing.T) {
 	manifests := "test/e2e/manifests/pkg/dependency-upgrade/no-valid"
 
@@ -465,6 +481,10 @@ func TestNoValidVersion(t *testing.T) {
 	)
 }
 
+// TestNoDowngrade tests that a Configuration will not become healthy because automatic downgrades are not allowed.
+// The packages used in this test are built and pushed manually and the manifests must remain unchanged to ensure
+// the test scenario is not broken. Corresponding meta file can be found under
+// test/e2e/manifests/pkg/dependency-upgrade/no-downgrade/package folder.
 func TestNoDowngrade(t *testing.T) {
 	manifests := "test/e2e/manifests/pkg/dependency-upgrade/no-downgrade"
 


### PR DESCRIPTION


<!--
Thank you for helping to improve Crossplane! Please read the contribution docs
(linked below) if this is your first Crossplane pull request.
-->

### Description of your changes

This PR adds dependency upgrade test manifests to renovate's ignore path and adds some comments.

<!--
Briefly describe what this pull request does, and how it is covered by tests.
Be proactive - direct your reviewers' attention to anything that needs special
consideration.

We love pull requests that fix an open issue. If yours does, use the below line
to indicate which issue it fixes, for example "Fixes #500".
-->

Fixes # 

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `earthly +reviewable` to ensure this PR is ready for review.
- [ ] ~Added or updated unit tests.~
- [ ] ~Added or updated e2e tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
