### PR TITLE
tests: ignore also image-configs manifests from renovate

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -22,8 +22,10 @@
     'design/**',
     // We test upgrades, so leave it on an older version on purpose.
     "test/e2e/manifests/pkg/provider/provider-initial.yaml",
-    // Manifests must remain unchanged to ensure the test scenario is not broken.
+    // We test dependencies' upgrades, manifests must remain unchanged to avoid breaking tests.
     "test/e2e/manifests/pkg/dependency-upgrade/**",
+    // We test packages signature verifications also on upgrades, manifests must remain unchanged to avoid breaking tests.
+    "test/e2e/manifests/pkg/image-config/signature-verification/**"
   ],
   postUpdateOptions: [
     'gomodTidy',

--- a/test/e2e/pkg_test.go
+++ b/test/e2e/pkg_test.go
@@ -522,6 +522,11 @@ func TestNoDowngrade(t *testing.T) {
 	)
 }
 
+// TestImageConfigAuth tests that we can install a private package as a dependency by providing registry pull
+// credentials through ImageConfig API.
+// The packages used in this test are built and pushed manually and the manifests must remain unchanged to ensure
+// the test scenario is not broken. Corresponding meta file can be found at
+// test/e2e/manifests/pkg/image-config/authentication/configuration-with-private-dependency/package.
 func TestImageConfigAuth(t *testing.T) {
 	manifests := "test/e2e/manifests/pkg/image-config/authentication/configuration-with-private-dependency"
 
@@ -562,6 +567,9 @@ func TestImageConfigAuth(t *testing.T) {
 	)
 }
 
+// TestImageConfigVerificationWithKey tests that we can verify signature on a configuration when signed with a key.
+// The providers used in this test are built and pushed manually with the necessary signatures and attestations, they
+// are just a copy of the provider-nop package.
 func TestImageConfigVerificationWithKey(t *testing.T) {
 	manifests := "test/e2e/manifests/pkg/image-config/signature-verification/with-key"
 
@@ -595,6 +603,9 @@ func TestImageConfigVerificationWithKey(t *testing.T) {
 	)
 }
 
+// TestImageConfigVerificationKeyless tests that we can verify signature on a provider when signed keyless.
+// The providers used in this test are built and pushed manually with the necessary signatures and attestations, they
+// are just a copy of the provider-nop package.
 func TestImageConfigVerificationKeyless(t *testing.T) {
 	manifests := "test/e2e/manifests/pkg/image-config/signature-verification/keyless"
 
@@ -632,6 +643,10 @@ func TestImageConfigVerificationKeyless(t *testing.T) {
 	)
 }
 
+// TestImageConfigAttestationVerificationPrivateKeyless tests that we can verify signature and attestations on a private
+// provider when signed keyless.
+// The providers used in this test are built and pushed manually with the necessary signatures and attestations, they
+// are just a copy of the provider-nop package.
 func TestImageConfigAttestationVerificationPrivateKeyless(t *testing.T) {
 	manifests := "test/e2e/manifests/pkg/image-config/signature-verification/keyless-private-with-attestation"
 


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane! Please read the contribution docs
(linked below) if this is your first Crossplane pull request.
-->

### Description of your changes

<!--
Briefly describe what this pull request does, and how it is covered by tests.
Be proactive - direct your reviewers' attention to anything that needs special
consideration.

We love pull requests that fix an open issue. If yours does, use the below line
to indicate which issue it fixes, for example "Fixes #500".
-->

Follow up to https://github.com/crossplane/crossplane/pull/6116, also ignoring manifests for image signature verification 

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `earthly +reviewable` to ensure this PR is ready for review.
- [ ] ~Added or updated unit tests.~
- [ ] ~Added or updated e2e tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
