### PR TITLE
feat(cli): include status conditions in output of render command

### DIFF
--- a/cmd/crank/render/cmd.go
+++ b/cmd/crank/render/cmd.go
@@ -44,15 +44,14 @@ type Cmd struct {
 	Functions         string `arg:"" help:"A YAML file or directory of YAML files specifying the Composition Functions to use to render the XR." type:"path"`
 
 	// Flags. Keep them in alphabetical order.
-	ContextFiles            map[string]string `help:"Comma-separated context key-value pairs to pass to the Function pipeline. Values must be files containing JSON."                           mapsep:""`
-	ContextValues           map[string]string `help:"Comma-separated context key-value pairs to pass to the Function pipeline. Values must be JSON. Keys take precedence over --context-files." mapsep:""`
-	IncludeFunctionResults  bool              `help:"Include informational and warning messages from Functions in the rendered output as resources of kind: Result."                            short:"r"`
-	IncludeFullXR           bool              `help:"Include a direct copy of the input XR's spec and metadata fields in the rendered output."                                                  short:"x"`
-	IncludeStatusConditions bool              `help:"Include the status conditions in the rendered output as a resource of kind: Condition."                                                    short:"s"`
-	ObservedResources       string            `help:"A YAML file or directory of YAML files specifying the observed state of composed resources."                                               placeholder:"PATH" short:"o"   type:"path"`
-	ExtraResources          string            `help:"A YAML file or directory of YAML files specifying extra resources to pass to the Function pipeline."                                       placeholder:"PATH" short:"e"   type:"path"`
-	IncludeContext          bool              `help:"Include the context in the rendered output as a resource of kind: Context."                                                                short:"c"`
-	FunctionCredentials     string            `help:"A YAML file or directory of YAML files specifying credentials to use for Functions to render the XR."                                      placeholder:"PATH" type:"path"`
+	ContextFiles           map[string]string `help:"Comma-separated context key-value pairs to pass to the Function pipeline. Values must be files containing JSON."                           mapsep:""`
+	ContextValues          map[string]string `help:"Comma-separated context key-value pairs to pass to the Function pipeline. Values must be JSON. Keys take precedence over --context-files." mapsep:""`
+	IncludeFunctionResults bool              `help:"Include informational and warning messages from Functions in the rendered output as resources of kind: Result."                            short:"r"`
+	IncludeFullXR          bool              `help:"Include a direct copy of the input XR's spec and metadata fields in the rendered output."                                                  short:"x"`
+	ObservedResources      string            `help:"A YAML file or directory of YAML files specifying the observed state of composed resources."                                               placeholder:"PATH" short:"o"   type:"path"`
+	ExtraResources         string            `help:"A YAML file or directory of YAML files specifying extra resources to pass to the Function pipeline."                                       placeholder:"PATH" short:"e"   type:"path"`
+	IncludeContext         bool              `help:"Include the context in the rendered output as a resource of kind: Context."                                                                short:"c"`
+	FunctionCredentials    string            `help:"A YAML file or directory of YAML files specifying credentials to use for Functions to render the XR."                                      placeholder:"PATH" type:"path"`
 
 	Timeout time.Duration `default:"1m" help:"How long to run before timing out."`
 
@@ -267,15 +266,6 @@ func (c *Cmd) Run(k *kong.Context, log logging.Logger) error { //nolint:gocognit
 			_, _ = fmt.Fprintln(k.Stdout, "---")
 			if err := s.Encode(&out.Results[i], k.Stdout); err != nil {
 				return errors.Wrap(err, "cannot marshal result to YAML")
-			}
-		}
-	}
-
-	if c.IncludeStatusConditions {
-		for i := range out.Conditions {
-			_, _ = fmt.Fprintln(k.Stdout, "---")
-			if err := s.Encode(&out.Conditions[i], os.Stdout); err != nil {
-				return errors.Wrap(err, "cannot marshal condition to YAML")
 			}
 		}
 	}

--- a/cmd/crank/render/cmd.go
+++ b/cmd/crank/render/cmd.go
@@ -44,14 +44,15 @@ type Cmd struct {
 	Functions         string `arg:"" help:"A YAML file or directory of YAML files specifying the Composition Functions to use to render the XR." type:"path"`
 
 	// Flags. Keep them in alphabetical order.
-	ContextFiles           map[string]string `help:"Comma-separated context key-value pairs to pass to the Function pipeline. Values must be files containing JSON."                           mapsep:""`
-	ContextValues          map[string]string `help:"Comma-separated context key-value pairs to pass to the Function pipeline. Values must be JSON. Keys take precedence over --context-files." mapsep:""`
-	IncludeFunctionResults bool              `help:"Include informational and warning messages from Functions in the rendered output as resources of kind: Result."                            short:"r"`
-	IncludeFullXR          bool              `help:"Include a direct copy of the input XR's spec and metadata fields in the rendered output."                                                  short:"x"`
-	ObservedResources      string            `help:"A YAML file or directory of YAML files specifying the observed state of composed resources."                                               placeholder:"PATH" short:"o"   type:"path"`
-	ExtraResources         string            `help:"A YAML file or directory of YAML files specifying extra resources to pass to the Function pipeline."                                       placeholder:"PATH" short:"e"   type:"path"`
-	IncludeContext         bool              `help:"Include the context in the rendered output as a resource of kind: Context."                                                                short:"c"`
-	FunctionCredentials    string            `help:"A YAML file or directory of YAML files specifying credentials to use for Functions to render the XR."                                      placeholder:"PATH" type:"path"`
+	ContextFiles            map[string]string `help:"Comma-separated context key-value pairs to pass to the Function pipeline. Values must be files containing JSON."                           mapsep:""`
+	ContextValues           map[string]string `help:"Comma-separated context key-value pairs to pass to the Function pipeline. Values must be JSON. Keys take precedence over --context-files." mapsep:""`
+	IncludeFunctionResults  bool              `help:"Include informational and warning messages from Functions in the rendered output as resources of kind: Result."                            short:"r"`
+	IncludeFullXR           bool              `help:"Include a direct copy of the input XR's spec and metadata fields in the rendered output."                                                  short:"x"`
+	IncludeStatusConditions bool              `help:"Include the status conditions in the rendered output as a resource of kind: Condition."                                                    short:"s"`
+	ObservedResources       string            `help:"A YAML file or directory of YAML files specifying the observed state of composed resources."                                               placeholder:"PATH" short:"o"   type:"path"`
+	ExtraResources          string            `help:"A YAML file or directory of YAML files specifying extra resources to pass to the Function pipeline."                                       placeholder:"PATH" short:"e"   type:"path"`
+	IncludeContext          bool              `help:"Include the context in the rendered output as a resource of kind: Context."                                                                short:"c"`
+	FunctionCredentials     string            `help:"A YAML file or directory of YAML files specifying credentials to use for Functions to render the XR."                                      placeholder:"PATH" type:"path"`
 
 	Timeout time.Duration `default:"1m" help:"How long to run before timing out."`
 
@@ -266,6 +267,15 @@ func (c *Cmd) Run(k *kong.Context, log logging.Logger) error { //nolint:gocognit
 			_, _ = fmt.Fprintln(k.Stdout, "---")
 			if err := s.Encode(&out.Results[i], k.Stdout); err != nil {
 				return errors.Wrap(err, "cannot marshal result to YAML")
+			}
+		}
+	}
+
+	if c.IncludeStatusConditions {
+		for i := range out.Conditions {
+			_, _ = fmt.Fprintln(k.Stdout, "---")
+			if err := s.Encode(&out.Conditions[i], os.Stdout); err != nil {
+				return errors.Wrap(err, "cannot marshal condition to YAML")
 			}
 		}
 	}


### PR DESCRIPTION
### Description of your changes

This PR updates the `render` command to include in its output the status conditions returned from functions that it runs. These conditions are included directly in the XR, as they would be with the real composition machinery.

This is essentially a scoped port of the work by @dalton-hill-0 [here](https://github.com/crossplane/crossplane/pull/5450/files#diff-e62ddfeee06c113f3ce89d4236b1a8295f2c6e0158d3abc07a866dfb36c75e63) and [here](https://github.com/crossplane/crossplane/pull/5450/files#diff-3b5422dbf23f23b03bf63ad49e9fbb05b2da0561bd247cb1ee19d76df9b3dc17R834-R845).

The idea is that we examine all conditions returned by a function, do a bit of processing on them similar to how the composite reconciler does it, then set them on the XR. There is additional work from @dalton-hill-0 that handles fatal results and setting previously existing conditions to unknown, but that is beyond the scope of `render` as it only has a lifecycle of a single run.  Also, since `render` doesn't support Claims yet, we only set the conditions on the XR, even if the conditions are targeting both XR and Claim.

Fixes #6120 

### How this change has been tested

Clone the changes from https://github.com/jbw976/crossplane/tree/render-conditions, then locally install the `crank` binary:
```
go install ./cmd/crank
```

Clone the demo repo from https://github.com/jbw976/demo-xfn-claim-com, then run the `render` testing [instructions](https://github.com/jbw976/demo-xfn-claim-com/blob/main/DEVELOPMENT.md#run-locally-with-render), i.e.:
```
go run . --insecure --debug
```
and then:
```
crank render -x -r example/xr-modern.yaml example/composition-modern.yaml example/functions-dev.yaml
```

You should see a condition included on the XR output, depending on the XR values. For example, a `environment: production` with `tier: low` is invalid and will generate an error condition that is included on the XR:
```
  - lastTransitionTime: "2024-01-01T00:00:00Z"
    message: environment 'production' does not support tier 'low'. supported tiers
      for 'production' include 'critical, standard'
    reason: Error
    status: "False"
    type: ProvisioningSuccess
```

Conversely, `environment: production` with `tier: critical` is valid and will generate a success condition on the XR:
```
  - lastTransitionTime: "2024-01-01T00:00:00Z"
    reason: Success
    status: "True"
    type: ProvisioningSuccess
```

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `earthly +reviewable` to ensure this PR is ready for review.
- [x] Added or updated unit tests.
- [ ] ~Added or updated e2e tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
