### PR TITLE
Usages: decomposed usages should not deleted properly

### DIFF
--- a/internal/controller/apiextensions/usage/reconciler.go
+++ b/internal/controller/apiextensions/usage/reconciler.go
@@ -47,6 +47,7 @@ import (
 	"github.com/crossplane/crossplane/apis/apiextensions/v1alpha1"
 	apiextensionscontroller "github.com/crossplane/crossplane/internal/controller/apiextensions/controller"
 	"github.com/crossplane/crossplane/internal/usage"
+	"github.com/crossplane/crossplane/internal/xcrd"
 )
 
 const (
@@ -253,7 +254,17 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 	}))
 
 	if meta.WasDeleted(u) {
-		if by != nil {
+		// Note (turkenh): A Usage can be composed as part of a Composition
+		// together with the using resource. When the composite is deleted, the
+		// usage resource will also be deleted. In this case, we need to wait
+		// for the using resource to be deleted; otherwise, we won’t be properly
+		// waiting for its deletion since Usage will be gone immediately. We
+		// intentionally avoid checking whether they are part of the same
+		// Composition, as they may not be, but could still be composed together
+		// as part of a higher-level Composition. Therefore, as an approximation
+		// we wait for the using resource to be deleted before deleting the
+		// usage resource, if the usage resource is part of a Composition.
+		if by != nil && u.Labels[xcrd.LabelKeyNamePrefixForComposed] != "" {
 			// Identify using resource as an unstructured object.
 			using := composed.New(composed.FromReference(v1.ObjectReference{
 				Kind:       by.Kind,

--- a/test/e2e/manifests/apiextensions/usage/composition-pipeline/claim.yaml
+++ b/test/e2e/manifests/apiextensions/usage/composition-pipeline/claim.yaml
@@ -1,0 +1,7 @@
+apiVersion: nop.example.org/v1alpha1
+kind: NopResource
+metadata:
+  namespace: default
+  name: test
+spec:
+  coolField: "I'm cool!"

--- a/test/e2e/manifests/apiextensions/usage/composition-pipeline/composition-updated.yaml
+++ b/test/e2e/manifests/apiextensions/usage/composition-pipeline/composition-updated.yaml
@@ -1,0 +1,92 @@
+apiVersion: apiextensions.crossplane.io/v1
+kind: Composition
+metadata:
+  name: xnopresources.nop.example.org
+spec:
+  compositeTypeRef:
+    apiVersion: nop.example.org/v1alpha1
+    kind: XNopResource
+  mode: Pipeline
+  pipeline:
+    - step: be-a-dummy
+      functionRef:
+        name: function-dummy
+      input:
+        apiVersion: dummy.fn.crossplane.io/v1beta1
+        kind: Response
+        # This is a YAML-serialized RunFunctionResponse. function-dummy will
+        # overlay the desired state on any that was passed into it.
+        response:
+          desired:
+            composite:
+              resource:
+                status:
+                  coolerField: "I'M COOLER!"
+            resources:
+              used-resource:
+                resource:
+                  apiVersion: nop.crossplane.io/v1alpha1
+                  kind: NopResource
+                  metadata:
+                    labels:
+                      usage: used
+                  spec:
+                    forProvider:
+                      conditionAfter:
+                        - conditionType: "Synced"
+                          conditionStatus: "True"
+                          time: "5s"
+                        - conditionType: "Ready"
+                          conditionStatus: "True"
+                          time: "10s"
+              using-resource:
+                resource:
+                  apiVersion: nop.crossplane.io/v1alpha1
+                  kind: NopResource
+                  metadata:
+                    # We are delaying deletion of using resource with this finalizer. This is to ensure that the used resource is
+                    # not deleted before the using resource. Imagine a scenario where a Release resource using a Cluster resource
+                    # where we expect the Cluster resource not to be deleted until the Release resource is deleted. We are mimicking
+                    # this behavior with the help of a finalizer on a NopResource.
+                    finalizers:
+                      - delay-deletion-of-using-resource
+                    labels:
+                      usage: using
+                  spec:
+                    forProvider:
+                      conditionAfter:
+                        - conditionType: "Synced"
+                          conditionStatus: "True"
+                          time: "5s"
+                        - conditionType: "Ready"
+                          conditionStatus: "True"
+                          time: "10s"
+              usage-resource-updated:
+                resource:
+                  apiVersion: apiextensions.crossplane.io/v1alpha1
+                  kind: Usage
+                  metadata:
+                    labels:
+                      version: updated
+                  spec:
+                    replayDeletion: true
+                    of:
+                      apiVersion: nop.crossplane.io/v1alpha1
+                      kind: NopResource
+                      resourceSelector:
+                        matchControllerRef: true
+                        matchLabels:
+                          usage: used
+                    by:
+                      apiVersion: nop.crossplane.io/v1alpha1
+                      kind: NopResource
+                      resourceSelector:
+                        matchControllerRef: true
+                        matchLabels:
+                          usage: using
+          results:
+            - severity: SEVERITY_NORMAL
+              message: "I am doing a compose!"
+    - step: detect-readiness
+      functionRef:
+        name: function-auto-ready

--- a/test/e2e/manifests/apiextensions/usage/composition-pipeline/setup/composition.yaml
+++ b/test/e2e/manifests/apiextensions/usage/composition-pipeline/setup/composition.yaml
@@ -1,0 +1,87 @@
+apiVersion: apiextensions.crossplane.io/v1
+kind: Composition
+metadata:
+  name: xnopresources.nop.example.org
+spec:
+  compositeTypeRef:
+    apiVersion: nop.example.org/v1alpha1
+    kind: XNopResource
+  mode: Pipeline
+  pipeline:
+    - step: be-a-dummy
+      functionRef:
+        name: function-dummy
+      input:
+        apiVersion: dummy.fn.crossplane.io/v1beta1
+        kind: Response
+        # This is a YAML-serialized RunFunctionResponse. function-dummy will
+        # overlay the desired state on any that was passed into it.
+        response:
+          desired:
+            resources:
+              used-resource:
+                resource:
+                  apiVersion: nop.crossplane.io/v1alpha1
+                  kind: NopResource
+                  metadata:
+                    labels:
+                      usage: used
+                  spec:
+                    forProvider:
+                      conditionAfter:
+                        - conditionType: "Synced"
+                          conditionStatus: "True"
+                          time: "5s"
+                        - conditionType: "Ready"
+                          conditionStatus: "True"
+                          time: "10s"
+              using-resource:
+                resource:
+                  apiVersion: nop.crossplane.io/v1alpha1
+                  kind: NopResource
+                  metadata:
+                    # We are delaying deletion of using resource with this finalizer. This is to ensure that the used resource is
+                    # not deleted before the using resource. Imagine a scenario where a Release resource using a Cluster resource
+                    # where we expect the Cluster resource not to be deleted until the Release resource is deleted. We are mimicking
+                    # this behavior with the help of a finalizer on a NopResource.
+                    finalizers:
+                      - delay-deletion-of-using-resource
+                    labels:
+                      usage: using
+                  spec:
+                    forProvider:
+                      conditionAfter:
+                        - conditionType: "Synced"
+                          conditionStatus: "True"
+                          time: "5s"
+                        - conditionType: "Ready"
+                          conditionStatus: "True"
+                          time: "10s"
+              usage-resource:
+                resource:
+                  apiVersion: apiextensions.crossplane.io/v1alpha1
+                  kind: Usage
+                  metadata:
+                    labels:
+                      version: initial
+                  spec:
+                    of:
+                      apiVersion: nop.crossplane.io/v1alpha1
+                      kind: NopResource
+                      resourceSelector:
+                        matchControllerRef: true
+                        matchLabels:
+                          usage: used
+                    by:
+                      apiVersion: nop.crossplane.io/v1alpha1
+                      kind: NopResource
+                      resourceSelector:
+                        matchControllerRef: true
+                        matchLabels:
+                          usage: using
+          results:
+            - severity: SEVERITY_NORMAL
+              message: "I am doing a compose!"
+    - step: detect-readiness
+      functionRef:
+        name: function-auto-ready

--- a/test/e2e/manifests/apiextensions/usage/composition-pipeline/setup/definition.yaml
+++ b/test/e2e/manifests/apiextensions/usage/composition-pipeline/setup/definition.yaml
@@ -1,0 +1,29 @@
+apiVersion: apiextensions.crossplane.io/v1
+kind: CompositeResourceDefinition
+metadata:
+  name: xnopresources.nop.example.org
+spec:
+  group: nop.example.org
+  names:
+    kind: XNopResource
+    plural: xnopresources
+  claimNames:
+    kind: NopResource
+    plural: nopresources
+  connectionSecretKeys:
+  - test
+  versions:
+  - name: v1alpha1
+    served: true
+    referenceable: true
+    schema:
+     openAPIV3Schema:
+       type: object
+       properties:
+        spec:
+          type: object
+          properties:
+            coolField:
+              type: string
+          required:
+          - coolField

--- a/test/e2e/manifests/apiextensions/usage/composition-pipeline/setup/functions.yaml
+++ b/test/e2e/manifests/apiextensions/usage/composition-pipeline/setup/functions.yaml
@@ -1,0 +1,24 @@
+---
+# We intentionally use v1beta1 here, to make sure it still works.
+apiVersion: pkg.crossplane.io/v1beta1
+kind: Function
+metadata:
+  name: function-dummy
+spec:
+  # NOTE(negz): This is currently manually pushed. See README.md at
+  # https://github.com/crossplane-contrib/function-dummy.
+  # NOTE(negz): This version of the function uses meta.pkg.crossplane.io/v1beta1
+  # and is built with an old SDK that only serves v1beta1 RPCs. This is
+  # intentional. We want to make sure Crossplane is backward compatible with
+  # older v1beta1 functions.
+  package: xpkg.upbound.io/crossplane-contrib/function-dummy:v0.2.1
+---
+apiVersion: pkg.crossplane.io/v1
+kind: Function
+metadata:
+  name: function-auto-ready
+spec:
+  # TODO(negz): This function should use meta.pkg.crossplane.io/v1 metadata.
+  # It supports the new v1 RPCs but it can't be built using v1 metadata until
+  # https://github.com/crossplane/crossplane/issues/5971 is fixed.
+  package: xpkg.upbound.io/crossplane-contrib/function-auto-ready:v0.3.0

--- a/test/e2e/manifests/apiextensions/usage/composition-pipeline/setup/provider.yaml
+++ b/test/e2e/manifests/apiextensions/usage/composition-pipeline/setup/provider.yaml
@@ -1,0 +1,7 @@
+apiVersion: pkg.crossplane.io/v1
+kind: Provider
+metadata:
+  name: provider-nop
+spec:
+  package: xpkg.upbound.io/crossplane-contrib/provider-nop:v0.3.0
+  ignoreCrossplaneConstraints: true

--- a/test/e2e/usage_test.go
+++ b/test/e2e/usage_test.go
@@ -198,3 +198,101 @@ func TestUsageComposition(t *testing.T) {
 			Feature(),
 	)
 }
+
+func TestUsageCompositionWithPipeline(t *testing.T) {
+	manifests := "test/e2e/manifests/apiextensions/usage/composition-pipeline"
+
+	usageList := composed.NewList(composed.FromReferenceToList(corev1.ObjectReference{
+		APIVersion: "apiextensions.crossplane.io/v1alpha1",
+		Kind:       "Usage",
+	}))
+
+	environment.Test(t,
+		features.NewWithDescription(t.Name(), "Tests scenarios for Crossplane's `Usage` resource as part of a composition pipeline and decomposed properly.").
+			WithLabel(LabelStage, LabelStageAlpha).
+			WithLabel(LabelArea, LabelAreaAPIExtensions).
+			WithLabel(LabelSize, LabelSizeSmall).
+			WithLabel(LabelModifyCrossplaneInstallation, LabelModifyCrossplaneInstallationTrue).
+			WithLabel(config.LabelTestSuite, SuiteUsage).
+			// Enable the usage feature flag.
+			WithSetup("EnableAlphaUsages", funcs.AllOf(
+				funcs.AsFeaturesFunc(environment.HelmUpgradeCrossplaneToSuite(SuiteUsage)),
+				funcs.ReadyToTestWithin(1*time.Minute, namespace),
+			)).
+			WithSetup("PrerequisitesAreCreated", funcs.AllOf(
+				funcs.ApplyResources(FieldManager, manifests, "setup/*.yaml"),
+				funcs.ResourcesCreatedWithin(30*time.Second, manifests, "setup/*.yaml"),
+				funcs.ResourcesHaveConditionWithin(1*time.Minute, manifests, "setup/definition.yaml", apiextensionsv1.WatchingComposite()),
+				funcs.ResourcesHaveConditionWithin(2*time.Minute, manifests, "setup/provider.yaml", pkgv1.Healthy(), pkgv1.Active()),
+				funcs.ResourcesHaveConditionWithin(2*time.Minute, manifests, "setup/functions.yaml", pkgv1.Healthy(), pkgv1.Active()),
+			)).
+			Assess("ClaimCreatedAndReady", funcs.AllOf(
+				funcs.ApplyResources(FieldManager, manifests, "claim.yaml"),
+				funcs.ResourcesCreatedWithin(30*time.Second, manifests, "claim.yaml"),
+				funcs.ResourcesHaveConditionWithin(5*time.Minute, manifests, "claim.yaml", xpv1.Available()),
+			)).
+			Assess("UsedResourceHasInUseLabel", funcs.AllOf(
+				funcs.ComposedResourcesHaveFieldValueWithin(1*time.Minute, manifests, "claim.yaml", "metadata.labels[crossplane.io/in-use]", "true", func(object k8s.Object) bool {
+					return object.GetLabels()["usage"] == "used"
+				}),
+			)).
+			Assess("UsageResourceIsInInitialVersion", funcs.AllOf(
+				funcs.ComposedResourcesHaveFieldValueWithin(1*time.Minute, manifests, "claim.yaml", "metadata.annotations[crossplane.io/composition-resource-name]", "usage-resource", func(object k8s.Object) bool {
+					return object.GetLabels()["version"] == "initial"
+				}),
+			)).
+			Assess("UpdateCompositionWithNewUsage",
+				funcs.ApplyResources(FieldManager, manifests, "composition-updated.yaml"),
+			).
+			Assess("OldUsageIsGoneNewOneIsComposed", funcs.AllOf(
+				funcs.ListedResourcesDeletedWithin(2*time.Minute, usageList, resources.WithLabelSelector("version=initial")),
+				funcs.ComposedResourcesHaveFieldValueWithin(1*time.Minute, manifests, "claim.yaml", "metadata.annotations[crossplane.io/composition-resource-name]", "usage-resource-updated", func(object k8s.Object) bool {
+					return object.GetLabels()["version"] == "updated"
+				}),
+			)).
+			Assess("ClaimDeleted", funcs.AllOf(
+				funcs.DeleteResources(manifests, "claim.yaml"),
+				funcs.ResourcesDeletedWithin(1*time.Minute, manifests, "claim.yaml"),
+			)).
+			// NOTE(turkenh): At this point, the claim is deleted and hence the
+			// garbage collector started attempting to delete all composed
+			// resources. With the help of a finalizer (namely
+			// `delay-deletion-of-using-resource`, see in the composition),
+			// we know that the using resource is still there and hence the
+			// deletion of the used resource should be blocked. We will assess
+			// that below.
+			Assess("OthersDeletedExceptUsed", funcs.AllOf(
+				// Using resource should have a deletion timestamp (i.e. deleted by the garbage collector).
+				funcs.ListedResourcesValidatedWithin(1*time.Minute, nopList, 1, func(object k8s.Object) bool {
+					return object.GetDeletionTimestamp() != nil
+				}, resources.WithLabelSelector(labels.FormatLabels(map[string]string{"usage": "using"}))),
+				// Usage resource should not have a deletion timestamp since it is owned by the using resource.
+				funcs.ListedResourcesValidatedWithin(1*time.Minute, usageList, 1, func(object k8s.Object) bool {
+					return object.GetDeletionTimestamp() == nil
+				}),
+				// Used resource should not have a deletion timestamp since it is still in use.
+				funcs.ListedResourcesValidatedWithin(1*time.Minute, nopList, 1, func(object k8s.Object) bool {
+					return object.GetDeletionTimestamp() == nil
+				}, resources.WithLabelSelector(labels.FormatLabels(map[string]string{"usage": "used"}))),
+			)).
+			Assess("UsingDeletedAllGone", funcs.AllOf(
+				// Remove the finalizer from the using resource.
+				funcs.ListedResourcesModifiedWith(nopList, 1, func(object k8s.Object) {
+					object.SetFinalizers(nil)
+				}, resources.WithLabelSelector(labels.FormatLabels(map[string]string{"usage": "using"}))),
+				// All composed resources should now be deleted including the Usage itself.
+				funcs.ListedResourcesDeletedWithin(2*time.Minute, nopList),
+				funcs.ListedResourcesDeletedWithin(2*time.Minute, usageList),
+			)).
+			WithTeardown("DeletePrerequisites", funcs.AllOf(
+				funcs.DeleteResources(manifests, "setup/*.yaml"),
+				funcs.ResourcesDeletedWithin(3*time.Minute, manifests, "setup/*.yaml"),
+			)).
+			// Disable our feature flag.
+			WithTeardown("DisableAlphaUsages", funcs.AllOf(
+				funcs.AsFeaturesFunc(environment.HelmUpgradeCrossplaneToBase()),
+				funcs.ReadyToTestWithin(1*time.Minute, namespace),
+			)).
+			Feature(),
+	)
+}


### PR DESCRIPTION
### Description of your changes

This PR fixes #5880 with the following changes:

- When the Usage itself deleted, the usage controller will wait for using resource before removing the finalizer, **only if the Usage is part of a composite (i.e has `crossplane.io/composite` label).**
- When a resource removed from a composition (i.e. decomposed), the composition controllers (both PT and function) will remove the composed resource labels before deleting the resource.

This is basically the idea proposed in [this comment](https://github.com/crossplane/crossplane/issues/5880#issuecomment-2363433313).

Fixes #5880 

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `earthly +reviewable` to ensure this PR is ready for review.
- [x] Added or updated unit tests.
- [x] Added or updated e2e tests.
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [x] Added `backport release-x.y` labels to auto-backport this PR.

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
