### PR TITLE
fix(environmentConfigs): revert to v1alpha1 as storageversion to fix rollback issues

### DIFF
--- a/apis/apiextensions/v1alpha1/zz_generated.environment_config_types.go
+++ b/apis/apiextensions/v1alpha1/zz_generated.environment_config_types.go
@@ -26,7 +26,6 @@ import (
 // +kubebuilder:object:root=true
 // +kubebuilder:storageversion
 // +genclient
-// +kubebuilder:storageversion
 // +genclient:nonNamespaced
 
 // An EnvironmentConfig contains user-defined unstructured values for

--- a/apis/apiextensions/v1alpha1/zz_generated.environment_config_types.go
+++ b/apis/apiextensions/v1alpha1/zz_generated.environment_config_types.go
@@ -24,7 +24,9 @@ import (
 )
 
 // +kubebuilder:object:root=true
+// +kubebuilder:storageversion
 // +genclient
+// +kubebuilder:storageversion
 // +genclient:nonNamespaced
 
 // An EnvironmentConfig contains user-defined unstructured values for

--- a/apis/apiextensions/v1beta1/environment_config_types.go
+++ b/apis/apiextensions/v1beta1/environment_config_types.go
@@ -22,7 +22,6 @@ import (
 )
 
 // +kubebuilder:object:root=true
-// +kubebuilder:storageversion
 // +genclient
 // +genclient:nonNamespaced
 

--- a/apis/generate.go
+++ b/apis/generate.go
@@ -31,7 +31,7 @@ limitations under the License.
 //go:generate ../hack/duplicate_api_type.sh apiextensions/v1/composition_patches.go apiextensions/v1beta1
 //go:generate ../hack/duplicate_api_type.sh apiextensions/v1/composition_transforms.go apiextensions/v1beta1
 
-//go:generate ../hack/duplicate_api_type.sh apiextensions/v1beta1/environment_config_types.go apiextensions/v1alpha1
+//go:generate ../hack/duplicate_api_type.sh apiextensions/v1beta1/environment_config_types.go apiextensions/v1alpha1 true
 
 //go:generate ../hack/duplicate_api_type.sh pkg/v1/package_types.go pkg/v1beta1
 //go:generate ../hack/duplicate_api_type.sh pkg/v1/package_runtime_types.go pkg/v1beta1

--- a/cluster/crds/apiextensions.crossplane.io_environmentconfigs.yaml
+++ b/cluster/crds/apiextensions.crossplane.io_environmentconfigs.yaml
@@ -58,7 +58,7 @@ spec:
             type: object
         type: object
     served: true
-    storage: false
+    storage: true
     subresources: {}
   - additionalPrinterColumns:
     - jsonPath: .metadata.creationTimestamp
@@ -100,5 +100,5 @@ spec:
             type: object
         type: object
     served: true
-    storage: true
+    storage: false
     subresources: {}

--- a/cmd/crossplane/core/init.go
+++ b/cmd/crossplane/core/init.go
@@ -73,7 +73,7 @@ func (c *initCommand) Run(s *runtime.Scheme, log logging.Logger) error {
 	steps = append(steps,
 		initializer.NewTLSCertificateGenerator(c.Namespace, c.TLSCASecretName, tlsGeneratorOpts...),
 		initializer.NewCoreCRDsMigrator("compositionrevisions.apiextensions.crossplane.io", "v1alpha1"),
-		initializer.NewCoreCRDsMigrator("environmentconfigs.apiextensions.crossplane.io", "v1alpha1"),
+		initializer.NewCoreCRDsMigrator("environmentconfigs.apiextensions.crossplane.io", "v1beta1"),
 		initializer.NewCoreCRDsMigrator("functions.pkg.crossplane.io", "v1beta1"),
 		initializer.NewCoreCRDsMigrator("functionrevisions.pkg.crossplane.io", "v1beta1"),
 		initializer.NewCoreCRDsMigrator("locks.pkg.crossplane.io", "v1alpha1"),

--- a/hack/duplicate_api_type.sh
+++ b/hack/duplicate_api_type.sh
@@ -24,17 +24,16 @@ FROM_PACKAGE=$(basename ${FROM_DIR})
 TO_PACKAGE=$(basename ${TO_DIR})
 TO_PATH="${TO_DIR}/zz_generated.${FROM_FILE}"
 
-if [ "${STORAGE_VERSION}" = "true" ] && grep -q "+kubebuilder:storageversion" ${FROM_PATH}; then
-  echo "Error: ${FROM_PATH} is a storage version and cannot be duplicated without dropping the storage version marker."
-  exit 1
-fi
-
 sed "s#^package ${FROM_PACKAGE}\$#${DO_NOT_EDIT}\n\npackage ${TO_PACKAGE}#" ${FROM_PATH} > ${TO_PATH}
 
 case $STORAGE_VERSION in
   true)
+    if grep -q "+kubebuilder:storageversion" ${FROM_PATH}; then
+      echo "Error: ${FROM_PATH} is marked as storage version and cannot be duplicated without dropping the marker."
+      exit 1
+    fi
     # Add the storageVersion marker before // +genclient
-    sed -i '\/\/ +genclient/i\/\/ +kubebuilder:storageversion' ${TO_PATH}
+    sed -i '\/\/ +genclient$/i\/\/ +kubebuilder:storageversion' ${TO_PATH}
     echo "Duplicated ${FROM_PATH} (package ${FROM_PACKAGE}) to ${TO_PATH} (package ${TO_PACKAGE})."
     ;;
   false)

--- a/hack/duplicate_api_type.sh
+++ b/hack/duplicate_api_type.sh
@@ -13,6 +13,7 @@ set -e
 
 FROM_PATH=${1}
 TO_DIR=${2}
+STORAGE_VERSION=${3:-false}
 
 DO_NOT_EDIT="// Generated from ${FROM_PATH} by ${0}. DO NOT EDIT."
 
@@ -23,6 +24,26 @@ FROM_PACKAGE=$(basename ${FROM_DIR})
 TO_PACKAGE=$(basename ${TO_DIR})
 TO_PATH="${TO_DIR}/zz_generated.${FROM_FILE}"
 
-sed "s#^package ${FROM_PACKAGE}\$#${DO_NOT_EDIT}\n\npackage ${TO_PACKAGE}#" ${FROM_PATH} | grep -v '// +kubebuilder:storageversion' > ${TO_PATH}
+if [ "${STORAGE_VERSION}" = "true" ] && grep -q "+kubebuilder:storageversion" ${FROM_PATH}; then
+  echo "Error: ${FROM_PATH} is a storage version and cannot be duplicated without dropping the storage version marker."
+  exit 1
+fi
 
-echo "Duplicated ${FROM_PATH} (package ${FROM_PACKAGE}) to ${TO_PATH} (package ${TO_PACKAGE})."
+sed "s#^package ${FROM_PACKAGE}\$#${DO_NOT_EDIT}\n\npackage ${TO_PACKAGE}#" ${FROM_PATH} > ${TO_PATH}
+
+case $STORAGE_VERSION in
+  true)
+    # Add the storageVersion marker before // +genclient
+    sed -i '\/\/ +genclient/i\/\/ +kubebuilder:storageversion' ${TO_PATH}
+    echo "Duplicated ${FROM_PATH} (package ${FROM_PACKAGE}) to ${TO_PATH} (package ${TO_PACKAGE})."
+    ;;
+  false)
+    # Remove the +kubebuilder:storageversion comment marker
+    sed -i '/+kubebuilder:storageversion/d' ${TO_PATH}
+    echo "Duplicated ${FROM_PATH} (package ${FROM_PACKAGE}) to ${TO_PATH} (package ${TO_PACKAGE}), removed storage version marker."
+    ;;
+  *)
+    echo "Error: Invalid STORAGE_VERSION value: ${STORAGE_VERSION}"
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane! Please read the contribution docs
(linked below) if this is your first Crossplane pull request.
-->

### Description of your changes

<!--
Briefly describe what this pull request does, and how it is covered by tests.
Be proactive - direct your reviewers' attention to anything that needs special
consideration.

We love pull requests that fix an open issue. If yours does, use the below line
to indicate which issue it fixes, for example "Fixes #500".
-->

Fixes https://github.com/crossplane/crossplane/issues/6148

We introduced `v1beta1` and bumped the storage version in the same minor release, `1.18`, this means a user rolling back to the previous minor, `1.17`, hit the issue above due to `v1beta1` being used as storage version while trying to drop it, not being defined by the previous minor.

The generated code was copy of `v1beta1` type, dropping the `storageVersion` marker. This patch allows explicitly marking the copy and runs the migration for all existing `EnvironmentConfigs to `v1alpha1`. Next minor release (`1.19`) we'll bump the `storageVersion` to `v1beta1` and switch to migrate all existing `EnvironmentConfigs` to `v1beta1`, and we'll be able to drop `v1alpha1` in `1.20`. This way downgrades between minors should go smoothly, `1.20` -> `1.19` -> `1.18` -> `1.17`.

Manually tested by:
```bash
# spin up a kind cluster using this PR's code
$ earthly +hack
...
# create some EnvironmentConfigs
$ kubectl apply -f test/e2e/manifests/apiextensions/environment/default/setup/environmentConfigs.yaml
...
# downgrade to 1.17.3
$ helm upgrade --install crossplane --namespace crossplane-system --create-namespace crossplane-stable/crossplane --version 1.17.3

```

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `earthly +reviewable` to ensure this PR is ready for review.
- [ ] ~Added or updated unit tests.~
- [ ] ~Added or updated e2e tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [x] Added `backport release-x.y` labels to auto-backport this PR.

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
