### PR TITLE
Remove Successfully composed resources event

### DIFF
--- a/internal/controller/apiextensions/composite/reconciler.go
+++ b/internal/controller/apiextensions/composite/reconciler.go
@@ -640,7 +640,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 		// considered synced (i.e. severe enough to return a ReconcileError) but
 		// they are severe enough that we probably shouldn't say we successfully
 		// composed resources.
-		r.record.Event(xr, event.Normal(reasonCompose, "Successfully composed resources"))
+		log.Debug("Successfully composed resources")
 	}
 
 	var unready []ComposedResource


### PR DESCRIPTION
### Description of your changes

Remove the Successfully composed resources event from the composite reconciler and print a debug log message instead.

Fixes #6166 

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [X] Read and followed Crossplane's [contribution process].
- [X] Run `earthly +reviewable` to ensure this PR is ready for review.
~- [ ] Added or updated unit tests.~
~- [ ] Added or updated e2e tests.~
~- [ ] Linked a PR or a [docs tracking issue] to [document this change].~
~- [ ] Added `backport release-x.y` labels to auto-backport this PR.~

