### PR TITLE
fix: allow running E2E tests in WSL environment

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -47,9 +47,14 @@ generate:
 # e2e runs end-to-end tests. See test/e2e/README.md for details.
 e2e:
   ARG FLAGS="-test-suite=base"
-  # Docker installs faster on Alpine, and we only need Go for go tool test2json.
-  FROM golang:${GO_VERSION}-alpine3.20
-  RUN apk add --no-cache docker jq
+  # Using earthly image to allow comability with different development environments e.g. WSL
+  FROM earthly/dind
+  RUN wget https://dl.google.com/go/go${GO_VERSION}.linux-amd64.tar.gz
+  RUN tar -C /usr/local -xzf go${GO_VERSION}.linux-amd64.tar.gz
+  ENV GOTOOLCHAIN=local
+  ENV GOPATH /go
+  ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
+  RUN apk add --no-cache jq
   COPY +helm-setup/helm /usr/local/bin/helm
   COPY +kind-setup/kind /usr/local/bin/kind
   COPY +gotestsum-setup/gotestsum /usr/local/bin/gotestsum

--- a/Earthfile
+++ b/Earthfile
@@ -47,7 +47,7 @@ generate:
 # e2e runs end-to-end tests. See test/e2e/README.md for details.
 e2e:
   ARG FLAGS="-test-suite=base"
-  # Using earthly image to allow comability with different development environments e.g. WSL
+  # Using earthly image to allow compatibility with different development environments e.g. WSL
   FROM earthly/dind
   RUN wget https://dl.google.com/go/go${GO_VERSION}.linux-amd64.tar.gz
   RUN tar -C /usr/local -xzf go${GO_VERSION}.linux-amd64.tar.gz

--- a/Earthfile
+++ b/Earthfile
@@ -48,7 +48,7 @@ generate:
 e2e:
   ARG FLAGS="-test-suite=base"
   # Using earthly image to allow compatibility with different development environments e.g. WSL
-  FROM earthly/dind
+  FROM earthly/dind:alpine-3.20-docker-26.1.5-r0
   RUN wget https://dl.google.com/go/go${GO_VERSION}.linux-amd64.tar.gz
   RUN tar -C /usr/local -xzf go${GO_VERSION}.linux-amd64.tar.gz
   ENV GOTOOLCHAIN=local

--- a/Earthfile
+++ b/Earthfile
@@ -46,11 +46,15 @@ generate:
 
 # e2e runs end-to-end tests. See test/e2e/README.md for details.
 e2e:
+  ARG TARGETARCH
+  ARG TARGETOS
+  ARG GOARCH=${TARGETARCH}
+  ARG GOOS=${TARGETOS}
   ARG FLAGS="-test-suite=base"
   # Using earthly image to allow compatibility with different development environments e.g. WSL
   FROM earthly/dind:alpine-3.20-docker-26.1.5-r0
-  RUN wget https://dl.google.com/go/go${GO_VERSION}.linux-amd64.tar.gz
-  RUN tar -C /usr/local -xzf go${GO_VERSION}.linux-amd64.tar.gz
+  RUN wget https://dl.google.com/go/go${GO_VERSION}.${GOOS}-${GOARCH}.tar.gz
+  RUN tar -C /usr/local -xzf go${GO_VERSION}.${GOOS}-${GOARCH}.tar.gz
   ENV GOTOOLCHAIN=local
   ENV GOPATH /go
   ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH


### PR DESCRIPTION
### Description of your changes

I want to contribute to the project and #4837 but as I'm working on Windows machine with golang dev env in WSL (because of certain policies), I get errors when trying to run the E2E tests:
```
$ earthly -P +e2e
 Init 🚀
————————————————————————————————————————————————————————————————————————————————

           buildkitd | Found buildkit daemon as docker container (earthly-buildkitd)

 Build 🔧
————————————————————————————————————————————————————————————————————————————————

      registry-proxy | Failed to start registry proxy: failed to start Darwin support container: context deadline exceeded
              logbus | Setting organization "crossplane" and project "crossplane"
                +e2e | --> FROM +base
golang:1.23.4-alpine3.20 | --> Load metadata golang:1.23.4-alpine3.20 linux/amd64
Warning: you are not logged into registry-1.docker.io, you may experience rate-limitting when pulling images
         +helm-setup | --> FROM +base
        c/curl:8.8.0 | --> Load metadata curlimages/curl:8.8.0 linux/amd64
Warning: you are not logged into registry-1.docker.io, you may experience rate-limitting when pulling images
         +kind-setup | --> FROM +base
    +gotestsum-setup | --> FROM +base
       +go-build-e2e | --> FROM +base
       +go-build-e2e | --> FROM +go-modules
         +helm-setup | --> FROM curlimages/curl:8.8.0
         +go-modules | --> FROM +base
       golang:1.23.4 | --> Load metadata golang:1.23.4 linux/amd64
         +helm-setup | [----------] 100% FROM curlimages/curl:8.8.0
         +helm-setup | --> RUN curl -fsSL [https://get.helm.sh/helm-${HELM_VERSION}-${TARGETOS}-${TARGETARCH}.tar.gz|tar](https://get.helm.sh/helm-$%7bHELM_VERSION%7d-$%7bTARGETOS%7d-$%7bTARGETARCH%7d.tar.gz%7Ctar) zx --strip-components=1
    +gotestsum-setup | --> RUN curl -fsSL [https://github.com/gotestyourself/gotestsum/releases/download/v${GOTESTSUM_VERSION}/gotestsum_${GOTESTSUM_VERSION}_${TARGETOS}_${TARGETARCH}.tar.gz|tar](https://github.com/gotestyourself/gotestsum/releases/download/v$%7bGOTESTSUM_VERSION%7d/gotestsum_$%7bGOTESTSUM_VERSION%7d_$%7bTARGETOS%7d_$%7bTARGETARCH%7d.tar.gz%7Ctar) zx>gotestsum
         +kind-setup | --> RUN curl -fsSLo kind [https://github.com/kubernetes-sigs/kind/releases/download/${KIND_VERSION}/kind-${TARGETOS}-${TARGETARCH}&&chmod](https://github.com/kubernetes-sigs/kind/releases/download/$%7bKIND_VERSION%7d/kind-$%7bTARGETOS%7d-$%7bTARGETARCH%7d&&chmod) +x kind
                +e2e | --> WITH DOCKER RUN
              +image | CROSSPLANE_VERSION=v0.0.0-e2e
              +image | --> FROM +base
g/d/static@sha256:5c7e2b465ac6a2a4e5f4f7f722ce43b147dabe87cb21ac6c4007ae5178a1fa58 | --> Load metadata gcr.io/distroless/static@sha256:5c7e2b465ac6a2a4e5f4f7f722ce43b147dabe87cb21ac6c4007ae5178a1fa58 linux/amd64
         +go-modules | --> FROM golang:1.23.4
         +go-modules | [----------] 100% FROM golang:1.23.4
           +go-build | CROSSPLANE_VERSION=v0.0.0-e2e GOARCH=amd64 GOOS=linux
           +go-build | --> FROM +base
           +go-build | CROSSPLANE_VERSION=v0.0.0-e2e GOARCH=amd64 GOOS=linux
           +go-build | --> FROM +go-modules
         +go-modules | CROSSPLANE_VERSION=v0.0.0-e2e GOARCH=amd64 GOOS=linux
         +go-modules | --> FROM +base
         +go-modules | [----------] 100% FROM golang:1.23.4
         +go-modules | --> WORKDIR /crossplane
         +go-modules | --> COPY go.mod go.sum ./
         +go-modules | --> RUN go mod download
         +go-modules | CROSSPLANE_VERSION=v0.0.0-e2e GOARCH=amd64 GOOS=linux
         +go-modules | *cached* --> COPY go.mod go.sum ./
         +go-modules | CROSSPLANE_VERSION=v0.0.0-e2e GOARCH=amd64 GOOS=linux
         +go-modules | *cached* --> RUN go mod download
           +go-build | CROSSPLANE_VERSION=v0.0.0-e2e GOARCH=amd64 GOOS=linux
           +go-build | --> mkdir /run
       +go-build-e2e | --> COPY --dir apis/ internal/ test/ .
           +go-build | CROSSPLANE_VERSION=v0.0.0-e2e GOARCH=amd64 GOOS=linux
           +go-build | --> IF [ "$GOOS" = "windows" ]
              +image | CROSSPLANE_VERSION=v0.0.0-e2e
              +image | --> SAVE IMAGE build-8cc3c3b8/crossplane:v0.0.0-e2e
              +image | CROSSPLANE_VERSION=v0.0.0-e2e
              +image | --> SAVE IMAGE build-8cc3c3b8/crossplane:nokia_main
              +image | CROSSPLANE_VERSION=v0.0.0-e2e
              +image | --> FROM gcr.io/distroless/static@sha256:5c7e2b465ac6a2a4e5f4f7f722ce43b147dabe87cb21ac6c4007ae5178a1fa58
           +go-build | CROSSPLANE_VERSION=v0.0.0-e2e GOARCH=amd64 GOOS=linux
           +go-build | --> COPY --dir apis/ cmd/ internal/ pkg/ .
       +go-build-e2e | --> RUN go test -c -o e2e ./test/e2e
              +image | [----------] 100% FROM gcr.io/distroless/static@sha256:5c7e2b465ac6a2a4e5f4f7f722ce43b147dabe87cb21ac6c4007ae5178a1fa58
           +go-build | CROSSPLANE_VERSION=v0.0.0-e2e GOARCH=amd64 GOOS=linux
           +go-build | --> RUN go build -o crossplane${ext} ./cmd/crossplane
           +go-build | CROSSPLANE_VERSION=v0.0.0-e2e GOARCH=amd64 GOOS=linux
           +go-build | --> RUN sha256sum crossplane${ext} | head -c 64 > crossplane${ext}.sha256
           +go-build | CROSSPLANE_VERSION=v0.0.0-e2e GOARCH=amd64 GOOS=linux
           +go-build | --> RUN go build -o crank${ext} ./cmd/crank
           +go-build | CROSSPLANE_VERSION=v0.0.0-e2e GOARCH=amd64 GOOS=linux
           +go-build | --> RUN sha256sum crank${ext} | head -c 64 > crank${ext}.sha256
           +go-build | CROSSPLANE_VERSION=v0.0.0-e2e GOARCH=amd64 GOOS=linux
           +go-build | --> RUN tar -czvf crank.tar.gz crank${ext} crank${ext}.sha256
           +go-build | crank
           +go-build | crank.sha256
           +go-build | CROSSPLANE_VERSION=v0.0.0-e2e GOARCH=amd64 GOOS=linux
           +go-build | --> RUN sha256sum crank.tar.gz | head -c 64 > crank.tar.gz.sha256
           +go-build | CROSSPLANE_VERSION=v0.0.0-e2e GOARCH=amd64 GOOS=linux
           +go-build | --> SAVE ARTIFACT crossplane.sha256 +go-build/crossplane.sha256
           +go-build | CROSSPLANE_VERSION=v0.0.0-e2e GOARCH=amd64 GOOS=linux
           +go-build | --> SAVE ARTIFACT crank +go-build/crank
           +go-build | CROSSPLANE_VERSION=v0.0.0-e2e GOARCH=amd64 GOOS=linux
           +go-build | --> SAVE ARTIFACT crank.sha256 +go-build/crank.sha256
           +go-build | CROSSPLANE_VERSION=v0.0.0-e2e GOARCH=amd64 GOOS=linux
           +go-build | --> SAVE ARTIFACT crank.tar.gz +go-build/crank.tar.gz
           +go-build | CROSSPLANE_VERSION=v0.0.0-e2e GOARCH=amd64 GOOS=linux
           +go-build | --> SAVE ARTIFACT crank.tar.gz.sha256 +go-build/crank.tar.gz.sha256
           +go-build | [----------] 100% SAVE ARTIFACT crank.tar.gz.sha256 +go-build/crank.tar.gz.sha256
              +image | CROSSPLANE_VERSION=v0.0.0-e2e
              +image | --> COPY (GOOS=linux GOARCH=amd64) +go-build/crossplane /usr/local/bin/
              +image | WARN Earthfile:237:2: The command
              +image |           COPY (GOOS=linux GOARCH=amd64) +go-build/crossplane /usr/local/bin/
              +image | failed: failed to apply diffs: 1 error occurred:
              +image |  * failed to handle changes: context canceled
              +image |
              +image | : context canceled
              +image | CROSSPLANE_VERSION=v0.0.0-e2e
              +image | --> COPY --dir cluster/crds/ /crds
              +image | CROSSPLANE_VERSION=v0.0.0-e2e
              +image | --> COPY --dir cluster/webhookconfigurations/ /webhookconfigurations
              output | --> exporting outputs
              output | [----------] 100% exporting outputs
                +e2e | --> FROM golang:1.23.4-alpine3.20
                +e2e | [----------] 100% FROM golang:1.23.4-alpine3.20
                +e2e | [----------] 100% FROM golang:1.23.4-alpine3.20
                +e2e | --> RUN apk add --no-cache docker jq
                +e2e | fetch https://dl-cdn.alpinelinux.org/alpine/v3.20/main/x86_64/APKINDEX.tar.gz
                +e2e | fetch https://dl-cdn.alpinelinux.org/alpine/v3.20/community/x86_64/APKINDEX.tar.gz
                +e2e | (1/14) Installing libseccomp (2.5.5-r1)
                +e2e | (2/14) Installing runc (1.1.14-r0)
                +e2e | (3/14) Installing containerd (1.7.17-r2)
                +e2e | (4/14) Installing libmnl (1.0.5-r2)
                +e2e | (5/14) Installing libnftnl (1.2.6-r0)
                +e2e | (6/14) Installing libxtables (1.8.10-r3)
                +e2e | (7/14) Installing iptables (1.8.10-r3)
                +e2e | (8/14) Installing tini-static (0.19.0-r3)
                +e2e | (9/14) Installing docker-engine (26.1.5-r0)
                +e2e | Executing docker-engine-26.1.5-r0.pre-install
                +e2e | (10/14) Installing docker-cli (26.1.5-r0)
                +e2e | (11/14) Installing docker-cli-buildx (0.14.0-r3)
                +e2e | (12/14) Installing docker (26.1.5-r0)
                +e2e | (13/14) Installing oniguruma (6.9.9-r0)
                +e2e | (14/14) Installing jq (1.7.1-r0)
                +e2e | Executing busybox-1.36.1-r29.trigger
                +e2e | OK: 282 MiB in 29 packages
                +e2e | --> COPY +helm-setup/helm /usr/local/bin/helm
                +e2e | --> COPY +kind-setup/kind /usr/local/bin/kind
                +e2e | --> COPY +gotestsum-setup/gotestsum /usr/local/bin/gotestsum
                +e2e | --> COPY +go-build-e2e/e2e ./
                +e2e | --> COPY --dir cluster test .
                +e2e | --> WITH DOCKER (install deps)
                +e2e | --> WITH DOCKER RUN --privileged gotestsum --no-color=false --format testname --junitfile e2e-tests.xml --raw-command go tool test2json -t -p E2E ./e2e -test.v ${FLAGS}
                +e2e | Starting dockerd with data root /var/earthly/dind/3982734f86eac4c6a0749806f5b1fd041d9af4a8c4f28ea3b24eae127cf22336/tmp.icmAMD
                +e2e | WARNING: WSL and iptables-nft may not work; attempting to switch to iptables-legacy
                +e2e | ERROR: dockerd crashed on startup
                +e2e | Architecture: x86_64
                +e2e | ==== Begin dockerd logs ====
                +e2e | time="2024-12-19T11:15:25.564567159Z" level=info msg="Starting up"
                +e2e | time="2024-12-19T11:15:25.565163667Z" level=info msg="containerd not running, starting managed containerd"
                +e2e | time="2024-12-19T11:15:25.567796013Z" level=info msg="started new containerd process" address=/var/run/docker/containerd/containerd.sock module=libcontainerd pid=44
                +e2e | time="2024-12-19T11:15:25.585812947Z" level=info msg="starting containerd" revision=3a4de459a68952ffb703bbe7f2290861a75b6b67 version=v1.7.17
                +e2e | time="2024-12-19T11:15:25.598481654Z" level=info msg="loading plugin \"io.containerd.snapshotter.v1.aufs\"..." type=io.containerd.snapshotter.v1
                +e2e | time="2024-12-19T11:15:25.599151696Z" level=info msg="skip loading plugin \"io.containerd.snapshotter.v1.aufs\"..." error="aufs is not supported (modprobe aufs failed: exit status 1 \"modprobe: can't change directory to '/lib/modules': No such file or directory\\n\"): skip plugin" type=io.containerd.snapshotter.v1
                +e2e | time="2024-12-19T11:15:25.599207913Z" level=info msg="loading plugin \"io.containerd.event.v1.exchange\"..." type=io.containerd.event.v1
                +e2e | time="2024-12-19T11:15:25.599228737Z" level=info msg="loading plugin \"io.containerd.internal.v1.opt\"..." type=io.containerd.internal.v1
                +e2e | time="2024-12-19T11:15:25.600061392Z" level=info msg="loading plugin \"io.containerd.warning.v1.deprecations\"..." type=io.containerd.warning.v1
                +e2e | time="2024-12-19T11:15:25.600081098Z" level=info msg="loading plugin \"io.containerd.snapshotter.v1.blockfile\"..." type=io.containerd.snapshotter.v1
                +e2e | time="2024-12-19T11:15:25.600287048Z" level=info msg="skip loading plugin \"io.containerd.snapshotter.v1.blockfile\"..." error="no scratch file generator: skip plugin" type=io.containerd.snapshotter.v1
                +e2e | time="2024-12-19T11:15:25.600301336Z" level=info msg="loading plugin \"io.containerd.snapshotter.v1.btrfs\"..." type=io.containerd.snapshotter.v1
                +e2e | time="2024-12-19T11:15:25.600849147Z" level=info msg="skip loading plugin \"io.containerd.snapshotter.v1.btrfs\"..." error="path /var/earthly/dind/3982734f86eac4c6a0749806f5b1fd041d9af4a8c4f28ea3b24eae127cf22336/tmp.icmAMD/containerd/daemon/io.containerd.snapshotter.v1.btrfs (ext4) must be a btrfs filesystem to be used with the btrfs snapshotter: skip plugin" type=io.containerd.snapshotter.v1
                +e2e | time="2024-12-19T11:15:25.600870319Z" level=info msg="loading plugin \"io.containerd.snapshotter.v1.devmapper\"..." type=io.containerd.snapshotter.v1
                +e2e | time="2024-12-19T11:15:25.600885238Z" level=warning msg="failed to load plugin io.containerd.snapshotter.v1.devmapper" error="devmapper not configured"
                +e2e | time="2024-12-19T11:15:25.600895686Z" level=info msg="loading plugin \"io.containerd.snapshotter.v1.native\"..." type=io.containerd.snapshotter.v1
                +e2e | time="2024-12-19T11:15:25.601251265Z" level=info msg="loading plugin \"io.containerd.snapshotter.v1.overlayfs\"..." type=io.containerd.snapshotter.v1
                +e2e | time="2024-12-19T11:15:25.602028825Z" level=info msg="loading plugin \"io.containerd.snapshotter.v1.zfs\"..." type=io.containerd.snapshotter.v1
                +e2e | time="2024-12-19T11:15:25.602204647Z" level=info msg="skip loading plugin \"io.containerd.snapshotter.v1.zfs\"..." error="path /var/earthly/dind/3982734f86eac4c6a0749806f5b1fd041d9af4a8c4f28ea3b24eae127cf22336/tmp.icmAMD/containerd/daemon/io.containerd.snapshotter.v1.zfs must be a zfs filesystem to be used with the zfs snapshotter: skip plugin" type=io.containerd.snapshotter.v1
                +e2e | time="2024-12-19T11:15:25.602216355Z" level=info msg="loading plugin \"io.containerd.content.v1.content\"..." type=io.containerd.content.v1
                +e2e | time="2024-12-19T11:15:25.602448935Z" level=info msg="loading plugin \"io.containerd.metadata.v1.bolt\"..." type=io.containerd.metadata.v1
                +e2e | time="2024-12-19T11:15:25.602566205Z" level=warning msg="could not use snapshotter devmapper in metadata plugin" error="devmapper not configured"
                +e2e | time="2024-12-19T11:15:25.602575449Z" level=info msg="metadata content store policy set" policy=shared
                +e2e | time="2024-12-19T11:15:25.610457804Z" level=info msg="loading plugin \"io.containerd.gc.v1.scheduler\"..." type=io.containerd.gc.v1
                +e2e | time="2024-12-19T11:15:25.610508699Z" level=info msg="loading plugin \"io.containerd.differ.v1.walking\"..." type=io.containerd.differ.v1
                +e2e | time="2024-12-19T11:15:25.610528477Z" level=info msg="loading plugin \"io.containerd.lease.v1.manager\"..." type=io.containerd.lease.v1
                +e2e | time="2024-12-19T11:15:25.610540456Z" level=info msg="loading plugin \"io.containerd.streaming.v1.manager\"..." type=io.containerd.streaming.v1
                +e2e | time="2024-12-19T11:15:25.610550581Z" level=info msg="loading plugin \"io.containerd.runtime.v1.linux\"..." type=io.containerd.runtime.v1
                +e2e | time="2024-12-19T11:15:25.610836545Z" level=info msg="loading plugin \"io.containerd.monitor.v1.cgroups\"..." type=io.containerd.monitor.v1
                +e2e | time="2024-12-19T11:15:25.611073421Z" level=info msg="loading plugin \"io.containerd.runtime.v2.task\"..." type=io.containerd.runtime.v2
                +e2e | time="2024-12-19T11:15:25.611346118Z" level=info msg="loading plugin \"io.containerd.runtime.v2.shim\"..." type=io.containerd.runtime.v2
                +e2e | time="2024-12-19T11:15:25.611356369Z" level=info msg="loading plugin \"io.containerd.sandbox.store.v1.local\"..." type=io.containerd.sandbox.store.v1
                +e2e | time="2024-12-19T11:15:25.611365964Z" level=info msg="loading plugin \"io.containerd.sandbox.controller.v1.local\"..." type=io.containerd.sandbox.controller.v1
                +e2e | time="2024-12-19T11:15:25.611375943Z" level=info msg="loading plugin \"io.containerd.service.v1.containers-service\"..." type=io.containerd.service.v1
                +e2e | time="2024-12-19T11:15:25.611384077Z" level=info msg="loading plugin \"io.containerd.service.v1.content-service\"..." type=io.containerd.service.v1
                +e2e | time="2024-12-19T11:15:25.611391727Z" level=info msg="loading plugin \"io.containerd.service.v1.diff-service\"..." type=io.containerd.service.v1
                +e2e | time="2024-12-19T11:15:25.611399595Z" level=info msg="loading plugin \"io.containerd.service.v1.images-service\"..." type=io.containerd.service.v1
                +e2e | time="2024-12-19T11:15:25.611408843Z" level=info msg="loading plugin \"io.containerd.service.v1.introspection-service\"..." type=io.containerd.service.v1
                +e2e | time="2024-12-19T11:15:25.611416450Z" level=info msg="loading plugin \"io.containerd.service.v1.namespaces-service\"..." type=io.containerd.service.v1
                +e2e | time="2024-12-19T11:15:25.611423478Z" level=info msg="loading plugin \"io.containerd.service.v1.snapshots-service\"..." type=io.containerd.service.v1
                +e2e | time="2024-12-19T11:15:25.611430435Z" level=info msg="loading plugin \"io.containerd.service.v1.tasks-service\"..." type=io.containerd.service.v1
                +e2e | time="2024-12-19T11:15:25.611442401Z" level=info msg="loading plugin \"io.containerd.grpc.v1.containers\"..." type=io.containerd.grpc.v1
                +e2e | time="2024-12-19T11:15:25.611450481Z" level=info msg="loading plugin \"io.containerd.grpc.v1.content\"..." type=io.containerd.grpc.v1
                +e2e | time="2024-12-19T11:15:25.611461650Z" level=info msg="loading plugin \"io.containerd.grpc.v1.diff\"..." type=io.containerd.grpc.v1
                +e2e | time="2024-12-19T11:15:25.611469821Z" level=info msg="loading plugin \"io.containerd.grpc.v1.events\"..." type=io.containerd.grpc.v1
                +e2e | time="2024-12-19T11:15:25.611477319Z" level=info msg="loading plugin \"io.containerd.grpc.v1.images\"..." type=io.containerd.grpc.v1
                +e2e | time="2024-12-19T11:15:25.611500642Z" level=info msg="loading plugin \"io.containerd.grpc.v1.introspection\"..." type=io.containerd.grpc.v1
                +e2e | time="2024-12-19T11:15:25.611509043Z" level=info msg="loading plugin \"io.containerd.grpc.v1.leases\"..." type=io.containerd.grpc.v1
                +e2e | time="2024-12-19T11:15:25.611517386Z" level=info msg="loading plugin \"io.containerd.grpc.v1.namespaces\"..." type=io.containerd.grpc.v1
                +e2e | time="2024-12-19T11:15:25.611525320Z" level=info msg="loading plugin \"io.containerd.grpc.v1.sandbox-controllers\"..." type=io.containerd.grpc.v1
                +e2e | time="2024-12-19T11:15:25.611533994Z" level=info msg="loading plugin \"io.containerd.grpc.v1.sandboxes\"..." type=io.containerd.grpc.v1
                +e2e | time="2024-12-19T11:15:25.611540869Z" level=info msg="loading plugin \"io.containerd.grpc.v1.snapshots\"..." type=io.containerd.grpc.v1
                +e2e | time="2024-12-19T11:15:25.611547855Z" level=info msg="loading plugin \"io.containerd.grpc.v1.streaming\"..." type=io.containerd.grpc.v1
                +e2e | time="2024-12-19T11:15:25.611555480Z" level=info msg="loading plugin \"io.containerd.grpc.v1.tasks\"..." type=io.containerd.grpc.v1
                +e2e | time="2024-12-19T11:15:25.611577094Z" level=info msg="loading plugin \"io.containerd.transfer.v1.local\"..." type=io.containerd.transfer.v1
                +e2e | time="2024-12-19T11:15:25.611590289Z" level=info msg="loading plugin \"io.containerd.grpc.v1.transfer\"..." type=io.containerd.grpc.v1
                +e2e | time="2024-12-19T11:15:25.611607183Z" level=info msg="loading plugin \"io.containerd.grpc.v1.version\"..." type=io.containerd.grpc.v1
                +e2e | time="2024-12-19T11:15:25.611616482Z" level=info msg="loading plugin \"io.containerd.internal.v1.restart\"..." type=io.containerd.internal.v1
                +e2e | time="2024-12-19T11:15:25.611654332Z" level=info msg="loading plugin \"io.containerd.tracing.processor.v1.otlp\"..." type=io.containerd.tracing.processor.v1
                +e2e | time="2024-12-19T11:15:25.611906810Z" level=info msg="loading plugin \"io.containerd.internal.v1.tracing\"..." type=io.containerd.internal.v1
                +e2e | time="2024-12-19T11:15:25.611973526Z" level=info msg="loading plugin \"io.containerd.grpc.v1.healthcheck\"..." type=io.containerd.grpc.v1
                +e2e | time="2024-12-19T11:15:25.611984309Z" level=info msg="loading plugin \"io.containerd.nri.v1.nri\"..." type=io.containerd.nri.v1
                +e2e | time="2024-12-19T11:15:25.611991138Z" level=info msg="NRI interface is disabled by configuration."
                +e2e | time="2024-12-19T11:15:25.612131831Z" level=info msg=serving... address=/var/run/docker/containerd/containerd-debug.sock
                +e2e | time="2024-12-19T11:15:25.612164603Z" level=info msg=serving... address=/var/run/docker/containerd/containerd.sock.ttrpc
                +e2e | time="2024-12-19T11:15:25.612192803Z" level=info msg=serving... address=/var/run/docker/containerd/containerd.sock
                +e2e | time="2024-12-19T11:15:25.612202937Z" level=info msg="containerd successfully booted in 0.027567s"
                +e2e | time="2024-12-19T11:15:26.630156047Z" level=info msg="Loading containers: start."
                +e2e | time="2024-12-19T11:15:26.636524124Z" level=warning msg="failed to find iptables" error="exec: \"iptables\": executable file not found in $PATH"
                +e2e | time="2024-12-19T11:15:26.637589057Z" level=info msg="stopping event stream following graceful shutdown" error="<nil>" module=libcontainerd namespace=moby
                +e2e | time="2024-12-19T11:15:26.637915893Z" level=info msg="stopping healthcheck following graceful shutdown" module=libcontainerd
                +e2e | time="2024-12-19T11:15:26.637969760Z" level=info msg="stopping event stream following graceful shutdown" error="context canceled" module=libcontainerd namespace=plugins.moby
                +e2e | time="2024-12-19T11:15:26.638235522Z" level=error msg="failed to close plugin" error="context canceled" id=io.containerd.internal.v1.tracing
                +e2e | failed to start daemon: Error initializing network controller: error obtaining controller instance: failed to register "bridge" driver: failed to create NAT chain DOCKER: iptables not found
                +e2e | ==== End dockerd logs ====
                +e2e | If you are having trouble running docker, try using the official earthly/dind image instead
                +e2e | ERROR Earthfile:65:6
                +e2e |       The command
                +e2e |           WITH DOCKER RUN --privileged gotestsum --no-color=false --format testname --junitfile e2e-tests.xml --raw-command go tool test2json -t -p E2E ./e2e -test.v ${FLAGS}
                +e2e |       did not complete successfully. Exit code 1

================================== ❌ FAILURE ===================================

                +e2e *failed* | Repeating the failure error...
                +e2e *failed* | --> WITH DOCKER RUN --privileged gotestsum --no-color=false --format testname --junitfile e2e-tests.xml --raw-command go tool test2json -t -p E2E ./e2e -test.v ${FLAGS}
                +e2e *failed* | Starting dockerd with data root /var/earthly/dind/3982734f86eac4c6a0749806f5b1fd041d9af4a8c4f28ea3b24eae127cf22336/tmp.icmAMD
                +e2e *failed* | WARNING: WSL and iptables-nft may not work; attempting to switch to iptables-legacy
                +e2e *failed* | ERROR: dockerd crashed on startup
                +e2e *failed* | Architecture: x86_64
                +e2e *failed* | ==== Begin dockerd logs ====
                +e2e *failed* | time="2024-12-19T11:15:25.564567159Z" level=info msg="Starting up"
                +e2e *failed* | time="2024-12-19T11:15:25.565163667Z" level=info msg="containerd not running, starting managed containerd"
                +e2e *failed* | time="2024-12-19T11:15:25.567796013Z" level=info msg="started new containerd process" address=/var/run/docker/containerd/containerd.sock module=libcontainerd pid=44
                +e2e *failed* | time="2024-12-19T11:15:25.585812947Z" level=info msg="starting containerd" revision=3a4de459a68952ffb703bbe7f2290861a75b6b67 version=v1.7.17
                +e2e *failed* | time="2024-12-19T11:15:25.598481654Z" level=info msg="loading plugin \"io.containerd.snapshotter.v1.aufs\"..." type=io.containerd.snapshotter.v1
                +e2e *failed* | time="2024-12-19T11:15:25.599151696Z" level=info msg="skip loading plugin \"io.containerd.snapshotter.v1.aufs\"..." error="aufs is not supported (modprobe aufs failed: exit status 1 \"modprobe: can't change directory to '/lib/modules': No such file or directory\\n\"): skip plugin" type=io.containerd.snapshotter.v1
                +e2e *failed* | time="2024-12-19T11:15:25.599207913Z" level=info msg="loading plugin \"io.containerd.event.v1.exchange\"..." type=io.containerd.event.v1
                +e2e *failed* | time="2024-12-19T11:15:25.599228737Z" level=info msg="loading plugin \"io.containerd.internal.v1.opt\"..." type=io.containerd.internal.v1
                +e2e *failed* | time="2024-12-19T11:15:25.600061392Z" level=info msg="loading plugin \"io.containerd.warning.v1.deprecations\"..." type=io.containerd.warning.v1
                +e2e *failed* | time="2024-12-19T11:15:25.600081098Z" level=info msg="loading plugin \"io.containerd.snapshotter.v1.blockfile\"..." type=io.containerd.snapshotter.v1
                +e2e *failed* | time="2024-12-19T11:15:25.600287048Z" level=info msg="skip loading plugin \"io.containerd.snapshotter.v1.blockfile\"..." error="no scratch file generator: skip plugin" type=io.containerd.snapshotter.v1
                +e2e *failed* | time="2024-12-19T11:15:25.600301336Z" level=info msg="loading plugin \"io.containerd.snapshotter.v1.btrfs\"..." type=io.containerd.snapshotter.v1
                +e2e *failed* | time="2024-12-19T11:15:25.600849147Z" level=info msg="skip loading plugin \"io.containerd.snapshotter.v1.btrfs\"..." error="path /var/earthly/dind/3982734f86eac4c6a0749806f5b1fd041d9af4a8c4f28ea3b24eae127cf22336/tmp.icmAMD/containerd/daemon/io.containerd.snapshotter.v1.btrfs (ext4) must be a btrfs filesystem to be used with the btrfs snapshotter: skip plugin" type=io.containerd.snapshotter.v1
                +e2e *failed* | time="2024-12-19T11:15:25.600870319Z" level=info msg="loading plugin \"io.containerd.snapshotter.v1.devmapper\"..." type=io.containerd.snapshotter.v1
                +e2e *failed* | time="2024-12-19T11:15:25.600885238Z" level=warning msg="failed to load plugin io.containerd.snapshotter.v1.devmapper" error="devmapper not configured"
                +e2e *failed* | time="2024-12-19T11:15:25.600895686Z" level=info msg="loading plugin \"io.containerd.snapshotter.v1.native\"..." type=io.containerd.snapshotter.v1
                +e2e *failed* | time="2024-12-19T11:15:25.601251265Z" level=info msg="loading plugin \"io.containerd.snapshotter.v1.overlayfs\"..." type=io.containerd.snapshotter.v1
                +e2e *failed* | time="2024-12-19T11:15:25.602028825Z" level=info msg="loading plugin \"io.containerd.snapshotter.v1.zfs\"..." type=io.containerd.snapshotter.v1
                +e2e *failed* | time="2024-12-19T11:15:25.602204647Z" level=info msg="skip loading plugin \"io.containerd.snapshotter.v1.zfs\"..." error="path /var/earthly/dind/3982734f86eac4c6a0749806f5b1fd041d9af4a8c4f28ea3b24eae127cf22336/tmp.icmAMD/containerd/daemon/io.containerd.snapshotter.v1.zfs must be a zfs filesystem to be used with the zfs snapshotter: skip plugin" type=io.containerd.snapshotter.v1
                +e2e *failed* | time="2024-12-19T11:15:25.602216355Z" level=info msg="loading plugin \"io.containerd.content.v1.content\"..." type=io.containerd.content.v1
                +e2e *failed* | time="2024-12-19T11:15:25.602448935Z" level=info msg="loading plugin \"io.containerd.metadata.v1.bolt\"..." type=io.containerd.metadata.v1
                +e2e *failed* | time="2024-12-19T11:15:25.602566205Z" level=warning msg="could not use snapshotter devmapper in metadata plugin" error="devmapper not configured"
                +e2e *failed* | time="2024-12-19T11:15:25.602575449Z" level=info msg="metadata content store policy set" policy=shared
                +e2e *failed* | time="2024-12-19T11:15:25.610457804Z" level=info msg="loading plugin \"io.containerd.gc.v1.scheduler\"..." type=io.containerd.gc.v1
                +e2e *failed* | time="2024-12-19T11:15:25.610508699Z" level=info msg="loading plugin \"io.containerd.differ.v1.walking\"..." type=io.containerd.differ.v1
                +e2e *failed* | time="2024-12-19T11:15:25.610528477Z" level=info msg="loading plugin \"io.containerd.lease.v1.manager\"..." type=io.containerd.lease.v1
                +e2e *failed* | time="2024-12-19T11:15:25.610540456Z" level=info msg="loading plugin \"io.containerd.streaming.v1.manager\"..." type=io.containerd.streaming.v1
                +e2e *failed* | time="2024-12-19T11:15:25.610550581Z" level=info msg="loading plugin \"io.containerd.runtime.v1.linux\"..." type=io.containerd.runtime.v1
                +e2e *failed* | time="2024-12-19T11:15:25.610836545Z" level=info msg="loading plugin \"io.containerd.monitor.v1.cgroups\"..." type=io.containerd.monitor.v1
                +e2e *failed* | time="2024-12-19T11:15:25.611073421Z" level=info msg="loading plugin \"io.containerd.runtime.v2.task\"..." type=io.containerd.runtime.v2
                +e2e *failed* | time="2024-12-19T11:15:25.611346118Z" level=info msg="loading plugin \"io.containerd.runtime.v2.shim\"..." type=io.containerd.runtime.v2
                +e2e *failed* | time="2024-12-19T11:15:25.611356369Z" level=info msg="loading plugin \"io.containerd.sandbox.store.v1.local\"..." type=io.containerd.sandbox.store.v1
                +e2e *failed* | time="2024-12-19T11:15:25.611365964Z" level=info msg="loading plugin \"io.containerd.sandbox.controller.v1.local\"..." type=io.containerd.sandbox.controller.v1
                +e2e *failed* | time="2024-12-19T11:15:25.611375943Z" level=info msg="loading plugin \"io.containerd.service.v1.containers-service\"..." type=io.containerd.service.v1
                +e2e *failed* | time="2024-12-19T11:15:25.611384077Z" level=info msg="loading plugin \"io.containerd.service.v1.content-service\"..." type=io.containerd.service.v1
                +e2e *failed* | time="2024-12-19T11:15:25.611391727Z" level=info msg="loading plugin \"io.containerd.service.v1.diff-service\"..." type=io.containerd.service.v1
                +e2e *failed* | time="2024-12-19T11:15:25.611399595Z" level=info msg="loading plugin \"io.containerd.service.v1.images-service\"..." type=io.containerd.service.v1
                +e2e *failed* | time="2024-12-19T11:15:25.611408843Z" level=info msg="loading plugin \"io.containerd.service.v1.introspection-service\"..." type=io.containerd.service.v1
                +e2e *failed* | time="2024-12-19T11:15:25.611416450Z" level=info msg="loading plugin \"io.containerd.service.v1.namespaces-service\"..." type=io.containerd.service.v1
                +e2e *failed* | time="2024-12-19T11:15:25.611423478Z" level=info msg="loading plugin \"io.containerd.service.v1.snapshots-service\"..." type=io.containerd.service.v1
                +e2e *failed* | time="2024-12-19T11:15:25.611430435Z" level=info msg="loading plugin \"io.containerd.service.v1.tasks-service\"..." type=io.containerd.service.v1
                +e2e *failed* | time="2024-12-19T11:15:25.611442401Z" level=info msg="loading plugin \"io.containerd.grpc.v1.containers\"..." type=io.containerd.grpc.v1
                +e2e *failed* | time="2024-12-19T11:15:25.611450481Z" level=info msg="loading plugin \"io.containerd.grpc.v1.content\"..." type=io.containerd.grpc.v1
                +e2e *failed* | time="2024-12-19T11:15:25.611461650Z" level=info msg="loading plugin \"io.containerd.grpc.v1.diff\"..." type=io.containerd.grpc.v1
                +e2e *failed* | time="2024-12-19T11:15:25.611469821Z" level=info msg="loading plugin \"io.containerd.grpc.v1.events\"..." type=io.containerd.grpc.v1
                +e2e *failed* | time="2024-12-19T11:15:25.611477319Z" level=info msg="loading plugin \"io.containerd.grpc.v1.images\"..." type=io.containerd.grpc.v1
                +e2e *failed* | time="2024-12-19T11:15:25.611500642Z" level=info msg="loading plugin \"io.containerd.grpc.v1.introspection\"..." type=io.containerd.grpc.v1
                +e2e *failed* | time="2024-12-19T11:15:25.611509043Z" level=info msg="loading plugin \"io.containerd.grpc.v1.leases\"..." type=io.containerd.grpc.v1
                +e2e *failed* | time="2024-12-19T11:15:25.611517386Z" level=info msg="loading plugin \"io.containerd.grpc.v1.namespaces\"..." type=io.containerd.grpc.v1
                +e2e *failed* | time="2024-12-19T11:15:25.611525320Z" level=info msg="loading plugin \"io.containerd.grpc.v1.sandbox-controllers\"..." type=io.containerd.grpc.v1
                +e2e *failed* | time="2024-12-19T11:15:25.611533994Z" level=info msg="loading plugin \"io.containerd.grpc.v1.sandboxes\"..." type=io.containerd.grpc.v1
                +e2e *failed* | time="2024-12-19T11:15:25.611540869Z" level=info msg="loading plugin \"io.containerd.grpc.v1.snapshots\"..." type=io.containerd.grpc.v1
                +e2e *failed* | time="2024-12-19T11:15:25.611547855Z" level=info msg="loading plugin \"io.containerd.grpc.v1.streaming\"..." type=io.containerd.grpc.v1
                +e2e *failed* | time="2024-12-19T11:15:25.611555480Z" level=info msg="loading plugin \"io.containerd.grpc.v1.tasks\"..." type=io.containerd.grpc.v1
                +e2e *failed* | time="2024-12-19T11:15:25.611577094Z" level=info msg="loading plugin \"io.containerd.transfer.v1.local\"..." type=io.containerd.transfer.v1
                +e2e *failed* | time="2024-12-19T11:15:25.611590289Z" level=info msg="loading plugin \"io.containerd.grpc.v1.transfer\"..." type=io.containerd.grpc.v1
                +e2e *failed* | time="2024-12-19T11:15:25.611607183Z" level=info msg="loading plugin \"io.containerd.grpc.v1.version\"..." type=io.containerd.grpc.v1
                +e2e *failed* | time="2024-12-19T11:15:25.611616482Z" level=info msg="loading plugin \"io.containerd.internal.v1.restart\"..." type=io.containerd.internal.v1
                +e2e *failed* | time="2024-12-19T11:15:25.611654332Z" level=info msg="loading plugin \"io.containerd.tracing.processor.v1.otlp\"..." type=io.containerd.tracing.processor.v1
                +e2e *failed* | time="2024-12-19T11:15:25.611906810Z" level=info msg="loading plugin \"io.containerd.internal.v1.tracing\"..." type=io.containerd.internal.v1
                +e2e *failed* | time="2024-12-19T11:15:25.611973526Z" level=info msg="loading plugin \"io.containerd.grpc.v1.healthcheck\"..." type=io.containerd.grpc.v1
                +e2e *failed* | time="2024-12-19T11:15:25.611984309Z" level=info msg="loading plugin \"io.containerd.nri.v1.nri\"..." type=io.containerd.nri.v1
                +e2e *failed* | time="2024-12-19T11:15:25.611991138Z" level=info msg="NRI interface is disabled by configuration."
                +e2e *failed* | time="2024-12-19T11:15:25.612131831Z" level=info msg=serving... address=/var/run/docker/containerd/containerd-debug.sock
                +e2e *failed* | time="2024-12-19T11:15:25.612164603Z" level=info msg=serving... address=/var/run/docker/containerd/containerd.sock.ttrpc
                +e2e *failed* | time="2024-12-19T11:15:25.612192803Z" level=info msg=serving... address=/var/run/docker/containerd/containerd.sock
                +e2e *failed* | time="2024-12-19T11:15:25.612202937Z" level=info msg="containerd successfully booted in 0.027567s"
                +e2e *failed* | time="2024-12-19T11:15:26.630156047Z" level=info msg="Loading containers: start."
                +e2e *failed* | time="2024-12-19T11:15:26.636524124Z" level=warning msg="failed to find iptables" error="exec: \"iptables\": executable file not found in $PATH"
                +e2e *failed* | time="2024-12-19T11:15:26.637589057Z" level=info msg="stopping event stream following graceful shutdown" error="<nil>" module=libcontainerd namespace=moby
                +e2e *failed* | time="2024-12-19T11:15:26.637915893Z" level=info msg="stopping healthcheck following graceful shutdown" module=libcontainerd
                +e2e *failed* | time="2024-12-19T11:15:26.637969760Z" level=info msg="stopping event stream following graceful shutdown" error="context canceled" module=libcontainerd namespace=plugins.moby
                +e2e *failed* | time="2024-12-19T11:15:26.638235522Z" level=error msg="failed to close plugin" error="context canceled" id=io.containerd.internal.v1.tracing
                +e2e *failed* | failed to start daemon: Error initializing network controller: error obtaining controller instance: failed to register "bridge" driver: failed to create NAT chain DOCKER: iptables not found
                +e2e *failed* | ==== End dockerd logs ====
                +e2e *failed* | If you are having trouble running docker, try using the official earthly/dind image instead
                +e2e *failed* | ERROR Earthfile:65:6
                +e2e *failed* |       The command
                +e2e *failed* |           WITH DOCKER RUN --privileged gotestsum --no-color=false --format testname --junitfile e2e-tests.xml --raw-command go tool test2json -t -p E2E ./e2e -test.v ${FLAGS}
                +e2e *failed* |       did not complete successfully. Exit code 1
                +e2e |       The command
                +e2e |           WITH DOCKER RUN
                +e2e |       did not complete successfully. Exit code 1

Help: To debug your build, you can use the --interactive (-i) flag to drop into a shell of the failing RUN step: "earthly -i -P +e2e"

🛰️ Reuse cache between CI runs with Earthly Satellites! 2-20X faster than without cache. Generous free tier https://cloud.earthly.dev/
```

After reverting to the official `earthly/dind` image and installing golang manually, as suggested in the above error message, I am able to go through E2E tests:

```
$ earthly -P +e2e
 Init 🚀
————————————————————————————————————————————————————————————————————————————————

           buildkitd | Found buildkit daemon as docker container (earthly-buildkitd)

 Build 🔧
————————————————————————————————————————————————————————————————————————————————

      registry-proxy | Failed to start registry proxy: failed to start Darwin support container: context deadline exceeded
              logbus | Setting organization "crossplane" and project "crossplane"
                +e2e | --> FROM +base
        earthly/dind | --> Load metadata earthly/dind linux/amd64
         +helm-setup | --> FROM +base
        c/curl:8.8.0 | --> Load metadata curlimages/curl:8.8.0 linux/amd64
Warning: you are not logged into registry-1.docker.io, you may experience rate-limitting when pulling images
         +kind-setup | --> FROM +base
    +gotestsum-setup | --> FROM +base
       +go-build-e2e | --> FROM +base
       +go-build-e2e | --> FROM +go-modules
         +go-modules | --> FROM +base
         +helm-setup | --> FROM curlimages/curl:8.8.0
       golang:1.23.3 | --> Load metadata golang:1.23.3 linux/amd64
         +helm-setup | [----------] 100% FROM curlimages/curl:8.8.0
    +gotestsum-setup | *cached* --> RUN curl -fsSL [https://github.com/gotestyourself/gotestsum/releases/download/v${GOTESTSUM_VERSION}/gotestsum_${GOTESTSUM_VERSION}_${TARGETOS}_${TARGETARCH}.tar.gz|tar](https://github.com/gotestyourself/gotestsum/releases/download/v$%7bGOTESTSUM_VERSION%7d/gotestsum_$%7bGOTESTSUM_VERSION%7d_$%7bTARGETOS%7d_$%7bTARGETARCH%7d.tar.gz%7Ctar) zx>gotestsum
         +kind-setup | *cached* --> RUN curl -fsSLo kind [https://github.com/kubernetes-sigs/kind/releases/download/${KIND_VERSION}/kind-${TARGETOS}-${TARGETARCH}&&chmod](https://github.com/kubernetes-sigs/kind/releases/download/$%7bKIND_VERSION%7d/kind-$%7bTARGETOS%7d-$%7bTARGETARCH%7d&&chmod) +x kind
         +helm-setup | *cached* --> RUN curl -fsSL [https://get.helm.sh/helm-${HELM_VERSION}-${TARGETOS}-${TARGETARCH}.tar.gz|tar](https://get.helm.sh/helm-$%7bHELM_VERSION%7d-$%7bTARGETOS%7d-$%7bTARGETARCH%7d.tar.gz%7Ctar) zx --strip-components=1
Warning: you are not logged into registry-1.docker.io, you may experience rate-limitting when pulling images
                +e2e | --> WITH DOCKER RUN
              +image | CROSSPLANE_VERSION=v0.0.0-e2e
              +image | --> FROM +base
         +go-modules | --> FROM golang:1.23.3
g/d/static@sha256:5c7e2b465ac6a2a4e5f4f7f722ce43b147dabe87cb21ac6c4007ae5178a1fa58 | --> Load metadata gcr.io/distroless/static@sha256:5c7e2b465ac6a2a4e5f4f7f722ce43b147dabe87cb21ac6c4007ae5178a1fa58 linux/amd64
           +go-build | CROSSPLANE_VERSION=v0.0.0-e2e GOARCH=amd64 GOOS=linux
           +go-build | --> FROM +base
           +go-build | CROSSPLANE_VERSION=v0.0.0-e2e GOARCH=amd64 GOOS=linux
           +go-build | --> FROM +go-modules
         +go-modules | CROSSPLANE_VERSION=v0.0.0-e2e GOARCH=amd64 GOOS=linux
         +go-modules | --> FROM +base
         +go-modules | [----------] 100% FROM golang:1.23.3
         +go-modules | CROSSPLANE_VERSION=v0.0.0-e2e GOARCH=amd64 GOOS=linux
         +go-modules | *cached* --> COPY go.mod go.sum ./
         +go-modules | CROSSPLANE_VERSION=v0.0.0-e2e GOARCH=amd64 GOOS=linux
         +go-modules | *cached* --> RUN go mod download
         +go-modules | *cached* --> WORKDIR /crossplane
           +go-build | CROSSPLANE_VERSION=v0.0.0-e2e GOARCH=amd64 GOOS=linux
           +go-build | *cached* --> mkdir /run
           +go-build | CROSSPLANE_VERSION=v0.0.0-e2e GOARCH=amd64 GOOS=linux
           +go-build | *cached* --> IF [ "$GOOS" = "windows" ]
              +image | CROSSPLANE_VERSION=v0.0.0-e2e
              +image | --> SAVE IMAGE build-2c5fec81/crossplane:v0.0.0-e2e
              +image | CROSSPLANE_VERSION=v0.0.0-e2e
              +image | --> SAVE IMAGE build-2c5fec81/crossplane:clearing-composition-revisions
              +image | CROSSPLANE_VERSION=v0.0.0-e2e
              +image | --> FROM gcr.io/distroless/static@sha256:5c7e2b465ac6a2a4e5f4f7f722ce43b147dabe87cb21ac6c4007ae5178a1fa58
              +image | [----------] 100% FROM gcr.io/distroless/static@sha256:5c7e2b465ac6a2a4e5f4f7f722ce43b147dabe87cb21ac6c4007ae5178a1fa58
           +go-build | CROSSPLANE_VERSION=v0.0.0-e2e GOARCH=amd64 GOOS=linux
           +go-build | *cached* --> COPY --dir apis/ cmd/ internal/ pkg/ .
           +go-build | CROSSPLANE_VERSION=v0.0.0-e2e GOARCH=amd64 GOOS=linux
           +go-build | *cached* --> RUN go build -o crossplane${ext} ./cmd/crossplane
           +go-build | CROSSPLANE_VERSION=v0.0.0-e2e GOARCH=amd64 GOOS=linux
           +go-build | *cached* --> RUN sha256sum crossplane${ext} | head -c 64 > crossplane${ext}.sha256
           +go-build | CROSSPLANE_VERSION=v0.0.0-e2e GOARCH=amd64 GOOS=linux
           +go-build | *cached* --> RUN go build -o crank${ext} ./cmd/crank
           +go-build | CROSSPLANE_VERSION=v0.0.0-e2e GOARCH=amd64 GOOS=linux
           +go-build | *cached* --> RUN sha256sum crank${ext} | head -c 64 > crank${ext}.sha256
           +go-build | CROSSPLANE_VERSION=v0.0.0-e2e GOARCH=amd64 GOOS=linux
           +go-build | *cached* --> RUN tar -czvf crank.tar.gz crank${ext} crank${ext}.sha256
           +go-build | CROSSPLANE_VERSION=v0.0.0-e2e GOARCH=amd64 GOOS=linux
           +go-build | *cached* --> RUN sha256sum crank.tar.gz | head -c 64 > crank.tar.gz.sha256
         +go-modules | *cached* --> COPY go.mod go.sum ./
         +go-modules | *cached* --> RUN go mod download
       +go-build-e2e | *cached* --> COPY --dir apis/ internal/ test/ .
       +go-build-e2e | *cached* --> RUN go test -c -o e2e ./test/e2e
           +go-build | CROSSPLANE_VERSION=v0.0.0-e2e GOARCH=amd64 GOOS=linux
           +go-build | *cached* --> SAVE ARTIFACT crossplane.sha256 +go-build/crossplane.sha256
           +go-build | CROSSPLANE_VERSION=v0.0.0-e2e GOARCH=amd64 GOOS=linux
           +go-build | *cached* --> SAVE ARTIFACT crank +go-build/crank
           +go-build | CROSSPLANE_VERSION=v0.0.0-e2e GOARCH=amd64 GOOS=linux
           +go-build | *cached* --> SAVE ARTIFACT crank.sha256 +go-build/crank.sha256
           +go-build | CROSSPLANE_VERSION=v0.0.0-e2e GOARCH=amd64 GOOS=linux
           +go-build | *cached* --> SAVE ARTIFACT crank.tar.gz +go-build/crank.tar.gz
           +go-build | CROSSPLANE_VERSION=v0.0.0-e2e GOARCH=amd64 GOOS=linux
           +go-build | *cached* --> SAVE ARTIFACT crank.tar.gz.sha256 +go-build/crank.tar.gz.sha256
              +image | CROSSPLANE_VERSION=v0.0.0-e2e
              +image | *cached* --> COPY (GOOS=linux GOARCH=amd64) +go-build/crossplane /usr/local/bin/
              +image | CROSSPLANE_VERSION=v0.0.0-e2e
              +image | *cached* --> COPY --dir cluster/crds/ /crds
              +image | CROSSPLANE_VERSION=v0.0.0-e2e
              +image | *cached* --> COPY --dir cluster/webhookconfigurations/ /webhookconfigurations
              output | --> exporting outputs
              output | [----------] 100% exporting outputs
                +e2e | --> FROM earthly/dind
                +e2e | [----------] 100% FROM earthly/dind
                +e2e | *cached* --> RUN wget [https://dl.google.com/go/go${GO_VERSION}.linux-amd64.tar.gz](https://dl.google.com/go/go$%7bGO_VERSION%7d.linux-amd64.tar.gz)
                +e2e | *cached* --> RUN tar -C /usr/local -xzf go${GO_VERSION}.linux-amd64.tar.gz
                +e2e | --> RUN apk add --no-cache docker jq
                +e2e | fetch https://dl-cdn.alpinelinux.org/alpine/v3.15/main/x86_64/APKINDEX.tar.gz
                +e2e | fetch https://dl-cdn.alpinelinux.org/alpine/v3.15/community/x86_64/APKINDEX.tar.gz
                +e2e | (1/8) Installing libseccomp (2.5.2-r0)
                +e2e | (2/8) Installing runc (1.1.2-r1)
                +e2e | (3/8) Installing containerd (1.5.11-r2)
                +e2e | (4/8) Installing tini-static (0.19.0-r0)
                +e2e | (5/8) Installing device-mapper-libs (2.02.187-r2)
                +e2e | (6/8) Installing docker-engine (20.10.16-r0)
                +e2e | (7/8) Installing docker-cli (20.10.16-r0)
                +e2e | (8/8) Installing docker (20.10.16-r0)
                +e2e | Executing docker-20.10.16-r0.pre-install
                +e2e | Executing busybox-1.34.1-r4.trigger
                +e2e | OK: 337 MiB in 109 packages
                +e2e | --> COPY +helm-setup/helm /usr/local/bin/helm
                +e2e | --> COPY +kind-setup/kind /usr/local/bin/kind
                +e2e | --> COPY +gotestsum-setup/gotestsum /usr/local/bin/gotestsum
                +e2e | --> COPY +go-build-e2e/e2e ./
                +e2e | --> COPY --dir cluster test .
                +e2e | --> WITH DOCKER (install deps)
                +e2e | --> WITH DOCKER RUN --privileged gotestsum --no-color=false --format testname --junitfile e2e-tests.xml --raw-command go tool test2json -t -p E2E ./e2e -test.v ${FLAGS}
                +e2e | Starting dockerd with data root /var/earthly/dind/678fdda5d60da04ad27a8b69d245619dfdc072fb556ff9b2cc0cb197f513a00d/tmp.bhnPGE
                +e2e | Loading images from BuildKit via embedded registry...
                +e2e | Pulling 172.30.0.1:8371/sess-p8h57j61e1vyntx1v4g52feni:img-0 and retagging as crossplane-e2e/crossplane:latest
                +e2e | 172.30.0.1:8371/sess-p8h57j61e1vyntx1v4g52feni:img-0
                +e2e | Untagged: 172.30.0.1:8371/sess-p8h57j61e1vyntx1v4g52feni:img-0
                +e2e | Untagged: 172.30.0.1:xxxxx@sha256:3dae8a7584c6959875143e750320483ba2ca61ec3c9656cbe6b157abb8261804
                +e2e | Loading images done in 1259 ms
                +e2e | I1219 10:54:56.927389     517 environment.go:77] "Setting test suite" value="base"
                +e2e | PASS E2E.TestCompositionMinimal/TestCompositionMinimal/CreateClaim (9.53s)
                +e2e | PASS E2E.TestCompositionMinimal/TestCompositionMinimal (20.13s)
...
                +e2e | PASS E2E.TestXRDValidation/TestXRDValidation (2.61s)
                +e2e | PASS E2E.TestXRDValidation (2.61s)
                +e2e | PASS E2E

                +e2e | === Skipped
                +e2e | === SKIP: E2E TestPropagateFieldsRemovalToXR (0.00s)
                +e2e |     env.go:211: Skipping feature "TestPropagateFieldsRemovalToXR": unmatched labels "[area=[apiextensions] size=[small] modify-crossplane-installation=[true] test-suite=[ssa-claims]]"

                +e2e | === SKIP: E2E TestPropagateFieldsRemovalToXRAfterUpgrade (0.00s)
                +e2e |     env.go:211: Skipping feature "TestPropagateFieldsRemovalToXRAfterUpgrade": unmatched labels "[area=[apiextensions] size=[small] modify-crossplane-installation=[true] test-suite=[ssa-claims]]"

...

                +e2e | === SKIP: E2E TestUsageComposition (0.00s)
                +e2e |     env.go:211: Skipping feature "TestUsageComposition": unmatched labels "[stage=[alpha] area=[apiextensions] size=[small] modify-crossplane-installation=[true] test-suite=[usage]]"

                +e2e | DONE 129 tests, 15 skipped in 647.593s
                +e2e | --> SAVE ARTIFACT --if-exists e2e-tests.xml +e2e/e2e-tests.xml AS LOCAL _output/tests/e2e-tests.xml
              output | --> exporting outputs
              output | sent 1 file stat
              output | [----------] 100% exporting outputs
              output | --> exporting outputs

 Push Summary ⏫ (disabled)
————————————————————————————————————————————————————————————————————————————————

To enable pushing use earthly --push
Did not push image build-2c5fec81/crossplane:v0.0.0-e2e
Did not push image build-2c5fec81/crossplane:clearing-composition-revisions

 Local Output Summary 🎁
————————————————————————————————————————————————————————————————————————————————

Artifact github.com/crossplane/crossplane:clearing-composition-revisions+e2e/e2e-tests.xml output as _output/tests/e2e-tests.xml


========================== 🌍 Earthly Build  ✅ SUCCESS ==========================

🛰️ Reuse cache between CI runs with Earthly Satellites! 2-20X faster than without cache. Generous free tier https://cloud.earthly.dev/
```

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `earthly +reviewable` to ensure this PR is ready for review.
- ~[ ] Added or updated unit tests.~
- [x] Added or updated e2e tests.
- ~[ ] Linked a PR or a [docs tracking issue] to [document this change].~
- ~[ ] Added `backport release-x.y` labels to auto-backport this PR.~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
