### PR TITLE
chore: renovate should do earthly postUpgradeTasks on release-1.17

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -177,7 +177,6 @@
       // Currently we only have an Earthfile on main and some release branches, so we ignore the ones we know don't have it.
       matchBaseBranches: [
         '!/release-1\.16/',
-        '!/release-1\.17/',
       ],
       postUpgradeTasks: {
         commands: [
@@ -197,7 +196,6 @@
       // Currently we only have an Earthfile on main and some release branches, so we only run this on older release branches.
       matchBaseBranches: [
         'release-1.16',
-        'release-1.17'
       ],
       postUpgradeTasks: {
         // Post-upgrade tasks that are executed before a commit is made by Renovate.
@@ -218,7 +216,6 @@
       // Currently we only have an Earthfile on main and some release branches, so we ignore the ones we know don't have it.
       matchBaseBranches: [
         '!/release-1\.16/',
-        '!/release-1\.17/',
       ],
       postUpgradeTasks: {
         // Post-upgrade tasks that are executed before a commit is made by Renovate.
@@ -239,7 +236,6 @@
       // Currently we only have an Earthfile on main and some release branches, so we only run this on older release branches.
       matchBaseBranches: [
         'release-1.16',
-        'release-1.17',
       ],
       postUpgradeTasks: {
         // Post-upgrade tasks that are executed before a commit is made by Renovate.


### PR DESCRIPTION
### Description of your changes

This PR updates the `matchBaseBranches` for `postUpgradeTasks` that renovate runs after updating dependencies. Earthly exists in every recent/supported branch except for `release-1.16`, so that is the only branch where `make` based commands should still be running.

Partially addresses https://github.com/crossplane/crossplane/issues/6186, this does not address the fact that Renovate isn't allowed to run `make` based commands in [renovate.yaml](https://github.com/crossplane/crossplane/blob/main/.github/workflows/renovate.yml#L48) still - so Renovate PRs would still run into an issue for `release-1.16`.

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `earthly +reviewable` to ensure this PR is ready for review.
- [ ] ~Added or updated unit tests.~
- [ ] ~Added or updated e2e tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
