### PR TITLE
docs: add Bluesky social info

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ delivery timeline.
 
 ## Get Involved
 
-[![Slack](https://img.shields.io/badge/slack-crossplane-red?logo=slack)](https://slack.crossplane.io) [![Twitter Follow](https://img.shields.io/twitter/follow/crossplane_io?logo=X&label=Follow&style=flat)](https://twitter.com/intent/follow?screen_name=crossplane_io&user_id=788180534543339520) [![YouTube Channel Subscribers](https://img.shields.io/youtube/channel/subscribers/UC19FgzMBMqBro361HbE46Fw)](https://www.youtube.com/@Crossplane)
+[![Slack](https://img.shields.io/badge/slack-crossplane-red?logo=slack)](https://slack.crossplane.io) [![Bluesky Follow](https://img.shields.io/badge/bluesky-Follow-blue?logo=bluesky)](https://bsky.app/profile/crossplane.io) [![Twitter Follow](https://img.shields.io/twitter/follow/crossplane_io?logo=X&label=Follow&style=flat)](https://twitter.com/intent/follow?screen_name=crossplane_io&user_id=788180534543339520) [![YouTube Channel Subscribers](https://img.shields.io/youtube/channel/subscribers/UC19FgzMBMqBro361HbE46Fw)](https://www.youtube.com/@Crossplane)
 
 Crossplane is a community driven project; we welcome your contribution. To file
 a bug, suggest an improvement, or request a new feature please open an [issue
@@ -67,7 +67,7 @@ against Crossplane] or the relevant provider. Refer to our [contributing guide]
 for more information on how you can help.
 
 * Discuss Crossplane on [Slack] or our [developer mailing list].
-* Follow us on [Twitter] or [LinkedIn], or subscribe to our [newsletter].
+* Follow us on [Bluesky], [Twitter], or [LinkedIn], or subscribe to our [newsletter].
 * Contact us via [Email].
 * Join our regular community meetings.
 * Provide feedback on our [roadmap and releases board].
@@ -120,6 +120,7 @@ Crossplane is under the Apache 2.0 license.
 [install]: https://crossplane.io/docs/latest
 [Slack]: https://slack.crossplane.io
 [developer mailing list]: https://groups.google.com/forum/#!forum/crossplane-dev
+[Bluesky]: https://bsky.app/profile/crossplane.io
 [Twitter]: https://twitter.com/crossplane_io
 [LinkedIn]: https://www.linkedin.com/company/crossplane/
 [newsletter]: https://eepurl.com/ivy4v-/

--- a/security/self-assessment.md
+++ b/security/self-assessment.md
@@ -87,8 +87,8 @@ considered out of scope.
           <li><code>XRD</code>: When a new <code>XRD</code> is created by a platform engineer, this controller reconciles this desired state of this definition to dynamically create a new platform API in the form of a CRD that extends the Kubernetes API.</li>
           <li><code>XR</code>: This controller reconciles instances of cluster scoped composite resources, executing the composition logic authored by the platform team to dynamically compose and configure a set of granular resources.</li>
           <li><code>Claim</code>: This controller reconciles the namespaced abstractions that application developers use to request infrastructure resources.</li>
-          <li><code>Composition</code>: Contains the "blueprint" logic for how to compose resources together. The platform engineer defines a simple pipeline of functions to execute, with the end goal being to defined and customized the composed resources. 
-         </ul> 
+          <li><code>Composition</code>: Contains the "blueprint" logic for how to compose resources together. The platform engineer defines a simple pipeline of functions to execute, with the end goal being to defined and customized the composed resources.
+         </ul>
     </td>
   </tr>
   <tr>
@@ -236,7 +236,7 @@ security audit.
   doc](https://github.com/crossplane/crossplane/blob/main/design/design-doc-packages-v2.md)
   and `xpkg` package format
   [specification](https://github.com/crossplane/crossplane/blob/main/contributing/specifications/xpkg.md)
-  are also useful resources. 
+  are also useful resources.
 
 **Security Relevant Security Components**
 
@@ -305,7 +305,8 @@ standards or sub-sections at this time.
   channels outlined in the main
   [README](https://github.com/crossplane/crossplane?tab=readme-ov-file#get-involved).
 * Outbound: The project makes announcements on the Crossplane Slack
-  `#announcements` channel, [Twitter](https://twitter.com/crossplane_io),
+  `#announcements` channel, [Bluesky](https://bsky.app/profile/crossplane.io),
+  [Twitter](https://twitter.com/crossplane_io),
   [LinkedIn](https://www.linkedin.com/company/crossplane), [blog
   posts](https://blog.crossplane.io/), and [release
   notes](https://github.com/crossplane/crossplane/releases).
@@ -407,11 +408,11 @@ Crossplane in more details on the Crossplane blog:
   Your Control
   Plane](https://blog.crossplane.io/building-crossplane-composition-functions-to-empower-your-control-plane/)
 * [How VSHN uses Composition Functions in
-  Production](https://blog.crossplane.io/composition-functions-in-production/) 
+  Production](https://blog.crossplane.io/composition-functions-in-production/)
 
 Further cases studies can be found on the [CNCF
 website](https://www.cncf.io/case-studies/?_sft_lf-project=crossplane) and
-[Upbound's website](https://www.upbound.io/resources/case-studies). 
+[Upbound's website](https://www.upbound.io/resources/case-studies).
 
 ### Related Projects and Vendors
 


### PR DESCRIPTION
### Description of your changes

This PR adds some links to Crossplane's Bluesky account https://bsky.app/profile/crossplane.io, basically anywhere we mention Twitter in this repo we now mention Bluesky too.

Partially addresses #6187 

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `earthly +reviewable` to ensure this PR is ready for review.
- [ ] ~Added or updated unit tests.~
- [ ] ~Added or updated e2e tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
