### PR TITLE
fix(cli): Resolve duplicate validate results due to multiple version of dependencies in cache

### DIFF
--- a/cmd/crank/beta/validate/cache.go
+++ b/cmd/crank/beta/validate/cache.go
@@ -32,7 +32,7 @@ type Cache interface {
 	Store(schemas [][]byte, path string) error
 	Flush() error
 	Init() error
-	Load() ([]*unstructured.Unstructured, error)
+	Load(deps map[string]bool) ([]*unstructured.Unstructured, error)
 	Exists(image string) (string, error)
 }
 
@@ -87,24 +87,26 @@ func (c *LocalCache) Flush() error {
 }
 
 // Load loads the schemas from the cache directory.
-func (c *LocalCache) Load() ([]*unstructured.Unstructured, error) {
-	loader, err := NewLoader(c.cacheDir)
-	if err != nil {
-		return nil, errors.Wrapf(err, "cannot create loader from the path %s", c.cacheDir)
+func (c *LocalCache) Load(deps map[string]bool) ([]*unstructured.Unstructured, error) {
+	schemas := make([]*unstructured.Unstructured, 0)
+	for dep, _ := range deps {
+		path := c.getCachePath(dep)
+		loader, err := NewLoader(path)
+		if err != nil {
+			return nil, errors.Wrapf(err, "cannot create loader from %s", path)
+		}
+		depSchemas, err := loader.Load()
+		if err != nil {
+			return nil, errors.Wrapf(err, "cannot load schemas from %s", path)
+		}
+		schemas = append(schemas, depSchemas...)
 	}
-
-	schemas, err := loader.Load()
-	if err != nil {
-		return nil, errors.Wrapf(err, "cannot load schemas from the path %s", c.cacheDir)
-	}
-
 	return schemas, nil
 }
 
 // Exists checks if the cache contains the image and returns the path if it doesn't exist.
 func (c *LocalCache) Exists(image string) (string, error) {
-	fName := strings.ReplaceAll(image, ":", "@")
-	path := filepath.Join(c.cacheDir, fName)
+	path := c.getCachePath(image)
 
 	_, err := os.Stat(path)
 	if err != nil && os.IsNotExist(err) {
@@ -114,4 +116,9 @@ func (c *LocalCache) Exists(image string) (string, error) {
 	}
 
 	return "", nil
+}
+
+func (c *LocalCache) getCachePath(image string) string {
+	fName := strings.ReplaceAll(image, ":", "@")
+	return filepath.Join(c.cacheDir, fName)
 }

--- a/cmd/crank/beta/validate/cache.go
+++ b/cmd/crank/beta/validate/cache.go
@@ -32,7 +32,7 @@ type Cache interface {
 	Store(schemas [][]byte, path string) error
 	Flush() error
 	Init() error
-	Load(deps map[string]bool) ([]*unstructured.Unstructured, error)
+	Load(path string) ([]*unstructured.Unstructured, error)
 	Exists(image string) (string, error)
 }
 
@@ -87,19 +87,17 @@ func (c *LocalCache) Flush() error {
 }
 
 // Load loads the schemas from the cache directory.
-func (c *LocalCache) Load(deps map[string]bool) ([]*unstructured.Unstructured, error) {
-	schemas := make([]*unstructured.Unstructured, 0)
-	for dep, _ := range deps {
-		path := c.getCachePath(dep)
-		loader, err := NewLoader(path)
-		if err != nil {
-			return nil, errors.Wrapf(err, "cannot create loader from %s", path)
-		}
-		depSchemas, err := loader.Load()
-		if err != nil {
-			return nil, errors.Wrapf(err, "cannot load schemas from %s", path)
-		}
-		schemas = append(schemas, depSchemas...)
+func (c *LocalCache) Load(path string) ([]*unstructured.Unstructured, error) {
+	if strings.ContainsRune(path, filepath.ListSeparator) {
+		path = c.getCachePath(path)
+	}
+	loader, err := NewLoader(path)
+	if err != nil {
+		return nil, errors.Wrapf(err, "cannot create loader from %s", path)
+	}
+	schemas, err := loader.Load()
+	if err != nil {
+		return nil, errors.Wrapf(err, "cannot load schemas from %s", path)
 	}
 	return schemas, nil
 }
@@ -107,7 +105,6 @@ func (c *LocalCache) Load(deps map[string]bool) ([]*unstructured.Unstructured, e
 // Exists checks if the cache contains the image and returns the path if it doesn't exist.
 func (c *LocalCache) Exists(image string) (string, error) {
 	path := c.getCachePath(image)
-
 	_, err := os.Stat(path)
 	if err != nil && os.IsNotExist(err) {
 		return path, nil

--- a/cmd/crank/beta/validate/cache_test.go
+++ b/cmd/crank/beta/validate/cache_test.go
@@ -193,9 +193,7 @@ func TestLocalCacheLoad(t *testing.T) {
 				cacheDir: tc.args.cacheDir,
 			}
 
-			got, err := c.Load(map[string]bool{
-				"xpkg.upbound.io/crossplane-contrib/provider-nop:v0.2.0": true,
-			})
+			got, err := c.Load(tc.args.cacheDir)
 			if diff := cmp.Diff(tc.want.schemas, got); diff != "" {
 				t.Errorf("%s\nLoad(...): -want, +got:\n%s", tc.reason, diff)
 			}

--- a/cmd/crank/beta/validate/cache_test.go
+++ b/cmd/crank/beta/validate/cache_test.go
@@ -193,7 +193,9 @@ func TestLocalCacheLoad(t *testing.T) {
 				cacheDir: tc.args.cacheDir,
 			}
 
-			got, err := c.Load()
+			got, err := c.Load(map[string]bool{
+				"xpkg.upbound.io/crossplane-contrib/provider-nop:v0.2.0": true,
+			})
 			if diff := cmp.Diff(tc.want.schemas, got); diff != "" {
 				t.Errorf("%s\nLoad(...): -want, +got:\n%s", tc.reason, diff)
 			}

--- a/cmd/crank/beta/validate/manager.go
+++ b/cmd/crank/beta/validate/manager.go
@@ -199,7 +199,7 @@ func (m *Manager) CacheAndLoad(cleanCache bool) error {
 		return errors.Wrapf(err, "cannot cache package dependencies")
 	}
 
-	schemas, err := m.cache.Load()
+	schemas, err := m.cache.Load(m.deps)
 	if err != nil {
 		return errors.Wrapf(err, "cannot load cache")
 	}

--- a/cmd/crank/beta/validate/manager.go
+++ b/cmd/crank/beta/validate/manager.go
@@ -199,7 +199,7 @@ func (m *Manager) CacheAndLoad(cleanCache bool) error {
 		return errors.Wrapf(err, "cannot cache package dependencies")
 	}
 
-	schemas, err := m.cache.Load(m.deps)
+	schemas, err := m.loadDependencies()
 	if err != nil {
 		return errors.Wrapf(err, "cannot load cache")
 	}
@@ -307,4 +307,16 @@ func (m *Manager) cacheDependencies() error {
 	}
 
 	return nil
+}
+
+func (m *Manager) loadDependencies() ([]*unstructured.Unstructured, error) {
+	schemas := make([]*unstructured.Unstructured, 0)
+	for dep := range m.deps {
+		cachedSchema, err := m.cache.Load(dep)
+		if err != nil {
+			return nil, errors.Wrapf(err, "cannot load cache for %s", dep)
+		}
+		schemas = append(schemas, cachedSchema...)
+	}
+	return schemas, nil
 }


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane! Please read the contribution docs
(linked below) if this is your first Crossplane pull request.
-->

### Description of your changes

<!--
Briefly describe what this pull request does, and how it is covered by tests.
Be proactive - direct your reviewers' attention to anything that needs special
consideration.

We love pull requests that fix an open issue. If yours does, use the below line
to indicate which issue it fixes, for example "Fixes #500".
-->

Fixes #6057 

The issue is due to multiple version of dependencies in a cache folder, and in the code it intend to load everything from the cache, and use whatever available in a cache folder to validate results.

To solve the issue, I have:
- Introduce a new function `loadDependencies` to load schemas based on what dependencies we need
- Modify Load function, instead of load everything from a `cacheDir`, load it from a specific folder instead

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `earthly +reviewable` to ensure this PR is ready for review.
- [x] Added or updated unit tests.
- [ ] ~~Added or updated e2e tests.~~
- [x] Linked a PR or a [docs tracking issue] to [document this change].
- [ ] ~~Added `backport release-x.y` labels to auto-backport this PR.~~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
