### PR TITLE
Close the cacheWrite channel in case `r.backend.Init` encounters error

### DIFF
--- a/internal/controller/pkg/revision/reconciler.go
+++ b/internal/controller/pkg/revision/reconciler.go
@@ -729,6 +729,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 			r.record.Event(pr, event.Warning(reasonParse, err))
 
 			close(cacheWrite)
+
 			// Requeue because we may be waiting for parent package
 			// controller to recreate Pod.
 			return reconcile.Result{}, err


### PR DESCRIPTION
### Description of your changes
This PR delays the creation of `cacheWrite` channel since it is not used by retrieval from cache.

This PR also adds closing of `cacheWrite` channel in case `r.backend.Init` encounters error.


I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [ x] Read and followed Crossplane's [contribution process].
- [ x] Run `earthly +reviewable` to ensure this PR is ready for review.
~~[ ] Added or updated unit tests.~~
~~[ ] Added or updated e2e tests.~~
~~[ ] Linked a PR or a [docs tracking issue] to [document this change].~~
~~[ ] Added `backport release-x.y` labels to auto-backport this PR.~~

