### PR TITLE
Close the cacheWrite channel before returning

### DIFF
--- a/internal/controller/pkg/revision/reconciler.go
+++ b/internal/controller/pkg/revision/reconciler.go
@@ -748,6 +748,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 			close(cacheWrite)
 		}()
 	} else {
+		// close the channel
 		close(cacheWrite)
 	}
 

--- a/internal/controller/pkg/revision/reconciler.go
+++ b/internal/controller/pkg/revision/reconciler.go
@@ -747,6 +747,8 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 			}
 			close(cacheWrite)
 		}()
+	} else {
+		close(cacheWrite)
 	}
 
 	// Parse package contents.

--- a/internal/controller/pkg/revision/reconciler.go
+++ b/internal/controller/pkg/revision/reconciler.go
@@ -680,7 +680,6 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 	}
 
 	var rc io.ReadCloser
-	cacheWrite := make(chan error)
 
 	if r.cache.Has(id) {
 		var err error
@@ -693,9 +692,6 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 			r.record.Event(pr, event.Warning(reasonParse, err))
 			return reconcile.Result{}, err
 		}
-		// If we got content from cache we don't need to wait for it to be
-		// written.
-		close(cacheWrite)
 	}
 
 	// packagePullPolicy is Never and contents are not in the cache so we return
@@ -710,6 +706,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 		return reconcile.Result{}, err
 	}
 
+	cacheWrite := make(chan error)
 	// If we didn't get a ReadCloser from cache, we need to get it from image.
 	if rc == nil {
 		bo := []parser.BackendOption{PackageRevision(pr)}
@@ -730,6 +727,8 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 			_ = r.client.Status().Update(ctx, pr)
 
 			r.record.Event(pr, event.Warning(reasonParse, err))
+
+			close(cacheWrite)
 
 			// Requeue because we may be waiting for parent package
 			// controller to recreate Pod.


### PR DESCRIPTION
This PR delays the creation of `cacheWrite` channel since it is not used by retrieval from cache.

This PR also adds closing of `cacheWrite` channel in case `r.backend.Init` encounters error.


I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `earthly +reviewable` to ensure this PR is ready for review.
~~[ ] Added or updated unit tests.~~
~~[ ] Added or updated e2e tests.~~
~~[ ] Linked a PR or a [docs tracking issue] to [document this change].~~
~~[ ] Added `backport release-x.y` labels to auto-backport this PR.~~

