### PR TITLE
Preserves custom status conditions on the claim when using claim ssa

### DIFF
--- a/internal/controller/apiextensions/claim/syncer_ssa.go
+++ b/internal/controller/apiextensions/claim/syncer_ssa.go
@@ -25,6 +25,7 @@ import (
 
 	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
 	"github.com/crossplane/crossplane-runtime/pkg/errors"
+	"github.com/crossplane/crossplane-runtime/pkg/fieldpath"
 	"github.com/crossplane/crossplane-runtime/pkg/meta"
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
 	"github.com/crossplane/crossplane-runtime/pkg/resource/unstructured/claim"
@@ -313,18 +314,15 @@ func (s *ServerSideCompositeSyncer) Sync(ctx context.Context, cm *claim.Unstruct
 	}
 
 	// Preserve Crossplane machinery, like status conditions.
-	synced := cm.GetCondition(xpv1.TypeSynced)
-	ready := cm.GetCondition(xpv1.TypeReady)
+	cmcs := xpv1.ConditionedStatus{}
+	_ = fieldpath.Pave(cm.Object).GetValueInto("status", &cmcs)
 	pub := cm.GetConnectionDetailsLastPublishedTime()
 
 	// Update the claim's user-defined status fields to match the XRs.
 	cm.Object["status"] = withoutKeys(xrStatus, xcrd.GetPropFields(xcrd.CompositeResourceStatusProps())...)
 
-	if !synced.Equal(xpv1.Condition{}) {
-		cm.SetConditions(synced)
-	}
-	if !ready.Equal(xpv1.Condition{}) {
-		cm.SetConditions(ready)
+	if cmcs.Conditions != nil {
+		cm.SetConditions(cmcs.Conditions...)
 	}
 	if pub != nil {
 		cm.SetConnectionDetailsLastPublishedTime(pub)


### PR DESCRIPTION
### Description of your changes

~Fixes [function-status-transformer/45](https://github.com/crossplane-contrib/function-status-transformer/issues/45) (asked submitter to open an issue here instead).~
Fixes #6228.

If SSA claims are enabled (`--enable-ssa-claims`) and a custom status condition is set on the claim, an infinite patch loop occurs on the claim's status conditions. I'm not entirely familiar with the SSA sync implementation, but it appears the SSA sync will remove the conditions while the reconciler will add them back.

This PR updates the SSA sync logic to preserve any custom conditions that may exist on the XR.

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `earthly +reviewable` to ensure this PR is ready for review.
- [x] Added or updated unit tests.
- [ ] ~Added or updated e2e tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~