### PR TITLE
define an API promotion process

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -14,7 +14,7 @@ We love pull requests that fix an open issue. If yours does, use the below line
 to indicate which issue it fixes, for example "Fixes #500".
 -->
 
-Fixes # 
+Fixes #
 
 I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->
 
@@ -24,6 +24,7 @@ I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->
 - [ ] Added or updated e2e tests.
 - [ ] Linked a PR or a [docs tracking issue] to [document this change].
 - [ ] Added `backport release-x.y` labels to auto-backport this PR.
+- [ ] Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.
 
 Need help with this checklist? See the [cheat sheet].
 
@@ -31,3 +32,4 @@ Need help with this checklist? See the [cheat sheet].
 [docs tracking issue]: https://github.com/crossplane/docs/issues/new
 [document this change]: https://docs.crossplane.io/contribute/contribute
 [cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
+[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md

--- a/cmd/crossplane/core/init.go
+++ b/cmd/crossplane/core/init.go
@@ -74,6 +74,7 @@ func (c *initCommand) Run(s *runtime.Scheme, log logging.Logger) error {
 		initializer.NewTLSCertificateGenerator(c.Namespace, c.TLSCASecretName, tlsGeneratorOpts...),
 		initializer.NewCoreCRDsMigrator("compositionrevisions.apiextensions.crossplane.io", "v1alpha1"),
 		initializer.NewCoreCRDsMigrator("environmentconfigs.apiextensions.crossplane.io", "v1beta1"),
+		initializer.NewCoreCRDsMigrator("usages.apiextensions.crossplane.io", "v1beta1"),
 		initializer.NewCoreCRDsMigrator("functions.pkg.crossplane.io", "v1beta1"),
 		initializer.NewCoreCRDsMigrator("functionrevisions.pkg.crossplane.io", "v1beta1"),
 		initializer.NewCoreCRDsMigrator("locks.pkg.crossplane.io", "v1alpha1"),

--- a/cmd/crossplane/core/init.go
+++ b/cmd/crossplane/core/init.go
@@ -72,12 +72,6 @@ func (c *initCommand) Run(s *runtime.Scheme, log logging.Logger) error {
 	}
 	steps = append(steps,
 		initializer.NewTLSCertificateGenerator(c.Namespace, c.TLSCASecretName, tlsGeneratorOpts...),
-		initializer.NewCoreCRDsMigrator("compositionrevisions.apiextensions.crossplane.io", "v1alpha1"),
-		initializer.NewCoreCRDsMigrator("environmentconfigs.apiextensions.crossplane.io", "v1beta1"),
-		initializer.NewCoreCRDsMigrator("usages.apiextensions.crossplane.io", "v1beta1"),
-		initializer.NewCoreCRDsMigrator("functions.pkg.crossplane.io", "v1beta1"),
-		initializer.NewCoreCRDsMigrator("functionrevisions.pkg.crossplane.io", "v1beta1"),
-		initializer.NewCoreCRDsMigrator("locks.pkg.crossplane.io", "v1alpha1"),
 	)
 	if c.WebhookEnabled {
 		nn := types.NamespacedName{
@@ -97,6 +91,17 @@ func (c *initCommand) Run(s *runtime.Scheme, log logging.Logger) error {
 			initializer.NewCoreCRDs("/crds", s),
 		)
 	}
+
+	// CRD migrator steps are done after core CRDs are applied/updated, so we
+	// are always migrating to the most current storage version
+	steps = append(steps,
+		initializer.NewCoreCRDsMigrator("compositionrevisions.apiextensions.crossplane.io", "v1alpha1"),
+		initializer.NewCoreCRDsMigrator("environmentconfigs.apiextensions.crossplane.io", "v1beta1"),
+		initializer.NewCoreCRDsMigrator("usages.apiextensions.crossplane.io", "v1beta1"),
+		initializer.NewCoreCRDsMigrator("functions.pkg.crossplane.io", "v1beta1"),
+		initializer.NewCoreCRDsMigrator("functionrevisions.pkg.crossplane.io", "v1beta1"),
+		initializer.NewCoreCRDsMigrator("locks.pkg.crossplane.io", "v1alpha1"),
+	)
 
 	if c.ESSTLSServerSecretName != "" {
 		steps = append(steps, initializer.NewTLSCertificateGenerator(c.Namespace, c.TLSCASecretName,

--- a/contributing/guide-api-promotion.md
+++ b/contributing/guide-api-promotion.md
@@ -1,0 +1,97 @@
+# Promoting an API
+
+This guide describes the process for promoting an API in Crossplane from one
+version to the next. This process should be handled with care over multiple
+releases, as it has proven fairly easy for Crossplane's API promotions of the
+past to be problematic for both upgrades and downgrades, as demonstrated by
+[#6148], [#5932], and [#4400].
+
+An explanation of Crossplane's feature lifecycle can be found in the [Feature
+Lifecycle] docs page.
+
+## Core Issue
+
+The root cause we have encountered in past problematic API promotions is that we
+try to drop a particular version from a CRD while there may still be resources
+of that version stored in etcd. Kubernetes does not allow this action because it
+can result in possible data loss.
+
+Note that this can happen on both upgrades as well as downgrades. Let's briefly
+summarize one common downgrade path where we've encountered this issue:
+
+1. A Crossplane API is promoted to Beta and the storage version for the CRD is
+   updated to Beta in the same release
+1. User installs this new Crossplane version and creates a Beta resource that is
+   stored in etcd as Beta
+1. User downgrades to the previous Crossplane version where the CRD's Beta
+   version did not exist
+1. The Crossplane init container tries to update the CRD back to the Alpha
+   version, which drops the Beta version
+1. The Kubernetes API server rejects this action because there might still be
+   Beta resources stored in etcd according to the CRD's
+   [`status.storedVersions`] field
+1. Crossplane init container crashes and the Crossplane pod restarts in a loop
+
+## Guiding Principles
+
+There are a few simple principles we can follow in order to avoid this common
+scenario when promoting Crossplane APIs:
+
+1. Never introduce or drop a CRD version while also bumping the storage version
+   in the same release
+1. Always migrate resources to the current storage version during Crossplane
+   initialization
+
+Adherence to these two principles should result in never dropping a CRD version
+that still has resources of that version stored in etcd, for both the upgrade
+and downgrade directions.
+
+## Promotion Workflow
+
+The following table outlines the steps to introduce and then promote an API
+safely across multiple versions while maintaining safe upgrades and downgrades:
+
+| Version | Description                | Alpha           | Beta            | Migration        |
+|---------|----------------------------|-----------------|-----------------|------------------|
+| v0.1    | introduce new API as alpha | storage, served | not exist       | none             |
+| v0.2    | promote to beta            | storage, served | served          | migrate to alpha |
+| v0.3    | bump storage to beta       | served          | storage, served | migrate to beta  |
+| v0.4    | drop alpha                 | not exist       | storage, served | none             |
+
+The same process could be applied again when promoting the API from Beta to v1
+GA.
+
+## Practical Pointers
+
+This section contains some helpful pointers to areas of the codebase involved
+in promoting an API. These are just general direction and not entirely
+prescriptive, because you'll need to make specific decisions for your promotion
+based on the workflow defined above.
+
+1. Define the API types under the `apis` directory, for example
+   [`apis/apiextensions/v1beta1`]
+1. Set the storage version `+kubebuilder:storageversion` marker on the correct
+   version, e.g., as shown here for [Usage v1alpha1]
+1. Duplicate the API to other versions if needed using [`generate.go`], also
+   instructing the [duplicate script] to set the storage version if needed
+1. Run `earthly +generate` to generate the CRDs and check them for sanity in the
+   [`cluster/crds`] directory
+1. Include a [migrator] if needed to ensure resources are migrated to the
+   current storage version and the CRD status is updated to declare that it only
+   has resources stored in etcd of the current storage version
+    * **Note** that the version passed into the migrator is the **"old"**
+      version you want to migrate **from**, not the target version you want to
+      migrate to
+
+<!-- Links -->
+[#6148]: https://github.com/crossplane/crossplane/issues/6148
+[#5932]: https://github.com/crossplane/crossplane/issues/5932
+[#4400]: https://github.com/crossplane/crossplane/issues/4400
+[Feature Lifecycle]: https://docs.crossplane.io/latest/learn/feature-lifecycle/
+[`status.storedVersions`]: https://github.com/kubernetes/apiextensions-apiserver/blob/v0.32.0/pkg/apis/apiextensions/v1/types.go#L368-L376
+[`apis/apiextensions/v1beta1`]: https://github.com/crossplane/crossplane/tree/release-1.18/apis/apiextensions/v1beta1
+[Usage v1alpha1]: https://github.com/crossplane/crossplane/blob/release-1.18/apis/apiextensions/v1alpha1/usage_types.go#L89
+[`generate.go`]: https://github.com/crossplane/crossplane/blob/release-1.18/apis/generate.go
+[duplicate script]: https://github.com/crossplane/crossplane/blob/release-1.18/hack/duplicate_api_type.sh
+[`cluster/crds`]: https://github.com/crossplane/crossplane/tree/release-1.18/cluster/crds
+[migrator]: https://github.com/crossplane/crossplane/blob/release-1.18/cmd/crossplane/core/init.go#L75-L79


### PR DESCRIPTION
### Description of your changes

This PR defines a process for promoting APIs in Crossplane in order to be able to safely upgrade and downgrade across all versions.  This process is in the form of a contributor guide and a link has been added to the PR checklist to remind contributors if they are adding/removing/promoting an API then they should follow this process.

This process was originally proposed/discussed in https://github.com/crossplane/crossplane/pull/6157#pullrequestreview-2482652310.

This PR also adds a migrator for the Usage API being promoted to Beta that was missed. The need for this migrator was discussed in https://github.com/crossplane/crossplane/pull/6175#pullrequestreview-2502835976.

Fixes #5932

### How has this change been tested?

I've gone through the entire upgrade and downgrade process across 4 versions as described in the proposed process. The details of how this testing was performed and the results observed can be found in this gist:
https://gist.github.com/jbw976/276a088a2cd0f3c1e99b5f7cd074124a

TL;DR: An alpha `Usage` resource was created on v1.18 and then Crossplane was upgraded to realistic, but not yet released, upcoming versions v1.19 -> v1.20 -> v1.21 to exercise the entire promotion workflow process. Then Crossplane was downgraded from v1.21 -> v1.20 -> v1.19 -> v1.18. The health of Crossplane and the state of the `Usage` CRD was verified at every version and no undesired behavior was observed.

The realistic changes used during testing that continue the `Usage` promotion workflow in not yet released versions of Crossplane can be seen in:
* v1.20: https://github.com/crossplane/crossplane/compare/main...jbw976:crossplane:crossplane-usages-1.20
* v1.21: https://github.com/crossplane/crossplane/compare/main...jbw976:crossplane:crossplane-usages-1.21

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `earthly +reviewable` to ensure this PR is ready for review.
- [ ] ~Added or updated unit tests.~
- [ ] ~Added or updated e2e tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
