### PR TITLE
fix(function): Apply composed resources concurrently

### DIFF
--- a/internal/controller/apiextensions/composite/composition_functions_test.go
+++ b/internal/controller/apiextensions/composite/composition_functions_test.go
@@ -643,7 +643,7 @@ func TestFunctionCompose(t *testing.T) {
 				},
 			},
 			want: want{
-				err: errors.Wrapf(errBoom, errFmtApplyCD, "uncool-resource"),
+				err: errors.Wrap(errors.Join(errors.Wrapf(errBoom, errFmtApplyCD, "uncool-resource")), errFmtApplyCDJoined),
 			},
 		},
 		"Successful": {


### PR DESCRIPTION
### Description of your changes

This changes the reconcilation of a function pipeline to apply all composed resource at once in separate goroutines. This makes the process a lot faster especially in situations where a function pipeline results in a lot of composed resources that need to be a applied.

This fixes issues we have on our systems where we have very large and complicated APIs that result in more than 50 composed resources to be created while at the same time we have slow response times of the kube API server due to the high load that is put on it. This frequently leads to reconcile errors of composites because it fails to apply all composed resources due to context timeouts.

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `earthly +reviewable` to ensure this PR is ready for review.
- [x] Added or updated unit tests.
- [ ] ~Added or updated e2e tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [x] Added `backport release-x.y` labels to auto-backport this PR.
- [ ] ~Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md