### PR TITLE
Promote Claim Server Side Apply to Beta

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -223,7 +223,6 @@ jobs:
       matrix:
         test-suite:
           - base
-          - ssa-claims
           - realtime-compositions
           - package-dependency-updates
           - package-signature-verification
@@ -278,7 +277,7 @@ jobs:
             echo "Error: Minor version cannot be decremented below 0"
             exit 1
           fi
-          
+
           echo "CROSSPLANE_PRIOR_VERSION=$MAJOR.$MINOR" >> $GITHUB_ENV
 
 

--- a/cmd/crossplane/core/core.go
+++ b/cmd/crossplane/core/core.go
@@ -112,13 +112,13 @@ type startCommand struct {
 
 	EnableExternalSecretStores      bool `group:"Alpha Features:" help:"Enable support for External Secret Stores."`
 	EnableRealtimeCompositions      bool `group:"Alpha Features:" help:"Enable support for realtime compositions, i.e. watching composed resources and reconciling compositions immediately when any of the composed resources is updated."`
-	EnableSSAClaims                 bool `group:"Alpha Features:" help:"Enable support for using Kubernetes server-side apply to sync claims with composite resources (XRs)."`
 	EnableDependencyVersionUpgrades bool `group:"Alpha Features:" help:"Enable support for upgrading dependency versions when the parent package is updated."`
 	EnableSignatureVerification     bool `group:"Alpha Features:" help:"Enable support for package signature verification via ImageConfig API."`
 
 	EnableCompositionWebhookSchemaValidation bool `default:"true" group:"Beta Features:" help:"Enable support for Composition validation using schemas."`
 	EnableDeploymentRuntimeConfigs           bool `default:"true" group:"Beta Features:" help:"Enable support for Deployment Runtime Configs."`
 	EnableUsages                             bool `default:"true" group:"Beta Features:" help:"Enable support for deletion ordering and resource protection with Usages."`
+	EnableSSAClaims                          bool `default:"true" group:"Beta Features:" help:"Enable support for using Kubernetes server-side apply to sync claims with composite resources (XRs)."`
 
 	// These are GA features that previously had alpha or beta feature flags.
 	// You can't turn off a GA feature. We maintain the flags to avoid breaking
@@ -280,8 +280,8 @@ func (c *startCommand) Run(s *runtime.Scheme, log logging.Logger) error { //noli
 		log.Info("Beta feature enabled", "flag", features.EnableBetaDeploymentRuntimeConfigs)
 	}
 	if c.EnableSSAClaims {
-		o.Features.Enable(features.EnableAlphaClaimSSA)
-		log.Info("Alpha feature enabled", "flag", features.EnableAlphaClaimSSA)
+		o.Features.Enable(features.EnableBetaClaimSSA)
+		log.Info("Beta feature enabled", "flag", features.EnableBetaClaimSSA)
 	}
 	if c.EnableDependencyVersionUpgrades {
 		o.Features.Enable(features.EnableAlphaDependencyVersionUpgrades)

--- a/contributing/guide-api-promotion.md
+++ b/contributing/guide-api-promotion.md
@@ -82,6 +82,8 @@ based on the workflow defined above.
     * **Note** that the version passed into the migrator is the **"old"**
       version you want to migrate **from**, not the target version you want to
       migrate to
+1. Update the [feature flag] for this API to reflect its new maturity level
+1. Update the [feature flag docs] to reflect the new maturity level there as well
 
 <!-- Links -->
 [#6148]: https://github.com/crossplane/crossplane/issues/6148
@@ -95,3 +97,5 @@ based on the workflow defined above.
 [duplicate script]: https://github.com/crossplane/crossplane/blob/release-1.18/hack/duplicate_api_type.sh
 [`cluster/crds`]: https://github.com/crossplane/crossplane/tree/release-1.18/cluster/crds
 [migrator]: https://github.com/crossplane/crossplane/blob/release-1.18/cmd/crossplane/core/init.go#L75-L79
+[feature flag]: https://github.com/crossplane/crossplane/blob/release-1.18/cmd/crossplane/core/core.go#L112-L134
+[feature flag docs]: https://docs.crossplane.io/latest/software/install/#feature-flags

--- a/internal/controller/apiextensions/offered/reconciler.go
+++ b/internal/controller/apiextensions/offered/reconciler.go
@@ -437,7 +437,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 	// flag is enabled. Otherwise, we start claim reconcilers with the default
 	// client-side syncer. If we use a server-side syncer we also need to handle
 	// upgrading fields that were previously managed using client-side apply.
-	if r.options.Features.Enabled(features.EnableAlphaClaimSSA) {
+	if r.options.Features.Enabled(features.EnableBetaClaimSSA) {
 		o = append(o,
 			claim.WithCompositeSyncer(claim.NewServerSideCompositeSyncer(r.engine.GetClient(), names.NewNameGenerator(r.engine.GetClient()))),
 			claim.WithManagedFieldsUpgrader(claim.NewPatchingManagedFieldsUpgrader(r.engine.GetClient())),

--- a/internal/features/features.go
+++ b/internal/features/features.go
@@ -31,11 +31,6 @@ const (
 	// when any MR is updated.
 	EnableAlphaRealtimeCompositions feature.Flag = "EnableAlphaRealtimeCompositions"
 
-	// EnableAlphaClaimSSA enables alpha support for using server-side apply in
-	// the claim controller. See the below issue for more details:
-	// https://github.com/crossplane/crossplane/issues/4581
-	EnableAlphaClaimSSA feature.Flag = "EnableAlphaClaimSSA"
-
 	// EnableAlphaDependencyVersionUpgrades enables alpha support for upgrading the version of a package's dependencies
 	// when needed.
 	EnableAlphaDependencyVersionUpgrades feature.Flag = "EnableAlphaDependencyVersionUpgrades"
@@ -61,4 +56,9 @@ const (
 	// protection with Usage resource. See the below design for more details.
 	// https://github.com/crossplane/crossplane/blob/19ea23/design/one-pager-generic-usage-type.md
 	EnableBetaUsages feature.Flag = "EnableBetaUsages"
+
+	// EnableBetaClaimSSA enables beta support for using server-side apply in
+	// the claim controller. See the below issue for more details:
+	// https://github.com/crossplane/crossplane/issues/4581
+	EnableBetaClaimSSA feature.Flag = "EnableBetaClaimSSA"
 )

--- a/test/e2e/apiextensions_test.go
+++ b/test/e2e/apiextensions_test.go
@@ -34,23 +34,6 @@ import (
 	"github.com/crossplane/crossplane/test/e2e/funcs"
 )
 
-const (
-	// SuiteSSAClaims is the value for the config.LabelTestSuite label to be
-	// assigned to tests that should be part of the SSAClaims  test suite.
-	SuiteSSAClaims = "ssa-claims"
-)
-
-func init() {
-	environment.AddTestSuite(SuiteSSAClaims,
-		config.WithHelmInstallOpts(
-			helm.WithArgs("--set args={--debug,--enable-ssa-claims}"),
-		),
-		config.WithLabelsToSelect(features.Labels{
-			config.LabelTestSuite: []string{SuiteSSAClaims, config.TestSuiteDefault},
-		}),
-	)
-}
-
 // LabelAreaAPIExtensions is applied to all features pertaining to API
 // extensions (i.e. Composition, XRDs, etc).
 const LabelAreaAPIExtensions = "apiextensions"
@@ -242,14 +225,11 @@ func TestPropagateFieldsRemovalToXR(t *testing.T) {
 	manifests := "test/e2e/manifests/apiextensions/composition/propagate-field-removals"
 	environment.Test(t,
 		features.NewWithDescription(t.Name(), "Tests that field removals in a claim are correctly propagated to the associated composite resource (XR), ensuring that updates and deletions are properly synchronized, and that the status from the XR is accurately reflected back to the claim.").
+			WithLabel(LabelStage, LabelStageBeta).
 			WithLabel(LabelArea, LabelAreaAPIExtensions).
 			WithLabel(LabelSize, LabelSizeSmall).
 			WithLabel(LabelModifyCrossplaneInstallation, LabelModifyCrossplaneInstallationTrue).
-			WithLabel(config.LabelTestSuite, SuiteSSAClaims).
-			WithSetup("EnableSSAClaims", funcs.AllOf(
-				funcs.AsFeaturesFunc(environment.HelmUpgradeCrossplaneToSuite(SuiteSSAClaims)),
-				funcs.ReadyToTestWithin(1*time.Minute, namespace),
-			)).
+			WithLabel(config.LabelTestSuite, config.TestSuiteDefault).
 			WithSetup("PrerequisitesAreCreated", funcs.AllOf(
 				funcs.ApplyResources(FieldManager, manifests, "setup/*.yaml"),
 				funcs.ResourcesCreatedWithin(30*time.Second, manifests, "setup/*.yaml"),
@@ -284,10 +264,6 @@ func TestPropagateFieldsRemovalToXR(t *testing.T) {
 				funcs.ResourcesDeletedWithin(2*time.Minute, manifests, "claim.yaml"),
 			)).
 			WithTeardown("DeletePrerequisites", funcs.ResourcesDeletedAfterListedAreGone(3*time.Minute, manifests, "setup/*.yaml", nopList)).
-			WithTeardown("DisableSSAClaims", funcs.AllOf(
-				funcs.AsFeaturesFunc(environment.HelmUpgradeCrossplaneToBase()), // Disable our feature flag.
-				funcs.ReadyToTestWithin(1*time.Minute, namespace),
-			)).
 			Feature(),
 	)
 }
@@ -296,15 +272,16 @@ func TestPropagateFieldsRemovalToXRAfterUpgrade(t *testing.T) {
 	manifests := "test/e2e/manifests/apiextensions/composition/propagate-field-removals"
 	environment.Test(t,
 		features.NewWithDescription(t.Name(), "Tests that field removals in a composite resource (XR) are correctly propagated after upgrading the field managers from CSA to SSA, verifying that the upgrade process does not interfere with the synchronization of fields between the claim and the XR.").
+			WithLabel(LabelStage, LabelStageBeta).
 			WithLabel(LabelArea, LabelAreaAPIExtensions).
 			WithLabel(LabelSize, LabelSizeSmall).
 			WithLabel(LabelModifyCrossplaneInstallation, LabelModifyCrossplaneInstallationTrue).
-			WithLabel(config.LabelTestSuite, SuiteSSAClaims).
-			// SSA claims are always enabled in this test suite, so we need to
-			// explicitly disable them first before we create anything.
+			WithLabel(config.LabelTestSuite, config.TestSuiteDefault).
+			// SSA claims are enabled by default, so we need to explicitly
+			// disable them first before we create anything.
 			WithSetup("DisableSSAClaims", funcs.AllOf(
-				funcs.AsFeaturesFunc(environment.HelmUpgradeCrossplaneToSuite(config.TestSuiteDefault)), // Disable our feature flag.
-				funcs.ArgUnsetWithin(1*time.Minute, "--enable-ssa-claims", namespace, "crossplane"),
+				funcs.AsFeaturesFunc(environment.HelmUpgradeCrossplaneToBase(helm.WithArgs("--set args={--debug,--enable-ssa-claims=false}"))), // Disable our feature flag.
+				funcs.ArgExistsWithin(1*time.Minute, "--enable-ssa-claims=false", namespace, "crossplane"),
 				funcs.ReadyToTestWithin(1*time.Minute, namespace),
 				funcs.DeploymentPodIsRunningMustNotChangeWithin(10*time.Second, namespace, "crossplane"),
 			)).
@@ -324,8 +301,8 @@ func TestPropagateFieldsRemovalToXRAfterUpgrade(t *testing.T) {
 			// field managers from CSA to SSA. If we didn't upgrade successfully
 			// would end up sharing ownership with the old CSA field manager.
 			Assess("EnableSSAClaims", funcs.AllOf(
-				funcs.AsFeaturesFunc(environment.HelmUpgradeCrossplaneToSuite(SuiteSSAClaims)),
-				funcs.ArgSetWithin(1*time.Minute, "--enable-ssa-claims", namespace, "crossplane"),
+				funcs.AsFeaturesFunc(environment.HelmUpgradeCrossplaneToBase()),
+				funcs.ArgNotExistsWithin(1*time.Minute, "--enable-ssa-claims=false", namespace, "crossplane"),
 				funcs.ReadyToTestWithin(1*time.Minute, namespace),
 				funcs.DeploymentPodIsRunningMustNotChangeWithin(10*time.Second, namespace, "crossplane"),
 			)).
@@ -356,10 +333,6 @@ func TestPropagateFieldsRemovalToXRAfterUpgrade(t *testing.T) {
 				funcs.ResourcesDeletedWithin(2*time.Minute, manifests, "claim.yaml"),
 			)).
 			WithTeardown("DeletePrerequisites", funcs.ResourcesDeletedAfterListedAreGone(3*time.Minute, manifests, "setup/*.yaml", nopList)).
-			WithTeardown("DisableSSAClaims", funcs.AllOf(
-				funcs.AsFeaturesFunc(environment.HelmUpgradeCrossplaneToBase()), // Disable our feature flag.
-				funcs.ReadyToTestWithin(1*time.Minute, namespace),
-			)).
 			Feature(),
 	)
 }
@@ -368,14 +341,11 @@ func TestPropagateFieldsRemovalToComposed(t *testing.T) {
 	manifests := "test/e2e/manifests/apiextensions/composition/propagate-field-removals"
 	environment.Test(t,
 		features.NewWithDescription(t.Name(), "Tests Crossplane's end-to-end SSA syncing functionality of clear propagation of fields from claim->XR->MR, when existing composition and resources are migrated from native P-and-T to functions pipeline mode.").
+			WithLabel(LabelStage, LabelStageBeta).
 			WithLabel(LabelArea, LabelAreaAPIExtensions).
 			WithLabel(LabelSize, LabelSizeSmall).
 			WithLabel(LabelModifyCrossplaneInstallation, LabelModifyCrossplaneInstallationTrue).
-			WithLabel(config.LabelTestSuite, SuiteSSAClaims).
-			WithSetup("EnableSSAClaims", funcs.AllOf(
-				funcs.AsFeaturesFunc(environment.HelmUpgradeCrossplaneToSuite(SuiteSSAClaims)),
-				funcs.ReadyToTestWithin(1*time.Minute, namespace),
-			)).
+			WithLabel(config.LabelTestSuite, config.TestSuiteDefault).
 			WithSetup("PrerequisitesAreCreated", funcs.AllOf(
 				funcs.ApplyResources(FieldManager, manifests, "setup/*.yaml"),
 				funcs.ResourcesCreatedWithin(30*time.Second, manifests, "setup/*.yaml"),
@@ -402,10 +372,6 @@ func TestPropagateFieldsRemovalToComposed(t *testing.T) {
 				funcs.ResourcesDeletedWithin(2*time.Minute, manifests, "claim.yaml"),
 			)).
 			WithTeardown("DeletePrerequisites", funcs.ResourcesDeletedAfterListedAreGone(3*time.Minute, manifests, "setup/*.yaml", nopList)).
-			WithTeardown("DisableSSAClaims", funcs.AllOf(
-				funcs.AsFeaturesFunc(environment.HelmUpgradeCrossplaneToBase()), // Disable our feature flag.
-				funcs.ReadyToTestWithin(1*time.Minute, namespace),
-			)).
 			Feature(),
 	)
 }
@@ -414,14 +380,11 @@ func TestCompositionSelection(t *testing.T) {
 	manifests := "test/e2e/manifests/apiextensions/composition/composition-selection"
 	environment.Test(t,
 		features.NewWithDescription(t.Name(), "Tests that label selectors in a claim are correctly propagated to the composite resource (XR), ensuring that the appropriate composition is selected and remains consistent even after updates to the label selectors.").
+			WithLabel(LabelStage, LabelStageBeta).
 			WithLabel(LabelArea, LabelAreaAPIExtensions).
 			WithLabel(LabelSize, LabelSizeSmall).
 			WithLabel(LabelModifyCrossplaneInstallation, LabelModifyCrossplaneInstallationTrue).
-			WithLabel(config.LabelTestSuite, SuiteSSAClaims).
-			WithSetup("EnableSSAClaims", funcs.AllOf(
-				funcs.AsFeaturesFunc(environment.HelmUpgradeCrossplaneToSuite(SuiteSSAClaims)),
-				funcs.ReadyToTestWithin(1*time.Minute, namespace),
-			)).
+			WithLabel(config.LabelTestSuite, config.TestSuiteDefault).
 			WithSetup("PrerequisitesAreCreated", funcs.AllOf(
 				funcs.ApplyResources(FieldManager, manifests, "setup/*.yaml"),
 				funcs.ResourcesCreatedWithin(30*time.Second, manifests, "setup/*.yaml"),
@@ -461,10 +424,6 @@ func TestCompositionSelection(t *testing.T) {
 				funcs.ResourcesDeletedWithin(2*time.Minute, manifests, "claim.yaml"),
 			)).
 			WithTeardown("DeletePrerequisites", funcs.ResourcesDeletedAfterListedAreGone(3*time.Minute, manifests, "setup/*.yaml", nopList)).
-			WithTeardown("DisableSSAClaims", funcs.AllOf(
-				funcs.AsFeaturesFunc(environment.HelmUpgradeCrossplaneToBase()), // Disable our feature flag.
-				funcs.ReadyToTestWithin(1*time.Minute, namespace),
-			)).
 			Feature(),
 	)
 }

--- a/test/e2e/config/environment.go
+++ b/test/e2e/config/environment.go
@@ -180,8 +180,8 @@ func (e *Environment) HelmUpgradeCrossplaneToSuite(suite string, extra ...helm.O
 
 // HelmUpgradeCrossplaneToBase returns a features.Func that upgrades crossplane using
 // the specified suite's helm install options.
-func (e *Environment) HelmUpgradeCrossplaneToBase() env.Func {
-	return e.HelmUpgradeCrossplaneToSuite(e.selectedTestSuite.String())
+func (e *Environment) HelmUpgradeCrossplaneToBase(extra ...helm.Option) env.Func {
+	return e.HelmUpgradeCrossplaneToSuite(e.selectedTestSuite.String(), extra...)
 }
 
 // HelmInstallBaseCrossplane returns a features.Func that installs crossplane using

--- a/test/e2e/funcs/feature.go
+++ b/test/e2e/funcs/feature.go
@@ -171,27 +171,27 @@ func DeploymentPodIsRunningMustNotChangeWithin(d time.Duration, namespace, name 
 	}
 }
 
-// ArgSetWithin fails a test if the supplied Deployment does not have a Pod with
-// the given argument set within the supplied duration.
-func ArgSetWithin(d time.Duration, arg, namespace, name string) features.Func {
-	return checkArgSetWithin(d, arg, true, namespace, name)
+// ArgExistsWithin fails a test if the supplied Deployment does not have a Pod with
+// the given argument within the supplied duration.
+func ArgExistsWithin(d time.Duration, arg, namespace, name string) features.Func {
+	return checkArgExistsWithin(d, arg, true, namespace, name)
 }
 
-// ArgUnsetWithin fails a test if the supplied Deployment does not have a Pod with
-// the given argument unset within the supplied duration.
-func ArgUnsetWithin(d time.Duration, arg, namespace, name string) features.Func {
-	return checkArgSetWithin(d, arg, false, namespace, name)
+// ArgNotExistsWithin fails a test if the supplied Deployment does not have a Pod with
+// the given argument not existing within the supplied duration.
+func ArgNotExistsWithin(d time.Duration, arg, namespace, name string) features.Func {
+	return checkArgExistsWithin(d, arg, false, namespace, name)
 }
 
-// checkArgSetWithin implements a check for the supplied Deployment having a Pod
-// with the given argument being either set or unset within the supplied
+// checkArgExistsWithin implements a check for the supplied Deployment having a Pod
+// with the given argument either existing or not existing within the supplied
 // duration.
-func checkArgSetWithin(d time.Duration, arg string, wantSet bool, namespace, name string) features.Func {
+func checkArgExistsWithin(d time.Duration, arg string, wantExist bool, namespace, name string) features.Func {
 	return func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
 		t.Helper()
 
 		dp := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: name}}
-		t.Logf("Waiting %s for pod in deployment %s/%s to have arg %s set=%t...", d, dp.GetNamespace(), dp.GetName(), arg, wantSet)
+		t.Logf("Waiting %s for pod in deployment %s/%s to have arg %s exist=%t...", d, dp.GetNamespace(), dp.GetName(), arg, wantExist)
 		start := time.Now()
 
 		if err := wait.For(func(ctx context.Context) (done bool, err error) {
@@ -210,10 +210,10 @@ func checkArgSetWithin(d time.Duration, arg string, wantSet bool, namespace, nam
 			}
 
 			switch {
-			case wantSet && !found:
+			case wantExist && !found:
 				t.Logf("did not find arg %s within %s", arg, c.Args)
 				return false, nil
-			case !wantSet && found:
+			case !wantExist && found:
 				t.Logf("unexpectedly found arg %s within %s", arg, c.Args)
 				return false, nil
 			default:
@@ -224,7 +224,7 @@ func checkArgSetWithin(d time.Duration, arg string, wantSet bool, namespace, nam
 			return ctx
 		}
 
-		t.Logf("Deployment %s/%s has pod with arg %s set=%t after %s", dp.GetNamespace(), dp.GetName(), arg, wantSet, since(start))
+		t.Logf("Deployment %s/%s has pod with arg %s exist=%t after %s", dp.GetNamespace(), dp.GetName(), arg, wantExist, since(start))
 		return ctx
 	}
 }


### PR DESCRIPTION
### Description of your changes

This PR bumps the claim server side apply functionality to beta, by performing the following actions:

* makes the `--enable-ssa-claims` arg default to `true`
* renames the feature flag to beta
* updates the API promotion guide to remind folks to update feature flags and their docs
* e2e test updates
  * removes the SSA test suite, the default test suite will run with SSA enabled now
  * removes the manual enabling/disabling of SSA in tests, except for the `TestPropagateFieldsRemovalToXRAfterUpgrade` upgrade test which still needs it
  * updates the `ArgSetWithin` helper to `ArgExistsWithin`, since it really is testing for existence of an arg, not it's value

Fixes #5656

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `earthly +reviewable` to ensure this PR is ready for review.
- [ ] ~Added or updated unit tests.~
- [x] Added or updated e2e tests.
- [x] Linked a PR or a [docs tracking issue] to [document this change].
  - https://github.com/crossplane/docs/pull/858
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~
- [x] Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md