### PR TITLE
Remove Successfully composed resources event

### DIFF
--- a/internal/controller/apiextensions/composite/reconciler.go
+++ b/internal/controller/apiextensions/composite/reconciler.go
@@ -640,7 +640,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 		// considered synced (i.e. severe enough to return a ReconcileError) but
 		// they are severe enough that we probably shouldn't say we successfully
 		// composed resources.
-		r.record.Event(xr, event.Normal(reasonCompose, "Successfully composed resources"))
+		log.Debug("Successfully composed resources")
 	}
 
 	var unready []ComposedResource

--- a/internal/controller/apiextensions/composite/reconciler_test.go
+++ b/internal/controller/apiextensions/composite/reconciler_test.go
@@ -749,15 +749,6 @@ func TestReconcile(t *testing.T) {
 								Annotations: map[string]string{},
 							},
 						},
-						eventArgs{
-							Kind: compositeKind,
-							Event: event.Event{
-								Type:        event.Type(corev1.EventTypeNormal),
-								Reason:      "ComposeResources",
-								Message:     "Successfully composed resources",
-								Annotations: map[string]string{},
-							},
-						},
 					)),
 					WithCompositeFinalizer(resource.NewNopFinalizer()),
 					WithCompositionSelector(CompositionSelectorFn(func(_ context.Context, cr resource.Composite) error {
@@ -1102,15 +1093,6 @@ func TestReconcile(t *testing.T) {
 								Annotations: map[string]string{},
 							},
 						},
-						eventArgs{
-							Kind: compositeKind,
-							Event: event.Event{
-								Type:        event.Type(corev1.EventTypeNormal),
-								Reason:      "ComposeResources",
-								Message:     "Successfully composed resources",
-								Annotations: map[string]string{},
-							},
-						},
 					)),
 					WithCompositeFinalizer(resource.NewNopFinalizer()),
 					WithCompositionSelector(CompositionSelectorFn(func(_ context.Context, cr resource.Composite) error {
@@ -1199,15 +1181,6 @@ func TestReconcile(t *testing.T) {
 								Annotations: map[string]string{},
 							},
 						},
-						eventArgs{
-							Kind: compositeKind,
-							Event: event.Event{
-								Type:        event.Type(corev1.EventTypeNormal),
-								Reason:      "ComposeResources",
-								Message:     "Successfully composed resources",
-								Annotations: map[string]string{},
-							},
-						},
 					)),
 					WithCompositeFinalizer(resource.NewNopFinalizer()),
 					WithCompositionSelector(CompositionSelectorFn(func(_ context.Context, cr resource.Composite) error {
@@ -1277,15 +1250,6 @@ func TestReconcile(t *testing.T) {
 								Type:        event.TypeNormal,
 								Reason:      "DatabaseAvailable",
 								Message:     "Pipeline step \"some-function\": This is an event for database availability.",
-								Annotations: map[string]string{},
-							},
-						},
-						eventArgs{
-							Kind: compositeKind,
-							Event: event.Event{
-								Type:        event.Type(corev1.EventTypeNormal),
-								Reason:      "ComposeResources",
-								Message:     "Successfully composed resources",
 								Annotations: map[string]string{},
 							},
 						},


### PR DESCRIPTION
### Description of your changes

This PR is a continuation of the work done by @bobh66 in #6167. I was able to find the time to update the failing unit tests from that PR, but don't have permission to update it and/or push to that fork. After discussing offline with @bobh66, we decided I'd just open a new PR and keep his original commit 😇 

Fixes #6166 
Closes #6167

### How has this been tested

I manually ran through the scenario described in https://github.com/jbw976/demo-xp-layers, particularly [layer 2 - composition](https://github.com/jbw976/demo-xp-layers/tree/main/02-composition).

Example DEBUG log statement that used to be an event:
```
2025-01-29T00:50:47Z	DEBUG	crossplane	Successfully composed resources	{"controller": "defined/compositeresourcedefinition.apiextensions.crossplane.io", "controller": "composite/xnetworks.xp-layers.crossplane.io", "request": {"name":"network-comp-0-bk4dg"}, "uid": "3c66b591-2bce-436b-b96a-5c1373831cd4", "version": "1471", "name": "network-comp-0-bk4dg"}
```

There are no more `Successfully composed resources` events for composite resources:
```
❯ k describe xnetwork.xp-layers.crossplane.io/network-comp-0-bk4dg
...
Events:
  Type     Reason                   Age                 From                                                             Message
  ----     ------                   ----                ----                                                             -------
  Warning  SelectComposition        105s                defined/compositeresourcedefinition.apiextensions.crossplane.io  cannot select Composition: cannot update composite resource: Operation cannot be fulfilled on xnetworks.xp-layers.crossplane.io "network-comp-0-bk4dg": the object has been modified; please apply your changes to the latest version and try again
  Normal   SelectComposition        105s                defined/compositeresourcedefinition.apiextensions.crossplane.io  Successfully selected composition: xp-layers.crossplane.io
  Normal   SelectComposition        105s                defined/compositeresourcedefinition.apiextensions.crossplane.io  Selected composition revision: xp-layers.crossplane.io-f98ccd5
  Normal   PublishConnectionSecret  104s                defined/compositeresourcedefinition.apiextensions.crossplane.io  Successfully published connection details
  Normal   ComposeResources         88s (x4 over 104s)  defined/compositeresourcedefinition.apiextensions.crossplane.io  Composed resource "vpc" is not yet ready
  Normal   ComposeResources         57s (x6 over 104s)  defined/compositeresourcedefinition.apiextensions.crossplane.io  Composed resource "gateway" is not yet ready
```

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `earthly +reviewable` to ensure this PR is ready for review.
- [x] Added or updated unit tests.
- [ ] ~Added or updated e2e tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~
- [ ] ~Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md