### PR TITLE
Use an uncached client to retrieve composed resources not found in the cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,8 @@ cover.out
 /.vendor-new
 .DS_Store
 Zone.Identifier
+.tmp-earthly-out/
+build/
 
 # gitlab example
 # exclude files generate by running the example

--- a/cmd/crossplane/core/core.go
+++ b/cmd/crossplane/core/core.go
@@ -346,7 +346,7 @@ func (c *startCommand) Run(s *runtime.Scheme, log logging.Logger) error { //noli
 		log.Info("API extensions cache stopped")
 	}()
 
-	cl, err := client.New(mgr.GetConfig(), client.Options{
+	cached, err := client.New(mgr.GetConfig(), client.Options{
 		HTTPClient: mgr.GetHTTPClient(),
 		Scheme:     mgr.GetScheme(),
 		Mapper:     mgr.GetRESTMapper(),
@@ -366,13 +366,13 @@ func (c *startCommand) Run(s *runtime.Scheme, log logging.Logger) error { //noli
 
 	// Create a separate no-cache client for use when the composite controller does not find an Unstructured
 	// resource that it expects to find in the cache.
-	nccl, err := client.New(mgr.GetConfig(), client.Options{
+	uncached, err := client.New(mgr.GetConfig(), client.Options{
 		HTTPClient: mgr.GetHTTPClient(),
 		Scheme:     mgr.GetScheme(),
 		Mapper:     mgr.GetRESTMapper(),
 	})
 	if err != nil {
-		return errors.Wrap(err, "cannot create no-cache client for API extension controllers")
+		return errors.Wrap(err, "cannot create uncached client for API extension controllers")
 	}
 
 	// It's important the engine's client is wrapped with unstructured.NewClient
@@ -381,8 +381,8 @@ func (c *startCommand) Run(s *runtime.Scheme, log logging.Logger) error { //noli
 	// automatically wrapping and unwrapping *unstructured.Unstructured.
 	ce := engine.New(mgr,
 		engine.TrackInformers(ca, mgr.GetScheme()),
-		unstructured.NewClient(cl),
-		unstructured.NewClient(nccl),
+		unstructured.NewClient(cached),
+		unstructured.NewClient(uncached),
 		engine.WithLogger(log),
 	)
 

--- a/cmd/crossplane/core/core.go
+++ b/cmd/crossplane/core/core.go
@@ -356,8 +356,10 @@ func (c *startCommand) Run(s *runtime.Scheme, log logging.Logger) error { //noli
 			// Don't cache secrets - there may be a lot of them.
 			DisableFor: []client.Object{&corev1.Secret{}},
 
-			// Cache unstructured resources (like XRs and MRs) on Get and List.
-			Unstructured: true,
+			// Do not cache unstructured resources (like XRs and MRs) on Get and List.
+			// Stale caches can cause Crossplane to leak resources.
+			// See https://github.com/crossplane/crossplane/issues/6260
+			Unstructured: false,
 		},
 	})
 	if err != nil {

--- a/internal/controller/apiextensions/composite/composition_functions.go
+++ b/internal/controller/apiextensions/composite/composition_functions.go
@@ -217,7 +217,7 @@ func WithManagedFieldsUpgrader(u ManagedFieldsUpgrader) FunctionComposerOption {
 
 // NewFunctionComposer returns a new Composer that supports composing resources using
 // both Patch and Transform (P&T) logic and a pipeline of Composition Functions.
-func NewFunctionComposer(kube client.Client, r FunctionRunner, o ...FunctionComposerOption) *FunctionComposer {
+func NewFunctionComposer(kube client.Client, nckube client.Client, r FunctionRunner, o ...FunctionComposerOption) *FunctionComposer {
 	f := NewSecretConnectionDetailsFetcher(kube)
 
 	c := &FunctionComposer{
@@ -225,7 +225,7 @@ func NewFunctionComposer(kube client.Client, r FunctionRunner, o ...FunctionComp
 
 		composite: xr{
 			ConnectionDetailsFetcher:         f,
-			ComposedResourceObserver:         NewExistingComposedResourceObserver(kube, f),
+			ComposedResourceObserver:         NewExistingComposedResourceObserver(kube, nckube, f),
 			ComposedResourceGarbageCollector: NewDeletingComposedResourceGarbageCollector(kube),
 			NameGenerator:                    names.NewNameGenerator(kube),
 			ManagedFieldsUpgrader:            NewPatchingManagedFieldsUpgrader(kube),
@@ -580,14 +580,15 @@ func ComposedFieldOwnerName(xr *composite.Unstructured) string {
 // any existing composed resources from the API server. It also loads their
 // connection details.
 type ExistingComposedResourceObserver struct {
-	resource client.Reader
-	details  managed.ConnectionDetailsFetcher
+	resource   client.Reader
+	ncresource client.Reader
+	details    managed.ConnectionDetailsFetcher
 }
 
 // NewExistingComposedResourceObserver returns a ComposedResourceGetter that
 // fetches an XR's existing composed resources.
-func NewExistingComposedResourceObserver(c client.Reader, f managed.ConnectionDetailsFetcher) *ExistingComposedResourceObserver {
-	return &ExistingComposedResourceObserver{resource: c, details: f}
+func NewExistingComposedResourceObserver(c client.Reader, uc client.Reader, f managed.ConnectionDetailsFetcher) *ExistingComposedResourceObserver {
+	return &ExistingComposedResourceObserver{resource: c, ncresource: uc, details: f}
 }
 
 // ObserveComposedResources begins building composed resource state by
@@ -615,8 +616,12 @@ func (g *ExistingComposedResourceObserver) ObserveComposedResources(ctx context.
 		nn := types.NamespacedName{Namespace: ref.Namespace, Name: ref.Name}
 		err := g.resource.Get(ctx, nn, r)
 		if kerrors.IsNotFound(err) {
-			// We believe we created this resource, but it doesn't exist.
-			continue
+			// We believe we created this resource, but it is not in the cache yet?  Try again without the cache.
+			err = g.ncresource.Get(ctx, nn, r)
+			if kerrors.IsNotFound(err) {
+				// We believe we created this resource, but it no longer exists.
+				continue
+			}
 		}
 		if err != nil {
 			return nil, errors.Wrap(err, errGetComposed)

--- a/internal/controller/apiextensions/composite/composition_pt.go
+++ b/internal/controller/apiextensions/composite/composition_pt.go
@@ -125,15 +125,15 @@ type PTComposer struct {
 
 // NewPTComposer returns a Composer that composes resources using Patch and
 // Transform (P&T) Composition - a Composition's bases, patches, and transforms.
-func NewPTComposer(kube client.Client, nckube client.Client, o ...PTComposerOption) *PTComposer {
+func NewPTComposer(cached, uncached client.Client, o ...PTComposerOption) *PTComposer {
 	c := &PTComposer{
-		client: resource.ClientApplicator{Client: kube, Applicator: resource.NewAPIPatchingApplicator(kube)},
+		client: resource.ClientApplicator{Client: cached, Applicator: resource.NewAPIPatchingApplicator(cached)},
 
-		composition: NewGarbageCollectingAssociator(kube, nckube),
+		composition: NewGarbageCollectingAssociator(cached, uncached),
 		composed: composedResource{
-			NameGenerator:              names.NewNameGenerator(kube),
+			NameGenerator:              names.NewNameGenerator(cached),
 			ReadinessChecker:           ReadinessCheckerFn(IsReady),
-			ConnectionDetailsFetcher:   NewSecretConnectionDetailsFetcher(kube),
+			ConnectionDetailsFetcher:   NewSecretConnectionDetailsFetcher(cached),
 			ConnectionDetailsExtractor: ConnectionDetailsExtractorFn(ExtractConnectionDetails),
 		},
 	}
@@ -442,14 +442,14 @@ func (fn CompositionTemplateAssociatorFn) AssociateTemplates(ctx context.Context
 // that corresponds to a non-existent template the resource will be garbage
 // collected (i.e. deleted).
 type GarbageCollectingAssociator struct {
-	client   client.Client
-	ncclient client.Client
+	cached   client.Client
+	uncached client.Client
 }
 
 // NewGarbageCollectingAssociator returns a CompositionTemplateAssociator that
 // may garbage collect composed resources.
-func NewGarbageCollectingAssociator(c client.Client, nc client.Client) *GarbageCollectingAssociator {
-	return &GarbageCollectingAssociator{client: c, ncclient: nc}
+func NewGarbageCollectingAssociator(c, uc client.Client) *GarbageCollectingAssociator {
+	return &GarbageCollectingAssociator{cached: c, uncached: uc}
 }
 
 // AssociateTemplates with composed resources.
@@ -477,11 +477,11 @@ func (a *GarbageCollectingAssociator) AssociateTemplates(ctx context.Context, cr
 		}
 		cd := composed.New(composed.FromReference(ref))
 		nn := types.NamespacedName{Namespace: ref.Namespace, Name: ref.Name}
-		err := a.client.Get(ctx, nn, cd)
+		err := a.cached.Get(ctx, nn, cd)
 
 		if kerrors.IsNotFound(err) {
 			// We believe we created this resource, but it is not in the cache yet?  Try again without the cache.
-			err = a.ncclient.Get(ctx, nn, cd)
+			err = a.uncached.Get(ctx, nn, cd)
 			if kerrors.IsNotFound(err) {
 				// We believe we created this resource, but it no longer exists.
 				continue
@@ -531,11 +531,11 @@ func (a *GarbageCollectingAssociator) AssociateTemplates(ctx context.Context, cr
 		// Composition. This helps differentiate whether a resource was deleted
 		// due to garbage collection or because its owning composite was deleted.
 		meta.RemoveLabels(cd, xcrd.LabelKeyNamePrefixForComposed, xcrd.LabelKeyClaimName, xcrd.LabelKeyClaimNamespace)
-		if err := a.client.Update(ctx, cd); resource.IgnoreNotFound(err) != nil {
+		if err := a.cached.Update(ctx, cd); resource.IgnoreNotFound(err) != nil {
 			return nil, errors.Wrap(err, errGCCleanupLabels)
 		}
 		// Delete the composed resource.
-		if err := a.client.Delete(ctx, cd); resource.IgnoreNotFound(err) != nil {
+		if err := a.cached.Delete(ctx, cd); resource.IgnoreNotFound(err) != nil {
 			return nil, errors.Wrap(err, errGCComposed)
 		}
 	}

--- a/internal/controller/apiextensions/composite/composition_pt_test.go
+++ b/internal/controller/apiextensions/composite/composition_pt_test.go
@@ -50,9 +50,9 @@ func TestPTCompose(t *testing.T) {
 	base := runtime.RawExtension{Raw: []byte(`{"apiVersion":"test.crossplane.io/v1","kind":"ComposedResource"}`)}
 
 	type params struct {
-		kube   client.Client
-		nckube client.Client
-		o      []PTComposerOption
+		c  client.Client
+		uc client.Client
+		o  []PTComposerOption
 	}
 	type args struct {
 		ctx context.Context
@@ -150,10 +150,10 @@ func TestPTCompose(t *testing.T) {
 		"UpdateCompositeError": {
 			reason: "We should return any error encountered while updating our composite resource with references.",
 			params: params{
-				kube: &test.MockClient{
+				c: &test.MockClient{
 					MockUpdate: test.NewMockUpdateFn(errBoom),
 				},
-				nckube: &test.MockClient{
+				uc: &test.MockClient{
 					MockUpdate: test.NewMockUpdateFn(errBoom),
 				},
 				o: []PTComposerOption{
@@ -182,13 +182,13 @@ func TestPTCompose(t *testing.T) {
 		"ApplyComposedError": {
 			reason: "We should return any error encountered while applying a composed resource.",
 			params: params{
-				kube: &test.MockClient{
+				c: &test.MockClient{
 					MockUpdate: test.NewMockUpdateFn(nil),
 
 					// Apply calls Create because GenerateName is set.
 					MockCreate: test.NewMockCreateFn(errBoom),
 				},
-				nckube: &test.MockClient{
+				uc: &test.MockClient{
 					MockUpdate: test.NewMockUpdateFn(errBoom),
 				},
 				o: []PTComposerOption{
@@ -217,13 +217,13 @@ func TestPTCompose(t *testing.T) {
 		"FetchConnectionDetailsError": {
 			reason: "We should return any error encountered while fetching a composed resource's connection details.",
 			params: params{
-				kube: &test.MockClient{
+				c: &test.MockClient{
 					MockUpdate: test.NewMockUpdateFn(nil),
 
 					// Apply calls Create because GenerateName is set.
 					MockCreate: test.NewMockCreateFn(nil),
 				},
-				nckube: &test.MockClient{
+				uc: &test.MockClient{
 					MockUpdate: test.NewMockUpdateFn(errBoom),
 				},
 				o: []PTComposerOption{
@@ -255,13 +255,13 @@ func TestPTCompose(t *testing.T) {
 		"ExtractConnectionDetailsError": {
 			reason: "We should return any error encountered while extracting a composed resource's connection details.",
 			params: params{
-				kube: &test.MockClient{
+				c: &test.MockClient{
 					MockUpdate: test.NewMockUpdateFn(nil),
 
 					// Apply calls Create because GenerateName is set.
 					MockCreate: test.NewMockCreateFn(nil),
 				},
-				nckube: &test.MockClient{
+				uc: &test.MockClient{
 					MockUpdate: test.NewMockUpdateFn(errBoom),
 				},
 				o: []PTComposerOption{
@@ -296,13 +296,13 @@ func TestPTCompose(t *testing.T) {
 		"CheckReadinessError": {
 			reason: "We should return any error encountered while checking whether a composed resource is ready.",
 			params: params{
-				kube: &test.MockClient{
+				c: &test.MockClient{
 					MockUpdate: test.NewMockUpdateFn(nil),
 
 					// Apply calls Create because GenerateName is set.
 					MockCreate: test.NewMockCreateFn(nil),
 				},
-				nckube: &test.MockClient{
+				uc: &test.MockClient{
 					MockUpdate: test.NewMockUpdateFn(errBoom),
 				},
 				o: []PTComposerOption{
@@ -340,7 +340,7 @@ func TestPTCompose(t *testing.T) {
 		"CompositeApplyError": {
 			reason: "We should return any error encountered while applying the Composite.",
 			params: params{
-				kube: &test.MockClient{
+				c: &test.MockClient{
 					MockUpdate: test.NewMockUpdateFn(nil),
 
 					// Apply calls Get and Patch. We won't hit this for any
@@ -349,7 +349,7 @@ func TestPTCompose(t *testing.T) {
 					MockGet:   test.NewMockGetFn(errBoom),
 					MockPatch: test.NewMockPatchFn(nil),
 				},
-				nckube: &test.MockClient{
+				uc: &test.MockClient{
 					MockUpdate: test.NewMockUpdateFn(errBoom),
 				},
 				o: []PTComposerOption{
@@ -371,7 +371,7 @@ func TestPTCompose(t *testing.T) {
 		"Success": {
 			reason: "We should return the resources we composed, and our derived connection details.",
 			params: params{
-				kube: &test.MockClient{
+				c: &test.MockClient{
 					MockUpdate: test.NewMockUpdateFn(nil),
 
 					// Apply uses Get, Create, and Patch.
@@ -379,7 +379,7 @@ func TestPTCompose(t *testing.T) {
 					MockCreate: test.NewMockCreateFn(nil),
 					MockPatch:  test.NewMockPatchFn(nil),
 				},
-				nckube: &test.MockClient{
+				uc: &test.MockClient{
 					MockUpdate: test.NewMockUpdateFn(errBoom),
 				},
 				o: []PTComposerOption{
@@ -424,7 +424,7 @@ func TestPTCompose(t *testing.T) {
 		"PartialSuccess": {
 			reason: "We should return the resources we composed, and our derived connection details. We should return events for any resources we couldn't compose",
 			params: params{
-				kube: &test.MockClient{
+				c: &test.MockClient{
 					MockUpdate: test.NewMockUpdateFn(nil),
 
 					// Apply uses Get, Create, and Patch.
@@ -432,7 +432,7 @@ func TestPTCompose(t *testing.T) {
 					MockCreate: test.NewMockCreateFn(nil),
 					MockPatch:  test.NewMockPatchFn(nil),
 				},
-				nckube: &test.MockClient{
+				uc: &test.MockClient{
 					MockUpdate: test.NewMockUpdateFn(errBoom),
 				},
 				o: []PTComposerOption{
@@ -506,7 +506,7 @@ func TestPTCompose(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			c := NewPTComposer(tc.params.kube, tc.params.nckube, tc.params.o...)
+			c := NewPTComposer(tc.params.c, tc.params.uc, tc.params.o...)
 			res, err := c.Compose(tc.args.ctx, tc.args.xr, tc.args.req)
 
 			if diff := cmp.Diff(tc.want.res, res, cmpopts.EquateEmpty()); diff != "" {
@@ -597,7 +597,7 @@ func TestGarbageCollectingAssociator(t *testing.T) {
 	cases := map[string]struct {
 		reason string
 		c      client.Client
-		nc     client.Client
+		uc     client.Client
 		args   args
 		want   want
 	}{
@@ -616,7 +616,7 @@ func TestGarbageCollectingAssociator(t *testing.T) {
 			c: &test.MockClient{
 				MockGet: test.NewMockGetFn(kerrors.NewNotFound(schema.GroupResource{}, "")),
 			},
-			nc: &test.MockClient{
+			uc: &test.MockClient{
 				MockGet: test.NewMockGetFn(kerrors.NewNotFound(schema.GroupResource{}, "")),
 			},
 			args: args{
@@ -634,7 +634,7 @@ func TestGarbageCollectingAssociator(t *testing.T) {
 			c: &test.MockClient{
 				MockGet: test.NewMockGetFn(errBoom),
 			},
-			nc: &test.MockClient{
+			uc: &test.MockClient{
 				MockGet: test.NewMockGetFn(kerrors.NewNotFound(schema.GroupResource{}, "")),
 			},
 			args: args{
@@ -653,7 +653,7 @@ func TestGarbageCollectingAssociator(t *testing.T) {
 				// Return an empty (and thus unannotated) composed resource.
 				MockGet: test.NewMockGetFn(nil),
 			},
-			nc: &test.MockClient{
+			uc: &test.MockClient{
 				MockGet: test.NewMockGetFn(kerrors.NewNotFound(schema.GroupResource{}, "")),
 			},
 			args: args{
@@ -674,7 +674,7 @@ func TestGarbageCollectingAssociator(t *testing.T) {
 					return nil
 				}),
 			},
-			nc: &test.MockClient{
+			uc: &test.MockClient{
 				MockGet: test.NewMockGetFn(kerrors.NewNotFound(schema.GroupResource{}, "")),
 			},
 			args: args{
@@ -706,7 +706,7 @@ func TestGarbageCollectingAssociator(t *testing.T) {
 					return nil
 				}),
 			},
-			nc: &test.MockClient{
+			uc: &test.MockClient{
 				MockGet: test.NewMockGetFn(kerrors.NewNotFound(schema.GroupResource{}, "")),
 			},
 			args: args{
@@ -733,7 +733,7 @@ func TestGarbageCollectingAssociator(t *testing.T) {
 				MockUpdate: test.NewMockUpdateFn(nil),
 				MockDelete: test.NewMockDeleteFn(nil),
 			},
-			nc: &test.MockClient{
+			uc: &test.MockClient{
 				MockGet: test.NewMockGetFn(kerrors.NewNotFound(schema.GroupResource{}, "")),
 			},
 			args: args{
@@ -766,7 +766,7 @@ func TestGarbageCollectingAssociator(t *testing.T) {
 				MockUpdate: test.NewMockUpdateFn(nil),
 				MockDelete: test.NewMockDeleteFn(errBoom),
 			},
-			nc: &test.MockClient{
+			uc: &test.MockClient{
 				MockGet: test.NewMockGetFn(kerrors.NewNotFound(schema.GroupResource{}, "")),
 			},
 			args: args{
@@ -811,7 +811,7 @@ func TestGarbageCollectingAssociator(t *testing.T) {
 				},
 				MockDelete: test.NewMockDeleteFn(nil),
 			},
-			nc: &test.MockClient{
+			uc: &test.MockClient{
 				MockGet: test.NewMockGetFn(kerrors.NewNotFound(schema.GroupResource{}, "")),
 			},
 			args: args{
@@ -829,7 +829,7 @@ func TestGarbageCollectingAssociator(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			a := NewGarbageCollectingAssociator(tc.c, tc.nc)
+			a := NewGarbageCollectingAssociator(tc.c, tc.uc)
 			got, err := a.AssociateTemplates(tc.args.ctx, tc.args.cr, tc.args.ct)
 
 			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {

--- a/internal/controller/apiextensions/composite/reconciler.go
+++ b/internal/controller/apiextensions/composite/reconciler.go
@@ -380,7 +380,7 @@ type compositeResource struct {
 }
 
 // NewReconciler returns a new Reconciler of composite resources.
-func NewReconciler(c client.Client, nc client.Client, of resource.CompositeKind, opts ...ReconcilerOption) *Reconciler {
+func NewReconciler(c, uc client.Client, of resource.CompositeKind, opts ...ReconcilerOption) *Reconciler {
 	r := &Reconciler{
 		client: c,
 
@@ -412,7 +412,7 @@ func NewReconciler(c client.Client, nc client.Client, of resource.CompositeKind,
 			ConnectionPublisher: NewAPIFilteredSecretPublisher(c, []string{}),
 		},
 
-		resource: NewPTComposer(c, nc),
+		resource: NewPTComposer(c, uc),
 
 		// Dynamic watches are disabled by default.
 		engine: &NopWatchStarter{},

--- a/internal/controller/apiextensions/composite/reconciler.go
+++ b/internal/controller/apiextensions/composite/reconciler.go
@@ -380,7 +380,7 @@ type compositeResource struct {
 }
 
 // NewReconciler returns a new Reconciler of composite resources.
-func NewReconciler(c client.Client, of resource.CompositeKind, opts ...ReconcilerOption) *Reconciler {
+func NewReconciler(c client.Client, nc client.Client, of resource.CompositeKind, opts ...ReconcilerOption) *Reconciler {
 	r := &Reconciler{
 		client: c,
 
@@ -412,7 +412,7 @@ func NewReconciler(c client.Client, of resource.CompositeKind, opts ...Reconcile
 			ConnectionPublisher: NewAPIFilteredSecretPublisher(c, []string{}),
 		},
 
-		resource: NewPTComposer(c),
+		resource: NewPTComposer(c, nc),
 
 		// Dynamic watches are disabled by default.
 		engine: &NopWatchStarter{},
@@ -433,8 +433,7 @@ func NewReconciler(c client.Client, of resource.CompositeKind, opts ...Reconcile
 // A Reconciler reconciles composite resources.
 type Reconciler struct {
 	client client.Client
-
-	gvk schema.GroupVersionKind
+	gvk    schema.GroupVersionKind
 
 	revision  revision
 	composite compositeResource

--- a/internal/controller/apiextensions/composite/reconciler_test.go
+++ b/internal/controller/apiextensions/composite/reconciler_test.go
@@ -55,9 +55,10 @@ func TestReconcile(t *testing.T) {
 	cd := managed.ConnectionDetails{"a": []byte("b")}
 
 	type args struct {
-		client client.Client
-		of     resource.CompositeKind
-		opts   []ReconcilerOption
+		client   client.Client
+		ncclient client.Client
+		of       resource.CompositeKind
+		opts     []ReconcilerOption
 	}
 	type want struct {
 		r   reconcile.Result
@@ -77,6 +78,9 @@ func TestReconcile(t *testing.T) {
 				client: &test.MockClient{
 					MockGet: test.NewMockGetFn(kerrors.NewNotFound(schema.GroupResource{}, "")),
 				},
+				ncclient: &test.MockClient{
+					MockGet: test.NewMockGetFn(kerrors.NewNotFound(schema.GroupResource{}, "")),
+				},
 			},
 			want: want{
 				r: reconcile.Result{Requeue: false},
@@ -87,6 +91,9 @@ func TestReconcile(t *testing.T) {
 			args: args{
 				client: &test.MockClient{
 					MockGet: test.NewMockGetFn(errBoom),
+				},
+				ncclient: &test.MockClient{
+					MockGet: test.NewMockGetFn(kerrors.NewNotFound(schema.GroupResource{}, "")),
 				},
 			},
 			want: want{
@@ -104,6 +111,9 @@ func TestReconcile(t *testing.T) {
 						want.SetDeletionTimestamp(&now)
 						want.SetConditions(xpv1.Deleting(), xpv1.ReconcileError(errors.Wrap(errBoom, errUnpublish)))
 					})),
+				},
+				ncclient: &test.MockClient{
+					MockGet: test.NewMockGetFn(kerrors.NewNotFound(schema.GroupResource{}, "")),
 				},
 				opts: []ReconcilerOption{
 					WithCompositeFinalizer(resource.NewNopFinalizer()),
@@ -129,6 +139,9 @@ func TestReconcile(t *testing.T) {
 						cr.SetDeletionTimestamp(&now)
 						cr.SetConditions(xpv1.Deleting(), xpv1.ReconcileError(errors.Wrap(errBoom, errRemoveFinalizer)))
 					})),
+				},
+				ncclient: &test.MockClient{
+					MockGet: test.NewMockGetFn(kerrors.NewNotFound(schema.GroupResource{}, "")),
 				},
 				opts: []ReconcilerOption{
 					WithCompositeFinalizer(resource.FinalizerFns{
@@ -159,6 +172,9 @@ func TestReconcile(t *testing.T) {
 						cr.SetConditions(xpv1.Deleting(), xpv1.ReconcileSuccess())
 					})),
 				},
+				ncclient: &test.MockClient{
+					MockGet: test.NewMockGetFn(kerrors.NewNotFound(schema.GroupResource{}, "")),
+				},
 				opts: []ReconcilerOption{
 					WithCompositeFinalizer(resource.FinalizerFns{
 						RemoveFinalizerFn: func(_ context.Context, _ resource.Object) error {
@@ -185,6 +201,9 @@ func TestReconcile(t *testing.T) {
 						cr.SetConditions(xpv1.ReconcileError(errors.Wrap(errBoom, errAddFinalizer)))
 					})),
 				},
+				ncclient: &test.MockClient{
+					MockGet: test.NewMockGetFn(kerrors.NewNotFound(schema.GroupResource{}, "")),
+				},
 				opts: []ReconcilerOption{
 					WithCompositeFinalizer(resource.FinalizerFns{
 						AddFinalizerFn: func(_ context.Context, _ resource.Object) error {
@@ -206,6 +225,9 @@ func TestReconcile(t *testing.T) {
 						cr.SetConditions(xpv1.ReconcileError(errors.Wrap(errBoom, errSelectComp)))
 					})),
 				},
+				ncclient: &test.MockClient{
+					MockGet: test.NewMockGetFn(kerrors.NewNotFound(schema.GroupResource{}, "")),
+				},
 				opts: []ReconcilerOption{
 					WithCompositeFinalizer(resource.NewNopFinalizer()),
 					WithCompositionSelector(CompositionSelectorFn(func(_ context.Context, _ resource.Composite) error {
@@ -226,6 +248,9 @@ func TestReconcile(t *testing.T) {
 						cr.SetCompositionReference(&corev1.ObjectReference{})
 						cr.SetConditions(xpv1.ReconcileError(errors.Wrap(errBoom, errFetchComp)))
 					})),
+				},
+				ncclient: &test.MockClient{
+					MockGet: test.NewMockGetFn(kerrors.NewNotFound(schema.GroupResource{}, "")),
 				},
 				opts: []ReconcilerOption{
 					WithCompositeFinalizer(resource.NewNopFinalizer()),
@@ -251,6 +276,9 @@ func TestReconcile(t *testing.T) {
 						cr.SetCompositionReference(&corev1.ObjectReference{})
 						cr.SetConditions(xpv1.ReconcileError(errors.Wrap(errBoom, errValidate)))
 					})),
+				},
+				ncclient: &test.MockClient{
+					MockGet: test.NewMockGetFn(kerrors.NewNotFound(schema.GroupResource{}, "")),
 				},
 				opts: []ReconcilerOption{
 					WithCompositeFinalizer(resource.NewNopFinalizer()),
@@ -280,6 +308,9 @@ func TestReconcile(t *testing.T) {
 						cr.SetConditions(xpv1.ReconcileError(errors.Wrap(errBoom, errConfigure)))
 					})),
 				},
+				ncclient: &test.MockClient{
+					MockGet: test.NewMockGetFn(kerrors.NewNotFound(schema.GroupResource{}, "")),
+				},
 				opts: []ReconcilerOption{
 					WithCompositeFinalizer(resource.NewNopFinalizer()),
 					WithCompositionSelector(CompositionSelectorFn(func(_ context.Context, cr resource.Composite) error {
@@ -308,6 +339,9 @@ func TestReconcile(t *testing.T) {
 						cr.SetCompositionReference(&corev1.ObjectReference{})
 						cr.SetConditions(xpv1.ReconcileError(errors.Wrap(errBoom, errCompose)))
 					})),
+				},
+				ncclient: &test.MockClient{
+					MockGet: test.NewMockGetFn(kerrors.NewNotFound(schema.GroupResource{}, "")),
 				},
 				opts: []ReconcilerOption{
 					WithCompositeFinalizer(resource.NewNopFinalizer()),
@@ -340,6 +374,9 @@ func TestReconcile(t *testing.T) {
 						cr.SetCompositionReference(&corev1.ObjectReference{})
 						cr.SetConditions(xpv1.ReconcileError(errors.Wrap(errBoom, errPublish)))
 					})),
+				},
+				ncclient: &test.MockClient{
+					MockGet: test.NewMockGetFn(kerrors.NewNotFound(schema.GroupResource{}, "")),
 				},
 				opts: []ReconcilerOption{
 					WithCompositeFinalizer(resource.NewNopFinalizer()),
@@ -377,6 +414,9 @@ func TestReconcile(t *testing.T) {
 						xr.SetCompositionReference(&corev1.ObjectReference{})
 						xr.SetConditions(xpv1.ReconcileSuccess(), xpv1.Available())
 					})),
+				},
+				ncclient: &test.MockClient{
+					MockGet: test.NewMockGetFn(kerrors.NewNotFound(schema.GroupResource{}, "")),
 				},
 				opts: []ReconcilerOption{
 					WithCompositeFinalizer(resource.NewNopFinalizer()),
@@ -424,6 +464,9 @@ func TestReconcile(t *testing.T) {
 						cr.SetCompositionReference(&corev1.ObjectReference{})
 						cr.SetConditions(xpv1.ReconcileSuccess(), xpv1.Creating().WithMessage("Unready resources: cat, cow, elephant, and 1 more"))
 					})),
+				},
+				ncclient: &test.MockClient{
+					MockGet: test.NewMockGetFn(kerrors.NewNotFound(schema.GroupResource{}, "")),
 				},
 				opts: []ReconcilerOption{
 					WithCompositeFinalizer(resource.NewNopFinalizer()),
@@ -500,6 +543,9 @@ func TestReconcile(t *testing.T) {
 						cr.SetConditions(xpv1.ReconcileSuccess(), xpv1.Available())
 						cr.SetConnectionDetailsLastPublishedTime(&now)
 					})),
+				},
+				ncclient: &test.MockClient{
+					MockGet: test.NewMockGetFn(kerrors.NewNotFound(schema.GroupResource{}, "")),
 				},
 				opts: []ReconcilerOption{
 					WithCompositeFinalizer(resource.NewNopFinalizer()),
@@ -594,6 +640,9 @@ func TestReconcile(t *testing.T) {
 						cr.SetCompositionReference(&corev1.ObjectReference{})
 					})),
 				},
+				ncclient: &test.MockClient{
+					MockGet: test.NewMockGetFn(kerrors.NewNotFound(schema.GroupResource{}, "")),
+				},
 				opts: []ReconcilerOption{
 					WithCompositeFinalizer(resource.NewNopFinalizer()),
 					WithCompositionSelector(CompositionSelectorFn(func(_ context.Context, cr resource.Composite) error {
@@ -638,6 +687,9 @@ func TestReconcile(t *testing.T) {
 						cr.SetConnectionDetailsLastPublishedTime(&now)
 						cr.SetCompositionReference(&corev1.ObjectReference{})
 					})),
+				},
+				ncclient: &test.MockClient{
+					MockGet: test.NewMockGetFn(kerrors.NewNotFound(schema.GroupResource{}, "")),
 				},
 				opts: []ReconcilerOption{
 					WithCompositeFinalizer(resource.NewNopFinalizer()),
@@ -708,6 +760,9 @@ func TestReconcile(t *testing.T) {
 						cr.(*composite.Unstructured).SetClaimConditionTypes("DatabaseReady")
 						cr.SetClaimReference(&reference.Claim{})
 					})),
+				},
+				ncclient: &test.MockClient{
+					MockGet: test.NewMockGetFn(kerrors.NewNotFound(schema.GroupResource{}, "")),
 				},
 				opts: []ReconcilerOption{
 					WithRecorder(newTestRecorder(
@@ -876,6 +931,9 @@ func TestReconcile(t *testing.T) {
 						)
 						cr.SetClaimReference(&reference.Claim{})
 					})),
+				},
+				ncclient: &test.MockClient{
+					MockGet: test.NewMockGetFn(kerrors.NewNotFound(schema.GroupResource{}, "")),
 				},
 				opts: []ReconcilerOption{
 					WithRecorder(newTestRecorder(
@@ -1082,6 +1140,9 @@ func TestReconcile(t *testing.T) {
 						cr.SetClaimReference(&reference.Claim{})
 					})),
 				},
+				ncclient: &test.MockClient{
+					MockGet: test.NewMockGetFn(kerrors.NewNotFound(schema.GroupResource{}, "")),
+				},
 				opts: []ReconcilerOption{
 					WithRecorder(newTestRecorder(
 						eventArgs{
@@ -1170,6 +1231,9 @@ func TestReconcile(t *testing.T) {
 						cr.SetClaimReference(&reference.Claim{})
 					})),
 				},
+				ncclient: &test.MockClient{
+					MockGet: test.NewMockGetFn(kerrors.NewNotFound(schema.GroupResource{}, "")),
+				},
 				opts: []ReconcilerOption{
 					WithRecorder(newTestRecorder(
 						eventArgs{
@@ -1233,6 +1297,9 @@ func TestReconcile(t *testing.T) {
 						cr.SetClaimReference(&reference.Claim{})
 					})),
 				},
+				ncclient: &test.MockClient{
+					MockGet: test.NewMockGetFn(kerrors.NewNotFound(schema.GroupResource{}, "")),
+				},
 				opts: []ReconcilerOption{
 					WithRecorder(newTestRecorder(
 						eventArgs{
@@ -1294,7 +1361,7 @@ func TestReconcile(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			r := NewReconciler(tc.args.client, tc.args.of, tc.args.opts...)
+			r := NewReconciler(tc.args.client, tc.args.ncclient, tc.args.of, tc.args.opts...)
 			got, err := r.Reconcile(context.Background(), reconcile.Request{})
 
 			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {

--- a/internal/controller/apiextensions/composite/reconciler_test.go
+++ b/internal/controller/apiextensions/composite/reconciler_test.go
@@ -55,10 +55,10 @@ func TestReconcile(t *testing.T) {
 	cd := managed.ConnectionDetails{"a": []byte("b")}
 
 	type args struct {
-		client   client.Client
-		ncclient client.Client
-		of       resource.CompositeKind
-		opts     []ReconcilerOption
+		c    client.Client
+		uc   client.Client
+		of   resource.CompositeKind
+		opts []ReconcilerOption
 	}
 	type want struct {
 		r   reconcile.Result
@@ -75,10 +75,10 @@ func TestReconcile(t *testing.T) {
 		"CompositeResourceNotFound": {
 			reason: "We should not return an error if the composite resource was not found.",
 			args: args{
-				client: &test.MockClient{
+				c: &test.MockClient{
 					MockGet: test.NewMockGetFn(kerrors.NewNotFound(schema.GroupResource{}, "")),
 				},
-				ncclient: &test.MockClient{
+				uc: &test.MockClient{
 					MockGet: test.NewMockGetFn(kerrors.NewNotFound(schema.GroupResource{}, "")),
 				},
 			},
@@ -89,10 +89,10 @@ func TestReconcile(t *testing.T) {
 		"GetCompositeResourceError": {
 			reason: "We should return error encountered while getting the composite resource.",
 			args: args{
-				client: &test.MockClient{
+				c: &test.MockClient{
 					MockGet: test.NewMockGetFn(errBoom),
 				},
-				ncclient: &test.MockClient{
+				uc: &test.MockClient{
 					MockGet: test.NewMockGetFn(kerrors.NewNotFound(schema.GroupResource{}, "")),
 				},
 			},
@@ -103,7 +103,7 @@ func TestReconcile(t *testing.T) {
 		"UnpublishConnectionError": {
 			reason: "We should return any error encountered while unpublishing connection details.",
 			args: args{
-				client: &test.MockClient{
+				c: &test.MockClient{
 					MockGet: WithComposite(t, NewComposite(func(cr resource.Composite) {
 						cr.SetDeletionTimestamp(&now)
 					})),
@@ -112,7 +112,7 @@ func TestReconcile(t *testing.T) {
 						want.SetConditions(xpv1.Deleting(), xpv1.ReconcileError(errors.Wrap(errBoom, errUnpublish)))
 					})),
 				},
-				ncclient: &test.MockClient{
+				uc: &test.MockClient{
 					MockGet: test.NewMockGetFn(kerrors.NewNotFound(schema.GroupResource{}, "")),
 				},
 				opts: []ReconcilerOption{
@@ -131,7 +131,7 @@ func TestReconcile(t *testing.T) {
 		"RemoveFinalizerError": {
 			reason: "We should return any error encountered while removing finalizer.",
 			args: args{
-				client: &test.MockClient{
+				c: &test.MockClient{
 					MockGet: WithComposite(t, NewComposite(func(cr resource.Composite) {
 						cr.SetDeletionTimestamp(&now)
 					})),
@@ -140,7 +140,7 @@ func TestReconcile(t *testing.T) {
 						cr.SetConditions(xpv1.Deleting(), xpv1.ReconcileError(errors.Wrap(errBoom, errRemoveFinalizer)))
 					})),
 				},
-				ncclient: &test.MockClient{
+				uc: &test.MockClient{
 					MockGet: test.NewMockGetFn(kerrors.NewNotFound(schema.GroupResource{}, "")),
 				},
 				opts: []ReconcilerOption{
@@ -163,7 +163,7 @@ func TestReconcile(t *testing.T) {
 		"SuccessfulDelete": {
 			reason: "We should return no error when deleted successfully.",
 			args: args{
-				client: &test.MockClient{
+				c: &test.MockClient{
 					MockGet: WithComposite(t, NewComposite(func(cr resource.Composite) {
 						cr.SetDeletionTimestamp(&now)
 					})),
@@ -172,7 +172,7 @@ func TestReconcile(t *testing.T) {
 						cr.SetConditions(xpv1.Deleting(), xpv1.ReconcileSuccess())
 					})),
 				},
-				ncclient: &test.MockClient{
+				uc: &test.MockClient{
 					MockGet: test.NewMockGetFn(kerrors.NewNotFound(schema.GroupResource{}, "")),
 				},
 				opts: []ReconcilerOption{
@@ -195,13 +195,13 @@ func TestReconcile(t *testing.T) {
 		"AddFinalizerError": {
 			reason: "We should return any error encountered while adding finalizer.",
 			args: args{
-				client: &test.MockClient{
+				c: &test.MockClient{
 					MockGet: test.NewMockGetFn(nil),
 					MockStatusUpdate: WantComposite(t, NewComposite(func(cr resource.Composite) {
 						cr.SetConditions(xpv1.ReconcileError(errors.Wrap(errBoom, errAddFinalizer)))
 					})),
 				},
-				ncclient: &test.MockClient{
+				uc: &test.MockClient{
 					MockGet: test.NewMockGetFn(kerrors.NewNotFound(schema.GroupResource{}, "")),
 				},
 				opts: []ReconcilerOption{
@@ -219,13 +219,13 @@ func TestReconcile(t *testing.T) {
 		"SelectCompositionError": {
 			reason: "We should return any error encountered while selecting a composition.",
 			args: args{
-				client: &test.MockClient{
+				c: &test.MockClient{
 					MockGet: test.NewMockGetFn(nil),
 					MockStatusUpdate: WantComposite(t, NewComposite(func(cr resource.Composite) {
 						cr.SetConditions(xpv1.ReconcileError(errors.Wrap(errBoom, errSelectComp)))
 					})),
 				},
-				ncclient: &test.MockClient{
+				uc: &test.MockClient{
 					MockGet: test.NewMockGetFn(kerrors.NewNotFound(schema.GroupResource{}, "")),
 				},
 				opts: []ReconcilerOption{
@@ -242,14 +242,14 @@ func TestReconcile(t *testing.T) {
 		"FetchCompositionError": {
 			reason: "We should return any error encountered while fetching a composition.",
 			args: args{
-				client: &test.MockClient{
+				c: &test.MockClient{
 					MockGet: test.NewMockGetFn(nil),
 					MockStatusUpdate: WantComposite(t, NewComposite(func(cr resource.Composite) {
 						cr.SetCompositionReference(&corev1.ObjectReference{})
 						cr.SetConditions(xpv1.ReconcileError(errors.Wrap(errBoom, errFetchComp)))
 					})),
 				},
-				ncclient: &test.MockClient{
+				uc: &test.MockClient{
 					MockGet: test.NewMockGetFn(kerrors.NewNotFound(schema.GroupResource{}, "")),
 				},
 				opts: []ReconcilerOption{
@@ -270,14 +270,14 @@ func TestReconcile(t *testing.T) {
 		"ValidateCompositionError": {
 			reason: "We should return any error encountered while validating our Composition.",
 			args: args{
-				client: &test.MockClient{
+				c: &test.MockClient{
 					MockGet: test.NewMockGetFn(nil),
 					MockStatusUpdate: WantComposite(t, NewComposite(func(cr resource.Composite) {
 						cr.SetCompositionReference(&corev1.ObjectReference{})
 						cr.SetConditions(xpv1.ReconcileError(errors.Wrap(errBoom, errValidate)))
 					})),
 				},
-				ncclient: &test.MockClient{
+				uc: &test.MockClient{
 					MockGet: test.NewMockGetFn(kerrors.NewNotFound(schema.GroupResource{}, "")),
 				},
 				opts: []ReconcilerOption{
@@ -301,14 +301,14 @@ func TestReconcile(t *testing.T) {
 		"ConfigureCompositeError": {
 			reason: "We should return any error encountered while configuring the composite resource.",
 			args: args{
-				client: &test.MockClient{
+				c: &test.MockClient{
 					MockGet: test.NewMockGetFn(nil),
 					MockStatusUpdate: WantComposite(t, NewComposite(func(cr resource.Composite) {
 						cr.SetCompositionReference(&corev1.ObjectReference{})
 						cr.SetConditions(xpv1.ReconcileError(errors.Wrap(errBoom, errConfigure)))
 					})),
 				},
-				ncclient: &test.MockClient{
+				uc: &test.MockClient{
 					MockGet: test.NewMockGetFn(kerrors.NewNotFound(schema.GroupResource{}, "")),
 				},
 				opts: []ReconcilerOption{
@@ -333,14 +333,14 @@ func TestReconcile(t *testing.T) {
 		"ComposeResourcesError": {
 			reason: "We should return any error encountered while composing resources.",
 			args: args{
-				client: &test.MockClient{
+				c: &test.MockClient{
 					MockGet: test.NewMockGetFn(nil),
 					MockStatusUpdate: WantComposite(t, NewComposite(func(cr resource.Composite) {
 						cr.SetCompositionReference(&corev1.ObjectReference{})
 						cr.SetConditions(xpv1.ReconcileError(errors.Wrap(errBoom, errCompose)))
 					})),
 				},
-				ncclient: &test.MockClient{
+				uc: &test.MockClient{
 					MockGet: test.NewMockGetFn(kerrors.NewNotFound(schema.GroupResource{}, "")),
 				},
 				opts: []ReconcilerOption{
@@ -368,14 +368,14 @@ func TestReconcile(t *testing.T) {
 		"PublishConnectionDetailsError": {
 			reason: "We should return any error encountered while publishing connection details.",
 			args: args{
-				client: &test.MockClient{
+				c: &test.MockClient{
 					MockGet: test.NewMockGetFn(nil),
 					MockStatusUpdate: WantComposite(t, NewComposite(func(cr resource.Composite) {
 						cr.SetCompositionReference(&corev1.ObjectReference{})
 						cr.SetConditions(xpv1.ReconcileError(errors.Wrap(errBoom, errPublish)))
 					})),
 				},
-				ncclient: &test.MockClient{
+				uc: &test.MockClient{
 					MockGet: test.NewMockGetFn(kerrors.NewNotFound(schema.GroupResource{}, "")),
 				},
 				opts: []ReconcilerOption{
@@ -408,14 +408,14 @@ func TestReconcile(t *testing.T) {
 		"CompositionWarnings": {
 			reason: "We should not requeue if our Composer returned warning events.",
 			args: args{
-				client: &test.MockClient{
+				c: &test.MockClient{
 					MockGet: test.NewMockGetFn(nil),
 					MockStatusUpdate: WantComposite(t, NewComposite(func(xr resource.Composite) {
 						xr.SetCompositionReference(&corev1.ObjectReference{})
 						xr.SetConditions(xpv1.ReconcileSuccess(), xpv1.Available())
 					})),
 				},
-				ncclient: &test.MockClient{
+				uc: &test.MockClient{
 					MockGet: test.NewMockGetFn(kerrors.NewNotFound(schema.GroupResource{}, "")),
 				},
 				opts: []ReconcilerOption{
@@ -458,14 +458,14 @@ func TestReconcile(t *testing.T) {
 		"ComposedResourcesNotReady": {
 			reason: "We should requeue if any of our composed resources are not yet ready.",
 			args: args{
-				client: &test.MockClient{
+				c: &test.MockClient{
 					MockGet: test.NewMockGetFn(nil),
 					MockStatusUpdate: WantComposite(t, NewComposite(func(cr resource.Composite) {
 						cr.SetCompositionReference(&corev1.ObjectReference{})
 						cr.SetConditions(xpv1.ReconcileSuccess(), xpv1.Creating().WithMessage("Unready resources: cat, cow, elephant, and 1 more"))
 					})),
 				},
-				ncclient: &test.MockClient{
+				uc: &test.MockClient{
 					MockGet: test.NewMockGetFn(kerrors.NewNotFound(schema.GroupResource{}, "")),
 				},
 				opts: []ReconcilerOption{
@@ -527,7 +527,7 @@ func TestReconcile(t *testing.T) {
 		"ComposedResourcesReady": {
 			reason: "We should requeue after our poll interval if all of our composed resources are ready.",
 			args: args{
-				client: &test.MockClient{
+				c: &test.MockClient{
 					MockGet: WithComposite(t, NewComposite(func(cr resource.Composite) {
 						cr.SetResourceReferences([]corev1.ObjectReference{{
 							APIVersion: "example.org/v1",
@@ -544,7 +544,7 @@ func TestReconcile(t *testing.T) {
 						cr.SetConnectionDetailsLastPublishedTime(&now)
 					})),
 				},
-				ncclient: &test.MockClient{
+				uc: &test.MockClient{
 					MockGet: test.NewMockGetFn(kerrors.NewNotFound(schema.GroupResource{}, "")),
 				},
 				opts: []ReconcilerOption{
@@ -597,7 +597,7 @@ func TestReconcile(t *testing.T) {
 		"ReconciliationPausedSuccessful": {
 			reason: `If a composite resource has the pause annotation with value "true", there should be no further requeue requests.`,
 			args: args{
-				client: &test.MockClient{
+				c: &test.MockClient{
 					MockGet: WithComposite(t, NewComposite(func(cr resource.Composite) {
 						cr.SetAnnotations(map[string]string{meta.AnnotationKeyReconciliationPaused: "true"})
 					})),
@@ -614,7 +614,7 @@ func TestReconcile(t *testing.T) {
 		"ReconciliationPausedError": {
 			reason: `If a composite resource has the pause annotation with value "true" and the status update due to reconciliation being paused fails, error should be reported causing an exponentially backed-off requeue.`,
 			args: args{
-				client: &test.MockClient{
+				c: &test.MockClient{
 					MockGet: WithComposite(t, NewComposite(func(cr resource.Composite) {
 						cr.SetAnnotations(map[string]string{meta.AnnotationKeyReconciliationPaused: "true"})
 					})),
@@ -628,7 +628,7 @@ func TestReconcile(t *testing.T) {
 		"ReconciliationResumes": {
 			reason: `If a composite resource has the pause annotation with some value other than "true" and the Synced=False/ReconcilePaused status condition, reconciliation should resume with requeueing.`,
 			args: args{
-				client: &test.MockClient{
+				c: &test.MockClient{
 					MockGet: WithComposite(t, NewComposite(func(cr resource.Composite) {
 						cr.SetAnnotations(map[string]string{meta.AnnotationKeyReconciliationPaused: ""})
 						cr.SetConditions(xpv1.ReconcilePaused())
@@ -640,7 +640,7 @@ func TestReconcile(t *testing.T) {
 						cr.SetCompositionReference(&corev1.ObjectReference{})
 					})),
 				},
-				ncclient: &test.MockClient{
+				uc: &test.MockClient{
 					MockGet: test.NewMockGetFn(kerrors.NewNotFound(schema.GroupResource{}, "")),
 				},
 				opts: []ReconcilerOption{
@@ -676,7 +676,7 @@ func TestReconcile(t *testing.T) {
 		"ReconciliationResumesAfterAnnotationRemoval": {
 			reason: `If a composite resource has the pause annotation removed and the Synced=False/ReconcilePaused status condition, reconciliation should resume with requeueing.`,
 			args: args{
-				client: &test.MockClient{
+				c: &test.MockClient{
 					MockGet: WithComposite(t, NewComposite(func(cr resource.Composite) {
 						// no annotation atm
 						// (but reconciliations were already paused)
@@ -688,7 +688,7 @@ func TestReconcile(t *testing.T) {
 						cr.SetCompositionReference(&corev1.ObjectReference{})
 					})),
 				},
-				ncclient: &test.MockClient{
+				uc: &test.MockClient{
 					MockGet: test.NewMockGetFn(kerrors.NewNotFound(schema.GroupResource{}, "")),
 				},
 				opts: []ReconcilerOption{
@@ -724,7 +724,7 @@ func TestReconcile(t *testing.T) {
 		"CustomEventsAndConditions": {
 			reason: "We should emit custom events and set custom conditions that were returned by the composer on both the composite resource and the claim.",
 			args: args{
-				client: &test.MockClient{
+				c: &test.MockClient{
 					MockGet: test.NewMockGetFn(nil, func(obj client.Object) error {
 						if xr, ok := obj.(*composite.Unstructured); ok {
 							// non-nil claim ref to trigger claim Get()
@@ -761,7 +761,7 @@ func TestReconcile(t *testing.T) {
 						cr.SetClaimReference(&reference.Claim{})
 					})),
 				},
-				ncclient: &test.MockClient{
+				uc: &test.MockClient{
 					MockGet: test.NewMockGetFn(kerrors.NewNotFound(schema.GroupResource{}, "")),
 				},
 				opts: []ReconcilerOption{
@@ -876,7 +876,7 @@ func TestReconcile(t *testing.T) {
 		"CustomEventsAndConditionFatal": {
 			reason: "In the case of a fatal result from the composer, we should set all custom conditions that were seen. If any custom conditions were not seen, they should be marked as Unknown. The error message should be emitted as an event to the composite but not the claim.",
 			args: args{
-				client: &test.MockClient{
+				c: &test.MockClient{
 					MockGet: test.NewMockGetFn(nil, func(obj client.Object) error {
 						if xr, ok := obj.(*composite.Unstructured); ok {
 							// non-nil claim ref to trigger claim Get()
@@ -932,7 +932,7 @@ func TestReconcile(t *testing.T) {
 						cr.SetClaimReference(&reference.Claim{})
 					})),
 				},
-				ncclient: &test.MockClient{
+				uc: &test.MockClient{
 					MockGet: test.NewMockGetFn(kerrors.NewNotFound(schema.GroupResource{}, "")),
 				},
 				opts: []ReconcilerOption{
@@ -1070,7 +1070,7 @@ func TestReconcile(t *testing.T) {
 		"CustomConditionUpdate": {
 			reason: "Custom conditions should be updated if they already exist. Additionally, if a condition already exists in the status but was not included in the response, it should remain in the status.",
 			args: args{
-				client: &test.MockClient{
+				c: &test.MockClient{
 					MockGet: test.NewMockGetFn(nil, func(obj client.Object) error {
 						if xr, ok := obj.(*composite.Unstructured); ok {
 							// non-nil claim ref to trigger claim Get()
@@ -1140,7 +1140,7 @@ func TestReconcile(t *testing.T) {
 						cr.SetClaimReference(&reference.Claim{})
 					})),
 				},
-				ncclient: &test.MockClient{
+				uc: &test.MockClient{
 					MockGet: test.NewMockGetFn(kerrors.NewNotFound(schema.GroupResource{}, "")),
 				},
 				opts: []ReconcilerOption{
@@ -1209,7 +1209,7 @@ func TestReconcile(t *testing.T) {
 		"SystemConditionUpdate": {
 			reason: "A system condition should be updated if it is explicitly allowed to do so",
 			args: args{
-				client: &test.MockClient{
+				c: &test.MockClient{
 					MockGet: test.NewMockGetFn(nil, func(obj client.Object) error {
 						if xr, ok := obj.(*composite.Unstructured); ok {
 							// non-nil claim ref to trigger claim Get()
@@ -1231,7 +1231,7 @@ func TestReconcile(t *testing.T) {
 						cr.SetClaimReference(&reference.Claim{})
 					})),
 				},
-				ncclient: &test.MockClient{
+				uc: &test.MockClient{
 					MockGet: test.NewMockGetFn(kerrors.NewNotFound(schema.GroupResource{}, "")),
 				},
 				opts: []ReconcilerOption{
@@ -1278,7 +1278,7 @@ func TestReconcile(t *testing.T) {
 		"CustomEventsFailToGetClaim": {
 			reason: "We should emit custom events that were returned by the composer. If we cannot get the claim, we should just emit events for the composite and continue as normal.",
 			args: args{
-				client: &test.MockClient{
+				c: &test.MockClient{
 					MockGet: test.NewMockGetFn(nil, func(obj client.Object) error {
 						if xr, ok := obj.(*composite.Unstructured); ok {
 							// non-nil claim ref to trigger claim Get()
@@ -1297,7 +1297,7 @@ func TestReconcile(t *testing.T) {
 						cr.SetClaimReference(&reference.Claim{})
 					})),
 				},
-				ncclient: &test.MockClient{
+				uc: &test.MockClient{
 					MockGet: test.NewMockGetFn(kerrors.NewNotFound(schema.GroupResource{}, "")),
 				},
 				opts: []ReconcilerOption{
@@ -1361,7 +1361,7 @@ func TestReconcile(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			r := NewReconciler(tc.args.client, tc.args.ncclient, tc.args.of, tc.args.opts...)
+			r := NewReconciler(tc.args.c, tc.args.uc, tc.args.of, tc.args.opts...)
 			got, err := r.Reconcile(context.Background(), reconcile.Request{})
 
 			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {

--- a/internal/controller/apiextensions/composite/watch/watch.go
+++ b/internal/controller/apiextensions/composite/watch/watch.go
@@ -38,6 +38,7 @@ type ControllerEngine interface {
 	GetWatches(name string) ([]engine.WatchID, error)
 	StopWatches(ctx context.Context, name string, ws ...engine.WatchID) (int, error)
 	GetClient() client.Client
+	GetNcClient() client.Client
 }
 
 // A GarbageCollector garbage collects watches for a single composite resource

--- a/internal/controller/apiextensions/composite/watch/watch.go
+++ b/internal/controller/apiextensions/composite/watch/watch.go
@@ -37,8 +37,8 @@ import (
 type ControllerEngine interface {
 	GetWatches(name string) ([]engine.WatchID, error)
 	StopWatches(ctx context.Context, name string, ws ...engine.WatchID) (int, error)
-	GetClient() client.Client
-	GetNcClient() client.Client
+	GetCached() client.Client
+	GetUncached() client.Client
 }
 
 // A GarbageCollector garbage collects watches for a single composite resource
@@ -107,7 +107,7 @@ func (gc *GarbageCollector) GarbageCollectWatchesNow(ctx context.Context) error 
 	l := &kunstructured.UnstructuredList{}
 	l.SetAPIVersion(gc.xrGVK.GroupVersion().String())
 	l.SetKind(gc.xrGVK.Kind + "List")
-	if err := gc.engine.GetClient().List(ctx, l); err != nil {
+	if err := gc.engine.GetCached().List(ctx, l); err != nil {
 		return errors.Wrap(err, "cannot list composite resources")
 	}
 

--- a/internal/controller/apiextensions/composite/watch/watch_test.go
+++ b/internal/controller/apiextensions/composite/watch/watch_test.go
@@ -42,6 +42,7 @@ type MockEngine struct {
 	MockGetWatches  func(name string) ([]engine.WatchID, error)
 	MockStopWatches func(ctx context.Context, name string, ws ...engine.WatchID) (int, error)
 	MockGetClient   func() client.Client
+	MockGetNcClient func() client.Client
 }
 
 func (m *MockEngine) GetWatches(name string) ([]engine.WatchID, error) {
@@ -54,6 +55,10 @@ func (m *MockEngine) StopWatches(ctx context.Context, name string, ws ...engine.
 
 func (m *MockEngine) GetClient() client.Client {
 	return m.MockGetClient()
+}
+
+func (m *MockEngine) GetNcClient() client.Client {
+	return m.MockGetNcClient()
 }
 
 func TestGarbageCollectWatchesNow(t *testing.T) {

--- a/internal/controller/apiextensions/composite/watch/watch_test.go
+++ b/internal/controller/apiextensions/composite/watch/watch_test.go
@@ -41,8 +41,8 @@ var _ ControllerEngine = &MockEngine{}
 type MockEngine struct {
 	MockGetWatches  func(name string) ([]engine.WatchID, error)
 	MockStopWatches func(ctx context.Context, name string, ws ...engine.WatchID) (int, error)
-	MockGetClient   func() client.Client
-	MockGetNcClient func() client.Client
+	MockGetCached   func() client.Client
+	MockGetUncached func() client.Client
 }
 
 func (m *MockEngine) GetWatches(name string) ([]engine.WatchID, error) {
@@ -53,12 +53,12 @@ func (m *MockEngine) StopWatches(ctx context.Context, name string, ws ...engine.
 	return m.MockStopWatches(ctx, name, ws...)
 }
 
-func (m *MockEngine) GetClient() client.Client {
-	return m.MockGetClient()
+func (m *MockEngine) GetCached() client.Client {
+	return m.MockGetCached()
 }
 
-func (m *MockEngine) GetNcClient() client.Client {
-	return m.MockGetNcClient()
+func (m *MockEngine) GetUncached() client.Client {
+	return m.MockGetUncached()
 }
 
 func TestGarbageCollectWatchesNow(t *testing.T) {
@@ -87,7 +87,7 @@ func TestGarbageCollectWatchesNow(t *testing.T) {
 			reason: "The method should return an error if it can't list XRs.",
 			params: params{
 				ce: &MockEngine{
-					MockGetClient: func() client.Client {
+					MockGetCached: func() client.Client {
 						return &test.MockClient{
 							MockList: test.NewMockListFn(errBoom),
 						}
@@ -102,7 +102,7 @@ func TestGarbageCollectWatchesNow(t *testing.T) {
 			reason: "The method should return an error if it can't get watches.",
 			params: params{
 				ce: &MockEngine{
-					MockGetClient: func() client.Client {
+					MockGetCached: func() client.Client {
 						return &test.MockClient{
 							MockList: test.NewMockListFn(nil),
 						}
@@ -120,7 +120,7 @@ func TestGarbageCollectWatchesNow(t *testing.T) {
 			reason: "The method should return an error if it can't stop watches.",
 			params: params{
 				ce: &MockEngine{
-					MockGetClient: func() client.Client {
+					MockGetCached: func() client.Client {
 						return &test.MockClient{
 							MockList: test.NewMockListFn(nil),
 						}
@@ -147,7 +147,7 @@ func TestGarbageCollectWatchesNow(t *testing.T) {
 			reason: "StopWatches shouldn't be called if there's no watches to stop.",
 			params: params{
 				ce: &MockEngine{
-					MockGetClient: func() client.Client {
+					MockGetCached: func() client.Client {
 						return &test.MockClient{
 							MockList: test.NewMockListFn(nil),
 						}
@@ -166,7 +166,7 @@ func TestGarbageCollectWatchesNow(t *testing.T) {
 			reason: "StopWatches shouldn't be called if there's no watches to stop.",
 			params: params{
 				ce: &MockEngine{
-					MockGetClient: func() client.Client {
+					MockGetCached: func() client.Client {
 						return &test.MockClient{
 							MockList: test.NewMockListFn(nil, func(obj client.ObjectList) error {
 								xr := composite.New()

--- a/internal/controller/apiextensions/definition/reconciler.go
+++ b/internal/controller/apiextensions/definition/reconciler.go
@@ -101,8 +101,8 @@ type ControllerEngine interface {
 	GetWatches(name string) ([]engine.WatchID, error)
 	StartWatches(name string, ws ...engine.Watch) error
 	StopWatches(ctx context.Context, name string, ws ...engine.WatchID) (int, error)
-	GetClient() client.Client
-	GetNcClient() client.Client
+	GetCached() client.Client
+	GetUncached() client.Client
 	GetFieldIndexer() client.FieldIndexer
 }
 
@@ -129,13 +129,13 @@ func (e *NopEngine) StopWatches(_ context.Context, _ string, _ ...engine.WatchID
 	return 0, nil
 }
 
-// GetClient returns a nil client.
-func (e *NopEngine) GetClient() client.Client {
+// GetCached returns a nil client.
+func (e *NopEngine) GetCached() client.Client {
 	return nil
 }
 
-// GetNcClient returns a nil client.
-func (e *NopEngine) GetNcClient() client.Client {
+// GetUncached returns a nil client.
+func (e *NopEngine) GetUncached() client.Client {
 	return nil
 }
 
@@ -475,7 +475,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 	ro := r.CompositeReconcilerOptions(ctx, d)
 	ck := resource.CompositeKind(d.GetCompositeGroupVersionKind())
 
-	cr := composite.NewReconciler(r.engine.GetClient(), r.engine.GetNcClient(), ck, ro...)
+	cr := composite.NewReconciler(r.engine.GetCached(), r.engine.GetUncached(), ck, ro...)
 	ko := r.options.ForControllerRuntime()
 
 	// Most controllers use this type of rate limiter to backoff requeues from 1
@@ -515,7 +515,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 	xr := &kunstructured.Unstructured{}
 	xr.SetGroupVersionKind(xrGVK)
 
-	crh := EnqueueForCompositionRevision(resource.CompositeKind(xrGVK), r.engine.GetClient(), log)
+	crh := EnqueueForCompositionRevision(resource.CompositeKind(xrGVK), r.engine.GetCached(), log)
 	if err := r.engine.StartWatches(name,
 		engine.WatchFor(xr, engine.WatchTypeCompositeResource, &handler.EnqueueRequestForObject{}),
 		engine.WatchFor(&v1.CompositionRevision{}, engine.WatchTypeCompositionRevision, crh),
@@ -538,11 +538,11 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 func (r *Reconciler) CompositeReconcilerOptions(ctx context.Context, d *v1.CompositeResourceDefinition) []composite.ReconcilerOption {
 	// The default set of reconciler options when no feature flags are enabled.
 	o := []composite.ReconcilerOption{
-		composite.WithConnectionPublishers(composite.NewAPIFilteredSecretPublisher(r.engine.GetClient(), d.GetConnectionSecretKeys())),
+		composite.WithConnectionPublishers(composite.NewAPIFilteredSecretPublisher(r.engine.GetCached(), d.GetConnectionSecretKeys())),
 		composite.WithCompositionSelector(composite.NewCompositionSelectorChain(
 			composite.NewEnforcedCompositionSelector(*d, r.record),
-			composite.NewAPIDefaultCompositionSelector(r.engine.GetClient(), *meta.ReferenceTo(d, v1.CompositeResourceDefinitionGroupVersionKind), r.record),
-			composite.NewAPILabelSelectorResolver(r.engine.GetClient()),
+			composite.NewAPIDefaultCompositionSelector(r.engine.GetCached(), *meta.ReferenceTo(d, v1.CompositeResourceDefinitionGroupVersionKind), r.record),
+			composite.NewAPILabelSelectorResolver(r.engine.GetCached()),
 		)),
 		composite.WithLogger(r.log.WithValues("controller", composite.ControllerName(d.GetName()))),
 		composite.WithRecorder(r.record.WithAnnotations("controller", composite.ControllerName(d.GetName()))),
@@ -551,7 +551,7 @@ func (r *Reconciler) CompositeReconcilerOptions(ctx context.Context, d *v1.Compo
 
 	// If external secret stores aren't enabled we just fetch connection details
 	// from Kubernetes secrets.
-	var fetcher managed.ConnectionDetailsFetcher = composite.NewSecretConnectionDetailsFetcher(r.engine.GetClient())
+	var fetcher managed.ConnectionDetailsFetcher = composite.NewSecretConnectionDetailsFetcher(r.engine.GetCached())
 
 	// We only want to enable ExternalSecretStore support if the relevant
 	// feature flag is enabled. Otherwise, we start the XR reconcilers with
@@ -561,22 +561,22 @@ func (r *Reconciler) CompositeReconcilerOptions(ctx context.Context, d *v1.Compo
 	// the composite resource.
 	if r.options.Features.Enabled(features.EnableAlphaExternalSecretStores) {
 		pc := []managed.ConnectionPublisher{
-			composite.NewAPIFilteredSecretPublisher(r.engine.GetClient(), d.GetConnectionSecretKeys()),
-			composite.NewSecretStoreConnectionPublisher(connection.NewDetailsManager(r.engine.GetClient(), v1alpha1.StoreConfigGroupVersionKind,
+			composite.NewAPIFilteredSecretPublisher(r.engine.GetCached(), d.GetConnectionSecretKeys()),
+			composite.NewSecretStoreConnectionPublisher(connection.NewDetailsManager(r.engine.GetCached(), v1alpha1.StoreConfigGroupVersionKind,
 				connection.WithTLSConfig(r.options.ESSOptions.TLSConfig)), d.GetConnectionSecretKeys()),
 		}
 
 		// If external secret stores are enabled we need to support fetching
 		// connection details from both secrets and external stores.
 		fetcher = composite.ConnectionDetailsFetcherChain{
-			composite.NewSecretConnectionDetailsFetcher(r.engine.GetClient()),
-			connection.NewDetailsManager(r.engine.GetClient(), v1alpha1.StoreConfigGroupVersionKind, connection.WithTLSConfig(r.options.ESSOptions.TLSConfig)),
+			composite.NewSecretConnectionDetailsFetcher(r.engine.GetCached()),
+			connection.NewDetailsManager(r.engine.GetCached(), v1alpha1.StoreConfigGroupVersionKind, connection.WithTLSConfig(r.options.ESSOptions.TLSConfig)),
 		}
 
 		cc := composite.NewConfiguratorChain(
-			composite.NewAPINamingConfigurator(r.engine.GetClient()),
-			composite.NewAPIConfigurator(r.engine.GetClient()),
-			composite.NewSecretStoreConnectionDetailsConfigurator(r.engine.GetClient()),
+			composite.NewAPINamingConfigurator(r.engine.GetCached()),
+			composite.NewAPIConfigurator(r.engine.GetCached()),
+			composite.NewSecretStoreConnectionDetailsConfigurator(r.engine.GetCached()),
 		)
 
 		o = append(o,
@@ -585,15 +585,15 @@ func (r *Reconciler) CompositeReconcilerOptions(ctx context.Context, d *v1.Compo
 	}
 
 	// This composer is used for mode: Resources Compositions (the default).
-	ptc := composite.NewPTComposer(r.engine.GetClient(), r.engine.GetNcClient(), composite.WithComposedConnectionDetailsFetcher(fetcher))
+	ptc := composite.NewPTComposer(r.engine.GetCached(), r.engine.GetUncached(), composite.WithComposedConnectionDetailsFetcher(fetcher))
 
 	// Wrap the PackagedFunctionRunner setup in main with support for loading
 	// extra resources to satisfy function requirements.
-	runner := composite.NewFetchingFunctionRunner(r.options.FunctionRunner, composite.NewExistingExtraResourcesFetcher(r.engine.GetClient()))
+	runner := composite.NewFetchingFunctionRunner(r.options.FunctionRunner, composite.NewExistingExtraResourcesFetcher(r.engine.GetCached()))
 
 	// This composer is used for mode: Pipeline Compositions.
-	fc := composite.NewFunctionComposer(r.engine.GetClient(), r.engine.GetNcClient(), runner,
-		composite.WithComposedResourceObserver(composite.NewExistingComposedResourceObserver(r.engine.GetClient(), r.engine.GetNcClient(), fetcher)),
+	fc := composite.NewFunctionComposer(r.engine.GetCached(), r.engine.GetUncached(), runner,
+		composite.WithComposedResourceObserver(composite.NewExistingComposedResourceObserver(r.engine.GetCached(), r.engine.GetUncached(), fetcher)),
 		composite.WithCompositeConnectionDetailsFetcher(fetcher),
 	)
 
@@ -630,7 +630,7 @@ func (r *Reconciler) CompositeReconcilerOptions(ctx context.Context, d *v1.Compo
 			r.log.Debug(errAddIndex, "error", err)
 		}
 
-		h := EnqueueCompositeResources(resource.CompositeKind(d.GetCompositeGroupVersionKind()), r.engine.GetClient(), r.log)
+		h := EnqueueCompositeResources(resource.CompositeKind(d.GetCompositeGroupVersionKind()), r.engine.GetCached(), r.log)
 		o = append(o, composite.WithWatchStarter(composite.ControllerName(d.GetName()), h, r.engine))
 	}
 

--- a/internal/controller/apiextensions/definition/reconciler_test.go
+++ b/internal/controller/apiextensions/definition/reconciler_test.go
@@ -50,7 +50,8 @@ type MockEngine struct {
 	MockGetWatches      func(name string) ([]engine.WatchID, error)
 	MockStartWatches    func(name string, ws ...engine.Watch) error
 	MockStopWatches     func(ctx context.Context, name string, ws ...engine.WatchID) (int, error)
-	MockGetClient       func() client.Client
+	MockGetCached       func() client.Client
+	MockGetUncached     func() client.Client
 	MockGetFieldIndexer func() client.FieldIndexer
 }
 
@@ -78,12 +79,12 @@ func (m *MockEngine) StopWatches(ctx context.Context, name string, ws ...engine.
 	return m.MockStopWatches(ctx, name, ws...)
 }
 
-func (m *MockEngine) GetClient() client.Client {
-	return m.MockGetClient()
+func (m *MockEngine) GetCached() client.Client {
+	return m.MockGetCached()
 }
 
-func (m *MockEngine) GetNcClient() client.Client {
-	return m.MockGetClient()
+func (m *MockEngine) GetUncached() client.Client {
+	return m.MockGetUncached()
 }
 
 func (m *MockEngine) GetFieldIndexer() client.FieldIndexer {
@@ -692,7 +693,8 @@ func TestReconcile(t *testing.T) {
 						MockStart: func(_ string, _ ...engine.ControllerOption) error {
 							return errBoom
 						},
-						MockGetClient: func() client.Client { return test.NewMockClient() },
+						MockGetCached:   func() client.Client { return test.NewMockClient() },
+						MockGetUncached: func() client.Client { return test.NewMockClient() },
 					}),
 				},
 			},
@@ -733,7 +735,8 @@ func TestReconcile(t *testing.T) {
 						MockStartWatches: func(_ string, _ ...engine.Watch) error {
 							return errBoom
 						},
-						MockGetClient: func() client.Client { return test.NewMockClient() },
+						MockGetCached:   func() client.Client { return test.NewMockClient() },
+						MockGetUncached: func() client.Client { return test.NewMockClient() },
 					}),
 				},
 			},
@@ -779,7 +782,8 @@ func TestReconcile(t *testing.T) {
 						MockIsRunning:    func(_ string) bool { return false },
 						MockStart:        func(_ string, _ ...engine.ControllerOption) error { return nil },
 						MockStartWatches: func(_ string, _ ...engine.Watch) error { return nil },
-						MockGetClient:    func() client.Client { return test.NewMockClient() },
+						MockGetCached:    func() client.Client { return test.NewMockClient() },
+						MockGetUncached:  func() client.Client { return test.NewMockClient() },
 					}),
 				},
 			},
@@ -838,7 +842,8 @@ func TestReconcile(t *testing.T) {
 						MockStop:         func(_ context.Context, _ string) error { return nil },
 						MockIsRunning:    func(_ string) bool { return false },
 						MockStartWatches: func(_ string, _ ...engine.Watch) error { return nil },
-						MockGetClient:    func() client.Client { return test.NewMockClient() },
+						MockGetCached:    func() client.Client { return test.NewMockClient() },
+						MockGetUncached:  func() client.Client { return test.NewMockClient() },
 					}),
 				},
 			},

--- a/internal/controller/apiextensions/definition/reconciler_test.go
+++ b/internal/controller/apiextensions/definition/reconciler_test.go
@@ -82,6 +82,10 @@ func (m *MockEngine) GetClient() client.Client {
 	return m.MockGetClient()
 }
 
+func (m *MockEngine) GetNcClient() client.Client {
+	return m.MockGetClient()
+}
+
 func (m *MockEngine) GetFieldIndexer() client.FieldIndexer {
 	return m.MockGetFieldIndexer()
 }

--- a/internal/controller/apiextensions/offered/reconciler.go
+++ b/internal/controller/apiextensions/offered/reconciler.go
@@ -95,7 +95,7 @@ type ControllerEngine interface {
 	Stop(ctx context.Context, name string) error
 	IsRunning(name string) bool
 	StartWatches(name string, ws ...engine.Watch) error
-	GetClient() client.Client
+	GetCached() client.Client
 }
 
 // A NopEngine does nothing.
@@ -113,8 +113,8 @@ func (e *NopEngine) IsRunning(_ string) bool { return true }
 // StartWatches does nothing.
 func (e *NopEngine) StartWatches(_ string, _ ...engine.Watch) error { return nil }
 
-// GetClient returns a nil client.
-func (e *NopEngine) GetClient() client.Client {
+// GetCached returns a nil client.
+func (e *NopEngine) GetCached() client.Client {
 	return nil
 }
 
@@ -439,8 +439,8 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 	// upgrading fields that were previously managed using client-side apply.
 	if r.options.Features.Enabled(features.EnableBetaClaimSSA) {
 		o = append(o,
-			claim.WithCompositeSyncer(claim.NewServerSideCompositeSyncer(r.engine.GetClient(), names.NewNameGenerator(r.engine.GetClient()))),
-			claim.WithManagedFieldsUpgrader(claim.NewPatchingManagedFieldsUpgrader(r.engine.GetClient())),
+			claim.WithCompositeSyncer(claim.NewServerSideCompositeSyncer(r.engine.GetCached(), names.NewNameGenerator(r.engine.GetCached()))),
+			claim.WithManagedFieldsUpgrader(claim.NewPatchingManagedFieldsUpgrader(r.engine.GetCached())),
 		)
 	}
 
@@ -449,12 +449,12 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 	// their default Connection Propagator.
 	if r.options.Features.Enabled(features.EnableAlphaExternalSecretStores) {
 		pc := claim.ConnectionPropagatorChain{
-			claim.NewAPIConnectionPropagator(r.engine.GetClient()),
-			connection.NewDetailsManager(r.engine.GetClient(), secretsv1alpha1.StoreConfigGroupVersionKind, connection.WithTLSConfig(r.options.ESSOptions.TLSConfig)),
+			claim.NewAPIConnectionPropagator(r.engine.GetCached()),
+			connection.NewDetailsManager(r.engine.GetCached(), secretsv1alpha1.StoreConfigGroupVersionKind, connection.WithTLSConfig(r.options.ESSOptions.TLSConfig)),
 		}
 
 		o = append(o, claim.WithConnectionPropagator(pc), claim.WithConnectionUnpublisher(
-			claim.NewSecretStoreConnectionUnpublisher(connection.NewDetailsManager(r.engine.GetClient(),
+			claim.NewSecretStoreConnectionUnpublisher(connection.NewDetailsManager(r.engine.GetCached(),
 				secretsv1alpha1.StoreConfigGroupVersionKind, connection.WithTLSConfig(r.options.ESSOptions.TLSConfig)))))
 	}
 
@@ -477,7 +477,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 		return reconcile.Result{Requeue: false}, errors.Wrap(r.client.Status().Update(ctx, d), errUpdateStatus)
 	}
 
-	cr := claim.NewReconciler(r.engine.GetClient(),
+	cr := claim.NewReconciler(r.engine.GetCached(),
 		resource.CompositeClaimKind(d.GetClaimGroupVersionKind()),
 		resource.CompositeKind(d.GetCompositeGroupVersionKind()), o...)
 

--- a/internal/controller/apiextensions/offered/reconciler_test.go
+++ b/internal/controller/apiextensions/offered/reconciler_test.go
@@ -70,7 +70,7 @@ func (m *MockEngine) StartWatches(name string, ws ...engine.Watch) error {
 	return m.MockStartWatches(name, ws...)
 }
 
-func (m *MockEngine) GetClient() client.Client {
+func (m *MockEngine) GetCached() client.Client {
 	return m.MockGetClient()
 }
 

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -53,11 +53,11 @@ type ControllerEngine struct {
 
 	// The client used by the engine's controllers. The client must be backed by
 	// the above TrackingInformers.
-	client client.Client
+	cached client.Client
 
-	// The ncclient is a non-cached readonly client used when Unstructured resources
+	// uncached is a non-cached client used when Unstructured resources
 	// are not found in the cache.
-	ncclient client.Client
+	uncached client.Client
 
 	log logging.Logger
 
@@ -79,8 +79,8 @@ func New(mgr manager.Manager, infs TrackingInformers, c client.Client, nc client
 	e := &ControllerEngine{
 		mgr:         mgr,
 		infs:        infs,
-		client:      c,
-		ncclient:    nc,
+		cached:      c,
+		uncached:    nc,
 		log:         logging.NewNopLogger(),
 		controllers: make(map[string]*controller),
 	}
@@ -157,14 +157,14 @@ func WithNewControllerFn(fn NewControllerFn) ControllerOption {
 	}
 }
 
-// GetClient gets a client backed by the controller engine's cache.
-func (e *ControllerEngine) GetClient() client.Client {
-	return e.client
+// GetCached gets a client backed by the controller engine's cache.
+func (e *ControllerEngine) GetCached() client.Client {
+	return e.cached
 }
 
-// GetNcClient gets a non-cached client.
-func (e *ControllerEngine) GetNcClient() client.Client {
-	return e.ncclient
+// GetUncached gets a non-cached client.
+func (e *ControllerEngine) GetUncached() client.Client {
+	return e.uncached
 }
 
 // GetFieldIndexer returns a FieldIndexer that can be used to add indexes to the

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -55,6 +55,10 @@ type ControllerEngine struct {
 	// the above TrackingInformers.
 	client client.Client
 
+	// The ncclient is a non-cached readonly client used when Unstructured resources
+	// are not found in the cache.
+	ncclient client.Client
+
 	log logging.Logger
 
 	// Protects everything below.
@@ -71,11 +75,12 @@ type TrackingInformers interface {
 }
 
 // New creates a new controller engine.
-func New(mgr manager.Manager, infs TrackingInformers, c client.Client, o ...ControllerEngineOption) *ControllerEngine {
+func New(mgr manager.Manager, infs TrackingInformers, c client.Client, nc client.Client, o ...ControllerEngineOption) *ControllerEngine {
 	e := &ControllerEngine{
 		mgr:         mgr,
 		infs:        infs,
 		client:      c,
+		ncclient:    nc,
 		log:         logging.NewNopLogger(),
 		controllers: make(map[string]*controller),
 	}
@@ -155,6 +160,11 @@ func WithNewControllerFn(fn NewControllerFn) ControllerOption {
 // GetClient gets a client backed by the controller engine's cache.
 func (e *ControllerEngine) GetClient() client.Client {
 	return e.client
+}
+
+// GetNcClient gets a non-cached client.
+func (e *ControllerEngine) GetNcClient() client.Client {
+	return e.ncclient
 }
 
 // GetFieldIndexer returns a FieldIndexer that can be used to add indexes to the

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -106,7 +106,7 @@ func TestStartController(t *testing.T) {
 		mgr  manager.Manager
 		infs TrackingInformers
 		c    client.Client
-		nc   client.Client
+		uc   client.Client
 		opts []ControllerEngineOption
 	}
 	type args struct {
@@ -213,7 +213,7 @@ func TestStartController(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			e := New(tc.params.mgr, tc.params.infs, tc.params.c, tc.params.nc, tc.params.opts...)
+			e := New(tc.params.mgr, tc.params.infs, tc.params.c, tc.params.uc, tc.params.opts...)
 			err := e.Start(tc.args.name, tc.args.opts...)
 			if diff := cmp.Diff(tc.want.err, err, cmpopts.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\ne.Start(...): -want error, +got error:\n%s", tc.reason, diff)
@@ -241,7 +241,7 @@ func TestIsRunning(t *testing.T) {
 		mgr  manager.Manager
 		infs TrackingInformers
 		c    client.Client
-		nc   client.Client
+		uc   client.Client
 		opts []ControllerEngineOption
 	}
 
@@ -330,7 +330,7 @@ func TestIsRunning(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			e := New(tc.params.mgr, tc.params.infs, tc.params.c, tc.params.nc, tc.params.opts...)
+			e := New(tc.params.mgr, tc.params.infs, tc.params.c, tc.params.uc, tc.params.opts...)
 			_ = e.Start(tc.args.name, tc.argsStart.opts...)
 
 			// Give the start goroutine a little time to fail.
@@ -360,7 +360,7 @@ func TestStopController(t *testing.T) {
 		mgr  manager.Manager
 		infs TrackingInformers
 		c    client.Client
-		nc   client.Client
+		uc   client.Client
 		opts []ControllerEngineOption
 	}
 	type args struct {
@@ -408,7 +408,7 @@ func TestStopController(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			e := New(tc.params.mgr, tc.params.infs, tc.params.c, tc.params.nc, tc.params.opts...)
+			e := New(tc.params.mgr, tc.params.infs, tc.params.c, tc.params.uc, tc.params.opts...)
 			err := e.Start(tc.args.name, WithNewControllerFn(func(_ string, _ manager.Manager, _ kcontroller.Options) (kcontroller.Controller, error) {
 				return &MockController{
 					MockStart: func(ctx context.Context) error {
@@ -453,7 +453,7 @@ func TestStartWatches(t *testing.T) {
 		mgr  manager.Manager
 		infs TrackingInformers
 		c    client.Client
-		nc   client.Client
+		uc   client.Client
 		opts []ControllerEngineOption
 	}
 	// We need to control how we start the controller.
@@ -621,7 +621,7 @@ func TestStartWatches(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			e := New(tc.params.mgr, tc.params.infs, tc.params.c, tc.params.nc, tc.params.opts...)
+			e := New(tc.params.mgr, tc.params.infs, tc.params.c, tc.params.uc, tc.params.opts...)
 			err := e.Start(tc.argsStart.name, tc.argsStart.opts...)
 			if diff := cmp.Diff(nil, err, cmpopts.EquateErrors()); diff != "" {
 				t.Fatalf("\n%s\ne.Start(...): -want error, +got error:\n%s", tc.reason, diff)
@@ -666,7 +666,7 @@ func TestStopWatches(t *testing.T) {
 		mgr  manager.Manager
 		infs TrackingInformers
 		c    client.Client
-		nc   client.Client
+		uc   client.Client
 		opts []ControllerEngineOption
 	}
 	type args struct {
@@ -845,7 +845,7 @@ func TestStopWatches(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			e := New(tc.params.mgr, tc.params.infs, tc.params.c, tc.params.nc, tc.params.opts...)
+			e := New(tc.params.mgr, tc.params.infs, tc.params.c, tc.params.uc, tc.params.opts...)
 			err := e.Start(tc.args.name, WithNewControllerFn(func(_ string, _ manager.Manager, _ kcontroller.Options) (kcontroller.Controller, error) {
 				return &MockController{
 					MockStart: func(ctx context.Context) error {

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -106,6 +106,7 @@ func TestStartController(t *testing.T) {
 		mgr  manager.Manager
 		infs TrackingInformers
 		c    client.Client
+		nc   client.Client
 		opts []ControllerEngineOption
 	}
 	type args struct {
@@ -212,7 +213,7 @@ func TestStartController(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			e := New(tc.params.mgr, tc.params.infs, tc.params.c, tc.params.opts...)
+			e := New(tc.params.mgr, tc.params.infs, tc.params.c, tc.params.nc, tc.params.opts...)
 			err := e.Start(tc.args.name, tc.args.opts...)
 			if diff := cmp.Diff(tc.want.err, err, cmpopts.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\ne.Start(...): -want error, +got error:\n%s", tc.reason, diff)
@@ -240,6 +241,7 @@ func TestIsRunning(t *testing.T) {
 		mgr  manager.Manager
 		infs TrackingInformers
 		c    client.Client
+		nc   client.Client
 		opts []ControllerEngineOption
 	}
 
@@ -328,7 +330,7 @@ func TestIsRunning(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			e := New(tc.params.mgr, tc.params.infs, tc.params.c, tc.params.opts...)
+			e := New(tc.params.mgr, tc.params.infs, tc.params.c, tc.params.nc, tc.params.opts...)
 			_ = e.Start(tc.args.name, tc.argsStart.opts...)
 
 			// Give the start goroutine a little time to fail.
@@ -358,6 +360,7 @@ func TestStopController(t *testing.T) {
 		mgr  manager.Manager
 		infs TrackingInformers
 		c    client.Client
+		nc   client.Client
 		opts []ControllerEngineOption
 	}
 	type args struct {
@@ -405,7 +408,7 @@ func TestStopController(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			e := New(tc.params.mgr, tc.params.infs, tc.params.c, tc.params.opts...)
+			e := New(tc.params.mgr, tc.params.infs, tc.params.c, tc.params.nc, tc.params.opts...)
 			err := e.Start(tc.args.name, WithNewControllerFn(func(_ string, _ manager.Manager, _ kcontroller.Options) (kcontroller.Controller, error) {
 				return &MockController{
 					MockStart: func(ctx context.Context) error {
@@ -450,6 +453,7 @@ func TestStartWatches(t *testing.T) {
 		mgr  manager.Manager
 		infs TrackingInformers
 		c    client.Client
+		nc   client.Client
 		opts []ControllerEngineOption
 	}
 	// We need to control how we start the controller.
@@ -617,7 +621,7 @@ func TestStartWatches(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			e := New(tc.params.mgr, tc.params.infs, tc.params.c, tc.params.opts...)
+			e := New(tc.params.mgr, tc.params.infs, tc.params.c, tc.params.nc, tc.params.opts...)
 			err := e.Start(tc.argsStart.name, tc.argsStart.opts...)
 			if diff := cmp.Diff(nil, err, cmpopts.EquateErrors()); diff != "" {
 				t.Fatalf("\n%s\ne.Start(...): -want error, +got error:\n%s", tc.reason, diff)
@@ -662,6 +666,7 @@ func TestStopWatches(t *testing.T) {
 		mgr  manager.Manager
 		infs TrackingInformers
 		c    client.Client
+		nc   client.Client
 		opts []ControllerEngineOption
 	}
 	type args struct {
@@ -840,7 +845,7 @@ func TestStopWatches(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			e := New(tc.params.mgr, tc.params.infs, tc.params.c, tc.params.opts...)
+			e := New(tc.params.mgr, tc.params.infs, tc.params.c, tc.params.nc, tc.params.opts...)
 			err := e.Start(tc.args.name, WithNewControllerFn(func(_ string, _ manager.Manager, _ kcontroller.Options) (kcontroller.Controller, error) {
 				return &MockController{
 					MockStart: func(ctx context.Context) error {


### PR DESCRIPTION
### Description of your changes
Disable caching of `Unstructured` resources for claims and XRs.  Caching can cause resource leaks when the local
cache is not updated quickly enough after a large number of resources are created.  Subsequent reconciliations
do not find the created resources in the cache and thus will create new resources, resulting in resource leaks.

Fixes #6260 

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [X] Read and followed Crossplane's [contribution process].
- [X] Run `earthly +reviewable` to ensure this PR is ready for review.
~- [ ] Added or updated unit tests.~
~- [ ] Added or updated e2e tests.~
~- [ ] Linked a PR or a [docs tracking issue] to [document this change].~
- [X ] Added `backport release-x.y` labels to auto-backport this PR.
~- [ ] Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~

This can be tested with an XR that creates a set of 8 `Objects`, for example a `Namespace` and seven `Secrets`.  Generate a number of these composites at the same time and observe the number of `Objects` that are created.  Without the fix the number of `Objects` increases faster than it should with the number of Composites.  With the fix the increase is linear as it should be.