### PR TITLE
Add COMPOSITIONREVISION to the composite object output for "-o wide"

### DIFF
--- a/cmd/crank/beta/validate/validate_test.go
+++ b/cmd/crank/beta/validate/validate_test.go
@@ -313,6 +313,12 @@ func TestConvertToCRDs(t *testing.T) {
 											JSONPath: ".spec.compositionRef.name",
 										},
 										{
+											Name:     "COMPOSITIONREVISION",
+											Type:     "string",
+											JSONPath: ".spec.compositionRevisionRef.name",
+											Priority: 1,
+										},
+										{
 											Name:     "AGE",
 											Type:     "date",
 											JSONPath: ".metadata.creationTimestamp",
@@ -649,6 +655,12 @@ func TestConvertToCRDs(t *testing.T) {
 											Name:     "COMPOSITION",
 											Type:     "string",
 											JSONPath: ".spec.compositionRef.name",
+										},
+										{
+											Name:     "COMPOSITIONREVISION",
+											Type:     "string",
+											JSONPath: ".spec.compositionRevisionRef.name",
+											Priority: 1,
 										},
 										{
 											Name:     "AGE",

--- a/internal/xcrd/crd_test.go
+++ b/internal/xcrd/crd_test.go
@@ -249,6 +249,12 @@ func TestForCompositeResource(t *testing.T) {
 									JSONPath: ".spec.compositionRef.name",
 								},
 								{
+									Name:     "COMPOSITIONREVISION",
+									Type:     "string",
+									JSONPath: ".spec.compositionRevisionRef.name",
+									Priority: 1,
+								},
+								{
 									Name:     "AGE",
 									Type:     "date",
 									JSONPath: ".metadata.creationTimestamp",
@@ -560,6 +566,12 @@ func TestForCompositeResource(t *testing.T) {
 									JSONPath: ".spec.compositionRef.name",
 								},
 								{
+									Name:     "COMPOSITIONREVISION",
+									Type:     "string",
+									JSONPath: ".spec.compositionRevisionRef.name",
+									Priority: 1,
+								},
+								{
 									Name:     "AGE",
 									Type:     "date",
 									JSONPath: ".metadata.creationTimestamp",
@@ -849,6 +861,12 @@ func TestForCompositeResource(t *testing.T) {
 									JSONPath: ".spec.compositionRef.name",
 								},
 								{
+									Name:     "COMPOSITIONREVISION",
+									Type:     "string",
+									JSONPath: ".spec.compositionRevisionRef.name",
+									Priority: 1,
+								},
+								{
 									Name:     "AGE",
 									Type:     "date",
 									JSONPath: ".metadata.creationTimestamp",
@@ -1099,6 +1117,12 @@ func TestForCompositeResource(t *testing.T) {
 									Name:     "COMPOSITION",
 									Type:     "string",
 									JSONPath: ".spec.compositionRef.name",
+								},
+								{
+									Name:     "COMPOSITIONREVISION",
+									Type:     "string",
+									JSONPath: ".spec.compositionRevisionRef.name",
+									Priority: 1,
 								},
 								{
 									Name:     "AGE",
@@ -1387,6 +1411,12 @@ func TestForCompositeResource(t *testing.T) {
 									Name:     "COMPOSITION",
 									Type:     "string",
 									JSONPath: ".spec.compositionRef.name",
+								},
+								{
+									Name:     "COMPOSITIONREVISION",
+									Type:     "string",
+									JSONPath: ".spec.compositionRevisionRef.name",
+									Priority: 1,
 								},
 								{
 									Name:     "AGE",
@@ -1685,6 +1715,12 @@ func TestForCompositeResource(t *testing.T) {
 									Name:     "COMPOSITION",
 									Type:     "string",
 									JSONPath: ".spec.compositionRef.name",
+								},
+								{
+									Name:     "COMPOSITIONREVISION",
+									Type:     "string",
+									JSONPath: ".spec.compositionRevisionRef.name",
+									Priority: 1,
 								},
 								{
 									Name:     "AGE",

--- a/internal/xcrd/schemas.go
+++ b/internal/xcrd/schemas.go
@@ -374,6 +374,12 @@ func CompositeResourcePrinterColumns() []extv1.CustomResourceColumnDefinition {
 			JSONPath: ".spec.compositionRef.name",
 		},
 		{
+			Name:     "COMPOSITIONREVISION",
+			Type:     "string",
+			JSONPath: ".spec.compositionRevisionRef.name",
+			Priority: 1,
+		},
+		{
 			Name:     "AGE",
 			Type:     "date",
 			JSONPath: ".metadata.creationTimestamp",


### PR DESCRIPTION
### Description of your changes
Add the COMPOSITIONREVISION output column for composite resources when the `-o wide` option is specified.

Fixes #6265 

Sample output:

Regular default output:
```
$ kubectl get xobjecttests.saas.nokia.com
NAME    SYNCED   READY   COMPOSITION   AGE
test1   True     False   objecttest3   6s
```

Wide output:
```
$ kubectl get xobjecttests.saas.nokia.com -o wide
NAME    SYNCED   READY   COMPOSITION   COMPOSITIONREVISION   AGE
test1   True     False   objecttest3   objecttest3-22a7325   11s
```


I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [X] Read and followed Crossplane's [contribution process].
- [X] Run `earthly +reviewable` to ensure this PR is ready for review.
- [X] Added or updated unit tests.
~- [ ] Added or updated e2e tests.~
~- [ ] Linked a PR or a [docs tracking issue] to [document this change].~
~- [ ] Added `backport release-x.y` labels to auto-backport this PR.~
~- [ ] Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md