### PR TITLE
engine: fix misplaced Unlock

### DIFF
--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -258,7 +258,6 @@ func (e *ControllerEngine) Stop(ctx context.Context, name string) error {
 	// Stop the controller's watches.
 	for wid, w := range c.sources {
 		if err := w.Stop(ctx); err != nil {
-			c.mx.Unlock()
 			return errors.Wrapf(err, "cannot stop %q watch for %q", wid.Type, wid.GVK)
 		}
 		delete(c.sources, wid)


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane! Please read the contribution docs
(linked below) if this is your first Crossplane pull request.
-->

### Description of your changes

<!--
Briefly describe what this pull request does, and how it is covered by tests.
Be proactive - direct your reviewers' attention to anything that needs special
consideration.

We love pull requests that fix an open issue. If yours does, use the below line
to indicate which issue it fixes, for example "Fixes #500".
-->

The controller engine had a misplaced `c.mu.Unlock` in error case. Another `Unlock` call is deferred. This panics.

Fixes #

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `earthly +reviewable` to ensure this PR is ready for review.
- ~~[ ] Added or updated unit tests.~~
- ~~[ ] Added or updated e2e tests.~~
- ~~[ ] Linked a PR or a [docs tracking issue] to [document this change].~~
- ~~[ ] Added `backport release-x.y` labels to auto-backport this PR.~~
- ~~[ ] Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md