### PR TITLE
governance: update steering committee details from 2025 election

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -55,20 +55,18 @@ The following are some guidelines for eligibility to the Steering Committee:
 * There is **no** minimum time period for contributions to the project by the
   proposed member.
 
-### Initial Steering Committee
+### Steering Committee
 
-The initial steering committee will be nominated by the founders of the project
-in order to ensure continuity of the project charter and vision as additional members come on board.
-Once the terms of the initial committee members expire, new members will be selected through the election
-process outlined below.
-
-Here are the members of the initial steering committee (listed in alphabetical order of first name):
+The members of the steering committee are listed in the table below (listed in
+alphabetical order of first name). When terms of the committee members expire,
+new members will be selected through the [election process](#election-process)
+outlined below.
 
 | &nbsp;                                                    | Member                                         | Organization | Email                       | Term Start | Term End   |
 |-----------------------------------------------------------|------------------------------------------------|--------------|-----------------------------|------------|------------|
 | <img width="30px" src="https://github.com/bassam.png">    | [Bassam Tabbara](https://github.com/bassam)    | Upbound      | bassam@upbound.io           | 2024-02-06 | 2026-02-06 |
-| <img width="30px" src="https://github.com/lindblombr.png">| [Brian Lindblom](https://github.com/lindblombr)| Apple        | blindblom@apple.com         | 2024-02-06 | 2025-02-07 |
-| <img width="30px" src="https://github.com/bobh66.png">    | [Bob Haddleton](https://github.com/bobh66)     | Nokia        | bob.haddleton@nokia.com     | 2024-02-06 | 2025-02-07 |
+| <img width="30px" src="https://github.com/lindblombr.png">| [Brian Lindblom](https://github.com/lindblombr)| Apple        | blindblom@apple.com         | 2025-02-06 | 2027-02-06 |
+| <img width="30px" src="https://github.com/bobh66.png">    | [Bob Haddleton](https://github.com/bobh66)     | Nokia        | bob.haddleton@nokia.com     | 2025-02-06 | 2027-02-06 |
 | <img width="30px" src="https://github.com/jbw976.png">    | [Jared Watts](https://github.com/jbw976)       | Upbound      | jared@upbound.io            | 2024-02-06 | 2026-02-06 |
 | <img width="30px" src="https://github.com/negz.png">      | [Nic Cope](https://github.com/negz)            | Upbound      | negz@upbound.io             | 2024-02-06 | 2026-02-06 |
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -65,8 +65,8 @@ outlined below.
 | &nbsp;                                                    | Member                                         | Organization | Email                       | Term Start | Term End   |
 |-----------------------------------------------------------|------------------------------------------------|--------------|-----------------------------|------------|------------|
 | <img width="30px" src="https://github.com/bassam.png">    | [Bassam Tabbara](https://github.com/bassam)    | Upbound      | bassam@upbound.io           | 2024-02-06 | 2026-02-06 |
-| <img width="30px" src="https://github.com/lindblombr.png">| [Brian Lindblom](https://github.com/lindblombr)| Apple        | blindblom@apple.com         | 2025-02-06 | 2027-02-06 |
 | <img width="30px" src="https://github.com/bobh66.png">    | [Bob Haddleton](https://github.com/bobh66)     | Nokia        | bob.haddleton@nokia.com     | 2025-02-06 | 2027-02-06 |
+| <img width="30px" src="https://github.com/lindblombr.png">| [Brian Lindblom](https://github.com/lindblombr)| Apple        | blindblom@apple.com         | 2025-02-06 | 2027-02-06 |
 | <img width="30px" src="https://github.com/jbw976.png">    | [Jared Watts](https://github.com/jbw976)       | Upbound      | jared@upbound.io            | 2024-02-06 | 2026-02-06 |
 | <img width="30px" src="https://github.com/negz.png">      | [Nic Cope](https://github.com/negz)            | Upbound      | negz@upbound.io             | 2024-02-06 | 2026-02-06 |
 


### PR DESCRIPTION
### Description of your changes

The steering committee election has ended as per the defined [election process](https://github.com/crossplane/crossplane/blob/main/GOVERNANCE.md#election-process) with the result of Bob Haddleton 
(@bobh66) and Brian Lindblom (@lindblombr) winning their seats again. As per [governance](https://github.com/crossplane/crossplane/blob/main/GOVERNANCE.md#composition), they now start 2 year terms that expire in 2027.

This PR updates the governance with their new term end dates. Congratulations Bob and Brian and thank you to all maintainers that participated in the election process! 🎉 

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `earthly +reviewable` to ensure this PR is ready for review.
- [ ] ~Added or updated unit tests.~
- [ ] ~Added or updated e2e tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~
- [ ] ~Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md