### PR TITLE
fix(crank): render private pull

### DIFF
--- a/cmd/crank/render/runtime_docker.go
+++ b/cmd/crank/render/runtime_docker.go
@@ -317,7 +317,7 @@ func (r *RuntimeDocker) getPullOptions() (typesimage.PullOptions, error) {
 	}
 
 	return typesimage.PullOptions{
-		RegistryAuth: base64.URLEncoding.EncodeToString(token),
+		RegistryAuth: base64.StdEncoding.EncodeToString(token),
 	}, nil
 }
 


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane! Please read the contribution docs
(linked below) if this is your first Crossplane pull request.
-->

### Description of your changes
fix an issue that crossplane render is unable to pull functions from private registries
similar to https://github.com/rancher/rancher/pull/44254

before this PR:
```
crank render tests/default/default_test.yaml apis/xclusters/composition-aws.yaml  functions.yaml
...
cannot start Function "xxx-upbound-function-auto-ready": cannot pull Docker image "ghcr.io/xxx/upbound/function-auto-ready:v0.4.2": Error response from daemon: failed to resolve reference "ghcr.io/xxx/upbound/function-auto-ready:v0.4.2": failed to authorize: failed to fetch anonymous token: unexpected status from GET request to https://ghcr.io/token?scope=repository%3Axxx%2Fupbound%2Ffunction-auto-ready%3Apull&service=ghcr.io: 401 Unauthorized
```

the only option was to pull all functions upfront 

after this PR:
```
crank render tests/default/default_test.yaml apis/xclusters/composition-aws.yaml  functions.yaml
---
apiVersion: aws.platform.xxx.at/v1alpha1
kind: XCluster
metadata:
  name: wkld-test
status:
  conditions:
  - lastTransitionTime: "2024-01-01T00:00:00Z"
    message: 'Unready resources: access-entry-eks-cluster-admin, access-entry-eks-cluster-viewer,
      access-policy-eks-cluster-admin, and 49 more'
    reason: Creating
    status: "False"
    type: Ready
  eks:
    accountId: "123456789"
    nodeGroupRoleArn: arn:aws:iam::123456789:role/wkld-test-nodegroup
    nodegroupRoleArn: null
    oidc: null
    oidcArn: null
    oidcUri: None
---
```

<!--
Briefly describe what this pull request does, and how it is covered by tests.
Be proactive - direct your reviewers' attention to anything that needs special
consideration.

We love pull requests that fix an open issue. If yours does, use the below line
to indicate which issue it fixes, for example "Fixes #500".
-->

Fixes #

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `earthly +reviewable` to ensure this PR is ready for review.
- [x] Added or updated unit tests.
- [x] Added or updated e2e tests.
- [x] Linked a PR or a [docs tracking issue] to [document this change].
- [x] Added `backport release-x.y` labels to auto-backport this PR.
- [x] Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md