### PR TITLE
feat(crank): add support for list input to validate

### DIFF
--- a/cmd/crank/beta/validate/cmd.go
+++ b/cmd/crank/beta/validate/cmd.go
@@ -36,8 +36,8 @@ import (
 // Cmd arguments and flags for render subcommand.
 type Cmd struct {
 	// Arguments.
-	Extensions string `arg:"" help:"Extensions source which can be a file, directory, or '-' for standard input."`
-	Resources  string `arg:"" help:"Resources source which can be a file, directory, or '-' for standard input."`
+	Extensions string `arg:"" help:"Extension sources as a comma-separated list of files, directories, or '-' for standard input."`
+	Resources  string `arg:"" help:"Resource sources as a comma-separated list of files, directories, or '-' for standard input."`
 
 	// Flags. Keep them in alphabetical order.
 	CacheDir           string `default:"~/.crossplane/cache"                                                       help:"Absolute path to the cache directory where downloaded schemas are stored."`
@@ -66,6 +66,9 @@ Examples:
 
   # Validate all resources in the resources.yaml file against the extensions in the extensions.yaml file
   crossplane beta validate extensions.yaml resources.yaml
+
+  # Validate all resources in the resourceDir folder against the extensions in the crossplane.yaml file and extensionsDir folder
+  crossplane beta validate crossplane.yaml,extensionsDir/ resourceDir/
 
   # Validate all resources in the resources.yaml file against the extensions in the extensions.yaml file using a specific Crossplane image version
   crossplane beta validate extensions.yaml resources.yaml --crossplane-image=xpkg.crossplane.io/crossplane/crossplane:v1.20.0

--- a/cmd/crank/beta/validate/loader_test.go
+++ b/cmd/crank/beta/validate/loader_test.go
@@ -53,6 +53,104 @@ var (
 	}
 )
 
+func TestNewLoader(t *testing.T) {
+	type args struct {
+		input string
+	}
+	type want struct {
+		loader Loader
+		err    error
+	}
+	cases := map[string]struct {
+		reason string
+		args   args
+		want   want
+	}{
+		"SucessWithStdin": {
+			reason: "Successfully create loader from stdin",
+			args: args{
+				input: "-",
+			},
+			want: want{
+				loader: &StdinLoader{},
+			},
+		},
+		"SucessWithFile": {
+			reason: "Successfully create loader from file",
+			args: args{
+				input: "testdata/resources.yaml",
+			},
+			want: want{
+				loader: &FileLoader{path: "testdata/resources.yaml"},
+			},
+		},
+		"SucessWithDirectory": {
+			reason: "Successfully create loader from directory",
+			args: args{
+				input: "testdata/folder",
+			},
+			want: want{
+				loader: &FolderLoader{path: "testdata/folder"},
+			},
+		},
+		"SucessWithMultiple": {
+			reason: "Successfully create loader from multiple sources",
+			args: args{
+				input: "testdata/resources.yaml,testdata/folder",
+			},
+			want: want{
+				loader: &MultiLoader{loaders: []Loader{
+					&FileLoader{path: "testdata/resources.yaml"},
+					&FolderLoader{path: "testdata/folder"},
+				}},
+			},
+		},
+		"ErrorWithFile": {
+			reason: "Error creating loader from file that does not exist",
+			args: args{
+				input: "testdata/does-not-exist.yaml",
+			},
+			want: want{
+				err: cmpopts.AnyError,
+			},
+		},
+		"ErrorWithFolder": {
+			reason: "Error creating loader from folder that does not exist",
+			args: args{
+				input: "testdata/does-not-exist",
+			},
+			want: want{
+				err: cmpopts.AnyError,
+			},
+		},
+		"ErrorWithMultiple": {
+			reason: "Error creating loader from multiple sources that does not exist",
+			args: args{
+				input: "testdata/does-not-exist.yaml,testdata/does-not-exist",
+			},
+			want: want{
+				err: cmpopts.AnyError,
+			},
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got, err := NewLoader(tc.args.input)
+			if diff := cmp.Diff(
+				tc.want.loader,
+				got,
+				cmpopts.IgnoreUnexported(FileLoader{}, FolderLoader{}, MultiLoader{}),
+			); diff != "" {
+				t.Errorf("%s\nLoad(...): -want, +got:\n%s", tc.reason, diff)
+			}
+
+			if diff := cmp.Diff(tc.want.err, err, cmpopts.EquateErrors()); diff != "" {
+				t.Errorf("%s\nLoad(...): -want error, +got error:\n%s", tc.reason, diff)
+			}
+		})
+	}
+}
+
 func TestMultiLoaderLoad(t *testing.T) {
 	type args struct {
 		loaders []Loader


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane! Please read the contribution docs
(linked below) if this is your first Crossplane pull request.
-->

### Description of your changes

<!--
Briefly describe what this pull request does, and how it is covered by tests.
Be proactive - direct your reviewers' attention to anything that needs special
consideration.

We love pull requests that fix an open issue. If yours does, use the below line
to indicate which issue it fixes, for example "Fixes #500".
-->

Fixes #6322

This adds support for parsing and loading lists of resources and extensions to `crossplane beta validate`. It does so by adding a new `MultiLoader` that merges resources provided by other loaders. The new loader is only called when input containing commas is provided, so this should have minimal impact on existing usage.

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `earthly +reviewable` to ensure this PR is ready for review.
- [x] Added or updated unit tests.
- [ ] ~Added or updated e2e tests.~
- [x] Linked a PR or a [docs tracking issue] to [document this change].
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~
- [ ] ~Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md