### PR TITLE
[v2] Don't explicitly "unpublish" connection details

### DIFF
--- a/internal/controller/apiextensions/claim/connection.go
+++ b/internal/controller/apiextensions/claim/connection.go
@@ -28,7 +28,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/crossplane/crossplane-runtime/pkg/errors"
-	"github.com/crossplane/crossplane-runtime/pkg/reconciler/managed"
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
 
 	"github.com/crossplane/crossplane/internal/xresource"
@@ -40,22 +39,6 @@ const (
 	errSecretConflict       = "cannot establish control of existing connection secret"
 	errCreateOrUpdateSecret = "cannot create or update connection secret"
 )
-
-// NopConnectionUnpublisher is a ConnectionUnpublisher that does nothing.
-type NopConnectionUnpublisher struct{}
-
-// NewNopConnectionUnpublisher returns a new NopConnectionUnpublisher.
-func NewNopConnectionUnpublisher() *NopConnectionUnpublisher {
-	return &NopConnectionUnpublisher{}
-}
-
-// UnpublishConnection does nothing and returns no error with
-// UnpublishConnection. Expected to be used where deletion of connection
-// secret is already handled by K8s garbage collection and there is actually
-// nothing to do to unpublish connection details.
-func (n *NopConnectionUnpublisher) UnpublishConnection(_ context.Context, _ xresource.LocalConnectionSecretOwner, _ managed.ConnectionDetails) error {
-	return nil
-}
 
 // An APIConnectionPropagator propagates connection details by reading
 // them from and writing them to a Kubernetes API server.

--- a/internal/controller/apiextensions/claim/reconciler_test.go
+++ b/internal/controller/apiextensions/claim/reconciler_test.go
@@ -33,7 +33,6 @@ import (
 	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
 	"github.com/crossplane/crossplane-runtime/pkg/errors"
 	"github.com/crossplane/crossplane-runtime/pkg/meta"
-	"github.com/crossplane/crossplane-runtime/pkg/reconciler/managed"
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
 	"github.com/crossplane/crossplane-runtime/pkg/test"
 
@@ -221,32 +220,6 @@ func TestReconcile(t *testing.T) {
 					WithClaimFinalizer(resource.FinalizerFns{
 						RemoveFinalizerFn: func(_ context.Context, _ resource.Object) error { return nil },
 					}),
-				},
-			},
-			want: want{
-				r: reconcile.Result{Requeue: true},
-			},
-		},
-		"UnpublishConnectionDetailsError": {
-			reason: "The reconcile should fail if we can't unpublish the claim's connection details.",
-			args: args{
-				client: &test.MockClient{
-					MockGet: test.NewMockGetFn(nil, func(obj client.Object) error {
-						obj.(*claim.Unstructured).SetDeletionTimestamp(&now)
-						return nil
-					}),
-					MockDelete: test.NewMockDeleteFn(nil),
-					MockStatusUpdate: WantClaim(t, NewClaim(func(cm *claim.Unstructured) {
-						// Check that we set our status condition.
-						cm.SetDeletionTimestamp(&now)
-						cm.SetConditions(xpv1.Deleting())
-						cm.SetConditions(xpv1.ReconcileError(errors.Wrap(errBoom, errDeleteCDs)))
-					})),
-				},
-				opts: []ReconcilerOption{
-					WithConnectionUnpublisher(ConnectionUnpublisherFn(func(_ context.Context, _ xresource.LocalConnectionSecretOwner, _ managed.ConnectionDetails) error {
-						return errBoom
-					})),
 				},
 			},
 			want: want{

--- a/internal/controller/apiextensions/composite/api.go
+++ b/internal/controller/apiextensions/composite/api.go
@@ -117,13 +117,6 @@ func (a *APIFilteredSecretPublisher) PublishConnection(ctx context.Context, o xr
 	return true, nil
 }
 
-// UnpublishConnection is no-op since PublishConnection only creates resources
-// that will be garbage collected by Kubernetes when the managed resource is
-// deleted.
-func (a *APIFilteredSecretPublisher) UnpublishConnection(_ context.Context, _ xresource.ConnectionSecretOwner, _ managed.ConnectionDetails) error {
-	return nil
-}
-
 // An APIRevisionFetcher selects the appropriate CompositionRevision for a
 // composite resource, fetches it, and returns it as a Composition. This is done
 // for compatibility with existing Composition logic while CompositionRevisions

--- a/internal/controller/apiextensions/composite/reconciler_test.go
+++ b/internal/controller/apiextensions/composite/reconciler_test.go
@@ -93,31 +93,6 @@ func TestReconcile(t *testing.T) {
 				err: errors.Wrap(errBoom, errGet),
 			},
 		},
-		"UnpublishConnectionError": {
-			reason: "We should return any error encountered while unpublishing connection details.",
-			args: args{
-				c: &test.MockClient{
-					MockGet: WithComposite(t, NewComposite(func(cr *composite.Unstructured) {
-						cr.SetDeletionTimestamp(&now)
-					})),
-					MockStatusUpdate: WantComposite(t, NewComposite(func(want *composite.Unstructured) {
-						want.SetDeletionTimestamp(&now)
-						want.SetConditions(xpv1.Deleting(), xpv1.ReconcileError(errors.Wrap(errBoom, errUnpublish)))
-					})),
-				},
-				opts: []ReconcilerOption{
-					WithCompositeFinalizer(resource.NewNopFinalizer()),
-					WithConnectionPublishers(ConnectionPublisherFns{
-						UnpublishConnectionFn: func(_ context.Context, _ xresource.ConnectionSecretOwner, _ managed.ConnectionDetails) error {
-							return errBoom
-						},
-					}),
-				},
-			},
-			want: want{
-				r: reconcile.Result{Requeue: true},
-			},
-		},
 		"RemoveFinalizerError": {
 			reason: "We should return any error encountered while removing finalizer.",
 			args: args{
@@ -134,11 +109,6 @@ func TestReconcile(t *testing.T) {
 					WithCompositeFinalizer(resource.FinalizerFns{
 						RemoveFinalizerFn: func(_ context.Context, _ resource.Object) error {
 							return errBoom
-						},
-					}),
-					WithConnectionPublishers(ConnectionPublisherFns{
-						UnpublishConnectionFn: func(_ context.Context, _ xresource.ConnectionSecretOwner, _ managed.ConnectionDetails) error {
-							return nil
 						},
 					}),
 				},
@@ -162,11 +132,6 @@ func TestReconcile(t *testing.T) {
 				opts: []ReconcilerOption{
 					WithCompositeFinalizer(resource.FinalizerFns{
 						RemoveFinalizerFn: func(_ context.Context, _ resource.Object) error {
-							return nil
-						},
-					}),
-					WithConnectionPublishers(ConnectionPublisherFns{
-						UnpublishConnectionFn: func(_ context.Context, _ xresource.ConnectionSecretOwner, _ managed.ConnectionDetails) error {
 							return nil
 						},
 					}),
@@ -326,11 +291,9 @@ func TestReconcile(t *testing.T) {
 					WithComposer(ComposerFn(func(_ context.Context, _ *composite.Unstructured, _ CompositionRequest) (CompositionResult, error) {
 						return CompositionResult{}, nil
 					})),
-					WithConnectionPublishers(ConnectionPublisherFns{
-						PublishConnectionFn: func(_ context.Context, _ xresource.ConnectionSecretOwner, _ managed.ConnectionDetails) (published bool, err error) {
-							return false, errBoom
-						},
-					}),
+					WithConnectionPublishers(ConnectionPublisherFn(func(_ context.Context, _ xresource.ConnectionSecretOwner, _ managed.ConnectionDetails) (published bool, err error) {
+						return false, errBoom
+					})),
 				},
 			},
 			want: want{
@@ -369,11 +332,9 @@ func TestReconcile(t *testing.T) {
 							},
 						}, nil
 					})),
-					WithConnectionPublishers(ConnectionPublisherFns{
-						PublishConnectionFn: func(_ context.Context, _ xresource.ConnectionSecretOwner, _ managed.ConnectionDetails) (published bool, err error) {
-							return false, nil
-						},
-					}),
+					WithConnectionPublishers(ConnectionPublisherFn(func(_ context.Context, _ xresource.ConnectionSecretOwner, _ managed.ConnectionDetails) (published bool, err error) {
+						return false, nil
+					})),
 				},
 			},
 			want: want{
@@ -431,11 +392,9 @@ func TestReconcile(t *testing.T) {
 							}},
 						}, nil
 					})),
-					WithConnectionPublishers(ConnectionPublisherFns{
-						PublishConnectionFn: func(_ context.Context, _ xresource.ConnectionSecretOwner, _ managed.ConnectionDetails) (published bool, err error) {
-							return false, nil
-						},
-					}),
+					WithConnectionPublishers(ConnectionPublisherFn(func(_ context.Context, _ xresource.ConnectionSecretOwner, _ managed.ConnectionDetails) (published bool, err error) {
+						return false, nil
+					})),
 				},
 			},
 			want: want{
@@ -477,15 +436,13 @@ func TestReconcile(t *testing.T) {
 					WithComposer(ComposerFn(func(_ context.Context, _ *composite.Unstructured, _ CompositionRequest) (CompositionResult, error) {
 						return CompositionResult{ConnectionDetails: cd}, nil
 					})),
-					WithConnectionPublishers(ConnectionPublisherFns{
-						PublishConnectionFn: func(_ context.Context, _ xresource.ConnectionSecretOwner, got managed.ConnectionDetails) (published bool, err error) {
-							want := cd
-							if diff := cmp.Diff(want, got); diff != "" {
-								t.Errorf("PublishConnection(...): -want, +got:\n%s", diff)
-							}
-							return true, nil
-						},
-					}),
+					WithConnectionPublishers(ConnectionPublisherFn(func(_ context.Context, _ xresource.ConnectionSecretOwner, got managed.ConnectionDetails) (published bool, err error) {
+						want := cd
+						if diff := cmp.Diff(want, got); diff != "" {
+							t.Errorf("PublishConnection(...): -want, +got:\n%s", diff)
+						}
+						return true, nil
+					})),
 					WithWatchStarter("cool-controller", nil, WatchStarterFn(func(_ string, ws ...engine.Watch) error {
 						cd := composed.New(composed.FromReference(corev1.ObjectReference{
 							APIVersion: "example.org/v1",
@@ -566,11 +523,9 @@ func TestReconcile(t *testing.T) {
 					WithComposer(ComposerFn(func(_ context.Context, _ *composite.Unstructured, _ CompositionRequest) (CompositionResult, error) {
 						return CompositionResult{}, nil
 					})),
-					WithConnectionPublishers(ConnectionPublisherFns{
-						PublishConnectionFn: func(_ context.Context, _ xresource.ConnectionSecretOwner, _ managed.ConnectionDetails) (published bool, err error) {
-							return true, nil
-						},
-					}),
+					WithConnectionPublishers(ConnectionPublisherFn(func(_ context.Context, _ xresource.ConnectionSecretOwner, _ managed.ConnectionDetails) (published bool, err error) {
+						return true, nil
+					})),
 				},
 			},
 			want: want{
@@ -607,11 +562,9 @@ func TestReconcile(t *testing.T) {
 					WithComposer(ComposerFn(func(_ context.Context, _ *composite.Unstructured, _ CompositionRequest) (CompositionResult, error) {
 						return CompositionResult{}, nil
 					})),
-					WithConnectionPublishers(ConnectionPublisherFns{
-						PublishConnectionFn: func(_ context.Context, _ xresource.ConnectionSecretOwner, _ managed.ConnectionDetails) (published bool, err error) {
-							return true, nil
-						},
-					}),
+					WithConnectionPublishers(ConnectionPublisherFn(func(_ context.Context, _ xresource.ConnectionSecretOwner, _ managed.ConnectionDetails) (published bool, err error) {
+						return true, nil
+					})),
 				},
 			},
 			want: want{


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane! Please read the contribution docs
(linked below) if this is your first Crossplane pull request.
-->

### Description of your changes

<!--
Briefly describe what this pull request does, and how it is covered by tests.
Be proactive - direct your reviewers' attention to anything that needs special
consideration.

We love pull requests that fix an open issue. If yours does, use the below line
to indicate which issue it fixes, for example "Fixes #500".
-->

The v2 branch only supports publishing connection details as Kubernetes secrets. We don't need to explicitly unpublish them, because we rely on Kubernetes garbage collection to delete connection secrets.

We needed to explicitly unpublish connection details from e.g. Vault, but that feature (external secret stores) is removed in the v2 branch.

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `earthly +reviewable` to ensure this PR is ready for review.
- [x] Added or updated unit tests.
- [ ] ~Added or updated e2e tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~
- [ ] ~Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md