### PR TITLE
[v2] Don't set composed resource `meta.generateName` if `meta.name` is set explicitly

### DIFF
--- a/internal/controller/apiextensions/composite/composition_render.go
+++ b/internal/controller/apiextensions/composite/composition_render.go
@@ -83,9 +83,11 @@ func RenderComposedResourceMetadata(cd, xr resource.Object, n ResourceName) erro
 		return errors.Errorf(errFmtNamePrefixLabel, xcrd.LabelKeyNamePrefixForComposed)
 	}
 
-	// We also set generate name in case we haven't yet named this composed
-	// resource.
-	cd.SetGenerateName(xr.GetLabels()[xcrd.LabelKeyNamePrefixForComposed] + "-")
+	// We recommend composed resources let us generate a name for them. They're
+	// allowed to explicitly specify a name if they want though.
+	if cd.GetName() == "" && cd.GetGenerateName() == "" {
+		cd.SetGenerateName(xr.GetLabels()[xcrd.LabelKeyNamePrefixForComposed] + "-")
+	}
 
 	// If the XR is namespaced it can only create composed resources in its own
 	// namespace. Cluster scoped XRs can compose cluster scoped resources, or

--- a/test/e2e/apiextensions_compositions_test.go
+++ b/test/e2e/apiextensions_compositions_test.go
@@ -58,7 +58,7 @@ func TestBasicCompositionNamespaced(t *testing.T) {
 				funcs.ResourcesCreatedWithin(30*time.Second, manifests, "xr.yaml"),
 			)).
 			Assess("XRIsReady",
-				funcs.ResourcesHaveConditionWithin(5*time.Minute, manifests, "xr.yaml", xpv1.Available())).
+				funcs.ResourcesHaveConditionWithin(5*time.Minute, manifests, "xr.yaml", xpv1.Available(), xpv1.ReconcileSuccess())).
 			Assess("XRHasStatusField",
 				funcs.ResourcesHaveFieldValueWithin(5*time.Minute, manifests, "xr.yaml", "status.coolerField", "I'M COOLER!"),
 			).
@@ -91,7 +91,7 @@ func TestBasicCompositionCluster(t *testing.T) {
 				funcs.ResourcesCreatedWithin(30*time.Second, manifests, "xr.yaml"),
 			)).
 			Assess("XRIsReady",
-				funcs.ResourcesHaveConditionWithin(5*time.Minute, manifests, "xr.yaml", xpv1.Available())).
+				funcs.ResourcesHaveConditionWithin(5*time.Minute, manifests, "xr.yaml", xpv1.Available(), xpv1.ReconcileSuccess())).
 			Assess("XRHasStatusField",
 				funcs.ResourcesHaveFieldValueWithin(5*time.Minute, manifests, "xr.yaml", "status.coolerField", "I'M COOLER!"),
 			).

--- a/test/e2e/manifests/apiextensions/composition/basic-cluster/setup/composition.yaml
+++ b/test/e2e/manifests/apiextensions/composition/basic-cluster/setup/composition.yaml
@@ -50,6 +50,9 @@ spec:
                   - name: v1alpha1
                     served: true
                     storage: true
+                    schema:
+                      openAPIV3Schema:
+                       type: object
               ready: READY_TRUE
         results:
          - severity: SEVERITY_NORMAL


### PR DESCRIPTION

<!--
Thank you for helping to improve Crossplane! Please read the contribution docs
(linked below) if this is your first Crossplane pull request.
-->

### Description of your changes

<!--
Briefly describe what this pull request does, and how it is covered by tests.
Be proactive - direct your reviewers' attention to anything that needs special
consideration.

We love pull requests that fix an open issue. If yours does, use the below line
to indicate which issue it fixes, for example "Fixes #500".
-->

I noticed the CRD composed by the new cluster scoped XR E2E was invalid - missing a schema - but the XR was still becoming ready. This was because the function was telling it the XR was ready, even though it wasn't applying correctly.

I fixed the invalid CRD and updated the E2E to test that the XR was ready and synced (i.e. not encountering errors). The E2E was still failing though.

Turns out the composed CRD was still invalid because Crossplane was trying to set `meta.generateName` to something that'd generate an invalid name for a CRD. CRDs must be named `<plural>.<group>`. I had thought `meta.generateName` was ignored if `meta.name` was set explicitly, but that's apparently not the case.



I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `earthly +reviewable` to ensure this PR is ready for review.
- [ ] ~Added or updated unit tests.~
- [x] Added or updated e2e tests.
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~
- [ ] ~Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md