### PR TITLE
Make XRD names,claimNames shortNames and categories mutable

### DIFF
--- a/apis/apiextensions/v1/xrd_types.go
+++ b/apis/apiextensions/v1/xrd_types.go
@@ -35,7 +35,10 @@ type CompositeResourceDefinitionSpec struct {
 
 	// Names specifies the resource and kind names of the defined composite
 	// resource.
-	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="Value is immutable"
+	// +kubebuilder:validation:XValidation:rule="self.plural == oldSelf.plural",message="plural is immutable"
+	// +kubebuilder:validation:XValidation:rule="self.singular == oldSelf.singular",message="singular is immutable"
+	// +kubebuilder:validation:XValidation:rule="self.kind == oldSelf.kind",message="kind is immutable"
+	// +kubebuilder:validation:XValidation:rule="self.listKind == oldSelf.listKind",message="listKind is immutable"
 	Names extv1.CustomResourceDefinitionNames `json:"names"`
 
 	// ClaimNames specifies the names of an optional composite resource claim.
@@ -47,7 +50,10 @@ type CompositeResourceDefinitionSpec struct {
 	// claim names to an existing CompositeResourceDefinition, but they cannot
 	// be changed or removed once they have been set.
 	// +optional
-	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="Value is immutable"
+	// +kubebuilder:validation:XValidation:rule="self.plural == oldSelf.plural",message="plural is immutable"
+	// +kubebuilder:validation:XValidation:rule="self.singular == oldSelf.singular",message="singular is immutable"
+	// +kubebuilder:validation:XValidation:rule="self.kind == oldSelf.kind",message="kind is immutable"
+	// +kubebuilder:validation:XValidation:rule="self.listKind == oldSelf.listKind",message="listKind is immutable"
 	ClaimNames *extv1.CustomResourceDefinitionNames `json:"claimNames,omitempty"`
 
 	// ConnectionSecretKeys is the list of keys that will be exposed to the end

--- a/cluster/crds/apiextensions.crossplane.io_compositeresourcedefinitions.yaml
+++ b/cluster/crds/apiextensions.crossplane.io_compositeresourcedefinitions.yaml
@@ -114,8 +114,14 @@ spec:
                 - plural
                 type: object
                 x-kubernetes-validations:
-                - message: Value is immutable
-                  rule: self == oldSelf
+                - message: plural is immutable
+                  rule: self.plural == oldSelf.plural
+                - message: singular is immutable
+                  rule: self.singular == oldSelf.singular
+                - message: kind is immutable
+                  rule: self.kind == oldSelf.kind
+                - message: listKind is immutable
+                  rule: self.listKind == oldSelf.listKind
               connectionSecretKeys:
                 description: |-
                   ConnectionSecretKeys is the list of keys that will be exposed to the end
@@ -353,8 +359,14 @@ spec:
                 - plural
                 type: object
                 x-kubernetes-validations:
-                - message: Value is immutable
-                  rule: self == oldSelf
+                - message: plural is immutable
+                  rule: self.plural == oldSelf.plural
+                - message: singular is immutable
+                  rule: self.singular == oldSelf.singular
+                - message: kind is immutable
+                  rule: self.kind == oldSelf.kind
+                - message: listKind is immutable
+                  rule: self.listKind == oldSelf.listKind
               versions:
                 description: |-
                   Versions is the list of all API versions of the defined composite


### PR DESCRIPTION
This has two purposes:

* These fields should be mutable (they work fine as mutable fields)

* Ensure that XRDs with shortNames: [] are un-broken. This probably has
  another root cause and should be diagnosed and fixed.

Signed-off-by: Carl Henrik Lunde <chlunde@ifi.uio.no>

<!--
Thank you for helping to improve Crossplane! Please read the contribution docs
(linked below) if this is your first Crossplane pull request.
-->

### Description of your changes

<!--
Briefly describe what this pull request does, and how it is covered by tests.
Be proactive - direct your reviewers' attention to anything that needs special
consideration.

We love pull requests that fix an open issue. If yours does, use the below line
to indicate which issue it fixes, for example "Fixes #500".
-->

Fixes #

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [ ] Read and followed Crossplane's [contribution process].
- [ ] Run `earthly +reviewable` to ensure this PR is ready for review.
- [ ] Added or updated unit tests.
- [ ] Added or updated e2e tests.
- [ ] Linked a PR or a [docs tracking issue] to [document this change].
- [ ] Added `backport release-x.y` labels to auto-backport this PR.
- [ ] Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md
