### PR TITLE
add env annotation to render docker runtime container

### DIFF
--- a/cmd/crank/render/runtime_docker.go
+++ b/cmd/crank/render/runtime_docker.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"strings"
 
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/filters"
@@ -53,6 +54,11 @@ const (
 	// be used for the container. it will also reuse the same container as long as
 	// it is available and also try to restart if it is not running.
 	AnnotationKeyRuntimeNamedContainer = "render.crossplane.io/runtime-docker-name"
+
+	// AnnotationKeyRuntimeEnvironmentVariables sets the environment variables
+	// that will be used for the container. This is helpful to control kpm registry
+	// access to use a different registry.
+	AnnotationKeyRuntimeEnvironmentVariables = "render.crossplane.io/runtime-docker-env"
 )
 
 // DockerCleanup specifies what Docker should do with a Function container after
@@ -117,6 +123,9 @@ type RuntimeDocker struct {
 
 	// log is the logger for this runtime.
 	log logging.Logger
+
+	// Env is the list of environment variables to set for the container.
+	Env []string
 }
 
 // GetDockerPullPolicy extracts PullPolicy configuration from the supplied
@@ -174,6 +183,17 @@ func GetRuntimeDocker(fn pkgv1.Function, log logging.Logger) (*RuntimeDocker, er
 	if i := fn.GetAnnotations()[AnnotationKeyRuntimeNamedContainer]; i != "" {
 		r.Name = i
 	}
+	if i := fn.GetAnnotations()[AnnotationKeyRuntimeEnvironmentVariables]; i != "" {
+		pairs := strings.Split(i, ",")
+		for _, pair := range pairs {
+			if !strings.Contains(pair, "=") {
+				r.log.Debug("ignoring invalid environment variable", "pair", pair)
+				continue
+			}
+			r.Env = append(r.Env, pair)
+		}
+	}
+
 	return r, nil
 }
 
@@ -248,6 +268,7 @@ func (r *RuntimeDocker) createContainer(ctx context.Context, cli *client.Client)
 		Image:        r.Image,
 		Cmd:          []string{"--insecure"},
 		ExposedPorts: expose,
+		Env:          r.Env,
 	}
 	hcfg := &container.HostConfig{
 		PortBindings: bind,

--- a/cmd/crank/render/runtime_docker.go
+++ b/cmd/crank/render/runtime_docker.go
@@ -58,6 +58,7 @@ const (
 	// AnnotationKeyRuntimeEnvironmentVariables sets the environment variables
 	// that will be used for the container. This is helpful to control kpm registry
 	// access to use a different registry.
+	// It is a comma separated string of key=value pairs e.g. "key1=value1,key2=value2".
 	AnnotationKeyRuntimeEnvironmentVariables = "render.crossplane.io/runtime-docker-env"
 )
 

--- a/cmd/crank/render/runtime_docker_test.go
+++ b/cmd/crank/render/runtime_docker_test.go
@@ -61,9 +61,10 @@ func TestGetRuntimeDocker(t *testing.T) {
 				fn: pkgv1.Function{
 					ObjectMeta: metav1.ObjectMeta{
 						Annotations: map[string]string{
-							AnnotationKeyRuntimeDockerCleanup:    string(AnnotationValueRuntimeDockerCleanupOrphan),
-							AnnotationKeyRuntimeDockerPullPolicy: string(AnnotationValueRuntimeDockerPullPolicyAlways),
-							AnnotationKeyRuntimeDockerImage:      "test-image-from-annotation",
+							AnnotationKeyRuntimeDockerCleanup:        string(AnnotationValueRuntimeDockerCleanupOrphan),
+							AnnotationKeyRuntimeDockerPullPolicy:     string(AnnotationValueRuntimeDockerPullPolicyAlways),
+							AnnotationKeyRuntimeDockerImage:          "test-image-from-annotation",
+							AnnotationKeyRuntimeEnvironmentVariables: "KCL_DEFAULT_REGISTRY=registry.example.com",
 						},
 					},
 					Spec: pkgv1.FunctionSpec{
@@ -78,6 +79,7 @@ func TestGetRuntimeDocker(t *testing.T) {
 					Image:      "test-image-from-annotation",
 					Cleanup:    AnnotationValueRuntimeDockerCleanupOrphan,
 					PullPolicy: AnnotationValueRuntimeDockerPullPolicyAlways,
+					Env:        []string{"KCL_DEFAULT_REGISTRY=registry.example.com"},
 				},
 			},
 		},
@@ -87,9 +89,10 @@ func TestGetRuntimeDocker(t *testing.T) {
 				fn: pkgv1.Function{
 					ObjectMeta: metav1.ObjectMeta{
 						Annotations: map[string]string{
-							AnnotationKeyRuntimeDockerCleanup:  string(AnnotationValueRuntimeDockerCleanupOrphan),
-							AnnotationKeyRuntimeNamedContainer: "test-container-name-function",
-							AnnotationKeyRuntimeDockerImage:    "test-image-from-annotation",
+							AnnotationKeyRuntimeDockerCleanup:        string(AnnotationValueRuntimeDockerCleanupOrphan),
+							AnnotationKeyRuntimeNamedContainer:       "test-container-name-function",
+							AnnotationKeyRuntimeDockerImage:          "test-image-from-annotation",
+							AnnotationKeyRuntimeEnvironmentVariables: "KCL_DEFAULT_REGISTRYregistry.example.com",
 						},
 					},
 					Spec: pkgv1.FunctionSpec{
@@ -105,6 +108,7 @@ func TestGetRuntimeDocker(t *testing.T) {
 					Cleanup:    AnnotationValueRuntimeDockerCleanupOrphan,
 					Name:       "test-container-name-function",
 					PullPolicy: AnnotationValueRuntimeDockerPullPolicyIfNotPresent,
+					Env:        nil,
 				},
 			},
 		},

--- a/cmd/crank/render/runtime_docker_test.go
+++ b/cmd/crank/render/runtime_docker_test.go
@@ -64,7 +64,7 @@ func TestGetRuntimeDocker(t *testing.T) {
 							AnnotationKeyRuntimeDockerCleanup:        string(AnnotationValueRuntimeDockerCleanupOrphan),
 							AnnotationKeyRuntimeDockerPullPolicy:     string(AnnotationValueRuntimeDockerPullPolicyAlways),
 							AnnotationKeyRuntimeDockerImage:          "test-image-from-annotation",
-							AnnotationKeyRuntimeEnvironmentVariables: "KCL_DEFAULT_REGISTRY=registry.example.com",
+							AnnotationKeyRuntimeEnvironmentVariables: "KCL_DEFAULT_REGISTRY=registry.example.com,ANOTHER_ENV_VAR=another-value",
 						},
 					},
 					Spec: pkgv1.FunctionSpec{
@@ -79,7 +79,7 @@ func TestGetRuntimeDocker(t *testing.T) {
 					Image:      "test-image-from-annotation",
 					Cleanup:    AnnotationValueRuntimeDockerCleanupOrphan,
 					PullPolicy: AnnotationValueRuntimeDockerPullPolicyAlways,
-					Env:        []string{"KCL_DEFAULT_REGISTRY=registry.example.com"},
+					Env:        []string{"KCL_DEFAULT_REGISTRY=registry.example.com", "ANOTHER_ENV_VAR=another-value"},
 				},
 			},
 		},
@@ -92,7 +92,7 @@ func TestGetRuntimeDocker(t *testing.T) {
 							AnnotationKeyRuntimeDockerCleanup:        string(AnnotationValueRuntimeDockerCleanupOrphan),
 							AnnotationKeyRuntimeNamedContainer:       "test-container-name-function",
 							AnnotationKeyRuntimeDockerImage:          "test-image-from-annotation",
-							AnnotationKeyRuntimeEnvironmentVariables: "KCL_DEFAULT_REGISTRYregistry.example.com",
+							AnnotationKeyRuntimeEnvironmentVariables: "SKIPPED_KEYvalue,KCL_DEFAULT_REGISTRY=registry.example.com",
 						},
 					},
 					Spec: pkgv1.FunctionSpec{
@@ -108,7 +108,7 @@ func TestGetRuntimeDocker(t *testing.T) {
 					Cleanup:    AnnotationValueRuntimeDockerCleanupOrphan,
 					Name:       "test-container-name-function",
 					PullPolicy: AnnotationValueRuntimeDockerPullPolicyIfNotPresent,
-					Env:        nil,
+					Env:        []string{"KCL_DEFAULT_REGISTRY=registry.example.com"},
 				},
 			},
 		},
@@ -180,7 +180,8 @@ func TestGetRuntimeDocker(t *testing.T) {
 				fn: pkgv1.Function{
 					ObjectMeta: metav1.ObjectMeta{
 						Annotations: map[string]string{
-							AnnotationKeyRuntimeDockerCleanup: string(AnnotationValueRuntimeDockerCleanupStop),
+							AnnotationKeyRuntimeDockerCleanup:        string(AnnotationValueRuntimeDockerCleanupStop),
+							AnnotationKeyRuntimeEnvironmentVariables: "SKIPPED_KEYvalue",
 						},
 					},
 					Spec: pkgv1.FunctionSpec{
@@ -195,6 +196,7 @@ func TestGetRuntimeDocker(t *testing.T) {
 					Image:      "test-package",
 					Cleanup:    AnnotationValueRuntimeDockerCleanupStop,
 					PullPolicy: AnnotationValueRuntimeDockerPullPolicyIfNotPresent,
+					Env:        nil,
 				},
 			},
 		},


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane! Please read the contribution docs
(linked below) if this is your first Crossplane pull request.
-->

### Description of your changes

<!--
Briefly describe what this pull request does, and how it is covered by tests.
Be proactive - direct your reviewers' attention to anything that needs special
consideration.

We love pull requests that fix an open issue. If yours does, use the below line
to indicate which issue it fixes, for example "Fixes #500".
-->

This MR adds the option to set docker runtime environment annotations to functions.
The annotations will be considered during the `crossplane render` command and the docker container 
will add environment variables with the key=value from the annoation.

This is useful to e.g. tell kcl to pull from other oci registries.

Docs PR: https://github.com/crossplane/docs/pull/910

Fixes #

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `earthly +reviewable` to ensure this PR is ready for review.
- [x] Added or updated unit tests.
- [ ] ~Added or updated e2e tests~.
- [x] Linked a PR or a [docs tracking issue] to [document this change].
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~
- [ ] ~Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md