### PR TITLE
fix: remove claim labels from XRs

### DIFF
--- a/internal/controller/apiextensions/composite/composition_render.go
+++ b/internal/controller/apiextensions/composite/composition_render.go
@@ -102,11 +102,16 @@ func RenderComposedResourceMetadata(cd, xr resource.Object, n ResourceName) erro
 
 	// TODO(negz): What happens if there is no claim? Will this set empty
 	// claim name/namespace labels?
-	meta.AddLabels(cd, map[string]string{
+
+	metaLabels := map[string]string{
 		xcrd.LabelKeyNamePrefixForComposed: xr.GetLabels()[xcrd.LabelKeyNamePrefixForComposed],
-		xcrd.LabelKeyClaimName:             xr.GetLabels()[xcrd.LabelKeyClaimName],
-		xcrd.LabelKeyClaimNamespace:        xr.GetLabels()[xcrd.LabelKeyClaimNamespace],
-	})
+	}
+	if xr.GetLabels()[xcrd.LabelKeyClaimName] != "" && xr.GetLabels()[xcrd.LabelKeyClaimNamespace] != "" {
+		metaLabels[xcrd.LabelKeyClaimName] = xr.GetLabels()[xcrd.LabelKeyClaimName]
+		metaLabels[xcrd.LabelKeyClaimNamespace] = xr.GetLabels()[xcrd.LabelKeyClaimNamespace]
+	}
+
+	meta.AddLabels(cd, metaLabels)
 
 	or := meta.AsController(meta.TypedReferenceTo(xr, xr.GetObjectKind().GroupVersionKind()))
 	return errors.Wrap(meta.AddControllerReference(cd, or), errSetControllerRef)


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane! Please read the contribution docs
(linked below) if this is your first Crossplane pull request.
-->

### Description of your changes

<!--
Briefly describe what this pull request does, and how it is covered by tests.
Be proactive - direct your reviewers' attention to anything that needs special
consideration.

We love pull requests that fix an open issue. If yours does, use the below line
to indicate which issue it fixes, for example "Fixes #500".
-->

Fixes #6363 

Since v2 doesn't support claims, this PR removes the labels from XRs.

I have tested it locally in a Kind cluster, and it works as expected.

Resulting XRs. 
![Screenshot 2025-04-06 at 13 48 53](https://github.com/user-attachments/assets/94676d8b-0aeb-411e-af86-2d39f99bd9e9)


I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `earthly +reviewable` to ensure this PR is ready for review.
- [ ] ~Added or updated unit tests.~
- [ ] ~Added or updated e2e tests.~
- [x] Linked a PR or a [docs tracking issue] to [document this change].
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~
- [ ] ~Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md