### PR TITLE
Only garbage collect composed resource watches

### DIFF
--- a/internal/controller/apiextensions/composite/reconciler.go
+++ b/internal/controller/apiextensions/composite/reconciler.go
@@ -355,21 +355,23 @@ func (fn CompositionRevisionValidatorFn) Validate(c *v1.CompositionRevision) err
 // start watches when they compose new kinds of resources.
 type WatchStarter interface {
 	// StartWatches starts the supplied watches, if they're not running already.
-	StartWatches(name string, ws ...engine.Watch) error
+	StartWatches(ctx context.Context, name string, ws ...engine.Watch) error
 }
 
 // A NopWatchStarter does nothing.
 type NopWatchStarter struct{}
 
 // StartWatches does nothing.
-func (n *NopWatchStarter) StartWatches(_ string, _ ...engine.Watch) error { return nil }
+func (n *NopWatchStarter) StartWatches(_ context.Context, _ string, _ ...engine.Watch) error {
+	return nil
+}
 
 // A WatchStarterFn is a function that can start a new watch.
-type WatchStarterFn func(name string, ws ...engine.Watch) error
+type WatchStarterFn func(ctx context.Context, name string, ws ...engine.Watch) error
 
 // StartWatches starts the supplied watches, if they're not running already.
-func (fn WatchStarterFn) StartWatches(name string, ws ...engine.Watch) error {
-	return fn(name, ws...)
+func (fn WatchStarterFn) StartWatches(ctx context.Context, name string, ws ...engine.Watch) error {
+	return fn(ctx, name, ws...)
 }
 
 type compositeResource struct {
@@ -610,7 +612,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 	// StartWatches is a no-op unless the realtime compositions feature flag is
 	// enabled. When the flag is enabled, the ControllerEngine that starts this
 	// controller also starts a garbage collector for its watches.
-	if err := r.engine.StartWatches(r.controllerName, ws...); err != nil {
+	if err := r.engine.StartWatches(ctx, r.controllerName, ws...); err != nil {
 		// TODO(negz): If we stop polling this will be a more serious error.
 		log.Debug("Cannot start watches for composed resources. Relying on polling to know when they change.", "controller-name", r.controllerName, "error", err)
 	}

--- a/internal/controller/apiextensions/composite/reconciler.go
+++ b/internal/controller/apiextensions/composite/reconciler.go
@@ -521,6 +521,9 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 
 	orig := xr.GetCompositionReference()
 	if err := r.composite.SelectComposition(ctx, xr); err != nil {
+		if kerrors.IsConflict(err) {
+			return reconcile.Result{Requeue: true}, nil
+		}
 		err = errors.Wrap(err, errSelectComp)
 		r.record.Event(xr, event.Warning(reasonResolve, err))
 		xr.SetConditions(xpv1.ReconcileError(err))
@@ -534,6 +537,9 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 	origRev := xr.GetCompositionRevisionReference()
 	rev, err := r.revision.Fetch(ctx, xr)
 	if err != nil {
+		if kerrors.IsConflict(err) {
+			return reconcile.Result{Requeue: true}, nil
+		}
 		log.Debug(errFetchComp, "error", err)
 		err = errors.Wrap(err, errFetchComp)
 		r.record.Event(xr, event.Warning(reasonCompose, err))
@@ -544,8 +550,6 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 		r.record.Event(xr, event.Normal(reasonResolve, fmt.Sprintf("Selected composition revision: %s", rev.Name)))
 	}
 
-	// TODO(negz): Update this to validate the revision? In practice that's what
-	// it's doing today when revis are enabled.
 	if err := r.revision.Validate(rev); err != nil {
 		log.Debug(errValidate, "error", err)
 		err = errors.Wrap(err, errValidate)

--- a/internal/controller/apiextensions/composite/reconciler_test.go
+++ b/internal/controller/apiextensions/composite/reconciler_test.go
@@ -575,7 +575,7 @@ func TestReconcile(t *testing.T) {
 							return true, nil
 						},
 					}),
-					WithWatchStarter("cool-controller", nil, WatchStarterFn(func(_ string, ws ...engine.Watch) error {
+					WithWatchStarter("cool-controller", nil, WatchStarterFn(func(_ context.Context, _ string, ws ...engine.Watch) error {
 						cd := composed.New(composed.FromReference(corev1.ObjectReference{
 							APIVersion: "example.org/v1",
 							Kind:       "ComposedResource",
@@ -626,7 +626,7 @@ func TestReconcile(t *testing.T) {
 			},
 		},
 		"ReconciliationResumes": {
-			reason: `If a composite resource has the pause annotation with some value other than "true" and the Synced=False/ReconcilePaused status condition, reconciliation should resume with requeueing.`,
+			reason: `If a composite resource has the pause annotation with some value other than "true" and the Synced=False/ReconcilePaused status condition, reconciliation should resume with requeuing.`,
 			args: args{
 				c: &test.MockClient{
 					MockGet: WithComposite(t, NewComposite(func(cr resource.Composite) {
@@ -674,7 +674,7 @@ func TestReconcile(t *testing.T) {
 			},
 		},
 		"ReconciliationResumesAfterAnnotationRemoval": {
-			reason: `If a composite resource has the pause annotation removed and the Synced=False/ReconcilePaused status condition, reconciliation should resume with requeueing.`,
+			reason: `If a composite resource has the pause annotation removed and the Synced=False/ReconcilePaused status condition, reconciliation should resume with requeuing.`,
 			args: args{
 				c: &test.MockClient{
 					MockGet: WithComposite(t, NewComposite(func(cr resource.Composite) {

--- a/internal/controller/apiextensions/composite/watch/watch_test.go
+++ b/internal/controller/apiextensions/composite/watch/watch_test.go
@@ -153,7 +153,21 @@ func TestGarbageCollectWatchesNow(t *testing.T) {
 						}
 					},
 					MockGetWatches: func(_ string) ([]engine.WatchID, error) {
-						return nil, nil
+						w := []engine.WatchID{
+							{
+								Type: engine.WatchTypeCompositeResource,
+								GVK:  schema.GroupVersionKind{},
+							},
+							{
+								Type: engine.WatchTypeClaim,
+								GVK:  schema.GroupVersionKind{},
+							},
+							{
+								Type: engine.WatchTypeCompositionRevision,
+								GVK:  schema.GroupVersionKind{},
+							},
+						}
+						return w, nil
 					},
 					// StopWatches would panic if called, since it's not mocked.
 				},
@@ -162,7 +176,7 @@ func TestGarbageCollectWatchesNow(t *testing.T) {
 				err: nil,
 			},
 		},
-		"UneededWatchesStopped": {
+		"UnneededWatchesStopped": {
 			reason: "StopWatches shouldn't be called if there's no watches to stop.",
 			params: params{
 				ce: &MockEngine{

--- a/internal/controller/apiextensions/definition/reconciler_test.go
+++ b/internal/controller/apiextensions/definition/reconciler_test.go
@@ -48,7 +48,7 @@ type MockEngine struct {
 	MockStop            func(ctx context.Context, name string) error
 	MockIsRunning       func(name string) bool
 	MockGetWatches      func(name string) ([]engine.WatchID, error)
-	MockStartWatches    func(name string, ws ...engine.Watch) error
+	MockStartWatches    func(ctx context.Context, name string, ws ...engine.Watch) error
 	MockStopWatches     func(ctx context.Context, name string, ws ...engine.WatchID) (int, error)
 	MockGetCached       func() client.Client
 	MockGetUncached     func() client.Client
@@ -71,8 +71,8 @@ func (m *MockEngine) GetWatches(name string) ([]engine.WatchID, error) {
 	return m.MockGetWatches(name)
 }
 
-func (m *MockEngine) StartWatches(name string, ws ...engine.Watch) error {
-	return m.MockStartWatches(name, ws...)
+func (m *MockEngine) StartWatches(ctx context.Context, name string, ws ...engine.Watch) error {
+	return m.MockStartWatches(ctx, name, ws...)
 }
 
 func (m *MockEngine) StopWatches(ctx context.Context, name string, ws ...engine.WatchID) (int, error) {
@@ -599,7 +599,7 @@ func TestReconcile(t *testing.T) {
 			},
 		},
 		"VersionChangedStopControllerError": {
-			reason: "We should return any error we encounter while stopping our controller because the XRD's referencable version changed.",
+			reason: "We should return any error we encounter while stopping our controller because the XRD's referenceable version changed.",
 			args: args{
 				ca: resource.ClientApplicator{
 					Client: &test.MockClient{
@@ -732,7 +732,7 @@ func TestReconcile(t *testing.T) {
 						MockStart: func(_ string, _ ...engine.ControllerOption) error {
 							return nil
 						},
-						MockStartWatches: func(_ string, _ ...engine.Watch) error {
+						MockStartWatches: func(_ context.Context, _ string, _ ...engine.Watch) error {
 							return errBoom
 						},
 						MockGetCached:   func() client.Client { return test.NewMockClient() },
@@ -746,7 +746,7 @@ func TestReconcile(t *testing.T) {
 			},
 		},
 		"SuccessfulStart": {
-			reason: "We should return without requeueing if we successfully ensured our CRD exists and controller is started.",
+			reason: "We should return without requeuing if we successfully ensured our CRD exists and controller is started.",
 			args: args{
 				ca: resource.ClientApplicator{
 					Client: &test.MockClient{
@@ -781,7 +781,7 @@ func TestReconcile(t *testing.T) {
 					WithControllerEngine(&MockEngine{
 						MockIsRunning:    func(_ string) bool { return false },
 						MockStart:        func(_ string, _ ...engine.ControllerOption) error { return nil },
-						MockStartWatches: func(_ string, _ ...engine.Watch) error { return nil },
+						MockStartWatches: func(_ context.Context, _ string, _ ...engine.Watch) error { return nil },
 						MockGetCached:    func() client.Client { return test.NewMockClient() },
 						MockGetUncached:  func() client.Client { return test.NewMockClient() },
 					}),
@@ -792,7 +792,7 @@ func TestReconcile(t *testing.T) {
 			},
 		},
 		"SuccessfulUpdateControllerVersion": {
-			reason: "We should return without requeueing if we successfully ensured our CRD exists, the old controller stopped, and the new one started.",
+			reason: "We should return without requeuing if we successfully ensured our CRD exists, the old controller stopped, and the new one started.",
 			args: args{
 				ca: resource.ClientApplicator{
 					Client: &test.MockClient{
@@ -841,7 +841,7 @@ func TestReconcile(t *testing.T) {
 						MockStart:        func(_ string, _ ...engine.ControllerOption) error { return nil },
 						MockStop:         func(_ context.Context, _ string) error { return nil },
 						MockIsRunning:    func(_ string) bool { return false },
-						MockStartWatches: func(_ string, _ ...engine.Watch) error { return nil },
+						MockStartWatches: func(_ context.Context, _ string, _ ...engine.Watch) error { return nil },
 						MockGetCached:    func() client.Client { return test.NewMockClient() },
 						MockGetUncached:  func() client.Client { return test.NewMockClient() },
 					}),
@@ -852,7 +852,7 @@ func TestReconcile(t *testing.T) {
 			},
 		},
 		"NotRestartingWithoutVersionChange": {
-			reason: "We should return without requeueing if we successfully ensured our CRD exists and controller is started.",
+			reason: "We should return without requeuing if we successfully ensured our CRD exists and controller is started.",
 			args: args{
 				ca: resource.ClientApplicator{
 					Client: &test.MockClient{

--- a/internal/controller/apiextensions/offered/reconciler.go
+++ b/internal/controller/apiextensions/offered/reconciler.go
@@ -94,7 +94,7 @@ type ControllerEngine interface {
 	Start(name string, o ...engine.ControllerOption) error
 	Stop(ctx context.Context, name string) error
 	IsRunning(name string) bool
-	StartWatches(name string, ws ...engine.Watch) error
+	StartWatches(ctx context.Context, name string, ws ...engine.Watch) error
 	GetCached() client.Client
 }
 
@@ -111,7 +111,7 @@ func (e *NopEngine) Stop(_ context.Context, _ string) error { return nil }
 func (e *NopEngine) IsRunning(_ string) bool { return true }
 
 // StartWatches does nothing.
-func (e *NopEngine) StartWatches(_ string, _ ...engine.Watch) error { return nil }
+func (e *NopEngine) StartWatches(_ context.Context, _ string, _ ...engine.Watch) error { return nil }
 
 // GetCached returns a nil client.
 func (e *NopEngine) GetCached() client.Client {
@@ -499,7 +499,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 	xr := &kunstructured.Unstructured{}
 	xr.SetGroupVersionKind(d.GetCompositeGroupVersionKind())
 
-	if err := r.engine.StartWatches(claim.ControllerName(d.GetName()),
+	if err := r.engine.StartWatches(ctx, claim.ControllerName(d.GetName()),
 		engine.WatchFor(cm, engine.WatchTypeClaim, &handler.EnqueueRequestForObject{}),
 		engine.WatchFor(xr, engine.WatchTypeCompositeResource, &EnqueueRequestForClaim{}),
 	); err != nil {

--- a/internal/controller/apiextensions/offered/reconciler_test.go
+++ b/internal/controller/apiextensions/offered/reconciler_test.go
@@ -45,7 +45,7 @@ type MockEngine struct {
 	MockStart        func(name string, o ...engine.ControllerOption) error
 	MockStop         func(ctx context.Context, name string) error
 	MockIsRunning    func(name string) bool
-	MockStartWatches func(name string, ws ...engine.Watch) error
+	MockStartWatches func(ctx context.Context, name string, ws ...engine.Watch) error
 	MockGetClient    func() client.Client
 }
 
@@ -66,8 +66,8 @@ func (m *MockEngine) IsRunning(name string) bool {
 	return m.MockIsRunning(name)
 }
 
-func (m *MockEngine) StartWatches(name string, ws ...engine.Watch) error {
-	return m.MockStartWatches(name, ws...)
+func (m *MockEngine) StartWatches(ctx context.Context, name string, ws ...engine.Watch) error {
+	return m.MockStartWatches(ctx, name, ws...)
 }
 
 func (m *MockEngine) GetCached() client.Client {
@@ -601,7 +601,7 @@ func TestReconcile(t *testing.T) {
 			},
 		},
 		"VersionChangedStopControllerError": {
-			reason: "We should return any error we encounter while stopping our controller because the XRD's referencable version changed.",
+			reason: "We should return any error we encounter while stopping our controller because the XRD's referenceable version changed.",
 			args: args{
 				ca: resource.ClientApplicator{
 					Client: &test.MockClient{
@@ -730,7 +730,7 @@ func TestReconcile(t *testing.T) {
 						MockStart: func(_ string, _ ...engine.ControllerOption) error {
 							return nil
 						},
-						MockStartWatches: func(_ string, _ ...engine.Watch) error {
+						MockStartWatches: func(_ context.Context, _ string, _ ...engine.Watch) error {
 							return errBoom
 						},
 						MockGetClient: func() client.Client { return test.NewMockClient() },
@@ -778,7 +778,7 @@ func TestReconcile(t *testing.T) {
 					WithControllerEngine(&MockEngine{
 						MockIsRunning:    func(_ string) bool { return false },
 						MockStart:        func(_ string, _ ...engine.ControllerOption) error { return nil },
-						MockStartWatches: func(_ string, _ ...engine.Watch) error { return nil },
+						MockStartWatches: func(_ context.Context, _ string, _ ...engine.Watch) error { return nil },
 						MockGetClient:    func() client.Client { return test.NewMockClient() },
 					},
 					),
@@ -840,7 +840,7 @@ func TestReconcile(t *testing.T) {
 						MockStart:        func(_ string, _ ...engine.ControllerOption) error { return nil },
 						MockStop:         func(_ context.Context, _ string) error { return nil },
 						MockIsRunning:    func(_ string) bool { return false },
-						MockStartWatches: func(_ string, _ ...engine.Watch) error { return nil },
+						MockStartWatches: func(_ context.Context, _ string, _ ...engine.Watch) error { return nil },
 						MockGetClient:    func() client.Client { return test.NewMockClient() },
 					}),
 				},
@@ -850,7 +850,7 @@ func TestReconcile(t *testing.T) {
 			},
 		},
 		"NotRestartingWithoutVersionChange": {
-			reason: "We should return without requeueing if we successfully ensured our CRD exists and controller is started.",
+			reason: "We should return without requeuing if we successfully ensured our CRD exists and controller is started.",
 			args: args{
 				ca: resource.ClientApplicator{
 					Client: &test.MockClient{

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -391,6 +391,9 @@ func TestStopController(t *testing.T) {
 					MockActiveInformers: func() []schema.GroupVersionKind {
 						return nil
 					},
+					MockGetInformer: func(_ context.Context, _ client.Object, _ ...cache.InformerGetOption) (cache.Informer, error) {
+						return nil, nil
+					},
 				},
 			},
 			args: args{
@@ -428,7 +431,7 @@ func TestStopController(t *testing.T) {
 			u := &unstructured.Unstructured{}
 			u.SetAPIVersion("test.crossplane.io/v1")
 			u.SetKind("Composed")
-			err = e.StartWatches(tc.args.name, WatchFor(u, WatchTypeComposedResource, nil))
+			err = e.StartWatches(tc.args.ctx, tc.args.name, WatchFor(u, WatchTypeComposedResource, nil))
 			if diff := cmp.Diff(nil, err, cmpopts.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\ne.StartWatches(...): -want error, +got error:\n%s", tc.reason, diff)
 			}
@@ -462,6 +465,7 @@ func TestStartWatches(t *testing.T) {
 		opts []ControllerOption
 	}
 	type args struct {
+		ctx  context.Context
 		name string
 		ws   []Watch
 	}
@@ -496,6 +500,9 @@ func TestStartWatches(t *testing.T) {
 								Kind:    "Composed",
 							},
 						}
+					},
+					MockGetInformer: func(_ context.Context, _ client.Object, _ ...cache.InformerGetOption) (cache.Informer, error) {
+						return nil, nil
 					},
 				},
 			},
@@ -550,6 +557,9 @@ func TestStartWatches(t *testing.T) {
 								Kind:    "Resource",
 							},
 						}
+					},
+					MockGetInformer: func(_ context.Context, _ client.Object, _ ...cache.InformerGetOption) (cache.Informer, error) {
+						return nil, nil
 					},
 				},
 			},
@@ -627,14 +637,14 @@ func TestStartWatches(t *testing.T) {
 				t.Fatalf("\n%s\ne.Start(...): -want error, +got error:\n%s", tc.reason, diff)
 			}
 
-			err = e.StartWatches(tc.args.name, tc.args.ws...)
+			err = e.StartWatches(tc.args.ctx, tc.args.name, tc.args.ws...)
 			if diff := cmp.Diff(tc.want.err, err, cmpopts.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\ne.StartWatches(...): -want error, +got error:\n%s", tc.reason, diff)
 			}
 
 			// Start the same watches again to exercise the code that ensures we
 			// only add each watch once.
-			err = e.StartWatches(tc.args.name, tc.args.ws...)
+			err = e.StartWatches(tc.args.ctx, tc.args.name, tc.args.ws...)
 			if diff := cmp.Diff(tc.want.err, err, cmpopts.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\ne.StartWatches(...): -want error, +got error:\n%s", tc.reason, diff)
 			}
@@ -700,6 +710,9 @@ func TestStopWatches(t *testing.T) {
 					MockActiveInformers: func() []schema.GroupVersionKind {
 						return nil
 					},
+					MockGetInformer: func(_ context.Context, _ client.Object, _ ...cache.InformerGetOption) (cache.Informer, error) {
+						return nil, nil
+					},
 				},
 			},
 			args: args{
@@ -754,6 +767,9 @@ func TestStopWatches(t *testing.T) {
 					MockActiveInformers: func() []schema.GroupVersionKind {
 						return nil
 					},
+					MockGetInformer: func(_ context.Context, _ client.Object, _ ...cache.InformerGetOption) (cache.Informer, error) {
+						return nil, nil
+					},
 				},
 			},
 			args: args{
@@ -799,6 +815,9 @@ func TestStopWatches(t *testing.T) {
 				infs: &MockTrackingInformers{
 					MockActiveInformers: func() []schema.GroupVersionKind {
 						return nil
+					},
+					MockGetInformer: func(_ context.Context, _ client.Object, _ ...cache.InformerGetOption) (cache.Informer, error) {
+						return nil, nil
 					},
 				},
 			},
@@ -865,7 +884,7 @@ func TestStopWatches(t *testing.T) {
 			u1 := &unstructured.Unstructured{}
 			u1.SetAPIVersion("test.crossplane.io/v1")
 			u1.SetKind("Resource")
-			err = e.StartWatches(tc.args.name,
+			err = e.StartWatches(tc.args.ctx, tc.args.name,
 				WatchFor(u1, WatchTypeComposedResource, nil),
 				WatchFor(u1, WatchTypeCompositeResource, nil),
 			)


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane! Please read the contribution docs
(linked below) if this is your first Crossplane pull request.
-->

### Description of your changes

<!--
Briefly describe what this pull request does, and how it is covered by tests.
Be proactive - direct your reviewers' attention to anything that needs special
consideration.

We love pull requests that fix an open issue. If yours does, use the below line
to indicate which issue it fixes, for example "Fixes #500".
-->

Fixes https://github.com/crossplane/crossplane/issues/5151
Fixes https://github.com/crossplane/crossplane/issues/5400
Fixes https://github.com/crossplane/crossplane/issues/6396 [^1]

Realtime compositions use a garbage collector to cleanup watches. We do this in part to keep memory consumption down, and in part to avoid watching a type that no longer exists.

Say for example some XRs of kind: A compose a resource of kind: B. The kind: A controller will watch kind: B. Later the XRs are updated to a new Composition. They no longer compose kind: B. The provider for kind: B is uninstalled, so it's no longer a valid type.

If Crossplane doesn't stop the watch for kind: B the watch's underlying informer will spew errors about being unable to list kind: B. This doesn't break anything per-se but it'll at a minimum flood Crossplane's logs with scary errors.

Realtime composition has four types of watches: claims, XRs, composed resources, and composition revisions. Before this commit the garbage collector would GC them all. Now it only GCs composed resource watches.

There's no reason to GC the other types of watches. Those watches should never be stopped while the XR controller is still running; they'll be stopped when the XR controller stops running.

The garbage collector uses a cache-backed client to determine what watches to stop. The cache can be stale. So it's possible that the garbage collector will stop a watch for a type that's actually in use. For example if the type should be watched, then shouldn't, then should again in rapid succession. e.g. If there's only one XR of kind: A and it composes one resource of kind: B, then stops composing it, then quickly starts composing it again.

Right now we can tolerate this for composed resource watches because XRs are still reconciled every poll interval - the watch'll be restarted anytime any XR that composes that resource type is reconciled at poll interval.

We can't tolerate this for claims, XRs, and composition revisions. If these watches are garbage collected nothing would restart them until Crossplane itself restarts (or their XRD was recreated).

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `earthly +reviewable` to ensure this PR is ready for review.
- [x] Added or updated unit tests.
- [ ] ~Added or updated e2e tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~
- [ ] ~Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md

[^1]: I pushed a second commit that fixes this issue - the one that causes the realtime composition E2E tests to fail so often. See the commit message for details on that.