### PR TITLE
Use in-memory etcd during E2E tests

### DIFF
--- a/test/e2e/manifests/kind/kind-config.yaml
+++ b/test/e2e/manifests/kind/kind-config.yaml
@@ -23,6 +23,11 @@ nodes:
                 mountPath: "/var/log/kubernetes"
                 readOnly: false
                 pathType: DirectoryOrCreate
+        # Store etcd data in-memory
+        # See https://github.com/kubernetes-sigs/kind/issues/845
+        etcd:
+          local:
+            dataDir: /tmp/etcd
     # mount the local file on the control plane
     extraMounts:
       - hostPath: ./test/e2e/manifests/kind/audit-policy.yaml


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane! Please read the contribution docs
(linked below) if this is your first Crossplane pull request.
-->

### Description of your changes

<!--
Briefly describe what this pull request does, and how it is covered by tests.
Be proactive - direct your reviewers' attention to anything that needs special
consideration.

We love pull requests that fix an open issue. If yours does, use the below line
to indicate which issue it fixes, for example "Fixes #500".
-->

Fixes https://github.com/crossplane/crossplane/issues/6403

This attempts to speed up E2E tests by reducing disk I/O due to etcd writes. Not sure we're _really_ bound by this today - I suspect we're more bound by poll intervals. Worth a shot though.

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [ ] ~Run `earthly +reviewable` to ensure this PR is ready for review.~
- [ ] ~Added or updated unit tests.~
- [ ] ~Added or updated e2e tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~
- [ ] ~Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md