### PR TITLE
feat: add defaultCompositionRevisionSelector

### DIFF
--- a/apis/apiextensions/v1/xrd_types.go
+++ b/apis/apiextensions/v1/xrd_types.go
@@ -93,6 +93,11 @@ type CompositeResourceDefinitionSpec struct {
 	// +optional
 	DefaultCompositionRef *CompositionReference `json:"defaultCompositionRef,omitempty"`
 
+	// DefaultCompositionRevisionSelector refers to the CompositionRevision that will be used
+	// in case no compositionRevision selector is given.
+	// +optional
+	DefaultCompositionRevisionSelector *metav1.LabelSelector `json:"defaultCompositionRevisionSelector,omitempty"`
+
 	// EnforcedCompositionRef refers to the Composition resource that will be used
 	// by all composite instances whose schema is defined by this definition.
 	// +optional

--- a/apis/apiextensions/v1/zz_generated.deepcopy.go
+++ b/apis/apiextensions/v1/zz_generated.deepcopy.go
@@ -23,6 +23,7 @@ package v1
 import (
 	commonv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -130,6 +131,11 @@ func (in *CompositeResourceDefinitionSpec) DeepCopyInto(out *CompositeResourceDe
 		in, out := &in.DefaultCompositionRef, &out.DefaultCompositionRef
 		*out = new(CompositionReference)
 		**out = **in
+	}
+	if in.DefaultCompositionRevisionSelector != nil {
+		in, out := &in.DefaultCompositionRevisionSelector, &out.DefaultCompositionRevisionSelector
+		*out = new(metav1.LabelSelector)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.EnforcedCompositionRef != nil {
 		in, out := &in.EnforcedCompositionRef, &out.EnforcedCompositionRef

--- a/cluster/crds/apiextensions.crossplane.io_compositeresourcedefinitions.yaml
+++ b/cluster/crds/apiextensions.crossplane.io_compositeresourcedefinitions.yaml
@@ -256,6 +256,54 @@ spec:
                 required:
                 - name
                 type: object
+              defaultCompositionRevisionSelector:
+                description: |-
+                  DefaultCompositionRevisionSelector refers to the CompositionRevision that will be used
+                  in case no compositionRevision selector is given.
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: |-
+                        A label selector requirement is a selector that contains values, a key, and an operator that
+                        relates the key and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: |-
+                            operator represents a key's relationship to a set of values.
+                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                          type: string
+                        values:
+                          description: |-
+                            values is an array of string values. If the operator is In or NotIn,
+                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                            the values array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                    type: object
+                type: object
+                x-kubernetes-map-type: atomic
               defaultCompositionUpdatePolicy:
                 default: Automatic
                 description: |-

--- a/internal/controller/apiextensions/claim/syncer_ssa.go
+++ b/internal/controller/apiextensions/claim/syncer_ssa.go
@@ -273,6 +273,10 @@ func (s *ServerSideCompositeSyncer) Sync(ctx context.Context, cm *claim.Unstruct
 		cm.SetCompositionReference(ref)
 	}
 
+	if ref := xr.GetCompositionRevisionSelector(); ref != nil && cm.GetCompositionRevisionSelector() == nil {
+		cm.SetCompositionRevisionSelector(ref)
+	}
+
 	// Propagate composition revision ref from the XR if the update policy is
 	// automatic. When the update policy is automatic the XR controller is
 	// authoritative for this field. It will update the XR's ref as new

--- a/internal/controller/apiextensions/composite/api.go
+++ b/internal/controller/apiextensions/composite/api.go
@@ -200,6 +200,27 @@ type CompositionSelectorChain struct {
 	list []CompositionSelector
 }
 
+// NewCompositionRevisionSelectorChain returns a new CompositionSelectorChain.
+func NewCompositionRevisionSelectorChain(list ...CompositionRevisionSelector) *CompositionRevisionSelectorChain {
+	return &CompositionRevisionSelectorChain{list: list}
+}
+
+// CompositionRevisionSelectorChain calls the given list of CompositionRevisionSelectors in order.
+type CompositionRevisionSelectorChain struct {
+	list []CompositionRevisionSelector
+}
+
+// SelectCompositionRevision calls all SelectCompositionRevision functions of CompositionRevisionSelectors
+// in the list.
+func (r *CompositionRevisionSelectorChain) SelectCompositionRevision(ctx context.Context, cp resource.Composite) error {
+	for _, cs := range r.list {
+		if err := cs.SelectCompositionRevision(ctx, cp); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // SelectComposition calls all SelectComposition functions of CompositionSelectors
 // in the list.
 func (r *CompositionSelectorChain) SelectComposition(ctx context.Context, cp xresource.Composite) error {
@@ -291,6 +312,27 @@ func (s *APIDefaultCompositionSelector) SelectComposition(ctx context.Context, c
 	}
 	cp.SetCompositionReference(&corev1.ObjectReference{Name: def.Spec.DefaultCompositionRef.Name})
 	s.recorder.Event(cp, event.Normal(reasonCompositionSelection, "Default composition has been selected"))
+	return nil
+}
+
+// SelectCompositionRevision selects the default composition revision if neither a reference nor
+// selector is given in composite resource.
+func (s *APIDefaultCompositionSelector) SelectCompositionRevision(ctx context.Context, cp xresource.Composite) error {
+	if cp.GetCompositionRevisionSelector() != nil {
+		return nil
+	}
+	def := &v1.CompositeResourceDefinition{}
+	if err := s.client.Get(ctx, meta.NamespacedNameOf(&s.defRef), def); err != nil {
+		return errors.Wrap(err, errGetXRD)
+	}
+
+	if def.Spec.DefaultCompositionRevisionSelector == nil {
+		return nil
+	}
+
+	cp.SetCompositionRevisionSelector(def.Spec.DefaultCompositionRevisionSelector)
+	s.recorder.Event(cp, event.Normal(reasonCompositionSelection, "Default revision selector has been selected"))
+
 	return nil
 }
 

--- a/internal/controller/apiextensions/composite/api_test.go
+++ b/internal/controller/apiextensions/composite/api_test.go
@@ -838,6 +838,128 @@ func TestAPIDefaultCompositionSelector(t *testing.T) {
 	}
 }
 
+func TestAPIDefaultCompositionRevisionSelector(t *testing.T) {
+	a, k := schema.EmptyObjectKind.GroupVersionKind().ToAPIVersionAndKind()
+	tref := v1.TypeReference{APIVersion: a, Kind: k}
+	comp := &v1.Composition{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "foo",
+		},
+		Spec: v1.CompositionSpec{
+			CompositeTypeRef: tref,
+		},
+	}
+	type args struct {
+		kube   client.Client
+		defRef corev1.ObjectReference
+		cp     resource.Composite
+	}
+	type want struct {
+		cp  resource.Composite
+		err error
+	}
+
+	cases := map[string]struct {
+		reason string
+		args
+		want
+	}{
+		"SelectorInPlace": {
+			reason: "Should be no-op if a composition revision selector is in place",
+			args: args{
+				defRef: corev1.ObjectReference{},
+				kube: &test.MockClient{
+					MockGet: test.NewMockGetFn(nil),
+				},
+				cp: &fake.Composite{
+					CompositionSelector: fake.CompositionSelector{Sel: &metav1.LabelSelector{MatchLabels: map[string]string{"foo": "bar"}}},
+				},
+			},
+			want: want{
+				cp: &fake.Composite{
+					CompositionSelector: fake.CompositionSelector{Sel: &metav1.LabelSelector{MatchLabels: map[string]string{"foo": "bar"}}},
+				},
+			},
+		},
+		"NoDefault": {
+			reason: "Should be no-op if no default is given in definition",
+			args: args{
+				kube: &test.MockClient{
+					MockGet: test.NewMockGetFn(nil),
+				},
+				cp: &fake.Composite{},
+			},
+			want: want{
+				cp: &fake.Composite{},
+			},
+		},
+		"Success": {
+			reason: "Successfully set the default composition revision selector",
+			args: args{
+				kube: &test.MockClient{
+					MockGet: func(_ context.Context, _ client.ObjectKey, obj client.Object) error {
+						switch cr := obj.(type) {
+						case *v1.CompositeResourceDefinition:
+							withRef := &v1.CompositeResourceDefinition{Spec: v1.CompositeResourceDefinitionSpec{DefaultCompositionRevisionSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"channel": "dev"}}}}
+							withRef.DeepCopyInto(cr)
+							return nil
+						case *v1.Composition:
+							comp.DeepCopyInto(cr)
+							return nil
+						}
+						return nil
+					},
+				},
+				cp: &fake.Composite{
+					CompositionRevisionSelector: fake.CompositionRevisionSelector{Sel: &metav1.LabelSelector{MatchLabels: map[string]string{"foo": "bar"}}},
+				},
+			},
+			want: want{
+				cp: &fake.Composite{
+					CompositionRevisionSelector: fake.CompositionRevisionSelector{Sel: &metav1.LabelSelector{MatchLabels: map[string]string{"foo": "bar"}}},
+				},
+			},
+		},
+		"SelectorInPlaceNoOverwrite": {
+			reason: "Should not overwrite the given selector with default",
+			args: args{
+				kube: &test.MockClient{
+					MockGet: func(_ context.Context, _ client.ObjectKey, obj client.Object) error {
+						switch cr := obj.(type) {
+						case *v1.CompositeResourceDefinition:
+							withRef := &v1.CompositeResourceDefinition{Spec: v1.CompositeResourceDefinitionSpec{DefaultCompositionRevisionSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"channel": "dev"}}}}
+							withRef.DeepCopyInto(cr)
+							return nil
+						case *v1.Composition:
+							comp.DeepCopyInto(cr)
+							return nil
+						}
+						return nil
+					},
+				},
+				cp: &fake.Composite{},
+			},
+			want: want{
+				cp: &fake.Composite{
+					CompositionRevisionSelector: fake.CompositionRevisionSelector{Sel: &metav1.LabelSelector{MatchLabels: map[string]string{"channel": "dev"}}},
+				},
+			},
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			c := NewAPIDefaultCompositionSelector(tc.args.kube, tc.args.defRef, event.NewNopRecorder())
+			err := c.SelectCompositionRevision(context.Background(), tc.args.cp)
+			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
+				t.Errorf("\n%s\nSelectComposition(...): -want, +got:\n%s", tc.reason, diff)
+			}
+			if diff := cmp.Diff(tc.want.cp, tc.args.cp); diff != "" {
+				t.Errorf("\n%s\nSelectComposition(...): -want, +got:\n%s", tc.reason, diff)
+			}
+		})
+	}
+}
+
 func TestAPIEnforcedCompositionSelector(t *testing.T) {
 	a, k := schema.EmptyObjectKind.GroupVersionKind().ToAPIVersionAndKind()
 	tref := v1.TypeReference{APIVersion: a, Kind: k}

--- a/internal/controller/apiextensions/composite/reconciler_test.go
+++ b/internal/controller/apiextensions/composite/reconciler_test.go
@@ -176,6 +176,9 @@ func TestReconcile(t *testing.T) {
 					WithCompositionSelector(CompositionSelectorFn(func(_ context.Context, _ xresource.Composite) error {
 						return errBoom
 					})),
+					WithCompositionRevisionSelector(CompositionRevisionSelectorFn(func(_ context.Context, _ xresource.Composite) error {
+						return nil
+					})),
 				},
 			},
 			want: want{
@@ -201,6 +204,9 @@ func TestReconcile(t *testing.T) {
 					WithCompositionRevisionFetcher(CompositionRevisionFetcherFn(func(_ context.Context, _ xresource.Composite) (*v1.CompositionRevision, error) {
 						return nil, errBoom
 					})),
+					WithCompositionRevisionSelector(CompositionRevisionSelectorFn(func(_ context.Context, _ xresource.Composite) error {
+						return nil
+					})),
 				},
 			},
 			want: want{
@@ -225,6 +231,9 @@ func TestReconcile(t *testing.T) {
 					})),
 					WithCompositionRevisionFetcher(CompositionRevisionFetcherFn(func(_ context.Context, _ xresource.Composite) (*v1.CompositionRevision, error) {
 						return &v1.CompositionRevision{}, nil
+					})),
+					WithCompositionRevisionSelector(CompositionRevisionSelectorFn(func(_ context.Context, _ xresource.Composite) error {
+						return nil
 					})),
 					WithConfigurator(ConfiguratorFn(func(_ context.Context, _ xresource.Composite, _ *v1.CompositionRevision) error {
 						return errBoom
@@ -253,6 +262,9 @@ func TestReconcile(t *testing.T) {
 					})),
 					WithCompositionRevisionFetcher(CompositionRevisionFetcherFn(func(_ context.Context, _ xresource.Composite) (*v1.CompositionRevision, error) {
 						return &v1.CompositionRevision{}, nil
+					})),
+					WithCompositionRevisionSelector(CompositionRevisionSelectorFn(func(_ context.Context, _ xresource.Composite) error {
+						return nil
 					})),
 					WithConfigurator(ConfiguratorFn(func(_ context.Context, _ xresource.Composite, _ *v1.CompositionRevision) error {
 						return nil
@@ -284,6 +296,9 @@ func TestReconcile(t *testing.T) {
 					})),
 					WithCompositionRevisionFetcher(CompositionRevisionFetcherFn(func(_ context.Context, _ xresource.Composite) (*v1.CompositionRevision, error) {
 						return &v1.CompositionRevision{}, nil
+					})),
+					WithCompositionRevisionSelector(CompositionRevisionSelectorFn(func(_ context.Context, _ xresource.Composite) error {
+						return nil
 					})),
 					WithConfigurator(ConfiguratorFn(func(_ context.Context, _ xresource.Composite, _ *v1.CompositionRevision) error {
 						return nil
@@ -318,6 +333,9 @@ func TestReconcile(t *testing.T) {
 					})),
 					WithCompositionRevisionFetcher(CompositionRevisionFetcherFn(func(_ context.Context, _ xresource.Composite) (*v1.CompositionRevision, error) {
 						return &v1.CompositionRevision{}, nil
+					})),
+					WithCompositionRevisionSelector(CompositionRevisionSelectorFn(func(_ context.Context, _ xresource.Composite) error {
+						return nil
 					})),
 					WithConfigurator(ConfiguratorFn(func(_ context.Context, _ xresource.Composite, _ *v1.CompositionRevision) error {
 						return nil
@@ -359,6 +377,9 @@ func TestReconcile(t *testing.T) {
 					})),
 					WithCompositionRevisionFetcher(CompositionRevisionFetcherFn(func(_ context.Context, _ xresource.Composite) (*v1.CompositionRevision, error) {
 						return &v1.CompositionRevision{}, nil
+					})),
+					WithCompositionRevisionSelector(CompositionRevisionSelectorFn(func(_ context.Context, _ xresource.Composite) error {
+						return nil
 					})),
 					WithConfigurator(ConfiguratorFn(func(_ context.Context, _ xresource.Composite, _ *v1.CompositionRevision) error {
 						return nil
@@ -431,6 +452,9 @@ func TestReconcile(t *testing.T) {
 						return &v1.CompositionRevision{}, nil
 					})),
 					WithConfigurator(ConfiguratorFn(func(_ context.Context, _ xresource.Composite, _ *v1.CompositionRevision) error {
+						return nil
+					})),
+					WithCompositionRevisionSelector(CompositionRevisionSelectorFn(func(_ context.Context, _ xresource.Composite) error {
 						return nil
 					})),
 					WithComposer(ComposerFn(func(_ context.Context, _ *composite.Unstructured, _ CompositionRequest) (CompositionResult, error) {
@@ -516,6 +540,9 @@ func TestReconcile(t *testing.T) {
 					WithCompositionRevisionFetcher(CompositionRevisionFetcherFn(func(_ context.Context, _ xresource.Composite) (*v1.CompositionRevision, error) {
 						return &v1.CompositionRevision{}, nil
 					})),
+					WithCompositionRevisionSelector(CompositionRevisionSelectorFn(func(_ context.Context, _ xresource.Composite) error {
+						return nil
+					})),
 					WithConfigurator(ConfiguratorFn(func(_ context.Context, _ xresource.Composite, _ *v1.CompositionRevision) error {
 						return nil
 					})),
@@ -556,6 +583,9 @@ func TestReconcile(t *testing.T) {
 						return &v1.CompositionRevision{}, nil
 					})),
 					WithConfigurator(ConfiguratorFn(func(_ context.Context, _ xresource.Composite, _ *v1.CompositionRevision) error {
+						return nil
+					})),
+					WithCompositionRevisionSelector(CompositionRevisionSelectorFn(func(_ context.Context, _ xresource.Composite) error {
 						return nil
 					})),
 					WithComposer(ComposerFn(func(_ context.Context, _ *composite.Unstructured, _ CompositionRequest) (CompositionResult, error) {
@@ -657,6 +687,9 @@ func TestReconcile(t *testing.T) {
 					WithCompositeFinalizer(resource.NewNopFinalizer()),
 					WithCompositionSelector(CompositionSelectorFn(func(_ context.Context, cr xresource.Composite) error {
 						cr.SetCompositionReference(&corev1.ObjectReference{})
+						return nil
+					})),
+					WithCompositionRevisionSelector(CompositionRevisionSelectorFn(func(_ context.Context, _ xresource.Composite) error {
 						return nil
 					})),
 					WithCompositionRevisionFetcher(CompositionRevisionFetcherFn(func(_ context.Context, _ xresource.Composite) (*v1.CompositionRevision, error) {
@@ -843,6 +876,11 @@ func TestReconcile(t *testing.T) {
 					})),
 					WithCompositionRevisionFetcher(CompositionRevisionFetcherFn(func(_ context.Context, _ xresource.Composite) (*v1.CompositionRevision, error) {
 						return &v1.CompositionRevision{}, nil
+					})), WithCompositionRevisionSelector(CompositionRevisionSelectorFn(func(_ context.Context, _ xresource.Composite) error {
+						return nil
+					})),
+					WithCompositionRevisionSelector(CompositionRevisionSelectorFn(func(_ context.Context, _ xresource.Composite) error {
+						return nil
 					})),
 					WithConfigurator(ConfiguratorFn(func(_ context.Context, _ xresource.Composite, _ *v1.CompositionRevision) error {
 						return nil
@@ -1008,6 +1046,8 @@ func TestReconcile(t *testing.T) {
 					})),
 					WithCompositionRevisionFetcher(CompositionRevisionFetcherFn(func(_ context.Context, _ xresource.Composite) (*v1.CompositionRevision, error) {
 						return &v1.CompositionRevision{}, nil
+					})), WithCompositionRevisionSelector(CompositionRevisionSelectorFn(func(_ context.Context, _ xresource.Composite) error {
+						return nil
 					})),
 					WithConfigurator(ConfiguratorFn(func(_ context.Context, _ xresource.Composite, _ *v1.CompositionRevision) error {
 						return nil
@@ -1096,6 +1136,9 @@ func TestReconcile(t *testing.T) {
 					WithCompositionRevisionFetcher(CompositionRevisionFetcherFn(func(_ context.Context, _ xresource.Composite) (*v1.CompositionRevision, error) {
 						return &v1.CompositionRevision{}, nil
 					})),
+					WithCompositionRevisionSelector(CompositionRevisionSelectorFn(func(_ context.Context, _ xresource.Composite) error {
+						return nil
+					})),
 					WithConfigurator(ConfiguratorFn(func(_ context.Context, _ xresource.Composite, _ *v1.CompositionRevision) error {
 						return nil
 					})),
@@ -1167,6 +1210,9 @@ func TestReconcile(t *testing.T) {
 					})),
 					WithCompositionRevisionFetcher(CompositionRevisionFetcherFn(func(_ context.Context, _ xresource.Composite) (*v1.CompositionRevision, error) {
 						return &v1.CompositionRevision{}, nil
+					})),
+					WithCompositionRevisionSelector(CompositionRevisionSelectorFn(func(_ context.Context, _ xresource.Composite) error {
+						return nil
 					})),
 					WithConfigurator(ConfiguratorFn(func(_ context.Context, _ xresource.Composite, _ *v1.CompositionRevision) error {
 						return nil

--- a/test/e2e/manifests/apiextensions/composition/composition-revision-selection/claim-update.yaml
+++ b/test/e2e/manifests/apiextensions/composition/composition-revision-selection/claim-update.yaml
@@ -1,0 +1,13 @@
+apiVersion: nop.example.org/v1alpha1
+kind: NopResource
+metadata:
+  namespace: default
+  name: composition-selection
+spec:
+  compositionRevisionSelector:
+    matchLabels:
+      environment: production
+  coolField: "I'm cool!"
+  # This is necessary to ensure the claim's MRs are actually gone before we
+  # delete the Provider - https://github.com/crossplane/crossplane/issues/4251
+  compositeDeletePolicy: Foreground

--- a/test/e2e/manifests/apiextensions/composition/composition-revision-selection/claim.yaml
+++ b/test/e2e/manifests/apiextensions/composition/composition-revision-selection/claim.yaml
@@ -1,0 +1,10 @@
+apiVersion: nop.example.org/v1alpha1
+kind: NopResource
+metadata:
+  namespace: default
+  name: composition-selection
+spec:
+  coolField: "I'm cool!"
+  # This is necessary to ensure the claim's MRs are actually gone before we
+  # delete the Provider - https://github.com/crossplane/crossplane/issues/4251
+  compositeDeletePolicy: Foreground

--- a/test/e2e/manifests/apiextensions/composition/composition-revision-selection/setup/composition.yaml
+++ b/test/e2e/manifests/apiextensions/composition/composition-revision-selection/setup/composition.yaml
@@ -1,0 +1,28 @@
+apiVersion: apiextensions.crossplane.io/v1
+kind: Composition
+metadata:
+  name: testing
+  labels:
+    environment: testing
+spec:
+  compositeTypeRef:
+    apiVersion: nop.example.org/v1alpha1
+    kind: XNopResource
+  resources:
+    - name: nop-resource-1
+      base:
+        apiVersion: nop.crossplane.io/v1alpha1
+        kind: NopResource
+        spec:
+          forProvider:
+            conditionAfter:
+              - conditionType: Ready
+                conditionStatus: "True"
+                time: 0s
+      patches:
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.coolField
+          toFieldPath: metadata.annotations["cf"]
+        - type: ToCompositeFieldPath
+          fromFieldPath: metadata.annotations["cf"]
+          toFieldPath: status.coolerField

--- a/test/e2e/manifests/apiextensions/composition/composition-revision-selection/setup/definition.yaml
+++ b/test/e2e/manifests/apiextensions/composition/composition-revision-selection/setup/definition.yaml
@@ -1,0 +1,51 @@
+apiVersion: apiextensions.crossplane.io/v1
+kind: CompositeResourceDefinition
+metadata:
+  name: xnopresources.nop.example.org
+spec:
+  group: nop.example.org
+  names:
+    kind: XNopResource
+    plural: xnopresources
+  claimNames:
+    kind: NopResource
+    plural: nopresources
+  defaultCompositionRevisionSelector:
+    matchLabels:
+      environment: testing
+  connectionSecretKeys:
+  - test
+  versions:
+  - name: v1alpha1
+    served: true
+    referenceable: true
+    schema:
+     openAPIV3Schema:
+       type: object
+       properties:
+        spec:
+          type: object
+          properties:
+            coolField:
+              type: string
+            numbers:
+              type: array
+              items:
+                type: string
+            parameters:
+              type: object
+              properties:
+                tags:
+                  type: object
+                  properties:
+                    tag:
+                      type: string
+                    newtag:
+                      type: string
+          required:
+          - coolField
+        status:
+          type: object
+          properties:
+            coolerField:
+              type: string

--- a/test/e2e/manifests/apiextensions/composition/composition-revision-selection/setup/provider.yaml
+++ b/test/e2e/manifests/apiextensions/composition/composition-revision-selection/setup/provider.yaml
@@ -1,0 +1,7 @@
+apiVersion: pkg.crossplane.io/v1
+kind: Provider
+metadata:
+  name: provider-nop
+spec:
+  package: xpkg.upbound.io/crossplane-contrib/provider-nop:v0.3.0
+  ignoreCrossplaneConstraints: true


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane! Please read the contribution docs
(linked below) if this is your first Crossplane pull request.
-->

### Description of your changes

- Adds a default for compositionRevisionSelector in XR defined in die XRD

<!--
Briefly describe what this pull request does, and how it is covered by tests.
Be proactive - direct your reviewers' attention to anything that needs special
consideration.

We love pull requests that fix an open issue. If yours does, use the below line
to indicate which issue it fixes, for example "Fixes #500".
-->

Fixes #4662

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `earthly +reviewable` to ensure this PR is ready for review.
- [x] Added or updated unit tests.
- [x] Added or updated e2e tests.
- [ ] Linked a PR or a [docs tracking issue] to [document this change].
- [ ] Added `backport release-x.y` labels to auto-backport this PR.
- [ ] Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md