### PR TITLE
Run E2Es with `--hide-summary output`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
       # TODO(negz): Remove this and all references to the v2 branches below
       # if/when v2 is merged into main. It's a temporary branch for v2 preview
       # development.
-      - v2 
+      - v2
   pull_request: {}
   workflow_dispatch: {}
 
@@ -299,6 +299,13 @@ jobs:
           key: ${{ secrets.BUILDPULSE_ACCESS_KEY_ID }}
           secret: ${{ secrets.BUILDPULSE_SECRET_ACCESS_KEY }}
           path: _output/tests/e2e-tests.xml
+
+      - name: Upload E2E Test Artifacts to GitHub
+        if: '!cancelled()'
+        uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b # v4
+        with:
+          name: e2e-tests-${{ matrix.test-suite }}
+          path: _output/tests/**
 
   publish-artifacts:
     runs-on: ubuntu-22.04

--- a/Earthfile
+++ b/Earthfile
@@ -74,6 +74,7 @@ e2e:
       # https://github.com/earthly/earthly/issues/4143 is fixed.
       RUN gotestsum \
         --rerun-fails \
+	--hide-summary output \ # See https://github.com/gotestyourself/gotestsum/issues/423
       	--no-color=false \
 	--format ${GOTESTSUM_FORMAT} \
 	--junitfile e2e-tests.xml \

--- a/Earthfile
+++ b/Earthfile
@@ -74,14 +74,16 @@ e2e:
       # https://github.com/earthly/earthly/issues/4143 is fixed.
       RUN gotestsum \
         --rerun-fails \
-	--hide-summary output \ # See https://github.com/gotestyourself/gotestsum/issues/423
-      	--no-color=false \
-	--format ${GOTESTSUM_FORMAT} \
-	--junitfile e2e-tests.xml \
-	--raw-command go tool test2json -t -p E2E ./e2e -test.v ${FLAGS}
+        --rerun-fails-report e2e-rerun-fails.txt \
+        --hide-summary output \ # See https://github.com/gotestyourself/gotestsum/issues/423
+        --no-color=false \
+        --format ${GOTESTSUM_FORMAT} \
+        --junitfile e2e-tests.xml \
+        --raw-command go tool test2json -t -p E2E ./e2e -test.v ${FLAGS}
     END
   FINALLY
     SAVE ARTIFACT --if-exists e2e-tests.xml AS LOCAL _output/tests/e2e-tests.xml
+    SAVE ARTIFACT --if-exists e2e-rerun-fails.txt AS LOCAL _output/tests/e2e-rerun-fails.txt
   END
 
 # hack builds Crossplane, and deploys it to a kind cluster. It runs in your


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane! Please read the contribution docs
(linked below) if this is your first Crossplane pull request.
-->

### Description of your changes

<!--
Briefly describe what this pull request does, and how it is covered by tests.
Be proactive - direct your reviewers' attention to anything that needs special
consideration.

We love pull requests that fix an open issue. If yours does, use the below line
to indicate which issue it fixes, for example "Fixes #500".
-->

Apparently without this flag E2Es will pass if a test is re-run several times and fails several times. I've seen this on 2-3 E2E runs.

See https://github.com/gotestyourself/gotestsum/issues/423

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [ ] ~Run `earthly +reviewable` to ensure this PR is ready for review.~
- [ ] ~Added or updated unit tests.~
- [ ] ~Added or updated e2e tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~
- [ ] ~Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md