### PR TITLE
Draft: Feature: Namespace-restricted option

### DIFF
--- a/cluster/charts/crossplane/README.md
+++ b/cluster/charts/crossplane/README.md
@@ -89,6 +89,7 @@ and their default values.
 | `leaderElection` | Enable [leader election](https://docs.crossplane.io/latest/concepts/pods/#leader-election) for the Crossplane pod. | `true` |
 | `metrics.enabled` | Enable Prometheus path, port and scrape annotations and expose port 8080 for both the Crossplane and RBAC Manager pods. | `false` |
 | `metrics.port` | The port the metrics server listens on. | `""` |
+| `namespaceRestricted` | Deploy Crossplane in namespace-restricted mode. This will: - disable the RBAC manager pod - disable webhooks - add the --namespace-restricted option to the core crossplane pod - restrict cluster-wide permissions on crossplane | `false` |
 | `nodeSelector` | Add `nodeSelectors` to the Crossplane pod deployment. | `{}` |
 | `packageCache.configMap` | The name of a ConfigMap to use as the package cache. Disables the default package cache `emptyDir` Volume. | `""` |
 | `packageCache.medium` | Set to `Memory` to hold the package cache in a RAM backed file system. Useful for Crossplane development. | `""` |

--- a/cluster/charts/crossplane/templates/clusterrole.yaml
+++ b/cluster/charts/crossplane/templates/clusterrole.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app: {{ template "crossplane.name" . }}
     {{- include "crossplane.labels" . | indent 4 }}
-{{- if .Values.rbacManager.deploy }}
+{{- if and (.Values.rbacManager.deploy) (not .Values.namespaceRestricted) }}
 aggregationRule:
   clusterRoleSelectors:
   - matchLabels:
@@ -22,6 +22,7 @@ metadata:
     rbac.crossplane.io/aggregate-to-crossplane: "true"
 {{- end }}
 rules:
+{{- if not .Values.namespaceRestricted }}
 - apiGroups:
   - ""
   resources:
@@ -31,13 +32,6 @@ rules:
   - update
   - patch
   - delete
-- apiGroups:
-  - apiextensions.k8s.io
-  resources:
-  - customresourcedefinitions
-  - customresourcedefinitions/status
-  verbs:
-  - "*"
 - apiGroups:
   - ""
   resources:
@@ -55,14 +49,6 @@ rules:
   resources:
   - serviceaccounts
   - services
-  verbs:
-  - "*"
-- apiGroups:
-  - apiextensions.crossplane.io
-  - pkg.crossplane.io
-  - secrets.crossplane.io
-  resources:
-  - "*"
   verbs:
   - "*"
 - apiGroups:
@@ -105,3 +91,19 @@ rules:
   - patch
   - watch
   - delete
+{{- end }}
+- apiGroups:
+  - apiextensions.crossplane.io
+  - pkg.crossplane.io
+  - secrets.crossplane.io
+  resources:
+  - "*"
+  verbs:
+  - "*"
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  - customresourcedefinitions/status
+  verbs:
+  - "*"

--- a/cluster/charts/crossplane/templates/deployment.yaml
+++ b/cluster/charts/crossplane/templates/deployment.yaml
@@ -102,7 +102,7 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: spec.serviceAccountName
-          {{- if .Values.webhooks.enabled }}
+          {{- if and (.Values.webhooks.enabled) (not .Values.namespaceRestricted) }}
           - name: "WEBHOOK_SERVICE_NAME"
             value: {{ template "crossplane.name" . }}-webhooks
           - name: "WEBHOOK_SERVICE_NAMESPACE"
@@ -149,7 +149,7 @@ spec:
         - name: metrics
           containerPort: {{ .Values.metrics.port | default 8080 }}
         {{- end }}
-        {{- if .Values.webhooks.enabled }}
+        {{- if and (.Values.webhooks.enabled) (not .Values.namespaceRestricted) }}
         - name: webhooks
           containerPort: {{ .Values.webhooks.port | default 9443 }}
         {{- end }}
@@ -184,13 +184,17 @@ spec:
           - name: CA_BUNDLE_PATH
             value: "/certs/{{ .Values.registryCaBundleConfig.key }}"
           {{- end}}
-          {{- if not .Values.webhooks.enabled }}
+          {{- if or (not .Values.webhooks.enabled) (.Values.namespaceRestricted) }}
           - name: "ENABLE_WEBHOOKS"
             value: "false"
-          {{- end }}
-          {{- if and .Values.webhooks.enabled .Values.webhooks.port }}
+          {{- end}}
+          {{- if and (.Values.webhooks.enabled) (.Values.webhooks.port) (not .Values.namespaceRestricted) }}
           - name: "WEBHOOK_PORT"
             value: "{{ .Values.webhooks.port }}"
+          {{- end}}
+          {{- if .Values.namespaceRestricted }}
+          - name: "NAMESPACE_RESTRICTED"
+            value: "true"
           {{- end}}
           {{- if and .Values.metrics.enabled .Values.metrics.port }}
           - name: "METRICS_PORT"

--- a/cluster/charts/crossplane/templates/ns-restricted-role.yaml
+++ b/cluster/charts/crossplane/templates/ns-restricted-role.yaml
@@ -1,0 +1,64 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ template "crossplane.name" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "crossplane.name" . }}
+    {{- include "crossplane.labels" . | indent 4 }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  - services
+  verbs:
+  - "*"
+- apiGroups:
+  - extensions
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - get
+  - list
+  - create
+  - update
+  - patch
+  - delete
+  - watch
+- apiGroups:
+  - ""
+  - coordination.k8s.io
+  resources:
+  - configmaps
+  - leases
+  verbs:
+  - get
+  - list
+  - create
+  - update
+  - patch
+  - watch
+  - delete

--- a/cluster/charts/crossplane/templates/ns-restricted-rolebinding.yaml
+++ b/cluster/charts/crossplane/templates/ns-restricted-rolebinding.yaml
@@ -1,0 +1,21 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ template "crossplane.name" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "crossplane.name" . }}
+    {{- include "crossplane.labels" . | indent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ template "crossplane.name" . }}
+  namespace: {{ .Release.Namespace }}
+subjects:
+- kind: ServiceAccount
+  {{- if not .Values.serviceAccount.create }}
+  name: {{ .Values.serviceAccount.name }}
+  {{- else }}
+  name: {{ template "crossplane.name" . }}
+  {{- end }}
+  namespace: {{ .Release.Namespace }}

--- a/cluster/charts/crossplane/templates/rbac-manager-allowed-provider-permissions.yaml
+++ b/cluster/charts/crossplane/templates/rbac-manager-allowed-provider-permissions.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.rbacManager.deploy }}
+{{- if and (.Values.rbacManager.deploy) (not .Values.namespaceRestricted) }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/cluster/charts/crossplane/templates/rbac-manager-clusterrole.yaml
+++ b/cluster/charts/crossplane/templates/rbac-manager-clusterrole.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.rbacManager.deploy }}
+{{- if and (.Values.rbacManager.deploy) (not .Values.namespaceRestricted) }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/cluster/charts/crossplane/templates/rbac-manager-clusterrolebinding.yaml
+++ b/cluster/charts/crossplane/templates/rbac-manager-clusterrolebinding.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.rbacManager.deploy }}
+{{- if and (.Values.rbacManager.deploy) (not .Values.namespaceRestricted) }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:

--- a/cluster/charts/crossplane/templates/rbac-manager-deployment.yaml
+++ b/cluster/charts/crossplane/templates/rbac-manager-deployment.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.rbacManager.deploy }}
+{{- if and (.Values.rbacManager.deploy) (not .Values.namespaceRestricted) }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/cluster/charts/crossplane/templates/rbac-manager-managed-clusterroles.yaml
+++ b/cluster/charts/crossplane/templates/rbac-manager-managed-clusterroles.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.rbacManager.deploy }}
+{{- if and (.Values.rbacManager.deploy) (not .Values.namespaceRestricted) }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/cluster/charts/crossplane/templates/rbac-manager-serviceaccount.yaml
+++ b/cluster/charts/crossplane/templates/rbac-manager-serviceaccount.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.rbacManager.deploy }}
+{{- if and (.Values.rbacManager.deploy) (not .Values.namespaceRestricted) }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/cluster/charts/crossplane/templates/service.yaml
+++ b/cluster/charts/crossplane/templates/service.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.webhooks.enabled }}
+{{- if and (.Values.webhooks.enabled) (not .Values.namespaceRestricted) }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/cluster/charts/crossplane/values.yaml
+++ b/cluster/charts/crossplane/values.yaml
@@ -10,6 +10,14 @@ revisionHistoryLimit: null
 # -- The deployment strategy for the Crossplane and RBAC Manager pods.
 deploymentStrategy: RollingUpdate
 
+# -- Deploy Crossplane in namespace-restricted mode.
+# This will:
+# - disable the RBAC manager pod
+# - disable webhooks
+# - add the --namespace-restricted option to the core crossplane pod
+# - restrict cluster-wide permissions on crossplane
+namespaceRestricted: false
+
 image:
   # -- Repository for the Crossplane pod image.
   repository: xpkg.crossplane.io/crossplane/crossplane

--- a/internal/controller/apiextensions/composition/reconciler.go
+++ b/internal/controller/apiextensions/composition/reconciler.go
@@ -66,9 +66,16 @@ const (
 func Setup(mgr ctrl.Manager, o controller.Options) error {
 	name := "revisions/" + strings.ToLower(v1.CompositionGroupKind)
 
+	var eventRecorder event.Recorder
+	if o.Options.NamespacedEvents {
+		eventRecorder = event.NewNamespacedAPIRecorder(mgr.GetEventRecorderFor(name))
+	} else {
+		eventRecorder = event.NewAPIRecorder(mgr.GetEventRecorderFor(name))
+	}
+
 	r := NewReconciler(mgr,
 		WithLogger(o.Logger.WithValues("controller", name)),
-		WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name))))
+		WithRecorder(eventRecorder))
 
 	return ctrl.NewControllerManagedBy(mgr).
 		Named(name).

--- a/internal/controller/apiextensions/definition/reconciler.go
+++ b/internal/controller/apiextensions/definition/reconciler.go
@@ -167,9 +167,16 @@ func (fn CRDRenderFn) Render(d *v1.CompositeResourceDefinition) (*extv1.CustomRe
 func Setup(mgr ctrl.Manager, o apiextensionscontroller.Options) error {
 	name := "defined/" + strings.ToLower(v1.CompositeResourceDefinitionGroupKind)
 
+	var eventRecorder event.Recorder
+	if o.Options.NamespacedEvents {
+		eventRecorder = event.NewNamespacedAPIRecorder(mgr.GetEventRecorderFor(name))
+	} else {
+		eventRecorder = event.NewAPIRecorder(mgr.GetEventRecorderFor(name))
+	}
+
 	r := NewReconciler(NewClientApplicator(mgr.GetClient()),
 		WithLogger(o.Logger.WithValues("controller", name)),
-		WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name))),
+		WithRecorder(eventRecorder),
 		WithControllerEngine(o.ControllerEngine),
 		WithOptions(o))
 

--- a/internal/controller/pkg/controller/options.go
+++ b/internal/controller/pkg/controller/options.go
@@ -33,6 +33,10 @@ type Options struct {
 	// Namespace used to unpack and run packages.
 	Namespace string
 
+	// Whether the controller should watch resources only in its own namespace or
+	// across all namespaces
+	NamespaceRestricted bool
+
 	// ServiceAccount is the core Crossplane ServiceAccount name.
 	ServiceAccount string
 

--- a/internal/controller/pkg/manager/reconciler.go
+++ b/internal/controller/pkg/manager/reconciler.go
@@ -187,6 +187,7 @@ func SetupProvider(mgr ctrl.Manager, o controller.Options) error {
 		WithRevisioner(NewPackageRevisioner(f, WithDefaultRegistry(o.DefaultRegistry))),
 		WithConfigStore(xpkg.NewImageConfigStore(mgr.GetClient(), o.Namespace)),
 		WithLogger(log),
+		// FIXME: use namespaced event recorder instead ?
 		WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name))),
 	}
 

--- a/internal/controller/pkg/revision/reconciler.go
+++ b/internal/controller/pkg/revision/reconciler.go
@@ -328,6 +328,7 @@ func SetupProviderRevision(mgr ctrl.Manager, o controller.Options) error {
 		WithConfigStore(xpkg.NewImageConfigStore(mgr.GetClient(), o.Namespace)),
 		WithLinter(xpkg.NewProviderLinter()),
 		WithLogger(log),
+		// FIXME: use namespaced event recorder instead ?
 		WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name))),
 		WithNamespace(o.Namespace),
 		WithServiceAccount(o.ServiceAccount),


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane! Please read the contribution docs
(linked below) if this is your first Crossplane pull request.
-->

### Description of your changes

Add a `--namespace-restricted` option to the core crossplane command. This option :

- Disables caching for resources outside of Crossplane's own namespace (to fix crashes)
- Disable events for cluster-scoped resources (to fix error logs if crossplane does not have rights on the `default` namespace)
- Disable RBAC manager pod (because it creates cluster-wide resources)
- Disable webhooks
- Give permissions to the core crosssplane pod only on resources in its own namespace
- Give cluster-wide permissions to the core crosssplane pod only on its custom resources

<!--
Briefly describe what this pull request does, and how it is covered by tests.
Be proactive - direct your reviewers' attention to anything that needs special
consideration.

We love pull requests that fix an open issue. If yours does, use the below line
to indicate which issue it fixes, for example "Fixes #500".
-->

Related docs PR : #6419

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [ ] Run `earthly +reviewable` to ensure this PR is ready for review. (waiting for crossplane-runtime dependency : https://github.com/crossplane/crossplane-runtime/pull/829)
- [ ] Added or updated unit tests. (todo)
- [ ] Added or updated e2e tests. (todo)
- [x] Linked a PR or a [docs tracking issue] to [document this change].
- ~[ ] Added `backport release-x.y` labels to auto-backport this PR.~
- ~[ ] Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~