### PR TITLE
feat(install.sh): download and unpack the compressed file

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -10,6 +10,7 @@ arch=$(uname -m)
 OS=${OS:-"${os}"}
 ARCH=${ARCH:-"${arch}"}
 OS_ARCH=""
+COMPRESSED=${COMPRESSED:-"False"}
 
 BIN=${BIN:-crank}
 
@@ -61,16 +62,42 @@ case $OS in
     ;;
 esac
 
-url="https://releases.crossplane.io/${XP_CHANNEL}/${XP_VERSION}/bin/${OS_ARCH}/${BIN}"
-if ! curl -sfLo crossplane "${url}"; then
-  echo "Failed to download Crossplane CLI. Please make sure version ${XP_VERSION} exists on channel ${XP_CHANNEL}."
-  exit 1
+_compr=`echo $COMPRESSED | tr '[:upper:]' '[:lower:]'`
+
+if [ "${_compr}" = "true" ]; then
+    url_dir="bundle"
+    url_file="crank.tar.gz"
+    url_error="a compressed file for "
+else
+    url_dir="bin"
+    url_file="${BIN}"
+    url_error=""
+fi
+
+url="https://releases.crossplane.io/${XP_CHANNEL}/${XP_VERSION}/${url_dir}/${OS_ARCH}/${url_file}"
+
+if ! curl -sfL "${url}" -o "${url_file}"; then
+    echo "Failed to download Crossplane CLI. Please make sure ${url_error}version ${XP_VERSION} exists on channel ${XP_CHANNEL}."
+    exit 1
+fi
+
+if [ "${_compr}" = "true" ]; then
+    if ! tar xzf "${url_file}"; then
+        echo "Failed to unpack the Crossplane CLI compressed file."
+        exit 1
+    fi
+    if ! mv "${BIN}" crossplane; then
+        echo "Failed to rename the unpacked Crossplane CLI binary: \"${BIN}\". Make sure it exists inside the compressed file."
+    fi
+    rm "${BIN}.sha256" "${url_file}"
+else
+    mv "${url_file}" crossplane
 fi
 
 chmod +x crossplane
 
 echo "crossplane CLI downloaded successfully! Run the following commands to finish installing it:"
-echo 
+echo
 echo sudo mv crossplane /usr/local/bin
 echo crossplane --help
 echo


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane! Please read the contribution docs
(linked below) if this is your first Crossplane pull request.
-->

### Description of your changes

<!--
Briefly describe what this pull request does, and how it is covered by tests.
Be proactive - direct your reviewers' attention to anything that needs special
consideration.

We love pull requests that fix an open issue. If yours does, use the below line
to indicate which issue it fixes, for example "Fixes #500".
-->

Since v1.18.0 there are compressed files available under the `bundle/` directory in releases.crossplane.io. This commit adds the functionality of downloading the compressed file and unpacking it, instead of downloading the binary, which would save some bandwidth.

In order to download/unpack a compressed file, a new env var needs to be passed COMPRESSED=True (or true), for example:

`COMPRESSED=True XP_VERSION="v1.18.0" ./install.sh`

Related PR: https://github.com/crossplane/docs/pull/929

Fixes #

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [X] Read and followed Crossplane's [contribution process].
- [X] Run `earthly +reviewable` to ensure this PR is ready for review.
- [ ] ~Added or updated unit tests.~
- [ ] ~Added or updated e2e tests.~
- [X] Linked a PR or a [docs tracking issue] to [document this change].
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~
- [ ] ~Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md