### PR TITLE
fix: consistently watch unstructured.Unstructured in real time compositions

### DIFF
--- a/internal/controller/apiextensions/composite/reconciler.go
+++ b/internal/controller/apiextensions/composite/reconciler.go
@@ -27,6 +27,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kunstructured "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -42,7 +43,6 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/reconciler/managed"
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
 	"github.com/crossplane/crossplane-runtime/pkg/resource/unstructured/claim"
-	"github.com/crossplane/crossplane-runtime/pkg/resource/unstructured/composed"
 	"github.com/crossplane/crossplane-runtime/pkg/resource/unstructured/composite"
 
 	v1 "github.com/crossplane/crossplane/apis/apiextensions/v1"
@@ -616,7 +616,9 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 
 	ws := make([]engine.Watch, len(xr.GetResourceReferences()))
 	for i, ref := range xr.GetResourceReferences() {
-		ws[i] = engine.WatchFor(composed.New(composed.FromReference(ref)), engine.WatchTypeComposedResource, r.watchHandler)
+		cr := &kunstructured.Unstructured{}
+		cr.SetGroupVersionKind(ref.GroupVersionKind())
+		ws[i] = engine.WatchFor(cr, engine.WatchTypeComposedResource, r.watchHandler)
 	}
 
 	// The ControllerEngine that starts this controller also starts a

--- a/internal/controller/apiextensions/composite/reconciler_test.go
+++ b/internal/controller/apiextensions/composite/reconciler_test.go
@@ -27,6 +27,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kunstructured "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/utils/ptr"
@@ -40,7 +41,6 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/reconciler/managed"
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
 	"github.com/crossplane/crossplane-runtime/pkg/resource/unstructured/claim"
-	"github.com/crossplane/crossplane-runtime/pkg/resource/unstructured/composed"
 	"github.com/crossplane/crossplane-runtime/pkg/resource/unstructured/composite"
 	"github.com/crossplane/crossplane-runtime/pkg/resource/unstructured/reference"
 	"github.com/crossplane/crossplane-runtime/pkg/test"
@@ -577,10 +577,9 @@ func TestReconcile(t *testing.T) {
 						},
 					}),
 					WithWatchStarter("cool-controller", nil, WatchStarterFn(func(_ context.Context, _ string, ws ...engine.Watch) error {
-						cd := composed.New(composed.FromReference(corev1.ObjectReference{
-							APIVersion: "example.org/v1",
-							Kind:       "ComposedResource",
-						}))
+						cd := &kunstructured.Unstructured{}
+						cd.SetAPIVersion("example.org/v1")
+						cd.SetKind("ComposedResource")
 						want := []engine.Watch{engine.WatchFor(cd, engine.WatchTypeComposedResource, nil)}
 
 						if diff := cmp.Diff(want, ws, cmp.AllowUnexported(engine.Watch{})); diff != "" {


### PR DESCRIPTION
### Description of your changes

This PR updates the type we use to start watches on composed resources - we'll now use the Kubernetes `unstructured.Unstructured` type, like we do for other watches. The current approach of using `composed.Unstructured` would be fine, except that we already set up watches on XRs using the `unstructured.Unstructured` type. When an XR is itself a composed resource, we can't try to start another watch using `composed.Unstructured`, because that is a different type than the watch we already started. When we use different types, the underlying watch runs into an unhandled error for encountering an unexpected type.

The underlying root cause is described in more detail in  https://github.com/crossplane/crossplane/issues/5957#issuecomment-2888496782.

Fixes #5957
Fixes #6455

Because this issue was hard to reproduce and track down, I prepared a repro and testing project at https://github.com/jbw976/debug-xp-rtc-watch-error. That project consistently reproduces the issue on [v1.20.0-rc.1](https://github.com/crossplane/crossplane/releases/tag/v1.20.0-rc.1).  With this fix in place, the issue no longer occurs, e.g. the logs don't have any `Unhandled Error` entries, and all resources reach a healthy ready status:

```
❯ kubectl -n crossplane-system logs --tail=-1 -l app=crossplane -c crossplane | grep -F -i 'Unhandled Error' | wc -l
       0

❯ crossplane beta trace parent.debug.crossplane.io/parent
NAME                                             SYNCED   READY   STATUS
Parent/parent (default)                          True     True    Available
└─ XParent/parent-45z4t                          True     True    Available
   ├─ XChild/xchild-debugging-0                  True     True    Available
   │  ├─ InternetGateway/gateway-debugging-0-0   True     True    Available
   │  ├─ InternetGateway/gateway-debugging-0-1   True     True    Available
   │  ├─ VPC/vpc-debugging-0-0                   True     True    Available
   │  └─ VPC/vpc-debugging-0-1                   True     True    Available
   ├─ XChild/xchild-debugging-1                  True     True    Available
   │  ├─ InternetGateway/gateway-debugging-1-0   True     True    Available
   │  ├─ InternetGateway/gateway-debugging-1-1   True     True    Available
   │  ├─ VPC/vpc-debugging-1-0                   True     True    Available
   │  └─ VPC/vpc-debugging-1-1                   True     True    Available
   └─ XChild/xchild-debugging-2                  True     True    Available
      ├─ InternetGateway/gateway-debugging-2-0   True     True    Available
      ├─ InternetGateway/gateway-debugging-2-1   True     True    Available
      ├─ VPC/vpc-debugging-2-0                   True     True    Available
      └─ VPC/vpc-debugging-2-1                   True     True    Available
```

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `earthly +reviewable` to ensure this PR is ready for review.
- [x] Added or updated unit tests.
- [ ] ~Added or updated e2e tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~
- [ ] ~Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md