### PR TITLE
Rate limit XR reconciles triggered by composed resource watches

### DIFF
--- a/internal/controller/apiextensions/definition/handlers_test.go
+++ b/internal/controller/apiextensions/definition/handlers_test.go
@@ -244,6 +244,6 @@ type rateLimitingQueueMock struct {
 	added []any
 }
 
-func (f *rateLimitingQueueMock) Add(item reconcile.Request) {
+func (f *rateLimitingQueueMock) AddRateLimited(item reconcile.Request) {
 	f.added = append(f.added, item)
 }

--- a/internal/controller/apiextensions/definition/ratelimiter.go
+++ b/internal/controller/apiextensions/definition/ratelimiter.go
@@ -1,0 +1,66 @@
+/*
+Copyright 2020 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package definition
+
+import (
+	"time"
+
+	"k8s.io/client-go/util/workqueue"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"github.com/crossplane/crossplane-runtime/pkg/logging"
+)
+
+var _ workqueue.TypedRateLimiter[reconcile.Request] = &DebuggingRateLimiter[reconcile.Request]{}
+
+// A DebuggingRateLimiter wraps a rate limiter with debugging information.
+type DebuggingRateLimiter[T comparable] struct {
+	name    string
+	wrapped workqueue.TypedRateLimiter[T]
+	log     logging.Logger
+}
+
+// NewDebuggingRateLimiter wraps a rate limiter with debug logging.
+func NewDebuggingRateLimiter[T comparable](name string, wrapped workqueue.TypedRateLimiter[T], log logging.Logger) *DebuggingRateLimiter[T] {
+	return &DebuggingRateLimiter[T]{name: name, wrapped: wrapped, log: log}
+}
+
+// When returns the duration after which the item can be requeued.
+func (r *DebuggingRateLimiter[T]) When(item T) time.Duration {
+	tries := r.wrapped.NumRequeues(item)
+	when := r.wrapped.When(item)
+
+	if when > 0 {
+		r.log.Debug("Rate limiting item", "rate-limiter", r.name, "item", item, "requeues", tries, "requeue-after", when)
+	}
+
+	return when
+}
+
+// NumRequeues returns the number of times the item has been requeued.
+func (r *DebuggingRateLimiter[T]) NumRequeues(item T) int {
+	return r.wrapped.NumRequeues(item)
+}
+
+// Forget the item.
+func (r *DebuggingRateLimiter[T]) Forget(item T) {
+	tries := r.wrapped.NumRequeues(item)
+	if tries > 0 {
+		r.log.Debug("Forgetting rate limited item", "rate-limiter", r.name, "item", item)
+	}
+	r.wrapped.Forget(item)
+}

--- a/internal/controller/apiextensions/definition/reconciler.go
+++ b/internal/controller/apiextensions/definition/reconciler.go
@@ -486,8 +486,12 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 	// {Requeue: true}. The XR reconciler returns {Requeue: true} while waiting
 	// for composed resources to become ready, and we don't want to back off as
 	// far as 60 seconds. Instead we cap the XR reconciler at 30 seconds.
-	ko.RateLimiter = workqueue.NewTypedItemExponentialFailureRateLimiter[reconcile.Request](1*time.Second, 30*time.Second)
-	ko.Reconciler = ratelimiter.NewReconciler(composite.ControllerName(d.GetName()), errors.WithSilentRequeueOnConflict(cr), r.options.GlobalRateLimiter)
+	rl := workqueue.NewTypedItemExponentialFailureRateLimiter[reconcile.Request](1*time.Second, 30*time.Second)
+	ko.RateLimiter = NewDebuggingRateLimiter(d.GetName()+"-per-item", rl, log)
+	ko.Reconciler = ratelimiter.NewReconciler(
+		composite.ControllerName(d.GetName()),
+		errors.WithSilentRequeueOnConflict(cr),
+		NewDebuggingRateLimiter(d.GetName()+"-global", r.options.GlobalRateLimiter, log))
 
 	xrGVK := d.GetCompositeGroupVersionKind()
 	name := composite.ControllerName(d.GetName())


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane! Please read the contribution docs
(linked below) if this is your first Crossplane pull request.
-->

### Description of your changes

<!--
Briefly describe what this pull request does, and how it is covered by tests.
Be proactive - direct your reviewers' attention to anything that needs special
consideration.

We love pull requests that fix an open issue. If yours does, use the below line
to indicate which issue it fixes, for example "Fixes #500".
-->

Fixes https://github.com/crossplane/crossplane/issues/6461 (in that it subjects the reconciles to rate limiting)

This guards against the scenario where the XR controller fights with some other controller over a composed resource's desired state. For example:

1. XR controller updates composed MR spec
2. This triggers a reconcile in the MR controller
3. MR controller updates composed MR spec
4. This triggers a reconcile in the XR controller
5. Back to step 1.

This should use the XR's per-item rate limiter, which backs off reconciles from 1 second to 30 seconds. Per-item means the rate limiter is keyed by `types.NamespacedName`, so one XR getting rate limited shouldn't affect others.

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `earthly +reviewable` to ensure this PR is ready for review.
- [ ] ~Added or updated unit tests.~
- [ ] ~Added or updated e2e tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~
- [ ] ~Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md