### PR TITLE
Enable extracting package.yaml from private repositories.

### DIFF
--- a/cmd/crank/xpkg/extract.go
+++ b/cmd/crank/xpkg/extract.go
@@ -25,6 +25,7 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/name"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/daemon"
@@ -60,7 +61,9 @@ type fetchFn func(context.Context, name.Reference) (v1.Image, error)
 
 // registryFetch fetches a package from the registry.
 func registryFetch(ctx context.Context, r name.Reference) (v1.Image, error) {
-	return remote.Image(r, remote.WithContext(ctx))
+	// Use default docker auth, i.e. for private repositories.
+	kc := authn.NewMultiKeychain(authn.DefaultKeychain)
+	return remote.Image(r, remote.WithContext(ctx), remote.WithAuthFromKeychain(kc))
 }
 
 // daemonFetch fetches a package from the Docker daemon.


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane! Please read the contribution docs
(linked below) if this is your first Crossplane pull request.
-->

### Description of your changes

Adds default auth for `crossplane xpkg extract` when fetching from a remote registry, to support private repositories.

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `earthly +reviewable` to ensure this PR is ready for review.
- [ ] ~~Added or updated unit tests.~~
- [ ] ~~Added or updated e2e tests.~~
- [ ] ~~Linked a PR or a [docs tracking issue] to [document this change].~~
- [ ] ~~Added `backport release-x.y` labels to auto-backport this PR.~~
- [ ] ~~Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md