### PR TITLE
Publish artifacts to CNCF owned buckets in Oracle Cloud object storage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,11 +19,11 @@ env:
   # Force Earthly to use color output
   FORCE_COLOR: "1"
 
-  # Common users. We can't run a step 'if secrets.AWS_USR != ""' but we can run
-  # a step 'if env.AWS_USR' != ""', so we copy these to succinctly test whether
+  # Common users. We can't run a step 'if secrets.DOCKER_USR != ""' but we can run
+  # a step 'if env.DOCKER_USR' != ""', so we copy these to succinctly test whether
   # credentials have been provided before trying to run steps that need them.
   DOCKER_USR: ${{ secrets.DOCKER_USR }}
-  AWS_USR: ${{ secrets.AWS_USR }}
+  ORACLE_USR: ${{ secrets.ORACLE_USR }}
   UPBOUND_MARKETPLACE_PUSH_ROBOT_USR: ${{ secrets.UPBOUND_MARKETPLACE_PUSH_ROBOT_USR }}
 
 
@@ -363,7 +363,7 @@ jobs:
         run: echo "EARTHLY_MAX_REMOTE_CACHE=true" >> $GITHUB_ENV
 
       - name: Configure Earthly to Push Artifacts
-        if: (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/v2' || startsWith(github.ref, 'refs/heads/release-')) && env.DOCKER_USR != '' && env.UPBOUND_MARKETPLACE_PUSH_ROBOT_USR != '' && env.AWS_USR != ''
+        if: (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/v2' || startsWith(github.ref, 'refs/heads/release-')) && env.DOCKER_USR != '' && env.UPBOUND_MARKETPLACE_PUSH_ROBOT_USR != '' && env.ORACLE_USR != ''
         run: echo "EARTHLY_PUSH=true" >> $GITHUB_ENV
 
       - name: Set CROSSPLANE_VERSION GitHub Environment Variable
@@ -373,28 +373,42 @@ jobs:
         run: earthly --strict --remote-cache ghcr.io/crossplane/earthly-cache:${{ github.job }} +ci-artifacts --CROSSPLANE_VERSION=${CROSSPLANE_VERSION}
 
       - name: Push Artifacts to https://releases.crossplane.io/build/
-        if: env.AWS_USR != ''
+        if: env.ORACLE_USR != ''
         run: |
           earthly --strict \
-            --secret=AWS_ACCESS_KEY_ID=${{ secrets.AWS_USR }} \
-            --secret=AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_PSW }} \
-            +ci-push-build-artifacts --AWS_DEFAULT_REGION=us-east-1 --CROSSPLANE_VERSION=${CROSSPLANE_VERSION} --BUILD_DIR=${GITHUB_REF##*/}
+            --secret=AWS_ACCESS_KEY_ID=${{ secrets.ORACLE_USR }} \
+            --secret=AWS_SECRET_ACCESS_KEY=${{ secrets.ORACLE_PSW }} \
+            +ci-push-build-artifacts \
+            --ENDPOINT_URL=${{ vars.ORACLE_ENDPOINT }} \
+            --AWS_DEFAULT_REGION=us-sanjose-1 \
+            --CROSSPLANE_VERSION=${CROSSPLANE_VERSION} \
+            --BUILD_DIR=${GITHUB_REF##*/}
 
       - name: Push Artifacts to https://releases.crossplane.io/master/ and https://charts.crossplane.io/master
-        if: env.AWS_USR != '' && github.ref == 'refs/heads/main'
+        if: env.ORACLE_USR != '' && github.ref == 'refs/heads/main'
         run: |
           earthly --strict \
-            --secret=AWS_ACCESS_KEY_ID=${{ secrets.AWS_USR }} \
-            --secret=AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_PSW }} \
-            +ci-promote-build-artifacts --AWS_DEFAULT_REGION=us-east-1 --CROSSPLANE_VERSION=${CROSSPLANE_VERSION} --BUILD_DIR=${GITHUB_REF##*/} --CHANNEL=master
+            --secret=AWS_ACCESS_KEY_ID=${{ secrets.ORACLE_USR }} \
+            --secret=AWS_SECRET_ACCESS_KEY=${{ secrets.ORACLE_PSW }} \
+            +ci-promote-build-artifacts \
+            --ENDPOINT_URL=${{ vars.ORACLE_ENDPOINT }} \
+            --AWS_DEFAULT_REGION=us-sanjose-1 \
+            --CROSSPLANE_VERSION=${CROSSPLANE_VERSION} \
+            --BUILD_DIR=${GITHUB_REF##*/} \
+            --CHANNEL=master
 
       - name: Push Artifacts to https://releases.crossplane.io/preview/ and https://charts.crossplane.io/preview
-        if: env.AWS_USR != '' && github.ref == 'refs/heads/v2'
+        if: env.ORACLE_USR != '' && github.ref == 'refs/heads/v2'
         run: |
           earthly --strict \
-            --secret=AWS_ACCESS_KEY_ID=${{ secrets.AWS_USR }} \
-            --secret=AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_PSW }} \
-            +ci-promote-build-artifacts --AWS_DEFAULT_REGION=us-east-1 --CROSSPLANE_VERSION=${CROSSPLANE_VERSION} --BUILD_DIR=${GITHUB_REF##*/} --CHANNEL=preview
+            --secret=AWS_ACCESS_KEY_ID=${{ secrets.ORACLE_USR }} \
+            --secret=AWS_SECRET_ACCESS_KEY=${{ secrets.ORACLE_PSW }} \
+            +ci-promote-build-artifacts \
+            --ENDPOINT_URL=${{ vars.ORACLE_ENDPOINT }} \
+            --AWS_DEFAULT_REGION=us-sanjose-1 \
+            --CROSSPLANE_VERSION=${CROSSPLANE_VERSION} \
+            --BUILD_DIR=${GITHUB_REF##*/} \
+            --CHANNEL=preview
 
       - name: Upload Artifacts to GitHub
         uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b # v4

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -22,12 +22,12 @@ env:
   # Common versions
   EARTHLY_VERSION: '0.8.15'
 
-  # Common users. We can't run a step 'if secrets.AWS_USR != ""' but we can run
-  # a step 'if env.AWS_USR' != ""', so we copy these to succinctly test whether
+  # Common users. We can't run a step 'if secrets.DOCKER_USR != ""' but we can run
+  # a step 'if env.DOCKER_USR' != ""', so we copy these to succinctly test whether
   # credentials have been provided before trying to run steps that need them.
   DOCKER_USR: ${{ secrets.DOCKER_USR }}
   GHCR_USR: ${{ github.actor }}
-  AWS_USR: ${{ secrets.AWS_USR }}
+  ORACLE_USR: ${{ secrets.ORACLE_USR }}
   UPBOUND_MARKETPLACE_PUSH_ROBOT_USR: ${{ secrets.UPBOUND_MARKETPLACE_PUSH_ROBOT_USR }}
 
 jobs:
@@ -72,10 +72,16 @@ jobs:
           +ci-promote-image --CHANNEL=${{ inputs.channel }} --CROSSPLANE_VERSION=${{ inputs.version }} --CROSSPLANE_REPO=xpkg.upbound.io/crossplane/crossplane
 
       - name: Promote Build Artifacts to https://releases.crossplane.io/${{ inputs.channel }}
-        if: env.AWS_USR != ''
+        if: env.ORACLE_USR != ''
         run: |
           earthly --strict \
             --push \
-            --secret=AWS_ACCESS_KEY_ID=${{ secrets.AWS_USR }} \
-            --secret=AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_PSW }} \
-            +ci-promote-build-artifacts --AWS_DEFAULT_REGION=us-east-1 --CHANNEL=${{ inputs.channel }} --BUILD_DIR=${GITHUB_REF##*/} --PRERELEASE=${{ inputs.pre-release }} --CROSSPLANE_VERSION=${{ inputs.version }}
+            --secret=AWS_ACCESS_KEY_ID=${{ secrets.ORACLE_USR }} \
+            --secret=AWS_SECRET_ACCESS_KEY=${{ secrets.ORACLE_PSW }} \
+            +ci-promote-build-artifacts \
+            --ENDPOINT_URL=${{ vars.ORACLE_ENDPOINT }} \
+            --AWS_DEFAULT_REGION=us-sanjose-1 \
+            --CHANNEL=${{ inputs.channel }} \
+            --BUILD_DIR=${GITHUB_REF##*/} \
+            --PRERELEASE=${{ inputs.pre-release }} \
+            --CROSSPLANE_VERSION=${{ inputs.version }}

--- a/Earthfile
+++ b/Earthfile
@@ -446,10 +446,11 @@ ci-push-build-artifacts:
   ARG --required BUILD_DIR
   ARG ARTIFACTS_DIR=_output
   ARG BUCKET_RELEASES=crossplane.releases
+  ARG ENDPOINT_URL
   ARG AWS_DEFAULT_REGION
   FROM amazon/aws-cli:2.15.61
   COPY --dir ${ARTIFACTS_DIR} artifacts
-  RUN --push --secret=AWS_ACCESS_KEY_ID --secret=AWS_SECRET_ACCESS_KEY aws s3 sync --delete --only-show-errors artifacts s3://${BUCKET_RELEASES}/build/${BUILD_DIR}/${CROSSPLANE_VERSION}
+  RUN --push --secret=AWS_ACCESS_KEY_ID --secret=AWS_SECRET_ACCESS_KEY aws s3 sync --endpoint-url ${ENDPOINT_URL} --delete --only-show-errors artifacts s3://${BUCKET_RELEASES}/build/${BUILD_DIR}/${CROSSPLANE_VERSION}
 
 # ci-promote-build-artifacts is used by CI to promote binary artifacts and Helm
 # charts to a channel. In practice, this means copying them from one S3
@@ -461,16 +462,17 @@ ci-promote-build-artifacts:
   ARG HELM_REPO_URL=https://charts.crossplane.io
   ARG BUCKET_RELEASES=crossplane.releases
   ARG BUCKET_CHARTS=crossplane.charts
+  ARG ENDPOINT_URL
   ARG PRERELEASE=false
   ARG AWS_DEFAULT_REGION
   FROM amazon/aws-cli:2.15.61
   COPY +helm-setup/helm /usr/local/bin/helm
-  RUN --secret=AWS_ACCESS_KEY_ID --secret=AWS_SECRET_ACCESS_KEY aws s3 sync --only-show-errors s3://${BUCKET_CHARTS}/${CHANNEL} repo
-  RUN --secret=AWS_ACCESS_KEY_ID --secret=AWS_SECRET_ACCESS_KEY aws s3 sync --only-show-errors s3://${BUCKET_RELEASES}/build/${BUILD_DIR}/${CROSSPLANE_VERSION}/charts repo
+  RUN --secret=AWS_ACCESS_KEY_ID --secret=AWS_SECRET_ACCESS_KEY aws s3 sync --endpoint-url ${ENDPOINT_URL} --only-show-errors s3://${BUCKET_CHARTS}/${CHANNEL} repo
+  RUN --secret=AWS_ACCESS_KEY_ID --secret=AWS_SECRET_ACCESS_KEY aws s3 sync --endpoint-url ${ENDPOINT_URL} --only-show-errors s3://${BUCKET_RELEASES}/build/${BUILD_DIR}/${CROSSPLANE_VERSION}/charts repo
   RUN helm repo index --url ${HELM_REPO_URL}/${CHANNEL} repo
-  RUN --push --secret=AWS_ACCESS_KEY_ID --secret=AWS_SECRET_ACCESS_KEY aws s3 sync --delete --only-show-errors repo s3://${BUCKET_CHARTS}/${CHANNEL}
-  RUN --push --secret=AWS_ACCESS_KEY_ID --secret=AWS_SECRET_ACCESS_KEY aws s3 cp --only-show-errors --cache-control "private, max-age=0, no-transform" repo/index.yaml s3://${BUCKET_CHARTS}/${CHANNEL}/index.yaml
-  RUN --push --secret=AWS_ACCESS_KEY_ID --secret=AWS_SECRET_ACCESS_KEY aws s3 sync --delete --only-show-errors s3://${BUCKET_RELEASES}/build/${BUILD_DIR}/${CROSSPLANE_VERSION} s3://${BUCKET_RELEASES}/${CHANNEL}/${CROSSPLANE_VERSION}
+  RUN --push --secret=AWS_ACCESS_KEY_ID --secret=AWS_SECRET_ACCESS_KEY aws s3 sync --endpoint-url ${ENDPOINT_URL} --delete --only-show-errors repo s3://${BUCKET_CHARTS}/${CHANNEL}
+  RUN --push --secret=AWS_ACCESS_KEY_ID --secret=AWS_SECRET_ACCESS_KEY aws s3 cp --endpoint-url ${ENDPOINT_URL} --only-show-errors --cache-control "private, max-age=0, no-transform" repo/index.yaml s3://${BUCKET_CHARTS}/${CHANNEL}/index.yaml
+  RUN --push --secret=AWS_ACCESS_KEY_ID --secret=AWS_SECRET_ACCESS_KEY aws s3 sync --endpoint-url ${ENDPOINT_URL} --delete --only-show-errors --copy-props metadata-directive s3://${BUCKET_RELEASES}/build/${BUILD_DIR}/${CROSSPLANE_VERSION} s3://${BUCKET_RELEASES}/${CHANNEL}/${CROSSPLANE_VERSION}
   IF [ "${PRERELEASE}" = "false" ]
-    RUN --push --secret=AWS_ACCESS_KEY_ID --secret=AWS_SECRET_ACCESS_KEY aws s3 sync --delete --only-show-errors s3://${BUCKET_RELEASES}/build/${BUILD_DIR}/${CROSSPLANE_VERSION} s3://${BUCKET_RELEASES}/${CHANNEL}/current
+    RUN --push --secret=AWS_ACCESS_KEY_ID --secret=AWS_SECRET_ACCESS_KEY aws s3 sync --endpoint-url ${ENDPOINT_URL} --delete --only-show-errors --copy-props metadata-directive s3://${BUCKET_RELEASES}/build/${BUILD_DIR}/${CROSSPLANE_VERSION} s3://${BUCKET_RELEASES}/${CHANNEL}/current
   END


### PR DESCRIPTION
### Description of your changes

This PR updates our build scripts to publish to a CNCF owned account in Oracle Cloud object storage, as opposed to AWS S3 where we have historically published to. Oracle buckets are mostly compatible with S3 buckets, and the `aws s3` CLI can be reused, but a few changes were necessary to make this happen:

* `--endpoint-url` needs to be used to point to the oracle bucket endpoint - just using the S3 protocol will by default go to AWS.
* [`--copy-props metadata-directive`](https://awscli.amazonaws.com/v2/documentation/api/2.9.6/reference/s3/sync.html#:~:text=%2D%2D-,copy,-%2Dprops%20(string)%20Determines) needs to be used to avoid `GetObjectTagging` calls during `s3 sync`, as it is [not supported](https://docs.oracle.com/en-us/iaas/Content/Object/Tasks/s3compatibleapi_topic-Amazon_S3_Compatibility_API_Support.htm) by Oracle.
* the default region has been changed to `us-sanjose-1` as Oracle seems to require tenants to use their home region for some bucket operations

I will keep this in DRAFT until the follow are completed:

- [x] remove build hack commit to publish from fork/branch
- [ ] get a vanity URL set up for the buckets - the endpoint now is a bit ugly
  - [ ] this seems to require a CDN setup, e.g. CloudFlare, as Oracle buckets [do not support vanity URLs](https://www.ateam-oracle.com/post/object-storage-vanity-cloudflare)
- [x] remove explicit setting of `BUCKET_RELEASES`, `BUCKET_CHARTS`, and `HELM_REPO_URL` to test values. default values should be final values.
- [x] copy supported versions/releases of Crossplane from old S3 buckets to new Oracle buckets. when we switch over, people still need to be able to install all currently supported versions.

### How has this change been tested?

A fair amount of trial and error to get everything setup in Oracle cloud (including their permissions model), figure out the right settings for S3 compatibility, and to get CI/promotion running out of my fork.

This commit contains some temporary hacks that were necessary to get CI running in my fork: https://github.com/crossplane/crossplane/commit/af719cda475bf8e36ccb633f1da97cd8a0e0c612 

After tagging my fork/branch with `1.27.0-rc.1` and running CI and promotion successfully, I tested with the following:

```
# install crossplane helm chart
helm repo add crossplane-oci-alpha https://objectstorage.us-sanjose-1.oraclecloud.com/n/axtwf1hkrwcy/b/crossplane.charts.test/o/alpha
helm repo update
helm install crossplane --namespace crossplane-system --create-namespace crossplane-oci-alpha/crossplane --devel --set image.repository=ghcr.io/jbw976/crossplane

# pods are running OK
❯ kcs get pod
NAME                                      READY   STATUS    RESTARTS   AGE
crossplane-6b7b7f77d8-rvhsp               1/1     Running   0          35m
crossplane-rbac-manager-d6bd79d84-xh6w7   1/1     Running   0          35m

# expected version was installed
❯ kubectl -n crossplane-system get pod -o json | jq '.items[].spec.containers[0].image'
"ghcr.io/jbw976/crossplane:v1.27.0-rc.1"
"ghcr.io/jbw976/crossplane:v1.27.0-rc.1"

# install crossplane CLI using the install script from my fork/branch (the changes to this script were only for testing and they have been reverted - this command won't work anymore):
curl -sL "https://raw.githubusercontent.com/jbw976/crossplane/refs/heads/oci-buckets/install.sh" | XP_CHANNEL=alpha sh

# expected version was installed
❯ ./crossplane version
Client Version: v1.27.0-rc.1
Server Version: v1.27.0-rc.1
```

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `earthly +reviewable` to ensure this PR is ready for review.
- [ ] ~Added or updated unit tests.~
- [ ] ~Added or updated e2e tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~
- [ ] ~Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md