### PR TITLE
Enable crossplane to be deployed via ko

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,9 @@ Zone.Identifier
 .tmp-earthly-out/
 build/
 
+# Exclude the ko data dir
+kodata/
+
 # gitlab example
 # exclude files generate by running the example
 external-dns-*.tgz

--- a/.ko.yaml
+++ b/.ko.yaml
@@ -1,0 +1,1 @@
+defaultBaseImage: gcr.io/distroless/static:nonroot

--- a/Earthfile
+++ b/Earthfile
@@ -324,7 +324,11 @@ ko-init:
   RUN echo && \
       echo "Now build the helm chart and apply the template in dry run mode through ko:" && \
       echo "   earthly +helm-build" && \
-      echo "   helm template --dry-run --namespace crossplane-system --set image.ko=true crossplane ./_output/charts/crossplane*.tgz | ko apply -f -" && \
+      echo "   helm template --dry-run --namespace crossplane-system --set image.ignoreTag=true \\" && \
+      echo "     --set image.repository=ko://github.com/crossplane/crossplane/cmd/crossplane \\" && \
+      echo "     --set extraEnvVarsCrossplaneInit.CRDS_PATH=/var/run/ko/crds \\" && \
+      echo "     --set extraEnvVarsCrossplaneInit.WEBHOOK_CONFIGS_PATH=/var/run/ko/webhookconfigurations \\" && \
+      echo "     crossplane ./_output/charts/crossplane*.tgz | ko apply -f -" && \
       echo
   SAVE ARTIFACT ./kodata AS LOCAL cmd/crossplane/kodata
 

--- a/Earthfile
+++ b/Earthfile
@@ -316,6 +316,18 @@ kubectl-setup:
   RUN curl -fsSL https://dl.k8s.io/${KUBECTL_VERSION}/kubernetes-client-${TARGETOS}-${TARGETARCH}.tar.gz|tar zx
   SAVE ARTIFACT kubernetes/client/bin/kubectl
 
+# Ko init will create the kodata dir for crd and webhook files in the crossplane controller binary path.
+ko-init:
+  FROM alpine:3.20
+  COPY (+go-generate/crds) ./kodata/crds
+  COPY --dir cluster/webhookconfigurations ./kodata/
+  RUN echo && \
+      echo "Now build the helm chart and apply the template in dry run mode through ko:" && \
+      echo "   earthly +helm-build" && \
+      echo "   helm template --dry-run --namespace crossplane-system --set image.ko=true crossplane ./_output/charts/crossplane*.tgz | ko apply -f -" && \
+      echo
+  SAVE ARTIFACT ./kodata AS LOCAL cmd/crossplane/kodata
+
 # kind-setup is used by other targets to setup kind.
 kind-setup:
   ARG KIND_VERSION=v0.25.0

--- a/cluster/charts/crossplane/README.md
+++ b/cluster/charts/crossplane/README.md
@@ -82,6 +82,7 @@ and their default values.
 | `functionCache.pvc` | The name of a PersistentVolumeClaim to use as the function cache. Disables the default function cache `emptyDir` Volume. | `""` |
 | `functionCache.sizeLimit` | The size limit for the function cache. If medium is `Memory` the `sizeLimit` can't exceed Node memory. | `"512Mi"` |
 | `hostNetwork` | Enable `hostNetwork` for the Crossplane deployment. Caution: enabling `hostNetwork` grants the Crossplane Pod access to the host network namespace. Consider setting `dnsPolicy` to `ClusterFirstWithHostNet`. | `false` |
+| `image.ko` | Override to use ko settings:    - image == ko://github.com/crossplane/crossplane/cmd/crossplane | `false` |
 | `image.pullPolicy` | The image pull policy used for Crossplane and RBAC Manager pods. | `"IfNotPresent"` |
 | `image.repository` | Repository for the Crossplane pod image. | `"xpkg.crossplane.io/crossplane/crossplane"` |
 | `image.tag` | The Crossplane image tag. Defaults to the value of `appVersion` in `Chart.yaml`. | `""` |

--- a/cluster/charts/crossplane/README.md
+++ b/cluster/charts/crossplane/README.md
@@ -72,7 +72,8 @@ and their default values.
 | `customLabels` | Add custom `labels` to the Crossplane pod deployment. | `{}` |
 | `deploymentStrategy` | The deployment strategy for the Crossplane and RBAC Manager pods. | `"RollingUpdate"` |
 | `dnsPolicy` | Specify the `dnsPolicy` to be used by the Crossplane pod. | `""` |
-| `extraEnvVarsCrossplane` | Add custom environmental variables to the Crossplane pod deployment. Replaces any `.` in a variable name with `_`. For example, `SAMPLE.KEY=value1` becomes `SAMPLE_KEY=value1`. | `{}` |
+| `extraEnvVarsCrossplane` | Add custom environmental variables to the Crossplane pod deployment application container. Replaces any `.` in a variable name with `_`. For example, `SAMPLE.KEY=value1` becomes `SAMPLE_KEY=value1`. | `{}` |
+| `extraEnvVarsCrossplaneInit` | Add custom environmental variables to the Crossplane pod deployment init container. Replaces any `.` in a variable name with `_`. For example, `SAMPLE.KEY=value1` becomes `SAMPLE_KEY=value1`. | `{}` |
 | `extraEnvVarsRBACManager` | Add custom environmental variables to the RBAC Manager pod deployment. Replaces any `.` in a variable name with `_`. For example, `SAMPLE.KEY=value1` becomes `SAMPLE_KEY=value1`. | `{}` |
 | `extraObjects` | To add arbitrary Kubernetes Objects during a Helm Install | `[]` |
 | `extraVolumeMountsCrossplane` | Add custom `volumeMounts` to the Crossplane pod. | `{}` |
@@ -82,7 +83,7 @@ and their default values.
 | `functionCache.pvc` | The name of a PersistentVolumeClaim to use as the function cache. Disables the default function cache `emptyDir` Volume. | `""` |
 | `functionCache.sizeLimit` | The size limit for the function cache. If medium is `Memory` the `sizeLimit` can't exceed Node memory. | `"512Mi"` |
 | `hostNetwork` | Enable `hostNetwork` for the Crossplane deployment. Caution: enabling `hostNetwork` grants the Crossplane Pod access to the host network namespace. Consider setting `dnsPolicy` to `ClusterFirstWithHostNet`. | `false` |
-| `image.ko` | Override to use ko settings:    - image == ko://github.com/crossplane/crossplane/cmd/crossplane | `false` |
+| `image.ignoreTag` | Do not use the {{ .image.tag }} value to compute the image uri. | `false` |
 | `image.pullPolicy` | The image pull policy used for Crossplane and RBAC Manager pods. | `"IfNotPresent"` |
 | `image.repository` | Repository for the Crossplane pod image. | `"xpkg.crossplane.io/crossplane/crossplane"` |
 | `image.tag` | The Crossplane image tag. Defaults to the value of `appVersion` in `Chart.yaml`. | `""` |

--- a/cluster/charts/crossplane/templates/deployment.yaml
+++ b/cluster/charts/crossplane/templates/deployment.yaml
@@ -57,7 +57,13 @@ spec:
       {{- end }}
       hostNetwork: {{ .Values.hostNetwork }}
       initContainers:
-        - image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default (printf "v%s" .Chart.AppVersion) }}"
+        - name: {{ .Chart.Name }}-init
+          {{- if .Values.image.ko }}
+          image: "ko://github.com/crossplane/crossplane/cmd/crossplane"
+          {{- else }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default (printf "v%s" .Chart.AppVersion) }}"
+          {{- end }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
           - core
           - init
@@ -73,8 +79,6 @@ spec:
           - --function
           - "{{ $arg }}"
           {{- end }}
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
-          name: {{ .Chart.Name }}-init
           resources:
             {{- toYaml .Values.resourcesCrossplane | nindent 12 }}
           {{- with .Values.securityContextCrossplane }}
@@ -82,6 +86,12 @@ spec:
             {{- toYaml . | nindent 12 }}
           {{- end }}
           env:
+          {{- if .Values.image.ko }}
+          - name: CRDS_PATH
+            value: "/var/run/ko/crds"
+          - name: WEBHOOK_CONFIGS_PATH
+            value: "/var/run/ko/webhookconfigurations"
+          {{- end }}
           - name: GOMAXPROCS
             valueFrom:
               resourceFieldRef:
@@ -126,7 +136,12 @@ spec:
           - name: "TLS_CLIENT_SECRET_NAME"
             value: crossplane-tls-client
       containers:
-      - image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default (printf "v%s" .Chart.AppVersion) }}"
+      - name: {{ .Chart.Name }}
+        {{- if .Values.image.ko }}
+        image: "ko://github.com/crossplane/crossplane/cmd/crossplane"
+        {{- else }}
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default (printf "v%s" .Chart.AppVersion) }}"
+        {{- end }}
         args:
         - core
         - start

--- a/cluster/charts/crossplane/templates/deployment.yaml
+++ b/cluster/charts/crossplane/templates/deployment.yaml
@@ -58,8 +58,8 @@ spec:
       hostNetwork: {{ .Values.hostNetwork }}
       initContainers:
         - name: {{ .Chart.Name }}-init
-          {{- if .Values.image.ko }}
-          image: "ko://github.com/crossplane/crossplane/cmd/crossplane"
+          {{- if .Values.image.ignoreTag }}
+          image: "{{ .Values.image.repository }}"
           {{- else }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default (printf "v%s" .Chart.AppVersion) }}"
           {{- end }}
@@ -86,12 +86,6 @@ spec:
             {{- toYaml . | nindent 12 }}
           {{- end }}
           env:
-          {{- if .Values.image.ko }}
-          - name: CRDS_PATH
-            value: "/var/run/ko/crds"
-          - name: WEBHOOK_CONFIGS_PATH
-            value: "/var/run/ko/webhookconfigurations"
-          {{- end }}
           - name: GOMAXPROCS
             valueFrom:
               resourceFieldRef:
@@ -135,10 +129,14 @@ spec:
             value: crossplane-tls-server
           - name: "TLS_CLIENT_SECRET_NAME"
             value: crossplane-tls-client
+          {{- range $key, $value := .Values.extraEnvVarsCrossplaneInit }}
+          - name: {{ $key | replace "." "_" }}
+            value: {{ $value | quote }}
+          {{- end}}
       containers:
       - name: {{ .Chart.Name }}
-        {{- if .Values.image.ko }}
-        image: "ko://github.com/crossplane/crossplane/cmd/crossplane"
+        {{- if .Values.image.ignoreTag }}
+        image: "{{ .Values.image.repository }}"
         {{- else }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default (printf "v%s" .Chart.AppVersion) }}"
         {{- end }}

--- a/cluster/charts/crossplane/templates/rbac-manager-deployment.yaml
+++ b/cluster/charts/crossplane/templates/rbac-manager-deployment.yaml
@@ -52,12 +52,16 @@ spec:
       runtimeClassName: {{ .Values.runtimeClassName | quote }}
       {{- end }}
       initContainers:
-      - image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default (printf "v%s" .Chart.AppVersion) }}"
+      - name: {{ .Chart.Name }}-init
+        {{- if .Values.image.ko }}
+        image: "ko://github.com/crossplane/crossplane/cmd/crossplane"
+        {{- else }}
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default (printf "v%s" .Chart.AppVersion) }}"
+        {{- end }}
         args:
         - rbac
         - init
         imagePullPolicy: {{ .Values.image.pullPolicy }}
-        name: {{ .Chart.Name }}-init
         resources:
           {{- toYaml .Values.resourcesRBACManager | nindent 12 }}
         {{- with .Values.securityContextRBACManager }}
@@ -78,7 +82,12 @@ spec:
                 resource: limits.memory
                 divisor: "1"
       containers:
-      - image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default (printf "v%s" .Chart.AppVersion) }}"
+      - name: {{ .Chart.Name }}
+        {{- if .Values.image.ko }}
+        image: "ko://github.com/crossplane/crossplane/cmd/crossplane"
+        {{- else }}
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default (printf "v%s" .Chart.AppVersion) }}"
+        {{- end }}
         args:
         - rbac
         - start
@@ -87,7 +96,6 @@ spec:
         {{- end }}
         - --provider-clusterrole={{ template "crossplane.name" . }}:allowed-provider-permissions
         imagePullPolicy: {{ .Values.image.pullPolicy }}
-        name: {{ .Chart.Name }}
         resources:
           {{- toYaml .Values.resourcesRBACManager | nindent 12 }}
         {{- if .Values.metrics.enabled }}

--- a/cluster/charts/crossplane/templates/rbac-manager-deployment.yaml
+++ b/cluster/charts/crossplane/templates/rbac-manager-deployment.yaml
@@ -53,8 +53,8 @@ spec:
       {{- end }}
       initContainers:
       - name: {{ .Chart.Name }}-init
-        {{- if .Values.image.ko }}
-        image: "ko://github.com/crossplane/crossplane/cmd/crossplane"
+        {{- if .Values.image.ignoreTag }}
+        image: "{{ .Values.image.repository }}"
         {{- else }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default (printf "v%s" .Chart.AppVersion) }}"
         {{- end }}
@@ -83,8 +83,8 @@ spec:
                 divisor: "1"
       containers:
       - name: {{ .Chart.Name }}
-        {{- if .Values.image.ko }}
-        image: "ko://github.com/crossplane/crossplane/cmd/crossplane"
+        {{- if .Values.image.ignoreTag }}
+        image: "{{ .Values.image.repository }}"
         {{- else }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default (printf "v%s" .Chart.AppVersion) }}"
         {{- end }}

--- a/cluster/charts/crossplane/values.yaml
+++ b/cluster/charts/crossplane/values.yaml
@@ -17,9 +17,8 @@ image:
   tag: ""
   # -- The image pull policy used for Crossplane and RBAC Manager pods.
   pullPolicy: IfNotPresent
-  # -- Override to use ko settings:
-  #    - image == ko://github.com/crossplane/crossplane/cmd/crossplane
-  ko: false
+  # -- Do not use the {{ .image.tag }} value to compute the image uri.
+  ignoreTag: false
 
 # -- Add `nodeSelectors` to the Crossplane pod deployment.
 nodeSelector: {}
@@ -186,7 +185,11 @@ readiness:
   # -- The port the readyz server listens on.
   port: ""
 
-# -- Add custom environmental variables to the Crossplane pod deployment.
+# -- Add custom environmental variables to the Crossplane pod deployment init container.
+# Replaces any `.` in a variable name with `_`. For example, `SAMPLE.KEY=value1` becomes `SAMPLE_KEY=value1`.
+extraEnvVarsCrossplaneInit: {}
+
+# -- Add custom environmental variables to the Crossplane pod deployment application container.
 # Replaces any `.` in a variable name with `_`. For example, `SAMPLE.KEY=value1` becomes `SAMPLE_KEY=value1`.
 extraEnvVarsCrossplane: {}
 

--- a/cluster/charts/crossplane/values.yaml
+++ b/cluster/charts/crossplane/values.yaml
@@ -17,6 +17,9 @@ image:
   tag: ""
   # -- The image pull policy used for Crossplane and RBAC Manager pods.
   pullPolicy: IfNotPresent
+  # -- Override to use ko settings:
+  #    - image == ko://github.com/crossplane/crossplane/cmd/crossplane
+  ko: false
 
 # -- Add `nodeSelectors` to the Crossplane pod deployment.
 nodeSelector: {}

--- a/cmd/crossplane/core/init.go
+++ b/cmd/crossplane/core/init.go
@@ -40,7 +40,7 @@ type initCommand struct {
 	Namespace                 string   `default:"crossplane-system"                                                                env:"POD_NAMESPACE"        help:"Namespace used to set as default scope in default secret store config." short:"n"`
 	ServiceAccount            string   `default:"crossplane"                                                                       env:"POD_SERVICE_ACCOUNT"  help:"Name of the Crossplane Service Account."`
 	CRDsPath                  string   `default:"/crds"                                                                            env:"CRDS_PATH"            help:"Path of Crossplane core Custom Resource Definitions."`
-	WebhookConfigurationsPath string   `default:"/webhookconfigurations"                                                           env:"WEBHOOK_CONFIGS_PATH" help:"Path of Crossplane core Custom Resource Definitions."`
+	WebhookConfigurationsPath string   `default:"/webhookconfigurations"                                                           env:"WEBHOOK_CONFIGS_PATH" help:"Path of Crossplane core Webhook Configurations."`
 
 	WebhookEnabled          bool   `default:"true"                   env:"WEBHOOK_ENABLED"                                                                         help:"Enable webhook configuration."`
 	WebhookServiceName      string `env:"WEBHOOK_SERVICE_NAME"       help:"The name of the Service object that the webhook service will be run."`
@@ -95,7 +95,7 @@ func (c *initCommand) Run(s *runtime.Scheme, log logging.Logger) error {
 			initializer.NewWebhookConfigurations(c.WebhookConfigurationsPath, s, nn, svc))
 	} else {
 		steps = append(steps,
-			initializer.NewCoreCRDs("/crds", s),
+			initializer.NewCoreCRDs(c.CRDsPath, s),
 		)
 	}
 

--- a/cmd/crossplane/core/init.go
+++ b/cmd/crossplane/core/init.go
@@ -34,11 +34,13 @@ import (
 
 // initCommand configuration for the initialization of core Crossplane controllers.
 type initCommand struct {
-	Providers      []string `help:"Pre-install a Provider by giving its image URI. This argument can be repeated."      name:"provider"`
-	Configurations []string `help:"Pre-install a Configuration by giving its image URI. This argument can be repeated." name:"configuration"`
-	Functions      []string `help:"Pre-install a Function by giving its image URI. This argument can be repeated."      name:"function"`
-	Namespace      string   `default:"crossplane-system"                                                                env:"POD_NAMESPACE"       help:"Namespace used to set as default scope in default secret store config." short:"n"`
-	ServiceAccount string   `default:"crossplane"                                                                       env:"POD_SERVICE_ACCOUNT" help:"Name of the Crossplane Service Account."`
+	Providers                 []string `help:"Pre-install a Provider by giving its image URI. This argument can be repeated."      name:"provider"`
+	Configurations            []string `help:"Pre-install a Configuration by giving its image URI. This argument can be repeated." name:"configuration"`
+	Functions                 []string `help:"Pre-install a Function by giving its image URI. This argument can be repeated."      name:"function"`
+	Namespace                 string   `default:"crossplane-system"                                                                env:"POD_NAMESPACE"        help:"Namespace used to set as default scope in default secret store config." short:"n"`
+	ServiceAccount            string   `default:"crossplane"                                                                       env:"POD_SERVICE_ACCOUNT"  help:"Name of the Crossplane Service Account."`
+	CRDsPath                  string   `default:"/crds"                                                                            env:"CRDS_PATH"            help:"Path of Crossplane core Custom Resource Definitions."`
+	WebhookConfigurationsPath string   `default:"/webhookconfigurations"                                                           env:"WEBHOOK_CONFIGS_PATH" help:"Path of Crossplane core Custom Resource Definitions."`
 
 	WebhookEnabled          bool   `default:"true"                   env:"WEBHOOK_ENABLED"                                                                         help:"Enable webhook configuration."`
 	WebhookServiceName      string `env:"WEBHOOK_SERVICE_NAME"       help:"The name of the Service object that the webhook service will be run."`
@@ -89,8 +91,8 @@ func (c *initCommand) Run(s *runtime.Scheme, log logging.Logger) error {
 			Port:      &c.WebhookServicePort,
 		}
 		steps = append(steps,
-			initializer.NewCoreCRDs("/crds", s, initializer.WithWebhookTLSSecretRef(nn)),
-			initializer.NewWebhookConfigurations("/webhookconfigurations", s, nn, svc))
+			initializer.NewCoreCRDs(c.CRDsPath, s, initializer.WithWebhookTLSSecretRef(nn)),
+			initializer.NewWebhookConfigurations(c.WebhookConfigurationsPath, s, nn, svc))
 	} else {
 		steps = append(steps,
 			initializer.NewCoreCRDs("/crds", s),

--- a/internal/controller/pkg/revision/imageback.go
+++ b/internal/controller/pkg/revision/imageback.go
@@ -20,6 +20,7 @@ import (
 	"archive/tar"
 	"context"
 	"io"
+	"path/filepath"
 
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/google/go-containerregistry/pkg/v1/mutate"
@@ -166,7 +167,7 @@ func (i *ImageBackend) Init(ctx context.Context, bo ...parser.BackendOption) (io
 		if err != nil {
 			return nil, errors.Wrapf(err, errFmtNoPackageFileFound, read, foundAnnotated)
 		}
-		if h.Name == xpkg.StreamFile {
+		if filepath.Base(h.Name) == xpkg.StreamFile {
 			break
 		}
 		read++


### PR DESCRIPTION
### Description of your changes

I am a [`ko`](https://ko.build) user. I have found the developer loop for crossplane to be tiresome without `ko` in the loop. The crossplane binary was close to working out of the box but I needed to make a couple strategic changes to enable `ko` to just work:

- the init container needed to be told where the `crds` and `webhookconfigurations` directory is on disk.
- the helm chart needed a ko mode flag to rewrite the image to be in the form `ko://<path to go main package>`
    - I need the tag because I need to not use tags here, it needs to be that `ko://` format and no tags.
- Added a `earthly +ko-init` entrypoint to copy the crds and webhook configs to a new ignored `kodata` directory. (this is how the files end up in the container for the init container to do it's thing.)

Defaults are left as there were, so you will not notice a change if not using `ko`.  But if you do want to start using to to dev-loop on crossplane (after setting up ko for your cluster correctly):

```
# do this once per change of the crd or webhook files:
earthly +ko-init
# make sure the helm chart is built:
earthly +helm-build
# then apply the helm template:
helm template --dry-run --namespace crossplane-system --set image.ko=true crossplane ./_output/charts/crossplane*.tgz | ko apply -f -
```

These instructions are also included as text output in the `earthly +ko-init` command.

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `earthly +reviewable` to ensure this PR is ready for review.
~- [ ] Added or updated unit tests.~
~- [ ] Added or updated e2e tests.~
~- [ ] Linked a PR or a [docs tracking issue] to [document this change].~
~- [ ] Added `backport release-x.y` labels to auto-backport this PR.~
~- [ ] Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md