### PR TITLE
Don't label RBAC roles with the XRD that created them

### DIFF
--- a/internal/controller/rbac/definition/roles.go
+++ b/internal/controller/rbac/definition/roles.go
@@ -45,8 +45,6 @@ const (
 
 	keyAggregateToBrowse = "rbac.crossplane.io/aggregate-to-browse"
 
-	keyXRD = "rbac.crossplane.io/xrd"
-
 	valTrue = "true"
 
 	suffixStatus     = "/status"
@@ -104,8 +102,6 @@ func RenderClusterRoles(d *v1.CompositeResourceDefinition) []rbacv1.ClusterRole 
 
 				keyAggregateToEdit:   valTrue,
 				keyAggregateToNSEdit: valTrue,
-
-				keyXRD: d.GetName(),
 			},
 		},
 		Rules: []rbacv1.PolicyRule{
@@ -126,8 +122,6 @@ func RenderClusterRoles(d *v1.CompositeResourceDefinition) []rbacv1.ClusterRole 
 			Labels: map[string]string{
 				keyAggregateToView:   valTrue,
 				keyAggregateToNSView: valTrue,
-
-				keyXRD: d.GetName(),
 			},
 		},
 		Rules: []rbacv1.PolicyRule{
@@ -147,8 +141,6 @@ func RenderClusterRoles(d *v1.CompositeResourceDefinition) []rbacv1.ClusterRole 
 			Name: namePrefix + d.GetName() + nameSuffixBrowse,
 			Labels: map[string]string{
 				keyAggregateToBrowse: valTrue,
-
-				keyXRD: d.GetName(),
 			},
 		},
 		Rules: []rbacv1.PolicyRule{

--- a/internal/controller/rbac/definition/roles_test.go
+++ b/internal/controller/rbac/definition/roles_test.go
@@ -90,7 +90,6 @@ func TestRenderClusterRoles(t *testing.T) {
 							keyAggregateToNSAdmin: valTrue,
 							keyAggregateToEdit:    valTrue,
 							keyAggregateToNSEdit:  valTrue,
-							keyXRD:                name,
 						},
 					},
 					Rules: []rbacv1.PolicyRule{
@@ -108,7 +107,6 @@ func TestRenderClusterRoles(t *testing.T) {
 						Labels: map[string]string{
 							keyAggregateToView:   valTrue,
 							keyAggregateToNSView: valTrue,
-							keyXRD:               name,
 						},
 					},
 					Rules: []rbacv1.PolicyRule{
@@ -125,7 +123,6 @@ func TestRenderClusterRoles(t *testing.T) {
 						OwnerReferences: []metav1.OwnerReference{owner},
 						Labels: map[string]string{
 							keyAggregateToBrowse: valTrue,
-							keyXRD:               name,
 						},
 					},
 					Rules: []rbacv1.PolicyRule{
@@ -189,7 +186,6 @@ func TestRenderClusterRoles(t *testing.T) {
 							keyAggregateToNSAdmin: valTrue,
 							keyAggregateToEdit:    valTrue,
 							keyAggregateToNSEdit:  valTrue,
-							keyXRD:                name,
 						},
 					},
 					Rules: []rbacv1.PolicyRule{
@@ -212,7 +208,6 @@ func TestRenderClusterRoles(t *testing.T) {
 						Labels: map[string]string{
 							keyAggregateToView:   valTrue,
 							keyAggregateToNSView: valTrue,
-							keyXRD:               name,
 						},
 					},
 					Rules: []rbacv1.PolicyRule{
@@ -235,7 +230,6 @@ func TestRenderClusterRoles(t *testing.T) {
 						OwnerReferences: []metav1.OwnerReference{owner},
 						Labels: map[string]string{
 							keyAggregateToBrowse: valTrue,
-							keyXRD:               name,
 						},
 					},
 					Rules: []rbacv1.PolicyRule{


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane! Please read the contribution docs
(linked below) if this is your first Crossplane pull request.
-->

### Description of your changes

<!--
Briefly describe what this pull request does, and how it is covered by tests.
Be proactive - direct your reviewers' attention to anything that needs special
consideration.

We love pull requests that fix an open issue. If yours does, use the below line
to indicate which issue it fixes, for example "Fixes #500".
-->

Fixes https://github.com/crossplane/crossplane/issues/6316

The label length limit means this effectively limits the length of the XRD name. XRD names follow the same rules as CRD names (plural kinds + api group) so this in turn limits those.

We don't use these labels anywhere, and the role names include the XRD name.

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `earthly +reviewable` to ensure this PR is ready for review.
- [x] Added or updated unit tests.
- [ ] ~Added or updated e2e tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~
- [ ] ~Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md