### PR TITLE
Use DeepCopy when assigning from the runtime config Deployment template's spec

### DIFF
--- a/internal/controller/pkg/runtime/runtime_defaults.go
+++ b/internal/controller/pkg/runtime/runtime_defaults.go
@@ -56,7 +56,9 @@ func deploymentFromRuntimeConfig(tmpl *v1beta1.DeploymentTemplate) *appsv1.Deplo
 	}
 
 	if spec := tmpl.Spec; spec != nil {
-		d.Spec = *spec
+		// use DeepCopy to prevent modifications to the
+		// DeploymentTemplate itself.
+		d.Spec = *spec.DeepCopy()
 	}
 
 	return d


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane! Please read the contribution docs
(linked below) if this is your first Crossplane pull request.
-->

### Description of your changes

<!--
Briefly describe what this pull request does, and how it is covered by tests.
Be proactive - direct your reviewers' attention to anything that needs special
consideration.

We love pull requests that fix an open issue. If yours does, use the below line
to indicate which issue it fixes, for example "Fixes #500".
-->

<!-- Fixes # -->
When working on an external package runtime, I realized that installing a provider package with a `DeploymentRuntimeConfig` is currently broken on main:
```shell
helm -n crossplane-system upgrade --install crossplane --create-namespace ./cluster/charts/crossplane --set "image.tag=v1.21.0-rc.0.163.g160125d58"
```

Deploy a provider package with a reference to a `DeploymentRuntimeConfig`, and observe the `.status.conditions` of the provider revision:
```yaml
...
status:
  conditions:
  - lastTransitionTime: "2025-06-13T13:55:33Z"
    message: 'post establish runtime hook failed for package: cannot apply provider
      package deployment: cannot create object: Deployment.apps "provider-stress-e5d53aa66a82"
      is invalid: [spec.template.spec.containers[0].volumeMounts[2].mountPath: Invalid
      value: "/tls/client": must be unique, spec.template.spec.containers[0].volumeMounts[3].mountPath:
      Invalid value: "/tls/server": must be unique]'
    observedGeneration: 1
    reason: UnhealthyPackageRevision
    status: "False"
    type: RuntimeHealthy
  - lastTransitionTime: "2025-06-13T13:55:33Z"
    observedGeneration: 1
    reason: HealthyPackageRevision
    status: "True"
    type: RevisionHealthy
  objectRefs:
  - apiVersion: apiextensions.k8s.io/v1
    kind: CustomResourceDefinition
    name: stressors.stress.crossplane.io
    uid: 48026821-b3c2-40ba-83d0-902d6238a697
  resolvedImage: xpkg.upbound.io/upbound/provider-stress:c406ae6
```

I think this is caused by the fact that we assign from the `DeploymentTemplate`'s `spec` [here](https://github.com/crossplane/crossplane/blob/160125d58fec72520d92f24e6222c90343a68bd2/internal/controller/pkg/runtime/runtime_defaults.go#L59). I suspect this causes a shallow copy of the container's `volumeMounts` slice and when volume mounts are added to the `Deployment` that's being built, the `DeploymentTemplate`'s container volume mounts slice is being modified. Probably the same `DeploymentTemplate` object is being reused to build a `Deployment` (more than once) and the final `Deployment` that ends up being applied against the API server has both volume mounts duplicated, resulting in a validation error from the API server.

I've validated that using a deep-copied spec actually prevents the issue.

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `earthly +reviewable` to ensure this PR is ready for review.
~~- [ ] Added or updated unit tests.~~
~~- [ ] Added or updated e2e tests.~~
~~- [ ] Linked a PR or a [docs tracking issue] to [document this change].~~
~~- [ ] Added `backport release-x.y` labels to auto-backport this PR.~~
~~- [ ] Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md