### PR TITLE
feat(helm): add podMonitor ability to chart

### DIFF
--- a/cluster/charts/crossplane/templates/podmonitor.yaml
+++ b/cluster/charts/crossplane/templates/podmonitor.yaml
@@ -1,0 +1,45 @@
+{{- if and .Values.metrics.enabled .Values.metrics.podMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  labels:
+    app: {{ template "crossplane.name" . }}
+    release: {{ .Release.Name }}
+    {{- include "crossplane.labels" . | indent 4 }}
+  name: {{ template "crossplane.name" . }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  jobLabel: {{ template "crossplane.name" . }}
+  namespaceSelector:
+    matchNames:
+    - {{ .Release.Namespace }}
+  podMetricsEndpoints:
+  - path: /metrics
+    port: metrics
+  selector:
+    matchLabels:
+      app: {{ template "crossplane.name" . }}
+{{- if .Values.rbacManager.deploy }}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  labels:
+    app: {{ template "crossplane.name" . }}-rbac-manager
+    release: {{ .Release.Name }}
+    {{- include "crossplane.labels" . | indent 4 }}
+  name: {{ template "crossplane.name" . }}-rbac-manager
+  namespace: {{ .Release.Namespace }}
+spec:
+  jobLabel: {{ template "crossplane.name" . }}-rbac-manager
+  namespaceSelector:
+    matchNames:
+    - {{ .Release.Namespace }}
+  podMetricsEndpoints:
+  - path: /metrics
+    port: metrics
+  selector:
+    matchLabels:
+      app: {{ template "crossplane.name" . }}-rbac-manager
+{{- end }}
+{{- end}}

--- a/cluster/charts/crossplane/values.yaml
+++ b/cluster/charts/crossplane/values.yaml
@@ -180,6 +180,9 @@ metrics:
   enabled: false
   # -- The port the metrics server listens on.
   port: ""
+  # -- Enable Prometheus-Operator PodMonitor
+  podMonitor:
+    enabled: false
 
 readiness:
   # -- The port the readyz server listens on.


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane! Please read the contribution docs
(linked below) if this is your first Crossplane pull request.
-->

### Description of your changes

<!--
Briefly describe what this pull request does, and how it is covered by tests.
Be proactive - direct your reviewers' attention to anything that needs special
consideration.

We love pull requests that fix an open issue. If yours does, use the below line
to indicate which issue it fixes, for example "Fixes #500".
-->
This adds the ability to deploy a prometheus-operator podMonitor. This feature is disabled by default and can be enabled via values.

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [ ] Run `earthly +reviewable` to ensure this PR is ready for review.
- [ ] Added or updated unit tests.
- [ ] Added or updated e2e tests.
- [ ] Linked a PR or a [docs tracking issue] to [document this change].
- [ ] Added `backport release-x.y` labels to auto-backport this PR.
- [ ] Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md