### PR TITLE
Issue 6544

### DIFF
--- a/cmd/crank/beta/trace/internal/resource/xpkg/client.go
+++ b/cmd/crank/beta/trace/internal/resource/xpkg/client.go
@@ -30,8 +30,8 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/errors"
 	"github.com/crossplane/crossplane-runtime/pkg/fieldpath"
 	xpresource "github.com/crossplane/crossplane-runtime/pkg/resource"
-
 	xpunstructured "github.com/crossplane/crossplane-runtime/pkg/resource/unstructured"
+
 	pkgv1 "github.com/crossplane/crossplane/apis/pkg/v1"
 	pkgv1beta1 "github.com/crossplane/crossplane/apis/pkg/v1beta1"
 	"github.com/crossplane/crossplane/cmd/crank/beta/trace/internal/resource"

--- a/cmd/crank/beta/trace/internal/resource/xrm/client.go
+++ b/cmd/crank/beta/trace/internal/resource/xrm/client.go
@@ -28,6 +28,7 @@ import (
 	xpunstructured "github.com/crossplane/crossplane-runtime/pkg/resource/unstructured"
 	"github.com/crossplane/crossplane-runtime/pkg/resource/unstructured/claim"
 	"github.com/crossplane/crossplane-runtime/pkg/resource/unstructured/composite"
+
 	"github.com/crossplane/crossplane/apis/apiextensions/v1alpha1"
 	"github.com/crossplane/crossplane/apis/apiextensions/v1beta1"
 	"github.com/crossplane/crossplane/cmd/crank/beta/trace/internal/resource"

--- a/cmd/crank/beta/trace/internal/resource/xrm/client_test.go
+++ b/cmd/crank/beta/trace/internal/resource/xrm/client_test.go
@@ -26,10 +26,10 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
-
 	"github.com/crossplane/crossplane-runtime/pkg/resource/unstructured/claim"
 	"github.com/crossplane/crossplane-runtime/pkg/resource/unstructured/composite"
 	"github.com/crossplane/crossplane-runtime/pkg/resource/unstructured/reference"
+
 	resource2 "github.com/crossplane/crossplane/cmd/crank/beta/trace/internal/resource"
 )
 

--- a/cmd/crank/render/cmd.go
+++ b/cmd/crank/render/cmd.go
@@ -31,8 +31,8 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/errors"
 	"github.com/crossplane/crossplane-runtime/pkg/fieldpath"
 	"github.com/crossplane/crossplane-runtime/pkg/logging"
-
 	"github.com/crossplane/crossplane-runtime/pkg/resource/unstructured/composed"
+
 	v1 "github.com/crossplane/crossplane/apis/apiextensions/v1"
 	"github.com/crossplane/crossplane/internal/xcrd"
 )

--- a/cmd/crank/render/load.go
+++ b/cmd/crank/render/load.go
@@ -27,9 +27,9 @@ import (
 	"k8s.io/apimachinery/pkg/util/yaml"
 
 	"github.com/crossplane/crossplane-runtime/pkg/errors"
-
 	"github.com/crossplane/crossplane-runtime/pkg/resource/unstructured/composed"
 	"github.com/crossplane/crossplane-runtime/pkg/resource/unstructured/composite"
+
 	apiextensionsv1 "github.com/crossplane/crossplane/apis/apiextensions/v1"
 	pkgv1 "github.com/crossplane/crossplane/apis/pkg/v1"
 	pkgv1beta1 "github.com/crossplane/crossplane/apis/pkg/v1beta1"

--- a/cmd/crank/render/load_test.go
+++ b/cmd/crank/render/load_test.go
@@ -30,10 +30,10 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 
-	"github.com/crossplane/crossplane-runtime/pkg/test"
-
 	"github.com/crossplane/crossplane-runtime/pkg/resource/unstructured/composed"
 	"github.com/crossplane/crossplane-runtime/pkg/resource/unstructured/composite"
+	"github.com/crossplane/crossplane-runtime/pkg/test"
+
 	apiextensionsv1 "github.com/crossplane/crossplane/apis/apiextensions/v1"
 	pkgv1 "github.com/crossplane/crossplane/apis/pkg/v1"
 )

--- a/cmd/crank/render/render.go
+++ b/cmd/crank/render/render.go
@@ -37,9 +37,9 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/logging"
 	"github.com/crossplane/crossplane-runtime/pkg/meta"
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
-
 	"github.com/crossplane/crossplane-runtime/pkg/resource/unstructured/composed"
 	ucomposite "github.com/crossplane/crossplane-runtime/pkg/resource/unstructured/composite"
+
 	fnv1 "github.com/crossplane/crossplane/apis/apiextensions/fn/proto/v1"
 	apiextensionsv1 "github.com/crossplane/crossplane/apis/apiextensions/v1"
 	pkgv1 "github.com/crossplane/crossplane/apis/pkg/v1"

--- a/cmd/crank/render/render_test.go
+++ b/cmd/crank/render/render_test.go
@@ -35,9 +35,9 @@ import (
 	"k8s.io/utils/ptr"
 
 	"github.com/crossplane/crossplane-runtime/pkg/logging"
-
 	"github.com/crossplane/crossplane-runtime/pkg/resource/unstructured/composed"
 	ucomposite "github.com/crossplane/crossplane-runtime/pkg/resource/unstructured/composite"
+
 	fnv1 "github.com/crossplane/crossplane/apis/apiextensions/fn/proto/v1"
 	apiextensionsv1 "github.com/crossplane/crossplane/apis/apiextensions/v1"
 	pkgv1 "github.com/crossplane/crossplane/apis/pkg/v1"

--- a/cmd/crossplane/core/core.go
+++ b/cmd/crossplane/core/core.go
@@ -47,8 +47,8 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/feature"
 	"github.com/crossplane/crossplane-runtime/pkg/logging"
 	"github.com/crossplane/crossplane-runtime/pkg/ratelimiter"
-
 	"github.com/crossplane/crossplane-runtime/pkg/resource/unstructured"
+
 	"github.com/crossplane/crossplane/internal/controller/apiextensions"
 	apiextensionscontroller "github.com/crossplane/crossplane/internal/controller/apiextensions/controller"
 	"github.com/crossplane/crossplane/internal/controller/pkg"

--- a/cmd/crossplane/core/core.go
+++ b/cmd/crossplane/core/core.go
@@ -379,6 +379,8 @@ func (c *startCommand) Run(s *runtime.Scheme, log logging.Logger) error { //noli
 		unstructured.NewClient(uncached),
 		engine.WithLogger(log),
 		engine.WithMetrics(cem),
+		engine.WithNamespace(c.Namespace),
+		engine.WithServiceAccount(c.ServiceAccount),
 	)
 
 	// TODO(negz): Garbage collect informers for CRs that are still defined

--- a/cmd/crossplane/main.go
+++ b/cmd/crossplane/main.go
@@ -24,6 +24,7 @@ import (
 	"github.com/alecthomas/kong"
 	admv1 "k8s.io/api/admissionregistration/v1"
 	appsv1 "k8s.io/api/apps/v1"
+	authv1 "k8s.io/api/authorization/v1"
 	coordinationv1 "k8s.io/api/coordination/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -106,6 +107,7 @@ func main() {
 		core.KongVars,
 	)
 	ctx.FatalIfErrorf(corev1.AddToScheme(s), "cannot add core v1 Kubernetes API types to scheme")
+	ctx.FatalIfErrorf(authv1.AddToScheme(s), "cannot add authorization v1 Kubernetes API types to scheme")
 	ctx.FatalIfErrorf(appsv1.AddToScheme(s), "cannot add apps v1 Kubernetes API types to scheme")
 	ctx.FatalIfErrorf(rbacv1.AddToScheme(s), "cannot add rbac v1 Kubernetes API types to scheme")
 	ctx.FatalIfErrorf(coordinationv1.AddToScheme(s), "cannot add coordination v1 Kubernetes API types to scheme")

--- a/internal/controller/apiextensions/claim/reconciler.go
+++ b/internal/controller/apiextensions/claim/reconciler.go
@@ -37,9 +37,9 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/logging"
 	"github.com/crossplane/crossplane-runtime/pkg/meta"
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
-
 	"github.com/crossplane/crossplane-runtime/pkg/resource/unstructured/claim"
 	"github.com/crossplane/crossplane-runtime/pkg/resource/unstructured/composite"
+
 	"github.com/crossplane/crossplane/internal/names"
 )
 

--- a/internal/controller/apiextensions/claim/reconciler_test.go
+++ b/internal/controller/apiextensions/claim/reconciler_test.go
@@ -34,11 +34,10 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/errors"
 	"github.com/crossplane/crossplane-runtime/pkg/meta"
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
-	"github.com/crossplane/crossplane-runtime/pkg/test"
-
 	"github.com/crossplane/crossplane-runtime/pkg/resource/unstructured/claim"
 	"github.com/crossplane/crossplane-runtime/pkg/resource/unstructured/composite"
 	"github.com/crossplane/crossplane-runtime/pkg/resource/unstructured/reference"
+	"github.com/crossplane/crossplane-runtime/pkg/test"
 )
 
 func TestReconcile(t *testing.T) {

--- a/internal/controller/apiextensions/claim/syncer_csa.go
+++ b/internal/controller/apiextensions/claim/syncer_csa.go
@@ -29,9 +29,9 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/errors"
 	"github.com/crossplane/crossplane-runtime/pkg/meta"
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
-
 	"github.com/crossplane/crossplane-runtime/pkg/resource/unstructured/claim"
 	"github.com/crossplane/crossplane-runtime/pkg/resource/unstructured/composite"
+
 	v1 "github.com/crossplane/crossplane/apis/apiextensions/v1"
 	"github.com/crossplane/crossplane/internal/names"
 	"github.com/crossplane/crossplane/internal/xcrd"

--- a/internal/controller/apiextensions/claim/syncer_csa_test.go
+++ b/internal/controller/apiextensions/claim/syncer_csa_test.go
@@ -28,11 +28,11 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/errors"
 	"github.com/crossplane/crossplane-runtime/pkg/meta"
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
-	"github.com/crossplane/crossplane-runtime/pkg/test"
-
 	"github.com/crossplane/crossplane-runtime/pkg/resource/unstructured/claim"
 	"github.com/crossplane/crossplane-runtime/pkg/resource/unstructured/composite"
 	"github.com/crossplane/crossplane-runtime/pkg/resource/unstructured/reference"
+	"github.com/crossplane/crossplane-runtime/pkg/test"
+
 	"github.com/crossplane/crossplane/internal/names"
 	"github.com/crossplane/crossplane/internal/xcrd"
 )

--- a/internal/controller/apiextensions/claim/syncer_ssa.go
+++ b/internal/controller/apiextensions/claim/syncer_ssa.go
@@ -28,9 +28,9 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/fieldpath"
 	"github.com/crossplane/crossplane-runtime/pkg/meta"
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
-
 	"github.com/crossplane/crossplane-runtime/pkg/resource/unstructured/claim"
 	"github.com/crossplane/crossplane-runtime/pkg/resource/unstructured/composite"
+
 	v1 "github.com/crossplane/crossplane/apis/apiextensions/v1"
 	"github.com/crossplane/crossplane/internal/names"
 	"github.com/crossplane/crossplane/internal/xcrd"

--- a/internal/controller/apiextensions/claim/syncer_ssa_test.go
+++ b/internal/controller/apiextensions/claim/syncer_ssa_test.go
@@ -29,11 +29,11 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/errors"
 	"github.com/crossplane/crossplane-runtime/pkg/meta"
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
-	"github.com/crossplane/crossplane-runtime/pkg/test"
-
 	"github.com/crossplane/crossplane-runtime/pkg/resource/unstructured/claim"
 	"github.com/crossplane/crossplane-runtime/pkg/resource/unstructured/composite"
 	"github.com/crossplane/crossplane-runtime/pkg/resource/unstructured/reference"
+	"github.com/crossplane/crossplane-runtime/pkg/test"
+
 	"github.com/crossplane/crossplane/internal/names"
 	"github.com/crossplane/crossplane/internal/xcrd"
 )

--- a/internal/controller/apiextensions/composite/composition_functions.go
+++ b/internal/controller/apiextensions/composite/composition_functions.go
@@ -20,6 +20,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
+	"github.com/crossplane/crossplane/internal/xerrors"
 	"sort"
 	"strings"
 	"time"
@@ -430,6 +431,8 @@ func (c *FunctionComposer) Compose(ctx context.Context, xr *composite.Unstructur
 			cd.SetName(or.Resource.GetName())
 		}
 
+		cd.GroupVersionKind()
+
 		// Set standard composed resource metadata that is derived from the XR.
 		if err := RenderComposedResourceMetadata(cd, xr, ResourceName(name)); err != nil {
 			return CompositionResult{}, errors.Wrapf(err, errFmtRenderMetadata, name)
@@ -444,7 +447,11 @@ func (c *FunctionComposer) Compose(ctx context.Context, xr *composite.Unstructur
 		// million names).
 		if cd.GetName() == "" {
 			if err := c.composite.GenerateName(ctx, cd); err != nil {
-				return CompositionResult{}, errors.Wrapf(err, errFmtGenerateName, name)
+				return CompositionResult{}, &xerrors.ComposedResourceError{
+					Message:  fmt.Sprintf(errFmtGenerateName, name),
+					Composed: cd,
+					Err:      err,
+				}
 			}
 		}
 

--- a/internal/controller/apiextensions/composite/composition_functions.go
+++ b/internal/controller/apiextensions/composite/composition_functions.go
@@ -20,7 +20,6 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
-	"github.com/crossplane/crossplane/internal/xerrors"
 	"sort"
 	"strings"
 	"time"
@@ -53,6 +52,7 @@ import (
 	v1 "github.com/crossplane/crossplane/apis/apiextensions/v1"
 	"github.com/crossplane/crossplane/internal/names"
 	"github.com/crossplane/crossplane/internal/xcrd"
+	"github.com/crossplane/crossplane/internal/xerrors"
 )
 
 // Error strings.

--- a/internal/controller/apiextensions/composite/composition_functions_test.go
+++ b/internal/controller/apiextensions/composite/composition_functions_test.go
@@ -18,6 +18,7 @@ package composite
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -30,6 +31,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
@@ -42,14 +44,15 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/meta"
 	"github.com/crossplane/crossplane-runtime/pkg/reconciler/managed"
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
-	"github.com/crossplane/crossplane-runtime/pkg/test"
-
 	"github.com/crossplane/crossplane-runtime/pkg/resource/fake"
 	"github.com/crossplane/crossplane-runtime/pkg/resource/unstructured/composed"
 	"github.com/crossplane/crossplane-runtime/pkg/resource/unstructured/composite"
+	"github.com/crossplane/crossplane-runtime/pkg/test"
+
 	fnv1 "github.com/crossplane/crossplane/apis/apiextensions/fn/proto/v1"
 	v1 "github.com/crossplane/crossplane/apis/apiextensions/v1"
 	"github.com/crossplane/crossplane/internal/xcrd"
+	"github.com/crossplane/crossplane/internal/xerrors"
 )
 
 func TestFunctionCompose(t *testing.T) {
@@ -509,7 +512,21 @@ func TestFunctionCompose(t *testing.T) {
 				},
 			},
 			want: want{
-				err: errors.Wrapf(errBoom, errFmtGenerateName, "cool-resource"),
+				err: &xerrors.ComposedResourceError{
+					Message: fmt.Sprintf(errFmtGenerateName, "cool-resource"),
+					Composed: &composed.Unstructured{
+						Unstructured: unstructured.Unstructured{
+							Object: map[string]any{
+								"apiVersion": "test.crossplane.io/v1",
+								"kind":       "CoolComposed",
+								"metadata": map[string]any{
+									"generateName": "parent-xr-",
+								},
+							},
+						},
+					},
+					Err: errBoom,
+				},
 			},
 		},
 		"GarbageCollectComposedResourcesError": {

--- a/internal/controller/apiextensions/composite/composition_render_test.go
+++ b/internal/controller/apiextensions/composite/composition_render_test.go
@@ -29,9 +29,9 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/meta"
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
 	"github.com/crossplane/crossplane-runtime/pkg/resource/fake"
+	"github.com/crossplane/crossplane-runtime/pkg/resource/unstructured/composed"
 	"github.com/crossplane/crossplane-runtime/pkg/test"
 
-	"github.com/crossplane/crossplane-runtime/pkg/resource/unstructured/composed"
 	"github.com/crossplane/crossplane/internal/xcrd"
 )
 

--- a/internal/controller/apiextensions/composite/reconciler.go
+++ b/internal/controller/apiextensions/composite/reconciler.go
@@ -45,11 +45,11 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
 	"github.com/crossplane/crossplane-runtime/pkg/resource/unstructured/claim"
 	"github.com/crossplane/crossplane-runtime/pkg/resource/unstructured/composite"
-	"github.com/crossplane/crossplane/internal/xerrors"
 
 	v1 "github.com/crossplane/crossplane/apis/apiextensions/v1"
 	"github.com/crossplane/crossplane/internal/engine"
 	"github.com/crossplane/crossplane/internal/features"
+	"github.com/crossplane/crossplane/internal/xerrors"
 )
 
 const (

--- a/internal/controller/apiextensions/composite/reconciler.go
+++ b/internal/controller/apiextensions/composite/reconciler.go
@@ -45,6 +45,7 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
 	"github.com/crossplane/crossplane-runtime/pkg/resource/unstructured/claim"
 	"github.com/crossplane/crossplane-runtime/pkg/resource/unstructured/composite"
+	"github.com/crossplane/crossplane/internal/xerrors"
 
 	v1 "github.com/crossplane/crossplane/apis/apiextensions/v1"
 	"github.com/crossplane/crossplane/internal/engine"
@@ -52,8 +53,9 @@ import (
 )
 
 const (
-	timeout   = 2 * time.Minute
-	finalizer = "composite.apiextensions.crossplane.io"
+	timeout       = 2 * time.Minute
+	timeoutUpdate = timeout + 20*time.Second
+	finalizer     = "composite.apiextensions.crossplane.io"
 )
 
 // Error strings.
@@ -358,6 +360,13 @@ func WithWatchStarter(controllerName string, h handler.EventHandler, w WatchStar
 	}
 }
 
+// WithAuthorizer specifies if the reconciler can ask authorization queries.
+func WithAuthorizer(a Authorizer) ReconcilerOption {
+	return func(r *Reconciler) {
+		r.authorizer = a
+	}
+}
+
 // WithCompositeSchema specifies whether the Reconciler should reconcile a
 // modern or a legacy type of composite resource.
 func WithCompositeSchema(s composite.Schema) ReconcilerOption {
@@ -375,6 +384,12 @@ type revision struct {
 type WatchStarter interface {
 	// StartWatches starts the supplied watches, if they're not running already.
 	StartWatches(ctx context.Context, name string, ws ...engine.Watch) error
+}
+
+// An Authorizer can explain what is allowed to be done to resources.
+type Authorizer interface {
+	// IsAuthorizedFor validates if this controller is allowed to control a GVK in an optional namespace.
+	IsAuthorizedFor(ctx context.Context, gvk schema.GroupVersionKind, namespace string) (bool, error)
 }
 
 // A NopWatchStarter does nothing.
@@ -465,6 +480,9 @@ type Reconciler struct {
 	engine         WatchStarter
 	watchHandler   handler.EventHandler
 
+	// Used to validate errors based on API issues.
+	authorizer Authorizer
+
 	log        logging.Logger
 	record     event.Recorder
 	conditions conditions.Manager
@@ -476,6 +494,9 @@ type Reconciler struct {
 func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) { //nolint:gocognit // Reconcile methods are often very complex. Be wary.
 	log := r.log.WithValues("request", req)
 	log.Debug("Reconciling")
+
+	updateCtx, updateCancel := context.WithTimeout(ctx, timeoutUpdate)
+	defer updateCancel()
 
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
@@ -500,7 +521,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 		status.MarkConditions(xpv1.ReconcilePaused().WithMessage(reconcilePausedMsg))
 		// If the pause annotation is removed, we will have a chance to reconcile again and resume
 		// and if status update fails, we will reconcile again to retry to update the status
-		return reconcile.Result{}, errors.Wrap(r.client.Status().Update(ctx, xr), errUpdateStatus)
+		return reconcile.Result{}, errors.Wrap(r.client.Status().Update(updateCtx, xr), errUpdateStatus)
 	}
 
 	if meta.WasDeleted(xr) {
@@ -515,12 +536,12 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 			err = errors.Wrap(err, errRemoveFinalizer)
 			r.record.Event(xr, event.Warning(reasonDelete, err))
 			status.MarkConditions(xpv1.ReconcileError(err))
-			return reconcile.Result{Requeue: true}, errors.Wrap(r.client.Status().Update(ctx, xr), errUpdateStatus)
+			return reconcile.Result{Requeue: true}, errors.Wrap(r.client.Status().Update(updateCtx, xr), errUpdateStatus)
 		}
 
 		log.Debug("Successfully deleted composite resource")
 		status.MarkConditions(xpv1.ReconcileSuccess())
-		return reconcile.Result{Requeue: false}, errors.Wrap(r.client.Status().Update(ctx, xr), errUpdateStatus)
+		return reconcile.Result{Requeue: false}, errors.Wrap(r.client.Status().Update(updateCtx, xr), errUpdateStatus)
 	}
 
 	if err := r.composite.AddFinalizer(ctx, xr); err != nil {
@@ -530,7 +551,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 		err = errors.Wrap(err, errAddFinalizer)
 		r.record.Event(xr, event.Warning(reasonInit, err))
 		status.MarkConditions(xpv1.ReconcileError(err))
-		return reconcile.Result{Requeue: true}, errors.Wrap(r.client.Status().Update(ctx, xr), errUpdateStatus)
+		return reconcile.Result{Requeue: true}, errors.Wrap(r.client.Status().Update(updateCtx, xr), errUpdateStatus)
 	}
 
 	orig := xr.GetCompositionReference()
@@ -541,7 +562,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 		err = errors.Wrap(err, errSelectComp)
 		r.record.Event(xr, event.Warning(reasonResolve, err))
 		status.MarkConditions(xpv1.ReconcileError(err))
-		return reconcile.Result{Requeue: true}, errors.Wrap(r.client.Status().Update(ctx, xr), errUpdateStatus)
+		return reconcile.Result{Requeue: true}, errors.Wrap(r.client.Status().Update(updateCtx, xr), errUpdateStatus)
 	}
 	if compRef := xr.GetCompositionReference(); compRef != nil && (orig == nil || *compRef != *orig) {
 		r.record.Event(xr, event.Normal(reasonResolve, fmt.Sprintf("Successfully selected composition: %s", compRef.Name)))
@@ -558,7 +579,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 		err = errors.Wrap(err, errFetchComp)
 		r.record.Event(xr, event.Warning(reasonCompose, err))
 		status.MarkConditions(xpv1.ReconcileError(err))
-		return reconcile.Result{Requeue: true}, errors.Wrap(r.client.Status().Update(ctx, xr), errUpdateStatus)
+		return reconcile.Result{Requeue: true}, errors.Wrap(r.client.Status().Update(updateCtx, xr), errUpdateStatus)
 	}
 	if rev := xr.GetCompositionRevisionReference(); rev != nil && (origRev == nil || *rev != *origRev) {
 		r.record.Event(xr, event.Normal(reasonResolve, fmt.Sprintf("Selected composition revision: %s", rev.Name)))
@@ -572,7 +593,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 		err = errors.Wrap(err, errConfigure)
 		r.record.Event(xr, event.Warning(reasonCompose, err))
 		status.MarkConditions(xpv1.ReconcileError(err))
-		return reconcile.Result{Requeue: true}, errors.Wrap(r.client.Status().Update(ctx, xr), errUpdateStatus)
+		return reconcile.Result{Requeue: true}, errors.Wrap(r.client.Status().Update(updateCtx, xr), errUpdateStatus)
 	}
 
 	res, err := r.resource.Compose(ctx, xr, CompositionRequest{Revision: rev})
@@ -594,9 +615,23 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 			// point to the event.
 			err = errors.Wrap(errors.New(errInvalidResources), errCompose)
 		}
+		if composeErr := new(xerrors.ComposedResourceError); errors.As(err, &composeErr) {
+			// Things to check:
+			// - Does the CRD exist?
+			// - Do we have rights to operate on that Kind?
+
+			if r.authorizer != nil {
+				// Context is already dead at this point.
+				ok, authErr := r.authorizer.IsAuthorizedFor(updateCtx, composeErr.Composed.GroupVersionKind(), composeErr.Composed.GetNamespace())
+				if !ok {
+					err = errors.Join(err, authErr)
+					r.record.Event(xr, event.Warning(reasonCompose+"Access", authErr))
+				}
+			}
+		}
 		status.MarkConditions(xpv1.ReconcileError(err))
 
-		meta := r.handleCommonCompositionResult(ctx, res, xr)
+		meta := r.handleCommonCompositionResult(updateCtx, res, xr)
 		// We encountered a fatal error. For any custom status conditions that were
 		// not received due to the fatal error, mark them as unknown.
 		for _, c := range xr.GetConditions() {
@@ -611,7 +646,9 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 			}
 		}
 
-		return reconcile.Result{Requeue: true}, errors.Wrap(r.client.Status().Update(ctx, xr), errUpdateStatus)
+		// TODO: there is a bug that if we get an error, we don't get the chance to update status on the xr.
+
+		return reconcile.Result{Requeue: true}, errors.Wrap(r.client.Status().Update(updateCtx, xr), errUpdateStatus)
 	}
 
 	ws := make([]engine.Watch, len(xr.GetResourceReferences()))
@@ -627,7 +664,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 		err = errors.Wrap(err, errWatch)
 		r.record.Event(xr, event.Warning(reasonWatch, err))
 		status.MarkConditions(xpv1.ReconcileError(err))
-		return reconcile.Result{Requeue: true}, errors.Wrap(r.client.Status().Update(ctx, xr), errUpdateStatus)
+		return reconcile.Result{Requeue: true}, errors.Wrap(r.client.Status().Update(updateCtx, xr), errUpdateStatus)
 	}
 
 	published, err := r.composite.PublishConnection(ctx, xr, res.ConnectionDetails)
@@ -639,7 +676,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 		err = errors.Wrap(err, errPublish)
 		r.record.Event(xr, event.Warning(reasonPublish, err))
 		status.MarkConditions(xpv1.ReconcileError(err))
-		return reconcile.Result{Requeue: true}, errors.Wrap(r.client.Status().Update(ctx, xr), errUpdateStatus)
+		return reconcile.Result{Requeue: true}, errors.Wrap(r.client.Status().Update(updateCtx, xr), errUpdateStatus)
 	}
 	if published {
 		xr.SetConnectionDetailsLastPublishedTime(&metav1.Time{Time: time.Now()})
@@ -647,7 +684,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 		r.record.Event(xr, event.Normal(reasonPublish, "Successfully published connection details"))
 	}
 
-	meta := r.handleCommonCompositionResult(ctx, res, xr)
+	meta := r.handleCommonCompositionResult(updateCtx, res, xr)
 
 	if meta.numWarningEvents == 0 {
 		// We don't consider warnings severe enough to prevent the XR from being
@@ -718,7 +755,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 		result = reconcile.Result{RequeueAfter: jitter(res.TTL)}
 	}
 
-	return result, errors.Wrap(r.client.Status().Update(ctx, xr), errUpdateStatus)
+	return result, errors.Wrap(r.client.Status().Update(updateCtx, xr), errUpdateStatus)
 }
 
 type compositionResultMeta struct {

--- a/internal/controller/apiextensions/composite/reconciler_test.go
+++ b/internal/controller/apiextensions/composite/reconciler_test.go
@@ -40,11 +40,11 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/meta"
 	"github.com/crossplane/crossplane-runtime/pkg/reconciler/managed"
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
-	"github.com/crossplane/crossplane-runtime/pkg/test"
-
 	"github.com/crossplane/crossplane-runtime/pkg/resource/unstructured/claim"
 	"github.com/crossplane/crossplane-runtime/pkg/resource/unstructured/composite"
 	"github.com/crossplane/crossplane-runtime/pkg/resource/unstructured/reference"
+	"github.com/crossplane/crossplane-runtime/pkg/test"
+
 	v1 "github.com/crossplane/crossplane/apis/apiextensions/v1"
 	"github.com/crossplane/crossplane/internal/engine"
 )

--- a/internal/controller/apiextensions/composite/watch/watch.go
+++ b/internal/controller/apiextensions/composite/watch/watch.go
@@ -27,8 +27,8 @@ import (
 
 	"github.com/crossplane/crossplane-runtime/pkg/errors"
 	"github.com/crossplane/crossplane-runtime/pkg/logging"
-
 	"github.com/crossplane/crossplane-runtime/pkg/resource/unstructured/composite"
+
 	"github.com/crossplane/crossplane/internal/engine"
 )
 

--- a/internal/controller/apiextensions/composite/watch/watch_test.go
+++ b/internal/controller/apiextensions/composite/watch/watch_test.go
@@ -29,9 +29,9 @@ import (
 
 	"github.com/crossplane/crossplane-runtime/pkg/errors"
 	"github.com/crossplane/crossplane-runtime/pkg/logging"
+	"github.com/crossplane/crossplane-runtime/pkg/resource/unstructured/composite"
 	"github.com/crossplane/crossplane-runtime/pkg/test"
 
-	"github.com/crossplane/crossplane-runtime/pkg/resource/unstructured/composite"
 	"github.com/crossplane/crossplane/internal/engine"
 )
 

--- a/internal/controller/apiextensions/definition/handlers.go
+++ b/internal/controller/apiextensions/definition/handlers.go
@@ -30,8 +30,8 @@ import (
 
 	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
 	"github.com/crossplane/crossplane-runtime/pkg/logging"
-
 	"github.com/crossplane/crossplane-runtime/pkg/resource/unstructured/composite"
+
 	v1 "github.com/crossplane/crossplane/apis/apiextensions/v1"
 )
 

--- a/internal/controller/apiextensions/definition/handlers_test.go
+++ b/internal/controller/apiextensions/definition/handlers_test.go
@@ -17,9 +17,9 @@ import (
 
 	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
 	"github.com/crossplane/crossplane-runtime/pkg/logging"
+	"github.com/crossplane/crossplane-runtime/pkg/resource/unstructured/composite"
 	"github.com/crossplane/crossplane-runtime/pkg/test"
 
-	"github.com/crossplane/crossplane-runtime/pkg/resource/unstructured/composite"
 	v1 "github.com/crossplane/crossplane/apis/apiextensions/v1"
 )
 

--- a/internal/controller/apiextensions/definition/reconciler.go
+++ b/internal/controller/apiextensions/definition/reconciler.go
@@ -20,6 +20,7 @@ package definition
 import (
 	"context"
 	"fmt"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"strings"
 	"time"
 
@@ -104,6 +105,7 @@ type ControllerEngine interface {
 	GetCached() client.Client
 	GetUncached() client.Client
 	GetFieldIndexer() client.FieldIndexer
+	IsAuthorizedFor(ctx context.Context, namespace string, gvk schema.GroupVersionKind) (bool, error)
 }
 
 // A NopEngine does nothing.
@@ -144,6 +146,11 @@ func (e *NopEngine) GetUncached() client.Client {
 // GetFieldIndexer returns a nil field indexer.
 func (e *NopEngine) GetFieldIndexer() client.FieldIndexer {
 	return nil
+}
+
+// IsAuthorizedFor validates if this controller is allowed to control a GVK in an optional namespace.
+func (e *NopEngine) IsAuthorizedFor(ctx context.Context, gvk schema.GroupVersionKind, namespace string) (bool, error) {
+	return false, nil
 }
 
 // A CRDRenderer renders a CompositeResourceDefinition's corresponding
@@ -529,6 +536,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 			composite.WithPollInterval(0), // Disable polling.
 		)
 	}
+	ro = append(ro, composite.WithAuthorizer(r.engine))
 
 	cr := composite.NewReconciler(r.engine.GetCached(), d.GetCompositeGroupVersionKind(), ro...)
 	ko := r.options.ForControllerRuntime()

--- a/internal/controller/apiextensions/definition/reconciler.go
+++ b/internal/controller/apiextensions/definition/reconciler.go
@@ -20,15 +20,19 @@ package definition
 import (
 	"context"
 	"fmt"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"strings"
 	"time"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	kmeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kunstructured "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/utils/ptr"
@@ -46,8 +50,8 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/meta"
 	"github.com/crossplane/crossplane-runtime/pkg/ratelimiter"
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
-
 	ucomposite "github.com/crossplane/crossplane-runtime/pkg/resource/unstructured/composite"
+
 	v1 "github.com/crossplane/crossplane/apis/apiextensions/v1"
 	"github.com/crossplane/crossplane/internal/controller/apiextensions/composite"
 	"github.com/crossplane/crossplane/internal/controller/apiextensions/composite/watch"
@@ -105,7 +109,7 @@ type ControllerEngine interface {
 	GetCached() client.Client
 	GetUncached() client.Client
 	GetFieldIndexer() client.FieldIndexer
-	IsAuthorizedFor(ctx context.Context, namespace string, gvk schema.GroupVersionKind) (bool, error)
+	IsAuthorizedFor(ctx context.Context, gvk schema.GroupVersionKind, namespace string) (bool, error)
 }
 
 // A NopEngine does nothing.
@@ -149,7 +153,7 @@ func (e *NopEngine) GetFieldIndexer() client.FieldIndexer {
 }
 
 // IsAuthorizedFor validates if this controller is allowed to control a GVK in an optional namespace.
-func (e *NopEngine) IsAuthorizedFor(ctx context.Context, gvk schema.GroupVersionKind, namespace string) (bool, error) {
+func (e *NopEngine) IsAuthorizedFor(_ context.Context, _ schema.GroupVersionKind, _ string) (bool, error) {
 	return false, nil
 }
 

--- a/internal/controller/apiextensions/definition/reconciler_test.go
+++ b/internal/controller/apiextensions/definition/reconciler_test.go
@@ -53,6 +53,7 @@ type MockEngine struct {
 	MockGetCached       func() client.Client
 	MockGetUncached     func() client.Client
 	MockGetFieldIndexer func() client.FieldIndexer
+	MockIsAuthorizedFor func(ctx context.Context, gvk schema.GroupVersionKind, namespace string) (bool, error)
 }
 
 func (m *MockEngine) IsRunning(name string) bool {
@@ -89,6 +90,10 @@ func (m *MockEngine) GetUncached() client.Client {
 
 func (m *MockEngine) GetFieldIndexer() client.FieldIndexer {
 	return m.MockGetFieldIndexer()
+}
+
+func (m *MockEngine) IsAuthorizedFor(ctx context.Context, gvk schema.GroupVersionKind, namespace string) (bool, error) {
+	return m.MockIsAuthorizedFor(ctx, gvk, namespace)
 }
 
 func TestReconcile(t *testing.T) {

--- a/internal/controller/apiextensions/offered/watch.go
+++ b/internal/controller/apiextensions/offered/watch.go
@@ -29,8 +29,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
-
 	"github.com/crossplane/crossplane-runtime/pkg/resource/unstructured/composite"
+
 	v1 "github.com/crossplane/crossplane/apis/apiextensions/v1"
 	"github.com/crossplane/crossplane/internal/xcrd"
 )

--- a/internal/controller/apiextensions/offered/watch_test.go
+++ b/internal/controller/apiextensions/offered/watch_test.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/crossplane/crossplane-runtime/pkg/resource/unstructured/composite"
 	"github.com/crossplane/crossplane-runtime/pkg/resource/unstructured/reference"
+
 	v1 "github.com/crossplane/crossplane/apis/apiextensions/v1"
 )
 

--- a/internal/controller/protection/usage/reconciler.go
+++ b/internal/controller/protection/usage/reconciler.go
@@ -42,9 +42,9 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/meta"
 	"github.com/crossplane/crossplane-runtime/pkg/ratelimiter"
 	xpresource "github.com/crossplane/crossplane-runtime/pkg/resource"
-
 	"github.com/crossplane/crossplane-runtime/pkg/resource/unstructured"
 	"github.com/crossplane/crossplane-runtime/pkg/resource/unstructured/composed"
+
 	legacy "github.com/crossplane/crossplane/apis/apiextensions/v1beta1"
 	"github.com/crossplane/crossplane/apis/protection/v1beta1"
 	"github.com/crossplane/crossplane/internal/protection"

--- a/internal/controller/protection/usage/reconciler_test.go
+++ b/internal/controller/protection/usage/reconciler_test.go
@@ -35,9 +35,9 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/errors"
 	xpresource "github.com/crossplane/crossplane-runtime/pkg/resource"
 	"github.com/crossplane/crossplane-runtime/pkg/resource/fake"
+	"github.com/crossplane/crossplane-runtime/pkg/resource/unstructured/composed"
 	"github.com/crossplane/crossplane-runtime/pkg/test"
 
-	"github.com/crossplane/crossplane-runtime/pkg/resource/unstructured/composed"
 	"github.com/crossplane/crossplane/apis/protection/v1beta1"
 	"github.com/crossplane/crossplane/internal/protection"
 	"github.com/crossplane/crossplane/internal/protection/usage"

--- a/internal/controller/protection/usage/selector.go
+++ b/internal/controller/protection/usage/selector.go
@@ -26,8 +26,8 @@ import (
 
 	"github.com/crossplane/crossplane-runtime/pkg/errors"
 	"github.com/crossplane/crossplane-runtime/pkg/meta"
-
 	"github.com/crossplane/crossplane-runtime/pkg/resource/unstructured/composed"
+
 	"github.com/crossplane/crossplane/internal/protection"
 )
 

--- a/internal/controller/protection/usage/selector_test.go
+++ b/internal/controller/protection/usage/selector_test.go
@@ -26,9 +26,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/crossplane/crossplane-runtime/pkg/errors"
+	"github.com/crossplane/crossplane-runtime/pkg/resource/unstructured/composed"
 	"github.com/crossplane/crossplane-runtime/pkg/test"
 
-	"github.com/crossplane/crossplane-runtime/pkg/resource/unstructured/composed"
 	"github.com/crossplane/crossplane/apis/protection/v1beta1"
 )
 

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -19,12 +19,15 @@ package engine
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"time"
 
+	authv1 "k8s.io/api/authorization/v1"
 	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/discovery"
 	kcache "k8s.io/client-go/tools/cache"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
@@ -37,6 +40,8 @@ import (
 
 	"github.com/crossplane/crossplane-runtime/pkg/errors"
 	"github.com/crossplane/crossplane-runtime/pkg/logging"
+
+	"github.com/crossplane/crossplane/internal/xerrors"
 )
 
 // A ControllerEngine manages a set of controllers that can be dynamically
@@ -46,6 +51,12 @@ type ControllerEngine struct {
 	// The manager of this engine's controllers. Controllers managed by the
 	// engine use the engine's client and cache, not the manager's.
 	mgr manager.Manager
+
+	// namespace  is the core Crossplane Namespace name.
+	namespace string
+
+	// serviceAccount is the core Crossplane ServiceAccount name.
+	serviceAccount string
 
 	// The engine must have exclusive use of these informers. All controllers
 	// managed by the engine should use these informers.
@@ -93,13 +104,15 @@ type Metrics interface {
 // New creates a new controller engine.
 func New(mgr manager.Manager, infs TrackingInformers, c client.Client, nc client.Client, o ...ControllerEngineOption) *ControllerEngine {
 	e := &ControllerEngine{
-		mgr:         mgr,
-		infs:        infs,
-		cached:      c,
-		uncached:    nc,
-		controllers: make(map[string]*controller),
-		log:         logging.NewNopLogger(),
-		metrics:     &NopMetrics{},
+		mgr:            mgr,
+		infs:           infs,
+		cached:         c,
+		uncached:       nc,
+		controllers:    make(map[string]*controller),
+		log:            logging.NewNopLogger(),
+		metrics:        &NopMetrics{},
+		namespace:      "crossplane-system",
+		serviceAccount: "crossplane",
 	}
 
 	for _, fn := range o {
@@ -123,6 +136,20 @@ func WithLogger(l logging.Logger) ControllerEngineOption {
 func WithMetrics(m Metrics) ControllerEngineOption {
 	return func(e *ControllerEngine) {
 		e.metrics = m
+	}
+}
+
+// WithNamespace configures the system namespace.
+func WithNamespace(namespace string) ControllerEngineOption {
+	return func(e *ControllerEngine) {
+		e.namespace = namespace
+	}
+}
+
+// WithServiceAccount configures the system service account.
+func WithServiceAccount(serviceAccount string) ControllerEngineOption {
+	return func(e *ControllerEngine) {
+		e.serviceAccount = serviceAccount
 	}
 }
 
@@ -179,6 +206,73 @@ func WithNewControllerFn(fn NewControllerFn) ControllerOption {
 	return func(o *ControllerOptions) {
 		o.nc = fn
 	}
+}
+
+// IsAuthorizedFor validates if this controller is allowed to control a GVK in an optional namespace.
+func (e *ControllerEngine) IsAuthorizedFor(ctx context.Context, gvk schema.GroupVersionKind, namespace string) (bool, error) {
+	dc, err := discovery.NewDiscoveryClientForConfig(e.mgr.GetConfig())
+	if err != nil {
+		return false, err
+	}
+	rs, err := dc.ServerResourcesForGroupVersion(gvk.GroupVersion().String())
+	if err != nil {
+		return false, err
+	}
+
+	resource := schema.GroupVersionResource{
+		Group:   gvk.Group,
+		Version: gvk.Version,
+	}
+	for _, r := range rs.APIResources {
+		if r.Kind == gvk.Kind {
+			resource.Resource = r.Name
+		}
+	}
+	if resource.Resource == "" {
+		return false, fmt.Errorf("no resource found for %q", gvk)
+	}
+
+	review := &authv1.SelfSubjectAccessReview{
+		Spec: authv1.SelfSubjectAccessReviewSpec{
+			ResourceAttributes: &authv1.ResourceAttributes{
+				Namespace: namespace,
+				// First try the Verb "*"
+				Verb:     "*",
+				Group:    resource.Group,
+				Version:  resource.Version,
+				Resource: resource.Resource,
+			},
+		},
+	}
+	if err := e.uncached.Create(ctx, review); err != nil {
+		return false, errors.Wrap(err, "cannot create self access review")
+	}
+
+	if review.Status.Allowed {
+		return true, nil
+	}
+
+	// We don't have *, but maybe we have all the needed rights?
+	var denied []string
+	for _, verb := range []string{"get", "list", "watch", "create", "update", "patch", "delete"} {
+		review.Spec.ResourceAttributes.Verb = verb
+		if err := e.uncached.Create(ctx, review); err != nil {
+			return false, errors.Wrap(err, "cannot create self access review")
+		}
+		if !review.Status.Allowed {
+			denied = append(denied, verb)
+		}
+	}
+	if len(denied) > 0 {
+		return false, xerrors.SubjectAccessReviewError{
+			User:        fmt.Sprintf("system:serviceaccount:%s:%s", e.namespace, e.serviceAccount),
+			Resource:    resource,
+			Namespace:   namespace,
+			DeniedVerbs: denied,
+		}
+	}
+
+	return true, nil
 }
 
 // GetCached gets a client backed by the controller engine's cache.

--- a/internal/names/generate.go
+++ b/internal/names/generate.go
@@ -26,7 +26,6 @@ import (
 
 	"github.com/crossplane/crossplane-runtime/pkg/errors"
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
-
 	"github.com/crossplane/crossplane-runtime/pkg/resource/unstructured/composite"
 )
 

--- a/internal/webhook/protection/usage/handler.go
+++ b/internal/webhook/protection/usage/handler.go
@@ -36,8 +36,8 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/errors"
 	"github.com/crossplane/crossplane-runtime/pkg/logging"
 	xpmeta "github.com/crossplane/crossplane-runtime/pkg/meta"
-
 	xpunstructured "github.com/crossplane/crossplane-runtime/pkg/resource/unstructured"
+
 	"github.com/crossplane/crossplane/internal/protection"
 	"github.com/crossplane/crossplane/internal/protection/usage"
 )

--- a/internal/xerrors/composed_resources.go
+++ b/internal/xerrors/composed_resources.go
@@ -32,7 +32,7 @@ type ComposedResourceError struct {
 	Err error
 }
 
-// Error implements errors.Error
+// Error implements errors.Error.
 func (e ComposedResourceError) Error() string {
 	if e.Err != nil {
 		return fmt.Sprintf("%s: %s", e.Message, e.Err.Error())
@@ -40,7 +40,7 @@ func (e ComposedResourceError) Error() string {
 	return e.Message
 }
 
-// Unwrap implements errors.Unwrap
+// Unwrap implements errors.Unwrap.
 func (e ComposedResourceError) Unwrap() error {
 	return e.Err
 }

--- a/internal/xerrors/composed_resources.go
+++ b/internal/xerrors/composed_resources.go
@@ -1,0 +1,46 @@
+/*
+Copyright 2025 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package xerrors
+
+import (
+	"fmt"
+
+	"github.com/crossplane/crossplane-runtime/pkg/resource/unstructured/composed"
+)
+
+// A ComposedResourceError allows the resource composer to return context around the composition error.
+type ComposedResourceError struct {
+	// Message is the body of a composed resource error.
+	Message string
+	// Composed is the Unstructured resource that was being composed.
+	Composed *composed.Unstructured
+	// Err is an optional wrapped error.
+	Err error
+}
+
+// Error implements errors.Error
+func (e ComposedResourceError) Error() string {
+	if e.Err != nil {
+		return fmt.Sprintf("%s: %s", e.Message, e.Err.Error())
+	}
+	return e.Message
+}
+
+// Unwrap implements errors.Unwrap
+func (e ComposedResourceError) Unwrap() error {
+	return e.Err
+}

--- a/internal/xerrors/composed_resources_test.go
+++ b/internal/xerrors/composed_resources_test.go
@@ -1,0 +1,198 @@
+/*
+Copyright 2025 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package xerrors
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/crossplane/crossplane-runtime/pkg/errors"
+	"github.com/crossplane/crossplane-runtime/pkg/resource/unstructured/composed"
+	"github.com/crossplane/crossplane-runtime/pkg/test"
+)
+
+func TestComposedResourceError_Error(t *testing.T) {
+	errBoom := errors.New("boom")
+	
+	testComposed := &composed.Unstructured{
+		Unstructured: unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": "example.org/v1",
+				"kind":       "TestResource",
+				"metadata": map[string]interface{}{
+					"name": "test-resource",
+				},
+			},
+		},
+	}
+	
+	type args struct {
+		message  string
+		composed *composed.Unstructured
+		err      error
+	}
+	type want struct {
+		result string
+	}
+	
+	cases := map[string]struct {
+		reason string
+		args   args
+		want   want
+	}{
+		"MessageOnly": {
+			reason: "Should return message when no wrapped error",
+			args: args{
+				message:  "failed to compose resource",
+				composed: testComposed,
+				err:      nil,
+			},
+			want: want{
+				result: "failed to compose resource",
+			},
+		},
+		"MessageWithWrappedError": {
+			reason: "Should return message with wrapped error when both present",
+			args: args{
+				message:  "failed to compose resource",
+				composed: testComposed,
+				err:      errBoom,
+			},
+			want: want{
+				result: "failed to compose resource: boom",
+			},
+		},
+		"EmptyMessage": {
+			reason: "Should handle empty message",
+			args: args{
+				message:  "",
+				composed: testComposed,
+				err:      nil,
+			},
+			want: want{
+				result: "",
+			},
+		},
+		"EmptyMessageWithError": {
+			reason: "Should handle empty message with wrapped error",
+			args: args{
+				message:  "",
+				composed: testComposed,
+				err:      errBoom,
+			},
+			want: want{
+				result: ": boom",
+			},
+		},
+		"NilComposed": {
+			reason: "Should handle nil composed resource",
+			args: args{
+				message:  "failed to compose resource",
+				composed: nil,
+				err:      errBoom,
+			},
+			want: want{
+				result: "failed to compose resource: boom",
+			},
+		},
+	}
+	
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			e := ComposedResourceError{
+				Message:  tc.args.message,
+				Composed: tc.args.composed,
+				Err:      tc.args.err,
+			}
+			
+			got := e.Error()
+			
+			if diff := cmp.Diff(tc.want.result, got); diff != "" {
+				t.Errorf("\n%s\nError(): -want, +got:\n%s", tc.reason, diff)
+			}
+		})
+	}
+}
+
+func TestComposedResourceError_Unwrap(t *testing.T) {
+	errBoom := errors.New("boom")
+	
+	testComposed := &composed.Unstructured{
+		Unstructured: unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": "example.org/v1",
+				"kind":       "TestResource",
+			},
+		},
+	}
+	
+	type args struct {
+		message  string
+		composed *composed.Unstructured
+		err      error
+	}
+	type want struct {
+		err error
+	}
+	
+	cases := map[string]struct {
+		reason string
+		args   args
+		want   want
+	}{
+		"WithWrappedError": {
+			reason: "Should return wrapped error when present",
+			args: args{
+				message:  "failed to compose resource",
+				composed: testComposed,
+				err:      errBoom,
+			},
+			want: want{
+				err: errBoom,
+			},
+		},
+		"WithoutWrappedError": {
+			reason: "Should return nil when no wrapped error",
+			args: args{
+				message:  "failed to compose resource",
+				composed: testComposed,
+				err:      nil,
+			},
+			want: want{
+				err: nil,
+			},
+		},
+	}
+	
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			e := ComposedResourceError{
+				Message:  tc.args.message,
+				Composed: tc.args.composed,
+				Err:      tc.args.err,
+			}
+			
+			got := e.Unwrap()
+			
+			if diff := cmp.Diff(tc.want.err, got, test.EquateErrors()); diff != "" {
+				t.Errorf("\n%s\nUnwrap(): -want error, +got error:\n%s", tc.reason, diff)
+			}
+		})
+	}
+}

--- a/internal/xerrors/composed_resources_test.go
+++ b/internal/xerrors/composed_resources_test.go
@@ -29,7 +29,7 @@ import (
 
 func TestComposedResourceError_Error(t *testing.T) {
 	errBoom := errors.New("boom")
-	
+
 	testComposed := &composed.Unstructured{
 		Unstructured: unstructured.Unstructured{
 			Object: map[string]interface{}{
@@ -41,7 +41,7 @@ func TestComposedResourceError_Error(t *testing.T) {
 			},
 		},
 	}
-	
+
 	type args struct {
 		message  string
 		composed *composed.Unstructured
@@ -50,7 +50,7 @@ func TestComposedResourceError_Error(t *testing.T) {
 	type want struct {
 		result string
 	}
-	
+
 	cases := map[string]struct {
 		reason string
 		args   args
@@ -112,7 +112,7 @@ func TestComposedResourceError_Error(t *testing.T) {
 			},
 		},
 	}
-	
+
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			e := ComposedResourceError{
@@ -120,9 +120,9 @@ func TestComposedResourceError_Error(t *testing.T) {
 				Composed: tc.args.composed,
 				Err:      tc.args.err,
 			}
-			
+
 			got := e.Error()
-			
+
 			if diff := cmp.Diff(tc.want.result, got); diff != "" {
 				t.Errorf("\n%s\nError(): -want, +got:\n%s", tc.reason, diff)
 			}
@@ -132,7 +132,7 @@ func TestComposedResourceError_Error(t *testing.T) {
 
 func TestComposedResourceError_Unwrap(t *testing.T) {
 	errBoom := errors.New("boom")
-	
+
 	testComposed := &composed.Unstructured{
 		Unstructured: unstructured.Unstructured{
 			Object: map[string]interface{}{
@@ -141,7 +141,7 @@ func TestComposedResourceError_Unwrap(t *testing.T) {
 			},
 		},
 	}
-	
+
 	type args struct {
 		message  string
 		composed *composed.Unstructured
@@ -150,7 +150,7 @@ func TestComposedResourceError_Unwrap(t *testing.T) {
 	type want struct {
 		err error
 	}
-	
+
 	cases := map[string]struct {
 		reason string
 		args   args
@@ -179,7 +179,7 @@ func TestComposedResourceError_Unwrap(t *testing.T) {
 			},
 		},
 	}
-	
+
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			e := ComposedResourceError{
@@ -187,9 +187,9 @@ func TestComposedResourceError_Unwrap(t *testing.T) {
 				Composed: tc.args.composed,
 				Err:      tc.args.err,
 			}
-			
+
 			got := e.Unwrap()
-			
+
 			if diff := cmp.Diff(tc.want.err, got, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\nUnwrap(): -want error, +got error:\n%s", tc.reason, diff)
 			}

--- a/internal/xerrors/docs.go
+++ b/internal/xerrors/docs.go
@@ -1,0 +1,19 @@
+/*
+Copyright 2025 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package xerrors defines typed errors that subsystems can use to provide more
+// context to the upper layers of the stack.
+package xerrors

--- a/internal/xerrors/subject_access_review.go
+++ b/internal/xerrors/subject_access_review.go
@@ -38,11 +38,18 @@ type SubjectAccessReviewError struct {
 	Err error
 }
 
-// Error implements errors.Error
+// Error implements errors.Error.
 func (e SubjectAccessReviewError) Error() string {
 	sb := strings.Builder{}
-	sb.WriteString(fmt.Sprintf("%s is not allowed to [%s] resource %s.%s",
-		e.User, strings.Join(e.DeniedVerbs, ", "), e.Resource.Version, e.Resource.GroupVersion()))
+	sb.WriteString(fmt.Sprintf("%s is not allowed to [%s] resource %s",
+		e.User, strings.Join(e.DeniedVerbs, ", "), e.Resource.Resource))
+
+	if e.Resource.Group != "" {
+		sb.WriteString(fmt.Sprintf(".%s", e.Resource.GroupVersion()))
+	} else {
+		sb.WriteString(fmt.Sprintf("/%s", e.Resource.GroupVersion()))
+	}
+
 	if e.Namespace != "" {
 		sb.WriteString(fmt.Sprintf(" in namespace %s", e.Namespace))
 	}
@@ -52,7 +59,7 @@ func (e SubjectAccessReviewError) Error() string {
 	return sb.String()
 }
 
-// Unwrap implements errors.Unwrap
+// Unwrap implements errors.Unwrap.
 func (e SubjectAccessReviewError) Unwrap() error {
 	return e.Err
 }

--- a/internal/xerrors/subject_access_review.go
+++ b/internal/xerrors/subject_access_review.go
@@ -1,0 +1,58 @@
+/*
+Copyright 2025 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package xerrors
+
+import (
+	"fmt"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// A SubjectAccessReviewError is a structured error reporting what an identity is not allowed to do.
+type SubjectAccessReviewError struct {
+	// User is the identity is attempting to act on the Resource.
+	// For service accounts, format them as "system:serviceaccount:{namespace}:{serviceaccount}".
+	User string
+	// Resource is the subject.
+	Resource schema.GroupVersionResource
+	// Namespace is the subject's namespace, or empty for cluster scoped subjects.
+	Namespace string
+	// DeniedVerbs is the list of verbs the user want to be able to do but can't.
+	DeniedVerbs []string
+	// Err is an optional wrapped error.
+	Err error
+}
+
+// Error implements errors.Error
+func (e SubjectAccessReviewError) Error() string {
+	sb := strings.Builder{}
+	sb.WriteString(fmt.Sprintf("%s is not allowed to [%s] resource %s.%s",
+		e.User, strings.Join(e.DeniedVerbs, ", "), e.Resource.Version, e.Resource.GroupVersion()))
+	if e.Namespace != "" {
+		sb.WriteString(fmt.Sprintf(" in namespace %s", e.Namespace))
+	}
+	if e.Err != nil {
+		sb.WriteString(fmt.Sprintf(": %s", e.Err.Error()))
+	}
+	return sb.String()
+}
+
+// Unwrap implements errors.Unwrap
+func (e SubjectAccessReviewError) Unwrap() error {
+	return e.Err
+}

--- a/internal/xerrors/subject_access_review_test.go
+++ b/internal/xerrors/subject_access_review_test.go
@@ -28,13 +28,13 @@ import (
 
 func TestSubjectAccessReviewError_Error(t *testing.T) {
 	errBoom := errors.New("boom")
-	
+
 	testResource := schema.GroupVersionResource{
 		Group:    "example.org",
 		Version:  "v1",
 		Resource: "bars",
 	}
-	
+
 	type args struct {
 		user        string
 		resource    schema.GroupVersionResource
@@ -45,7 +45,7 @@ func TestSubjectAccessReviewError_Error(t *testing.T) {
 	type want struct {
 		result string
 	}
-	
+
 	cases := map[string]struct {
 		reason string
 		args   args
@@ -61,7 +61,7 @@ func TestSubjectAccessReviewError_Error(t *testing.T) {
 				err:         nil,
 			},
 			want: want{
-				result: "system:serviceaccount:crossplane-system:crossplane is not allowed to [get, list, watch] resource v1.example.org/v1",
+				result: "system:serviceaccount:crossplane-system:crossplane is not allowed to [get, list, watch] resource bars.example.org/v1",
 			},
 		},
 		"NamespacedResource": {
@@ -74,7 +74,7 @@ func TestSubjectAccessReviewError_Error(t *testing.T) {
 				err:         nil,
 			},
 			want: want{
-				result: "system:serviceaccount:crossplane-system:crossplane is not allowed to [create, update, delete] resource v1.example.org/v1 in namespace test-namespace",
+				result: "system:serviceaccount:crossplane-system:crossplane is not allowed to [create, update, delete] resource bars.example.org/v1 in namespace test-namespace",
 			},
 		},
 		"SingleVerb": {
@@ -87,7 +87,7 @@ func TestSubjectAccessReviewError_Error(t *testing.T) {
 				err:         nil,
 			},
 			want: want{
-				result: "system:serviceaccount:crossplane-system:crossplane is not allowed to [delete] resource v1.example.org/v1",
+				result: "system:serviceaccount:crossplane-system:crossplane is not allowed to [delete] resource bars.example.org/v1",
 			},
 		},
 		"WithWrappedError": {
@@ -100,7 +100,7 @@ func TestSubjectAccessReviewError_Error(t *testing.T) {
 				err:         errBoom,
 			},
 			want: want{
-				result: "system:serviceaccount:crossplane-system:crossplane is not allowed to [get] resource v1.example.org/v1: boom",
+				result: "system:serviceaccount:crossplane-system:crossplane is not allowed to [get] resource bars.example.org/v1: boom",
 			},
 		},
 		"EmptyDeniedVerbs": {
@@ -113,7 +113,7 @@ func TestSubjectAccessReviewError_Error(t *testing.T) {
 				err:         nil,
 			},
 			want: want{
-				result: "system:serviceaccount:crossplane-system:crossplane is not allowed to [] resource v1.example.org/v1",
+				result: "system:serviceaccount:crossplane-system:crossplane is not allowed to [] resource bars.example.org/v1",
 			},
 		},
 		"CoreResource": {
@@ -130,7 +130,7 @@ func TestSubjectAccessReviewError_Error(t *testing.T) {
 				err:         nil,
 			},
 			want: want{
-				result: "system:serviceaccount:crossplane-system:crossplane is not allowed to [get, list] resource v1./v1 in namespace kube-system",
+				result: "system:serviceaccount:crossplane-system:crossplane is not allowed to [get, list] resource secrets/v1 in namespace kube-system",
 			},
 		},
 		"EmptyUser": {
@@ -143,11 +143,11 @@ func TestSubjectAccessReviewError_Error(t *testing.T) {
 				err:         nil,
 			},
 			want: want{
-				result: " is not allowed to [patch] resource v1.example.org/v1 in namespace test-namespace",
+				result: " is not allowed to [patch] resource bars.example.org/v1 in namespace test-namespace",
 			},
 		},
 	}
-	
+
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			e := SubjectAccessReviewError{
@@ -157,9 +157,9 @@ func TestSubjectAccessReviewError_Error(t *testing.T) {
 				DeniedVerbs: tc.args.deniedVerbs,
 				Err:         tc.args.err,
 			}
-			
+
 			got := e.Error()
-			
+
 			if diff := cmp.Diff(tc.want.result, got); diff != "" {
 				t.Errorf("\n%s\nError(): -want, +got:\n%s", tc.reason, diff)
 			}
@@ -169,13 +169,13 @@ func TestSubjectAccessReviewError_Error(t *testing.T) {
 
 func TestSubjectAccessReviewError_Unwrap(t *testing.T) {
 	errBoom := errors.New("boom")
-	
+
 	testResource := schema.GroupVersionResource{
 		Group:    "example.org",
 		Version:  "v1",
 		Resource: "bars",
 	}
-	
+
 	type args struct {
 		user        string
 		resource    schema.GroupVersionResource
@@ -186,7 +186,7 @@ func TestSubjectAccessReviewError_Unwrap(t *testing.T) {
 	type want struct {
 		err error
 	}
-	
+
 	cases := map[string]struct {
 		reason string
 		args   args
@@ -219,7 +219,7 @@ func TestSubjectAccessReviewError_Unwrap(t *testing.T) {
 			},
 		},
 	}
-	
+
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			e := SubjectAccessReviewError{
@@ -229,9 +229,9 @@ func TestSubjectAccessReviewError_Unwrap(t *testing.T) {
 				DeniedVerbs: tc.args.deniedVerbs,
 				Err:         tc.args.err,
 			}
-			
+
 			got := e.Unwrap()
-			
+
 			if diff := cmp.Diff(tc.want.err, got, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\nUnwrap(): -want error, +got error:\n%s", tc.reason, diff)
 			}

--- a/internal/xerrors/subject_access_review_test.go
+++ b/internal/xerrors/subject_access_review_test.go
@@ -1,0 +1,240 @@
+/*
+Copyright 2025 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package xerrors
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/crossplane/crossplane-runtime/pkg/errors"
+	"github.com/crossplane/crossplane-runtime/pkg/test"
+)
+
+func TestSubjectAccessReviewError_Error(t *testing.T) {
+	errBoom := errors.New("boom")
+	
+	testResource := schema.GroupVersionResource{
+		Group:    "example.org",
+		Version:  "v1",
+		Resource: "bars",
+	}
+	
+	type args struct {
+		user        string
+		resource    schema.GroupVersionResource
+		namespace   string
+		deniedVerbs []string
+		err         error
+	}
+	type want struct {
+		result string
+	}
+	
+	cases := map[string]struct {
+		reason string
+		args   args
+		want   want
+	}{
+		"ClusterScopedResource": {
+			reason: "Should format error for cluster-scoped resource",
+			args: args{
+				user:        "system:serviceaccount:crossplane-system:crossplane",
+				resource:    testResource,
+				namespace:   "",
+				deniedVerbs: []string{"get", "list", "watch"},
+				err:         nil,
+			},
+			want: want{
+				result: "system:serviceaccount:crossplane-system:crossplane is not allowed to [get, list, watch] resource v1.example.org/v1",
+			},
+		},
+		"NamespacedResource": {
+			reason: "Should format error for namespaced resource",
+			args: args{
+				user:        "system:serviceaccount:crossplane-system:crossplane",
+				resource:    testResource,
+				namespace:   "test-namespace",
+				deniedVerbs: []string{"create", "update", "delete"},
+				err:         nil,
+			},
+			want: want{
+				result: "system:serviceaccount:crossplane-system:crossplane is not allowed to [create, update, delete] resource v1.example.org/v1 in namespace test-namespace",
+			},
+		},
+		"SingleVerb": {
+			reason: "Should format error for single denied verb",
+			args: args{
+				user:        "system:serviceaccount:crossplane-system:crossplane",
+				resource:    testResource,
+				namespace:   "",
+				deniedVerbs: []string{"delete"},
+				err:         nil,
+			},
+			want: want{
+				result: "system:serviceaccount:crossplane-system:crossplane is not allowed to [delete] resource v1.example.org/v1",
+			},
+		},
+		"WithWrappedError": {
+			reason: "Should include wrapped error in message",
+			args: args{
+				user:        "system:serviceaccount:crossplane-system:crossplane",
+				resource:    testResource,
+				namespace:   "",
+				deniedVerbs: []string{"get"},
+				err:         errBoom,
+			},
+			want: want{
+				result: "system:serviceaccount:crossplane-system:crossplane is not allowed to [get] resource v1.example.org/v1: boom",
+			},
+		},
+		"EmptyDeniedVerbs": {
+			reason: "Should handle empty denied verbs list",
+			args: args{
+				user:        "system:serviceaccount:crossplane-system:crossplane",
+				resource:    testResource,
+				namespace:   "",
+				deniedVerbs: []string{},
+				err:         nil,
+			},
+			want: want{
+				result: "system:serviceaccount:crossplane-system:crossplane is not allowed to [] resource v1.example.org/v1",
+			},
+		},
+		"CoreResource": {
+			reason: "Should handle core Kubernetes resources",
+			args: args{
+				user: "system:serviceaccount:crossplane-system:crossplane",
+				resource: schema.GroupVersionResource{
+					Group:    "",
+					Version:  "v1",
+					Resource: "secrets",
+				},
+				namespace:   "kube-system",
+				deniedVerbs: []string{"get", "list"},
+				err:         nil,
+			},
+			want: want{
+				result: "system:serviceaccount:crossplane-system:crossplane is not allowed to [get, list] resource v1./v1 in namespace kube-system",
+			},
+		},
+		"EmptyUser": {
+			reason: "Should handle empty user",
+			args: args{
+				user:        "",
+				resource:    testResource,
+				namespace:   "test-namespace",
+				deniedVerbs: []string{"patch"},
+				err:         nil,
+			},
+			want: want{
+				result: " is not allowed to [patch] resource v1.example.org/v1 in namespace test-namespace",
+			},
+		},
+	}
+	
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			e := SubjectAccessReviewError{
+				User:        tc.args.user,
+				Resource:    tc.args.resource,
+				Namespace:   tc.args.namespace,
+				DeniedVerbs: tc.args.deniedVerbs,
+				Err:         tc.args.err,
+			}
+			
+			got := e.Error()
+			
+			if diff := cmp.Diff(tc.want.result, got); diff != "" {
+				t.Errorf("\n%s\nError(): -want, +got:\n%s", tc.reason, diff)
+			}
+		})
+	}
+}
+
+func TestSubjectAccessReviewError_Unwrap(t *testing.T) {
+	errBoom := errors.New("boom")
+	
+	testResource := schema.GroupVersionResource{
+		Group:    "example.org",
+		Version:  "v1",
+		Resource: "bars",
+	}
+	
+	type args struct {
+		user        string
+		resource    schema.GroupVersionResource
+		namespace   string
+		deniedVerbs []string
+		err         error
+	}
+	type want struct {
+		err error
+	}
+	
+	cases := map[string]struct {
+		reason string
+		args   args
+		want   want
+	}{
+		"WithWrappedError": {
+			reason: "Should return wrapped error when present",
+			args: args{
+				user:        "system:serviceaccount:crossplane-system:crossplane",
+				resource:    testResource,
+				namespace:   "",
+				deniedVerbs: []string{"get"},
+				err:         errBoom,
+			},
+			want: want{
+				err: errBoom,
+			},
+		},
+		"WithoutWrappedError": {
+			reason: "Should return nil when no wrapped error",
+			args: args{
+				user:        "system:serviceaccount:crossplane-system:crossplane",
+				resource:    testResource,
+				namespace:   "",
+				deniedVerbs: []string{"get"},
+				err:         nil,
+			},
+			want: want{
+				err: nil,
+			},
+		},
+	}
+	
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			e := SubjectAccessReviewError{
+				User:        tc.args.user,
+				Resource:    tc.args.resource,
+				Namespace:   tc.args.namespace,
+				DeniedVerbs: tc.args.deniedVerbs,
+				Err:         tc.args.err,
+			}
+			
+			got := e.Unwrap()
+			
+			if diff := cmp.Diff(tc.want.err, got, test.EquateErrors()); diff != "" {
+				t.Errorf("\n%s\nUnwrap(): -want error, +got error:\n%s", tc.reason, diff)
+			}
+		})
+	}
+}

--- a/test/e2e/apiextensions_compositions_test.go
+++ b/test/e2e/apiextensions_compositions_test.go
@@ -25,8 +25,8 @@ import (
 	"sigs.k8s.io/e2e-framework/third_party/helm"
 
 	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
-
 	"github.com/crossplane/crossplane-runtime/pkg/resource/unstructured/composed"
+
 	apiextensionsv1 "github.com/crossplane/crossplane/apis/apiextensions/v1"
 	pkgv1 "github.com/crossplane/crossplane/apis/pkg/v1"
 	"github.com/crossplane/crossplane/test/e2e/config"

--- a/test/e2e/apiextensions_usage_legacy_test.go
+++ b/test/e2e/apiextensions_usage_legacy_test.go
@@ -11,8 +11,8 @@ import (
 	"sigs.k8s.io/e2e-framework/pkg/features"
 
 	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
-
 	"github.com/crossplane/crossplane-runtime/pkg/resource/unstructured/composed"
+
 	apiextensionsv1 "github.com/crossplane/crossplane/apis/apiextensions/v1"
 	pkgv1 "github.com/crossplane/crossplane/apis/pkg/v1"
 	"github.com/crossplane/crossplane/test/e2e/config"

--- a/test/e2e/funcs/collect.go
+++ b/test/e2e/funcs/collect.go
@@ -32,7 +32,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 
 	"github.com/crossplane/crossplane-runtime/pkg/errors"
-
 	"github.com/crossplane/crossplane-runtime/pkg/resource/unstructured/composite"
 )
 

--- a/test/e2e/funcs/feature.go
+++ b/test/e2e/funcs/feature.go
@@ -57,7 +57,6 @@ import (
 	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
 	"github.com/crossplane/crossplane-runtime/pkg/errors"
 	"github.com/crossplane/crossplane-runtime/pkg/fieldpath"
-
 	"github.com/crossplane/crossplane-runtime/pkg/resource/unstructured/claim"
 	"github.com/crossplane/crossplane-runtime/pkg/resource/unstructured/composite"
 )


### PR DESCRIPTION
### Description of your changes

Use `SelfSubjectAccessReview` to clarify errors around composition.

If crossplane has no rights to the composed resource we will now see:

```
Every 2.0s: kubectl describe foobar                                                                                                                                                                                                                                                                                                                              scotts-mbp.lan: 14:09:33
                                                                                                                                                                                                                                                                                                                                                                            in 0.245s (0)
Name:         test-foobar
Namespace:    default
Labels:       crossplane.io/composite=test-foobar
Annotations:  <none>
API Version:  wat.io/v1alpha1
Kind:         FooBar
Metadata:
  Creation Timestamp:  2025-06-26T21:06:25Z
  Finalizers:
    composite.apiextensions.crossplane.io
  Generation:        3
  Resource Version:  1750972105706287018
  UID:               c5380b2f-5314-4604-bb20-fbb869dba36b
Spec:
  Crossplane:
    Composition Ref:
      Name:  foobar.wat.io
    Composition Revision Ref:
      Name:                     foobar.wat.io-2c5c65a
    Composition Update Policy:  Automatic
Status:
  Conditions:
    Last Transition Time:  2025-06-26T21:08:25Z
    Message:               [cannot compose resources: cannot generate a name for composed resource "bar": Timeout: failed waiting for *unstructured.Unstructured Informer to sync, system:serviceaccount:crossplane-system:crossplane is not allowed to [get, list, watch, create, update, patch, delete] resource v1.issue.example.com/v1 in namespace default]
    Observed Generation:   3
    Reason:                ReconcileError
    Status:                False
    Type:                  Synced
Events:
  Type     Reason                  Age   From                                                             Message
  ----     ------                  ----  ----                                                             -------
  Normal   SelectComposition       3m8s  defined/compositeresourcedefinition.apiextensions.crossplane.io  Successfully selected composition: foobar.wat.io
  Normal   SelectComposition       3m8s  defined/compositeresourcedefinition.apiextensions.crossplane.io  Selected composition revision: foobar.wat.io-2c5c65a
  Warning  ComposeResources        68s   defined/compositeresourcedefinition.apiextensions.crossplane.io  cannot compose resources: cannot generate a name for composed resource "bar": Timeout: failed waiting for *unstructured.Unstructured Informer to sync
  Warning  ComposeResourcesAccess  68s   defined/compositeresourcedefinition.apiextensions.crossplane.io  system:serviceaccount:crossplane-system:crossplane is not allowed to [get, list, watch, create, update, patch, delete] resource v1.issue.example.com/v1 in namespace default
```

Which is a much nicer error to figure out why this thing is broken (I forgot to give crossplane RBAC rights)

Fixes #6544 

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `earthly +reviewable` to ensure this PR is ready for review.
- [x] Added or updated unit tests.
- [ ] Added or updated e2e tests.
~- [ ] Linked a PR or a [docs tracking issue] to [document this change].~
~- [ ] Added `backport release-x.y` labels to auto-backport this PR.~
~- [ ] Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md