### PR TITLE
Block namespaced XRs from composing cluster scoped resources

### DIFF
--- a/test/e2e/manifests/apiextensions/composition/namespaced-xr-no-cluster-scoped-resource/setup/composition.yaml
+++ b/test/e2e/manifests/apiextensions/composition/namespaced-xr-no-cluster-scoped-resource/setup/composition.yaml
@@ -1,0 +1,33 @@
+apiVersion: apiextensions.crossplane.io/v1
+kind: Composition
+metadata:
+  name: invalid-namespaced-xr-cluster-composition
+spec:
+  compositeTypeRef:
+    apiVersion: validation.example.org/v1alpha1
+    kind: NamespacedTest
+  mode: Pipeline
+  pipeline:
+  - step: create-cluster-resource
+    functionRef:
+      name: function-dummy-ext-basic
+    input:
+      apiVersion: dummy.fn.crossplane.io/v1beta1
+      kind: Response
+      response:
+        desired:
+          resources:
+            cluster-role-test:
+              resource:
+                apiVersion: rbac.authorization.k8s.io/v1
+                kind: ClusterRole
+                metadata:
+                  name: cluster-role
+                rules:
+                  - apiGroups:
+                      - example.org
+                    resources:
+                      - clustertests
+                    verbs:
+                      - '*'
+              ready: READY_TRUE

--- a/test/e2e/manifests/apiextensions/composition/namespaced-xr-no-cluster-scoped-resource/setup/definition.yaml
+++ b/test/e2e/manifests/apiextensions/composition/namespaced-xr-no-cluster-scoped-resource/setup/definition.yaml
@@ -1,0 +1,25 @@
+apiVersion: apiextensions.crossplane.io/v2alpha1
+kind: CompositeResourceDefinition
+metadata:
+  name: namespacedtests.validation.example.org
+spec:
+  scope: Namespaced
+  group: validation.example.org
+  names:
+    kind: NamespacedTest
+    plural: namespacedtests
+  versions:
+  - name: v1alpha1
+    served: true
+    referenceable: true
+    schema:
+     openAPIV3Schema:
+       type: object
+       properties:
+        spec:
+          type: object
+          properties:
+            testField:
+              type: string
+          required:
+          - testField

--- a/test/e2e/manifests/apiextensions/composition/namespaced-xr-no-cluster-scoped-resource/setup/functions.yaml
+++ b/test/e2e/manifests/apiextensions/composition/namespaced-xr-no-cluster-scoped-resource/setup/functions.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: pkg.crossplane.io/v1beta1
+kind: Function
+metadata:
+  name: function-dummy-ext-basic
+spec:
+  package: xpkg.upbound.io/crossplane-contrib/function-dummy:v0.2.1

--- a/test/e2e/manifests/apiextensions/composition/namespaced-xr-no-cluster-scoped-resource/xr.yaml
+++ b/test/e2e/manifests/apiextensions/composition/namespaced-xr-no-cluster-scoped-resource/xr.yaml
@@ -1,0 +1,10 @@
+apiVersion: validation.example.org/v1alpha1
+kind: NamespacedTest
+metadata:
+  name: test-namespaced-xr
+  namespace: crossplane-system
+spec:
+  testField: "test-value"
+  crossplane:
+    compositionRef:
+      name: invalid-namespaced-xr-cluster-composition


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane! Please read the contribution docs
(linked below) if this is your first Crossplane pull request.
-->

### Description of your changes

As stated in #6361, the v2 namespace scoped XRs should not be allowed to compose cluster scoped resources. This is because Kubernetes doesn't allow a cluster scoped resource to be owned by (i.e. have owner references to) a namespaced resource. We recommend using cluster scoped XRs to compose cluster scoped (and/or namespaced) resources.

This PR adds a check for this situation. The check is after the composed resources are rendered and before they are applied. 

The check is skipped if the XR is not namespaced, or if the resource in question has a namespace set. If all goes good, the resource should be checked only once if it is namespaced, as in future reconciliations it will have the namespace set from the observation in the reconcile loop.

If a namespaced XR tries to compose a cluster scoped resource the XR will get into a `ReconcileError` condition with the corresponding message.

```yaml
Status:
  Conditions:
    Last Transition Time:  2025-07-04T18:26:01Z
    Message:               cannot compose resources: cannot apply cluster scoped composed resource "cluster-role-test" (a ClusterRole named cluster-role) for a namespaced composite resource.
    Observed Generation:   2
    Reason:                ReconcileError
    Status:                False
    Type:                  Synced
Events:
  Type     Reason             Age                From                                                             Message
  ----     ------             ----               ----                                                             -------
  Normal   SelectComposition  21s                defined/compositeresourcedefinition.apiextensions.crossplane.io  Selected composition revision: invalid-namespaced-xr-cluster-composition-9a79fe1
  Warning  ComposeResources   11s (x5 over 20s)  defined/compositeresourcedefinition.apiextensions.crossplane.io  cannot compose resources: cannot apply cluster scoped composed resource "cluster-role-test" (a ClusterRole named cluster-role) for a namespaced composite resource.

```

<!--
Briefly describe what this pull request does, and how it is covered by tests.
Be proactive - direct your reviewers' attention to anything that needs special
consideration.

We love pull requests that fix an open issue. If yours does, use the below line
to indicate which issue it fixes, for example "Fixes #500".
-->

Fixes #6361 

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `earthly +reviewable` to ensure this PR is ready for review.
- [x] Added or updated unit tests.
- [x] Added or updated e2e tests.
- ~[ ] Linked a PR or a [docs tracking issue] to [document this change].~
- ~[ ] Added `backport release-x.y` labels to auto-backport this PR.~
- ~[ ] Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md