### PR TITLE
Use foreground cascading deletion for unneeded composed resources

### DIFF
--- a/internal/controller/apiextensions/composite/composition_functions.go
+++ b/internal/controller/apiextensions/composite/composition_functions.go
@@ -820,6 +820,10 @@ func (d *DeletingComposedResourceGarbageCollector) GarbageCollectComposedResourc
 		}
 	}
 
+	// Always use foreground deletion.  There is no impact on Managed Resources,
+	// and nested XRs will be deleted "bottom up".
+	do := &client.DeleteOptions{}
+	client.PropagationPolicy(metav1.DeletePropagationForeground).ApplyToDelete(do)
 	for name, cd := range del {
 		// Don't garbage collect composed resources that someone else controls.
 		//
@@ -842,8 +846,11 @@ func (d *DeletingComposedResourceGarbageCollector) GarbageCollectComposedResourc
 		if err := d.client.Update(ctx, cd.Resource); resource.IgnoreNotFound(err) != nil {
 			return errors.Wrapf(err, errFmtCleanupLabelsCD, name, cd.Resource.GetObjectKind().GroupVersionKind().Kind, cd.Resource.GetName())
 		}
+		if uid := cd.Resource.GetUID(); uid != "" {
+			do.Preconditions = &metav1.Preconditions{UID: &uid}
+		}
 		// Delete the composed resource.
-		if err := d.client.Delete(ctx, cd.Resource); resource.IgnoreNotFound(err) != nil {
+		if err := d.client.Delete(ctx, cd.Resource, do); resource.IgnoreNotFound(err) != nil {
 			return errors.Wrapf(err, errFmtDeleteCD, name, cd.Resource.GetObjectKind().GroupVersionKind().Kind, cd.Resource.GetName())
 		}
 	}


### PR DESCRIPTION
### Description of your changes

With the introduction of Composition Functions the Crossplane composite reconciler is now able to explicitly request deletion of composed resources that are no longer required by the composite. 

For example, a composition function may request a resource to do a lookup on a specific ID and then once that ID is available it can omit that resource from the `desired` list and Crossplane will delete it.

This raises the possibility that Crossplane could delete a nested composite resource that requires the use of `Foreground` cascading deletion in order to ensure that resources are cleaned up properly, and/or that any explicit `Usage` resources are processed correctly.  This would require the reconciler to have access to the Composite Resource Definition for the composed resource, which specifies the `defaultCompositeResourceDeletionPolicy`.

A simpler solution is to just use `Foreground` deletion for _all_ composed resources that are deleted explicitly by the composite reconciler.  This will have no impact on `Managed Resources` which are already at the edge of the resource tree.  The impact on nested `Composite Resources` will be minimal, as it will cause all of the nested MRs to be deleted before their composites, and it will also allow any embedded `Usage` resources to work properly.

Overall there should be no negative impact beyond a slightly slower deletion process which will be ignored by the reconciler.

Fixes #6288

I have: 

- [X] Read and followed Crossplane's [contribution process].
- [X] Run `earthly +reviewable` to ensure this PR is ready for review.
~- [ ] Added or updated unit tests.~
~- [ ] Added or updated e2e tests.~
~- [ ] Linked a PR or a [docs tracking issue] to [document this change].~
~- [ ] Added `backport release-x.y` labels to auto-backport this PR.~
~- [ ] Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md