### PR TITLE
ci(e2es): export kind logs on failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -333,6 +333,13 @@ jobs:
           name: e2e-tests-${{ matrix.test-area }}-${{ matrix.test-suite }}
           path: _output/tests/**
 
+      - name: Upload E2E Test Logs to GitHub for Debugging
+        if: 'failure() && !cancelled()'
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: e2e-tests-logs-${{ matrix.test-area }}-${{ matrix.test-suite }}
+          path: _output/kind-logs/**
+
   publish-artifacts:
     runs-on: ubuntu-22.04
 

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -137,6 +137,7 @@ func TestMain(m *testing.M) {
 	setup = append(setup, funcs.AddCrossplaneTypesToScheme(), funcs.AddCRDsToScheme())
 
 	if environment.ShouldCollectKindLogsOnFailure() {
+		setup = append(setup, funcs.InstallFluentd("test-main"))
 		finish = append(finish, envfuncs.ExportClusterLogs(environment.GetKindClusterName(), environment.GetKindClusterLogsLocation()))
 	}
 

--- a/test/e2e/manifests/kind/fluentd.yaml
+++ b/test/e2e/manifests/kind/fluentd.yaml
@@ -1,0 +1,161 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: fluentd
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: fluentd
+  namespace: kube-system
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: fluentd
+roleRef:
+  kind: ClusterRole
+  name: fluentd
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: ServiceAccount
+  name: fluentd
+  namespace: kube-system
+---
+apiVersion: v1
+data:
+  fluentd.conf: |+
+    <label @FLUENT_LOG>
+      <match fluent.**>
+        @type null
+      </match>
+    </label>
+    <source>
+      @type tail
+      path /var/log/containers/*.log
+      pos_file /var/log/fluentd-containers.log.pos
+      tag "kubernetes.*"
+      exclude_path "#{ENV['FLUENT_CONTAINER_TAIL_EXCLUDE_PATH'] || use_default}"
+      read_from_head true
+      <parse>
+        @type regexp
+        expression /^(?<time>[^ ]+) (?<stream>stdout|stderr) (?<logtag>[^ ]*) (?<message>.*)$/
+        time_format %Y-%m-%dT%H:%M:%S.%L%z
+      </parse>
+      @label @CONCAT
+    </source>
+
+    <label @CONCAT>
+      <filter kubernetes.**>
+        @type concat
+        key message
+        use_partial_cri_logtag true
+        partial_cri_logtag_key logtag
+        partial_cri_stream_key stream
+      </filter>
+      <match kubernetes.**>
+        @type relabel
+        @label @OUTPUT
+      </match>
+    </label>
+
+    <source>
+      @type tail
+      @id in_tail_kube_apiserver_audit
+      multiline_flush_interval 5s
+      path /var/log/kubernetes/kube-apiserver-audit.log
+      pos_file /var/log/kube-apiserver-audit.log.pos
+      tag kube-apiserver-audit
+      <parse>
+        @type json
+        keep_time_key true
+        time_key timestamp
+        time_format %Y-%m-%dT%T.%L%Z
+      </parse>
+      @label @OUTPUT
+    </source>
+
+    <label @OUTPUT>
+      <match>
+        @type stdout
+      </match>
+    </label>
+
+kind: ConfigMap
+metadata:
+  name: fluentd-conf
+  namespace: kube-system
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: fluentd
+  namespace: kube-system
+  labels:
+    k8s-app: fluentd-logging
+    version: v1
+spec:
+  selector:
+    matchLabels:
+      k8s-app: fluentd-logging
+      version: v1
+  template:
+    metadata:
+      labels:
+        k8s-app: fluentd-logging
+        version: v1
+    spec:
+      serviceAccount: fluentd
+      serviceAccountName: fluentd
+      tolerations:
+      - key: node-role.kubernetes.io/master
+        effect: NoSchedule
+      - key: node-role.kubernetes.io/control-plane
+        effect: NoSchedule
+      imagePullSecrets:
+      - name: upbound-pull-secret
+      containers:
+      - name: fluentd
+        image: fluent/fluentd-kubernetes-daemonset:v1.14.3-debian-forward-1.0
+        env:
+          - name:  FLUENTD_CONF
+            value: "custom/fluentd.conf"
+          - name: FLUENT_CONTAINER_TAIL_EXCLUDE_PATH
+            value: "/var/log/containers/fluentd-*"
+        resources:
+          limits:
+            memory: 200Mi
+          requests:
+            cpu: 100m
+            memory: 200Mi
+        volumeMounts:
+        - name: varlog
+          mountPath: /var/log
+        - name: varlibdockercontainers
+          mountPath: /var/lib/docker/containers
+          readOnly: true
+        - name: fluentd-conf
+          mountPath: /fluentd/etc/custom/
+      terminationGracePeriodSeconds: 30
+      volumes:
+      - name: varlog
+        hostPath:
+          path: /var/log
+      - name: varlibdockercontainers
+        hostPath:
+          path: /var/lib/docker/containers
+      - name: fluentd-conf
+        configMap:
+          name: fluentd-conf


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane! Please read the contribution docs
(linked below) if this is your first Crossplane pull request.
-->

### Description of your changes

<!--
Briefly describe what this pull request does, and how it is covered by tests.
Be proactive - direct your reviewers' attention to anything that needs special
consideration.

We love pull requests that fix an open issue. If yours does, use the below line
to indicate which issue it fixes, for example "Fixes #500".
-->

Export all logs from the kind cluster on failure, to allow debugging.
Add a Fluentd daemonset so that we can inspect logs for deleted pods too.

In the future we could also collect additional resources using something like https://troubleshoot.sh.

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `earthly +reviewable` to ensure this PR is ready for review.
- [x] Added or updated unit tests.
- [x] Added or updated e2e tests.
- [x] Linked a PR or a [docs tracking issue] to [document this change].
- [x] Added `backport release-x.y` labels to auto-backport this PR.
- [x] Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md