### PR TITLE
Name XR Children in a deterministic way.

### DIFF
--- a/cmd/crank/beta/trace/internal/printer/default.go
+++ b/cmd/crank/beta/trace/internal/printer/default.go
@@ -18,7 +18,6 @@ package printer
 
 import (
 	"fmt"
-	"github.com/crossplane/crossplane/internal/xcrd"
 	"io"
 	"strings"
 
@@ -34,6 +33,7 @@ import (
 	pkgv1 "github.com/crossplane/crossplane/apis/pkg/v1"
 	"github.com/crossplane/crossplane/cmd/crank/beta/trace/internal/resource"
 	"github.com/crossplane/crossplane/cmd/crank/beta/trace/internal/resource/xpkg"
+	"github.com/crossplane/crossplane/internal/xcrd"
 )
 
 const (

--- a/cmd/crank/beta/trace/internal/printer/default.go
+++ b/cmd/crank/beta/trace/internal/printer/default.go
@@ -18,6 +18,7 @@ package printer
 
 import (
 	"fmt"
+	"github.com/crossplane/crossplane/internal/xcrd"
 	"io"
 	"strings"
 
@@ -33,7 +34,6 @@ import (
 	pkgv1 "github.com/crossplane/crossplane/apis/pkg/v1"
 	"github.com/crossplane/crossplane/cmd/crank/beta/trace/internal/resource"
 	"github.com/crossplane/crossplane/cmd/crank/beta/trace/internal/resource/xpkg"
-	"github.com/crossplane/crossplane/internal/controller/apiextensions/composite"
 )
 
 const (
@@ -269,7 +269,7 @@ func getResourceStatus(r *resource.Resource, name string, wide bool) fmt.Stringe
 	return &defaultPrinterRow{
 		wide:         wide,
 		name:         name,
-		resourceName: r.Unstructured.GetAnnotations()[composite.AnnotationKeyCompositionResourceName],
+		resourceName: r.Unstructured.GetAnnotations()[xcrd.AnnotationKeyCompositionResourceName],
 		ready:        mapEmptyStatusToDash(readyCond.Status),
 		synced:       mapEmptyStatusToDash(syncedCond.Status),
 		status:       status,

--- a/cmd/crank/beta/trace/internal/printer/printer_test.go
+++ b/cmd/crank/beta/trace/internal/printer/printer_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package printer
 
 import (
-	"github.com/crossplane/crossplane/internal/xcrd"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
@@ -27,6 +26,7 @@ import (
 
 	v1 "github.com/crossplane/crossplane/apis/pkg/v1"
 	"github.com/crossplane/crossplane/cmd/crank/beta/trace/internal/resource"
+	"github.com/crossplane/crossplane/internal/xcrd"
 )
 
 // DummyManifestOpt can be passed to customize a dummy manifest.

--- a/cmd/crank/beta/trace/internal/printer/printer_test.go
+++ b/cmd/crank/beta/trace/internal/printer/printer_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package printer
 
 import (
+	"github.com/crossplane/crossplane/internal/xcrd"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
@@ -26,7 +27,6 @@ import (
 
 	v1 "github.com/crossplane/crossplane/apis/pkg/v1"
 	"github.com/crossplane/crossplane/cmd/crank/beta/trace/internal/resource"
-	"github.com/crossplane/crossplane/internal/controller/apiextensions/composite"
 )
 
 // DummyManifestOpt can be passed to customize a dummy manifest.
@@ -75,7 +75,7 @@ func WithConditions(conds ...xpv1.Condition) DummyManifestOpt {
 
 func WithCompositionResourceName(n string) DummyManifestOpt {
 	return func(m *unstructured.Unstructured) {
-		meta.AddAnnotations(m, map[string]string{composite.AnnotationKeyCompositionResourceName: n})
+		meta.AddAnnotations(m, map[string]string{xcrd.AnnotationKeyCompositionResourceName: n})
 	}
 }
 

--- a/cmd/crank/beta/validate/validate.go
+++ b/cmd/crank/beta/validate/validate.go
@@ -19,6 +19,7 @@ package validate
 import (
 	"context"
 	"fmt"
+	"github.com/crossplane/crossplane/internal/xcrd"
 	"io"
 
 	ext "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
@@ -33,8 +34,6 @@ import (
 	celconfig "k8s.io/apiserver/pkg/apis/cel"
 
 	"github.com/crossplane/crossplane-runtime/pkg/errors"
-
-	"github.com/crossplane/crossplane/internal/controller/apiextensions/composite"
 )
 
 const (
@@ -182,7 +181,7 @@ func getResourceName(r *unstructured.Unstructured) string {
 	}
 
 	// fallback to composition resource name
-	return r.GetAnnotations()[composite.AnnotationKeyCompositionResourceName]
+	return r.GetAnnotations()[xcrd.AnnotationKeyCompositionResourceName]
 }
 
 // applyDefaults applies default values from the CRD schema to the unstructured resource.

--- a/cmd/crank/beta/validate/validate.go
+++ b/cmd/crank/beta/validate/validate.go
@@ -19,7 +19,6 @@ package validate
 import (
 	"context"
 	"fmt"
-	"github.com/crossplane/crossplane/internal/xcrd"
 	"io"
 
 	ext "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
@@ -34,6 +33,8 @@ import (
 	celconfig "k8s.io/apiserver/pkg/apis/cel"
 
 	"github.com/crossplane/crossplane-runtime/pkg/errors"
+
+	"github.com/crossplane/crossplane/internal/xcrd"
 )
 
 const (

--- a/go.mod
+++ b/go.mod
@@ -179,7 +179,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sso v1.21.1 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.25.1 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sts v1.29.1 // indirect
-	github.com/aws/smithy-go v1.20.2 // indirect
+	github.com/aws/smithy-go v1.20.2
 	github.com/awslabs/amazon-ecr-credential-helper/ecr-login v0.0.0-20231024185945-8841054dbdb8 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect

--- a/internal/controller/apiextensions/composite/composition_functions.go
+++ b/internal/controller/apiextensions/composite/composition_functions.go
@@ -58,7 +58,7 @@ const (
 	errGarbageCollectCDs        = "cannot garbage collect composed resources that are no longer desired"
 	errApplyXRRefs              = "cannot update composed resource references"
 	errApplyXRStatus            = "cannot apply composite resource status"
-	errAnonymousCD              = "encountered composed resource without required \"" + AnnotationKeyCompositionResourceName + "\" annotation"
+	errAnonymousCD              = "encountered composed resource without required \"" + xcrd.AnnotationKeyCompositionResourceName + "\" annotation"
 	errUnmarshalDesiredXRStatus = "cannot unmarshal desired composite resource status from RunFunctionResponse"
 	errXRAsStruct               = "cannot encode composite resource to protocol buffer Struct well-known type"
 	errStructFromUnstructured   = "cannot create Struct"
@@ -720,7 +720,7 @@ func (g *ExistingComposedResourceObserver) ObserveComposedResources(ctx context.
 			continue
 		}
 
-		name := GetCompositionResourceName(r)
+		name := ResourceName(xcrd.GetCompositionResourceName(r))
 		if name == "" {
 			return nil, errors.New(errAnonymousCD)
 		}

--- a/internal/controller/apiextensions/composite/composition_functions_test.go
+++ b/internal/controller/apiextensions/composite/composition_functions_test.go
@@ -1143,6 +1143,106 @@ func TestFunctionCompose(t *testing.T) {
 				err: nil,
 			},
 		},
+		"ResourceReferencesWithoutObservedResources": {
+			reason: "When XR has resourceRefs but the actual resources don't exist, the function should use the existing names from resourceRefs.",
+			params: params{
+				c: &test.MockClient{
+					MockGet: test.NewMockGetFn(kerrors.NewNotFound(schema.GroupResource{Resource: "Deployment"}, "")), // all names are available
+					MockPatch: test.NewMockPatchFn(nil, func(obj client.Object) error {
+						// Check if the composed resource uses the expected name from resourceRefs
+						if cd, ok := obj.(*composed.Unstructured); ok {
+							// This test demonstrates the bug: the composed resource should use "existing-deployment-name" from resourceRefs,
+							// but currently it generates a new name instead
+							if cd.GetName() != "existing-deployment-name" {
+								// This is the current buggy behavior - it generates a new name instead of using the existing one
+								// Log this for debugging when we run the test
+								return errors.Errorf("BUG: Composed resource generated new name %s instead of using existing name from resourceRefs: existing-deployment-name", cd.GetName())
+							}
+						}
+						return nil
+					}),
+					MockStatusPatch: test.NewMockSubResourcePatchFn(nil),
+				},
+				uc: &test.MockClient{
+					MockGet: test.NewMockGetFn(kerrors.NewNotFound(schema.GroupResource{Resource: "secrets"}, "")),
+				},
+				r: FunctionRunnerFn(func(_ context.Context, _ string, req *fnv1.RunFunctionRequest) (*fnv1.RunFunctionResponse, error) {
+					// Function returns a desired resource with the same name as referenced
+					rsp := &fnv1.RunFunctionResponse{
+						Meta: &fnv1.ResponseMeta{Ttl: durationpb.New(5 * time.Minute)},
+						Desired: &fnv1.State{
+							Resources: map[string]*fnv1.Resource{
+								"test-resource": {
+									Resource: MustStruct(map[string]any{
+										"apiVersion": "apps/v1",
+										"kind":       "Deployment",
+										"metadata":   map[string]any{},
+										"spec": map[string]any{
+											"replicas": 1,
+										},
+									}),
+								},
+							},
+						},
+					}
+					return rsp, nil
+				}),
+				o: []FunctionComposerOption{
+					WithCompositeConnectionDetailsFetcher(ConnectionDetailsFetcherFn(func(_ context.Context, _ ConnectionSecretOwner) (managed.ConnectionDetails, error) {
+						return nil, nil
+					})),
+					WithComposedResourceObserver(ComposedResourceObserverFn(func(_ context.Context, _ resource.Composite) (ComposedResourceStates, error) {
+						// Return empty observed resources - simulating that the resources don't exist in cluster
+						return ComposedResourceStates{}, nil
+					})),
+					WithComposedResourceGarbageCollector(ComposedResourceGarbageCollectorFn(func(_ context.Context, _ metav1.Object, _, _ ComposedResourceStates) error {
+						return nil
+					})),
+				},
+			},
+			args: args{
+				xr: func() *composite.Unstructured {
+					xr := composite.New(composite.WithGroupVersionKind(schema.GroupVersionKind{
+						Group:   "test.crossplane.io",
+						Version: "v1",
+						Kind:    "CoolComposite",
+					}))
+					xr.SetLabels(map[string]string{
+						xcrd.LabelKeyNamePrefixForComposed: "parent-xr",
+					})
+					// Set resource references that exist from a previous reconciliation
+					xr.SetResourceReferences([]corev1.ObjectReference{
+						{
+							APIVersion: "apps/v1",
+							Kind:       "Deployment",
+							Name:       "existing-deployment-name",
+						},
+					})
+					return xr
+				}(),
+				req: CompositionRequest{
+					Revision: &v1.CompositionRevision{
+						Spec: v1.CompositionRevisionSpec{
+							Pipeline: []v1.PipelineStep{
+								{
+									Step:        "run-cool-function",
+									FunctionRef: v1.FunctionReference{Name: "cool-function"},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: want{
+				res: CompositionResult{
+					Composed: []ComposedResource{
+						{ResourceName: "test-resource", Synced: true},
+					},
+					TTL: 5 * time.Minute,
+				},
+				err: nil,
+			},
+		},
 	}
 
 	for name, tc := range cases {

--- a/internal/controller/apiextensions/composite/composition_functions_test.go
+++ b/internal/controller/apiextensions/composite/composition_functions_test.go
@@ -1153,10 +1153,10 @@ func TestFunctionCompose(t *testing.T) {
 						if cd, ok := obj.(*composed.Unstructured); ok {
 							// This test demonstrates the bug: the composed resource should use "existing-deployment-name" from resourceRefs,
 							// but currently it generates a new name instead
-							if cd.GetName() != "parent-xr-73edf0cb4924472922c78401ca75c166test-resource-with-a" {
+							if cd.GetName() != "parent-xr-f4d3ac8501550bf84c63a814cc31ecb3161cbb88370f-test-res" {
 								// This is the current buggy behavior - it generates a new name instead of using the existing one
 								// Log this for debugging when we run the test
-								return errors.Errorf("BUG: Composed resource generated new name %s instead of using existing name from resourceRefs: parent-xr-73edf0cb4924472922c78401ca75c166test-resource-with-a", cd.GetName())
+								return errors.Errorf("BUG: Composed resource generated new name %s instead of using existing name from resourceRefs: parent-xr-f4d3ac8501550bf84c63a814cc31ecb3161cbb88370f-test-res", cd.GetName())
 							}
 						}
 						return nil
@@ -1172,7 +1172,7 @@ func TestFunctionCompose(t *testing.T) {
 						Meta: &fnv1.ResponseMeta{Ttl: durationpb.New(5 * time.Minute)},
 						Desired: &fnv1.State{
 							Resources: map[string]*fnv1.Resource{
-								"test-resource-with-a-really-long-name-to-test-compaction": {
+								"test-resource-with-a-super-duper-really-long-name-to-test-compaction": {
 									Resource: MustStruct(map[string]any{
 										"apiVersion": "apps/v1",
 										"kind":       "Deployment",
@@ -1237,7 +1237,7 @@ func TestFunctionCompose(t *testing.T) {
 			want: want{
 				res: CompositionResult{
 					Composed: []ComposedResource{
-						{ResourceName: "test-resource-with-a-really-long-name-to-test-compaction", Synced: true},
+						{ResourceName: "test-resource-with-a-super-duper-really-long-name-to-test-compaction", Synced: true},
 					},
 					TTL: 5 * time.Minute,
 				},

--- a/internal/controller/apiextensions/composite/composition_functions_test.go
+++ b/internal/controller/apiextensions/composite/composition_functions_test.go
@@ -1153,10 +1153,10 @@ func TestFunctionCompose(t *testing.T) {
 						if cd, ok := obj.(*composed.Unstructured); ok {
 							// This test demonstrates the bug: the composed resource should use "existing-deployment-name" from resourceRefs,
 							// but currently it generates a new name instead
-							if cd.GetName() != "existing-deployment-name" {
+							if cd.GetName() != "parent-xr-73edf0cb4924472922c78401ca75c166test-resource-with-a" {
 								// This is the current buggy behavior - it generates a new name instead of using the existing one
 								// Log this for debugging when we run the test
-								return errors.Errorf("BUG: Composed resource generated new name %s instead of using existing name from resourceRefs: existing-deployment-name", cd.GetName())
+								return errors.Errorf("BUG: Composed resource generated new name %s instead of using existing name from resourceRefs: parent-xr-73edf0cb4924472922c78401ca75c166test-resource-with-a", cd.GetName())
 							}
 						}
 						return nil
@@ -1172,7 +1172,7 @@ func TestFunctionCompose(t *testing.T) {
 						Meta: &fnv1.ResponseMeta{Ttl: durationpb.New(5 * time.Minute)},
 						Desired: &fnv1.State{
 							Resources: map[string]*fnv1.Resource{
-								"test-resource": {
+								"test-resource-with-a-really-long-name-to-test-compaction": {
 									Resource: MustStruct(map[string]any{
 										"apiVersion": "apps/v1",
 										"kind":       "Deployment",
@@ -1210,12 +1210,13 @@ func TestFunctionCompose(t *testing.T) {
 					xr.SetLabels(map[string]string{
 						xcrd.LabelKeyNamePrefixForComposed: "parent-xr",
 					})
+					xr.SetUID("75e4a668-035f-4ce8-8c45-f4d3ac850155")
 					// Set resource references that exist from a previous reconciliation
 					xr.SetResourceReferences([]corev1.ObjectReference{
 						{
 							APIVersion: "apps/v1",
 							Kind:       "Deployment",
-							Name:       "existing-deployment-name",
+							Name:       "parent-xr-73edf0cb4924472922c78401ca75c166test-resource-with-a",
 						},
 					})
 					return xr
@@ -1236,7 +1237,7 @@ func TestFunctionCompose(t *testing.T) {
 			want: want{
 				res: CompositionResult{
 					Composed: []ComposedResource{
-						{ResourceName: "test-resource", Synced: true},
+						{ResourceName: "test-resource-with-a-really-long-name-to-test-compaction", Synced: true},
 					},
 					TTL: 5 * time.Minute,
 				},
@@ -1443,7 +1444,7 @@ func TestGetComposedResources(t *testing.T) {
 				c: &test.MockClient{
 					MockGet: test.NewMockGetFn(nil, func(obj client.Object) error {
 						obj.SetName("cool-resource-42")
-						SetCompositionResourceName(obj, "cool-resource")
+						xcrd.SetCompositionResourceName(obj, "cool-resource")
 						return nil
 					}),
 				},
@@ -1481,7 +1482,7 @@ func TestGetComposedResources(t *testing.T) {
 				uc: &test.MockClient{
 					MockGet: test.NewMockGetFn(nil, func(obj client.Object) error {
 						obj.SetName("cool-resource-42")
-						SetCompositionResourceName(obj, "cool-resource")
+						xcrd.SetCompositionResourceName(obj, "cool-resource")
 						return nil
 					}),
 				},
@@ -1511,7 +1512,7 @@ func TestGetComposedResources(t *testing.T) {
 							cd.SetAPIVersion("example.org/v1")
 							cd.SetKind("Composed")
 							cd.SetName("cool-resource-42")
-							SetCompositionResourceName(cd, "cool-resource")
+							xcrd.SetCompositionResourceName(cd, "cool-resource")
 							return cd
 						}(),
 					},
@@ -1524,7 +1525,7 @@ func TestGetComposedResources(t *testing.T) {
 				c: &test.MockClient{
 					MockGet: test.NewMockGetFn(nil, func(obj client.Object) error {
 						obj.SetName("cool-resource-42")
-						SetCompositionResourceName(obj, "cool-resource")
+						xcrd.SetCompositionResourceName(obj, "cool-resource")
 						return nil
 					}),
 				},
@@ -1559,7 +1560,7 @@ func TestGetComposedResources(t *testing.T) {
 							cd.SetAPIVersion("example.org/v1")
 							cd.SetKind("Composed")
 							cd.SetName("cool-resource-42")
-							SetCompositionResourceName(cd, "cool-resource")
+							xcrd.SetCompositionResourceName(cd, "cool-resource")
 							return cd
 						}(),
 					},

--- a/internal/controller/apiextensions/composite/composition_functions_test.go
+++ b/internal/controller/apiextensions/composite/composition_functions_test.go
@@ -1144,7 +1144,7 @@ func TestFunctionCompose(t *testing.T) {
 			},
 		},
 		"ResourceReferencesWithoutObservedResources": {
-			reason: "When XR has resourceRefs but the actual resources don't exist, the function should use the existing names from resourceRefs.",
+			reason: "When XR has resourceRefs but the actual resources don't exist, the function should use a deterministic name (same as resourceRefs).",
 			params: params{
 				c: &test.MockClient{
 					MockGet: test.NewMockGetFn(kerrors.NewNotFound(schema.GroupResource{Resource: "Deployment"}, "")), // all names are available
@@ -1166,7 +1166,7 @@ func TestFunctionCompose(t *testing.T) {
 				uc: &test.MockClient{
 					MockGet: test.NewMockGetFn(kerrors.NewNotFound(schema.GroupResource{Resource: "secrets"}, "")),
 				},
-				r: FunctionRunnerFn(func(_ context.Context, _ string, req *fnv1.RunFunctionRequest) (*fnv1.RunFunctionResponse, error) {
+				r: FunctionRunnerFn(func(_ context.Context, _ string, _ *fnv1.RunFunctionRequest) (*fnv1.RunFunctionResponse, error) {
 					// Function returns a desired resource with the same name as referenced
 					rsp := &fnv1.RunFunctionResponse{
 						Meta: &fnv1.ResponseMeta{Ttl: durationpb.New(5 * time.Minute)},

--- a/internal/controller/apiextensions/composite/composition_functions_test.go
+++ b/internal/controller/apiextensions/composite/composition_functions_test.go
@@ -1216,7 +1216,7 @@ func TestFunctionCompose(t *testing.T) {
 						{
 							APIVersion: "apps/v1",
 							Kind:       "Deployment",
-							Name:       "parent-xr-73edf0cb4924472922c78401ca75c166test-resource-with-a",
+							Name:       "parent-xr-f4d3ac8501550bf84c63a814cc31ecb3161cbb88370f-test-res",
 						},
 					})
 					return xr

--- a/internal/controller/apiextensions/composite/composition_render.go
+++ b/internal/controller/apiextensions/composite/composition_render.go
@@ -97,7 +97,7 @@ func RenderComposedResourceMetadata(cd, xr resource.Object, n ResourceName) erro
 	}
 
 	if n != "" {
-		SetCompositionResourceName(cd, n)
+		xcrd.SetCompositionResourceName(cd, string(n))
 	}
 
 	// TODO(negz): What happens if there is no claim? Will this set empty

--- a/internal/names/generate.go
+++ b/internal/names/generate.go
@@ -19,8 +19,10 @@ package names
 
 import (
 	"context"
-
+	"fmt"
+	"github.com/crossplane/crossplane/internal/xcrd"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apiserver/pkg/storage/names"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -62,6 +64,18 @@ func NewNameGenerator(c client.Client) NameGenerator {
 	return &nameGenerator{reader: c, namer: names.SimpleNameGenerator}
 }
 
+func (r *nameGenerator) isAvailable(ctx context.Context, cd resource.Object, name string) (bool, error) {
+	obj := composite.Unstructured{}
+	obj.SetGroupVersionKind(cd.GetObjectKind().GroupVersionKind())
+
+	err := r.reader.Get(ctx, client.ObjectKey{Name: name, Namespace: cd.GetNamespace()}, &obj)
+	if kerrors.IsNotFound(err) {
+		return true, nil
+	}
+
+	return false, err
+}
+
 // GenerateName generates a name using the same algorithm as the API server, and
 // verifies temporary name availability. It does not submit the resource
 // to the API server and hence it does not fall over validation errors.
@@ -70,6 +84,23 @@ func (r *nameGenerator) GenerateName(ctx context.Context, cd resource.Object) er
 	if cd.GetName() != "" || cd.GetGenerateName() == "" {
 		return nil
 	}
+
+	// If we find the right information on the resource, try once.
+	compositeName := xcrd.GetCompositionResourceName(cd)
+	if compositeName != "" {
+		owner := metav1.GetControllerOf(cd)
+		if owner != nil && owner.UID != "" {
+			name := ChildName(cd.GetGenerateName(), fmt.Sprintf("%s-%s", compositeName, owner.UID))
+			if available, err := r.isAvailable(ctx, cd, name); err != nil {
+				return err
+			} else if available {
+				// The name is available.
+				cd.SetName(name)
+				return nil
+			}
+		}
+	}
+	// Fallback to a random name.
 
 	// We guess a random name and verify that it is available. Names can become
 	// unavailable shortly after. We accept that very little risk of a name collision though:
@@ -86,18 +117,12 @@ func (r *nameGenerator) GenerateName(ctx context.Context, cd resource.Object) er
 	maxTries := 10
 	for range maxTries {
 		name := r.namer.GenerateName(cd.GetGenerateName())
-		obj := composite.Unstructured{}
-		obj.SetGroupVersionKind(cd.GetObjectKind().GroupVersionKind())
-
-		err := r.reader.Get(ctx, client.ObjectKey{Name: name}, &obj)
-		if kerrors.IsNotFound(err) {
+		if available, err := r.isAvailable(ctx, cd, name); err != nil {
+			return err
+		} else if available {
 			// The name is available.
 			cd.SetName(name)
 			return nil
-		}
-
-		if err != nil {
-			return err
 		}
 	}
 

--- a/internal/names/generate.go
+++ b/internal/names/generate.go
@@ -99,13 +99,8 @@ func (r *nameGenerator) GenerateName(ctx context.Context, cd resource.Object) er
 			uidParts := strings.Split(string(owner.UID), "-")
 			uidPart := uidParts[len(uidParts)-1]
 			name := ChildName(fmt.Sprintf("%s%s", cd.GetGenerateName(), uidPart), fmt.Sprintf("-%s", cName))
-			if available, err := r.isAvailable(ctx, cd, name); err != nil {
-				return err
-			} else if available {
-				// The name is available.
-				cd.SetName(name)
-				return nil
-			}
+			cd.SetName(name)
+			return nil
 		}
 	}
 	// Fallback to a random name.

--- a/internal/names/generate.go
+++ b/internal/names/generate.go
@@ -20,7 +20,7 @@ package names
 import (
 	"context"
 	"fmt"
-	"github.com/crossplane/crossplane/internal/xcrd"
+
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apiserver/pkg/storage/names"
@@ -29,6 +29,8 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/errors"
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
 	"github.com/crossplane/crossplane-runtime/pkg/resource/unstructured/composite"
+
+	"github.com/crossplane/crossplane/internal/xcrd"
 )
 
 const (

--- a/internal/names/generate_test.go
+++ b/internal/names/generate_test.go
@@ -174,7 +174,7 @@ func TestGenerateName(t *testing.T) {
 			client: &test.MockClient{MockGet: test.NewMockGetFn(kerrors.NewNotFound(schema.GroupResource{Resource: "CoolResource"}, "cool-resource-42"))},
 			args: args{
 				cd: &fake.Composed{ObjectMeta: metav1.ObjectMeta{
-					GenerateName: "cool-resource-",
+					GenerateName: "cool-resource-with-a-really-long-name-that-can-not-fit-all-in-one-place-",
 					OwnerReferences: []metav1.OwnerReference{{
 						APIVersion: "Foo/v1",
 						Kind:       "Bar",
@@ -189,8 +189,8 @@ func TestGenerateName(t *testing.T) {
 			},
 			want: want{
 				cd: &fake.Composed{ObjectMeta: metav1.ObjectMeta{
-					GenerateName: "cool-resource-",
-					Name:         "cool-resource-59f97ca4a7eebb99beb694a77f42de28pipeline-name-of",
+					GenerateName: "cool-resource-with-a-really-long-name-that-can-not-fit-all-in-one-place-",
+					Name:         "cool-resource-with-a-really-lonab455e7d35d099adea15e918d64db893",
 					OwnerReferences: []metav1.OwnerReference{{
 						APIVersion: "Foo/v1",
 						Kind:       "Bar",
@@ -225,7 +225,7 @@ func TestGenerateName(t *testing.T) {
 			want: want{
 				cd: &fake.Composed{ObjectMeta: metav1.ObjectMeta{
 					GenerateName: "cool-resource-",
-					Name:         "cool-resource-kid1-75e4a668-035f-4ce8-8c45-f4d3ac850155",
+					Name:         "cool-resource-f4d3ac850155-kid1",
 					OwnerReferences: []metav1.OwnerReference{{
 						APIVersion: "Foo/v1",
 						Kind:       "Bar",

--- a/internal/names/generate_test.go
+++ b/internal/names/generate_test.go
@@ -18,11 +18,10 @@ package names
 
 import (
 	"context"
-	"github.com/aws/smithy-go/ptr"
-	"github.com/crossplane/crossplane/internal/xcrd"
 	"strconv"
 	"testing"
 
+	"github.com/aws/smithy-go/ptr"
 	"github.com/google/go-cmp/cmp"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -33,6 +32,8 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
 	"github.com/crossplane/crossplane-runtime/pkg/resource/fake"
 	"github.com/crossplane/crossplane-runtime/pkg/test"
+
+	"github.com/crossplane/crossplane/internal/xcrd"
 )
 
 func TestGenerateName(t *testing.T) {

--- a/internal/names/names.go
+++ b/internal/names/names.go
@@ -42,7 +42,7 @@ import (
 )
 
 // The longest name supported by the K8s is 63.
-// These constants
+// These constants.
 const (
 	longest = 63
 	md5Len  = 32

--- a/internal/names/names.go
+++ b/internal/names/names.go
@@ -1,0 +1,94 @@
+/*
+Copyright 2025 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Forked from https://github.com/knative/pkg/blob/ee1db869c7ef25eb4ac5c9ba0ab73fdc3f1b9dfa/kmeta/names.go
+
+/*
+copyright 2019 the knative authors
+
+licensed under the apache license, version 2.0 (the "license");
+you may not use this file except in compliance with the license.
+you may obtain a copy of the license at
+
+    http://www.apache.org/licenses/license-2.0
+
+unless required by applicable law or agreed to in writing, software
+distributed under the license is distributed on an "as is" basis,
+without warranties or conditions of any kind, either express or implied.
+see the license for the specific language governing permissions and
+limitations under the license.
+*/
+
+package names
+
+import (
+	"crypto/md5" //nolint:gosec // No strong cryptography needed.
+	"encoding/hex"
+	"fmt"
+	"regexp"
+)
+
+// The longest name supported by the K8s is 63.
+// These constants
+const (
+	longest = 63
+	md5Len  = 32
+	head    = longest - md5Len // How much to truncate to fit the hash.
+)
+
+var isAlphanumeric = regexp.MustCompile(`^[a-zA-Z0-9]*$`)
+
+// ChildName generates a name for the resource based upon the parent resource and suffix.
+// If the concatenated name is longer than K8s permits the name is hashed and truncated to permit
+// construction of the resource, but still keeps it unique.
+// If the suffix itself is longer than 31 characters, then the whole string will be hashed
+// and `parent|hash|suffix` will be returned, where parent and suffix will be trimmed to
+// fit (prefix of parent at most of length 31, and prefix of suffix at most length 30).
+func ChildName(parent, suffix string) string {
+	n := parent
+	if len(parent) > (longest - len(suffix)) {
+		// If the suffix is longer than the longest allowed suffix, then
+		// we hash the whole combined string and use that as the suffix.
+		if head-len(suffix) <= 0 {
+			//nolint:gosec // No strong cryptography needed.
+			h := md5.Sum([]byte(parent + suffix))
+			// 1. trim parent, if needed
+			if head < len(parent) {
+				parent = parent[:head]
+			}
+			// Format the return string, if it's shorter than longest: pad with
+			// beginning of the suffix. This happens, for example, when parent is
+			// short, but the suffix is very long.
+			ret := parent + hex.EncodeToString(h[:])
+			if d := longest - len(ret); d > 0 {
+				ret += suffix[:d]
+			}
+			return makeValidName(ret)
+		}
+		//nolint:gosec // No strong cryptography needed.
+		n = fmt.Sprintf("%s%x", parent[:head-len(suffix)], md5.Sum([]byte(parent)))
+	}
+	return n + suffix
+}
+
+// If due to trimming above we're terminating the string with a non-alphanumeric
+// character, remove it.
+func makeValidName(n string) string {
+	for i := len(n) - 1; !isAlphanumeric.MatchString(string(n[i])); i-- {
+		n = n[:len(n)-1]
+	}
+	return n
+}

--- a/internal/names/names_test.go
+++ b/internal/names/names_test.go
@@ -1,0 +1,97 @@
+/*
+Copyright 2025 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Forked from https://github.com/knative/pkg/blob/ee1db869c7ef25eb4ac5c9ba0ab73fdc3f1b9dfa/kmeta/names_test.go
+
+/*
+copyright 2019 the knative authors
+
+licensed under the apache license, version 2.0 (the "license");
+you may not use this file except in compliance with the license.
+you may obtain a copy of the license at
+
+    http://www.apache.org/licenses/license-2.0
+
+unless required by applicable law or agreed to in writing, software
+distributed under the license is distributed on an "as is" basis,
+without warranties or conditions of any kind, either express or implied.
+see the license for the specific language governing permissions and
+limitations under the license.
+*/
+
+package names
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"k8s.io/apimachinery/pkg/util/validation"
+)
+
+func TestChildName(t *testing.T) {
+	tests := []struct {
+		parent string
+		suffix string
+		want   string
+	}{
+		{
+			parent: "asdf",
+			suffix: "-deployment",
+			want:   "asdf-deployment",
+		}, {
+			parent: strings.Repeat("f", 63),
+			suffix: "-deployment",
+			want:   "ffffffffffffffffffff105d7597f637e83cc711605ac3ea4957-deployment",
+		}, {
+			parent: strings.Repeat("f", 63),
+			suffix: "-deploy",
+			want:   "ffffffffffffffffffffffff105d7597f637e83cc711605ac3ea4957-deploy",
+		}, {
+			parent: strings.Repeat("f", 63),
+			suffix: strings.Repeat("f", 63),
+			want:   "fffffffffffffffffffffffffffffff0502661254f13c89973cb3a83e0cbec0",
+		}, {
+			parent: "a",
+			suffix: strings.Repeat("f", 63),
+			want:   "ab5cfd486935decbc0d305799f4ce4414ffffffffffffffffffffffffffffff",
+		}, {
+			parent: strings.Repeat("b", 32),
+			suffix: strings.Repeat("f", 32),
+			want:   "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb329c7c81b9ab3ba71aa139066aa5625d",
+		}, {
+			parent: "aaaa",
+			suffix: strings.Repeat("b---a", 20),
+			want:   "aaaa7a3f7966594e3f0849720eced8212c18b---ab---ab---ab---ab---ab",
+		}, {
+			parent: strings.Repeat("a", 17),
+			suffix: "a.-.-.-.-.-.-.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+			want:   "aaaaaaaaaaaaaaaaaa1eb10dc911444f8434af83b7225442da",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.parent+"-"+test.suffix, func(t *testing.T) {
+			got, want := ChildName(test.parent, test.suffix), test.want
+			if errs := validation.IsDNS1123Subdomain(got); len(errs) != 0 {
+				t.Errorf("Invalid DNS1123 Subdomain %s\n\n Errors: %v", got, errs)
+			}
+			if got != want {
+				t.Errorf("%s-%s: got: %63s want: %63s\ndiff:%s", test.parent, test.suffix, got, want, cmp.Diff(want, got))
+			}
+		})
+	}
+}

--- a/internal/xcrd/composite.go
+++ b/internal/xcrd/composite.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package composite
+package xcrd
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -24,17 +24,18 @@ import (
 
 // Annotation keys.
 const (
+	// AnnotationKeyCompositionResourceName is the name of the composite resource as described from a composition.
 	AnnotationKeyCompositionResourceName = "crossplane.io/composition-resource-name"
 )
 
 // SetCompositionResourceName sets the name of the composition template used to
 // reconcile a composed resource as an annotation.
-func SetCompositionResourceName(o metav1.Object, n ResourceName) {
-	meta.AddAnnotations(o, map[string]string{AnnotationKeyCompositionResourceName: string(n)})
+func SetCompositionResourceName(o metav1.Object, n string) {
+	meta.AddAnnotations(o, map[string]string{AnnotationKeyCompositionResourceName: n})
 }
 
 // GetCompositionResourceName gets the name of the composition template used to
 // reconcile a composed resource from its annotations.
-func GetCompositionResourceName(o metav1.Object) ResourceName {
-	return ResourceName(o.GetAnnotations()[AnnotationKeyCompositionResourceName])
+func GetCompositionResourceName(o metav1.Object) string {
+	return o.GetAnnotations()[AnnotationKeyCompositionResourceName]
 }


### PR DESCRIPTION
fixes: https://github.com/crossplane/crossplane/issues/6631

This PR adds deterministic child name generation based on the UID of the parent, and the key of the composite resource from the pipeline, and a fork of Knative's ChildName method to shrink all that if it is too large.

New names will be in the form: `<PrefixForComposed>-<CompositionResourceName>-<Parent UID>`

---

We have identified a critical issue with resource name consistency in Crossplane's composition function pipeline when composed resources fail to be created or are deleted and need to be recreated.

## The Problem

  When a composite resource (XR) has resource references in spec.resourceRefs but the actual composed resources either don't exist in the cluster (e.g., due to external deletion) or failed to be created during previous
  reconciliation attempts, the composition function pipeline generates new random names for the resources instead of reusing the existing names from the resource references.

## Root Cause

  The issue stems from a fundamental gap in how the composition system links function pipeline resource names to XR resource references:

  1. Function Pipeline Context: The composition function pipeline works with logical resource names (e.g., "database", "web-server") that identify resources within the composition template.
  2. XR Resource References: The XR's spec.resourceRefs contains actual Kubernetes resource references with concrete names (e.g., "my-app-db-abc123", "my-app-web-def456") that were generated during previous
  reconciliations or failed creation attempts.
  3. Missing Link: The only connection between these two naming schemes is stored in the crossplane.io/composition-resource-name annotation on the actual composed resource instances. When the composed resource is
  deleted from the cluster or fails to be created, this critical linking information is lost or never established.
  4. Broken Chain: During resource observation (ObserveComposedResources), if a resource referenced in spec.resourceRefs doesn't exist in the cluster, the system cannot determine which function pipeline resource name it
   corresponds to, so it's excluded from the observed state.
  5. Name Regeneration: Later, when the function pipeline produces a desired resource with a logical name (e.g., "database"), the system cannot find it in the observed state (because the link was broken or never
  established), so it generates a completely new random name instead of reusing the existing reference.

## Impact

This bug causes:
  - Resource name drift: Resources get different names each time they're recreated or retried after failed creation
  - Broken references: External systems that reference composed resources by name lose their connections
  - Inconsistent behavior: The same composition produces different resource names across reconciliation cycles
  - Potential resource leaks: Lost references may prevent proper cleanup of orphaned resources
  - Creation retry failures: Failed resource creation attempts result in new names on retry, potentially creating confusion and inconsistency

## Example Scenarios

### Scenario 1 - Resource Deletion:
  1. Initial state: XR has spec.resourceRefs with {name: "my-app-db-abc123", kind: "Database"}
  2. The Database resource "my-app-db-abc123" gets deleted externally
  3. Next reconciliation: Function pipeline requests a "database" resource
  4. System cannot link "database" (function name) to "my-app-db-abc123" (reference name) because the linking annotation was on the deleted resource
  5. Result: New Database resource gets created with a different random name like "my-app-db-xyz789"

### Scenario 2 - Failed Resource Creation:
  1. Initial state: XR has spec.resourceRefs with {name: "my-app-db-abc123", kind: "Database"}
  2. The Database resource "my-app-db-abc123" fails to be created (e.g., due to validation errors, insufficient permissions, or resource constraints)
  3. Next reconciliation: Function pipeline requests a "database" resource
  4. System cannot link "database" (function name) to "my-app-db-abc123" (reference name) because the resource was never successfully created and doesn't have the linking annotation
  5. Result: New Database resource gets created with a different random name like "my-app-db-xyz789"

The core issue is that the composition system lacks a persistent mapping between function pipeline resource names and XR resource references that survives resource deletion or creation failures.

---

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `earthly +reviewable` to ensure this PR is ready for review.
- [x] Added or updated unit tests.
~- [ ] Added or updated e2e tests.~
~- [ ] Linked a PR or a [docs tracking issue] to [document this change].~
~- [ ] Added `backport release-x.y` labels to auto-backport this PR.~
~- [ ] Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md