### PR TITLE
Pass provider, function and revisions names to runtime pods

### DIFF
--- a/apis/pkg/v1/interfaces.go
+++ b/apis/pkg/v1/interfaces.go
@@ -43,6 +43,15 @@ const (
 	// revisions, and can be used to select all provider revisions that belong
 	// to a particular family. It is not added to providers, only revisions.
 	LabelProviderFamily = "pkg.crossplane.io/provider-family"
+
+	// LabelProvider is used as the key for the provider name label.
+	LabelProvider = "pkg.crossplane.io/provider"
+
+	// LabelFunction is used as the key for the function name label.
+	LabelFunction = "pkg.crossplane.io/function"
+
+	// LabelRevision is used as the key for the package revision name label.
+	LabelRevision = "pkg.crossplane.io/revision"
 )
 
 var (

--- a/cmd/crank/beta/top/top_test.go
+++ b/cmd/crank/beta/top/top_test.go
@@ -11,6 +11,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/crossplane/crossplane-runtime/pkg/test"
+
+	v1 "github.com/crossplane/crossplane/apis/pkg/v1"
 )
 
 func TestGetCrossplanePods(t *testing.T) {
@@ -40,7 +42,7 @@ func TestGetCrossplanePods(t *testing.T) {
 						Name:      "function-12345abcd-xyzwv",
 						Namespace: "crossplane-system",
 						Labels: map[string]string{
-							"pkg.crossplane.io/function": "function-go-templating",
+							v1.LabelFunction: "function-go-templating",
 						},
 					},
 				},
@@ -88,7 +90,7 @@ func TestGetCrossplanePods(t *testing.T) {
 						Name:      "function-go-templating-213wer",
 						Namespace: "crossplane-system",
 						Labels: map[string]string{
-							"pkg.crossplane.io/function": "function-go-templating",
+							v1.LabelFunction: "function-go-templating",
 						},
 					},
 				},
@@ -97,7 +99,7 @@ func TestGetCrossplanePods(t *testing.T) {
 						Name:      "provider-azure-storage",
 						Namespace: "crossplane-system",
 						Labels: map[string]string{
-							"pkg.crossplane.io/provider": "provider-azure-storage",
+							v1.LabelProvider: "provider-azure-storage",
 						},
 					},
 				},

--- a/internal/controller/pkg/runtime/migration.go
+++ b/internal/controller/pkg/runtime/migration.go
@@ -115,7 +115,7 @@ func (m *DeletingDeploymentSelectorMigrator) MigrateDeploymentSelector(ctx conte
 		return nil
 	}
 
-	expected := existingDeploy.Spec.Selector.MatchLabels["pkg.crossplane.io/provider"]
+	expected := existingDeploy.Spec.Selector.MatchLabels[v1.LabelProvider]
 
 	// Check if the provider label needs migration
 	if expected == existing {

--- a/internal/controller/pkg/runtime/migration_test.go
+++ b/internal/controller/pkg/runtime/migration_test.go
@@ -242,7 +242,7 @@ func TestDeletingDeploymentSelectorMigrator_MigrateDeploymentSelector(t *testing
 						deploy.Namespace = testNamespaceName
 						deploy.Spec.Selector = &metav1.LabelSelector{
 							MatchLabels: map[string]string{
-								"pkg.crossplane.io/provider": "crossplane-provider-nop",
+								v1.LabelProvider: "crossplane-provider-nop",
 							},
 						}
 						return nil
@@ -276,7 +276,7 @@ func TestDeletingDeploymentSelectorMigrator_MigrateDeploymentSelector(t *testing
 						deploy.Namespace = testNamespaceName
 						deploy.Spec.Selector = &metav1.LabelSelector{
 							MatchLabels: map[string]string{
-								"pkg.crossplane.io/provider": "provider-nop", // Old format
+								v1.LabelProvider: "provider-nop", // Old format
 							},
 						}
 						return nil
@@ -290,7 +290,7 @@ func TestDeletingDeploymentSelectorMigrator_MigrateDeploymentSelector(t *testing
 							Spec: appsv1.DeploymentSpec{
 								Selector: &metav1.LabelSelector{
 									MatchLabels: map[string]string{
-										"pkg.crossplane.io/provider": "provider-nop",
+										v1.LabelProvider: "provider-nop",
 									},
 								},
 							},
@@ -330,7 +330,7 @@ func TestDeletingDeploymentSelectorMigrator_MigrateDeploymentSelector(t *testing
 						deploy.Namespace = testNamespaceName
 						deploy.Spec.Selector = &metav1.LabelSelector{
 							MatchLabels: map[string]string{
-								"pkg.crossplane.io/provider": "provider-nop", // Old format
+								v1.LabelProvider: "provider-nop", // Old format
 							},
 						}
 						return nil

--- a/internal/controller/pkg/runtime/runtime.go
+++ b/internal/controller/pkg/runtime/runtime.go
@@ -331,7 +331,7 @@ func (b *DeploymentRuntimeBuilder) TLSServerSecret() *corev1.Secret {
 
 func (b *DeploymentRuntimeBuilder) podSelectors() map[string]string {
 	return map[string]string{
-		"pkg.crossplane.io/revision":           b.revision.GetName(),
+		v1.LabelRevision:                       b.revision.GetName(),
 		"pkg.crossplane.io/" + b.packageType(): b.packageName(),
 	}
 }

--- a/internal/controller/pkg/runtime/runtime_provider.go
+++ b/internal/controller/pkg/runtime/runtime_provider.go
@@ -205,6 +205,26 @@ func providerDeploymentOverrides(pr v1.PackageRevisionWithRuntime, image string)
 					},
 				},
 			},
+			{
+				Name: "PROVIDER_NAME",
+				ValueFrom: &corev1.EnvVarSource{
+					FieldRef: &corev1.ObjectFieldSelector{
+						FieldPath: fmt.Sprintf("metadata.labels['%s']", v1.LabelProvider),
+					},
+				},
+			},
+			{
+				Name: "REVISION_NAME",
+				ValueFrom: &corev1.EnvVarSource{
+					FieldRef: &corev1.ObjectFieldSelector{
+						FieldPath: fmt.Sprintf("metadata.labels['%s']", v1.LabelRevision),
+					},
+				},
+			},
+			{
+				Name:  "REVISION_UID",
+				Value: string(pr.GetUID()),
+			},
 		}),
 
 		// Add optional scrape annotations to the deployment. It is possible to


### PR DESCRIPTION
### Description of your changes

There could be some cases where the process running inside the provider/function runtime may want to know the provider or revision name.
This PR passes `REVISION_NAME`, `REVISION_UID` and  `PROVIDER_NAME` or `FUNCTION_NAME` environment variables to runtime pods through downwards api.

I've validated the resulting function has the following, and I can access the correct values from the process running inside (similarly for provider): 

```yaml
      containers:
      - env:
       - name: FUNCTION_NAME
          valueFrom:
            fieldRef:
              apiVersion: v1
              fieldPath: metadata.labels['pkg.crossplane.io/function']
        - name: REVISION_NAME
          valueFrom:
            fieldRef:
              apiVersion: v1
              fieldPath: metadata.labels['pkg.crossplane.io/revision']
        - name: REVISION_UID
          value: 87d9b221-3608-4ba5-b421-b2282e616cea
```

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `earthly +reviewable` to ensure this PR is ready for review.
- [x] Added or updated unit tests.
- [ ] ~Added or updated e2e tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~
- [ ] ~Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md