### PR TITLE
chore: clean up info mailing list link, remove obsolete dev mailing list

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ a bug, suggest an improvement, or request a new feature please open an [issue
 against Crossplane] or the relevant provider. Refer to our [contributing guide]
 for more information on how you can help.
 
-* Discuss Crossplane on [Slack] or our [developer mailing list].
+* Discuss Crossplane on [Slack].
 * Follow us on [Bluesky], [Twitter], or [LinkedIn].
 * Contact us via [Email].
 * Join our regular community meetings.
@@ -120,11 +120,10 @@ Crossplane is under the Apache 2.0 license.
 [release cycle documentation]: https://docs.crossplane.io/knowledge-base/guides/release-cycle
 [install]: https://crossplane.io/docs/latest
 [Slack]: https://slack.crossplane.io
-[developer mailing list]: https://groups.google.com/forum/#!forum/crossplane-dev
 [Bluesky]: https://bsky.app/profile/crossplane.io
 [Twitter]: https://twitter.com/crossplane_io
 [LinkedIn]: https://www.linkedin.com/company/crossplane/
-[Email]: crossplane-info@lists.cncf.io
+[Email]: mailto:crossplane-info@lists.cncf.io
 [issue against Crossplane]: https://github.com/crossplane/crossplane/issues
 [contributing guide]: contributing/README.md
 [community meeting time]: https://www.thetimezoneconverter.com/?t=10:00&tz=PT%20%28Pacific%20Time%29


### PR DESCRIPTION
### Description of your changes

This PR makes 2 minor updates to the README:

* fixes the format of the info mailing list link
* removes the obsolete dev mailing list, which hasn't been used in years

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `earthly +reviewable` to ensure this PR is ready for review.
- [ ] ~Added or updated unit tests.~
- [ ] ~Added or updated e2e tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~
- [ ] ~Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md