### PR TITLE
Conform

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ gitlab/
 # go build output (from go build ./cmd/crank etc)
 /crank
 /crossplane
+
+# ignore AI tools settings/config
+/.claude

--- a/internal/controller/apiextensions/managed/reconciler.go
+++ b/internal/controller/apiextensions/managed/reconciler.go
@@ -19,12 +19,12 @@ package managed
 
 import (
 	"context"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"time"
 
 	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"

--- a/internal/xcrd/crd_test.go
+++ b/internal/xcrd/crd_test.go
@@ -431,18 +431,6 @@ func TestForCompositeResource(t *testing.T) {
 														},
 													},
 												},
-												"crossplane": {
-													Description: "Indicates how Crossplane is reconciling this composite resource",
-													Type:        "object",
-													Properties: map[string]extv1.JSONSchemaProps{
-														"connectionDetails": {
-															Type: "object",
-															Properties: map[string]extv1.JSONSchemaProps{
-																"lastPublishedTime": {Type: "string", Format: "date-time"},
-															},
-														},
-													},
-												},
 											},
 											XValidations: extv1.ValidationRules{
 												{

--- a/internal/xcrd/schemas.go
+++ b/internal/xcrd/schemas.go
@@ -320,19 +320,8 @@ func CompositeResourceStatusProps(s v1.CompositeResourceScope) map[string]extv1.
 
 	switch s {
 	case v1.CompositeResourceScopeNamespaced, v1.CompositeResourceScopeCluster:
-		// Modern XRs use status.crossplane, and don't support claims.
-		props["crossplane"] = extv1.JSONSchemaProps{
-			Type:        "object",
-			Description: "Indicates how Crossplane is reconciling this composite resource",
-			Properties: map[string]extv1.JSONSchemaProps{
-				"connectionDetails": {
-					Type: "object",
-					Properties: map[string]extv1.JSONSchemaProps{
-						"lastPublishedTime": {Type: "string", Format: "date-time"},
-					},
-				},
-			},
-		}
+		// Modern XRs don't have connection details or support claims, so
+		// there's nothing else to put in the status for them
 	case v1.CompositeResourceScopeLegacyCluster:
 		// Legacy XRs don't use status.crossplane, and support claims.
 		props["connectionDetails"] = extv1.JSONSchemaProps{

--- a/test/e2e/apiextensions_activation_policy_test.go
+++ b/test/e2e/apiextensions_activation_policy_test.go
@@ -17,11 +17,11 @@ limitations under the License.
 package e2e
 
 import (
-	"sigs.k8s.io/e2e-framework/third_party/helm"
 	"testing"
 	"time"
 
 	"sigs.k8s.io/e2e-framework/pkg/features"
+	"sigs.k8s.io/e2e-framework/third_party/helm"
 
 	"github.com/crossplane/crossplane/apis/apiextensions/v2alpha1"
 	"github.com/crossplane/crossplane/test/e2e/config"


### PR DESCRIPTION
### Description of your changes

This PR removes `.status.crossplane.connectionDetails` from the schema of modern XRs.

I have tested this with the latest v2 conformance tests from https://github.com/crossplane/conformance/pull/31.  The `TestCompositeResourceDefinition*` tests were failing because of this unexpected field and now they are happy.

```
❯ go test -v -run TestCompositeResourceDefinitionNamespace tests/*
=== RUN   TestCompositeResourceDefinitionNamespace
    apiextensions_test.go:82: Created XRD "namespaceconformances.test.crossplane.io"
=== RUN   TestCompositeResourceDefinitionNamespace/BecomesEstablished
    apiextensions_test.go:523: Testing that the XRD's Established status condition becomes 'True'.
    apiextensions_test.go:530: XRD "namespaceconformances.test.crossplane.io" is not yet Established
    apiextensions_test.go:539: XRD "namespaceconformances.test.crossplane.io" is Established
=== RUN   TestCompositeResourceDefinitionNamespace/CRDIsCreatedForXR
    apiextensions_test.go:99: Testing that the XRD creates a conformant CRD for its XR.
    apiextensions_test.go:569: XRD "namespaceconformances.test.crossplane.io" created a conformant XR CRD
=== NAME  TestCompositeResourceDefinitionNamespace
    apiextensions_test.go:85: Cleaning up XRD "namespaceconformances.test.crossplane.io".
    apiextensions_test.go:92: Deleted XRD "namespaceconformances.test.crossplane.io"
--- PASS: TestCompositeResourceDefinitionNamespace (10.08s)
    --- PASS: TestCompositeResourceDefinitionNamespace/BecomesEstablished (10.01s)
    --- PASS: TestCompositeResourceDefinitionNamespace/CRDIsCreatedForXR (0.04s)
PASS
ok  	command-line-arguments	10.492s
```

Fixes #6652

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `earthly +reviewable` to ensure this PR is ready for review.
- [x] Added or updated unit tests.
- [ ] ~Added or updated e2e tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~
- [ ] ~Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md