### PR TITLE
Mutate MRDs in the APIEstablisher validate method like CRDs

### DIFF
--- a/apis/apiextensions/v2alpha1/mrd_types.go
+++ b/apis/apiextensions/v2alpha1/mrd_types.go
@@ -34,7 +34,7 @@ type ManagedResourceDefinitionSpec struct {
 	// +kubebuilder:validation:Enum=Active;Inactive
 	// +kubebuilder:default=Inactive
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf || oldSelf != 'Active'",message="state cannot be changed once it becomes Active"
-	State ManagedResourceDefinitionState `json:"state"`
+	State ManagedResourceDefinitionState `json:"state,omitempty"`
 }
 
 // ManagedResourceDefinitionState is the state of the resource definition.

--- a/cluster/crds/apiextensions.crossplane.io_managedresourcedefinitions.yaml
+++ b/cluster/crds/apiextensions.crossplane.io_managedresourcedefinitions.yaml
@@ -452,7 +452,6 @@ spec:
             - group
             - names
             - scope
-            - state
             - versions
             type: object
           status:

--- a/internal/converter/custom_to_managed_test.go
+++ b/internal/converter/custom_to_managed_test.go
@@ -135,102 +135,90 @@ func TestCustomToManagedResourceDefinitions(t *testing.T) {
 	}
 
 	// Expected MRD from structured CRD (inactive)
-	expectedMRDFromCRDInactive := &unstructured.Unstructured{
-		Object: map[string]any{
-			"apiVersion": v2alpha1.SchemeGroupVersion.String(),
-			"kind":       v2alpha1.ManagedResourceDefinitionKind,
-			"metadata": map[string]any{
-				"creationTimestamp": nil,
-				"name":              "buckets.example.org",
-				"namespace":         "test-namespace",
-			},
-			"spec": map[string]any{
-				"group": "example.org",
-				"names": map[string]any{
-					"kind":     "Bucket",
-					"plural":   "buckets",
-					"singular": "bucket",
+	expectedMRDFromCRDInactive := &v2alpha1.ManagedResourceDefinition{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "apiextensions.crossplane.io/v2alpha1",
+			Kind:       "ManagedResourceDefinition",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "buckets.example.org",
+			Namespace: "test-namespace",
+		},
+		Spec: v2alpha1.ManagedResourceDefinitionSpec{
+			CustomResourceDefinitionSpec: v2alpha1.CustomResourceDefinitionSpec{
+				Group: "example.org",
+				Names: extv1.CustomResourceDefinitionNames{
+					Kind:     "Bucket",
+					Plural:   "buckets",
+					Singular: "bucket",
 				},
-				"scope": "Namespaced",
-				"versions": []any{
-					map[string]any{
-						"name":    "v1",
-						"served":  true,
-						"storage": true,
+				Scope: "Namespaced",
+				Versions: []v2alpha1.CustomResourceDefinitionVersion{
+					{
+						Name:    "v1",
+						Served:  true,
+						Storage: true,
 					},
 				},
-			},
-			"status": map[string]any{
-				"acceptedNames": map[string]any{
-					"kind":   "",
-					"plural": "",
-				},
-				"conditions":     nil,
-				"storedVersions": nil,
 			},
 		},
 	}
 
 	// Expected MRD from structured CRD (active)
-	expectedMRDFromCRDActive := &unstructured.Unstructured{
-		Object: map[string]any{
-			"apiVersion": v2alpha1.SchemeGroupVersion.String(),
-			"kind":       v2alpha1.ManagedResourceDefinitionKind,
-			"metadata": map[string]any{
-				"creationTimestamp": nil,
-				"name":              "buckets.example.org",
-				"namespace":         "test-namespace",
-			},
-			"spec": map[string]any{
-				"group": "example.org",
-				"names": map[string]any{
-					"kind":     "Bucket",
-					"plural":   "buckets",
-					"singular": "bucket",
+	expectedMRDFromCRDActive := &v2alpha1.ManagedResourceDefinition{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "apiextensions.crossplane.io/v2alpha1",
+			Kind:       "ManagedResourceDefinition",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "buckets.example.org",
+			Namespace: "test-namespace",
+		},
+		Spec: v2alpha1.ManagedResourceDefinitionSpec{
+			CustomResourceDefinitionSpec: v2alpha1.CustomResourceDefinitionSpec{
+				Group: "example.org",
+				Names: extv1.CustomResourceDefinitionNames{
+					Kind:     "Bucket",
+					Plural:   "buckets",
+					Singular: "bucket",
 				},
-				"scope": "Namespaced",
-				"state": string(v2alpha1.ManagedResourceDefinitionActive),
-				"versions": []any{
-					map[string]any{
-						"name":    "v1",
-						"served":  true,
-						"storage": true,
+				Scope: "Namespaced",
+				Versions: []v2alpha1.CustomResourceDefinitionVersion{
+					{
+						Name:    "v1",
+						Served:  true,
+						Storage: true,
 					},
 				},
 			},
-			"status": map[string]any{
-				"acceptedNames": map[string]any{
-					"kind":   "",
-					"plural": "",
-				},
-				"conditions":     nil,
-				"storedVersions": nil,
-			},
+			State: v2alpha1.ManagedResourceDefinitionActive,
 		},
 	}
 
 	// Expected MRD from unstructured CRD (inactive)
-	expectedMRDFromUnstructuredInactive := &unstructured.Unstructured{
-		Object: map[string]any{
-			"apiVersion": v2alpha1.SchemeGroupVersion.String(),
-			"kind":       v2alpha1.ManagedResourceDefinitionKind,
-			"metadata": map[string]any{
-				"name":      "instances.example.org",
-				"namespace": "test-namespace",
-			},
-			"spec": map[string]any{
-				"group": "example.org",
-				"names": map[string]any{
-					"kind":     "Instance",
-					"plural":   "instances",
-					"singular": "instance",
+	expectedMRDFromUnstructuredInactive := &v2alpha1.ManagedResourceDefinition{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "apiextensions.crossplane.io/v2alpha1",
+			Kind:       "ManagedResourceDefinition",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "instances.example.org",
+			Namespace: "test-namespace",
+		},
+		Spec: v2alpha1.ManagedResourceDefinitionSpec{
+			CustomResourceDefinitionSpec: v2alpha1.CustomResourceDefinitionSpec{
+				Group: "example.org",
+				Names: extv1.CustomResourceDefinitionNames{
+					Kind:     "Instance",
+					Plural:   "instances",
+					Singular: "instance",
 				},
-				"scope": "Namespaced",
-				"versions": []any{
-					map[string]any{
-						"name":    "v1",
-						"served":  true,
-						"storage": true,
+				Scope: "Namespaced",
+				Versions: []v2alpha1.CustomResourceDefinitionVersion{
+					{
+						Name:    "v1",
+						Served:  true,
+						Storage: true,
 					},
 				},
 			},
@@ -238,31 +226,33 @@ func TestCustomToManagedResourceDefinitions(t *testing.T) {
 	}
 
 	// Expected MRD from unstructured CRD (active)
-	expectedMRDFromUnstructuredActive := &unstructured.Unstructured{
-		Object: map[string]any{
-			"apiVersion": v2alpha1.SchemeGroupVersion.String(),
-			"kind":       v2alpha1.ManagedResourceDefinitionKind,
-			"metadata": map[string]any{
-				"name":      "instances.example.org",
-				"namespace": "test-namespace",
-			},
-			"spec": map[string]any{
-				"group": "example.org",
-				"names": map[string]any{
-					"kind":     "Instance",
-					"plural":   "instances",
-					"singular": "instance",
+	expectedMRDFromUnstructuredActive := &v2alpha1.ManagedResourceDefinition{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "apiextensions.crossplane.io/v2alpha1",
+			Kind:       "ManagedResourceDefinition",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "instances.example.org",
+			Namespace: "test-namespace",
+		},
+		Spec: v2alpha1.ManagedResourceDefinitionSpec{
+			CustomResourceDefinitionSpec: v2alpha1.CustomResourceDefinitionSpec{
+				Group: "example.org",
+				Names: extv1.CustomResourceDefinitionNames{
+					Kind:     "Instance",
+					Plural:   "instances",
+					Singular: "instance",
 				},
-				"scope": "Namespaced",
-				"state": string(v2alpha1.ManagedResourceDefinitionActive),
-				"versions": []any{
-					map[string]any{
-						"name":    "v1",
-						"served":  true,
-						"storage": true,
+				Scope: "Namespaced",
+				Versions: []v2alpha1.CustomResourceDefinitionVersion{
+					{
+						Name:    "v1",
+						Served:  true,
+						Storage: true,
 					},
 				},
 			},
+			State: v2alpha1.ManagedResourceDefinitionActive,
 		},
 	}
 
@@ -421,7 +411,7 @@ func TestConvertCRDToMRD(t *testing.T) {
 		in            map[string]any
 	}
 	type want struct {
-		out map[string]any
+		out *v2alpha1.ManagedResourceDefinition
 		err error
 	}
 
@@ -450,17 +440,21 @@ func TestConvertCRDToMRD(t *testing.T) {
 				},
 			},
 			want: want{
-				out: map[string]any{
-					"apiVersion": v2alpha1.SchemeGroupVersion.String(),
-					"kind":       v2alpha1.ManagedResourceDefinitionKind,
-					"metadata": map[string]any{
-						"name": "buckets.example.org",
+				out: &v2alpha1.ManagedResourceDefinition{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "apiextensions.crossplane.io/v2alpha1",
+						Kind:       "ManagedResourceDefinition",
 					},
-					"spec": map[string]any{
-						"group": "example.org",
-						"names": map[string]any{
-							"kind":   "Bucket",
-							"plural": "buckets",
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "buckets.example.org",
+					},
+					Spec: v2alpha1.ManagedResourceDefinitionSpec{
+						CustomResourceDefinitionSpec: v2alpha1.CustomResourceDefinitionSpec{
+							Group: "example.org",
+							Names: extv1.CustomResourceDefinitionNames{
+								Kind:   "Bucket",
+								Plural: "buckets",
+							},
 						},
 					},
 				},
@@ -486,19 +480,23 @@ func TestConvertCRDToMRD(t *testing.T) {
 				},
 			},
 			want: want{
-				out: map[string]any{
-					"apiVersion": v2alpha1.SchemeGroupVersion.String(),
-					"kind":       v2alpha1.ManagedResourceDefinitionKind,
-					"metadata": map[string]any{
-						"name": "buckets.example.org",
+				out: &v2alpha1.ManagedResourceDefinition{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "apiextensions.crossplane.io/v2alpha1",
+						Kind:       "ManagedResourceDefinition",
 					},
-					"spec": map[string]any{
-						"group": "example.org",
-						"names": map[string]any{
-							"kind":   "Bucket",
-							"plural": "buckets",
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "buckets.example.org",
+					},
+					Spec: v2alpha1.ManagedResourceDefinitionSpec{
+						CustomResourceDefinitionSpec: v2alpha1.CustomResourceDefinitionSpec{
+							Group: "example.org",
+							Names: extv1.CustomResourceDefinitionNames{
+								Kind:   "Bucket",
+								Plural: "buckets",
+							},
 						},
-						"state": string(v2alpha1.ManagedResourceDefinitionActive),
+						State: v2alpha1.ManagedResourceDefinitionActive,
 					},
 				},
 			},
@@ -546,42 +544,41 @@ func TestConvertCRDToMRD(t *testing.T) {
 				},
 			},
 			want: want{
-				out: map[string]any{
-					"apiVersion": v2alpha1.SchemeGroupVersion.String(),
-					"kind":       v2alpha1.ManagedResourceDefinitionKind,
-					"metadata": map[string]any{
-						"name":      "databases.example.org",
-						"namespace": "test-namespace",
-						"labels": map[string]any{
+				out: &v2alpha1.ManagedResourceDefinition{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "apiextensions.crossplane.io/v2alpha1",
+						Kind:       "ManagedResourceDefinition",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "databases.example.org",
+						Namespace: "test-namespace",
+						Labels: map[string]string{
 							"app": "test",
 						},
 					},
-					"spec": map[string]any{
-						"group": "example.org",
-						"names": map[string]any{
-							"kind":     "Database",
-							"plural":   "databases",
-							"singular": "database",
-						},
-						"scope": "Namespaced",
-						"state": string(v2alpha1.ManagedResourceDefinitionActive),
-						"versions": []any{
-							map[string]any{
-								"name":    "v1",
-								"served":  true,
-								"storage": true,
-								"schema": map[string]any{
-									"openAPIV3Schema": map[string]any{
-										"type": "object",
-										"properties": map[string]any{
-											"spec": map[string]any{
-												"type": "object",
-											},
+					Spec: v2alpha1.ManagedResourceDefinitionSpec{
+						CustomResourceDefinitionSpec: v2alpha1.CustomResourceDefinitionSpec{
+							Group: "example.org",
+							Names: extv1.CustomResourceDefinitionNames{
+								Kind:     "Database",
+								Plural:   "databases",
+								Singular: "database",
+							},
+							Scope: "Namespaced",
+							Versions: []v2alpha1.CustomResourceDefinitionVersion{
+								{
+									Name:    "v1",
+									Served:  true,
+									Storage: true,
+									Schema: &v2alpha1.CustomResourceValidation{
+										OpenAPIV3Schema: runtime.RawExtension{
+											Raw: []byte(`{"properties":{"spec":{"type":"object"}},"type":"object"}`),
 										},
 									},
 								},
 							},
 						},
+						State: v2alpha1.ManagedResourceDefinitionActive,
 					},
 				},
 			},
@@ -600,13 +597,14 @@ func TestConvertCRDToMRD(t *testing.T) {
 				},
 			},
 			want: want{
-				out: map[string]any{
-					"apiVersion": v2alpha1.SchemeGroupVersion.String(),
-					"kind":       v2alpha1.ManagedResourceDefinitionKind,
-					"metadata": map[string]any{
-						"name": "minimal.example.org",
+				out: &v2alpha1.ManagedResourceDefinition{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "apiextensions.crossplane.io/v2alpha1",
+						Kind:       "ManagedResourceDefinition",
 					},
-					"spec": map[string]any{},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "minimal.example.org",
+					},
 				},
 			},
 		},
@@ -624,36 +622,16 @@ func TestConvertCRDToMRD(t *testing.T) {
 				},
 			},
 			want: want{
-				out: map[string]any{
-					"apiVersion": v2alpha1.SchemeGroupVersion.String(),
-					"kind":       v2alpha1.ManagedResourceDefinitionKind,
-					"metadata": map[string]any{
-						"name": "minimal.example.org",
+				out: &v2alpha1.ManagedResourceDefinition{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "apiextensions.crossplane.io/v2alpha1",
+						Kind:       "ManagedResourceDefinition",
 					},
-					"spec": map[string]any{
-						"state": string(v2alpha1.ManagedResourceDefinitionActive),
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "minimal.example.org",
 					},
-				},
-			},
-		},
-		"InvalidInputStructure": {
-			reason: "Should handle invalid input structure gracefully",
-			args: args{
-				defaultActive: false,
-				in: map[string]any{
-					"apiVersion": 123, // invalid type
-					"kind":       customResourceDefinition,
-					"metadata": map[string]any{
-						"name": "test.example.org",
-					},
-				},
-			},
-			want: want{
-				out: map[string]any{
-					"apiVersion": v2alpha1.SchemeGroupVersion.String(),
-					"kind":       v2alpha1.ManagedResourceDefinitionKind,
-					"metadata": map[string]any{
-						"name": "test.example.org",
+					Spec: v2alpha1.ManagedResourceDefinitionSpec{
+						State: v2alpha1.ManagedResourceDefinitionActive,
 					},
 				},
 			},
@@ -665,11 +643,13 @@ func TestConvertCRDToMRD(t *testing.T) {
 				in:            map[string]any{},
 			},
 			want: want{
-				out: map[string]any{
-					"apiVersion": v2alpha1.SchemeGroupVersion.String(),
-					"kind":       v2alpha1.ManagedResourceDefinitionKind,
-					"spec": map[string]any{
-						"state": string(v2alpha1.ManagedResourceDefinitionActive),
+				out: &v2alpha1.ManagedResourceDefinition{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "apiextensions.crossplane.io/v2alpha1",
+						Kind:       "ManagedResourceDefinition",
+					},
+					Spec: v2alpha1.ManagedResourceDefinitionSpec{
+						State: v2alpha1.ManagedResourceDefinitionActive,
 					},
 				},
 			},
@@ -680,8 +660,15 @@ func TestConvertCRDToMRD(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			got, err := convertCRDToMRD(tc.args.defaultActive, tc.args.in)
 
-			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
-				t.Errorf("\n%s\nconvertCRDToMRD(...): -want error, +got error:\n%s", tc.reason, diff)
+			if tc.want.err != nil {
+				// Just check that we got an error when we expected one
+				if err == nil {
+					t.Errorf("\n%s\nconvertCRDToMRD(...): expected error but got none", tc.reason)
+				}
+			} else {
+				if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
+					t.Errorf("\n%s\nconvertCRDToMRD(...): -want error, +got error:\n%s", tc.reason, diff)
+				}
 			}
 			if diff := cmp.Diff(tc.want.out, got); diff != "" {
 				t.Errorf("\n%s\nconvertCRDToMRD(...): -want, +got:\n%s", tc.reason, diff)

--- a/test/e2e/apiextensions_mrds_test.go
+++ b/test/e2e/apiextensions_mrds_test.go
@@ -33,6 +33,16 @@ func TestMRDValidation(t *testing.T) {
 	cases := features.Table{
 		{
 			// A valid MRD should be created.
+			Name:        "ValidNewMRDIsDefaulted",
+			Description: "A valid MRD should be created with defaults.",
+			Assessment: funcs.AllOf(
+				funcs.ApplyResources(FieldManager, manifests, "mrd-defaulted.yaml"),
+				funcs.ResourcesCreatedWithin(30*time.Second, manifests, "mrd-defaulted.yaml"),
+				funcs.ResourcesHaveConditionWithin(1*time.Minute, manifests, "mrd-defaulted.yaml", v2alpha1.InactiveManaged()),
+			),
+		},
+		{
+			// A valid MRD should be created.
 			Name:        "ValidNewMRDIsAccepted",
 			Description: "A valid MRD should be created.",
 			Assessment: funcs.AllOf(

--- a/test/e2e/manifests/apiextensions/mrd/validation/mrd-defaulted.yaml
+++ b/test/e2e/manifests/apiextensions/mrd/validation/mrd-defaulted.yaml
@@ -1,0 +1,29 @@
+apiVersion: apiextensions.crossplane.io/v2alpha1
+kind: ManagedResourceDefinition
+metadata:
+  name: xnopresources.nop.mrd.example.org
+spec:
+  # state: Inactive <-- This will be defaulted.
+  scope: Namespaced
+  group: nop.mrd.example.org
+  names:
+    kind: XNopResource
+    plural: xnopresources
+    singular: xnopresource
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      subresources:
+        status: { }
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                coolField:
+                  type: string
+              required:
+                - coolField


### PR DESCRIPTION
### Description of your changes

til: crossplane api establisher validate method mutates resources

Update: Also convert the new MRD to a typed object from unstructured. 

Installing the k8s provider: `crossplane xpkg install provider xpkg.crossplane.io/crossplane-contrib/provider-kubernetes:v0.18.0`

```
NAME                                                                                                       STATE    ESTABLISHED   AGE
managedresourcedefinition.apiextensions.crossplane.io/objects.kubernetes.crossplane.io                     Active   Unknown       45s
managedresourcedefinition.apiextensions.crossplane.io/observedobjectcollections.kubernetes.crossplane.io   Active   True          45s
managedresourcedefinition.apiextensions.crossplane.io/providerconfigs.kubernetes.crossplane.io             Active   True          45s
managedresourcedefinition.apiextensions.crossplane.io/providerconfigusages.kubernetes.crossplane.io        Active   True          45s

NAME                                                                INSTALLED   HEALTHY   PACKAGE
                       AGE
provider.pkg.crossplane.io/crossplane-contrib-provider-kubernetes   True        True      xpkg.crossplane.io/crossplane-contrib/provide
r-kubernetes:v0.18.0   48s

kubectl get crd | grep 2025-07-28 
objects.kubernetes.crossplane.io                                2025-07-28T21:29:53Z
observedobjectcollections.kubernetes.crossplane.io              2025-07-28T21:29:53Z
providerconfigs.kubernetes.crossplane.io                        2025-07-28T21:29:53Z
providerconfigusages.kubernetes.crossplane.io                   2025-07-28T21:29:53Z


```


Fixes https://github.com/crossplane-contrib/provider-kubernetes/issues/379

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `earthly +reviewable` to ensure this PR is ready for review.
- [x] Added or updated unit tests.
~- [ ] Added or updated e2e tests.~
- [x] Linked a PR or a [docs tracking issue] to [document this change].
~- [ ] Added `backport release-x.y` labels to auto-backport this PR.~
~- [ ] Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md