### PR TITLE
Use a standard to represent the deleted time in a named operation

### DIFF
--- a/internal/controller/ops/watched/reconciler.go
+++ b/internal/controller/ops/watched/reconciler.go
@@ -214,7 +214,7 @@ func OperationName(wo *v1alpha1.WatchOperation, watched *unstructured.Unstructur
 	// ensure different resource instances (even with the same
 	// name/namespace) create different Operation names.
 	if t := watched.GetDeletionTimestamp(); t != nil {
-		in = in + "/" + t.String()
+		in = in + "/" + t.UTC().Format(time.RFC3339)
 	}
 
 	hash := sha256.Sum256([]byte(in))

--- a/internal/controller/ops/watched/reconciler_test.go
+++ b/internal/controller/ops/watched/reconciler_test.go
@@ -628,7 +628,7 @@ func TestOperationName(t *testing.T) {
 				},
 			},
 			want: want{
-				name: "test-watch-a95edb5", // Hash includes deletion timestamp for uniqueness
+				name: "test-watch-ef68891", // Hash includes deletion timestamp for uniqueness
 			},
 		},
 	}


### PR DESCRIPTION
### Description of your changes

Using a time string with a local timestamp leads to different constant strings and unit test errors locally vs in CI.

Fixes https://github.com/crossplane/crossplane/issues/6654

I am not sure why the named operation wants the deletion timestamp to begin with, but at least this passes locally and in earthly now.

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `earthly +reviewable` to ensure this PR is ready for review.
- [x] Added or updated unit tests.
~- [ ] Added or updated e2e tests.~
- [x] Linked a PR or a [docs tracking issue] to [document this change].
~- [ ] Added `backport release-x.y` labels to auto-backport this PR.~
~- [ ] Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md