### PR TITLE
fix(render): Render CLI command ignores XR Ready state

### DIFF
--- a/cmd/crank/render/render.go
+++ b/cmd/crank/render/render.go
@@ -374,7 +374,9 @@ func Render(ctx context.Context, log logging.Logger, in Inputs) (Outputs, error)
 	xr.SetName(in.CompositeResource.GetName())
 
 	xrCond := xpv1.Available()
-	if len(unready) > 0 {
+	if d.GetComposite().Ready == fnv1.Ready_READY_FALSE {
+		xrCond = xpv1.Creating()
+	} else if d.GetComposite().Ready == fnv1.Ready_READY_UNSPECIFIED && len(unready) > 0 {
 		xrCond = xpv1.Creating().WithMessage(fmt.Sprintf("Unready resources: %s", resource.StableNAndSomeMore(resource.DefaultFirstN, unready)))
 	}
 


### PR DESCRIPTION
### Description of your changes

Updated `crossplane render` command to take explicit XR `Ready` state value into account.

This functionality was added in https://github.com/crossplane/crossplane/pull/6021

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [ ] Read and followed Crossplane's [contribution process].
- [ ] Run `earthly +reviewable` to ensure this PR is ready for review.
- [ ] Added or updated unit tests.
- [ ] Added or updated e2e tests.
- [ ] Linked a PR or a [docs tracking issue] to [document this change].
- [ ] Added `backport release-x.y` labels to auto-backport this PR.
- [ ] Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.
