### PR TITLE
move crd view rbac rules to provider system role

### DIFF
--- a/internal/controller/rbac/provider/roles/roles_test.go
+++ b/internal/controller/rbac/provider/roles/roles_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	coordinationv1 "k8s.io/api/coordination/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -212,11 +213,6 @@ func TestRenderClusterRoles(t *testing.T) {
 							Resources: []string{pluralA, pluralA + suffixStatus},
 							Verbs:     verbsView,
 						},
-						{
-							APIGroups: []string{"apiextensions.k8s.io"},
-							Resources: []string{"customresourcedefinitions"},
-							Verbs:     verbsView,
-						},
 					},
 				},
 				{
@@ -225,7 +221,7 @@ func TestRenderClusterRoles(t *testing.T) {
 						Labels:          map[string]string{keyProviderName: prName},
 						OwnerReferences: []metav1.OwnerReference{crCtrlr},
 					},
-					Rules: append([]rbacv1.PolicyRule{
+					Rules: []rbacv1.PolicyRule{
 						{
 							APIGroups: []string{groupA},
 							Resources: []string{pluralA, pluralA + suffixStatus},
@@ -236,7 +232,17 @@ func TestRenderClusterRoles(t *testing.T) {
 							Resources: []string{rbacv1.ResourceAll + suffixFinalizers},
 							Verbs:     verbsUpdate,
 						},
-					}, rulesSystemExtra...),
+						{
+							APIGroups: []string{"", coordinationv1.GroupName},
+							Resources: []string{pluralSecrets, pluralConfigmaps, pluralEvents, pluralLeases},
+							Verbs:     verbsEdit,
+						},
+						{
+							Verbs:     verbsView,
+							APIGroups: []string{"apiextensions.k8s.io"},
+							Resources: []string{"customresourcedefinitions"},
+						},
+					},
 				},
 			},
 		},


### PR DESCRIPTION

### Description of your changes

In https://github.com/crossplane/crossplane/pull/6660 I made a mistake where I attached the new CRD view rules to the viewer agg role rather than the system role. it was a bad assumption that the controller used that role. It did not. 

Fixes https://github.com/crossplane-contrib/provider-kubernetes/issues/379

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `earthly +reviewable` to ensure this PR is ready for review.
- [x] Added or updated unit tests.
~- [ ] Added or updated e2e tests.~
~- [ ] Linked a PR or a [docs tracking issue] to [document this change].~
~- [ ] Added `backport release-x.y` labels to auto-backport this PR.~
~- [ ] Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md