### PR TITLE
api: roll back run function protobuf extra resources field name change

### DIFF
--- a/cmd/crank/render/render.go
+++ b/cmd/crank/render/render.go
@@ -374,9 +374,9 @@ func Render(ctx context.Context, log logging.Logger, in Inputs) (Outputs, error)
 	xr.SetName(in.CompositeResource.GetName())
 
 	xrCond := xpv1.Available()
-	if d.GetComposite().Ready == fnv1.Ready_READY_FALSE {
+	if d.GetComposite().GetReady() == fnv1.Ready_READY_FALSE {
 		xrCond = xpv1.Creating()
-	} else if d.GetComposite().Ready == fnv1.Ready_READY_UNSPECIFIED && len(unready) > 0 {
+	} else if d.GetComposite().GetReady() == fnv1.Ready_READY_UNSPECIFIED && len(unready) > 0 {
 		xrCond = xpv1.Creating().WithMessage(fmt.Sprintf("Unready resources: %s", resource.StableNAndSomeMore(resource.DefaultFirstN, unready)))
 	}
 

--- a/cmd/crank/render/render_test.go
+++ b/cmd/crank/render/render_test.go
@@ -574,7 +574,7 @@ func TestRender(t *testing.T) {
 								case 0:
 									return &fnv1.RunFunctionResponse{
 										Requirements: &fnv1.Requirements{
-											Resources: map[string]*fnv1.ResourceSelector{
+											ExtraResources: map[string]*fnv1.ResourceSelector{
 												"extra-resource-by-name": {
 													ApiVersion: "test.crossplane.io/v1",
 													Kind:       "Foo",
@@ -586,17 +586,17 @@ func TestRender(t *testing.T) {
 										},
 									}, nil
 								case 1:
-									if len(request.GetRequiredResources()) == 0 {
+									if len(request.GetExtraResources()) == 0 {
 										t.Fatalf("expected extra resources to be passed to function on second call")
 									}
-									res := request.GetRequiredResources()["extra-resource-by-name"]
+									res := request.GetExtraResources()["extra-resource-by-name"]
 									if res == nil || len(res.GetItems()) == 0 {
 										t.Fatalf("expected extra resource to be passed to function on second call")
 									}
 									foo := (res.GetItems()[0].GetResource().AsMap()["spec"].(map[string]interface{}))["foo"].(string)
 									return &fnv1.RunFunctionResponse{
 										Requirements: &fnv1.Requirements{
-											Resources: map[string]*fnv1.ResourceSelector{
+											ExtraResources: map[string]*fnv1.ResourceSelector{
 												"extra-resource-by-name": {
 													ApiVersion: "test.crossplane.io/v1",
 													Kind:       "Foo",

--- a/internal/controller/apiextensions/composite/composition_functions.go
+++ b/internal/controller/apiextensions/composite/composition_functions.go
@@ -334,13 +334,13 @@ func (c *FunctionComposer) Compose(ctx context.Context, xr *composite.Unstructur
 
 		// Pre-populate bootstrap requirements
 		if fn.Requirements != nil {
-			req.RequiredResources = map[string]*fnv1.Resources{}
+			req.ExtraResources = map[string]*fnv1.Resources{}
 			for _, sel := range fn.Requirements.RequiredResources {
 				resources, err := c.resources.Fetch(ctx, ToProtobufResourceSelector(sel))
 				if err != nil {
 					return CompositionResult{}, errors.Wrapf(err, errFmtFetchBootstrapRequirements, sel.RequirementName)
 				}
-				req.RequiredResources[sel.RequirementName] = resources
+				req.ExtraResources[sel.RequirementName] = resources
 			}
 		}
 

--- a/internal/controller/ops/operation/reconciler.go
+++ b/internal/controller/ops/operation/reconciler.go
@@ -225,7 +225,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 
 		// Pre-populate bootstrap requirements
 		if fn.Requirements != nil {
-			req.RequiredResources = map[string]*fnv1.Resources{}
+			req.ExtraResources = map[string]*fnv1.Resources{}
 			for _, sel := range fn.Requirements.RequiredResources {
 				resources, err := r.resources.Fetch(ctx, ToProtobufResourceSelector(sel))
 				if err != nil {
@@ -241,7 +241,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 				}
 
 				// Add to request (resources could be nil if not found)
-				req.RequiredResources[sel.RequirementName] = resources
+				req.ExtraResources[sel.RequirementName] = resources
 			}
 		}
 

--- a/internal/xfn/required_resources.go
+++ b/internal/xfn/required_resources.go
@@ -90,17 +90,17 @@ func (c *FetchingFunctionRunner) RunFunction(ctx context.Context, name string, r
 		requirements = newRequirements
 
 		// Clean up the required resources from the previous iteration to store the new ones
-		req.RequiredResources = make(map[string]*fnv1.Resources)
+		req.ExtraResources = make(map[string]*fnv1.Resources)
 
 		// Fetch the requested resources and add them to the desired state.
-		for name, selector := range newRequirements.GetResources() {
+		for name, selector := range newRequirements.GetExtraResources() {
 			resources, err := c.resources.Fetch(ctx, selector)
 			if err != nil {
 				return nil, errors.Wrapf(err, "fetching resources for %s", name)
 			}
 
 			// Resources would be nil in case of not found resources.
-			req.RequiredResources[name] = resources
+			req.ExtraResources[name] = resources
 		}
 
 		// Pass down the updated context across iterations.

--- a/internal/xfn/required_resources_test.go
+++ b/internal/xfn/required_resources_test.go
@@ -350,7 +350,7 @@ func TestFetchingFunctionRunner(t *testing.T) {
 				wrapped: FunctionRunnerFn(func(_ context.Context, _ string, _ *fnv1.RunFunctionRequest) (*fnv1.RunFunctionResponse, error) {
 					rsp := &fnv1.RunFunctionResponse{
 						Requirements: &fnv1.Requirements{
-							Resources: map[string]*fnv1.ResourceSelector{
+							ExtraResources: map[string]*fnv1.ResourceSelector{
 								"gimme": {
 									ApiVersion: "test.crossplane.io/v1",
 									Kind:       "CoolResource",
@@ -377,7 +377,7 @@ func TestFetchingFunctionRunner(t *testing.T) {
 				wrapped: FunctionRunnerFn(func(_ context.Context, _ string, _ *fnv1.RunFunctionRequest) (*fnv1.RunFunctionResponse, error) {
 					rsp := &fnv1.RunFunctionResponse{
 						Requirements: &fnv1.Requirements{
-							Resources: map[string]*fnv1.ResourceSelector{
+							ExtraResources: map[string]*fnv1.ResourceSelector{
 								"gimme": {
 									ApiVersion: "test.crossplane.io/v1",
 
@@ -408,7 +408,7 @@ func TestFetchingFunctionRunner(t *testing.T) {
 					// we're called, in response to our requirements.
 					if called {
 						want := &fnv1.RunFunctionRequest{
-							RequiredResources: map[string]*fnv1.Resources{
+							ExtraResources: map[string]*fnv1.Resources{
 								"gimme": {
 									Items: []*fnv1.Resource{{Resource: coolResource}},
 								},
@@ -425,7 +425,7 @@ func TestFetchingFunctionRunner(t *testing.T) {
 
 					rsp := &fnv1.RunFunctionResponse{
 						Requirements: &fnv1.Requirements{
-							Resources: map[string]*fnv1.ResourceSelector{
+							ExtraResources: map[string]*fnv1.ResourceSelector{
 								"gimme": {
 									ApiVersion: "test.crossplane.io/v1",
 									Kind:       "CoolResource",
@@ -448,7 +448,7 @@ func TestFetchingFunctionRunner(t *testing.T) {
 			want: want{
 				rsp: &fnv1.RunFunctionResponse{
 					Requirements: &fnv1.Requirements{
-						Resources: map[string]*fnv1.ResourceSelector{
+						ExtraResources: map[string]*fnv1.ResourceSelector{
 							"gimme": {
 								ApiVersion: "test.crossplane.io/v1",
 								Kind:       "CoolResource",

--- a/proto/fn/v1/run_function.pb.go
+++ b/proto/fn/v1/run_function.pb.go
@@ -299,7 +299,7 @@ type RunFunctionRequest struct {
 	// function requested required resources that did not exist, Crossplane sets
 	// the map key to an empty Resources message to indicate that it attempted to
 	// satisfy the request.
-	RequiredResources map[string]*Resources `protobuf:"bytes,6,rep,name=required_resources,json=requiredResources,proto3" json:"required_resources,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	ExtraResources map[string]*Resources `protobuf:"bytes,6,rep,name=extra_resources,json=extraResources,proto3" json:"extra_resources,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
 	// Optional credentials that this function may use to communicate with an
 	// external system.
 	Credentials   map[string]*Credentials `protobuf:"bytes,7,rep,name=credentials,proto3" json:"credentials,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
@@ -372,9 +372,9 @@ func (x *RunFunctionRequest) GetContext() *structpb.Struct {
 	return nil
 }
 
-func (x *RunFunctionRequest) GetRequiredResources() map[string]*Resources {
+func (x *RunFunctionRequest) GetExtraResources() map[string]*Resources {
 	if x != nil {
-		return x.RequiredResources
+		return x.ExtraResources
 	}
 	return nil
 }
@@ -714,9 +714,9 @@ type Requirements struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Resources that this function requires. The map key uniquely identifies the
 	// group of resources.
-	Resources     map[string]*ResourceSelector `protobuf:"bytes,1,rep,name=resources,proto3" json:"resources,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	ExtraResources map[string]*ResourceSelector `protobuf:"bytes,1,rep,name=extra_resources,json=extraResources,proto3" json:"extra_resources,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
 }
 
 func (x *Requirements) Reset() {
@@ -749,9 +749,9 @@ func (*Requirements) Descriptor() ([]byte, []int) {
 	return file_proto_fn_v1_run_function_proto_rawDescGZIP(), []int{6}
 }
 
-func (x *Requirements) GetResources() map[string]*ResourceSelector {
+func (x *Requirements) GetExtraResources() map[string]*ResourceSelector {
 	if x != nil {
-		return x.Resources
+		return x.ExtraResources
 	}
 	return nil
 }
@@ -1303,16 +1303,16 @@ var File_proto_fn_v1_run_function_proto protoreflect.FileDescriptor
 
 const file_proto_fn_v1_run_function_proto_rawDesc = "" +
 	"\n" +
-	"\x1eproto/fn/v1/run_function.proto\x12\x19apiextensions.fn.proto.v1\x1a\x1egoogle/protobuf/duration.proto\x1a\x1cgoogle/protobuf/struct.proto\"\xf7\x05\n" +
+	"\x1eproto/fn/v1/run_function.proto\x12\x19apiextensions.fn.proto.v1\x1a\x1egoogle/protobuf/duration.proto\x1a\x1cgoogle/protobuf/struct.proto\"\xeb\x05\n" +
 	"\x12RunFunctionRequest\x12:\n" +
 	"\x04meta\x18\x01 \x01(\v2&.apiextensions.fn.proto.v1.RequestMetaR\x04meta\x12<\n" +
 	"\bobserved\x18\x02 \x01(\v2 .apiextensions.fn.proto.v1.StateR\bobserved\x12:\n" +
 	"\adesired\x18\x03 \x01(\v2 .apiextensions.fn.proto.v1.StateR\adesired\x122\n" +
 	"\x05input\x18\x04 \x01(\v2\x17.google.protobuf.StructH\x00R\x05input\x88\x01\x01\x126\n" +
-	"\acontext\x18\x05 \x01(\v2\x17.google.protobuf.StructH\x01R\acontext\x88\x01\x01\x12s\n" +
-	"\x12required_resources\x18\x06 \x03(\v2D.apiextensions.fn.proto.v1.RunFunctionRequest.RequiredResourcesEntryR\x11requiredResources\x12`\n" +
-	"\vcredentials\x18\a \x03(\v2>.apiextensions.fn.proto.v1.RunFunctionRequest.CredentialsEntryR\vcredentials\x1aj\n" +
-	"\x16RequiredResourcesEntry\x12\x10\n" +
+	"\acontext\x18\x05 \x01(\v2\x17.google.protobuf.StructH\x01R\acontext\x88\x01\x01\x12j\n" +
+	"\x0fextra_resources\x18\x06 \x03(\v2A.apiextensions.fn.proto.v1.RunFunctionRequest.ExtraResourcesEntryR\x0eextraResources\x12`\n" +
+	"\vcredentials\x18\a \x03(\v2>.apiextensions.fn.proto.v1.RunFunctionRequest.CredentialsEntryR\vcredentials\x1ag\n" +
+	"\x13ExtraResourcesEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12:\n" +
 	"\x05value\x18\x02 \x01(\v2$.apiextensions.fn.proto.v1.ResourcesR\x05value:\x028\x01\x1af\n" +
 	"\x10CredentialsEntry\x12\x10\n" +
@@ -1345,10 +1345,10 @@ const file_proto_fn_v1_run_function_proto_rawDesc = "" +
 	"\b_contextB\t\n" +
 	"\a_output\"\x1f\n" +
 	"\vRequestMeta\x12\x10\n" +
-	"\x03tag\x18\x01 \x01(\tR\x03tag\"\xcf\x01\n" +
-	"\fRequirements\x12T\n" +
-	"\tresources\x18\x01 \x03(\v26.apiextensions.fn.proto.v1.Requirements.ResourcesEntryR\tresources\x1ai\n" +
-	"\x0eResourcesEntry\x12\x10\n" +
+	"\x03tag\x18\x01 \x01(\tR\x03tag\"\xe4\x01\n" +
+	"\fRequirements\x12d\n" +
+	"\x0fextra_resources\x18\x01 \x03(\v2;.apiextensions.fn.proto.v1.Requirements.ExtraResourcesEntryR\x0eextraResources\x1an\n" +
+	"\x13ExtraResourcesEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12A\n" +
 	"\x05value\x18\x02 \x01(\v2+.apiextensions.fn.proto.v1.ResourceSelectorR\x05value:\x028\x01\"\xef\x01\n" +
 	"\x10ResourceSelector\x12\x1f\n" +
@@ -1455,10 +1455,10 @@ var file_proto_fn_v1_run_function_proto_goTypes = []any{
 	(*Resource)(nil),            // 15: apiextensions.fn.proto.v1.Resource
 	(*Result)(nil),              // 16: apiextensions.fn.proto.v1.Result
 	(*Condition)(nil),           // 17: apiextensions.fn.proto.v1.Condition
-	nil,                         // 18: apiextensions.fn.proto.v1.RunFunctionRequest.RequiredResourcesEntry
+	nil,                         // 18: apiextensions.fn.proto.v1.RunFunctionRequest.ExtraResourcesEntry
 	nil,                         // 19: apiextensions.fn.proto.v1.RunFunctionRequest.CredentialsEntry
 	nil,                         // 20: apiextensions.fn.proto.v1.CredentialData.DataEntry
-	nil,                         // 21: apiextensions.fn.proto.v1.Requirements.ResourcesEntry
+	nil,                         // 21: apiextensions.fn.proto.v1.Requirements.ExtraResourcesEntry
 	nil,                         // 22: apiextensions.fn.proto.v1.MatchLabels.LabelsEntry
 	nil,                         // 23: apiextensions.fn.proto.v1.State.ResourcesEntry
 	nil,                         // 24: apiextensions.fn.proto.v1.Resource.ConnectionDetailsEntry
@@ -1471,7 +1471,7 @@ var file_proto_fn_v1_run_function_proto_depIdxs = []int32{
 	14, // 2: apiextensions.fn.proto.v1.RunFunctionRequest.desired:type_name -> apiextensions.fn.proto.v1.State
 	25, // 3: apiextensions.fn.proto.v1.RunFunctionRequest.input:type_name -> google.protobuf.Struct
 	25, // 4: apiextensions.fn.proto.v1.RunFunctionRequest.context:type_name -> google.protobuf.Struct
-	18, // 5: apiextensions.fn.proto.v1.RunFunctionRequest.required_resources:type_name -> apiextensions.fn.proto.v1.RunFunctionRequest.RequiredResourcesEntry
+	18, // 5: apiextensions.fn.proto.v1.RunFunctionRequest.extra_resources:type_name -> apiextensions.fn.proto.v1.RunFunctionRequest.ExtraResourcesEntry
 	19, // 6: apiextensions.fn.proto.v1.RunFunctionRequest.credentials:type_name -> apiextensions.fn.proto.v1.RunFunctionRequest.CredentialsEntry
 	6,  // 7: apiextensions.fn.proto.v1.Credentials.credential_data:type_name -> apiextensions.fn.proto.v1.CredentialData
 	20, // 8: apiextensions.fn.proto.v1.CredentialData.data:type_name -> apiextensions.fn.proto.v1.CredentialData.DataEntry
@@ -1483,7 +1483,7 @@ var file_proto_fn_v1_run_function_proto_depIdxs = []int32{
 	10, // 14: apiextensions.fn.proto.v1.RunFunctionResponse.requirements:type_name -> apiextensions.fn.proto.v1.Requirements
 	17, // 15: apiextensions.fn.proto.v1.RunFunctionResponse.conditions:type_name -> apiextensions.fn.proto.v1.Condition
 	25, // 16: apiextensions.fn.proto.v1.RunFunctionResponse.output:type_name -> google.protobuf.Struct
-	21, // 17: apiextensions.fn.proto.v1.Requirements.resources:type_name -> apiextensions.fn.proto.v1.Requirements.ResourcesEntry
+	21, // 17: apiextensions.fn.proto.v1.Requirements.extra_resources:type_name -> apiextensions.fn.proto.v1.Requirements.ExtraResourcesEntry
 	12, // 18: apiextensions.fn.proto.v1.ResourceSelector.match_labels:type_name -> apiextensions.fn.proto.v1.MatchLabels
 	22, // 19: apiextensions.fn.proto.v1.MatchLabels.labels:type_name -> apiextensions.fn.proto.v1.MatchLabels.LabelsEntry
 	26, // 20: apiextensions.fn.proto.v1.ResponseMeta.ttl:type_name -> google.protobuf.Duration
@@ -1496,9 +1496,9 @@ var file_proto_fn_v1_run_function_proto_depIdxs = []int32{
 	2,  // 27: apiextensions.fn.proto.v1.Result.target:type_name -> apiextensions.fn.proto.v1.Target
 	3,  // 28: apiextensions.fn.proto.v1.Condition.status:type_name -> apiextensions.fn.proto.v1.Status
 	2,  // 29: apiextensions.fn.proto.v1.Condition.target:type_name -> apiextensions.fn.proto.v1.Target
-	7,  // 30: apiextensions.fn.proto.v1.RunFunctionRequest.RequiredResourcesEntry.value:type_name -> apiextensions.fn.proto.v1.Resources
+	7,  // 30: apiextensions.fn.proto.v1.RunFunctionRequest.ExtraResourcesEntry.value:type_name -> apiextensions.fn.proto.v1.Resources
 	5,  // 31: apiextensions.fn.proto.v1.RunFunctionRequest.CredentialsEntry.value:type_name -> apiextensions.fn.proto.v1.Credentials
-	11, // 32: apiextensions.fn.proto.v1.Requirements.ResourcesEntry.value:type_name -> apiextensions.fn.proto.v1.ResourceSelector
+	11, // 32: apiextensions.fn.proto.v1.Requirements.ExtraResourcesEntry.value:type_name -> apiextensions.fn.proto.v1.ResourceSelector
 	15, // 33: apiextensions.fn.proto.v1.State.ResourcesEntry.value:type_name -> apiextensions.fn.proto.v1.Resource
 	4,  // 34: apiextensions.fn.proto.v1.FunctionRunnerService.RunFunction:input_type -> apiextensions.fn.proto.v1.RunFunctionRequest
 	8,  // 35: apiextensions.fn.proto.v1.FunctionRunnerService.RunFunction:output_type -> apiextensions.fn.proto.v1.RunFunctionResponse

--- a/proto/fn/v1/run_function.proto
+++ b/proto/fn/v1/run_function.proto
@@ -73,7 +73,7 @@ message RunFunctionRequest {
   // function requested required resources that did not exist, Crossplane sets
   // the map key to an empty Resources message to indicate that it attempted to
   // satisfy the request.
-  map<string, Resources> required_resources = 6;
+  map<string, Resources> extra_resources = 6;
 
   // Optional credentials that this function may use to communicate with an
   // external system.
@@ -150,7 +150,7 @@ message RequestMeta {
 message Requirements {
   // Resources that this function requires. The map key uniquely identifies the
   // group of resources.
-  map<string, ResourceSelector> resources = 1;
+  map<string, ResourceSelector> extra_resources = 1;
 }
 
 // ResourceSelector selects a group of resources, either by name or by label.

--- a/proto/fn/v1beta1/zz_generated_run_function.pb.go
+++ b/proto/fn/v1beta1/zz_generated_run_function.pb.go
@@ -301,7 +301,7 @@ type RunFunctionRequest struct {
 	// function requested required resources that did not exist, Crossplane sets
 	// the map key to an empty Resources message to indicate that it attempted to
 	// satisfy the request.
-	RequiredResources map[string]*Resources `protobuf:"bytes,6,rep,name=required_resources,json=requiredResources,proto3" json:"required_resources,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	ExtraResources map[string]*Resources `protobuf:"bytes,6,rep,name=extra_resources,json=extraResources,proto3" json:"extra_resources,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
 	// Optional credentials that this function may use to communicate with an
 	// external system.
 	Credentials   map[string]*Credentials `protobuf:"bytes,7,rep,name=credentials,proto3" json:"credentials,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
@@ -374,9 +374,9 @@ func (x *RunFunctionRequest) GetContext() *structpb.Struct {
 	return nil
 }
 
-func (x *RunFunctionRequest) GetRequiredResources() map[string]*Resources {
+func (x *RunFunctionRequest) GetExtraResources() map[string]*Resources {
 	if x != nil {
-		return x.RequiredResources
+		return x.ExtraResources
 	}
 	return nil
 }
@@ -716,9 +716,9 @@ type Requirements struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Resources that this function requires. The map key uniquely identifies the
 	// group of resources.
-	Resources     map[string]*ResourceSelector `protobuf:"bytes,1,rep,name=resources,proto3" json:"resources,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	ExtraResources map[string]*ResourceSelector `protobuf:"bytes,1,rep,name=extra_resources,json=extraResources,proto3" json:"extra_resources,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
 }
 
 func (x *Requirements) Reset() {
@@ -751,9 +751,9 @@ func (*Requirements) Descriptor() ([]byte, []int) {
 	return file_proto_fn_v1beta1_zz_generated_run_function_proto_rawDescGZIP(), []int{6}
 }
 
-func (x *Requirements) GetResources() map[string]*ResourceSelector {
+func (x *Requirements) GetExtraResources() map[string]*ResourceSelector {
 	if x != nil {
-		return x.Resources
+		return x.ExtraResources
 	}
 	return nil
 }
@@ -1305,16 +1305,16 @@ var File_proto_fn_v1beta1_zz_generated_run_function_proto protoreflect.FileDescr
 
 const file_proto_fn_v1beta1_zz_generated_run_function_proto_rawDesc = "" +
 	"\n" +
-	"0proto/fn/v1beta1/zz_generated_run_function.proto\x12\x1eapiextensions.fn.proto.v1beta1\x1a\x1egoogle/protobuf/duration.proto\x1a\x1cgoogle/protobuf/struct.proto\"\x9a\x06\n" +
+	"0proto/fn/v1beta1/zz_generated_run_function.proto\x12\x1eapiextensions.fn.proto.v1beta1\x1a\x1egoogle/protobuf/duration.proto\x1a\x1cgoogle/protobuf/struct.proto\"\x8e\x06\n" +
 	"\x12RunFunctionRequest\x12?\n" +
 	"\x04meta\x18\x01 \x01(\v2+.apiextensions.fn.proto.v1beta1.RequestMetaR\x04meta\x12A\n" +
 	"\bobserved\x18\x02 \x01(\v2%.apiextensions.fn.proto.v1beta1.StateR\bobserved\x12?\n" +
 	"\adesired\x18\x03 \x01(\v2%.apiextensions.fn.proto.v1beta1.StateR\adesired\x122\n" +
 	"\x05input\x18\x04 \x01(\v2\x17.google.protobuf.StructH\x00R\x05input\x88\x01\x01\x126\n" +
-	"\acontext\x18\x05 \x01(\v2\x17.google.protobuf.StructH\x01R\acontext\x88\x01\x01\x12x\n" +
-	"\x12required_resources\x18\x06 \x03(\v2I.apiextensions.fn.proto.v1beta1.RunFunctionRequest.RequiredResourcesEntryR\x11requiredResources\x12e\n" +
-	"\vcredentials\x18\a \x03(\v2C.apiextensions.fn.proto.v1beta1.RunFunctionRequest.CredentialsEntryR\vcredentials\x1ao\n" +
-	"\x16RequiredResourcesEntry\x12\x10\n" +
+	"\acontext\x18\x05 \x01(\v2\x17.google.protobuf.StructH\x01R\acontext\x88\x01\x01\x12o\n" +
+	"\x0fextra_resources\x18\x06 \x03(\v2F.apiextensions.fn.proto.v1beta1.RunFunctionRequest.ExtraResourcesEntryR\x0eextraResources\x12e\n" +
+	"\vcredentials\x18\a \x03(\v2C.apiextensions.fn.proto.v1beta1.RunFunctionRequest.CredentialsEntryR\vcredentials\x1al\n" +
+	"\x13ExtraResourcesEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12?\n" +
 	"\x05value\x18\x02 \x01(\v2).apiextensions.fn.proto.v1beta1.ResourcesR\x05value:\x028\x01\x1ak\n" +
 	"\x10CredentialsEntry\x12\x10\n" +
@@ -1347,10 +1347,10 @@ const file_proto_fn_v1beta1_zz_generated_run_function_proto_rawDesc = "" +
 	"\b_contextB\t\n" +
 	"\a_output\"\x1f\n" +
 	"\vRequestMeta\x12\x10\n" +
-	"\x03tag\x18\x01 \x01(\tR\x03tag\"\xd9\x01\n" +
-	"\fRequirements\x12Y\n" +
-	"\tresources\x18\x01 \x03(\v2;.apiextensions.fn.proto.v1beta1.Requirements.ResourcesEntryR\tresources\x1an\n" +
-	"\x0eResourcesEntry\x12\x10\n" +
+	"\x03tag\x18\x01 \x01(\tR\x03tag\"\xee\x01\n" +
+	"\fRequirements\x12i\n" +
+	"\x0fextra_resources\x18\x01 \x03(\v2@.apiextensions.fn.proto.v1beta1.Requirements.ExtraResourcesEntryR\x0eextraResources\x1as\n" +
+	"\x13ExtraResourcesEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12F\n" +
 	"\x05value\x18\x02 \x01(\v20.apiextensions.fn.proto.v1beta1.ResourceSelectorR\x05value:\x028\x01\"\xf4\x01\n" +
 	"\x10ResourceSelector\x12\x1f\n" +
@@ -1457,10 +1457,10 @@ var file_proto_fn_v1beta1_zz_generated_run_function_proto_goTypes = []any{
 	(*Resource)(nil),            // 15: apiextensions.fn.proto.v1beta1.Resource
 	(*Result)(nil),              // 16: apiextensions.fn.proto.v1beta1.Result
 	(*Condition)(nil),           // 17: apiextensions.fn.proto.v1beta1.Condition
-	nil,                         // 18: apiextensions.fn.proto.v1beta1.RunFunctionRequest.RequiredResourcesEntry
+	nil,                         // 18: apiextensions.fn.proto.v1beta1.RunFunctionRequest.ExtraResourcesEntry
 	nil,                         // 19: apiextensions.fn.proto.v1beta1.RunFunctionRequest.CredentialsEntry
 	nil,                         // 20: apiextensions.fn.proto.v1beta1.CredentialData.DataEntry
-	nil,                         // 21: apiextensions.fn.proto.v1beta1.Requirements.ResourcesEntry
+	nil,                         // 21: apiextensions.fn.proto.v1beta1.Requirements.ExtraResourcesEntry
 	nil,                         // 22: apiextensions.fn.proto.v1beta1.MatchLabels.LabelsEntry
 	nil,                         // 23: apiextensions.fn.proto.v1beta1.State.ResourcesEntry
 	nil,                         // 24: apiextensions.fn.proto.v1beta1.Resource.ConnectionDetailsEntry
@@ -1473,7 +1473,7 @@ var file_proto_fn_v1beta1_zz_generated_run_function_proto_depIdxs = []int32{
 	14, // 2: apiextensions.fn.proto.v1beta1.RunFunctionRequest.desired:type_name -> apiextensions.fn.proto.v1beta1.State
 	25, // 3: apiextensions.fn.proto.v1beta1.RunFunctionRequest.input:type_name -> google.protobuf.Struct
 	25, // 4: apiextensions.fn.proto.v1beta1.RunFunctionRequest.context:type_name -> google.protobuf.Struct
-	18, // 5: apiextensions.fn.proto.v1beta1.RunFunctionRequest.required_resources:type_name -> apiextensions.fn.proto.v1beta1.RunFunctionRequest.RequiredResourcesEntry
+	18, // 5: apiextensions.fn.proto.v1beta1.RunFunctionRequest.extra_resources:type_name -> apiextensions.fn.proto.v1beta1.RunFunctionRequest.ExtraResourcesEntry
 	19, // 6: apiextensions.fn.proto.v1beta1.RunFunctionRequest.credentials:type_name -> apiextensions.fn.proto.v1beta1.RunFunctionRequest.CredentialsEntry
 	6,  // 7: apiextensions.fn.proto.v1beta1.Credentials.credential_data:type_name -> apiextensions.fn.proto.v1beta1.CredentialData
 	20, // 8: apiextensions.fn.proto.v1beta1.CredentialData.data:type_name -> apiextensions.fn.proto.v1beta1.CredentialData.DataEntry
@@ -1485,7 +1485,7 @@ var file_proto_fn_v1beta1_zz_generated_run_function_proto_depIdxs = []int32{
 	10, // 14: apiextensions.fn.proto.v1beta1.RunFunctionResponse.requirements:type_name -> apiextensions.fn.proto.v1beta1.Requirements
 	17, // 15: apiextensions.fn.proto.v1beta1.RunFunctionResponse.conditions:type_name -> apiextensions.fn.proto.v1beta1.Condition
 	25, // 16: apiextensions.fn.proto.v1beta1.RunFunctionResponse.output:type_name -> google.protobuf.Struct
-	21, // 17: apiextensions.fn.proto.v1beta1.Requirements.resources:type_name -> apiextensions.fn.proto.v1beta1.Requirements.ResourcesEntry
+	21, // 17: apiextensions.fn.proto.v1beta1.Requirements.extra_resources:type_name -> apiextensions.fn.proto.v1beta1.Requirements.ExtraResourcesEntry
 	12, // 18: apiextensions.fn.proto.v1beta1.ResourceSelector.match_labels:type_name -> apiextensions.fn.proto.v1beta1.MatchLabels
 	22, // 19: apiextensions.fn.proto.v1beta1.MatchLabels.labels:type_name -> apiextensions.fn.proto.v1beta1.MatchLabels.LabelsEntry
 	26, // 20: apiextensions.fn.proto.v1beta1.ResponseMeta.ttl:type_name -> google.protobuf.Duration
@@ -1498,9 +1498,9 @@ var file_proto_fn_v1beta1_zz_generated_run_function_proto_depIdxs = []int32{
 	2,  // 27: apiextensions.fn.proto.v1beta1.Result.target:type_name -> apiextensions.fn.proto.v1beta1.Target
 	3,  // 28: apiextensions.fn.proto.v1beta1.Condition.status:type_name -> apiextensions.fn.proto.v1beta1.Status
 	2,  // 29: apiextensions.fn.proto.v1beta1.Condition.target:type_name -> apiextensions.fn.proto.v1beta1.Target
-	7,  // 30: apiextensions.fn.proto.v1beta1.RunFunctionRequest.RequiredResourcesEntry.value:type_name -> apiextensions.fn.proto.v1beta1.Resources
+	7,  // 30: apiextensions.fn.proto.v1beta1.RunFunctionRequest.ExtraResourcesEntry.value:type_name -> apiextensions.fn.proto.v1beta1.Resources
 	5,  // 31: apiextensions.fn.proto.v1beta1.RunFunctionRequest.CredentialsEntry.value:type_name -> apiextensions.fn.proto.v1beta1.Credentials
-	11, // 32: apiextensions.fn.proto.v1beta1.Requirements.ResourcesEntry.value:type_name -> apiextensions.fn.proto.v1beta1.ResourceSelector
+	11, // 32: apiextensions.fn.proto.v1beta1.Requirements.ExtraResourcesEntry.value:type_name -> apiextensions.fn.proto.v1beta1.ResourceSelector
 	15, // 33: apiextensions.fn.proto.v1beta1.State.ResourcesEntry.value:type_name -> apiextensions.fn.proto.v1beta1.Resource
 	4,  // 34: apiextensions.fn.proto.v1beta1.FunctionRunnerService.RunFunction:input_type -> apiextensions.fn.proto.v1beta1.RunFunctionRequest
 	8,  // 35: apiextensions.fn.proto.v1beta1.FunctionRunnerService.RunFunction:output_type -> apiextensions.fn.proto.v1beta1.RunFunctionResponse

--- a/proto/fn/v1beta1/zz_generated_run_function.proto
+++ b/proto/fn/v1beta1/zz_generated_run_function.proto
@@ -75,7 +75,7 @@ message RunFunctionRequest {
   // function requested required resources that did not exist, Crossplane sets
   // the map key to an empty Resources message to indicate that it attempted to
   // satisfy the request.
-  map<string, Resources> required_resources = 6;
+  map<string, Resources> extra_resources = 6;
 
   // Optional credentials that this function may use to communicate with an
   // external system.
@@ -152,7 +152,7 @@ message RequestMeta {
 message Requirements {
   // Resources that this function requires. The map key uniquely identifies the
   // group of resources.
-  map<string, ResourceSelector> resources = 1;
+  map<string, ResourceSelector> extra_resources = 1;
 }
 
 // ResourceSelector selects a group of resources, either by name or by label.


### PR DESCRIPTION
### Description of your changes

Due to unexpected impact on the function ecosystem, this PR rolls back the field name change in the run function protobufs that was made in https://github.com/crossplane/crossplane/commit/782cc67bd090b756cd1bc3c29feb8c333c999c17#diff-8bf2503679f9cc9e6977f350dc0c5331b2d08e70f262a62947af263929cfdb78, so we once again use the `extra_resources` field name that many functions in the ecosystem are expecting.

We will need to make a similar change in the SDKs so functions will also have this change and fix this issue completely.

Part of: https://github.com/crossplane/function-sdk-go/issues/219

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `earthly +reviewable` to ensure this PR is ready for review.
- [x] Added or updated unit tests.
- [ ] ~Added or updated e2e tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~
- [ ] ~Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md