### PR TITLE
chore(deps) bump crossplane-runtime to v2.0.0-rc.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -308,15 +308,20 @@ jobs:
           # Extract the major and minor parts of the version
           MAJOR=$(echo "$VERSION" | cut -d. -f1)
           MINOR=$(echo "$VERSION" | cut -d. -f2)
-          # Decrement the MINOR version
-          if [[ "$MINOR" -gt 0 ]]; then
-            MINOR=$((MINOR - 1))
-          else
-            echo "Error: Minor version cannot be decremented below 0"
-            exit 1
-          fi
 
-          echo "CROSSPLANE_PRIOR_VERSION=$MAJOR.$MINOR" >> $GITHUB_ENV
+          # handle 2.0 with a hard coded prior version of 1.20
+          if [[ "$MAJOR" -eq 2 && "$MINOR" -eq 0 ]]; then
+            echo "CROSSPLANE_PRIOR_VERSION=1.20" >> $GITHUB_ENV
+          else
+            # Decrement the MINOR version for other releases
+            if [[ "$MINOR" -gt 0 ]]; then
+              MINOR=$((MINOR - 1))
+              echo "CROSSPLANE_PRIOR_VERSION=$MAJOR.$MINOR" >> $GITHUB_ENV
+            else
+              echo "Error: Minor version cannot be decremented below 0"
+              exit 1
+            fi
+          fi
 
       - name: Run E2E Tests
         uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/AdaLogics/go-fuzz-headers v0.0.0-20230811130428-ced1acdcaa24
 	github.com/Masterminds/semver v1.5.0
 	github.com/alecthomas/kong v1.4.0
-	github.com/crossplane/crossplane-runtime/v2 v2.0.0-20250730183803-7de4de7ae1af
+	github.com/crossplane/crossplane-runtime/v2 v2.0.0-rc.1
 	github.com/docker/docker v27.5.0+incompatible
 	github.com/docker/go-connections v0.5.0
 	github.com/emicklei/dot v1.8.0

--- a/go.sum
+++ b/go.sum
@@ -209,8 +209,8 @@ github.com/cpuguy83/go-md2man/v2 v2.0.1/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46t
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/creack/pty v1.1.18 h1:n56/Zwd5o6whRC5PMGretI4IdRLlmBXYNjScPaBgsbY=
 github.com/creack/pty v1.1.18/go.mod h1:MOBLtS5ELjhRRrroQr9kyvTxUAFNvYEK993ew/Vr4O4=
-github.com/crossplane/crossplane-runtime/v2 v2.0.0-20250730183803-7de4de7ae1af h1:W3KbSQZ9P0zWtetjwGeht7c0ogjJmKQvt8HrMuTC7gQ=
-github.com/crossplane/crossplane-runtime/v2 v2.0.0-20250730183803-7de4de7ae1af/go.mod h1:pkd5UzmE8esaZAApevMutR832GjJ1Qgc5Ngr78ByxrI=
+github.com/crossplane/crossplane-runtime/v2 v2.0.0-rc.1 h1:ux9lBmdZbYyQPsnJIDLFlA+8al1NVWKtj4Em0L00Iuo=
+github.com/crossplane/crossplane-runtime/v2 v2.0.0-rc.1/go.mod h1:pkd5UzmE8esaZAApevMutR832GjJ1Qgc5Ngr78ByxrI=
 github.com/cyberphone/json-canonicalization v0.0.0-20231011164504-785e29786b46 h1:2Dx4IHfC1yHWI12AxQDJM1QbRCDfk6M+blLzlZCXdrc=
 github.com/cyberphone/json-canonicalization v0.0.0-20231011164504-785e29786b46/go.mod h1:uzvlm1mxhHkdfqitSA92i7Se+S9ksOn3a3qmv/kyOCw=
 github.com/cyphar/filepath-securejoin v0.2.5 h1:6iR5tXJ/e6tJZzzdMc1km3Sa7RRIVBKAK32O2s7AYfo=


### PR DESCRIPTION
### Description of your changes

From https://github.com/crossplane/release/issues/46:

> (On the Release Branch) created and merged a PR bumping the Crossplane Runtime dependency to the release candidate tag on the release branch, vX.Y.0-rc.1.

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `earthly +reviewable` to ensure this PR is ready for review.
- [ ] ~Added or updated unit tests.~
- [ ] ~Added or updated e2e tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~
- [ ] ~Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md