### PR TITLE
Use FILE level buf breaking change detection

### DIFF
--- a/buf.yaml
+++ b/buf.yaml
@@ -10,7 +10,7 @@ lint:
     - PACKAGE_NO_IMPORT_CYCLE
 breaking:
   use:
-    - WIRE
+    - WIRE_JSON  # Includes JSON breaking changes, same as crossplane-runtime
   except:
     - EXTENSION_NO_DELETE
     - FIELD_SAME_DEFAULT


### PR DESCRIPTION
### Description of your changes

This PR reverts buf breaking change detection from WIRE to FILE level to catch JSON serialization breaking changes. We recently tried allowing these changes but found them too disruptive to the community. The FILE level ensures we detect protobuf changes that would break JSON compatibility, not just binary wire protocol changes.

The change updates `buf.yaml` to use `WIRE_JSON` level breaking change detection instead of the more permissive `WIRE` level that only checks binary protocol compatibility.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `earthly +reviewable` to ensure this PR is ready for review.
- [ ] ~Added or updated unit tests.~
- [ ] ~Added or updated e2e tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~
- [ ] ~Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md