### PR TITLE
chore: bump releases table, remove 1.18 from renovate baseBranches

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -14,7 +14,6 @@
   // PLEASE UPDATE THIS WHEN RELEASING.
   baseBranches: [
     'main',
-    'release-1.18',
     'release-1.19',
     'release-1.20',
     'release-2.0',

--- a/README.md
+++ b/README.md
@@ -24,12 +24,12 @@ documentation].
 
 | Release | Release Date  |   EOL    |
 |:-------:|:-------------:|:--------:|
-|  v1.18  |  Nov 5, 2024  | Aug 2025 |
 |  v1.19  | Feb 11, 2025  | Nov 2025 |
 |  v1.20  | May 21, 2025  | Feb 2026 |
-|  v2.0   | Early Aug '25 | May 2026 |
+|  v2.0   |  Aug 8, 2025  | May 2026 |
 |  v2.1   | Early Nov '25 | Aug 2026 |
 |  v2.2   | Early Feb '26 | Nov 2026 |
+|  v2.3   | Early May '26 | Feb 2027 |
 
 You can subscribe to the [community calendar] to track all release dates, and
 find the most recent releases on the [releases] page.


### PR DESCRIPTION
### Description of your changes

As per https://github.com/crossplane/release/issues/46:

> Updated, in a single PR, the following on main:
>
> The [releases table](https://github.com/crossplane/crossplane#releases) in the README.md, removing the now old unsupported release and adding the new one.
> 
> The baseBranches list in .github/renovate.json5, removing the now old unsupported release.

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [ ] Read and followed Crossplane's [contribution process].
- [ ] Run `earthly +reviewable` to ensure this PR is ready for review.
- [ ] Added or updated unit tests.
- [ ] Added or updated e2e tests.
- [ ] Linked a PR or a [docs tracking issue] to [document this change].
- [ ] Added `backport release-x.y` labels to auto-backport this PR.
- [ ] Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md