### PR TITLE
Support  function cache XfnCacheMaxTTL CLI option

### DIFF
--- a/cmd/crossplane/core/core.go
+++ b/cmd/crossplane/core/core.go
@@ -269,6 +269,7 @@ func (c *startCommand) Run(s *runtime.Scheme, log logging.Logger) error { //noli
 		// Wrap the packaged function runner with a caching one.
 		cfr := cached.NewFileBackedRunner(pfr, c.XfnCacheDir,
 			cached.WithLogger(log),
+			cached.WithMaxTTL(c.XfnCacheMaxTTL),
 			cached.WithMetrics(cfrm),
 		)
 


### PR DESCRIPTION
### Description of your changes

The function response cache was implemented in #6422. However, during implementation the CLI argument `XfnCacheMaxTTL` is not applied. 



- [x] Read and followed Crossplane's [contribution process].
- [x] Run `earthly +reviewable` to ensure this PR is ready for review.
- [x] Added or updated unit tests.
- [x] Added or updated e2e tests.
- [x] Linked a PR or a [docs tracking issue] to [document this change].
- [x] Added `backport release-x.y` labels to auto-backport this PR.
- [x] Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md