### PR TITLE
Add an option to prevent caching of resources in other namespaces

### DIFF
--- a/cmd/crossplane/core/core.go
+++ b/cmd/crossplane/core/core.go
@@ -132,6 +132,8 @@ type startCommand struct {
 	EnableRealtimeCompositions              bool `default:"true" group:"Beta Features:" help:"Enable support for realtime compositions, i.e. watching composed resources and reconciling compositions immediately when any of the composed resources is updated."`
 	EnableCustomToManagedResourceConversion bool `default:"true" group:"Beta Features:" help:"Enable support CRD to MRD conversion when installing a package."`
 
+	RestrictCacheOptions bool `default:"false" help:"Disable resource caching in the controller-runtime manager for resources outside of crossplane's current namespace."`
+
 	// These are features that we've removed support for. Crossplane returns an
 	// error when you enable them. This ensures you'll see an explicit and
 	// informative error on startup, instead of a potentially surprising one
@@ -174,11 +176,21 @@ func (c *startCommand) Run(s *runtime.Scheme, log logging.Logger) error { //noli
 	// They use their own. They're setup later in this method.
 	eb := record.NewBroadcaster()
 
+	cacheOptions := cache.Options{
+		SyncPeriod: &c.SyncInterval,
+	}
+	if c.RestrictCacheOptions {
+		// This makes the cache controller watch resources only in crossplane's namespace.
+		// Otherwise, it tries to watch resources in all namespaces, and crashes if the
+		// crossplane ServiceAccount doesn't have enough permissions.
+		cacheOptions.DefaultNamespaces = map[string]cache.Config{
+			c.Namespace: {},
+		}
+	}
+
 	mgr, err := ctrl.NewManager(ratelimiter.LimitRESTConfig(cfg, c.MaxReconcileRate), ctrl.Options{
 		Scheme: s,
-		Cache: cache.Options{
-			SyncPeriod: &c.SyncInterval,
-		},
+		Cache:  cacheOptions,
 		WebhookServer: webhook.NewServer(webhook.Options{
 			CertDir: c.TLSServerCertsDir,
 			TLSOpts: []func(*tls.Config){


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane! Please read the contribution docs
(linked below) if this is your first Crossplane pull request.
-->

### Description of your changes

Add a `--restrict-cache-options` config flag in core cmd to avoid caching resources from other namespaces (and prevent crashes when crossplane does not have permissions on other namespaces)

Fixes #6348

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `earthly +reviewable` to ensure this PR is ready for review.
- ~[ ] Added or updated unit tests.~
- ~[ ] Added or updated e2e tests.~
- [x] Linked a PR or a [docs tracking issue] to [document this change].
- [ ] Added `backport release-x.y` labels to auto-backport this PR.
- ~[ ] Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md