### PR TITLE
Apply consistent error handling pattern in apiextensions reconcilers 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,5 @@ gitlab/
 
 # ignore AI tools settings/config
 /.claude
+CLAUDE.md
+AGENTS.md

--- a/internal/controller/apiextensions/activationpolicy/reconciler.go
+++ b/internal/controller/apiextensions/activationpolicy/reconciler.go
@@ -50,7 +50,7 @@ const (
 	reconcileActivateSuccessMsg = "Successfully activated ManagedResourceDefinition"
 )
 
-// A Reconciler reconciles CompositeResourceDefinitions.
+// A Reconciler reconciles ManagedResourceActivationPolicies.
 type Reconciler struct {
 	client.Client
 
@@ -87,11 +87,11 @@ func (r *Reconciler) Reconcile(ogctx context.Context, req reconcile.Request) (re
 	if meta.WasDeleted(mrap) {
 		status.MarkConditions(v1alpha1.TerminatingActivationPolicy())
 		if err := r.Status().Update(ogctx, mrap); err != nil {
-			log.Debug("cannot update status of ManagedResourceDefinition", "error", err)
+			log.Debug("cannot update status of ManagedResourceActivationPolicy", "error", err)
 			if kerrors.IsConflict(err) {
 				return reconcile.Result{Requeue: true}, nil
 			}
-			return reconcile.Result{}, errors.Wrap(err, "cannot update status of ManagedResourceDefinition")
+			return reconcile.Result{}, errors.Wrap(err, "cannot update status of ManagedResourceActivationPolicy")
 		}
 
 		return reconcile.Result{}, nil
@@ -144,5 +144,5 @@ func (r *Reconciler) Reconcile(ogctx context.Context, req reconcile.Request) (re
 	}
 
 	// TODO: we should really do a diff of the status to see if we should update or not.
-	return reconcile.Result{}, errors.Wrap(r.Status().Update(ogctx, mrap), "cannot update status of ManagedResourceDefinition")
+	return reconcile.Result{}, errors.Wrap(r.Status().Update(ogctx, mrap), "cannot update status of ManagedResourceActivationPolicy")
 }

--- a/internal/controller/apiextensions/activationpolicy/reconciler.go
+++ b/internal/controller/apiextensions/activationpolicy/reconciler.go
@@ -38,11 +38,6 @@ import (
 
 const (
 	timeout = 2 * time.Minute
-
-	errGetMRAP              = "cannot get ManagedResourceActivationPolicy"
-	errListMRD              = "cannot list ManagedResourceDefinition"
-	errUpdateStatus         = "cannot update status of ManagedResourceDefinition"
-	errFailedToActivateMRDs = "failed to activate %d of %d ManagedResourceDefinitions"
 )
 
 // Event reasons.
@@ -77,8 +72,8 @@ func (r *Reconciler) Reconcile(ogctx context.Context, req reconcile.Request) (re
 		// In case object is not found, most likely the object was deleted and
 		// then disappeared while the event was in the processing queue. We
 		// don't need to take any action in that case.
-		log.Debug(errGetMRAP, "error", err)
-		return reconcile.Result{}, errors.Wrap(resource.IgnoreNotFound(err), errGetMRAP)
+		log.Debug("cannot get ManagedResourceActivationPolicy", "error", err)
+		return reconcile.Result{}, errors.Wrap(resource.IgnoreNotFound(err), "cannot get ManagedResourceActivationPolicy")
 	}
 
 	status := r.conditions.For(mrap)
@@ -92,12 +87,11 @@ func (r *Reconciler) Reconcile(ogctx context.Context, req reconcile.Request) (re
 	if meta.WasDeleted(mrap) {
 		status.MarkConditions(v1alpha1.TerminatingActivationPolicy())
 		if err := r.Status().Update(ogctx, mrap); err != nil {
-			log.Debug(errUpdateStatus, "error", err)
+			log.Debug("cannot update status of ManagedResourceDefinition", "error", err)
 			if kerrors.IsConflict(err) {
 				return reconcile.Result{Requeue: true}, nil
 			}
-			err = errors.Wrap(err, errUpdateStatus)
-			return reconcile.Result{}, err
+			return reconcile.Result{}, errors.Wrap(err, "cannot update status of ManagedResourceDefinition")
 		}
 
 		return reconcile.Result{}, nil
@@ -112,19 +106,12 @@ func (r *Reconciler) Reconcile(ogctx context.Context, req reconcile.Request) (re
 	// List all MRDs
 	mrds := &v1alpha1.ManagedResourceDefinitionList{}
 	if err := r.List(ctx, mrds); err != nil {
-		log.Debug(errListMRD, "error", err)
+		log.Debug("cannot list ManagedResourceDefinition", "error", err)
 
-		status.MarkConditions(v1alpha1.BlockedActivationPolicy().WithMessage(errListMRD))
-		if err := r.Status().Update(ogctx, mrap); err != nil {
-			log.Debug(errUpdateStatus, "error", err)
-			if kerrors.IsConflict(err) {
-				return reconcile.Result{Requeue: true}, nil
-			}
-			err = errors.Wrap(err, errUpdateStatus)
-			return reconcile.Result{}, err
-		}
+		status.MarkConditions(v1alpha1.BlockedActivationPolicy().WithMessage("cannot list ManagedResourceDefinition"))
+		_ = r.Status().Update(ogctx, mrap)
 
-		return reconcile.Result{}, errors.Wrap(err, errListMRD)
+		return reconcile.Result{}, errors.Wrap(err, "cannot list ManagedResourceDefinition")
 	}
 
 	// Start fresh.
@@ -151,11 +138,11 @@ func (r *Reconciler) Reconcile(ogctx context.Context, req reconcile.Request) (re
 	}
 	if errs != nil {
 		status.MarkConditions(v1alpha1.Unhealthy().WithMessage(
-			fmt.Sprintf(errFailedToActivateMRDs, len(errs), len(mrap.Status.Activated))))
+			fmt.Sprintf("failed to activate %d of %d ManagedResourceDefinitions", len(errs), len(mrap.Status.Activated))))
 	} else {
 		status.MarkConditions(v1alpha1.Healthy())
 	}
 
 	// TODO: we should really do a diff of the status to see if we should update or not.
-	return reconcile.Result{}, errors.Wrap(r.Status().Update(ogctx, mrap), errUpdateStatus)
+	return reconcile.Result{}, errors.Wrap(r.Status().Update(ogctx, mrap), "cannot update status of ManagedResourceDefinition")
 }

--- a/internal/controller/apiextensions/activationpolicy/reconciler_test.go
+++ b/internal/controller/apiextensions/activationpolicy/reconciler_test.go
@@ -199,7 +199,7 @@ func TestReconcile(t *testing.T) {
 				},
 			},
 			want: want{
-				err: errors.Wrap(errBoom, errGetMRAP),
+				err: cmpopts.AnyError,
 			},
 		},
 		"MRAPBeingDeleted": {
@@ -238,7 +238,7 @@ func TestReconcile(t *testing.T) {
 				},
 			},
 			want: want{
-				err: errors.Wrap(errBoom, errUpdateStatus),
+				err: cmpopts.AnyError,
 			},
 		},
 		"ReconciliationPaused": {
@@ -259,12 +259,12 @@ func TestReconcile(t *testing.T) {
 					MockGet:  WithMRAP(t, NewMRAP()),
 					MockList: test.NewMockListFn(errBoom),
 					MockStatusUpdate: WantMRAP(t, NewMRAP(func(mrap *v1alpha1.ManagedResourceActivationPolicy) {
-						mrap.SetConditions(v1alpha1.BlockedActivationPolicy().WithMessage(errListMRD))
+						mrap.SetConditions(v1alpha1.BlockedActivationPolicy().WithMessage("cannot list ManagedResourceDefinition"))
 					})),
 				},
 			},
 			want: want{
-				err: errors.Wrap(errBoom, errListMRD),
+				err: cmpopts.AnyError,
 			},
 		},
 		"ListMRDErrorStatusUpdateConflict": {
@@ -277,7 +277,7 @@ func TestReconcile(t *testing.T) {
 				},
 			},
 			want: want{
-				r: reconcile.Result{Requeue: true},
+				err: cmpopts.AnyError,
 			},
 		},
 		"NoMRDsToActivate": {
@@ -453,7 +453,7 @@ func TestReconcile(t *testing.T) {
 				},
 			},
 			want: want{
-				err: errors.Wrap(errBoom, errUpdateStatus),
+				err: cmpopts.AnyError,
 			},
 		},
 	}
@@ -471,7 +471,7 @@ func TestReconcile(t *testing.T) {
 				NamespacedName: types.NamespacedName{Name: "test-mrap"},
 			})
 
-			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
+			if diff := cmp.Diff(tc.want.err, err, cmpopts.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\nr.Reconcile(...): -want error, +got error:\n%s", tc.reason, diff)
 			}
 			if diff := cmp.Diff(tc.want.r, got, test.EquateErrors()); diff != "" {

--- a/internal/controller/apiextensions/claim/reconciler.go
+++ b/internal/controller/apiextensions/claim/reconciler.go
@@ -339,8 +339,9 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 			err = errors.Wrap(err, errGetComposite)
 			record.Event(cm, event.Warning(reasonBind, err))
 			status.MarkConditions(xpv1.ReconcileError(err))
+			_ = r.client.Status().Update(ctx, cm)
 
-			return reconcile.Result{Requeue: true}, errors.Wrap(r.client.Status().Update(ctx, cm), errUpdateClaimStatus)
+			return reconcile.Result{}, err
 		}
 	}
 
@@ -359,8 +360,10 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 		err := errors.Errorf(errFmtUnbound, xr.GetName(), ref.Name)
 		record.Event(cm, event.Warning(reasonBind, err))
 		status.MarkConditions(xpv1.ReconcileError(err))
+		_ = r.client.Status().Update(ctx, cm)
 
-		return reconcile.Result{Requeue: false}, errors.Wrap(r.client.Status().Update(ctx, cm), errUpdateClaimStatus)
+		// Returning nil is intentional - see comment above.
+		return reconcile.Result{}, nil
 	}
 
 	// TODO(negz): Remove this call to Upgrade once no supported version of
@@ -376,8 +379,9 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 		err = errors.Wrap(err, errUpgradeManagedFields)
 		record.Event(cm, event.Warning(reasonBind, err))
 		status.MarkConditions(xpv1.ReconcileError(err))
+		_ = r.client.Status().Update(ctx, cm)
 
-		return reconcile.Result{Requeue: true}, errors.Wrap(r.client.Status().Update(ctx, cm), errUpdateClaimStatus)
+		return reconcile.Result{}, err
 	}
 
 	if meta.WasDeleted(cm) {
@@ -405,8 +409,9 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 				err = errors.Wrap(err, errDeleteComposite)
 				record.Event(cm, event.Warning(reasonDelete, err))
 				status.MarkConditions(xpv1.ReconcileError(err))
+				_ = r.client.Status().Update(ctx, cm)
 
-				return reconcile.Result{Requeue: true}, errors.Wrap(r.client.Status().Update(ctx, cm), errUpdateClaimStatus)
+				return reconcile.Result{}, err
 			}
 
 			if requiresForegroundDeletion {
@@ -421,8 +426,9 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 			err = errors.Wrap(err, errRemoveFinalizer)
 			record.Event(cm, event.Warning(reasonDelete, err))
 			status.MarkConditions(xpv1.ReconcileError(err))
+			_ = r.client.Status().Update(ctx, cm)
 
-			return reconcile.Result{Requeue: true}, errors.Wrap(r.client.Status().Update(ctx, cm), errUpdateClaimStatus)
+			return reconcile.Result{}, err
 		}
 
 		log.Debug("Successfully deleted claim")
@@ -439,8 +445,9 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 		err = errors.Wrap(err, errAddFinalizer)
 		record.Event(cm, event.Warning(reasonBind, err))
 		status.MarkConditions(xpv1.ReconcileError(err))
+		_ = r.client.Status().Update(ctx, cm)
 
-		return reconcile.Result{Requeue: true}, errors.Wrap(r.client.Status().Update(ctx, cm), errUpdateClaimStatus)
+		return reconcile.Result{}, err
 	}
 
 	// The XR's claim reference before syncing. Used to determine if we bind it.
@@ -455,8 +462,9 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 		err = errors.Wrap(err, errSync)
 		record.Event(cm, event.Warning(reasonBind, err))
 		status.MarkConditions(xpv1.ReconcileError(err))
+		_ = r.client.Status().Update(ctx, cm)
 
-		return reconcile.Result{Requeue: true}, errors.Wrap(r.client.Status().Update(ctx, cm), errUpdateClaimStatus)
+		return reconcile.Result{}, err
 	}
 
 	// The XR didn't reference the claim before the sync, but does now.
@@ -487,8 +495,9 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 		err = errors.Wrap(err, errPropagateCDs)
 		record.Event(cm, event.Warning(reasonPropagate, err))
 		status.MarkConditions(xpv1.ReconcileError(err))
+		_ = r.client.Status().Update(ctx, cm)
 
-		return reconcile.Result{Requeue: true}, errors.Wrap(r.client.Status().Update(ctx, cm), errUpdateClaimStatus)
+		return reconcile.Result{}, err
 	}
 
 	if propagated {

--- a/internal/controller/apiextensions/claim/reconciler_test.go
+++ b/internal/controller/apiextensions/claim/reconciler_test.go
@@ -81,7 +81,7 @@ func TestReconcile(t *testing.T) {
 			},
 			want: want{
 				r:   reconcile.Result{},
-				err: errors.Wrap(errBoom, errGetClaim),
+				err: cmpopts.AnyError,
 			},
 		},
 		"ReconciliationPaused": {
@@ -157,11 +157,12 @@ func TestReconcile(t *testing.T) {
 				},
 			},
 			want: want{
-				r: reconcile.Result{Requeue: true},
+				r:   reconcile.Result{},
+				err: cmpopts.AnyError,
 			},
 		},
 		"CompositeAlreadyBoundError": {
-			reason: "The reconcile should fail if the referenced XR is bound to another claim",
+			reason: "The reconcile should not return an error if the referenced XR is bound to another claim",
 			args: args{
 				client: &test.MockClient{
 					MockGet: test.NewMockGetFn(nil, func(obj client.Object) error {
@@ -222,7 +223,8 @@ func TestReconcile(t *testing.T) {
 				},
 			},
 			want: want{
-				r: reconcile.Result{Requeue: true},
+				r:   reconcile.Result{},
+				err: cmpopts.AnyError,
 			},
 		},
 		"RemoveFinalizerError": {
@@ -248,7 +250,8 @@ func TestReconcile(t *testing.T) {
 				},
 			},
 			want: want{
-				r: reconcile.Result{Requeue: true},
+				r:   reconcile.Result{},
+				err: cmpopts.AnyError,
 			},
 		},
 		"SuccessfulDelete": {
@@ -371,7 +374,8 @@ func TestReconcile(t *testing.T) {
 				},
 			},
 			want: want{
-				r: reconcile.Result{Requeue: true},
+				r:   reconcile.Result{},
+				err: cmpopts.AnyError,
 			},
 		},
 		"SyncCompositeError": {
@@ -392,7 +396,8 @@ func TestReconcile(t *testing.T) {
 				},
 			},
 			want: want{
-				r: reconcile.Result{Requeue: true},
+				r:   reconcile.Result{},
+				err: cmpopts.AnyError,
 			},
 		},
 		"CompositeNotReady": {
@@ -467,7 +472,8 @@ func TestReconcile(t *testing.T) {
 				},
 			},
 			want: want{
-				r: reconcile.Result{Requeue: true},
+				r:   reconcile.Result{},
+				err: cmpopts.AnyError,
 			},
 		},
 		"SuccessfulReconcile": {
@@ -604,7 +610,7 @@ func TestReconcile(t *testing.T) {
 			r := NewReconciler(tc.args.client, tc.args.of, tc.args.with, tc.args.opts...)
 
 			got, err := r.Reconcile(context.Background(), reconcile.Request{})
-			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
+			if diff := cmp.Diff(tc.want.err, err, cmpopts.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\nr.Reconcile(...): -want error, +got error:\n%s", tc.reason, diff)
 			}
 

--- a/internal/controller/apiextensions/composite/reconciler.go
+++ b/internal/controller/apiextensions/composite/reconciler.go
@@ -543,8 +543,9 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 			err = errors.Wrap(err, errRemoveFinalizer)
 			r.record.Event(xr, event.Warning(reasonDelete, err))
 			status.MarkConditions(xpv1.ReconcileError(err))
+			_ = r.client.Status().Update(updateCtx, xr)
 
-			return reconcile.Result{Requeue: true}, errors.Wrap(r.client.Status().Update(updateCtx, xr), errUpdateStatus)
+			return reconcile.Result{}, err
 		}
 
 		log.Debug("Successfully deleted composite resource")
@@ -561,8 +562,9 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 		err = errors.Wrap(err, errAddFinalizer)
 		r.record.Event(xr, event.Warning(reasonInit, err))
 		status.MarkConditions(xpv1.ReconcileError(err))
+		_ = r.client.Status().Update(ctx, xr)
 
-		return reconcile.Result{Requeue: true}, errors.Wrap(r.client.Status().Update(ctx, xr), errUpdateStatus)
+		return reconcile.Result{}, err
 	}
 
 	orig := xr.GetCompositionReference()
@@ -574,8 +576,9 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 		err = errors.Wrap(err, errSelectComp)
 		r.record.Event(xr, event.Warning(reasonResolve, err))
 		status.MarkConditions(xpv1.ReconcileError(err))
+		_ = r.client.Status().Update(updateCtx, xr)
 
-		return reconcile.Result{Requeue: true}, errors.Wrap(r.client.Status().Update(updateCtx, xr), errUpdateStatus)
+		return reconcile.Result{}, err
 	}
 
 	if compRef := xr.GetCompositionReference(); compRef != nil && (orig == nil || *compRef != *orig) {
@@ -596,8 +599,9 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 		err = errors.Wrap(err, errFetchComp)
 		r.record.Event(xr, event.Warning(reasonCompose, err))
 		status.MarkConditions(xpv1.ReconcileError(err))
+		_ = r.client.Status().Update(updateCtx, xr)
 
-		return reconcile.Result{Requeue: true}, errors.Wrap(r.client.Status().Update(updateCtx, xr), errUpdateStatus)
+		return reconcile.Result{}, err
 	}
 
 	if rev := xr.GetCompositionRevisionReference(); rev != nil && (origRev == nil || *rev != *origRev) {
@@ -616,8 +620,9 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 
 		r.record.Event(xr, event.Warning(reasonCompose, err))
 		status.MarkConditions(xpv1.ReconcileError(err))
+		_ = r.client.Status().Update(ctx, xr)
 
-		return reconcile.Result{Requeue: true}, errors.Wrap(r.client.Status().Update(ctx, xr), errUpdateStatus)
+		return reconcile.Result{}, err
 	}
 
 	if err := r.composite.Configure(ctx, xr, rev); err != nil {
@@ -630,8 +635,9 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 		err = errors.Wrap(err, errConfigure)
 		r.record.Event(xr, event.Warning(reasonCompose, err))
 		status.MarkConditions(xpv1.ReconcileError(err))
+		_ = r.client.Status().Update(updateCtx, xr)
 
-		return reconcile.Result{Requeue: true}, errors.Wrap(r.client.Status().Update(updateCtx, xr), errUpdateStatus)
+		return reconcile.Result{}, err
 	}
 
 	res, err := r.resource.Compose(ctx, xr, CompositionRequest{Revision: rev})
@@ -679,7 +685,8 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 				status.MarkConditions(c)
 			}
 		}
-		return reconcile.Result{Requeue: true}, errors.Wrap(r.client.Status().Update(updateCtx, xr), errUpdateStatus)
+		_ = r.client.Status().Update(updateCtx, xr)
+		return reconcile.Result{}, err
 	}
 
 	ws := make([]engine.Watch, len(xr.GetResourceReferences()))
@@ -695,8 +702,9 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 		err = errors.Wrap(err, errWatch)
 		r.record.Event(xr, event.Warning(reasonWatch, err))
 		status.MarkConditions(xpv1.ReconcileError(err))
+		_ = r.client.Status().Update(updateCtx, xr)
 
-		return reconcile.Result{Requeue: true}, errors.Wrap(r.client.Status().Update(updateCtx, xr), errUpdateStatus)
+		return reconcile.Result{}, err
 	}
 
 	published, err := r.composite.PublishConnection(ctx, xr, res.ConnectionDetails)
@@ -710,8 +718,9 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 		err = errors.Wrap(err, errPublish)
 		r.record.Event(xr, event.Warning(reasonPublish, err))
 		status.MarkConditions(xpv1.ReconcileError(err))
+		_ = r.client.Status().Update(updateCtx, xr)
 
-		return reconcile.Result{Requeue: true}, errors.Wrap(r.client.Status().Update(updateCtx, xr), errUpdateStatus)
+		return reconcile.Result{}, err
 	}
 
 	if published {

--- a/internal/controller/apiextensions/composite/reconciler_test.go
+++ b/internal/controller/apiextensions/composite/reconciler_test.go
@@ -90,7 +90,8 @@ func TestReconcile(t *testing.T) {
 				},
 			},
 			want: want{
-				err: errors.Wrap(errBoom, errGet),
+				r:   reconcile.Result{},
+				err: cmpopts.AnyError,
 			},
 		},
 		"RemoveFinalizerError": {
@@ -114,7 +115,8 @@ func TestReconcile(t *testing.T) {
 				},
 			},
 			want: want{
-				r: reconcile.Result{Requeue: true},
+				r:   reconcile.Result{},
+				err: cmpopts.AnyError,
 			},
 		},
 		"SuccessfulDelete": {
@@ -159,7 +161,8 @@ func TestReconcile(t *testing.T) {
 				},
 			},
 			want: want{
-				r: reconcile.Result{Requeue: true},
+				r:   reconcile.Result{},
+				err: cmpopts.AnyError,
 			},
 		},
 		"SelectCompositionError": {
@@ -179,7 +182,8 @@ func TestReconcile(t *testing.T) {
 				},
 			},
 			want: want{
-				r: reconcile.Result{Requeue: true},
+				r:   reconcile.Result{},
+				err: cmpopts.AnyError,
 			},
 		},
 		"FetchCompositionError": {
@@ -204,7 +208,8 @@ func TestReconcile(t *testing.T) {
 				},
 			},
 			want: want{
-				r: reconcile.Result{Requeue: true},
+				r:   reconcile.Result{},
+				err: cmpopts.AnyError,
 			},
 		},
 		"InvalidPipelineError": {
@@ -232,7 +237,8 @@ func TestReconcile(t *testing.T) {
 				},
 			},
 			want: want{
-				r: reconcile.Result{Requeue: true},
+				r:   reconcile.Result{},
+				err: cmpopts.AnyError,
 			},
 		},
 		"InvalidPipelineWithMessageError": {
@@ -260,7 +266,8 @@ func TestReconcile(t *testing.T) {
 				},
 			},
 			want: want{
-				r: reconcile.Result{Requeue: true},
+				r:   reconcile.Result{},
+				err: cmpopts.AnyError,
 			},
 		},
 		"ConfigureCompositeError": {
@@ -288,7 +295,8 @@ func TestReconcile(t *testing.T) {
 				},
 			},
 			want: want{
-				r: reconcile.Result{Requeue: true},
+				r:   reconcile.Result{},
+				err: cmpopts.AnyError,
 			},
 		},
 		"ComposeResourcesError": {
@@ -319,7 +327,8 @@ func TestReconcile(t *testing.T) {
 				},
 			},
 			want: want{
-				r: reconcile.Result{Requeue: true},
+				r:   reconcile.Result{},
+				err: cmpopts.AnyError,
 			},
 		},
 		"PublishConnectionDetailsError": {
@@ -353,7 +362,8 @@ func TestReconcile(t *testing.T) {
 				},
 			},
 			want: want{
-				r: reconcile.Result{Requeue: true},
+				r:   reconcile.Result{},
+				err: cmpopts.AnyError,
 			},
 		},
 		"CompositionWarnings": {
@@ -545,7 +555,8 @@ func TestReconcile(t *testing.T) {
 				},
 			},
 			want: want{
-				err: errors.Wrap(errBoom, errUpdateStatus),
+				r:   reconcile.Result{},
+				err: cmpopts.AnyError,
 			},
 		},
 		"ReconciliationResumes": {
@@ -966,7 +977,8 @@ func TestReconcile(t *testing.T) {
 				},
 			},
 			want: want{
-				r: reconcile.Result{Requeue: true},
+				r:   reconcile.Result{},
+				err: cmpopts.AnyError,
 			},
 		},
 		"CustomConditionUpdate": {
@@ -1258,16 +1270,16 @@ func TestReconcile(t *testing.T) {
 			r := NewReconciler(tc.args.c, tc.args.of, tc.args.opts...)
 
 			got, err := r.Reconcile(context.Background(), reconcile.Request{})
-			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
+			if diff := cmp.Diff(tc.want.err, err, cmpopts.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\nr.Reconcile(...): -want error, +got error:\n%s", tc.reason, diff)
 			}
 
-			if diff := cmp.Diff(tc.want.r, got, test.EquateErrors()); diff != "" {
+			if diff := cmp.Diff(tc.want.r, got); diff != "" {
 				t.Errorf("\n%s\nr.Reconcile(...): -want, +got:\n%s", tc.reason, diff)
 			}
 
 			if tr, ok := r.record.(*testRecorder); ok {
-				if diff := cmp.Diff(tr.Want, tr.Got, test.EquateErrors()); diff != "" {
+				if diff := cmp.Diff(tr.Want, tr.Got); diff != "" {
 					t.Errorf("\n%s\nr.Reconcile(...): -want events, +got events:\n%s", tc.reason, diff)
 				}
 			}

--- a/internal/controller/apiextensions/managed/reconciler.go
+++ b/internal/controller/apiextensions/managed/reconciler.go
@@ -119,9 +119,7 @@ func (r *Reconciler) Reconcile(ogctx context.Context, req reconcile.Request) (re
 		log.Debug("failed to reconcile CustomResourceDefinition", "error", err)
 		r.record.Event(mrd, event.Warning(reasonReconcile, err))
 		status.MarkConditions(v1alpha1.BlockedManaged().WithMessage("unable to reconcile CustomResourceDefinition, see events"))
-		if err := r.Status().Update(ogctx, mrd); err != nil {
-			log.Info("cannot update status of ManagedResourceDefinition", "error", err)
-		}
+		_ = r.Status().Update(ogctx, mrd)
 		return reconcile.Result{}, errors.Wrap(err, "cannot reconcile CustomResourceDefinition")
 	}
 

--- a/internal/controller/apiextensions/managed/reconciler_test.go
+++ b/internal/controller/apiextensions/managed/reconciler_test.go
@@ -79,7 +79,7 @@ func TestReconcile(t *testing.T) {
 				},
 			},
 			want: want{
-				err: errors.Wrap(errBoom, "cannot get ManagedResourceDefinition"),
+				err: cmpopts.AnyError,
 			},
 		},
 		"MRDBeingDeleted": {
@@ -110,7 +110,7 @@ func TestReconcile(t *testing.T) {
 				},
 			},
 			want: want{
-				err: errors.Wrap(errBoom, "cannot update status of ManagedResourceDefinition"),
+				err: cmpopts.AnyError,
 			},
 		},
 		"MRDBeingDeletedStatusUpdateConflict": {
@@ -186,7 +186,7 @@ func TestReconcile(t *testing.T) {
 				},
 			},
 			want: want{
-				err: errors.Wrap(errors.Wrap(errBoom, "cannot get CustomResourceDefinition"), "cannot reconcile CustomResourceDefinition"),
+				err: cmpopts.AnyError,
 			},
 		},
 		"MRDActiveCRDCreateSuccess": {
@@ -326,7 +326,7 @@ func TestReconcile(t *testing.T) {
 				},
 			},
 			want: want{
-				err: errors.Wrap(errors.Wrap(errBoom, "cannot create CustomResourceDefinition"), "cannot reconcile CustomResourceDefinition"),
+				err: cmpopts.AnyError,
 			},
 		},
 		"MRDActiveCRDUpdateSuccess": {
@@ -498,7 +498,7 @@ func TestReconcile(t *testing.T) {
 				},
 			},
 			want: want{
-				err: errors.Wrap(errors.Wrap(errBoom, "cannot update CustomResourceDefinition"), "cannot reconcile CustomResourceDefinition"),
+				err: cmpopts.AnyError,
 			},
 		},
 		"MRDActiveCRDEstablished": {
@@ -671,7 +671,7 @@ func TestReconcile(t *testing.T) {
 				},
 			},
 			want: want{
-				err: errors.Wrap(errors.New("crd was deleted"), "cannot reconcile CustomResourceDefinition"),
+				err: cmpopts.AnyError,
 			},
 		},
 		"StatusUpdateError": {
@@ -685,7 +685,7 @@ func TestReconcile(t *testing.T) {
 				},
 			},
 			want: want{
-				err: errors.Wrap(errBoom, "cannot update status of ManagedResourceDefinition"),
+				err: cmpopts.AnyError,
 			},
 		},
 	}
@@ -707,7 +707,7 @@ func TestReconcile(t *testing.T) {
 				NamespacedName: types.NamespacedName{Name: "test-mrd"},
 			})
 
-			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
+			if diff := cmp.Diff(tc.want.err, err, cmpopts.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\nr.Reconcile(...): -want error, +got error:\n%s", tc.reason, diff)
 			}
 			if diff := cmp.Diff(tc.want.r, got, test.EquateErrors()); diff != "" {


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane! Please read the contribution docs
(linked below) if this is your first Crossplane pull request.
-->

### Description of your changes

<!--
Briefly describe what this pull request does, and how it is covered by tests.
Be proactive - direct your reviewers' attention to anything that needs special
consideration.

We love pull requests that fix an open issue. If yours does, use the below line
to indicate which issue it fixes, for example "Fixes #500".
-->

This uses the same error handling patterns in Reconcile methods as the new ops controllers. Notably we return errors to controller-runtime rather than swallowing them.

Note this shouldn't be a behavior change. We previously returned `{Requeue: true}`, which triggers the same rate-limiting as returning an error.

https://github.com/kubernetes-sigs/controller-runtime/blob/v0.19.0/pkg/internal/controller/controller.go#L304-L329

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `earthly +reviewable` to ensure this PR is ready for review.
- [x] Added or updated unit tests.
- [ ] ~Added or updated e2e tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~
- [ ] ~Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md