### PR TITLE
fix(cli): render remote daemon container address

### DIFF
--- a/cmd/crank/render/cmd.go
+++ b/cmd/crank/render/cmd.go
@@ -101,6 +101,10 @@ Use the standard DOCKER_HOST, DOCKER_API_VERSION, DOCKER_CERT_PATH, and
 DOCKER_TLS_VERIFY environment variables to configure how this command connects
 to the Docker daemon.
 
+When using a remote Docker daemon (DOCKER_HOST=tcp://...), set CROSSPLANE_RENDER_HOST
+to specify the IP address that Docker containers should use to connect back to
+the render process. If not set, the IP from DOCKER_HOST will be used.
+
 Examples:
 
   # Simulate creating a new XR.

--- a/cmd/crank/render/runtime_docker.go
+++ b/cmd/crank/render/runtime_docker.go
@@ -22,6 +22,8 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"net/url"
+	"os"
 	"strings"
 
 	"github.com/docker/docker/api/types/container"
@@ -261,29 +263,88 @@ func (r *RuntimeDocker) createContainer(ctx context.Context, cli *client.Client)
 	// Find a random, available port. There's a chance of a race here, where
 	// something else binds to the port before we start our container.
 
-	lis, err := net.Listen("tcp", "localhost:0")
+	// Check if we're using a remote Docker daemon
+	// Remote means TCP or SSH connection, not Unix socket (which is always local)
+	dockerHost := os.Getenv("DOCKER_HOST")
+	isRemoteDocker := dockerHost != "" && !strings.Contains(dockerHost, "unix://")
+
+	// Determine the bind address
+	bindAddr := "localhost"
+	if isRemoteDocker {
+		// When using remote Docker, bind to all interfaces
+		bindAddr = "0.0.0.0"
+	}
+
+	lis, err := net.Listen("tcp", fmt.Sprintf("%s:0", bindAddr))
 	if err != nil {
 		return "", "", errors.Wrap(err, "cannot get available TCP port")
 	}
 
-	containerAddr := lis.Addr().String()
+	listenerAddr := lis.Addr().String()
 	_ = lis.Close()
 
-	spec := fmt.Sprintf("%s:9443/tcp", containerAddr)
-
-	expose, bind, err := nat.ParsePortSpecs([]string{spec})
-	if err != nil {
-		return "", "", errors.Wrapf(err, "cannot parse Docker port spec %q", spec)
+	// Determine the address that containers should connect to
+	var containerConnectAddr string
+	if isRemoteDocker {
+		// Check for explicit host override
+		if renderHost := os.Getenv("CROSSPLANE_RENDER_HOST"); renderHost != "" {
+			_, port, _ := net.SplitHostPort(listenerAddr)
+			containerConnectAddr = net.JoinHostPort(renderHost, port)
+			r.log.Debug("Using CROSSPLANE_RENDER_HOST for container connection", "address", containerConnectAddr)
+		} else {
+			// Try to determine the host IP from DOCKER_HOST
+			parsedURL, err := url.Parse(dockerHost)
+			if err == nil && parsedURL.Host != "" {
+				dockerHostIP, _, _ := net.SplitHostPort(parsedURL.Host)
+				if dockerHostIP == "" {
+					dockerHostIP = parsedURL.Host
+				}
+				// Get the port from our listener
+				_, port, _ := net.SplitHostPort(listenerAddr)
+				// Use the same host as Docker daemon for container callback
+				containerConnectAddr = net.JoinHostPort(dockerHostIP, port)
+				r.log.Info("Using Docker daemon host for container connection", "address", containerConnectAddr, "note", "Set CROSSPLANE_RENDER_HOST if containers should connect to a different IP")
+			} else {
+				return "", "", errors.New("cannot determine host IP for remote Docker. Please set CROSSPLANE_RENDER_HOST environment variable")
+			}
+		}
+	} else {
+		// Local Docker - use the listener address as-is
+		containerConnectAddr = listenerAddr
 	}
+
+	// Get the host and port from listener address
+	_, listenerPort, _ := net.SplitHostPort(listenerAddr)
+
+	// Create port bindings
+	containerPort := nat.Port("9443/tcp")
 
 	cfg := &container.Config{
-		Image:        r.Image,
-		Cmd:          []string{"--insecure"},
-		ExposedPorts: expose,
-		Env:          r.Env,
+		Image: r.Image,
+		Cmd:   []string{"--insecure"},
+		ExposedPorts: nat.PortSet{
+			containerPort: struct{}{},
+		},
+		Env: r.Env,
 	}
+
+	// When using remote Docker, bind to all interfaces (both IPv4 and IPv6)
+	// by leaving HostIP empty.
+	hostIP := ""
+	if !isRemoteDocker {
+		// For local Docker, explicitly bind to 127.0.0.1
+		hostIP = "127.0.0.1"
+	}
+
 	hcfg := &container.HostConfig{
-		PortBindings: bind,
+		PortBindings: nat.PortMap{
+			containerPort: []nat.PortBinding{
+				{
+					HostIP:   hostIP,
+					HostPort: listenerPort,
+				},
+			},
+		},
 	}
 
 	options, err := r.getPullOptions()
@@ -303,7 +364,7 @@ func (r *RuntimeDocker) createContainer(ctx context.Context, cli *client.Client)
 	}
 
 	// TODO(negz): Set a container name? Presumably unique across runs.
-	r.log.Debug("Creating Docker container", "image", r.Image, "address", containerAddr, "name", r.Name)
+	r.log.Debug("Creating Docker container", "image", r.Image, "listener", listenerAddr, "container_target", containerConnectAddr, "name", r.Name)
 
 	rsp, err := cli.ContainerCreate(ctx, cfg, hcfg, nil, nil, r.Name)
 	if err != nil {
@@ -329,7 +390,7 @@ func (r *RuntimeDocker) createContainer(ctx context.Context, cli *client.Client)
 		return "", "", errors.Wrap(err, "cannot start Docker container")
 	}
 
-	return rsp.ID, containerAddr, errors.Wrap(err, "cannot start Docker container")
+	return rsp.ID, containerConnectAddr, errors.Wrap(err, "cannot start Docker container")
 }
 
 func (r *RuntimeDocker) getPullOptions() (typesimage.PullOptions, error) {


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane! Please read the contribution docs
(linked below) if this is your first Crossplane pull request.
-->

### Description of your changes
Fix crossplane cli render to work with remote Docker daemons by properly configuring network connectivity between the render process and function containers.

When using `DOCKER_HOST` with a `TCP` endpoint, function containers couldn't connect back to the render process because it was listening on localhost which isn't reachable from remote Docker hosts.

#### Changes:

- Detect remote Docker usage (TCP/SSH) vs local Docker (Unix socket)
- Bind to 0.0.0.0 instead of localhost when using remote Docker
- Use Docker daemon's IP for container callback address automatically
- Add `CROSSPLANE_RENDER_HOST` environment variable to override callback IP when needed
- Maintain secure `127.0.0.1` binding for local Docker connections

Example error before fix:
```
DOCKER_HOST="tcp://192.168.1.91:2375" crossplane render example.yaml composition.yaml function.yaml 
crossplane: error: cannot render composite resource: cannot run pipeline step "go-templating":  rpc error: code = DeadlineExceeded desc = connection error: dial tcp 127.0.0.1:57030: connect: connection refused
```

Example with the fix:

```
DOCKER_HOST="tcp://192-168-1-91.nip.io:2375" ./crank render example.yaml composition.yaml function.yaml
---
apiVersion: aws.platform.upbound.io/v1alpha1
kind: XNetwork
metadata:
  name: configuration-aws-network-gotpl
status:
  conditions:
  - lastTransitionTime: "2024-01-01T00:00:00Z"
    message: 'Unready resources: igw, mrt, route, and 13 more'
    reason: Creating
    status: "False"
    type: Ready
```

```
DOCKER_HOST="tcp://192-168-1-91.nip.io:2375" CROSSPLANE_RENDER_HOST="10.10.10.10" ./crank render example.yaml composition.yaml function.yaml
---
apiVersion: aws.platform.upbound.io/v1alpha1
kind: XNetwork
metadata:
  name: configuration-aws-network-gotpl
status:
  conditions:
  - lastTransitionTime: "2024-01-01T00:00:00Z"
    message: 'Unready resources: igw, mrt, route, and 13 more'
    reason: Creating
    status: "False"
    type: Ready
```




<!--
Briefly describe what this pull request does, and how it is covered by tests.
Be proactive - direct your reviewers' attention to anything that needs special
consideration.

We love pull requests that fix an open issue. If yours does, use the below line
to indicate which issue it fixes, for example "Fixes #500".
-->

Fixes #

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `earthly +reviewable` to ensure this PR is ready for review.
- [x] Added or updated unit tests.
- [x] Added or updated e2e tests.
- [x] Linked a PR or a [docs tracking issue] to [document this change].
- [x] Added `backport release-x.y` labels to auto-backport this PR.
- [x] Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md