### PR TITLE
Queue reconciles for packages when ImageConfigs change 

### DIFF
--- a/apis/pkg/v1/interfaces.go
+++ b/apis/pkg/v1/interfaces.go
@@ -930,6 +930,19 @@ func (p *ConfigurationRevision) SetCapabilities(caps []string) {
 	p.Status.Capabilities = caps
 }
 
+// PackageList is the interface satisfied by package list types.
+// +k8s:deepcopy-gen=false
+type PackageList interface {
+	client.ObjectList
+
+	// GetPackages gets the list of Packages in a PackageList.
+	// This is a costly operation, but allows for treating different package
+	// list types as a single interface. If causing a performance bottleneck in
+	// a shared reconciler, consider refactoring the controller to use a
+	// reconciler for the specific type.
+	GetPackages() []Package
+}
+
 // PackageRevisionList is the interface satisfied by package revision list
 // types.
 // +k8s:deepcopy-gen=false
@@ -1356,4 +1369,31 @@ func (p *FunctionRevisionList) GetRevisions() []PackageRevision {
 	}
 
 	return prs
+}
+
+// GetPackages of this ProviderList.
+func (p *ProviderList) GetPackages() []Package {
+	pkgs := make([]Package, len(p.Items))
+	for i, pkg := range p.Items {
+		pkgs[i] = &pkg
+	}
+	return pkgs
+}
+
+// GetPackages of this ConfigurationList.
+func (p *ConfigurationList) GetPackages() []Package {
+	pkgs := make([]Package, len(p.Items))
+	for i, pkg := range p.Items {
+		pkgs[i] = &pkg
+	}
+	return pkgs
+}
+
+// GetPackages of this FunctionList.
+func (p *FunctionList) GetPackages() []Package {
+	pkgs := make([]Package, len(p.Items))
+	for i, pkg := range p.Items {
+		pkgs[i] = &pkg
+	}
+	return pkgs
 }

--- a/apis/pkg/v1/interfaces_test.go
+++ b/apis/pkg/v1/interfaces_test.go
@@ -33,3 +33,9 @@ var (
 	_ PackageRevisionList = &ConfigurationRevisionList{}
 	_ PackageRevisionList = &FunctionRevisionList{}
 )
+
+var (
+	_ PackageList = &ProviderList{}
+	_ PackageList = &ConfigurationList{}
+	_ PackageList = &FunctionList{}
+)

--- a/internal/controller/pkg/manager/reconciler.go
+++ b/internal/controller/pkg/manager/reconciler.go
@@ -27,12 +27,10 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	xpv1 "github.com/crossplane/crossplane-runtime/v2/apis/common/v1"
@@ -218,7 +216,7 @@ func SetupProvider(mgr ctrl.Manager, o controller.Options) error {
 		Named(name).
 		For(&v1.Provider{}).
 		Owns(&v1.ProviderRevision{}).
-		Watches(&v1beta1.ImageConfig{}, enqueueProvidersForImageConfig(mgr.GetClient(), log)).
+		Watches(&v1beta1.ImageConfig{}, EnqueuePackagesForImageConfig(mgr.GetClient(), &v1.ProviderList{}, log)).
 		WithOptions(o.ForControllerRuntime()).
 		Complete(ratelimiter.NewReconciler(name, errors.WithSilentRequeueOnConflict(NewReconciler(mgr, opts...)), o.GlobalRateLimiter))
 }
@@ -255,7 +253,7 @@ func SetupConfiguration(mgr ctrl.Manager, o controller.Options) error {
 		Named(name).
 		For(&v1.Configuration{}).
 		Owns(&v1.ConfigurationRevision{}).
-		Watches(&v1beta1.ImageConfig{}, enqueueConfigurationsForImageConfig(mgr.GetClient(), log)).
+		Watches(&v1beta1.ImageConfig{}, EnqueuePackagesForImageConfig(mgr.GetClient(), &v1.ConfigurationList{}, log)).
 		WithOptions(o.ForControllerRuntime()).
 		Complete(ratelimiter.NewReconciler(name, errors.WithSilentRequeueOnConflict(r), o.GlobalRateLimiter))
 }
@@ -296,7 +294,7 @@ func SetupFunction(mgr ctrl.Manager, o controller.Options) error {
 		Named(name).
 		For(&v1.Function{}).
 		Owns(&v1.FunctionRevision{}).
-		Watches(&v1beta1.ImageConfig{}, enqueueFunctionsForImageConfig(mgr.GetClient(), log)).
+		Watches(&v1beta1.ImageConfig{}, EnqueuePackagesForImageConfig(mgr.GetClient(), &v1.FunctionList{}, log)).
 		WithOptions(o.ForControllerRuntime()).
 		Complete(ratelimiter.NewReconciler(name, errors.WithSilentRequeueOnConflict(NewReconciler(mgr, opts...)), o.GlobalRateLimiter))
 }
@@ -598,103 +596,4 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 	// its health. If updating from an existing revision, the package health
 	// will match the health of the old revision until the next reconcile.
 	return pullBasedRequeue(p.GetPackagePullPolicy()), errors.Wrap(r.client.Status().Update(ctx, p), errUpdateStatus)
-}
-
-func enqueueProvidersForImageConfig(kube client.Client, log logging.Logger) handler.EventHandler {
-	return handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, o client.Object) []reconcile.Request {
-		ic, ok := o.(*v1beta1.ImageConfig)
-		if !ok {
-			return nil
-		}
-		// We only care about ImageConfigs that have a pull secret.
-		if ic.Spec.Registry == nil || ic.Spec.Registry.Authentication == nil || ic.Spec.Registry.Authentication.PullSecretRef.Name == "" {
-			return nil
-		}
-		// Enqueue all Providers matching the prefixes in the ImageConfig.
-		l := &v1.ProviderList{}
-		if err := kube.List(ctx, l); err != nil {
-			// Nothing we can do, except logging, if we can't list Providers.
-			log.Debug("Cannot list providers while attempting to enqueue from ImageConfig", "error", err)
-			return nil
-		}
-
-		var matches []reconcile.Request
-
-		for _, p := range l.Items {
-			for _, m := range ic.Spec.MatchImages {
-				if strings.HasPrefix(p.GetSource(), m.Prefix) || strings.HasPrefix(p.GetResolvedSource(), m.Prefix) {
-					log.Debug("Enqueuing provider for image config", "provider", p.Name, "imageConfig", ic.Name)
-					matches = append(matches, reconcile.Request{NamespacedName: types.NamespacedName{Name: p.Name}})
-				}
-			}
-		}
-
-		return matches
-	})
-}
-
-func enqueueConfigurationsForImageConfig(kube client.Client, log logging.Logger) handler.EventHandler {
-	return handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, o client.Object) []reconcile.Request {
-		ic, ok := o.(*v1beta1.ImageConfig)
-		if !ok {
-			return nil
-		}
-		// We only care about ImageConfigs that have a pull secret.
-		if ic.Spec.Registry == nil || ic.Spec.Registry.Authentication == nil || ic.Spec.Registry.Authentication.PullSecretRef.Name == "" {
-			return nil
-		}
-		// Enqueue all Configurations matching the prefixes in the ImageConfig.
-		l := &v1.ConfigurationList{}
-		if err := kube.List(ctx, l); err != nil {
-			// Nothing we can do, except logging, if we can't list Configurations.
-			log.Debug("Cannot list configurations while attempting to enqueue from ImageConfig", "error", err)
-			return nil
-		}
-
-		var matches []reconcile.Request
-
-		for _, c := range l.Items {
-			for _, m := range ic.Spec.MatchImages {
-				if strings.HasPrefix(c.GetSource(), m.Prefix) || strings.HasPrefix(c.GetResolvedSource(), m.Prefix) {
-					log.Debug("Enqueuing configuration for image config", "configuration", c.Name, "imageConfig", ic.Name)
-					matches = append(matches, reconcile.Request{NamespacedName: types.NamespacedName{Name: c.Name}})
-				}
-			}
-		}
-
-		return matches
-	})
-}
-
-func enqueueFunctionsForImageConfig(kube client.Client, log logging.Logger) handler.EventHandler {
-	return handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, o client.Object) []reconcile.Request {
-		ic, ok := o.(*v1beta1.ImageConfig)
-		if !ok {
-			return nil
-		}
-		// We only care about ImageConfigs that have a pull secret.
-		if ic.Spec.Registry == nil || ic.Spec.Registry.Authentication == nil || ic.Spec.Registry.Authentication.PullSecretRef.Name == "" {
-			return nil
-		}
-		// Enqueue all Functions matching the prefixes in the ImageConfig.
-		l := &v1.FunctionList{}
-		if err := kube.List(ctx, l); err != nil {
-			// Nothing we can do, except logging, if we can't list Functions.
-			log.Debug("Cannot list functions while attempting to enqueue from ImageConfig", "error", err)
-			return nil
-		}
-
-		var matches []reconcile.Request
-
-		for _, fn := range l.Items {
-			for _, m := range ic.Spec.MatchImages {
-				if strings.HasPrefix(fn.GetSource(), m.Prefix) || strings.HasPrefix(fn.GetResolvedSource(), m.Prefix) {
-					log.Debug("Enqueuing function for image config", "function", fn.Name, "imageConfig", ic.Name)
-					matches = append(matches, reconcile.Request{NamespacedName: types.NamespacedName{Name: fn.Name}})
-				}
-			}
-		}
-
-		return matches
-	})
 }

--- a/internal/controller/pkg/manager/watch.go
+++ b/internal/controller/pkg/manager/watch.go
@@ -1,0 +1,71 @@
+/*
+Copyright 2021 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package manager
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"github.com/crossplane/crossplane-runtime/v2/pkg/logging"
+
+	v1 "github.com/crossplane/crossplane/v2/apis/pkg/v1"
+	"github.com/crossplane/crossplane/v2/apis/pkg/v1beta1"
+)
+
+// EnqueuePackagesForImageConfig enqueues a reconcile for all packages
+// an ImageConfig applies to.
+func EnqueuePackagesForImageConfig(kube client.Client, l v1.PackageList, log logging.Logger) handler.EventHandler {
+	return handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, o client.Object) []reconcile.Request {
+		ic, ok := o.(*v1beta1.ImageConfig)
+		if !ok {
+			return nil
+		}
+		// We only care about ImageConfigs that have a pull secret.
+		if ic.Spec.Registry == nil || ic.Spec.Registry.Authentication == nil || ic.Spec.Registry.Authentication.PullSecretRef.Name == "" {
+			return nil
+		}
+		// Enqueue all packages matching the prefixes in the ImageConfig.
+		pl := l.DeepCopyObject().(v1.PackageList) //nolint:forcetypeassert // Guaranteed to be PackageList.
+		if err := kube.List(ctx, pl); err != nil {
+			// Nothing we can do, except logging, if we can't list packages.
+			log.Debug("Cannot list packages while attempting to enqueue from ImageConfig", "error", err)
+			return nil
+		}
+
+		var matches []reconcile.Request
+
+		for _, pkg := range pl.GetPackages() {
+			for _, m := range ic.Spec.MatchImages {
+				if strings.HasPrefix(pkg.GetSource(), m.Prefix) || strings.HasPrefix(pkg.GetResolvedSource(), m.Prefix) {
+					log.Debug("Enqueuing package for image config",
+						"package-type", fmt.Sprintf("%T", pkg),
+						"package-name", pkg.GetName(),
+						"image-config-name", ic.GetName())
+					matches = append(matches, reconcile.Request{NamespacedName: types.NamespacedName{Name: pkg.GetName()}})
+				}
+			}
+		}
+
+		return matches
+	})
+}

--- a/internal/controller/pkg/manager/watch.go
+++ b/internal/controller/pkg/manager/watch.go
@@ -32,6 +32,22 @@ import (
 	"github.com/crossplane/crossplane/v2/apis/pkg/v1beta1"
 )
 
+// hasPullSecret returns true if the ImageConfig has authentication with a pull secret.
+func hasPullSecret(ic *v1beta1.ImageConfig) bool {
+	if ic.Spec.Registry == nil {
+		return false
+	}
+	if ic.Spec.Registry.Authentication == nil {
+		return false
+	}
+	return ic.Spec.Registry.Authentication.PullSecretRef.Name != ""
+}
+
+// hasRewriteRules returns true if the ImageConfig has image rewrite rules.
+func hasRewriteRules(ic *v1beta1.ImageConfig) bool {
+	return ic.Spec.RewriteImage != nil
+}
+
 // EnqueuePackagesForImageConfig enqueues a reconcile for all packages
 // an ImageConfig applies to.
 func EnqueuePackagesForImageConfig(kube client.Client, l v1.PackageList, log logging.Logger) handler.EventHandler {
@@ -40,8 +56,8 @@ func EnqueuePackagesForImageConfig(kube client.Client, l v1.PackageList, log log
 		if !ok {
 			return nil
 		}
-		// We only care about ImageConfigs that have a pull secret.
-		if ic.Spec.Registry == nil || ic.Spec.Registry.Authentication == nil || ic.Spec.Registry.Authentication.PullSecretRef.Name == "" {
+		// We only care about ImageConfigs that have a pull secret or rewrite rules.
+		if !hasPullSecret(ic) && !hasRewriteRules(ic) {
 			return nil
 		}
 		// Enqueue all packages matching the prefixes in the ImageConfig.

--- a/internal/controller/pkg/manager/watch_test.go
+++ b/internal/controller/pkg/manager/watch_test.go
@@ -133,7 +133,7 @@ func TestHasRewriteRules(t *testing.T) {
 	}
 }
 
-// testEnqueuePackagesForImageConfig tests the handler by calling it with mock events and queues
+// testEnqueuePackagesForImageConfig tests the handler by calling it with mock events and queues.
 func TestEnqueuePackagesForImageConfig(t *testing.T) {
 	errBoom := errors.New("boom")
 
@@ -354,7 +354,7 @@ func TestEnqueuePackagesForImageConfig(t *testing.T) {
 	}
 }
 
-// MockWorkQueue implements workqueue.TypedRateLimitingInterface for testing
+// MockWorkQueue implements workqueue.TypedRateLimitingInterface for testing.
 type MockWorkQueue struct {
 	workqueue.TypedRateLimitingInterface[reconcile.Request]
 	requests []reconcile.Request
@@ -363,4 +363,3 @@ type MockWorkQueue struct {
 func (m *MockWorkQueue) Add(item reconcile.Request) {
 	m.requests = append(m.requests, item)
 }
-

--- a/internal/controller/pkg/manager/watch_test.go
+++ b/internal/controller/pkg/manager/watch_test.go
@@ -1,0 +1,366 @@
+/*
+Copyright 2021 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package manager
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/workqueue"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"github.com/crossplane/crossplane-runtime/v2/pkg/errors"
+	"github.com/crossplane/crossplane-runtime/v2/pkg/logging"
+	"github.com/crossplane/crossplane-runtime/v2/pkg/test"
+
+	v1 "github.com/crossplane/crossplane/v2/apis/pkg/v1"
+	"github.com/crossplane/crossplane/v2/apis/pkg/v1beta1"
+)
+
+func TestHasPullSecret(t *testing.T) {
+	cases := map[string]struct {
+		reason string
+		ic     *v1beta1.ImageConfig
+		want   bool
+	}{
+		"NilRegistry": {
+			reason: "Should return false when Registry is nil",
+			ic: &v1beta1.ImageConfig{
+				Spec: v1beta1.ImageConfigSpec{},
+			},
+			want: false,
+		},
+		"NilAuthentication": {
+			reason: "Should return false when Authentication is nil",
+			ic: &v1beta1.ImageConfig{
+				Spec: v1beta1.ImageConfigSpec{
+					Registry: &v1beta1.RegistryConfig{},
+				},
+			},
+			want: false,
+		},
+		"EmptyPullSecretName": {
+			reason: "Should return false when PullSecretRef name is empty",
+			ic: &v1beta1.ImageConfig{
+				Spec: v1beta1.ImageConfigSpec{
+					Registry: &v1beta1.RegistryConfig{
+						Authentication: &v1beta1.RegistryAuthentication{
+							PullSecretRef: corev1.LocalObjectReference{Name: ""},
+						},
+					},
+				},
+			},
+			want: false,
+		},
+		"HasPullSecret": {
+			reason: "Should return true when PullSecretRef name is set",
+			ic: &v1beta1.ImageConfig{
+				Spec: v1beta1.ImageConfigSpec{
+					Registry: &v1beta1.RegistryConfig{
+						Authentication: &v1beta1.RegistryAuthentication{
+							PullSecretRef: corev1.LocalObjectReference{Name: "my-secret"},
+						},
+					},
+				},
+			},
+			want: true,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got := hasPullSecret(tc.ic)
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("\n%s\nhasPullSecret(...): -want, +got:\n%s", tc.reason, diff)
+			}
+		})
+	}
+}
+
+func TestHasRewriteRules(t *testing.T) {
+	cases := map[string]struct {
+		reason string
+		ic     *v1beta1.ImageConfig
+		want   bool
+	}{
+		"NilRewriteImage": {
+			reason: "Should return false when RewriteImage is nil",
+			ic: &v1beta1.ImageConfig{
+				Spec: v1beta1.ImageConfigSpec{},
+			},
+			want: false,
+		},
+		"HasRewriteRules": {
+			reason: "Should return true when RewriteImage is set",
+			ic: &v1beta1.ImageConfig{
+				Spec: v1beta1.ImageConfigSpec{
+					RewriteImage: &v1beta1.ImageRewrite{
+						Prefix: "xpkg.crossplane.io/crossplane-contrib/",
+					},
+				},
+			},
+			want: true,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got := hasRewriteRules(tc.ic)
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("\n%s\nhasRewriteRules(...): -want, +got:\n%s", tc.reason, diff)
+			}
+		})
+	}
+}
+
+// testEnqueuePackagesForImageConfig tests the handler by calling it with mock events and queues
+func TestEnqueuePackagesForImageConfig(t *testing.T) {
+	errBoom := errors.New("boom")
+
+	type params struct {
+		kube client.Client
+		l    v1.PackageList
+		log  logging.Logger
+		obj  client.Object
+	}
+
+	type want struct {
+		reqs []reconcile.Request
+	}
+
+	cases := map[string]struct {
+		reason string
+		params params
+		want   want
+	}{
+		"NotImageConfig": {
+			reason: "Should not enqueue when object is not an ImageConfig",
+			params: params{
+				obj: &v1.Provider{},
+			},
+			want: want{
+				reqs: nil,
+			},
+		},
+		"NoPullSecretOrRewriteRules": {
+			reason: "Should not enqueue when ImageConfig has neither pull secret nor rewrite rules",
+			params: params{
+				obj: &v1beta1.ImageConfig{
+					Spec: v1beta1.ImageConfigSpec{},
+				},
+			},
+			want: want{
+				reqs: nil,
+			},
+		},
+		"ErrorListingPackages": {
+			reason: "Should not enqueue when listing packages fails",
+			params: params{
+				kube: &test.MockClient{
+					MockList: test.NewMockListFn(errBoom),
+				},
+				l:   &v1.ProviderList{},
+				log: logging.NewNopLogger(),
+				obj: &v1beta1.ImageConfig{
+					Spec: v1beta1.ImageConfigSpec{
+						Registry: &v1beta1.RegistryConfig{
+							Authentication: &v1beta1.RegistryAuthentication{
+								PullSecretRef: corev1.LocalObjectReference{Name: "my-secret"},
+							},
+						},
+					},
+				},
+			},
+			want: want{
+				reqs: nil,
+			},
+		},
+		"SuccessfulWithPullSecret": {
+			reason: "Should enqueue matching packages when ImageConfig has pull secret",
+			params: params{
+				kube: &test.MockClient{
+					MockList: test.NewMockListFn(nil, func(obj client.ObjectList) error {
+						list := obj.(*v1.ProviderList)
+						list.Items = []v1.Provider{
+							{
+								ObjectMeta: metav1.ObjectMeta{Name: "provider-aws"},
+								Spec: v1.ProviderSpec{
+									PackageSpec: v1.PackageSpec{
+										Package: "xpkg.upbound.io/upbound/provider-aws:v1.0.0",
+									},
+								},
+							},
+							{
+								ObjectMeta: metav1.ObjectMeta{Name: "provider-gcp"},
+								Spec: v1.ProviderSpec{
+									PackageSpec: v1.PackageSpec{
+										Package: "xpkg.crossplane.io/crossplane-contrib/provider-gcp:v1.0.0",
+									},
+								},
+							},
+						}
+						return nil
+					}),
+				},
+				l:   &v1.ProviderList{},
+				log: logging.NewNopLogger(),
+				obj: &v1beta1.ImageConfig{
+					ObjectMeta: metav1.ObjectMeta{Name: "test-config"},
+					Spec: v1beta1.ImageConfigSpec{
+						MatchImages: []v1beta1.ImageMatch{
+							{Prefix: "xpkg.upbound.io/upbound/"},
+						},
+						Registry: &v1beta1.RegistryConfig{
+							Authentication: &v1beta1.RegistryAuthentication{
+								PullSecretRef: corev1.LocalObjectReference{Name: "my-secret"},
+							},
+						},
+					},
+				},
+			},
+			want: want{
+				reqs: []reconcile.Request{
+					{NamespacedName: types.NamespacedName{Name: "provider-aws"}},
+				},
+			},
+		},
+		"SuccessfulWithRewriteRules": {
+			reason: "Should enqueue matching packages when ImageConfig has rewrite rules",
+			params: params{
+				kube: &test.MockClient{
+					MockList: test.NewMockListFn(nil, func(obj client.ObjectList) error {
+						list := obj.(*v1.ProviderList)
+						list.Items = []v1.Provider{
+							{
+								ObjectMeta: metav1.ObjectMeta{Name: "provider-aws"},
+								Spec: v1.ProviderSpec{
+									PackageSpec: v1.PackageSpec{
+										Package: "xpkg.upbound.io/upbound/provider-aws:v1.0.0",
+									},
+								},
+								Status: v1.ProviderStatus{
+									PackageStatus: v1.PackageStatus{
+										ResolvedPackage: "xpkg.crossplane.io/crossplane-contrib/provider-aws:v1.0.0",
+									},
+								},
+							},
+						}
+						return nil
+					}),
+				},
+				l:   &v1.ProviderList{},
+				log: logging.NewNopLogger(),
+				obj: &v1beta1.ImageConfig{
+					ObjectMeta: metav1.ObjectMeta{Name: "test-config"},
+					Spec: v1beta1.ImageConfigSpec{
+						MatchImages: []v1beta1.ImageMatch{
+							{Prefix: "xpkg.crossplane.io/crossplane-contrib/"},
+						},
+						RewriteImage: &v1beta1.ImageRewrite{
+							Prefix: "xpkg.crossplane.io/crossplane-contrib/",
+						},
+					},
+				},
+			},
+			want: want{
+				reqs: []reconcile.Request{
+					{NamespacedName: types.NamespacedName{Name: "provider-aws"}},
+				},
+			},
+		},
+		"NoMatchingPackages": {
+			reason: "Should not enqueue when no packages match the prefix",
+			params: params{
+				kube: &test.MockClient{
+					MockList: test.NewMockListFn(nil, func(obj client.ObjectList) error {
+						list := obj.(*v1.ProviderList)
+						list.Items = []v1.Provider{
+							{
+								ObjectMeta: metav1.ObjectMeta{Name: "provider-aws"},
+								Spec: v1.ProviderSpec{
+									PackageSpec: v1.PackageSpec{
+										Package: "xpkg.crossplane.io/crossplane-contrib/provider-aws:v1.0.0",
+									},
+								},
+							},
+						}
+						return nil
+					}),
+				},
+				l:   &v1.ProviderList{},
+				log: logging.NewNopLogger(),
+				obj: &v1beta1.ImageConfig{
+					ObjectMeta: metav1.ObjectMeta{Name: "test-config"},
+					Spec: v1beta1.ImageConfigSpec{
+						MatchImages: []v1beta1.ImageMatch{
+							{Prefix: "xpkg.upbound.io/upbound/"},
+						},
+						Registry: &v1beta1.RegistryConfig{
+							Authentication: &v1beta1.RegistryAuthentication{
+								PullSecretRef: corev1.LocalObjectReference{Name: "my-secret"},
+							},
+						},
+					},
+				},
+			},
+			want: want{
+				reqs: nil,
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			// Create the handler
+			handler := EnqueuePackagesForImageConfig(tc.params.kube, tc.params.l, tc.params.log)
+
+			// Create a mock workqueue to capture enqueued requests
+			mockQueue := &MockWorkQueue{}
+
+			// Create a create event
+			event := event.CreateEvent{
+				Object: tc.params.obj,
+			}
+
+			// Call the handler's Create method
+			ctx := context.Background()
+			handler.Create(ctx, event, mockQueue)
+
+			// Check what was enqueued
+			if diff := cmp.Diff(tc.want.reqs, mockQueue.requests); diff != "" {
+				t.Errorf("\n%s\nEnqueuePackagesForImageConfig(...): -want, +got:\n%s", tc.reason, diff)
+			}
+		})
+	}
+}
+
+// MockWorkQueue implements workqueue.TypedRateLimitingInterface for testing
+type MockWorkQueue struct {
+	workqueue.TypedRateLimitingInterface[reconcile.Request]
+	requests []reconcile.Request
+}
+
+func (m *MockWorkQueue) Add(item reconcile.Request) {
+	m.requests = append(m.requests, item)
+}
+

--- a/internal/controller/pkg/revision/watch_test.go
+++ b/internal/controller/pkg/revision/watch_test.go
@@ -1,0 +1,364 @@
+/*
+Copyright 2021 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package revision
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	corev1 "k8s.io/api/core/v1"
+	k8sworkqueue "k8s.io/client-go/util/workqueue"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"github.com/crossplane/crossplane-runtime/v2/pkg/errors"
+	"github.com/crossplane/crossplane-runtime/v2/pkg/logging"
+	"github.com/crossplane/crossplane-runtime/v2/pkg/test"
+
+	v1 "github.com/crossplane/crossplane/v2/apis/pkg/v1"
+	"github.com/crossplane/crossplane/v2/apis/pkg/v1beta1"
+)
+
+func TestHasPullSecret(t *testing.T) {
+	cases := map[string]struct {
+		reason string
+		ic     *v1beta1.ImageConfig
+		want   bool
+	}{
+		"NilRegistry": {
+			reason: "Should return false when Registry is nil",
+			ic: &v1beta1.ImageConfig{
+				Spec: v1beta1.ImageConfigSpec{},
+			},
+			want: false,
+		},
+		"NilAuthentication": {
+			reason: "Should return false when Authentication is nil",
+			ic: &v1beta1.ImageConfig{
+				Spec: v1beta1.ImageConfigSpec{
+					Registry: &v1beta1.RegistryConfig{},
+				},
+			},
+			want: false,
+		},
+		"EmptyPullSecretName": {
+			reason: "Should return false when PullSecretRef name is empty",
+			ic: &v1beta1.ImageConfig{
+				Spec: v1beta1.ImageConfigSpec{
+					Registry: &v1beta1.RegistryConfig{
+						Authentication: &v1beta1.RegistryAuthentication{
+							PullSecretRef: corev1.LocalObjectReference{Name: ""},
+						},
+					},
+				},
+			},
+			want: false,
+		},
+		"HasPullSecret": {
+			reason: "Should return true when PullSecretRef name is set",
+			ic: &v1beta1.ImageConfig{
+				Spec: v1beta1.ImageConfigSpec{
+					Registry: &v1beta1.RegistryConfig{
+						Authentication: &v1beta1.RegistryAuthentication{
+							PullSecretRef: corev1.LocalObjectReference{Name: "my-secret"},
+						},
+					},
+				},
+			},
+			want: true,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got := hasPullSecret(tc.ic)
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("\n%s\nhasPullSecret(...): -want, +got:\n%s", tc.reason, diff)
+			}
+		})
+	}
+}
+
+func TestHasRewriteRules(t *testing.T) {
+	cases := map[string]struct {
+		reason string
+		ic     *v1beta1.ImageConfig
+		want   bool
+	}{
+		"NilRewriteImage": {
+			reason: "Should return false when RewriteImage is nil",
+			ic: &v1beta1.ImageConfig{
+				Spec: v1beta1.ImageConfigSpec{},
+			},
+			want: false,
+		},
+		"HasRewriteRules": {
+			reason: "Should return true when RewriteImage is set",
+			ic: &v1beta1.ImageConfig{
+				Spec: v1beta1.ImageConfigSpec{
+					RewriteImage: &v1beta1.ImageRewrite{
+						Prefix: "xpkg.crossplane.io/crossplane-contrib/",
+					},
+				},
+			},
+			want: true,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got := hasRewriteRules(tc.ic)
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("\n%s\nhasRewriteRules(...): -want, +got:\n%s", tc.reason, diff)
+			}
+		})
+	}
+}
+
+func TestEnqueuePackageRevisionsForImageConfig(t *testing.T) {
+	errBoom := errors.New("boom")
+
+	type params struct {
+		kube client.Client
+		l    v1.PackageRevisionList
+		log  logging.Logger
+		obj  client.Object
+	}
+
+	type want struct {
+		reqs []reconcile.Request
+	}
+
+	cases := map[string]struct {
+		reason string
+		params params
+		want   want
+	}{
+		"NotImageConfig": {
+			reason: "Should not enqueue when object is not an ImageConfig",
+			params: params{
+				obj: &v1.Provider{},
+			},
+			want: want{
+				reqs: nil,
+			},
+		},
+		"NoPullSecretOrRewriteRules": {
+			reason: "Should not enqueue when ImageConfig has neither pull secret nor rewrite rules",
+			params: params{
+				obj: &v1beta1.ImageConfig{
+					Spec: v1beta1.ImageConfigSpec{},
+				},
+			},
+			want: want{
+				reqs: nil,
+			},
+		},
+		"ErrorListingPackageRevisions": {
+			reason: "Should not enqueue when listing package revisions fails",
+			params: params{
+				kube: &test.MockClient{
+					MockList: test.NewMockListFn(errBoom),
+				},
+				l:   &v1.ProviderRevisionList{},
+				log: logging.NewNopLogger(),
+				obj: &v1beta1.ImageConfig{
+					Spec: v1beta1.ImageConfigSpec{
+						Registry: &v1beta1.RegistryConfig{
+							Authentication: &v1beta1.RegistryAuthentication{
+								PullSecretRef: corev1.LocalObjectReference{Name: "my-secret"},
+							},
+						},
+					},
+				},
+			},
+			want: want{
+				reqs: nil,
+			},
+		},
+		"SuccessfulWithPullSecret": {
+			reason: "Should enqueue matching package revisions when ImageConfig has pull secret",
+			params: params{
+				kube: &test.MockClient{
+					MockList: test.NewMockListFn(nil, func(obj client.ObjectList) error {
+						list := obj.(*v1.ProviderRevisionList)
+						list.Items = []v1.ProviderRevision{
+							{
+								ObjectMeta: metav1.ObjectMeta{Name: "provider-aws-abc123"},
+								Spec: v1.ProviderRevisionSpec{
+									PackageRevisionSpec: v1.PackageRevisionSpec{
+										Package: "xpkg.upbound.io/upbound/provider-aws:v1.0.0",
+									},
+								},
+							},
+							{
+								ObjectMeta: metav1.ObjectMeta{Name: "provider-gcp-def456"},
+								Spec: v1.ProviderRevisionSpec{
+									PackageRevisionSpec: v1.PackageRevisionSpec{
+										Package: "xpkg.crossplane.io/crossplane-contrib/provider-gcp:v1.0.0",
+									},
+								},
+							},
+						}
+						return nil
+					}),
+				},
+				l:   &v1.ProviderRevisionList{},
+				log: logging.NewNopLogger(),
+				obj: &v1beta1.ImageConfig{
+					ObjectMeta: metav1.ObjectMeta{Name: "test-config"},
+					Spec: v1beta1.ImageConfigSpec{
+						MatchImages: []v1beta1.ImageMatch{
+							{Prefix: "xpkg.upbound.io/upbound/"},
+						},
+						Registry: &v1beta1.RegistryConfig{
+							Authentication: &v1beta1.RegistryAuthentication{
+								PullSecretRef: corev1.LocalObjectReference{Name: "my-secret"},
+							},
+						},
+					},
+				},
+			},
+			want: want{
+				reqs: []reconcile.Request{
+					{NamespacedName: types.NamespacedName{Name: "provider-aws-abc123"}},
+				},
+			},
+		},
+		"SuccessfulWithRewriteRules": {
+			reason: "Should enqueue matching package revisions when ImageConfig has rewrite rules",
+			params: params{
+				kube: &test.MockClient{
+					MockList: test.NewMockListFn(nil, func(obj client.ObjectList) error {
+						list := obj.(*v1.ProviderRevisionList)
+						list.Items = []v1.ProviderRevision{
+							{
+								ObjectMeta: metav1.ObjectMeta{Name: "provider-aws-abc123"},
+								Spec: v1.ProviderRevisionSpec{
+									PackageRevisionSpec: v1.PackageRevisionSpec{
+										Package: "xpkg.upbound.io/upbound/provider-aws:v1.0.0",
+									},
+								},
+								Status: v1.ProviderRevisionStatus{
+									PackageRevisionStatus: v1.PackageRevisionStatus{
+										ResolvedPackage: "xpkg.crossplane.io/crossplane-contrib/provider-aws:v1.0.0",
+									},
+								},
+							},
+						}
+						return nil
+					}),
+				},
+				l:   &v1.ProviderRevisionList{},
+				log: logging.NewNopLogger(),
+				obj: &v1beta1.ImageConfig{
+					ObjectMeta: metav1.ObjectMeta{Name: "test-config"},
+					Spec: v1beta1.ImageConfigSpec{
+						MatchImages: []v1beta1.ImageMatch{
+							{Prefix: "xpkg.crossplane.io/crossplane-contrib/"},
+						},
+						RewriteImage: &v1beta1.ImageRewrite{
+							Prefix: "xpkg.crossplane.io/crossplane-contrib/",
+						},
+					},
+				},
+			},
+			want: want{
+				reqs: []reconcile.Request{
+					{NamespacedName: types.NamespacedName{Name: "provider-aws-abc123"}},
+				},
+			},
+		},
+		"NoMatchingPackageRevisions": {
+			reason: "Should not enqueue when no package revisions match the prefix",
+			params: params{
+				kube: &test.MockClient{
+					MockList: test.NewMockListFn(nil, func(obj client.ObjectList) error {
+						list := obj.(*v1.ProviderRevisionList)
+						list.Items = []v1.ProviderRevision{
+							{
+								ObjectMeta: metav1.ObjectMeta{Name: "provider-aws-abc123"},
+								Spec: v1.ProviderRevisionSpec{
+									PackageRevisionSpec: v1.PackageRevisionSpec{
+										Package: "xpkg.crossplane.io/crossplane-contrib/provider-aws:v1.0.0",
+									},
+								},
+							},
+						}
+						return nil
+					}),
+				},
+				l:   &v1.ProviderRevisionList{},
+				log: logging.NewNopLogger(),
+				obj: &v1beta1.ImageConfig{
+					ObjectMeta: metav1.ObjectMeta{Name: "test-config"},
+					Spec: v1beta1.ImageConfigSpec{
+						MatchImages: []v1beta1.ImageMatch{
+							{Prefix: "xpkg.upbound.io/upbound/"},
+						},
+						Registry: &v1beta1.RegistryConfig{
+							Authentication: &v1beta1.RegistryAuthentication{
+								PullSecretRef: corev1.LocalObjectReference{Name: "my-secret"},
+							},
+						},
+					},
+				},
+			},
+			want: want{
+				reqs: nil,
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			// Create the handler
+			handler := EnqueuePackageRevisionsForImageConfig(tc.params.kube, tc.params.l, tc.params.log)
+			
+			// Create a mock workqueue to capture enqueued requests
+			mockQueue := &MockWorkQueue{}
+			
+			// Create a create event
+			event := event.CreateEvent{
+				Object: tc.params.obj,
+			}
+			
+			// Call the handler's Create method
+			ctx := context.Background()
+			handler.Create(ctx, event, mockQueue)
+			
+			// Check what was enqueued
+			if diff := cmp.Diff(tc.want.reqs, mockQueue.requests); diff != "" {
+				t.Errorf("\n%s\nEnqueuePackageRevisionsForImageConfig(...): -want, +got:\n%s", tc.reason, diff)
+			}
+		})
+	}
+}
+
+// MockWorkQueue implements workqueue.TypedRateLimitingInterface for testing
+type MockWorkQueue struct {
+	k8sworkqueue.TypedRateLimitingInterface[reconcile.Request]
+	requests []reconcile.Request
+}
+
+func (m *MockWorkQueue) Add(item reconcile.Request) {
+	m.requests = append(m.requests, item)
+}

--- a/internal/controller/pkg/revision/watch_test.go
+++ b/internal/controller/pkg/revision/watch_test.go
@@ -22,9 +22,9 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	corev1 "k8s.io/api/core/v1"
-	k8sworkqueue "k8s.io/client-go/util/workqueue"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	k8sworkqueue "k8s.io/client-go/util/workqueue"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -332,19 +332,19 @@ func TestEnqueuePackageRevisionsForImageConfig(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			// Create the handler
 			handler := EnqueuePackageRevisionsForImageConfig(tc.params.kube, tc.params.l, tc.params.log)
-			
+
 			// Create a mock workqueue to capture enqueued requests
 			mockQueue := &MockWorkQueue{}
-			
+
 			// Create a create event
 			event := event.CreateEvent{
 				Object: tc.params.obj,
 			}
-			
+
 			// Call the handler's Create method
 			ctx := context.Background()
 			handler.Create(ctx, event, mockQueue)
-			
+
 			// Check what was enqueued
 			if diff := cmp.Diff(tc.want.reqs, mockQueue.requests); diff != "" {
 				t.Errorf("\n%s\nEnqueuePackageRevisionsForImageConfig(...): -want, +got:\n%s", tc.reason, diff)
@@ -353,7 +353,7 @@ func TestEnqueuePackageRevisionsForImageConfig(t *testing.T) {
 	}
 }
 
-// MockWorkQueue implements workqueue.TypedRateLimitingInterface for testing
+// MockWorkQueue implements workqueue.TypedRateLimitingInterface for testing.
 type MockWorkQueue struct {
 	k8sworkqueue.TypedRateLimitingInterface[reconcile.Request]
 	requests []reconcile.Request


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane! Please read the contribution docs
(linked below) if this is your first Crossplane pull request.
-->

### Description of your changes

<!--
Briefly describe what this pull request does, and how it is covered by tests.
Be proactive - direct your reviewers' attention to anything that needs special
consideration.

We love pull requests that fix an open issue. If yours does, use the below line
to indicate which issue it fixes, for example "Fixes #500".
-->

Fixes https://github.com/crossplane/crossplane/issues/6763
Fixes https://github.com/crossplane/crossplane/issues/6764

This PR fixes two related issues with ImageConfig handling in the package manager:

1. **ImageConfig watch handlers only triggered for pull secrets, not rewrite rules** - Previously we'd only enqueue reconciles when ImageConfigs with pull secrets changed. Now we consider rewrite rules too, ensuring packages are immediately reconciled when ImageConfigs with rewrite rules are created or updated.

2. **Resolver didn't check resolved package source when matching existing dependencies** - The resolver controller was only checking `spec.package` when looking for existing packages to satisfy dependencies, ignoring `status.resolvedPackage`. ~This broke ImageConfig rewrite functionality for dependency resolution, causing duplicate providers to be created instead of reusing existing ones with rewritten sources.~

Actually, this commit only fixes one small edge case when updating existing providers. I think it's still worth fixing but it won't actually prevent creating duplicate packages.

Trying to make the Lock and dependency resolution ImageConfig turns out to be fraught with peril. I took a pass in  https://github.com/crossplane/crossplane/commit/2545d74993803fd87e2e4cd945f0e10526d3907f but it still doesn't work (race issues still cause duplicate dependencies you need to manually clean up). My current thinking is it's just not a good approach to pursue.

Additionally, this standardizes the ImageConfig handler pattern across package types and adds comprehensive tests for the ImageConfig watch handlers, which previously had none.

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `earthly +reviewable` to ensure this PR is ready for review.
- [x] Added or updated unit tests.
- [ ] ~Added or updated e2e tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [x] Added `backport release-x.y` labels to auto-backport this PR.
- [ ] ~Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md