### PR TITLE
pkg: Ignore tags that are incomplete semantic versions

### DIFF
--- a/internal/controller/pkg/resolver/reconciler.go
+++ b/internal/controller/pkg/resolver/reconciler.go
@@ -527,6 +527,13 @@ func (r *Reconciler) findDependencyVersionToInstall(ctx context.Context, dep *v1
 			continue
 		}
 
+		// We also skip any tags that are incomplete semantic versions (e.g.,
+		// "v1" will parse as "v1.0.0"). This prevents a "v1" tag, which may not
+		// point to v1.0.0 of a package, from matching a "v1.0.0" constraint.
+		if v.String() != strings.TrimPrefix(v.Original(), "v") {
+			continue
+		}
+
 		vs = append(vs, v)
 	}
 


### PR DESCRIPTION
### Description of your changes

If a package is tagged with an incomplete semantic version (e.g., `v1`), the package manager will happily parse it and consider it as a candidate for installation as a dependency (`v1` parses to `v1.0.0`). This can lead to the wrong version being installed if the incomplete tag points to a different version and the dependency has an exact version constraint. Avoid this by filtering out any versions that don't match the tags they were parsed from.

Note that this will break anyone intentionally trying to depend on a `v1` tag. However, note also that anyone doing this probably wasn't getting the behavior they wanted before, since `v1.0.0` would also match a constraint of `v1`.

Fixes #6772

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `earthly +reviewable` to ensure this PR is ready for review.
- [x] Added or updated unit tests.
~- [ ] Added or updated e2e tests.~
~- [ ] Linked a PR or a [docs tracking issue] to [document this change].~
- [x] Added `backport release-x.y` labels to auto-backport this PR.
~- [ ] Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md
