### PR TITLE
Add circuit breaker to prevent XR reconciliation thrashing

### DIFF
--- a/apis/apiextensions/v1/conditions.go
+++ b/apis/apiextensions/v1/conditions.go
@@ -17,6 +17,8 @@ limitations under the License.
 package v1
 
 import (
+	"fmt"
+
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -36,6 +38,9 @@ const (
 	// A TypeValidPipeline CompositionRevision has a valid function
 	// pipeline.
 	TypeValidPipeline xpv1.ConditionType = "ValidPipeline"
+
+	// A TypeResponsive indicates whether the resource is responsive to changes.
+	TypeResponsive xpv1.ConditionType = "Responsive"
 )
 
 // Reasons a resource is or is not established or offered.
@@ -48,6 +53,9 @@ const (
 
 	ReasonValidPipeline       xpv1.ConditionReason = "ValidPipeline"
 	ReasonMissingCapabilities xpv1.ConditionReason = "MissingCapabilities"
+
+	ReasonWatchCircuitOpen   xpv1.ConditionReason = "WatchCircuitOpen"
+	ReasonWatchCircuitClosed xpv1.ConditionReason = "WatchCircuitClosed"
 )
 
 // WatchingComposite indicates that Crossplane has defined and is watching for a
@@ -114,5 +122,44 @@ func MissingCapabilities(message string) xpv1.Condition {
 		LastTransitionTime: metav1.Now(),
 		Reason:             ReasonMissingCapabilities,
 		Message:            message,
+	}
+}
+
+// WatchCircuitOpen indicates the circuit breaker is open due to excessive watch events.
+func WatchCircuitOpen(triggeredBy string) xpv1.Condition {
+	return xpv1.Condition{
+		Type:               TypeResponsive,
+		Status:             corev1.ConditionFalse,
+		LastTransitionTime: metav1.Now(),
+		Reason:             ReasonWatchCircuitOpen,
+		Message:            fmt.Sprintf("Too many watch events from %s. Allowing events periodically.", triggeredBy),
+	}
+}
+
+// WatchCircuitClosed indicates the circuit breaker is closed (normal operation).
+func WatchCircuitClosed() xpv1.Condition {
+	return xpv1.Condition{
+		Type:               TypeResponsive,
+		Status:             corev1.ConditionTrue,
+		LastTransitionTime: metav1.Now(),
+		Reason:             ReasonWatchCircuitClosed,
+	}
+}
+
+// IsSystemConditionType returns true if the condition type is a system
+// condition. This includes both crossplane-runtime system conditions and
+// apiextensions-specific system conditions like the circuit breaker.
+func IsSystemConditionType(t xpv1.ConditionType) bool {
+	// First check crossplane-runtime system conditions
+	if xpv1.IsSystemConditionType(t) {
+		return true
+	}
+
+	// Then check Crossplane-specific system conditions
+	switch t {
+	case TypeResponsive:
+		return true
+	default:
+		return false
 	}
 }

--- a/apis/apiextensions/v1/conditions_test.go
+++ b/apis/apiextensions/v1/conditions_test.go
@@ -24,26 +24,32 @@ import (
 
 func TestIsSystemConditionType(t *testing.T) {
 	cases := map[string]struct {
+		reason        string
 		conditionType xpv1.ConditionType
 		want          bool
 	}{
 		"CrossplaneRuntimeSystemCondition": {
+			reason:        "builtin ready condition should be system type",
 			conditionType: xpv1.TypeReady,
 			want:          true,
 		},
 		"CrossplaneRuntimeSystemConditionSynced": {
+			reason:        "builtin synced condition should be system type",
 			conditionType: xpv1.TypeSynced,
 			want:          true,
 		},
 		"CrossplaneCircuitCondition": {
+			reason:        "circuit responsive condition should be system type",
 			conditionType: TypeResponsive,
 			want:          true,
 		},
 		"CustomCondition": {
+			reason:        "custom database condition should not be system type",
 			conditionType: "DatabaseReady",
 			want:          false,
 		},
 		"AnotherCustomCondition": {
+			reason:        "custom bucket condition should not be system type",
 			conditionType: "BucketReady",
 			want:          false,
 		},
@@ -53,7 +59,7 @@ func TestIsSystemConditionType(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			got := IsSystemConditionType(tc.conditionType)
 			if got != tc.want {
-				t.Errorf("IsSystemConditionType(%q) = %v, want %v", tc.conditionType, got, tc.want)
+				t.Errorf("%s: IsSystemConditionType(%q) = %v, want %v", tc.reason, tc.conditionType, got, tc.want)
 			}
 		})
 	}

--- a/apis/apiextensions/v1/conditions_test.go
+++ b/apis/apiextensions/v1/conditions_test.go
@@ -1,0 +1,60 @@
+/*
+Copyright 2025 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1
+
+import (
+	"testing"
+
+	xpv1 "github.com/crossplane/crossplane-runtime/v2/apis/common/v1"
+)
+
+func TestIsSystemConditionType(t *testing.T) {
+	cases := map[string]struct {
+		conditionType xpv1.ConditionType
+		want          bool
+	}{
+		"CrossplaneRuntimeSystemCondition": {
+			conditionType: xpv1.TypeReady,
+			want:          true,
+		},
+		"CrossplaneRuntimeSystemConditionSynced": {
+			conditionType: xpv1.TypeSynced,
+			want:          true,
+		},
+		"CrossplaneCircuitCondition": {
+			conditionType: TypeResponsive,
+			want:          true,
+		},
+		"CustomCondition": {
+			conditionType: "DatabaseReady",
+			want:          false,
+		},
+		"AnotherCustomCondition": {
+			conditionType: "BucketReady",
+			want:          false,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got := IsSystemConditionType(tc.conditionType)
+			if got != tc.want {
+				t.Errorf("IsSystemConditionType(%q) = %v, want %v", tc.conditionType, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/circuit/breaker.go
+++ b/internal/circuit/breaker.go
@@ -1,0 +1,87 @@
+/*
+Copyright 2025 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package circuit provides circuit breaker functionality for Crossplane controllers.
+// It helps prevent tight reconciliation loops when controllers fight over resource state.
+package circuit
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+// Breaker tracks reconciliation events and opens when thresholds are exceeded.
+type Breaker interface {
+	// GetState returns the current circuit breaker state for a target resource.
+	GetState(ctx context.Context, target types.NamespacedName) State
+
+	// RecordEvent records a reconciliation event triggered by a watched resource.
+	RecordEvent(ctx context.Context, target types.NamespacedName, source EventSource)
+
+	// RecordAllowed updates the last allowed time for half-open state tracking.
+	RecordAllowed(ctx context.Context, target types.NamespacedName)
+}
+
+// EventSource identifies the watched resource that triggered a reconciliation.
+type EventSource struct {
+	// GVK is the GroupVersionKind of the watched resource that triggered the event.
+	GVK schema.GroupVersionKind
+
+	// Name is the name of the watched resource that triggered the event.
+	Name string
+
+	// Namespace is the namespace of the watched resource that triggered the event.
+	// Empty for cluster-scoped resources.
+	Namespace string
+}
+
+// String returns a human-readable representation of the watched resource.
+func (es EventSource) String() string {
+	if es.Namespace == "" {
+		return fmt.Sprintf("%s/%s", es.GVK.Kind, es.Name)
+	}
+	return fmt.Sprintf("%s/%s (%s)", es.GVK.Kind, es.Name, es.Namespace)
+}
+
+// State represents the current circuit breaker state for a target.
+type State struct {
+	// IsOpen indicates whether the circuit breaker is currently open.
+	IsOpen bool
+
+	// NextAllowedAt is when the next request can be allowed in half-open state.
+	NextAllowedAt time.Time
+
+	// TriggeredBy is the most frequently seen watched resource when the circuit opened.
+	TriggeredBy string
+}
+
+// NopBreaker is a no-op implementation of Breaker that never opens.
+type NopBreaker struct{}
+
+// GetState always returns a closed circuit.
+func (n *NopBreaker) GetState(_ context.Context, _ types.NamespacedName) State {
+	return State{IsOpen: false}
+}
+
+// RecordEvent does nothing.
+func (n *NopBreaker) RecordEvent(_ context.Context, _ types.NamespacedName, _ EventSource) {}
+
+// RecordAllowed does nothing.
+func (n *NopBreaker) RecordAllowed(_ context.Context, _ types.NamespacedName) {}

--- a/internal/circuit/mapfunc.go
+++ b/internal/circuit/mapfunc.go
@@ -28,7 +28,7 @@ import (
 // NewMapFunc wraps a handler.MapFunc with circuit breaker functionality.
 // It records events for each target resource and filters out requests when the
 // circuit breaker is open, allowing occasional requests through in half-open state.
-func NewMapFunc(wrapped handler.MapFunc, breaker *TokenBucketBreaker) handler.MapFunc {
+func NewMapFunc(wrapped handler.MapFunc, breaker Breaker) handler.MapFunc {
 	return func(ctx context.Context, obj client.Object) []reconcile.Request {
 		// Get the original requests
 		requests := wrapped(ctx, obj)

--- a/internal/circuit/mapfunc.go
+++ b/internal/circuit/mapfunc.go
@@ -1,0 +1,78 @@
+/*
+Copyright 2025 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package circuit
+
+import (
+	"context"
+	"time"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+// NewMapFunc wraps a handler.MapFunc with circuit breaker functionality.
+// It records events for each target resource and filters out requests when the
+// circuit breaker is open, allowing occasional requests through in half-open state.
+func NewMapFunc(wrapped handler.MapFunc, breaker *TokenBucketBreaker) handler.MapFunc {
+	return func(ctx context.Context, obj client.Object) []reconcile.Request {
+		// Get the original requests
+		requests := wrapped(ctx, obj)
+
+		// Record events for each target resource
+		source := EventSource{
+			GVK:       obj.GetObjectKind().GroupVersionKind(),
+			Name:      obj.GetName(),
+			Namespace: obj.GetNamespace(),
+		}
+
+		// Filter out requests for resources with open circuit breakers
+		keep := make([]reconcile.Request, 0, len(requests))
+		for _, req := range requests {
+			// If object is marked for deletion, always allow the
+			// event through without affecting circuit breaker
+			// timing. This ensures deletion events (which are
+			// MODIFIED events with deletionTimestamp set) can reach
+			// the reconciler to remove finalizers.
+			if obj.GetDeletionTimestamp() != nil {
+				keep = append(keep, req)
+				continue
+			}
+
+			// Always record the event for tracking
+			breaker.RecordEvent(ctx, req.NamespacedName, source)
+
+			// Get current state
+			state := breaker.GetState(ctx, req.NamespacedName)
+
+			// If breaker is closed, allow the request
+			if !state.IsOpen {
+				keep = append(keep, req)
+				continue
+			}
+
+			// Breaker is open - check if we should allow in half-open state
+			if time.Now().After(state.NextAllowedAt) {
+				keep = append(keep, req)
+				breaker.RecordAllowed(ctx, req.NamespacedName)
+			}
+			// Otherwise filter out - fully open state
+		}
+
+		return keep
+	}
+}

--- a/internal/circuit/token_bucket.go
+++ b/internal/circuit/token_bucket.go
@@ -191,16 +191,16 @@ func (b *TokenBucketBreaker) RecordEvent(_ context.Context, target types.Namespa
 	events := make(map[string]int)
 	maxEvents := 0
 
-	for _, source := range state.recentSources {
-		if source == "" {
+	for _, src := range state.recentSources {
+		if src == "" {
 			continue
 		}
-		events[source]++
-		if events[source] < maxEvents {
+		events[src]++
+		if events[src] < maxEvents {
 			continue
 		}
-		maxEvents = events[source]
-		state.triggerSource = source
+		maxEvents = events[src]
+		state.triggerSource = src
 	}
 }
 

--- a/internal/circuit/token_bucket.go
+++ b/internal/circuit/token_bucket.go
@@ -1,0 +1,271 @@
+/*
+Copyright 2025 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package circuit
+
+import (
+	"context"
+	"math"
+	"sync"
+	"time"
+
+	"k8s.io/apimachinery/pkg/types"
+)
+
+// Config controls circuit breaker behavior using a token bucket approach.
+type Config struct {
+	capacity            float64       // Token bucket capacity (burst allowance)
+	refillRatePerSecond float64       // Tokens per second refill rate
+	cooldownTime        time.Duration // How long circuit stays open after opening
+	halfOpenInterval    time.Duration // How often to allow requests when open
+	expireAfter         time.Duration // How long to keep inactive target states
+}
+
+// Option configures a circuit breaker.
+type Option func(*Config)
+
+// WithBurst sets the token bucket burst allowance.
+func WithBurst(b float64) Option {
+	return func(c *Config) {
+		c.capacity = b
+	}
+}
+
+// WithRefillRatePerSecond sets the token bucket refill rate.
+func WithRefillRatePerSecond(r float64) Option {
+	return func(c *Config) {
+		c.refillRatePerSecond = r
+	}
+}
+
+// WithOpenDuration sets how long the circuit stays open before auto-closing.
+func WithOpenDuration(d time.Duration) Option {
+	return func(c *Config) {
+		c.cooldownTime = d
+	}
+}
+
+// WithHalfOpenInterval sets how often to allow requests in half-open state.
+func WithHalfOpenInterval(i time.Duration) Option {
+	return func(c *Config) {
+		c.halfOpenInterval = i
+	}
+}
+
+// WithGarbageCollectTargetsAfter sets how long to keep inactive target states
+// before garbage collection.
+func WithGarbageCollectTargetsAfter(d time.Duration) Option {
+	return func(c *Config) {
+		c.expireAfter = d
+	}
+}
+
+// TokenBucketBreaker is a concrete implementation of the Breaker interface that uses
+// a token bucket approach to rate limit reconciliation events.
+type TokenBucketBreaker struct {
+	config  Config
+	mu      sync.RWMutex
+	targets map[types.NamespacedName]*state
+}
+
+// state tracks the circuit breaker state for a single target resource.
+type state struct {
+	mu sync.RWMutex
+
+	// Token bucket for rate limiting.
+	tokens     float64
+	lastRefill time.Time
+
+	// Ring buffer for source tracking.
+	recentSources [16]string
+	recentIdx     int
+
+	// Circuit state.
+	isOpen        bool
+	openedAt      time.Time
+	lastAllowed   time.Time
+	triggerSource string // Most frequent watched resource when circuit opened
+}
+
+// NewTokenBucketBreaker creates a new token bucket-based circuit breaker.
+func NewTokenBucketBreaker(opts ...Option) *TokenBucketBreaker {
+	config := Config{
+		capacity:            50.0,             // Allow 50-event burst.
+		refillRatePerSecond: 0.5,              // Allow 1 every 2s sustained.
+		cooldownTime:        5 * time.Minute,  // Circuit stays open for 5 minutes.
+		halfOpenInterval:    30 * time.Second, // Allow probe every 30s when open.
+		expireAfter:         24 * time.Hour,   // Clean up targets after 24 hours.
+	}
+
+	for _, opt := range opts {
+		opt(&config)
+	}
+
+	b := &TokenBucketBreaker{
+		config:  config,
+		targets: make(map[types.NamespacedName]*state),
+	}
+
+	return b
+}
+
+// RecordEvent records a reconciliation event for the target resource.
+func (b *TokenBucketBreaker) RecordEvent(_ context.Context, target types.NamespacedName, source EventSource) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	now := time.Now()
+
+	if b.targets[target] == nil {
+		b.targets[target] = &state{
+			tokens:     b.config.capacity, // Start with full bucket
+			lastRefill: now,
+		}
+	}
+	state := b.targets[target]
+	state.mu.Lock()
+	defer state.mu.Unlock()
+
+	// Refill tokens based on elapsed time
+	elapsed := now.Sub(state.lastRefill).Seconds()
+	state.tokens = math.Min(b.config.capacity, state.tokens+b.config.refillRatePerSecond*elapsed)
+	state.lastRefill = now
+
+	// Add source to ring buffer
+	state.recentSources[state.recentIdx] = source.String()
+	state.recentIdx = (state.recentIdx + 1) % len(state.recentSources)
+
+	if state.isOpen {
+		// Circuit is open and cooldown time hasn't expired yet.
+		if now.Sub(state.openedAt) < b.config.cooldownTime {
+			return
+		}
+
+		// Cooldown period has expired. Close the circuit.
+		state.isOpen = false
+
+		// Clear ring buffer on close
+		for i := range state.recentSources {
+			state.recentSources[i] = ""
+		}
+		state.recentIdx = 0
+	}
+
+	// It there's a token available, consume it.
+	if state.tokens >= 1.0 {
+		state.tokens -= 1.0
+		return
+	}
+
+	// No tokens available - open circuit.
+	state.isOpen = true
+	state.openedAt = now
+	state.lastAllowed = now
+
+	// Analyze ring buffer to find most frequent source
+	events := make(map[string]int)
+	maxEvents := 0
+
+	for _, source := range state.recentSources {
+		if source == "" {
+			continue
+		}
+		events[source]++
+		if events[source] < maxEvents {
+			continue
+		}
+		maxEvents = events[source]
+		state.triggerSource = source
+	}
+}
+
+// GetState returns the current circuit breaker state for the target resource.
+func (b *TokenBucketBreaker) GetState(_ context.Context, target types.NamespacedName) State {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+
+	state := b.targets[target]
+	if state == nil {
+		return State{IsOpen: false}
+	}
+
+	state.mu.RLock()
+	defer state.mu.RUnlock()
+
+	if !state.isOpen {
+		return State{IsOpen: false}
+	}
+
+	return State{
+		IsOpen:        state.isOpen,
+		TriggeredBy:   state.triggerSource,
+		NextAllowedAt: state.lastAllowed.Add(b.config.halfOpenInterval),
+	}
+}
+
+// RecordAllowed updates the last reconcile time for half-open state tracking.
+func (b *TokenBucketBreaker) RecordAllowed(_ context.Context, target types.NamespacedName) {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+
+	state := b.targets[target]
+	if state == nil {
+		return
+	}
+
+	state.mu.Lock()
+	defer state.mu.Unlock()
+
+	state.lastAllowed = time.Now()
+}
+
+// GarbageCollectTargets runs every interval until the supplied context is
+// cancelled. It garbage collects target states that haven't seen activity recently.
+func (b *TokenBucketBreaker) GarbageCollectTargets(ctx context.Context, interval time.Duration) {
+	t := time.NewTicker(interval)
+	defer t.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+			b.GarbageCollectTargetsNow()
+		}
+	}
+}
+
+// GarbageCollectTargetsNow immediately garbage collects target states that
+// haven't seen activity recently.
+func (b *TokenBucketBreaker) GarbageCollectTargetsNow() int {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	collected := 0
+
+	for target, state := range b.targets {
+		state.mu.RLock()
+		shouldDelete := !state.lastRefill.IsZero() && time.Since(state.lastRefill) > b.config.expireAfter
+		state.mu.RUnlock()
+
+		if shouldDelete {
+			delete(b.targets, target)
+			collected++
+		}
+	}
+
+	return collected
+}

--- a/internal/circuit/token_bucket.go
+++ b/internal/circuit/token_bucket.go
@@ -176,7 +176,7 @@ func (b *TokenBucketBreaker) RecordEvent(_ context.Context, target types.Namespa
 		state.recentIdx = 0
 	}
 
-	// It there's a token available, consume it.
+	// If there's a token available, consume it.
 	if state.tokens >= 1.0 {
 		state.tokens -= 1.0
 		return

--- a/internal/circuit/token_bucket_test.go
+++ b/internal/circuit/token_bucket_test.go
@@ -1,0 +1,540 @@
+/*
+Copyright 2025 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package circuit
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+func TestTokenBucketBreakerRecordEvent(t *testing.T) {
+	target := types.NamespacedName{Name: "test-xr", Namespace: "default"}
+	source := EventSource{
+		GVK:       schema.GroupVersionKind{Group: "example.com", Version: "v1", Kind: "Bucket"},
+		Name:      "test-bucket",
+		Namespace: "default",
+	}
+
+	type args struct {
+		ctx    context.Context
+		target types.NamespacedName
+		source EventSource
+	}
+
+	type want struct {
+		state State
+	}
+
+	cases := map[string]struct {
+		reason  string
+		breaker *TokenBucketBreaker
+		setup   func(*TokenBucketBreaker)
+		args    args
+		want    want
+	}{
+		"EventWithinCapacity": {
+			reason: "Recording an event within token capacity should keep circuit closed",
+			breaker: NewTokenBucketBreaker(
+				WithBurst(5),
+				WithRefillRatePerSecond(1.0),
+			),
+			args: args{
+				ctx:    context.Background(),
+				target: target,
+			},
+			want: want{
+				state: State{
+					IsOpen: false,
+				},
+			},
+		},
+		"EventExceedsCapacity": {
+			reason: "Recording events that exceed token capacity should open circuit",
+			breaker: NewTokenBucketBreaker(
+				WithBurst(2),
+				WithRefillRatePerSecond(0.1),
+			),
+			setup: func(b *TokenBucketBreaker) {
+				ctx := context.Background()
+
+				// Consume all tokens
+				b.RecordEvent(ctx, target, source)
+				b.RecordEvent(ctx, target, source)
+			},
+			args: args{
+				ctx:    context.Background(),
+				target: target,
+				source: source,
+			},
+			want: want{
+				state: State{
+					IsOpen:        true,
+					TriggeredBy:   source.String(),
+					NextAllowedAt: time.Now().Add(30 * time.Second),
+				},
+			},
+		},
+		"EventAfterCooldownWithTokens": {
+			reason: "Recording an event after cooldown period with sufficient tokens should keep circuit closed",
+			breaker: NewTokenBucketBreaker(
+				WithBurst(2),
+				WithRefillRatePerSecond(10), // Fast refill to ensure tokens are available
+				WithOpenDuration(100*time.Millisecond),
+			),
+			setup: func(b *TokenBucketBreaker) {
+				ctx := context.Background()
+				// Consume tokens and open circuit
+				b.RecordEvent(ctx, target, source)
+				b.RecordEvent(ctx, target, source)
+				b.RecordEvent(ctx, target, source) // This opens the circuit
+				// Wait for cooldown and token refill
+				time.Sleep(150 * time.Millisecond)
+			},
+			args: args{
+				ctx:    context.Background(),
+				target: target,
+				source: source,
+			},
+			want: want{
+				state: State{
+					IsOpen: false,
+				},
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			if tc.setup != nil {
+				tc.setup(tc.breaker)
+			}
+
+			tc.breaker.RecordEvent(tc.args.ctx, tc.args.target, tc.args.source)
+			got := tc.breaker.GetState(tc.args.ctx, tc.args.target)
+
+			if diff := cmp.Diff(tc.want.state, got, cmpopts.EquateApproxTime(2*time.Second)); diff != "" {
+				t.Errorf("%s\nTokenBucketBreaker.RecordEvent(...): -want, +got:\n%s", tc.reason, diff)
+			}
+		})
+	}
+}
+
+func TestTokenBucketBreakerGetState(t *testing.T) {
+	target := types.NamespacedName{Name: "test-xr", Namespace: "default"}
+	source := EventSource{
+		GVK:       schema.GroupVersionKind{Group: "example.com", Version: "v1", Kind: "Bucket"},
+		Name:      "test-bucket",
+		Namespace: "default",
+	}
+
+	type args struct {
+		ctx    context.Context
+		target types.NamespacedName
+	}
+
+	type want struct {
+		state State
+	}
+
+	cases := map[string]struct {
+		reason  string
+		breaker *TokenBucketBreaker
+		setup   func(*TokenBucketBreaker)
+		args    args
+		want    want
+	}{
+		"UnknownTarget": {
+			reason:  "Getting state for unknown target should return closed circuit",
+			breaker: NewTokenBucketBreaker(),
+			args: args{
+				ctx:    context.Background(),
+				target: target,
+			},
+			want: want{
+				state: State{
+					IsOpen: false,
+				},
+			},
+		},
+		"ClosedCircuit": {
+			reason:  "Getting state for target with closed circuit should return correct state",
+			breaker: NewTokenBucketBreaker(),
+			setup: func(b *TokenBucketBreaker) {
+				ctx := context.Background()
+				b.RecordEvent(ctx, target, source)
+			},
+			args: args{
+				ctx:    context.Background(),
+				target: target,
+			},
+			want: want{
+				state: State{
+					IsOpen: false,
+				},
+			},
+		},
+		"OpenCircuit": {
+			reason: "Getting state for target with open circuit should return correct state",
+			breaker: NewTokenBucketBreaker(
+				WithBurst(1),
+				WithRefillRatePerSecond(0.1),
+			),
+			setup: func(b *TokenBucketBreaker) {
+				ctx := context.Background()
+				// Open circuit
+				b.RecordEvent(ctx, target, source)
+				b.RecordEvent(ctx, target, source)
+			},
+			args: args{
+				ctx:    context.Background(),
+				target: target,
+			},
+			want: want{
+				state: State{
+					IsOpen:        true,
+					TriggeredBy:   source.String(),
+					NextAllowedAt: time.Now().Add(30 * time.Second),
+				},
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			if tc.setup != nil {
+				tc.setup(tc.breaker)
+			}
+
+			got := tc.breaker.GetState(tc.args.ctx, tc.args.target)
+
+			if diff := cmp.Diff(tc.want.state, got, cmpopts.EquateApproxTime(2*time.Second)); diff != "" {
+				t.Errorf("%s\nTokenBucketBreaker.GetState(...): -want, +got:\n%s", tc.reason, diff)
+			}
+		})
+	}
+}
+
+func TestTokenBucketBreakerRecordAllowed(t *testing.T) {
+	target := types.NamespacedName{Name: "test-xr", Namespace: "default"}
+	source := EventSource{
+		GVK:  schema.GroupVersionKind{Group: "example.com", Version: "v1", Kind: "Bucket"},
+		Name: "test-bucket",
+	}
+
+	type args struct {
+		ctx    context.Context
+		target types.NamespacedName
+	}
+
+	type want struct {
+		state State
+	}
+
+	cases := map[string]struct {
+		reason  string
+		breaker *TokenBucketBreaker
+		setup   func(*TokenBucketBreaker)
+		args    args
+		want    want
+	}{
+		"UnknownTarget": {
+			reason:  "Recording allowed for unknown target should not panic",
+			breaker: NewTokenBucketBreaker(),
+			args: args{
+				ctx:    context.Background(),
+				target: types.NamespacedName{Name: "unknown", Namespace: "default"},
+			},
+			want: want{
+				state: State{
+					IsOpen: false,
+				},
+			},
+		},
+		"KnownTarget": {
+			reason: "Recording allowed for known target should update last allowed time",
+			breaker: NewTokenBucketBreaker(
+				WithHalfOpenInterval(1 * time.Second),
+			),
+			setup: func(b *TokenBucketBreaker) {
+				ctx := context.Background()
+				b.RecordEvent(ctx, target, source)
+			},
+			args: args{
+				ctx:    context.Background(),
+				target: target,
+			},
+			want: want{
+				state: State{
+					IsOpen: false,
+				},
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			if tc.setup != nil {
+				tc.setup(tc.breaker)
+			}
+
+			tc.breaker.RecordAllowed(tc.args.ctx, tc.args.target)
+			got := tc.breaker.GetState(tc.args.ctx, tc.args.target)
+
+			if diff := cmp.Diff(tc.want.state, got, cmpopts.EquateApproxTime(2*time.Second)); diff != "" {
+				t.Errorf("%s\nTokenBucketBreaker.RecordAllowed(...): -want, +got:\n%s", tc.reason, diff)
+			}
+		})
+	}
+}
+
+func TestTokenBucketBreakerSourceTracking(t *testing.T) {
+	breaker := NewTokenBucketBreaker(
+		WithBurst(1),
+		WithRefillRatePerSecond(0.1),
+	)
+
+	ctx := context.Background()
+	target := types.NamespacedName{Name: "test-xr", Namespace: "default"}
+
+	// Record events from different sources
+	sources := []EventSource{
+		{
+			GVK:       schema.GroupVersionKind{Group: "example.com", Version: "v1", Kind: "Bucket"},
+			Name:      "bucket-1",
+			Namespace: "default",
+		},
+		{
+			GVK:       schema.GroupVersionKind{Group: "example.com", Version: "v1", Kind: "Database"},
+			Name:      "db-1",
+			Namespace: "default",
+		},
+		{
+			GVK:       schema.GroupVersionKind{Group: "example.com", Version: "v1", Kind: "Bucket"},
+			Name:      "bucket-1",
+			Namespace: "default",
+		},
+	}
+
+	// Consume token
+	breaker.RecordEvent(ctx, target, sources[0])
+
+	// Record events to fill ring buffer and trigger circuit
+	for _, source := range sources {
+		breaker.RecordEvent(ctx, target, source)
+	}
+
+	state := breaker.GetState(ctx, target)
+	want := State{
+		IsOpen:        true,
+		NextAllowedAt: time.Now().Add(30 * time.Second),
+		TriggeredBy:   "Bucket/bucket-1 (default)",
+	}
+
+	if diff := cmp.Diff(want, state, cmpopts.EquateApproxTime(1*time.Second)); diff != "" {
+		t.Errorf("Expected circuit to be open with correct trigger source: -want, +got:\n%s", diff)
+	}
+}
+
+func TestTokenBucketBreakerTokenRefill(t *testing.T) {
+	breaker := NewTokenBucketBreaker(
+		WithBurst(2),
+		WithRefillRatePerSecond(10),            // Fast refill for test
+		WithOpenDuration(200*time.Millisecond), // Longer cooldown
+	)
+
+	ctx := context.Background()
+	target := types.NamespacedName{Name: "test-xr", Namespace: "default"}
+	source := EventSource{
+		GVK:  schema.GroupVersionKind{Group: "example.com", Version: "v1", Kind: "Bucket"},
+		Name: "test-bucket",
+	}
+
+	// Consume all tokens
+	breaker.RecordEvent(ctx, target, source)
+	breaker.RecordEvent(ctx, target, source)
+
+	// This should open the circuit
+	breaker.RecordEvent(ctx, target, source)
+	state := breaker.GetState(ctx, target)
+	wantOpen := State{
+		IsOpen:        true,
+		NextAllowedAt: time.Now().Add(30 * time.Second),
+		TriggeredBy:   source.String(),
+	}
+	if diff := cmp.Diff(wantOpen, state, cmpopts.EquateApproxTime(1*time.Second)); diff != "" {
+		t.Errorf("Expected circuit to be open after exhausting tokens: -want, +got:\n%s", diff)
+	}
+
+	// Wait for tokens to refill but not for cooldown to expire
+	time.Sleep(100 * time.Millisecond)
+
+	// Circuit should still be open due to cooldown, even though tokens refilled
+	state = breaker.GetState(ctx, target)
+	if diff := cmp.Diff(wantOpen, state, cmpopts.EquateApproxTime(1*time.Second)); diff != "" {
+		t.Errorf("Expected circuit to remain open during cooldown period: -want, +got:\n%s", diff)
+	}
+
+	// Wait for cooldown to expire
+	time.Sleep(150 * time.Millisecond)
+
+	// Record another event - tokens should have refilled enough to allow it
+	breaker.RecordEvent(ctx, target, source)
+	state = breaker.GetState(ctx, target)
+	want := State{IsOpen: false}
+	if diff := cmp.Diff(want, state, cmpopts.EquateApproxTime(1*time.Second)); diff != "" {
+		t.Errorf("Expected circuit to remain closed after cooldown and token refill: -want, +got:\n%s", diff)
+	}
+}
+
+func TestTokenBucketBreakerConcurrency(t *testing.T) {
+	breaker := NewTokenBucketBreaker(
+		WithBurst(95), // Not quite enough for 10 goroutines making 10 requests in parallel.
+		WithRefillRatePerSecond(1),
+	)
+
+	ctx := context.Background()
+	target := types.NamespacedName{Name: "test-xr", Namespace: "default"}
+	source := EventSource{
+		GVK:  schema.GroupVersionKind{Group: "example.com", Version: "v1", Kind: "Bucket"},
+		Name: "test-bucket",
+	}
+
+	// Run concurrent operations
+	var wg sync.WaitGroup
+	for range 10 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for range 10 {
+				breaker.RecordEvent(ctx, target, source)
+				breaker.GetState(ctx, target)
+				breaker.RecordAllowed(ctx, target)
+			}
+		}()
+	}
+
+	wg.Wait()
+
+	// Should not panic and should have consistent state
+	state := breaker.GetState(ctx, target)
+
+	want := State{
+		IsOpen:        true,
+		NextAllowedAt: time.Now().Add(30 * time.Second),
+		TriggeredBy:   source.String(),
+	}
+	if diff := cmp.Diff(want, state, cmpopts.EquateApproxTime(2*time.Second)); diff != "" {
+		t.Errorf("Open circuit state mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestTokenBucketBreakerGarbageCollection(t *testing.T) {
+	breaker := NewTokenBucketBreaker(
+		WithGarbageCollectTargetsAfter(100 * time.Millisecond),
+	)
+
+	ctx := context.Background()
+	target := types.NamespacedName{Name: "test-xr", Namespace: "default"}
+	source := EventSource{
+		GVK:  schema.GroupVersionKind{Group: "example.com", Version: "v1", Kind: "Bucket"},
+		Name: "test-bucket",
+	}
+
+	// Record an event to create target state
+	breaker.RecordEvent(ctx, target, source)
+
+	// Verify target exists
+	state := breaker.GetState(ctx, target)
+	want := State{
+		IsOpen:      false,
+		TriggeredBy: "",
+		// NextAllowedAt left unset (zero value) when circuit is closed
+	}
+	if diff := cmp.Diff(want, state, cmpopts.EquateApproxTime(2*time.Second)); diff != "" {
+		t.Errorf("Initial circuit state mismatch (-want +got):\n%s", diff)
+	}
+
+	// Wait for expiration
+	time.Sleep(150 * time.Millisecond)
+
+	// Run garbage collection
+	collected := breaker.GarbageCollectTargetsNow()
+	if collected != 1 {
+		t.Errorf("Expected to collect 1 target, got %d", collected)
+	}
+
+	// Verify target was removed (should return default state)
+	state = breaker.GetState(ctx, target)
+	want = State{IsOpen: false}
+	if diff := cmp.Diff(want, state, cmpopts.EquateApproxTime(2*time.Second)); diff != "" {
+		t.Errorf("Post-GC circuit state mismatch (-want +got):\n%s", diff)
+	}
+}
+
+// ExampleTokenBucketBreaker demonstrates circuit breaker behavior including
+// triggering the breaker and half-open state management.
+func ExampleTokenBucketBreaker() {
+	// Create a circuit breaker with small capacity to easily trigger it
+	breaker := NewTokenBucketBreaker(
+		WithBurst(3),                    // Small capacity for demo
+		WithRefillRatePerSecond(0.1),    // Slow refill
+		WithOpenDuration(1*time.Minute), // Short cooldown for demo
+		WithHalfOpenInterval(10*time.Second),
+	)
+
+	ctx := context.Background()
+	target := types.NamespacedName{Name: "my-xr", Namespace: "default"}
+	source := EventSource{
+		GVK:       schema.GroupVersionKind{Group: "example.com", Version: "v1", Kind: "Bucket"},
+		Name:      "my-bucket",
+		Namespace: "default",
+	}
+
+	// Record events within capacity - circuit stays closed
+	for range 3 {
+		breaker.RecordEvent(ctx, target, source)
+	}
+
+	state := breaker.GetState(ctx, target)
+	fmt.Printf("After 3 events - Open: %v\n", state.IsOpen)
+
+	// This event will exhaust tokens and open the circuit
+	breaker.RecordEvent(ctx, target, source)
+
+	state = breaker.GetState(ctx, target)
+	fmt.Printf("After 4th event - Open: %v, TriggeredBy: %s\n", state.IsOpen, state.TriggeredBy)
+
+	// When circuit is open, RecordAllowed tracks when we allow requests through
+	// (this would typically be called by the controller when it allows a reconcile)
+	breaker.RecordAllowed(ctx, target)
+
+	state = breaker.GetState(ctx, target)
+	fmt.Printf("Half-open behavior - NextAllowed set: %v\n", !state.NextAllowedAt.IsZero())
+
+	// Output:
+	// After 3 events - Open: false
+	// After 4th event - Open: true, TriggeredBy: Bucket/my-bucket (default)
+	// Half-open behavior - NextAllowed set: true
+}

--- a/internal/circuit/token_bucket_test.go
+++ b/internal/circuit/token_bucket_test.go
@@ -138,7 +138,7 @@ func TestTokenBucketBreakerRecordEvent(t *testing.T) {
 			tc.breaker.RecordEvent(tc.args.ctx, tc.args.target, tc.args.source)
 			got := tc.breaker.GetState(tc.args.ctx, tc.args.target)
 
-			if diff := cmp.Diff(tc.want.state, got, cmpopts.EquateApproxTime(50*time.Millisecond)); diff != "" {
+			if diff := cmp.Diff(tc.want.state, got, cmpopts.EquateApproxTime(1*time.Second)); diff != "" {
 				t.Errorf("%s\nTokenBucketBreaker.RecordEvent(...): -want, +got:\n%s", tc.reason, diff)
 			}
 		})
@@ -246,7 +246,7 @@ func TestTokenBucketBreakerGetState(t *testing.T) {
 
 			got := tc.breaker.GetState(tc.args.ctx, tc.args.target)
 
-			if diff := cmp.Diff(tc.want.state, got, cmpopts.EquateApproxTime(50*time.Millisecond)); diff != "" {
+			if diff := cmp.Diff(tc.want.state, got, cmpopts.EquateApproxTime(1*time.Second)); diff != "" {
 				t.Errorf("%s\nTokenBucketBreaker.GetState(...): -want, +got:\n%s", tc.reason, diff)
 			}
 		})
@@ -325,7 +325,7 @@ func TestTokenBucketBreakerRecordAllowed(t *testing.T) {
 			tc.breaker.RecordAllowed(tc.args.ctx, tc.args.target)
 			got := tc.breaker.GetState(tc.args.ctx, tc.args.target)
 
-			if diff := cmp.Diff(tc.want.state, got, cmpopts.EquateApproxTime(50*time.Millisecond)); diff != "" {
+			if diff := cmp.Diff(tc.want.state, got, cmpopts.EquateApproxTime(1*time.Second)); diff != "" {
 				t.Errorf("%s\nTokenBucketBreaker.RecordAllowed(...): -want, +got:\n%s", tc.reason, diff)
 			}
 		})

--- a/internal/circuit/token_bucket_test.go
+++ b/internal/circuit/token_bucket_test.go
@@ -29,6 +29,8 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 )
 
+var _ Breaker = &TokenBucketBreaker{}
+
 func TestTokenBucketBreakerRecordEvent(t *testing.T) {
 	target := types.NamespacedName{Name: "test-xr", Namespace: "default"}
 	source := EventSource{

--- a/internal/controller/apiextensions/composite/composition_functions.go
+++ b/internal/controller/apiextensions/composite/composition_functions.go
@@ -599,8 +599,9 @@ func (c *FunctionComposer) Compose(ctx context.Context, xr *composite.Unstructur
 	k := xr.GetKind()
 	ns := xr.GetNamespace()
 	n := xr.GetName()
-
 	u := xr.GetUID()
+	cs := xr.GetConditions()
+
 	if err := xfn.FromStruct(xr, d.GetComposite().GetResource()); err != nil {
 		return CompositionResult{}, errors.Wrap(err, errUnmarshalDesiredXRStatus)
 	}
@@ -610,6 +611,14 @@ func (c *FunctionComposer) Compose(ctx context.Context, xr *composite.Unstructur
 	xr.SetNamespace(ns)
 	xr.SetName(n)
 	xr.SetUID(u)
+
+	// Include any pending conditions so we don't lose them. SetConditions
+	// will set conditions to nil if it's not passed any arguments. SSA
+	// interprets this as null and rejects it, so we only set them if
+	// there's actually some to set.
+	if len(cs) > 0 {
+		xr.SetConditions(cs...)
+	}
 
 	// NOTE(phisco): Here we are fine using a hardcoded field owner as there is
 	// no risk of conflict between different XRs.

--- a/internal/controller/apiextensions/definition/handlers.go
+++ b/internal/controller/apiextensions/definition/handlers.go
@@ -52,7 +52,7 @@ func CompositionRevisionMapFunc(of schema.GroupVersionKind, s composite.Schema, 
 		}
 
 		// This handler is for a specific type of XR. This
-		// revisionisn't compatible with that type.
+		// revision isn't compatible with that type.
 		if rev.Spec.CompositeTypeRef.APIVersion != of.GroupVersion().String() {
 			return nil
 		}

--- a/internal/controller/apiextensions/definition/handlers.go
+++ b/internal/controller/apiextensions/definition/handlers.go
@@ -22,9 +22,7 @@ import (
 	kunstructured "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/util/workqueue"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	kevent "sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -35,90 +33,106 @@ import (
 	v1 "github.com/crossplane/crossplane/v2/apis/apiextensions/v1"
 )
 
-// EnqueueForCompositionRevision enqueues reconciles for all XRs that will use a
-// newly created CompositionRevision.
-func EnqueueForCompositionRevision(of schema.GroupVersionKind, s composite.Schema, c client.Reader, log logging.Logger) handler.Funcs {
-	return handler.Funcs{
-		CreateFunc: func(ctx context.Context, e kevent.CreateEvent, q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
-			rev, ok := e.Object.(*v1.CompositionRevision)
-			if !ok {
-				return
+// CompositionRevisionMapFunc returns a MapFunc that maps CompositionRevisions to affected XRs.
+func CompositionRevisionMapFunc(of schema.GroupVersionKind, s composite.Schema, c client.Reader, log logging.Logger) handler.MapFunc {
+	return func(ctx context.Context, obj client.Object) []reconcile.Request {
+		rev, ok := obj.(*v1.CompositionRevision)
+		if !ok {
+			return nil
+		}
+
+		// We don't know what composition this revision is for,
+		// so we can't determine whether an XR might use it.
+		// This should never happen in practice - the
+		// composition controller sets this label when it
+		// creates a revision.
+		compName := rev.Labels[v1.LabelCompositionName]
+		if compName == "" {
+			return nil
+		}
+
+		// This handler is for a specific type of XR. This
+		// revisionisn't compatible with that type.
+		if rev.Spec.CompositeTypeRef.APIVersion != of.GroupVersion().String() {
+			return nil
+		}
+		if rev.Spec.CompositeTypeRef.Kind != of.Kind {
+			return nil
+		}
+
+		xrs := kunstructured.UnstructuredList{}
+		xrs.SetGroupVersionKind(of)
+		xrs.SetKind(of.Kind + "List")
+		// TODO(negz): Index XRs by composition revision name?
+		if err := c.List(ctx, &xrs); err != nil {
+			// Logging is most we can do here. This is a programming error if it happens.
+			log.Info("cannot list in CompositionRevision handler", "type", of.String(), "error", err)
+			return nil
+		}
+
+		requests := make([]reconcile.Request, 0)
+		for _, u := range xrs.Items {
+			xr := composite.Unstructured{Unstructured: u, Schema: s}
+
+			// We only care about XRs that would
+			// automatically update to this new revision.
+			if pol := xr.GetCompositionUpdatePolicy(); pol != nil && *pol == xpv1.UpdateManual {
+				continue
 			}
 
-			// We don't know what composition this revision is for,
-			// so we can't determine whether an XR might use it.
-			// This should never happen in practice - the
-			// composition controller sets this label when it
-			// creates a revision.
-			compName := rev.Labels[v1.LabelCompositionName]
-			if compName == "" {
-				return
+			// We only care about XRs that reference the
+			// composition this revision derives from.
+			if ref := xr.GetCompositionReference(); ref == nil || ref.Name != compName {
+				continue
 			}
 
-			// This handler is for a specific type of XR. This
-			// revisionisn't compatible with that type.
-			if rev.Spec.CompositeTypeRef.APIVersion != of.GroupVersion().String() {
-				return
-			}
-			if rev.Spec.CompositeTypeRef.Kind != of.Kind {
-				return
-			}
+			requests = append(requests, reconcile.Request{NamespacedName: types.NamespacedName{
+				Name:      xr.GetName(),
+				Namespace: xr.GetNamespace(),
+			}})
+		}
 
-			xrs := kunstructured.UnstructuredList{}
-			xrs.SetGroupVersionKind(of)
-			xrs.SetKind(of.Kind + "List")
-			// TODO(negz): Index XRs by composition revision name?
-			if err := c.List(ctx, &xrs); err != nil {
-				// Logging is most we can do here. This is a programming error if it happens.
-				log.Info("cannot list in CompositionRevision handler", "type", of.String(), "error", err)
-				return
-			}
-
-			for _, u := range xrs.Items {
-				xr := composite.Unstructured{Unstructured: u, Schema: s}
-
-				// We only care about XRs that would
-				// automatically update to this new revision.
-				if pol := xr.GetCompositionUpdatePolicy(); pol != nil && *pol == xpv1.UpdateManual {
-					continue
-				}
-
-				// We only care about XRs that reference the
-				// composition this revision derives from.
-				if ref := xr.GetCompositionReference(); ref == nil || ref.Name != compName {
-					continue
-				}
-
-				q.Add(reconcile.Request{NamespacedName: types.NamespacedName{
-					Name:      xr.GetName(),
-					Namespace: xr.GetNamespace(),
-				}})
-			}
-		},
+		return requests
 	}
 }
 
-// EnqueueCompositeResources enqueues reconciles for all XRs that reference an
-// updated composed resource.
-func EnqueueCompositeResources(of schema.GroupVersionKind, c client.Reader, log logging.Logger) handler.Funcs {
-	return handler.Funcs{
-		UpdateFunc: func(ctx context.Context, ev kevent.UpdateEvent, q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
-			xrGVK := of
-			cdGVK := ev.ObjectNew.GetObjectKind().GroupVersionKind()
-			key := refKey(ev.ObjectNew.GetNamespace(), ev.ObjectNew.GetName(), cdGVK.Kind, cdGVK.GroupVersion().String())
+// SelfMapFunc returns a MapFunc that maps an object to itself for reconciliation.
+// This is equivalent to handler.EnqueueRequestForObject but as a MapFunc.
+func SelfMapFunc() handler.MapFunc {
+	return func(_ context.Context, obj client.Object) []reconcile.Request {
+		return []reconcile.Request{{
+			NamespacedName: types.NamespacedName{
+				Name:      obj.GetName(),
+				Namespace: obj.GetNamespace(),
+			},
+		}}
+	}
+}
 
-			composites := kunstructured.UnstructuredList{}
-			composites.SetGroupVersionKind(xrGVK.GroupVersion().WithKind(xrGVK.Kind + "List"))
-			if err := c.List(ctx, &composites, client.MatchingFields{compositeResourcesRefsIndex: key}); err != nil {
-				log.Debug("cannot list composite resources related to a composed resource change", "error", err, "gvk", xrGVK.String(), "fieldSelector", compositeResourcesRefsIndex+"="+key)
-				return
-			}
+// CompositeResourcesMapFunc returns a MapFunc that maps composed resources to affected XRs.
+func CompositeResourcesMapFunc(of schema.GroupVersionKind, c client.Reader, log logging.Logger) handler.MapFunc {
+	return func(ctx context.Context, obj client.Object) []reconcile.Request {
+		cdGVK := obj.GetObjectKind().GroupVersionKind()
+		key := refKey(obj.GetNamespace(), obj.GetName(), cdGVK.Kind, cdGVK.GroupVersion().String())
 
-			// queue those composites for reconciliation
-			for _, xr := range composites.Items {
-				log.Debug("Enqueueing composite resource because composed resource changed", "name", xr.GetName(), "namespace", xr.GetNamespace(), "cdGVK", cdGVK.String(), "cdName", ev.ObjectNew.GetName())
-				q.Add(reconcile.Request{NamespacedName: types.NamespacedName{Name: xr.GetName(), Namespace: xr.GetNamespace()}})
-			}
-		},
+		composites := kunstructured.UnstructuredList{}
+		composites.SetGroupVersionKind(of.GroupVersion().WithKind(of.Kind + "List"))
+		if err := c.List(ctx, &composites, client.MatchingFields{compositeResourcesRefsIndex: key}); err != nil {
+			log.Debug("cannot list composite resources related to a composed resource change", "error", err, "gvk", of.String(), "fieldSelector", compositeResourcesRefsIndex+"="+key)
+			return nil
+		}
+
+		requests := make([]reconcile.Request, len(composites.Items))
+		for i, xr := range composites.Items {
+			log.Debug("Mapping composite resource because composed resource changed",
+				"namespace", xr.GetNamespace(),
+				"name", xr.GetName(),
+				"cdGVK", cdGVK.String(),
+				"cdName", obj.GetName(),
+			)
+			requests[i] = reconcile.Request{NamespacedName: client.ObjectKeyFromObject(&xr)}
+		}
+
+		return requests
 	}
 }

--- a/internal/controller/apiextensions/definition/handlers_test.go
+++ b/internal/controller/apiextensions/definition/handlers_test.go
@@ -10,9 +10,7 @@ import (
 	kunstructured "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/util/workqueue"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	kevent "sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	xpv1 "github.com/crossplane/crossplane-runtime/v2/apis/common/v1"
@@ -23,16 +21,16 @@ import (
 	v1 "github.com/crossplane/crossplane/v2/apis/apiextensions/v1"
 )
 
-func TestEnqueueForCompositionRevisionFunc(t *testing.T) {
+func TestCompositionRevisionMapFunc(t *testing.T) {
 	type args struct {
 		of     schema.GroupVersionKind
 		schema composite.Schema
 		reader client.Reader
-		event  kevent.CreateEvent
+		obj    client.Object
 	}
 
 	type want struct {
-		added []any
+		requests []reconcile.Request
 	}
 
 	dog := schema.GroupVersionKind{Group: "example.com", Version: "v1", Kind: "Dog"}
@@ -44,12 +42,11 @@ func TestEnqueueForCompositionRevisionFunc(t *testing.T) {
 		want   want
 	}{
 		"NoXRs": {
-			reason: "If there are no XRs of the specified type, no reconciles should be enqueued.",
+			reason: "If there are no XRs of the specified type, no reconciles should be returned.",
 			args: args{
 				of: dog,
 				reader: &test.MockClient{
 					MockList: func(_ context.Context, list client.ObjectList, opts ...client.ListOption) error {
-						// test parameters only here, not in the later tests for brevity.
 						u, ok := list.(*kunstructured.UnstructuredList)
 						if !ok {
 							t.Errorf("list was not an UnstructuredList")
@@ -62,10 +59,24 @@ func TestEnqueueForCompositionRevisionFunc(t *testing.T) {
 						return nil
 					},
 				},
+				obj: &v1.CompositionRevision{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "dachshund-sadfa8",
+						Labels: map[string]string{
+							v1.LabelCompositionName: "dachshund",
+						},
+					},
+					Spec: v1.CompositionRevisionSpec{
+						CompositeTypeRef: v1.TypeReferenceTo(dog),
+					},
+				},
+			},
+			want: want{
+				requests: []reconcile.Request{},
 			},
 		},
 		"AutomaticManagementPolicy": {
-			reason: "A reconcile should be enqueued for XRs with an automatic revision update policy.",
+			reason: "A reconcile should be returned for XRs with an automatic revision update policy.",
 			args: args{
 				of: dog,
 				reader: &test.MockClient{
@@ -82,29 +93,27 @@ func TestEnqueueForCompositionRevisionFunc(t *testing.T) {
 						return nil
 					},
 				},
-				event: kevent.CreateEvent{
-					Object: &v1.CompositionRevision{
-						ObjectMeta: metav1.ObjectMeta{
-							Name: "dachshund-sadfa8",
-							Labels: map[string]string{
-								v1.LabelCompositionName: "dachshund",
-							},
+				obj: &v1.CompositionRevision{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "dachshund-sadfa8",
+						Labels: map[string]string{
+							v1.LabelCompositionName: "dachshund",
 						},
-						Spec: v1.CompositionRevisionSpec{
-							CompositeTypeRef: v1.TypeReferenceTo(dog),
-						},
+					},
+					Spec: v1.CompositionRevisionSpec{
+						CompositeTypeRef: v1.TypeReferenceTo(dog),
 					},
 				},
 			},
 			want: want{
-				added: []any{reconcile.Request{NamespacedName: types.NamespacedName{
+				requests: []reconcile.Request{{NamespacedName: types.NamespacedName{
 					Namespace: "ns",
 					Name:      "obj1",
 				}}},
 			},
 		},
 		"ManualManagementPolicy": {
-			reason: "A reconcile shouldn't be enqueued for XRs with a manual revision update policy.",
+			reason: "A reconcile shouldn't be returned for XRs with a manual revision update policy.",
 			args: args{
 				of: dog,
 				reader: &test.MockClient{
@@ -121,58 +130,24 @@ func TestEnqueueForCompositionRevisionFunc(t *testing.T) {
 						return nil
 					},
 				},
-				event: kevent.CreateEvent{
-					Object: &v1.CompositionRevision{
-						ObjectMeta: metav1.ObjectMeta{
-							Name: "dachshund-sadfa8",
-							Labels: map[string]string{
-								v1.LabelCompositionName: "dachshund",
-							},
+				obj: &v1.CompositionRevision{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "dachshund-sadfa8",
+						Labels: map[string]string{
+							v1.LabelCompositionName: "dachshund",
 						},
-						Spec: v1.CompositionRevisionSpec{
-							CompositeTypeRef: v1.TypeReferenceTo(dog),
-						},
+					},
+					Spec: v1.CompositionRevisionSpec{
+						CompositeTypeRef: v1.TypeReferenceTo(dog),
 					},
 				},
 			},
-			want: want{},
-		},
-		"OtherComposition": {
-			reason: "A reconcile shouldn't be enqueued for an XR that references a different Composition",
-			args: args{
-				of: dog,
-				reader: &test.MockClient{
-					MockList: func(_ context.Context, list client.ObjectList, _ ...client.ListOption) error {
-						var obj1 composite.Unstructured
-						obj1.SetNamespace("ns")
-						obj1.SetName("obj1")
-						policy := xpv1.UpdateAutomatic
-						obj1.SetCompositionUpdatePolicy(&policy)
-						obj1.SetCompositionReference(&corev1.ObjectReference{Name: "bernese"})
-
-						list.(*kunstructured.UnstructuredList).Items = []kunstructured.Unstructured{obj1.Unstructured}
-
-						return nil
-					},
-				},
-				event: kevent.CreateEvent{
-					Object: &v1.CompositionRevision{
-						ObjectMeta: metav1.ObjectMeta{
-							Name: "dachshund-sadfa8",
-							Labels: map[string]string{
-								v1.LabelCompositionName: "dachshund",
-							},
-						},
-						Spec: v1.CompositionRevisionSpec{
-							CompositeTypeRef: v1.TypeReferenceTo(dog),
-						},
-					},
-				},
+			want: want{
+				requests: []reconcile.Request{},
 			},
-			want: want{},
 		},
 		"Multiple": {
-			reason: "Reconciles should be enqueued only for the XRs that reference the relevant Composition, and have an automatic composition revision update policy.",
+			reason: "Reconciles should be returned only for the XRs that reference the relevant Composition, and have an automatic composition revision update policy.",
 			args: args{
 				of: dog,
 				reader: &test.MockClient{
@@ -205,46 +180,212 @@ func TestEnqueueForCompositionRevisionFunc(t *testing.T) {
 						return nil
 					},
 				},
-				event: kevent.CreateEvent{
-					Object: &v1.CompositionRevision{
-						ObjectMeta: metav1.ObjectMeta{
-							Name: "dachshund-sadfa8",
-							Labels: map[string]string{
-								v1.LabelCompositionName: "dachshund",
-							},
+				obj: &v1.CompositionRevision{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "dachshund-sadfa8",
+						Labels: map[string]string{
+							v1.LabelCompositionName: "dachshund",
 						},
-						Spec: v1.CompositionRevisionSpec{
-							CompositeTypeRef: v1.TypeReferenceTo(dog),
-						},
+					},
+					Spec: v1.CompositionRevisionSpec{
+						CompositeTypeRef: v1.TypeReferenceTo(dog),
 					},
 				},
 			},
 			want: want{
-				added: []any{
-					reconcile.Request{NamespacedName: types.NamespacedName{Namespace: "ns", Name: "obj1"}},
-					reconcile.Request{NamespacedName: types.NamespacedName{Namespace: "ns", Name: "obj2"}},
+				requests: []reconcile.Request{
+					{NamespacedName: types.NamespacedName{Namespace: "ns", Name: "obj1"}},
+					{NamespacedName: types.NamespacedName{Namespace: "ns", Name: "obj2"}},
 				},
 			},
 		},
 	}
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			fns := EnqueueForCompositionRevision(tc.args.of, tc.args.schema, tc.args.reader, logging.NewNopLogger())
-			q := rateLimitingQueueMock{}
-			fns.Create(context.TODO(), tc.args.event, &q)
+			mapFunc := CompositionRevisionMapFunc(tc.args.of, tc.args.schema, tc.args.reader, logging.NewNopLogger())
+			requests := mapFunc(context.TODO(), tc.args.obj)
 
-			if diff := cmp.Diff(tc.want.added, q.added); diff != "" {
-				t.Errorf("\n%s\nfns.Create(...): -want, +got:\n%s", tc.reason, diff)
+			if diff := cmp.Diff(tc.want.requests, requests); diff != "" {
+				t.Errorf("\n%s\nCompositionRevisionMapFunc(...): -want, +got:\n%s", tc.reason, diff)
 			}
 		})
 	}
 }
 
-type rateLimitingQueueMock struct {
-	workqueue.TypedRateLimitingInterface[reconcile.Request]
-	added []any
+func TestCompositeResourcesMapFunc(t *testing.T) {
+	type args struct {
+		of     schema.GroupVersionKind
+		reader client.Reader
+		obj    client.Object
+	}
+
+	type want struct {
+		requests []reconcile.Request
+	}
+
+	dog := schema.GroupVersionKind{Group: "example.com", Version: "v1", Kind: "Dog"}
+	bucket := schema.GroupVersionKind{Group: "s3.aws.crossplane.io", Version: "v1alpha1", Kind: "Bucket"}
+
+	tests := map[string]struct {
+		reason string
+		args   args
+		want   want
+	}{
+		"NoXRs": {
+			reason: "If there are no XRs that reference the composed resource, no reconciles should be returned.",
+			args: args{
+				of: dog,
+				reader: &test.MockClient{
+					MockList: func(_ context.Context, _ client.ObjectList, _ ...client.ListOption) error {
+						return nil
+					},
+				},
+				obj: &kunstructured.Unstructured{
+					Object: map[string]interface{}{
+						"apiVersion": bucket.GroupVersion().String(),
+						"kind":       bucket.Kind,
+						"metadata": map[string]interface{}{
+							"name":      "my-bucket",
+							"namespace": "default",
+						},
+					},
+				},
+			},
+			want: want{
+				requests: []reconcile.Request{},
+			},
+		},
+		"SingleXR": {
+			reason: "A reconcile should be returned for XRs that reference the composed resource.",
+			args: args{
+				of: dog,
+				reader: &test.MockClient{
+					MockList: func(_ context.Context, list client.ObjectList, _ ...client.ListOption) error {
+						var xr1 kunstructured.Unstructured
+						xr1.SetName("xr1")
+						xr1.SetNamespace("")
+
+						list.(*kunstructured.UnstructuredList).Items = []kunstructured.Unstructured{xr1}
+						return nil
+					},
+				},
+				obj: &kunstructured.Unstructured{
+					Object: map[string]interface{}{
+						"apiVersion": bucket.GroupVersion().String(),
+						"kind":       bucket.Kind,
+						"metadata": map[string]interface{}{
+							"name":      "my-bucket",
+							"namespace": "default",
+						},
+					},
+				},
+			},
+			want: want{
+				requests: []reconcile.Request{{NamespacedName: types.NamespacedName{
+					Name: "xr1",
+				}}},
+			},
+		},
+		"MultipleXRs": {
+			reason: "Reconciles should be returned for all XRs that reference the composed resource.",
+			args: args{
+				of: dog,
+				reader: &test.MockClient{
+					MockList: func(_ context.Context, list client.ObjectList, _ ...client.ListOption) error {
+						var xr1 kunstructured.Unstructured
+						xr1.SetName("xr1")
+						xr1.SetNamespace("")
+
+						var xr2 kunstructured.Unstructured
+						xr2.SetName("xr2")
+						xr2.SetNamespace("")
+
+						list.(*kunstructured.UnstructuredList).Items = []kunstructured.Unstructured{xr1, xr2}
+						return nil
+					},
+				},
+				obj: &kunstructured.Unstructured{
+					Object: map[string]interface{}{
+						"apiVersion": bucket.GroupVersion().String(),
+						"kind":       bucket.Kind,
+						"metadata": map[string]interface{}{
+							"name":      "my-bucket",
+							"namespace": "default",
+						},
+					},
+				},
+			},
+			want: want{
+				requests: []reconcile.Request{
+					{NamespacedName: types.NamespacedName{Name: "xr1"}},
+					{NamespacedName: types.NamespacedName{Name: "xr2"}},
+				},
+			},
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			// Set the GVK on the object since MapFunc needs it
+			tc.args.obj.GetObjectKind().SetGroupVersionKind(bucket)
+
+			mapFunc := CompositeResourcesMapFunc(tc.args.of, tc.args.reader, logging.NewNopLogger())
+			requests := mapFunc(context.TODO(), tc.args.obj)
+
+			if diff := cmp.Diff(tc.want.requests, requests); diff != "" {
+				t.Errorf("\n%s\nCompositeResourcesMapFunc(...): -want, +got:\n%s", tc.reason, diff)
+			}
+		})
+	}
 }
 
-func (f *rateLimitingQueueMock) Add(item reconcile.Request) {
-	f.added = append(f.added, item)
+func TestSelfMapFunc(t *testing.T) {
+	tests := map[string]struct {
+		reason string
+		obj    client.Object
+		want   []reconcile.Request
+	}{
+		"ClusterScoped": {
+			reason: "Should return a reconcile request for the object itself (cluster-scoped).",
+			obj: &kunstructured.Unstructured{
+				Object: map[string]interface{}{
+					"metadata": map[string]interface{}{
+						"name": "my-object",
+					},
+				},
+			},
+			want: []reconcile.Request{{
+				NamespacedName: types.NamespacedName{
+					Name: "my-object",
+				},
+			}},
+		},
+		"Namespaced": {
+			reason: "Should return a reconcile request for the object itself (namespaced).",
+			obj: &kunstructured.Unstructured{
+				Object: map[string]interface{}{
+					"metadata": map[string]interface{}{
+						"name":      "my-object",
+						"namespace": "my-namespace",
+					},
+				},
+			},
+			want: []reconcile.Request{{
+				NamespacedName: types.NamespacedName{
+					Name:      "my-object",
+					Namespace: "my-namespace",
+				},
+			}},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			mapFunc := SelfMapFunc()
+			requests := mapFunc(context.TODO(), tc.obj)
+
+			if diff := cmp.Diff(tc.want, requests); diff != "" {
+				t.Errorf("\n%s\nSelfMapFunc(...): -want, +got:\n%s", tc.reason, diff)
+			}
+		})
+	}
 }

--- a/internal/controller/apiextensions/definition/reconciler.go
+++ b/internal/controller/apiextensions/definition/reconciler.go
@@ -50,6 +50,7 @@ import (
 	ucomposite "github.com/crossplane/crossplane-runtime/v2/pkg/resource/unstructured/composite"
 
 	v1 "github.com/crossplane/crossplane/v2/apis/apiextensions/v1"
+	"github.com/crossplane/crossplane/v2/internal/circuit"
 	"github.com/crossplane/crossplane/v2/internal/controller/apiextensions/composite"
 	"github.com/crossplane/crossplane/v2/internal/controller/apiextensions/composite/watch"
 	apiextensionscontroller "github.com/crossplane/crossplane/v2/internal/controller/apiextensions/controller"
@@ -523,6 +524,9 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 		composite.WithCompositeConnectionDetailsFetcher(fetcher),
 	)
 
+	// Create circuit breaker for this XR controller
+	cb := circuit.NewTokenBucketBreaker()
+
 	// All XRs have modern schema unless their XRD's scope is LegacyCluster.
 	schema := ucomposite.SchemaModern
 	if ptr.Deref(d.Spec.Scope, v1.CompositeResourceScopeLegacyCluster) == v1.CompositeResourceScopeLegacyCluster {
@@ -539,6 +543,8 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 		composite.WithLogger(r.log.WithValues("controller", composite.ControllerName(d.GetName()))),
 		composite.WithRecorder(r.record.WithAnnotations("controller", composite.ControllerName(d.GetName()))),
 		composite.WithPollInterval(r.options.PollInterval),
+		composite.WithCircuitBreaker(cb),
+		composite.WithAuthorizer(r.engine),
 		composite.WithComposer(fc),
 		composite.WithFeatures(r.options.Features),
 	}
@@ -562,13 +568,13 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 			r.log.Debug(errAddIndex, "error", err)
 		}
 
-		h := EnqueueCompositeResources(d.GetCompositeGroupVersionKind(), r.engine.GetCached(), r.log)
+		cmf := CompositeResourcesMapFunc(d.GetCompositeGroupVersionKind(), r.engine.GetCached(), r.log)
+		h := handler.EnqueueRequestsFromMapFunc(circuit.NewMapFunc(cmf, cb))
 		ro = append(ro,
 			composite.WithWatchStarter(composite.ControllerName(d.GetName()), h, r.engine),
 			composite.WithPollInterval(0), // Disable polling.
 		)
 	}
-	ro = append(ro, composite.WithAuthorizer(r.engine))
 
 	cr := composite.NewReconciler(r.engine.GetCached(), d.GetCompositeGroupVersionKind(), ro...)
 	ko := r.options.ForControllerRuntime()
@@ -611,9 +617,13 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 	xr := &kunstructured.Unstructured{}
 	xr.SetGroupVersionKind(gvk)
 
-	crh := EnqueueForCompositionRevision(gvk, schema, r.engine.GetCached(), log)
+	crmf := CompositionRevisionMapFunc(gvk, schema, r.engine.GetCached(), log)
+	crh := handler.EnqueueRequestsFromMapFunc(circuit.NewMapFunc(crmf, cb))
+
+	h := handler.EnqueueRequestsFromMapFunc(circuit.NewMapFunc(SelfMapFunc(), cb))
+
 	if err := r.engine.StartWatches(ctx, name,
-		engine.WatchFor(xr, engine.WatchTypeCompositeResource, &handler.EnqueueRequestForObject{}),
+		engine.WatchFor(xr, engine.WatchTypeCompositeResource, h),
 		engine.WatchFor(&v1.CompositionRevision{}, engine.WatchTypeCompositionRevision, crh),
 	); err != nil {
 		log.Debug(errStartWatches, "error", err)

--- a/test/e2e/apiextensions_compositions_test.go
+++ b/test/e2e/apiextensions_compositions_test.go
@@ -371,7 +371,7 @@ func TestCircuitBreaker(t *testing.T) {
 				t.Log("Starting rapid ConfigMap updates using Server-Side Apply to trigger circuit breaker...")
 
 				// Rapidly apply ConfigMap updates using SSA
-				// We'll do 60 updates over 2 seconds (30 updates/second)
+				// We'll do 60 updates over 3 seconds (20 updates/second)
 				// This should exhaust the 50-token bucket quickly
 				for i := range 60 {
 					cm := &unstructured.Unstructured{}

--- a/test/e2e/manifests/apiextensions/composition/circuit-breaker/setup/composition.yaml
+++ b/test/e2e/manifests/apiextensions/composition/circuit-breaker/setup/composition.yaml
@@ -8,7 +8,7 @@ spec:
     kind: CircuitBreakerTest
   mode: Pipeline
   pipeline:
-  - step: create-with-short-ttl
+  - step: create-configmap
     functionRef:
       name: function-dummy-circuit-breaker
     input:

--- a/test/e2e/manifests/apiextensions/composition/circuit-breaker/setup/composition.yaml
+++ b/test/e2e/manifests/apiextensions/composition/circuit-breaker/setup/composition.yaml
@@ -1,0 +1,39 @@
+apiVersion: apiextensions.crossplane.io/v1
+kind: Composition
+metadata:
+  name: circuit-breaker-composition
+spec:
+  compositeTypeRef:
+    apiVersion: example.org/v1alpha1
+    kind: CircuitBreakerTest
+  mode: Pipeline
+  pipeline:
+  - step: create-with-short-ttl
+    functionRef:
+      name: function-dummy-circuit-breaker
+    input:
+      apiVersion: dummy.fn.crossplane.io/v1beta1
+      kind: Response
+      # This is a YAML-serialized RunFunctionResponse. function-dummy will
+      # return this response to create a ConfigMap that we'll update rapidly in the test.
+      response:
+        desired:
+          composite:
+            resource:
+              status:
+                message: "Circuit breaker test - ConfigMap will be updated rapidly"
+          resources:
+            configmap:
+              resource:
+                apiVersion: v1
+                kind: ConfigMap
+                metadata:
+                  name: circuit-breaker-configmap
+                  namespace: default
+                data:
+                  message: "This ConfigMap will be updated rapidly to trigger circuit breaker"
+                  counter: "0"
+              ready: READY_TRUE
+        results:
+         - severity: SEVERITY_NORMAL
+           message: "Creating ConfigMap for circuit breaker test"

--- a/test/e2e/manifests/apiextensions/composition/circuit-breaker/setup/definition.yaml
+++ b/test/e2e/manifests/apiextensions/composition/circuit-breaker/setup/definition.yaml
@@ -1,0 +1,30 @@
+apiVersion: apiextensions.crossplane.io/v2
+kind: CompositeResourceDefinition
+metadata:
+  name: circuitbreakertests.example.org
+spec:
+  scope: Cluster
+  group: example.org
+  names:
+    kind: CircuitBreakerTest
+    plural: circuitbreakertests
+  versions:
+  - name: v1alpha1
+    served: true
+    referenceable: true
+    schema:
+     openAPIV3Schema:
+       type: object
+       properties:
+        spec:
+          type: object
+          properties:
+            message:
+              type: string
+          required:
+          - message
+        status:
+          type: object
+          properties:
+            message:
+              type: string

--- a/test/e2e/manifests/apiextensions/composition/circuit-breaker/setup/functions.yaml
+++ b/test/e2e/manifests/apiextensions/composition/circuit-breaker/setup/functions.yaml
@@ -1,0 +1,6 @@
+apiVersion: pkg.crossplane.io/v1
+kind: Function
+metadata:
+  name: function-dummy-circuit-breaker
+spec:
+  package: xpkg.crossplane.io/crossplane-contrib/function-dummy:v0.4.1

--- a/test/e2e/manifests/apiextensions/composition/circuit-breaker/xr.yaml
+++ b/test/e2e/manifests/apiextensions/composition/circuit-breaker/xr.yaml
@@ -1,0 +1,9 @@
+apiVersion: example.org/v1alpha1
+kind: CircuitBreakerTest
+metadata:
+  name: circuit-breaker-xr
+spec:
+  message: "Testing circuit breaker functionality"
+  crossplane:
+    compositionRef:
+      name: circuit-breaker-composition


### PR DESCRIPTION
### Description of your changes

Fixes https://github.com/crossplane/crossplane/issues/6751
Fixes https://github.com/crossplane/crossplane/issues/6461
Helps with https://github.com/crossplane/crossplane/issues/6470
Closes https://github.com/crossplane/crossplane/issues/6481

This PR adds a circuit breaker to XR controllers to prevent reconciliation thrashing when controllers fight over composed resource state. Since enabling realtime composition by default, we've seen patterns where:

1. XR changes something about a composed resource
2. Some other controller (e.g. MR controller) undoes the change  
3. This triggers the XR's watch on the composed resource
4. Back to 1

This results in a tight loop with no rate limiting because there's no error - the controllers just fight as fast as they can.

**Solution**: A token bucket-based circuit breaker that monitors reconciliation rates per XR and opens when thresholds are exceeded (50 burst, 1 every 2s sustained). When open, it identifies which watched resources are causing the thrashing and sets clear status conditions.

**Key changes**:
- Convert XR watch handlers to MapFunc pattern for better composability
- Implement circuit breaker with source tracking and automatic recovery
- Integrate into XR controllers with status condition reporting

**User experience**: When thrashing occurs, users see a clear `Responsive` condition like:
```yaml
conditions:
- type: Responsive
  status: "False" 
  reason: WatchCircuitOpen
  message: "Too many watch events from ConfigMap/my-config (default). Allowing events periodically."
```

Each XR has its own circuit breaker. When open, it blocks most reconcile requests but allows one through every 30 seconds. The circuit stays open for 5 minutes, then automatically closes and returns to normal operation. If thrashing resumes, the circuit will open again.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `earthly +reviewable` to ensure this PR is ready for review.
- [x] Added or updated unit tests.
- [x] Added or updated e2e tests.
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~
- [ ] ~Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md