### PR TITLE
fix realtime Compositions for Namespaced XRs

### DIFF
--- a/internal/controller/apiextensions/definition/handlers.go
+++ b/internal/controller/apiextensions/definition/handlers.go
@@ -116,8 +116,8 @@ func EnqueueCompositeResources(of schema.GroupVersionKind, c client.Reader, log 
 
 			// queue those composites for reconciliation
 			for _, xr := range composites.Items {
-				log.Debug("Enqueueing composite resource because composed resource changed", "name", xr.GetName(), "cdGVK", cdGVK.String(), "cdName", ev.ObjectNew.GetName())
-				q.Add(reconcile.Request{NamespacedName: types.NamespacedName{Name: xr.GetName()}})
+				log.Debug("Enqueueing composite resource because composed resource changed", "name", xr.GetName(), "namespace", xr.GetNamespace(), "cdGVK", cdGVK.String(), "cdName", ev.ObjectNew.GetName())
+				q.Add(reconcile.Request{NamespacedName: types.NamespacedName{Name: xr.GetName(), Namespace: xr.GetNamespace()}})
 			}
 		},
 	}

--- a/internal/controller/apiextensions/definition/indexes.go
+++ b/internal/controller/apiextensions/definition/indexes.go
@@ -43,10 +43,16 @@ func IndexCompositeResourcesRefs(s composite.Schema) client.IndexerFunc {
 
 		xr := composite.Unstructured{Unstructured: *u, Schema: s}
 		refs := xr.GetResourceReferences()
+		xrNamespace := xr.GetNamespace()
 
 		keys := make([]string, 0, len(refs))
 		for _, ref := range refs {
-			keys = append(keys, refKey(ref.Namespace, ref.Name, ref.Kind, ref.APIVersion))
+			namespace := ref.Namespace
+			if namespace == "" {
+				namespace = xrNamespace
+			}
+
+			keys = append(keys, refKey(namespace, ref.Name, ref.Kind, ref.APIVersion))
 		}
 
 		return keys


### PR DESCRIPTION
### Description of your changes

<!--
Briefly describe what this pull request does, and how it is covered by tests.
Be proactive - direct your reviewers' attention to anything that needs special
consideration.

We love pull requests that fix an open issue. If yours does, use the below line
to indicate which issue it fixes, for example "Fixes #500".
-->

Looks like realtime Compositions are broken for Namespaced XRs. I think the problem is in this code from `internal/controller/apiextensions/definition/indexes.go`:
```go
        for _, ref := range refs {
			// PROBLEM: ref.Namespace is empty for namespaced XRs
			keys = append(keys, refKey(ref.Namespace, ref.Name, ref.Kind, ref.APIVersion))
		}
```

As `ref.Namespace` is empty, this will generate keys like `foo1..Object.kubernetes.m.crossplane.io/v1alpha1` (while for Cluster-scoped XRs this will generate keys like `foo1.default.Object.kubernetes.m.crossplane.io/v1alpha1`).

Later, when a composed resource changes, the `EnqueueCompositeResources` handler creates a lookup key using the actual namespace of the changed resource (`internal/controller/apiextensions/definition/handlers.go`):

```go
key := refKey(ev.ObjectNew.GetNamespace(), ev.ObjectNew.GetName(), cdGVK.Kind, cdGVK.GroupVersion().String())
```

This generates keys like `foo1.default.Object.kubernetes.m.crossplane.io/v1alpha1` (with the actual namespace), but the index for namespaced XRs contains keys like `foo1..Object.kubernetes.m.crossplane.io/v1alpha1` (with empty namespace).

Since the lookup key doesn't match any index keys, no XRs are found and enqueued for reconciliation, causing realtime compositions to fall back to polling (~1 minute delay) instead of immediate updates.

Additionally, the `EnqueueCompositeResources` handler was missing the namespace when enqueueing XRs for reconciliation. The original code only set the `Name` field (`internal/controller/apiextensions/definition/handlers.go`):

```go
q.Add(reconcile.Request{NamespacedName: types.NamespacedName{Name: xr.GetName()}})
```

For namespaced XRs, this would cause the reconcile request to target the wrong resource (or no resource at all), since Kubernetes requires both name and namespace to uniquely identify a namespaced resource. The fix ensures both fields are properly set:

```go
q.Add(reconcile.Request{NamespacedName: types.NamespacedName{Name: xr.GetName(), Namespace: xr.GetNamespace()}})
```

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `earthly +reviewable` to ensure this PR is ready for review.
- [ ] ~Added or updated unit tests.~
- [ ] ~Added or updated e2e tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [x] Added `backport release-x.y` labels to auto-backport this PR.
- [ ] ~Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md