### PR TITLE
Rename WebhooksEnabled by EnableWebhooks in init cmd

### DIFF
--- a/cmd/crossplane/core/init.go
+++ b/cmd/crossplane/core/init.go
@@ -45,7 +45,8 @@ type initCommand struct {
 	CRDsPath                  string `default:"/crds"                  env:"CRDS_PATH"            help:"Path of Crossplane core Custom Resource Definitions."`
 	WebhookConfigurationsPath string `default:"/webhookconfigurations" env:"WEBHOOK_CONFIGS_PATH" help:"Path of Crossplane core Webhook Configurations."`
 
-	WebhookEnabled          bool   `default:"true"                   env:"WEBHOOK_ENABLED"                                                                         help:"Enable webhook configuration."`
+	EnableWebhooks bool `aliases:"webhook-enabled" default:"true" env:"ENABLE_WEBHOOKS,WEBHOOK_ENABLED" help:"Enable webhook configuration."`
+
 	WebhookServiceName      string `env:"WEBHOOK_SERVICE_NAME"       help:"The name of the Service object that the webhook service will be run."`
 	WebhookServiceNamespace string `env:"WEBHOOK_SERVICE_NAMESPACE"  help:"The namespace of the Service object that the webhook service will be run."`
 	WebhookServicePort      int32  `env:"WEBHOOK_SERVICE_PORT"       help:"The port of the Service that the webhook service will be run."`
@@ -73,7 +74,7 @@ func (c *initCommand) Run(s *runtime.Scheme, log logging.Logger) error {
 		initializer.TLSCertificateGeneratorWithClientSecretName(c.TLSClientSecretName, []string{fmt.Sprintf("%s.%s", c.ServiceAccount, c.Namespace)}),
 		initializer.TLSCertificateGeneratorWithLogger(log.WithValues("Step", "TLSCertificateGenerator")),
 	}
-	if c.WebhookEnabled {
+	if c.EnableWebhooks {
 		tlsGeneratorOpts = append(tlsGeneratorOpts,
 			initializer.TLSCertificateGeneratorWithServerSecretName(c.TLSServerSecretName, initializer.DNSNamesForService(c.WebhookServiceName, c.WebhookServiceNamespace)))
 	}
@@ -86,7 +87,7 @@ func (c *initCommand) Run(s *runtime.Scheme, log logging.Logger) error {
 			"compositions.apiextensions.crossplane.io",
 		),
 	)
-	if c.WebhookEnabled {
+	if c.EnableWebhooks {
 		nn := types.NamespacedName{
 			Name:      c.TLSServerSecretName,
 			Namespace: c.Namespace,


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane! Please read the contribution docs
(linked below) if this is your first Crossplane pull request.
-->

### Description of your changes

Rename this variable to be consistent with the rest of the code and the helm chart.

Fixes #6539

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `earthly +reviewable` to ensure this PR is ready for review.
- ~~[ ] Added or updated unit tests.~~
- ~~[ ] Added or updated e2e tests.~~
- [x] Linked a PR or a [docs tracking issue] to [document this change].
- ~~[ ] Added `backport release-x.y` labels to auto-backport this PR.~~
- ~~[ ] Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduced --enable-webhooks CLI flag (alias: --webhook-enabled).
  - Added support for ENABLE_WEBHOOKS and WEBHOOK_ENABLED environment variables.
  - Webhook setup, including TLS and server secret handling, is now fully controlled by this flag.

- Refactor
  - Standardized webhook configuration naming for consistency while maintaining backward compatibility via alias and dual env var support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->