### PR TITLE
Support remote Docker daemons in render commands

### DIFF
--- a/cmd/crank/alpha/render/op/cmd.go
+++ b/cmd/crank/alpha/render/op/cmd.go
@@ -42,14 +42,14 @@ type Cmd struct {
 	Functions string `arg:"" help:"A YAML file or directory of YAML files specifying the operation functions to use to render the Operation." predictor:"yaml_file_or_directory" type:"path"`
 
 	// Flags. Keep them in alphabetical order.
-	ContextFiles           map[string]string `help:"Comma-separated context key-value pairs to pass to the function pipeline. Values must be files containing JSON."                           mapsep:""          predictor:"file"`
+	ContextFiles           map[string]string `help:"Comma-separated context key-value pairs to pass to the function pipeline. Values must be files containing JSON."                           mapsep:""               predictor:"file"`
 	ContextValues          map[string]string `help:"Comma-separated context key-value pairs to pass to the function pipeline. Values must be JSON. Keys take precedence over --context-files." mapsep:""`
-	FunctionCredentials    string            `help:"A YAML file or directory of YAML files specifying credentials to use for functions."                                                       placeholder:"PATH" predictor:"yaml_file_or_directory" type:"path"`
-	FunctionAnnotations    []string          `help:"Override function annotations for all functions. Can be repeated."                                                                    placeholder:"KEY=VALUE" short:"a"`
+	FunctionCredentials    string            `help:"A YAML file or directory of YAML files specifying credentials to use for functions."                                                       placeholder:"PATH"      predictor:"yaml_file_or_directory" type:"path"`
+	FunctionAnnotations    []string          `help:"Override function annotations for all functions. Can be repeated."                                                                         placeholder:"KEY=VALUE" short:"a"`
 	IncludeContext         bool              `help:"Include the context in the rendered output as a resource of kind: Context."                                                                short:"c"`
 	IncludeFullOperation   bool              `help:"Include a direct copy of the input Operation's spec and metadata fields in the rendered output."                                           short:"o"`
 	IncludeFunctionResults bool              `help:"Include informational and warning messages from functions in the rendered output as resources of kind: Result."                            short:"r"`
-	RequiredResources      string            `help:"A YAML file or directory of YAML files specifying required resources to pass to the function pipeline."                                    placeholder:"PATH" predictor:"yaml_file_or_directory" short:"e"   type:"path"`
+	RequiredResources      string            `help:"A YAML file or directory of YAML files specifying required resources to pass to the function pipeline."                                    placeholder:"PATH"      predictor:"yaml_file_or_directory" short:"e"   type:"path"`
 
 	Timeout time.Duration `default:"1m" help:"How long to run before timing out."`
 
@@ -123,7 +123,7 @@ Examples:
   # Override function annotations for remote Docker daemon.
   crossplane alpha render op operation.yaml functions.yaml \
 	-a render.crossplane.io/runtime-docker-publish-address=0.0.0.0 \
-	-a render.crossplane.io/runtime-docker-target=docker-host
+	-a render.crossplane.io/runtime-docker-target=192.168.1.100
 
   # Use development runtime with custom target.
   crossplane alpha render op operation.yaml functions.yaml \

--- a/cmd/crank/render/cmd.go
+++ b/cmd/crank/render/cmd.go
@@ -47,16 +47,16 @@ type Cmd struct {
 	Functions         string `arg:"" help:"A YAML file or directory of YAML files specifying the Composition Functions to use to render the XR." predictor:"yaml_file_or_directory" type:"path"`
 
 	// Flags. Keep them in alphabetical order.
-	ContextFiles           map[string]string `help:"Comma-separated context key-value pairs to pass to the Function pipeline. Values must be files containing JSON."                           mapsep:""          predictor:"file"`
+	ContextFiles           map[string]string `help:"Comma-separated context key-value pairs to pass to the Function pipeline. Values must be files containing JSON."                           mapsep:""               predictor:"file"`
 	ContextValues          map[string]string `help:"Comma-separated context key-value pairs to pass to the Function pipeline. Values must be JSON. Keys take precedence over --context-files." mapsep:""`
 	IncludeFunctionResults bool              `help:"Include informational and warning messages from Functions in the rendered output as resources of kind: Result."                            short:"r"`
 	IncludeFullXR          bool              `help:"Include a direct copy of the input XR's spec and metadata fields in the rendered output."                                                  short:"x"`
-	ObservedResources      string            `help:"A YAML file or directory of YAML files specifying the observed state of composed resources."                                               placeholder:"PATH" predictor:"yaml_file_or_directory" short:"o"   type:"path"`
-	ExtraResources         string            `help:"A YAML file or directory of YAML files specifying required resources (deprecated, use --required-resources)."                              placeholder:"PATH" predictor:"yaml_file_or_directory" type:"path"`
-	RequiredResources      string            `help:"A YAML file or directory of YAML files specifying required resources to pass to the Function pipeline."                                    placeholder:"PATH" predictor:"yaml_file_or_directory" short:"e"   type:"path"`
+	ObservedResources      string            `help:"A YAML file or directory of YAML files specifying the observed state of composed resources."                                               placeholder:"PATH"      predictor:"yaml_file_or_directory" short:"o"   type:"path"`
+	ExtraResources         string            `help:"A YAML file or directory of YAML files specifying required resources (deprecated, use --required-resources)."                              placeholder:"PATH"      predictor:"yaml_file_or_directory" type:"path"`
+	RequiredResources      string            `help:"A YAML file or directory of YAML files specifying required resources to pass to the Function pipeline."                                    placeholder:"PATH"      predictor:"yaml_file_or_directory" short:"e"   type:"path"`
 	IncludeContext         bool              `help:"Include the context in the rendered output as a resource of kind: Context."                                                                short:"c"`
-	FunctionCredentials    string            `help:"A YAML file or directory of YAML files specifying credentials to use for Functions to render the XR."                                      placeholder:"PATH" predictor:"yaml_file_or_directory" type:"path"`
-	FunctionAnnotations    []string          `help:"Override function annotations for all functions. Can be repeated."                                                                    placeholder:"KEY=VALUE" short:"a"`
+	FunctionCredentials    string            `help:"A YAML file or directory of YAML files specifying credentials to use for Functions to render the XR."                                      placeholder:"PATH"      predictor:"yaml_file_or_directory" type:"path"`
+	FunctionAnnotations    []string          `help:"Override function annotations for all functions. Can be repeated."                                                                         placeholder:"KEY=VALUE" short:"a"`
 
 	Timeout time.Duration `default:"1m"                                                                                                     help:"How long to run before timing out."`
 	XRD     string        `help:"A YAML file specifying the CompositeResourceDefinition (XRD) that defines the XR's schema and properties." optional:""                               placeholder:"PATH" type:"existingfile"`
@@ -85,7 +85,7 @@ the following annotations to each Function to change how they're run:
   render.crossplane.io/runtime-development-target: "dns:///example.org:7443"
 
     Connect to a Function running somewhere other than localhost:9443. The
-	target uses gRPC target syntax.
+	target uses gRPC target syntax (e.g., dns:///example.org:7443 or simply example.org:7443).
 
   render.crossplane.io/runtime-docker-cleanup: "Orphan"
 
@@ -140,10 +140,10 @@ Examples:
   crossplane render xr.yaml composition.yaml functions.yaml \
 	--function-credentials=credentials.yaml
 
-  # Override function annotations for remote Docker daemon.
-  crossplane render xr.yaml composition.yaml functions.yaml \
+  # Override function annotations for a remote Docker daemon.
+  DOCKER_HOST=tcp://192.168.1.100:2376 crossplane render xr.yaml composition.yaml functions.yaml \
 	-a render.crossplane.io/runtime-docker-publish-address=0.0.0.0 \
-	-a render.crossplane.io/runtime-docker-target=docker-host
+	-a render.crossplane.io/runtime-docker-target=192.168.1.100
 
   # Force all functions to use development runtime.
   crossplane render xr.yaml composition.yaml functions.yaml \

--- a/cmd/crank/render/cmd.go
+++ b/cmd/crank/render/cmd.go
@@ -97,6 +97,17 @@ the following annotations to each Function to change how they're run:
     Always pull the Function's package, even if it already exists locally.
 	Other supported values are Never, or IfNotPresent.
 
+  render.crossplane.io/runtime-docker-publish-address: "0.0.0.0"
+
+    Host address that Docker should publish the Function's container port to.
+    Defaults to 127.0.0.1 (localhost only). Use 0.0.0.0 to publish to all host
+    network interfaces, enabling access from remote machines.
+
+  render.crossplane.io/runtime-docker-target: "docker-host"
+
+    Address that the render CLI should use to connect to the Function's Docker
+    container. If not specified, uses the publish address.
+
 Use the standard DOCKER_HOST, DOCKER_API_VERSION, DOCKER_CERT_PATH, and
 DOCKER_TLS_VERIFY environment variables to configure how this command connects
 to the Docker daemon.

--- a/cmd/crank/render/runtime_docker.go
+++ b/cmd/crank/render/runtime_docker.go
@@ -142,7 +142,8 @@ type RuntimeDocker struct {
 	BindAddress string
 
 	// Target is the host address to use when connecting to the function.
-	// If empty, defaults to BindAddress.
+	// If empty, it defaults to the published HostIP from Docker inspect.
+	// When published on 0.0.0.0, set this explicitly (e.g. the remote Docker host).
 	Target string
 }
 

--- a/cmd/crank/render/runtime_docker_test.go
+++ b/cmd/crank/render/runtime_docker_test.go
@@ -77,10 +77,11 @@ func TestGetRuntimeDocker(t *testing.T) {
 			},
 			want: want{
 				rd: &RuntimeDocker{
-					Image:      "test-image-from-annotation",
-					Cleanup:    AnnotationValueRuntimeDockerCleanupOrphan,
-					PullPolicy: AnnotationValueRuntimeDockerPullPolicyAlways,
-					Env:        []string{"KCL_DEFAULT_REGISTRY=registry.example.com", "ANOTHER_ENV_VAR=another-value"},
+					Image:       "test-image-from-annotation",
+					Cleanup:     AnnotationValueRuntimeDockerCleanupOrphan,
+					PullPolicy:  AnnotationValueRuntimeDockerPullPolicyAlways,
+					Env:         []string{"KCL_DEFAULT_REGISTRY=registry.example.com", "ANOTHER_ENV_VAR=another-value"},
+					BindAddress: "127.0.0.1",
 				},
 			},
 		},
@@ -105,11 +106,12 @@ func TestGetRuntimeDocker(t *testing.T) {
 			},
 			want: want{
 				rd: &RuntimeDocker{
-					Image:      "test-image-from-annotation",
-					Cleanup:    AnnotationValueRuntimeDockerCleanupOrphan,
-					Name:       "test-container-name-function",
-					PullPolicy: AnnotationValueRuntimeDockerPullPolicyIfNotPresent,
-					Env:        []string{"KCL_DEFAULT_REGISTRY=registry.example.com"},
+					Image:       "test-image-from-annotation",
+					Cleanup:     AnnotationValueRuntimeDockerCleanupOrphan,
+					Name:        "test-container-name-function",
+					PullPolicy:  AnnotationValueRuntimeDockerPullPolicyIfNotPresent,
+					Env:         []string{"KCL_DEFAULT_REGISTRY=registry.example.com"},
+					BindAddress: "127.0.0.1",
 				},
 			},
 		},
@@ -129,9 +131,10 @@ func TestGetRuntimeDocker(t *testing.T) {
 			},
 			want: want{
 				rd: &RuntimeDocker{
-					Image:      "test-package",
-					Cleanup:    AnnotationValueRuntimeDockerCleanupRemove,
-					PullPolicy: AnnotationValueRuntimeDockerPullPolicyIfNotPresent,
+					Image:       "test-package",
+					Cleanup:     AnnotationValueRuntimeDockerCleanupRemove,
+					PullPolicy:  AnnotationValueRuntimeDockerPullPolicyIfNotPresent,
+					BindAddress: "127.0.0.1",
 				},
 			},
 		},
@@ -194,10 +197,11 @@ func TestGetRuntimeDocker(t *testing.T) {
 			},
 			want: want{
 				rd: &RuntimeDocker{
-					Image:      "test-package",
-					Cleanup:    AnnotationValueRuntimeDockerCleanupStop,
-					PullPolicy: AnnotationValueRuntimeDockerPullPolicyIfNotPresent,
-					Env:        nil,
+					Image:       "test-package",
+					Cleanup:     AnnotationValueRuntimeDockerCleanupStop,
+					PullPolicy:  AnnotationValueRuntimeDockerPullPolicyIfNotPresent,
+					Env:         nil,
+					BindAddress: "127.0.0.1",
 				},
 			},
 		},


### PR DESCRIPTION
Fixes #6798  
Closes #6758

The `crossplane render` CLI fails when using remote Docker daemons because it hardcodes container port publishing to `127.0.0.1` and connection addresses to `localhost`. When `DOCKER_HOST` points to a remote daemon, the CLI finds a free port on the local machine, binds the container port to `localhost:port` on the remote Docker host, then tries to connect to `localhost:port` from the local CLI. This fails because `localhost` means different things in each context.

This PR adds support for remote Docker daemons through new function annotations and command-line overrides. The Docker runtime now supports two new annotations:
- `render.crossplane.io/runtime-docker-publish-address` controls the host address Docker publishes the container port to (defaults to `127.0.0.1` for security)  
- `render.crossplane.io/runtime-docker-target` controls the address the CLI connects to (defaults to the publish address)

Both render commands (`crossplane render` and `crossplane alpha render op`) now accept `-a/--function-annotations` flags that allow overriding any function annotation from the command line. The flag accepts `key=value` pairs, can be repeated multiple times, and takes precedence over existing annotations in function definitions.

The implementation includes some refactoring improvements:
- Uses Docker's automatic port allocation instead of manual port discovery
- Leverages Docker's unique container name guarantee and idempotent `ContainerStart()` for simplified container lifecycle management

Usage with remote Docker daemons:

```bash
export DOCKER_HOST="tcp://192.168.1.91:2375"
crossplane render xr.yaml composition.yaml functions.yaml \
  -a render.crossplane.io/runtime-docker-publish-address=0.0.0.0 \
  -a render.crossplane.io/runtime-docker-target=192.168.1.91
```

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `earthly +reviewable` to ensure this PR is ready for review.
- [x] Added or updated unit tests.
- [ ] ~Added or updated e2e tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~
- [ ] ~Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md