### PR TITLE
Validating webhook remover step now returns early if permissions are missing on validatingwebhookconfigurations

### DIFF
--- a/internal/initializer/webhook_configurations.go
+++ b/internal/initializer/webhook_configurations.go
@@ -164,8 +164,10 @@ func (c *RemoveValidatingWebhooks) Run(ctx context.Context, kube client.Client) 
 	vwc := &admv1.ValidatingWebhookConfiguration{}
 
 	err := kube.Get(ctx, client.ObjectKey{Name: c.ConfigName}, vwc)
-	if kerrors.IsNotFound(err) {
+	if kerrors.IsNotFound(err) || kerrors.IsForbidden(err) {
 		// If the webhook configuration doesn't exist there's nothing to cleanup.
+		// If the pod does not have rights on ValidationWebhookConfigurations, return nil
+		// to avoid crashes.
 		return nil
 	}
 

--- a/internal/initializer/webhook_configurations_test.go
+++ b/internal/initializer/webhook_configurations_test.go
@@ -290,6 +290,16 @@ func TestRemoveValidatingWebhooks(t *testing.T) {
 				},
 			},
 		},
+		"Forbidden": {
+			reason: "If the request to get the webhook configuration is forbidden, we should return early.",
+			args: args{
+				kube: &test.MockClient{
+					MockGet: func(_ context.Context, _ client.ObjectKey, _ client.Object) error {
+						return kerrors.NewForbidden(schema.GroupResource{}, "", errBoom)
+					},
+				},
+			},
+		},
 		"NoOp": {
 			reason: "If the config doesn't have any entries to delete we should return early.",
 			params: params{


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane! Please read the contribution docs
(linked below) if this is your first Crossplane pull request.
-->

### Description of your changes

This is the implementation of solution 2 described in [this comment](https://github.com/crossplane/crossplane/issues/6768#issuecomment-3275377461)

The objective is to make crossplane be able to run without permissions on ValidatingWebhookConfigurations.

This solution makes the step run in all cases, but it does not crash if permissions are missing.

<!--
Briefly describe what this pull request does, and how it is covered by tests.
Be proactive - direct your reviewers' attention to anything that needs special
consideration.

We love pull requests that fix an open issue. If yours does, use the below line
to indicate which issue it fixes, for example "Fixes #500".
-->

Fixes #6768

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `earthly +reviewable` to ensure this PR is ready for review.
- [x] Added or updated unit tests.
- ~~[ ] Added or updated e2e tests.~~
- [x] Linked a PR or a [docs tracking issue] to [document this change].
- ~~[ ] Added `backport release-x.y` labels to auto-backport this PR.~~
- ~~[ ] Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md