### PR TITLE
Fix XRD controller restart to detect all spec changes

### DIFF
--- a/internal/controller/apiextensions/definition/reconciler.go
+++ b/internal/controller/apiextensions/definition/reconciler.go
@@ -494,10 +494,8 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 		return reconcile.Result{Requeue: true}, nil
 	}
 
-	observed := d.Status.Controllers.CompositeResourceTypeRef
-
-	desired := v1.TypeReferenceTo(d.GetCompositeGroupVersionKind())
-	if observed.APIVersion != "" && observed != desired {
+	// Check if XRD has changed since controller was last started
+	if ControllerNeedsRestart(d) {
 		if err := r.engine.Stop(ctx, composite.ControllerName(d.GetName())); err != nil {
 			err = errors.Wrap(err, errStopController)
 			r.record.Event(d, event.Warning(reasonEstablishXR, err))
@@ -505,9 +503,9 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 			return reconcile.Result{}, err
 		}
 
-		log.Debug("Referenceable version changed; stopped composite resource controller",
-			"observed-version", observed.APIVersion,
-			"desired-version", desired.APIVersion)
+		log.Debug("XRD generation changed; stopped composite resource controller",
+			"observed-generation", d.GetCondition(v1.TypeEstablished).ObservedGeneration,
+			"current-generation", d.GetGeneration())
 	}
 
 	if r.engine.IsRunning(composite.ControllerName(d.GetName())) {
@@ -629,4 +627,24 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 	status.MarkConditions(v1.WatchingComposite())
 
 	return reconcile.Result{Requeue: false}, errors.Wrap(r.client.Status().Update(ctx, d), errUpdateStatus)
+}
+
+// ControllerNeedsRestart returns true if the composite resource controller
+// needs to be restarted based on the XRD's current generation compared to
+// when the controller was last started.
+func ControllerNeedsRestart(d *v1.CompositeResourceDefinition) bool {
+	c := d.GetCondition(v1.TypeEstablished)
+
+	// Only check if we have a WatchingComposite condition
+	if c.Reason != v1.ReasonWatchingComposite {
+		return false
+	}
+
+	// If observedGeneration is 0, the condition was never properly set
+	if c.ObservedGeneration == 0 {
+		return false
+	}
+
+	// Restart needed if the XRD has changed since the controller was started
+	return c.ObservedGeneration != d.GetGeneration()
 }

--- a/test/e2e/apiextensions_xrds_test.go
+++ b/test/e2e/apiextensions_xrds_test.go
@@ -83,3 +83,54 @@ func TestXRDValidation(t *testing.T) {
 			Feature(),
 	)
 }
+
+func TestXRDReferenceableVersionChange(t *testing.T) {
+	manifests := "test/e2e/manifests/apiextensions/xrd/referenceable-version-change"
+
+	// TODO(negz): https://github.com/crossplane/crossplane/issues/6805
+	// This test would be more robust if it could verify that the WatchingComposite
+	// condition's observedGeneration changes from 1 to 2 when the XRD is updated.
+	// Currently we can only see this in the test logs due to the observedGeneration
+	// workaround in ResourcesHaveConditionWithin.
+
+	environment.Test(t,
+		features.New("XRDReferenceableVersionChange").
+			WithLabel(LabelStage, LabelStageAlpha).
+			WithLabel(LabelArea, LabelAreaAPIExtensions).
+			WithLabel(LabelSize, LabelSizeSmall).
+			WithLabel(config.LabelTestSuite, config.TestSuiteDefault).
+			WithSetup("CreateXRDWithV1Referenceable", funcs.AllOf(
+				funcs.ApplyResources(FieldManager, manifests, "setup/*.yaml"),
+				funcs.ResourcesCreatedWithin(30*time.Second, manifests, "setup/*.yaml"),
+				funcs.ResourcesHaveConditionWithin(1*time.Minute, manifests, "setup/xrd-v1-referenceable.yaml", apiextensionsv1.WatchingComposite()),
+			)).
+			Assess("CreateV2XRBeforeChange", funcs.AllOf(
+				funcs.ApplyResources(FieldManager, manifests, "xr-before-change.yaml"),
+				funcs.ResourcesCreatedWithin(30*time.Second, manifests, "xr-before-change.yaml"),
+				// XR should select v1 composition because referenceable version is v1
+				funcs.ResourcesHaveFieldValueWithin(1*time.Minute, manifests, "xr-before-change.yaml", "spec.crossplane.compositionRef.name", "test-composition-v1"),
+			)).
+			Assess("UpdateXRDToV2Referenceable", funcs.AllOf(
+				funcs.ApplyResources(FieldManager, manifests, "xrd-v2-referenceable.yaml"),
+				funcs.ResourcesCreatedWithin(30*time.Second, manifests, "xrd-v2-referenceable.yaml"),
+				// Wait for controller to restart with new generation
+				funcs.ResourcesHaveConditionWithin(1*time.Minute, manifests, "xrd-v2-referenceable.yaml", apiextensionsv1.WatchingComposite()),
+			)).
+			Assess("CreateV2XRAfterChange", funcs.AllOf(
+				funcs.ApplyResources(FieldManager, manifests, "xr-after-change.yaml"),
+				funcs.ResourcesCreatedWithin(30*time.Second, manifests, "xr-after-change.yaml"),
+				// XR should select v2 composition because referenceable version is v2
+				funcs.ResourcesHaveFieldValueWithin(1*time.Minute, manifests, "xr-after-change.yaml", "spec.crossplane.compositionRef.name", "test-composition-v2"),
+			)).
+			WithTeardown("DeleteResources", funcs.AllOf(
+				// Delete XRs first, then XRD and compositions
+				funcs.DeleteResources(manifests, "xr-*.yaml"),
+				funcs.ResourcesDeletedWithin(30*time.Second, manifests, "xr-*.yaml"),
+				funcs.DeleteResources(manifests, "xrd-*.yaml"),
+				funcs.DeleteResources(manifests, "setup/*.yaml"),
+				funcs.ResourcesDeletedWithin(30*time.Second, manifests, "xrd-*.yaml"),
+				funcs.ResourcesDeletedWithin(30*time.Second, manifests, "setup/*.yaml"),
+			)).
+			Feature(),
+	)
+}

--- a/test/e2e/apiextensions_xrds_test.go
+++ b/test/e2e/apiextensions_xrds_test.go
@@ -94,7 +94,10 @@ func TestXRDReferenceableVersionChange(t *testing.T) {
 	// workaround in ResourcesHaveConditionWithin.
 
 	environment.Test(t,
-		features.New("XRDReferenceableVersionChange").
+		features.NewWithDescription(
+			"XRDReferenceableVersionChange",
+			"Controller restarts on XRD generation change; composition selection switches from v1 to v2.",
+		).
 			WithLabel(LabelStage, LabelStageAlpha).
 			WithLabel(LabelArea, LabelAreaAPIExtensions).
 			WithLabel(LabelSize, LabelSizeSmall).
@@ -104,7 +107,7 @@ func TestXRDReferenceableVersionChange(t *testing.T) {
 				funcs.ResourcesCreatedWithin(30*time.Second, manifests, "setup/*.yaml"),
 				funcs.ResourcesHaveConditionWithin(1*time.Minute, manifests, "setup/xrd-v1-referenceable.yaml", apiextensionsv1.WatchingComposite()),
 			)).
-			Assess("CreateV2XRBeforeChange", funcs.AllOf(
+			Assess("CreateXRBeforeChange", funcs.AllOf(
 				funcs.ApplyResources(FieldManager, manifests, "xr-before-change.yaml"),
 				funcs.ResourcesCreatedWithin(30*time.Second, manifests, "xr-before-change.yaml"),
 				// XR should select v1 composition because referenceable version is v1
@@ -116,7 +119,7 @@ func TestXRDReferenceableVersionChange(t *testing.T) {
 				// Wait for controller to restart with new generation
 				funcs.ResourcesHaveConditionWithin(1*time.Minute, manifests, "xrd-v2-referenceable.yaml", apiextensionsv1.WatchingComposite()),
 			)).
-			Assess("CreateV2XRAfterChange", funcs.AllOf(
+			Assess("CreateXRAfterChange", funcs.AllOf(
 				funcs.ApplyResources(FieldManager, manifests, "xr-after-change.yaml"),
 				funcs.ResourcesCreatedWithin(30*time.Second, manifests, "xr-after-change.yaml"),
 				// XR should select v2 composition because referenceable version is v2

--- a/test/e2e/manifests/apiextensions/xrd/referenceable-version-change/setup/composition-v1.yaml
+++ b/test/e2e/manifests/apiextensions/xrd/referenceable-version-change/setup/composition-v1.yaml
@@ -1,0 +1,27 @@
+apiVersion: apiextensions.crossplane.io/v1
+kind: Composition
+metadata:
+  name: test-composition-v1
+  labels:
+    test.example.org/version: v1
+spec:
+  compositeTypeRef:
+    apiVersion: test.example.org/v1
+    kind: TestResource
+  mode: Pipeline
+  pipeline:
+  - step: dummy
+    functionRef:
+      name: function-dummy
+    input:
+      apiVersion: dummy.fn.crossplane.io/v1beta1
+      kind: Resources
+      resources:
+      - name: dummy-resource-v1
+        base:
+          apiVersion: v1
+          kind: ConfigMap
+          metadata:
+            name: dummy-v1
+          data:
+            version: "v1"

--- a/test/e2e/manifests/apiextensions/xrd/referenceable-version-change/setup/composition-v2.yaml
+++ b/test/e2e/manifests/apiextensions/xrd/referenceable-version-change/setup/composition-v2.yaml
@@ -1,0 +1,27 @@
+apiVersion: apiextensions.crossplane.io/v1
+kind: Composition
+metadata:
+  name: test-composition-v2
+  labels:
+    test.example.org/version: v2
+spec:
+  compositeTypeRef:
+    apiVersion: test.example.org/v2
+    kind: TestResource
+  mode: Pipeline
+  pipeline:
+  - step: dummy
+    functionRef:
+      name: function-dummy
+    input:
+      apiVersion: dummy.fn.crossplane.io/v1beta1
+      kind: Resources
+      resources:
+      - name: dummy-resource-v2
+        base:
+          apiVersion: v1
+          kind: ConfigMap
+          metadata:
+            name: dummy-v2
+          data:
+            version: "v2"

--- a/test/e2e/manifests/apiextensions/xrd/referenceable-version-change/setup/xrd-v1-referenceable.yaml
+++ b/test/e2e/manifests/apiextensions/xrd/referenceable-version-change/setup/xrd-v1-referenceable.yaml
@@ -1,0 +1,39 @@
+apiVersion: apiextensions.crossplane.io/v2
+kind: CompositeResourceDefinition
+metadata:
+  name: testresources.test.example.org
+spec:
+  scope: Namespaced
+  group: test.example.org
+  names:
+    kind: TestResource
+    plural: testresources
+  versions:
+  - name: v1
+    served: true
+    referenceable: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            type: object
+            properties:
+              field:
+                type: string
+            required:
+            - field
+  - name: v2
+    served: true
+    referenceable: false
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            type: object
+            properties:
+              field:
+                type: string
+            required:
+            - field

--- a/test/e2e/manifests/apiextensions/xrd/referenceable-version-change/xr-after-change.yaml
+++ b/test/e2e/manifests/apiextensions/xrd/referenceable-version-change/xr-after-change.yaml
@@ -1,0 +1,7 @@
+apiVersion: test.example.org/v2
+kind: TestResource
+metadata:
+  name: test-xr-after-change
+  namespace: default
+spec:
+  field: "test-value"

--- a/test/e2e/manifests/apiextensions/xrd/referenceable-version-change/xr-before-change.yaml
+++ b/test/e2e/manifests/apiextensions/xrd/referenceable-version-change/xr-before-change.yaml
@@ -1,0 +1,7 @@
+apiVersion: test.example.org/v2
+kind: TestResource
+metadata:
+  name: test-xr-before-change
+  namespace: default
+spec:
+  field: "test-value"

--- a/test/e2e/manifests/apiextensions/xrd/referenceable-version-change/xrd-v2-referenceable.yaml
+++ b/test/e2e/manifests/apiextensions/xrd/referenceable-version-change/xrd-v2-referenceable.yaml
@@ -1,0 +1,39 @@
+apiVersion: apiextensions.crossplane.io/v2
+kind: CompositeResourceDefinition
+metadata:
+  name: testresources.test.example.org
+spec:
+  scope: Namespaced
+  group: test.example.org
+  names:
+    kind: TestResource
+    plural: testresources
+  versions:
+  - name: v1
+    served: true
+    referenceable: false
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            type: object
+            properties:
+              field:
+                type: string
+            required:
+            - field
+  - name: v2
+    served: true
+    referenceable: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            type: object
+            properties:
+              field:
+                type: string
+            required:
+            - field


### PR DESCRIPTION
### Description of your changes

Fixes #6328
Fixes #2024
Related to #6736

When XRD spec fields change, the XR controller doesn't always restart automatically. Users must manually restart the Crossplane deployment for some changes to take effect.

The existing restart logic only detected referenceable version changes. This missed other spec changes like connection details modifications.

This PR replaces the referenceable version based detection with generation-based controller restart detection using the existing condition system. The ControllerNeedsRestart() helper checks if the WatchingComposite condition's observedGeneration differs from the current metadata.generation. When any XRD spec change increments metadata.generation, the mismatch triggers an automatic controller restart.

The E2E test validates the functional impact by verifying that composition selection changes from test-composition-v1 to test-composition-v2 when the referenceable version changes, proving the controller restart worked correctly.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `earthly +reviewable` to ensure this PR is ready for review.
- [x] Added or updated unit tests.
- [x] Added or updated e2e tests.
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~
- [ ] ~Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md