### PR TITLE
fix: propagate namespace from XR to composed resources in render command

### DIFF
--- a/cmd/crank/render/render.go
+++ b/cmd/crank/render/render.go
@@ -400,6 +400,7 @@ func Render(ctx context.Context, log logging.Logger, in Inputs) (Outputs, error)
 	xr.SetAPIVersion(in.CompositeResource.GetAPIVersion())
 	xr.SetKind(in.CompositeResource.GetKind())
 	xr.SetName(in.CompositeResource.GetName())
+	xr.SetNamespace(in.CompositeResource.GetNamespace())
 
 	xrCond := xpv1.Available()
 	if d.GetComposite().GetReady() == fnv1.Ready_READY_FALSE {
@@ -446,6 +447,13 @@ func SetComposedResourceMetadata(cd resource.Object, xr resource.LegacyComposite
 	// allowed to explicitly specify a name if they want though.
 	if cd.GetName() == "" && cd.GetGenerateName() == "" {
 		cd.SetGenerateName(xr.GetName() + "-")
+	}
+
+	// If the XR is namespaced it can only create composed resources in its own
+	// namespace. Cluster scoped XRs can compose cluster scoped resources, or
+	// resources in any namespace.
+	if xr.GetNamespace() != "" {
+		cd.SetNamespace(xr.GetNamespace())
 	}
 
 	meta.AddAnnotations(cd, map[string]string{AnnotationKeyCompositionResourceName: name})


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane! Please read the contribution docs
(linked below) if this is your first Crossplane pull request.
-->

### Description of your changes
This PR fixes a bug where the `crossplane render` command fails to properly propagate namespaces from namespaced XRs to their composed resources, causing the rendered output to be invalid for namespaced CRDs.

**Problem:** 
- The render command's `SetComposedResourceMetadata` function was missing the namespace propagation logic present in the actual controller 
- Namespaced XRs would lose their namespace in the rendered output 
- Composed resources wouldn't inherit the XR's namespace, making them invalid for namespaced CRDs 
- This caused discrepancies between render output and actual controller behavior 

**Solution:** 
- Added namespace propagation logic in `SetComposedResourceMetadata` function (mirroring controller's `RenderComposedResourceMetadata`) 
- Ensured XR namespace is preserved in the render function output 
- Added comprehensive integration test `NamespacedXRPropagatesToComposed` to verify the fix 

<!--
Briefly describe what this pull request does, and how it is covered by tests.
Be proactive - direct your reviewers' attention to anything that needs special
consideration.

We love pull requests that fix an open issue. If yours does, use the below line
to indicate which issue it fixes, for example "Fixes #500".
-->

Fixes #6782

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [ ] Run `earthly +reviewable` to ensure this PR is ready for review.
- [x] Added or updated unit tests.
- [ ] Added or updated e2e tests.
- [ ] Linked a PR or a [docs tracking issue] to [document this change].
- [ ] Added `backport release-x.y` labels to auto-backport this PR.
- [ ] Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md