### PR TITLE
Separate go mod tidy from code generation to speed development

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,9 @@ jobs:
       - name: Generate Files
         run: earthly --strict --remote-cache ghcr.io/crossplane/earthly-cache:${{ github.job }} +generate
 
+      - name: Tidy Modules
+        run: earthly --strict --remote-cache ghcr.io/crossplane/earthly-cache:${{ github.job }} +tidy
+
       - name: Count Changed Files
         id: changed_files
         run: echo "count=$(git status --porcelain | wc -l)" >> $GITHUB_OUTPUT

--- a/Earthfile
+++ b/Earthfile
@@ -40,10 +40,15 @@ multiplatform-build:
 # the build target. It's important to run it explicitly when code needs to be
 # generated, for example when you update an API type.
 generate:
-  BUILD +go-modules-tidy
-  BUILD +go-modules-tools-tidy
   BUILD +go-generate
   BUILD +helm-generate
+
+# tidy runs go mod tidy to clean up module dependencies. This is separated from
+# generate to avoid unnecessary downloads during development when source files
+# change but dependencies don't.
+tidy:
+  BUILD +go-modules-tidy
+  BUILD +go-modules-tools-tidy
 
 # e2e runs end-to-end tests. See test/e2e/README.md for details.
 e2e:


### PR DESCRIPTION
### Description of your changes

Fixes #6813

The `+generate` target runs `go mod tidy` every time any Go source file changes, causing unnecessary downloads of transitive dependencies during development. This slows down the `earthly +reviewable` workflow when developers edit implementation code without changing dependencies.

The issue occurs because `go mod tidy` analyzes source code to determine the complete dependency graph, downloading test dependencies of dependencies that aren't needed for builds. These get cached in `go.sum` but invalidated whenever the `COPY` statement copies changed source files.

This PR moves `+go-modules-tidy` and `+go-modules-tools-tidy` from `+generate` into a new `+tidy` target. The CI `check-diff` job now runs both `+generate` and `+tidy` to maintain the same safety guarantees while allowing fast development builds.

**Before:**
```bash
# Any source file change triggers transitive dependency downloads
$ touch internal/controller/apiextensions/composite/reconciler.go
$ earthly +reviewable
# Downloads 100+ transitive test dependencies unnecessarily
```

**After:**
```bash
# Source file changes don't trigger dependency downloads
$ touch internal/controller/apiextensions/composite/reconciler.go  
$ earthly +reviewable
# Fast - no unnecessary downloads

# Explicit tidy when needed
$ earthly +tidy
# Downloads dependencies only when explicitly requested
```

The CI workflow maintains identical behavior - the `check-diff` job runs both targets and fails if any files change, ensuring dependency management stays correct.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `earthly +reviewable` to ensure this PR is ready for review.
- [ ] ~Added or updated unit tests.~
- [ ] ~Added or updated e2e tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~
- [ ] ~Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md