### PR TITLE
Fix circuit breaker tests to match consistent error handling pattern

### DIFF
--- a/internal/controller/apiextensions/composite/reconciler_test.go
+++ b/internal/controller/apiextensions/composite/reconciler_test.go
@@ -1296,7 +1296,8 @@ func TestReconcile(t *testing.T) {
 				},
 			},
 			want: want{
-				r: reconcile.Result{Requeue: true},
+				r:   reconcile.Result{},
+				err: cmpopts.AnyError,
 			},
 		},
 		"CircuitBreakerClosed": {
@@ -1326,7 +1327,8 @@ func TestReconcile(t *testing.T) {
 				},
 			},
 			want: want{
-				r: reconcile.Result{Requeue: true},
+				r:   reconcile.Result{},
+				err: cmpopts.AnyError,
 			},
 		},
 	}


### PR DESCRIPTION
### Description of your changes

The circuit breaker tests were expecting the old error handling behavior where reconcilers returned `{Requeue: true}` with no error on failures. This caused test failures after the error handling pattern was updated to return errors to controller-runtime instead of swallowing them.

The circuit breaker tests were added in PR #6777 after the error handling pattern was established, but weren't updated when PR #6765 changed all other reconciler tests to expect the new pattern. The `CircuitBreakerOpen` and `CircuitBreakerClosed` test cases were still expecting `reconcile.Result{Requeue: true}` with no error, while the reconciler now returns `reconcile.Result{}` with the actual error.

This PR updates both test cases to expect `reconcile.Result{}` with `cmpopts.AnyError`, matching the behavior implemented by the reconciler and used consistently across all other error test cases in the composite controller.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `earthly +reviewable` to ensure this PR is ready for review.
- [ ] ~Added or updated unit tests.~
- [ ] ~Added or updated e2e tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~
- [ ] ~Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md