### PR TITLE
Move cached function response protos to internal/proto

### DIFF
--- a/internal/proto/fn/v1alpha1/cached_response.pb.go
+++ b/internal/proto/fn/v1alpha1/cached_response.pb.go
@@ -17,7 +17,7 @@
 // versions:
 // 	protoc-gen-go v1.36.9
 // 	protoc        (unknown)
-// source: internal/xfn/cached/proto/v1alpha1/cached_response.proto
+// source: internal/proto/fn/v1alpha1/cached_response.proto
 
 package v1alpha1
 
@@ -52,7 +52,7 @@ type CachedRunFunctionResponse struct {
 
 func (x *CachedRunFunctionResponse) Reset() {
 	*x = CachedRunFunctionResponse{}
-	mi := &file_internal_xfn_cached_proto_v1alpha1_cached_response_proto_msgTypes[0]
+	mi := &file_internal_proto_fn_v1alpha1_cached_response_proto_msgTypes[0]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -64,7 +64,7 @@ func (x *CachedRunFunctionResponse) String() string {
 func (*CachedRunFunctionResponse) ProtoMessage() {}
 
 func (x *CachedRunFunctionResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_xfn_cached_proto_v1alpha1_cached_response_proto_msgTypes[0]
+	mi := &file_internal_proto_fn_v1alpha1_cached_response_proto_msgTypes[0]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -77,7 +77,7 @@ func (x *CachedRunFunctionResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CachedRunFunctionResponse.ProtoReflect.Descriptor instead.
 func (*CachedRunFunctionResponse) Descriptor() ([]byte, []int) {
-	return file_internal_xfn_cached_proto_v1alpha1_cached_response_proto_rawDescGZIP(), []int{0}
+	return file_internal_proto_fn_v1alpha1_cached_response_proto_rawDescGZIP(), []int{0}
 }
 
 func (x *CachedRunFunctionResponse) GetDeadline() *timestamppb.Timestamp {
@@ -94,36 +94,36 @@ func (x *CachedRunFunctionResponse) GetResponse() *v1.RunFunctionResponse {
 	return nil
 }
 
-var File_internal_xfn_cached_proto_v1alpha1_cached_response_proto protoreflect.FileDescriptor
+var File_internal_proto_fn_v1alpha1_cached_response_proto protoreflect.FileDescriptor
 
-const file_internal_xfn_cached_proto_v1alpha1_cached_response_proto_rawDesc = "" +
+const file_internal_proto_fn_v1alpha1_cached_response_proto_rawDesc = "" +
 	"\n" +
-	"8internal/xfn/cached/proto/v1alpha1/cached_response.proto\x12\"internal.xfn.cached.proto.v1alpha1\x1a\x1fgoogle/protobuf/timestamp.proto\x1a\x1eproto/fn/v1/run_function.proto\"\x9f\x01\n" +
+	"0internal/proto/fn/v1alpha1/cached_response.proto\x12\x1ainternal.proto.fn.v1alpha1\x1a\x1fgoogle/protobuf/timestamp.proto\x1a\x1eproto/fn/v1/run_function.proto\"\x9f\x01\n" +
 	"\x19CachedRunFunctionResponse\x126\n" +
 	"\bdeadline\x18\x01 \x01(\v2\x1a.google.protobuf.TimestampR\bdeadline\x12J\n" +
-	"\bresponse\x18\x02 \x01(\v2..apiextensions.fn.proto.v1.RunFunctionResponseR\bresponseBHZFgithub.com/crossplane/crossplane/v2/internal/xfn/cached/proto/v1alpha1b\x06proto3"
+	"\bresponse\x18\x02 \x01(\v2..apiextensions.fn.proto.v1.RunFunctionResponseR\bresponseB@Z>github.com/crossplane/crossplane/v2/internal/proto/fn/v1alpha1b\x06proto3"
 
 var (
-	file_internal_xfn_cached_proto_v1alpha1_cached_response_proto_rawDescOnce sync.Once
-	file_internal_xfn_cached_proto_v1alpha1_cached_response_proto_rawDescData []byte
+	file_internal_proto_fn_v1alpha1_cached_response_proto_rawDescOnce sync.Once
+	file_internal_proto_fn_v1alpha1_cached_response_proto_rawDescData []byte
 )
 
-func file_internal_xfn_cached_proto_v1alpha1_cached_response_proto_rawDescGZIP() []byte {
-	file_internal_xfn_cached_proto_v1alpha1_cached_response_proto_rawDescOnce.Do(func() {
-		file_internal_xfn_cached_proto_v1alpha1_cached_response_proto_rawDescData = protoimpl.X.CompressGZIP(unsafe.Slice(unsafe.StringData(file_internal_xfn_cached_proto_v1alpha1_cached_response_proto_rawDesc), len(file_internal_xfn_cached_proto_v1alpha1_cached_response_proto_rawDesc)))
+func file_internal_proto_fn_v1alpha1_cached_response_proto_rawDescGZIP() []byte {
+	file_internal_proto_fn_v1alpha1_cached_response_proto_rawDescOnce.Do(func() {
+		file_internal_proto_fn_v1alpha1_cached_response_proto_rawDescData = protoimpl.X.CompressGZIP(unsafe.Slice(unsafe.StringData(file_internal_proto_fn_v1alpha1_cached_response_proto_rawDesc), len(file_internal_proto_fn_v1alpha1_cached_response_proto_rawDesc)))
 	})
-	return file_internal_xfn_cached_proto_v1alpha1_cached_response_proto_rawDescData
+	return file_internal_proto_fn_v1alpha1_cached_response_proto_rawDescData
 }
 
-var file_internal_xfn_cached_proto_v1alpha1_cached_response_proto_msgTypes = make([]protoimpl.MessageInfo, 1)
-var file_internal_xfn_cached_proto_v1alpha1_cached_response_proto_goTypes = []any{
-	(*CachedRunFunctionResponse)(nil), // 0: internal.xfn.cached.proto.v1alpha1.CachedRunFunctionResponse
+var file_internal_proto_fn_v1alpha1_cached_response_proto_msgTypes = make([]protoimpl.MessageInfo, 1)
+var file_internal_proto_fn_v1alpha1_cached_response_proto_goTypes = []any{
+	(*CachedRunFunctionResponse)(nil), // 0: internal.proto.fn.v1alpha1.CachedRunFunctionResponse
 	(*timestamppb.Timestamp)(nil),     // 1: google.protobuf.Timestamp
 	(*v1.RunFunctionResponse)(nil),    // 2: apiextensions.fn.proto.v1.RunFunctionResponse
 }
-var file_internal_xfn_cached_proto_v1alpha1_cached_response_proto_depIdxs = []int32{
-	1, // 0: internal.xfn.cached.proto.v1alpha1.CachedRunFunctionResponse.deadline:type_name -> google.protobuf.Timestamp
-	2, // 1: internal.xfn.cached.proto.v1alpha1.CachedRunFunctionResponse.response:type_name -> apiextensions.fn.proto.v1.RunFunctionResponse
+var file_internal_proto_fn_v1alpha1_cached_response_proto_depIdxs = []int32{
+	1, // 0: internal.proto.fn.v1alpha1.CachedRunFunctionResponse.deadline:type_name -> google.protobuf.Timestamp
+	2, // 1: internal.proto.fn.v1alpha1.CachedRunFunctionResponse.response:type_name -> apiextensions.fn.proto.v1.RunFunctionResponse
 	2, // [2:2] is the sub-list for method output_type
 	2, // [2:2] is the sub-list for method input_type
 	2, // [2:2] is the sub-list for extension type_name
@@ -131,26 +131,26 @@ var file_internal_xfn_cached_proto_v1alpha1_cached_response_proto_depIdxs = []in
 	0, // [0:2] is the sub-list for field type_name
 }
 
-func init() { file_internal_xfn_cached_proto_v1alpha1_cached_response_proto_init() }
-func file_internal_xfn_cached_proto_v1alpha1_cached_response_proto_init() {
-	if File_internal_xfn_cached_proto_v1alpha1_cached_response_proto != nil {
+func init() { file_internal_proto_fn_v1alpha1_cached_response_proto_init() }
+func file_internal_proto_fn_v1alpha1_cached_response_proto_init() {
+	if File_internal_proto_fn_v1alpha1_cached_response_proto != nil {
 		return
 	}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
-			RawDescriptor: unsafe.Slice(unsafe.StringData(file_internal_xfn_cached_proto_v1alpha1_cached_response_proto_rawDesc), len(file_internal_xfn_cached_proto_v1alpha1_cached_response_proto_rawDesc)),
+			RawDescriptor: unsafe.Slice(unsafe.StringData(file_internal_proto_fn_v1alpha1_cached_response_proto_rawDesc), len(file_internal_proto_fn_v1alpha1_cached_response_proto_rawDesc)),
 			NumEnums:      0,
 			NumMessages:   1,
 			NumExtensions: 0,
 			NumServices:   0,
 		},
-		GoTypes:           file_internal_xfn_cached_proto_v1alpha1_cached_response_proto_goTypes,
-		DependencyIndexes: file_internal_xfn_cached_proto_v1alpha1_cached_response_proto_depIdxs,
-		MessageInfos:      file_internal_xfn_cached_proto_v1alpha1_cached_response_proto_msgTypes,
+		GoTypes:           file_internal_proto_fn_v1alpha1_cached_response_proto_goTypes,
+		DependencyIndexes: file_internal_proto_fn_v1alpha1_cached_response_proto_depIdxs,
+		MessageInfos:      file_internal_proto_fn_v1alpha1_cached_response_proto_msgTypes,
 	}.Build()
-	File_internal_xfn_cached_proto_v1alpha1_cached_response_proto = out.File
-	file_internal_xfn_cached_proto_v1alpha1_cached_response_proto_goTypes = nil
-	file_internal_xfn_cached_proto_v1alpha1_cached_response_proto_depIdxs = nil
+	File_internal_proto_fn_v1alpha1_cached_response_proto = out.File
+	file_internal_proto_fn_v1alpha1_cached_response_proto_goTypes = nil
+	file_internal_proto_fn_v1alpha1_cached_response_proto_depIdxs = nil
 }

--- a/internal/proto/fn/v1alpha1/cached_response.proto
+++ b/internal/proto/fn/v1alpha1/cached_response.proto
@@ -16,12 +16,12 @@
 
 syntax = "proto3";
 
-package internal.xfn.cached.proto.v1alpha1;
+package internal.proto.fn.v1alpha1;
 
 import "google/protobuf/timestamp.proto";
 import "proto/fn/v1/run_function.proto";
 
-option go_package = "github.com/crossplane/crossplane/v2/internal/xfn/cached/proto/v1alpha1";
+option go_package = "github.com/crossplane/crossplane/v2/internal/proto/fn/v1alpha1";
 
 // A CachedRunFunctionResponse is Crossplane's on-disk cache format for a
 // RunFunctionResponse.

--- a/internal/xfn/cached/cached_runner.go
+++ b/internal/xfn/cached/cached_runner.go
@@ -29,7 +29,7 @@ import (
 	"github.com/crossplane/crossplane-runtime/v2/pkg/errors"
 	"github.com/crossplane/crossplane-runtime/v2/pkg/logging"
 
-	"github.com/crossplane/crossplane/v2/internal/xfn/cached/proto/v1alpha1"
+	"github.com/crossplane/crossplane/v2/internal/proto/fn/v1alpha1"
 	fnv1 "github.com/crossplane/crossplane/v2/proto/fn/v1"
 )
 

--- a/internal/xfn/cached/cached_runner_test.go
+++ b/internal/xfn/cached/cached_runner_test.go
@@ -32,7 +32,7 @@ import (
 
 	"github.com/crossplane/crossplane-runtime/v2/pkg/logging"
 
-	"github.com/crossplane/crossplane/v2/internal/xfn/cached/proto/v1alpha1"
+	"github.com/crossplane/crossplane/v2/internal/proto/fn/v1alpha1"
 	fnv1 "github.com/crossplane/crossplane/v2/proto/fn/v1"
 )
 


### PR DESCRIPTION
### Description of your changes

The cached function response protobuf definitions were located under `internal/xfn/cached/proto/v1alpha1/`, mixed with the cached runner implementation. This made the proto organization inconsistent, as all other protobuf definitions live under the top-level `proto/` directory.

The cached response proto is used only for internal disk serialization of function responses, not for gRPC communication. Having it buried under the cached runner implementation made it less discoverable and didn't follow the established pattern of separating proto definitions from their consumers.

This PR moves the cached response proto from `internal/xfn/cached/proto/v1alpha1/` to `internal/proto/fn/v1alpha1/`. The package name changes from `internal.xfn.cached.proto.v1alpha1` to `internal.proto.fn.v1alpha1`, and the go_package option updates to match the new location. Import statements in the cached runner are updated accordingly.

**Breaking Change:** This change will invalidate existing cached function responses on disk due to the package name change in the protobuf wire format. The cached runner handles deserialization failures gracefully by treating them as cache misses and rebuilding the cache, so there's no functional impact beyond initial cache misses after upgrade.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `earthly +reviewable` to ensure this PR is ready for review.
- [ ] ~Added or updated unit tests.~
- [ ] ~Added or updated e2e tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~
- [ ] ~Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md