### PR TITLE
fix: add missing permissions on protection and ops groups

### DIFF
--- a/cluster/charts/crossplane/templates/rbac-manager-managed-clusterroles.yaml
+++ b/cluster/charts/crossplane/templates/rbac-manager-managed-clusterroles.yaml
@@ -111,6 +111,14 @@ rules:
 - apiGroups: [apiextensions.k8s.io]
   resources: [customresourcedefinitions]
   verbs: [get, list, watch]
+- apiGroups:
+    - protection.crossplane.io
+  resources: ["*"]
+  verbs: ["*"]
+- apiGroups:
+    - ops.crossplane.io
+  resources: ["*"]
+  verbs: ["*"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -147,6 +155,14 @@ rules:
   - secrets.crossplane.io
   resources: ["*"]
   verbs: ["*"]
+- apiGroups:
+    - protection.crossplane.io
+  resources: ["*"]
+  verbs: ["*"]
+- apiGroups:
+    - ops.crossplane.io
+  resources: ["*"]
+  verbs: ["*"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -176,6 +192,14 @@ rules:
   verbs: [get, list, watch]
 - apiGroups:
   - secrets.crossplane.io
+  resources: ["*"]
+  verbs: [get, list, watch]
+- apiGroups:
+    - protection.crossplane.io
+  resources: ["*"]
+  verbs: [get, list, watch]
+- apiGroups:
+    - ops.crossplane.io
   resources: ["*"]
   verbs: [get, list, watch]
 ---


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane! Please read the contribution docs
(linked below) if this is your first Crossplane pull request.
-->

### Description of your changes

<!--
Briefly describe what this pull request does, and how it is covered by tests.
Be proactive - direct your reviewers' attention to anything that needs special
consideration.

We love pull requests that fix an open issue. If yours does, use the below line
to indicate which issue it fixes, for example "Fixes #500".
-->

I noticed that relying on the admin/edit/view/browse `ClusterRoles` meant not being able to access newly added resources from the ops and protection groups.

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `earthly +reviewable` to ensure this PR is ready for review.
- [x] Added or updated unit tests.
- [x] Added or updated e2e tests.
- [x] Linked a PR or a [docs tracking issue] to [document this change].
- [x] Added `backport release-x.y` labels to auto-backport this PR.
- [x] Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md