### PR TITLE
ClusterRoles management for Functions

### DIFF
--- a/cluster/charts/crossplane/templates/rbac-manager-clusterrole.yaml
+++ b/cluster/charts/crossplane/templates/rbac-manager-clusterrole.yaml
@@ -85,6 +85,26 @@ rules:
   verbs:
   - update
 - apiGroups:
+  - pkg.crossplane.io
+  resources:
+  - functionrevisions
+  verbs:
+  - get
+  - list
+  - watch
+# The RBAC manager creates a series of RBAC cluster roles for each FunctionRevision
+# it sees. These cluster roles are controlled (in the owner reference sense) by the
+# FunctionRevision. The RBAC manager needs permission to set finalizers on
+# FunctionRevisions in order to create resources that block their deletion when the
+# OwnerReferencesPermissionEnforcement admission controller is enabled.
+# See https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#ownerreferencespermissionenforcement
+- apiGroups:
+  - pkg.crossplane.io
+  resources:
+  - functionrevisions/finalizers
+  verbs:
+  - update
+- apiGroups:
   - apiextensions.k8s.io
   resources:
   - customresourcedefinitions

--- a/internal/controller/rbac/function/roles/fuzz_test.go
+++ b/internal/controller/rbac/function/roles/fuzz_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2023 The Crossplane Authors.
+Copyright 2025 The Crossplane Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -28,8 +28,8 @@ import (
 func FuzzRenderClusterRoles(f *testing.F) {
 	f.Fuzz(func(_ *testing.T, data []byte) {
 		ff := fuzz.NewConsumer(data)
-		pr := &v1.ProviderRevision{}
-		ff.GenerateStruct(pr)
+		fr := &v1.FunctionRevision{}
+		ff.GenerateStruct(fr)
 
 		rs := make([]roles.Resource, 0)
 		ff.CreateSlice(&rs)
@@ -38,6 +38,6 @@ func FuzzRenderClusterRoles(f *testing.F) {
 			return
 		}
 
-		_ = RenderClusterRoles(pr, rs)
+		_ = RenderClusterRoles(fr, rs)
 	})
 }

--- a/internal/controller/rbac/function/roles/reconciler.go
+++ b/internal/controller/rbac/function/roles/reconciler.go
@@ -44,13 +44,14 @@ import (
 const (
 	timeout = 2 * time.Minute
 
-	errGetFR     = "cannot get FunctionRevision"
-	errApplyRole = "cannot apply ClusterRole"
+	errGetFR         = "cannot get FunctionRevision"
+	errFmtApplyRole = "cannot apply ClusterRole %q"
 )
 
 // Event reasons.
 const (
-	reasonApplyRoles event.Reason = "ApplyClusterRoles"
+	reasonApplyRoles       event.Reason = "ApplyClusterRoles"
+	reasonApplyRolesFailed event.Reason = "ApplyClusterRolesFailed"
 )
 
 // A ClusterRoleRenderer renders ClusterRoles for the given resources.
@@ -214,8 +215,8 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 				return reconcile.Result{Requeue: true}, nil
 			}
 
-			err = errors.Wrap(err, errApplyRole)
-			r.record.Event(fr, event.Warning(reasonApplyRoles, err))
+			err = errors.Wrapf(err, errFmtApplyRole, cr.GetName())
+			r.record.Event(fr, event.Warning(reasonApplyRolesFailed, err))
 
 			return reconcile.Result{}, err
 		}

--- a/internal/controller/rbac/function/roles/reconciler.go
+++ b/internal/controller/rbac/function/roles/reconciler.go
@@ -1,0 +1,288 @@
+/*
+Copyright 2020 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package roles implements the RBAC manager's support for functions.
+package roles
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	xpv1 "github.com/crossplane/crossplane-runtime/v2/apis/common/v1"
+	"github.com/crossplane/crossplane-runtime/v2/pkg/errors"
+	"github.com/crossplane/crossplane-runtime/v2/pkg/event"
+	"github.com/crossplane/crossplane-runtime/v2/pkg/logging"
+	"github.com/crossplane/crossplane-runtime/v2/pkg/meta"
+	"github.com/crossplane/crossplane-runtime/v2/pkg/ratelimiter"
+	"github.com/crossplane/crossplane-runtime/v2/pkg/resource"
+
+	"github.com/crossplane/crossplane/v2/apis/apiextensions/v1alpha1"
+	v1 "github.com/crossplane/crossplane/v2/apis/pkg/v1"
+	"github.com/crossplane/crossplane/v2/internal/controller/rbac/controller"
+)
+
+const (
+	timeout = 2 * time.Minute
+
+	errGetFR     = "cannot get FunctionRevision"
+	errApplyRole = "cannot apply ClusterRole"
+)
+
+// Event reasons.
+const (
+	reasonApplyRoles event.Reason = "ApplyClusterRoles"
+)
+
+// A ClusterRoleRenderer renders ClusterRoles for the given resources.
+type ClusterRoleRenderer interface {
+	// RenderClusterRoles for the supplied resources.
+	RenderClusterRoles(fr *v1.FunctionRevision, rs []Resource) []rbacv1.ClusterRole
+}
+
+// A ClusterRoleRenderFn renders ClusterRoles for the supplied resources.
+type ClusterRoleRenderFn func(fr *v1.FunctionRevision, rs []Resource) []rbacv1.ClusterRole
+
+// RenderClusterRoles renders ClusterRoles for the supplied CRDs.
+func (fn ClusterRoleRenderFn) RenderClusterRoles(fr *v1.FunctionRevision, rs []Resource) []rbacv1.ClusterRole {
+	return fn(fr, rs)
+}
+
+// Setup adds a controller that reconciles a FunctionRevision by creating a
+// series of opinionated ClusterRoles that may be bound to allow access to the
+// resources it defines.
+func Setup(mgr ctrl.Manager, o controller.Options) error {
+	name := "rbac-roles/" + strings.ToLower(v1.FunctionRevisionGroupKind)
+
+	r := NewReconciler(mgr,
+		WithLogger(o.Logger.WithValues("controller", name)),
+		WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name))))
+
+	return ctrl.NewControllerManagedBy(mgr).
+		Named(name).
+		For(&v1.FunctionRevision{}).
+		Owns(&rbacv1.ClusterRole{}).
+		WithOptions(o.ForControllerRuntime()).
+		Complete(ratelimiter.NewReconciler(name, errors.WithSilentRequeueOnConflict(r), o.GlobalRateLimiter))
+}
+
+// ReconcilerOption is used to configure the Reconciler.
+type ReconcilerOption func(*Reconciler)
+
+// WithLogger specifies how the Reconciler should log messages.
+func WithLogger(log logging.Logger) ReconcilerOption {
+	return func(r *Reconciler) {
+		r.log = log
+	}
+}
+
+// WithRecorder specifies how the Reconciler should record Kubernetes events.
+func WithRecorder(er event.Recorder) ReconcilerOption {
+	return func(r *Reconciler) {
+		r.record = er
+	}
+}
+
+// WithClientApplicator specifies how the Reconciler should interact with the
+// Kubernetes API.
+func WithClientApplicator(ca resource.ClientApplicator) ReconcilerOption {
+	return func(r *Reconciler) {
+		r.client = ca
+	}
+}
+
+// WithClusterRoleRenderer specifies how the Reconciler should render RBAC
+// ClusterRoles.
+func WithClusterRoleRenderer(rr ClusterRoleRenderer) ReconcilerOption {
+	return func(r *Reconciler) {
+		r.rbac.ClusterRoleRenderer = rr
+	}
+}
+
+// NewReconciler returns a Reconciler of FunctionRevisions.
+func NewReconciler(mgr manager.Manager, opts ...ReconcilerOption) *Reconciler {
+	r := &Reconciler{
+		// TODO(negz): Is Updating appropriate here? Probably.
+		client: resource.ClientApplicator{
+			Client:     mgr.GetClient(),
+			Applicator: resource.NewAPIUpdatingApplicator(mgr.GetClient()),
+		},
+
+		rbac: rbac{
+			ClusterRoleRenderer: ClusterRoleRenderFn(RenderClusterRoles),
+		},
+
+		log:    logging.NewNopLogger(),
+		record: event.NewNopRecorder(),
+	}
+
+	for _, f := range opts {
+		f(r)
+	}
+
+	return r
+}
+
+type rbac struct {
+	ClusterRoleRenderer
+}
+
+// A Reconciler reconciles FunctionRevisions.
+type Reconciler struct {
+	client resource.ClientApplicator
+	rbac   rbac
+
+	log    logging.Logger
+	record event.Recorder
+}
+
+// Reconcile a FunctionRevision by creating a series of opinionated ClusterRoles
+// that may be bound to allow access to the resources it defines.
+func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
+	log := r.log.WithValues("request", req)
+	log.Debug("Reconciling")
+
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	fr := &v1.FunctionRevision{}
+	if err := r.client.Get(ctx, req.NamespacedName, fr); err != nil {
+		// In case object is not found, most likely the object was deleted and
+		// then disappeared while the event was in the processing queue. We
+		// don't need to take any action in that case.
+		log.Debug(errGetFR, "error", err)
+		return reconcile.Result{}, errors.Wrap(resource.IgnoreNotFound(err), errGetFR)
+	}
+
+	log = log.WithValues(
+		"uid", fr.GetUID(),
+		"version", fr.GetResourceVersion(),
+		"name", fr.GetName(),
+	)
+
+	// Check the pause annotation and return if it has the value "true"
+	// after logging, publishing an event and updating the SYNC status condition
+	if meta.IsPaused(fr) {
+		return reconcile.Result{}, nil
+	}
+
+	if meta.WasDeleted(fr) {
+		// There's nothing to do if our FR is being deleted. Any ClusterRoles
+		// we created will be garbage collected by Kubernetes.
+		return reconcile.Result{Requeue: false}, nil
+	}
+
+	resources := DefinedResources(fr.Status.ObjectRefs)
+
+	applied := make([]string, 0)
+
+	for _, cr := range r.rbac.RenderClusterRoles(fr, resources) {
+		log := log.WithValues("role-name", cr.GetName())
+		origRV := ""
+
+		err := r.client.Apply(ctx, &cr,
+			resource.MustBeControllableBy(fr.GetUID()),
+			resource.AllowUpdateIf(ClusterRolesDiffer),
+			resource.StoreCurrentRV(&origRV),
+		)
+		if resource.IsNotAllowed(err) {
+			log.Debug("Skipped no-op RBAC ClusterRole apply")
+			continue
+		}
+
+		if err != nil {
+			if kerrors.IsConflict(err) {
+				return reconcile.Result{Requeue: true}, nil
+			}
+
+			err = errors.Wrap(err, errApplyRole)
+			r.record.Event(fr, event.Warning(reasonApplyRoles, err))
+
+			return reconcile.Result{}, err
+		}
+
+		if cr.GetResourceVersion() != origRV {
+			log.Debug("Applied RBAC ClusterRole")
+
+			applied = append(applied, cr.GetName())
+		}
+	}
+
+	if len(applied) > 0 {
+		r.record.Event(fr, event.Normal(reasonApplyRoles, fmt.Sprintf("Applied RBAC ClusterRoles: %s", resource.StableNAndSomeMore(resource.DefaultFirstN, applied))))
+	}
+
+	// TODO(negz): Add a condition that indicates the RBAC manager is
+	// managing cluster roles for this FunctionRevision?
+
+	// There's no need to requeue explicitly - we're watching all FRs.
+	return reconcile.Result{Requeue: false}, nil
+}
+
+// DefinedResources returns the resources defined by the supplied references.
+func DefinedResources(refs []xpv1.TypedReference) []Resource {
+	out := make([]Resource, 0, len(refs))
+	for _, ref := range refs {
+		// This would only return an error if the APIVersion contained more than
+		// one "/". This should be impossible, but if it somehow happens we'll
+		// just skip this resource since it can't be a CRD.
+		gv, _ := schema.ParseGroupVersion(ref.APIVersion)
+
+		// We're only concerned with CRDs or MRDs.
+		switch {
+		case gv.Group == apiextensions.GroupName && ref.Kind == "CustomResourceDefinition":
+		// Do the work!
+		case gv.Group == v1alpha1.Group && ref.Kind == v1alpha1.ManagedResourceDefinitionKind:
+		// Do the work!
+		default:
+			// Filter out the non CRD or MRD.
+			continue
+		}
+
+		p, g, valid := strings.Cut(ref.Name, ".")
+		if !valid {
+			// This shouldn't be possible - CRDs must be named <plural>.<group>.
+			continue
+		}
+
+		out = append(out, Resource{Group: g, Plural: p})
+	}
+
+	return out
+}
+
+// ClusterRolesDiffer returns true if the supplied objects are different
+// ClusterRoles. We consider ClusterRoles to be different if their labels and
+// rules do not match.
+func ClusterRolesDiffer(current, desired runtime.Object) bool {
+	// Calling this with anything but ClusterRoles is a programming error. If it
+	// happens, we probably do want to panic.
+	c := current.(*rbacv1.ClusterRole) //nolint:forcetypeassert // See above.
+	d := desired.(*rbacv1.ClusterRole) //nolint:forcetypeassert // See above.
+
+	return !cmp.Equal(c.GetLabels(), d.GetLabels()) || !cmp.Equal(c.Rules, d.Rules)
+}

--- a/internal/controller/rbac/function/roles/reconciler.go
+++ b/internal/controller/rbac/function/roles/reconciler.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 The Crossplane Authors.
+Copyright 2025 The Crossplane Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -23,17 +23,12 @@ import (
 	"strings"
 	"time"
 
-	"github.com/google/go-cmp/cmp"
 	rbacv1 "k8s.io/api/rbac/v1"
-	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	xpv1 "github.com/crossplane/crossplane-runtime/v2/apis/common/v1"
 	"github.com/crossplane/crossplane-runtime/v2/pkg/errors"
 	"github.com/crossplane/crossplane-runtime/v2/pkg/event"
 	"github.com/crossplane/crossplane-runtime/v2/pkg/logging"
@@ -41,9 +36,9 @@ import (
 	"github.com/crossplane/crossplane-runtime/v2/pkg/ratelimiter"
 	"github.com/crossplane/crossplane-runtime/v2/pkg/resource"
 
-	"github.com/crossplane/crossplane/v2/apis/apiextensions/v1alpha1"
 	v1 "github.com/crossplane/crossplane/v2/apis/pkg/v1"
 	"github.com/crossplane/crossplane/v2/internal/controller/rbac/controller"
+	"github.com/crossplane/crossplane/v2/internal/controller/rbac/roles"
 )
 
 const (
@@ -61,14 +56,14 @@ const (
 // A ClusterRoleRenderer renders ClusterRoles for the given resources.
 type ClusterRoleRenderer interface {
 	// RenderClusterRoles for the supplied resources.
-	RenderClusterRoles(fr *v1.FunctionRevision, rs []Resource) []rbacv1.ClusterRole
+	RenderClusterRoles(fr *v1.FunctionRevision, rs []roles.Resource) []rbacv1.ClusterRole
 }
 
 // A ClusterRoleRenderFn renders ClusterRoles for the supplied resources.
-type ClusterRoleRenderFn func(fr *v1.FunctionRevision, rs []Resource) []rbacv1.ClusterRole
+type ClusterRoleRenderFn func(fr *v1.FunctionRevision, rs []roles.Resource) []rbacv1.ClusterRole
 
 // RenderClusterRoles renders ClusterRoles for the supplied CRDs.
-func (fn ClusterRoleRenderFn) RenderClusterRoles(fr *v1.FunctionRevision, rs []Resource) []rbacv1.ClusterRole {
+func (fn ClusterRoleRenderFn) RenderClusterRoles(fr *v1.FunctionRevision, rs []roles.Resource) []rbacv1.ClusterRole {
 	return fn(fr, rs)
 }
 
@@ -196,7 +191,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 		return reconcile.Result{Requeue: false}, nil
 	}
 
-	resources := DefinedResources(fr.Status.ObjectRefs)
+	resources := roles.DefinedResources(fr.Status.ObjectRefs)
 
 	applied := make([]string, 0)
 
@@ -206,7 +201,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 
 		err := r.client.Apply(ctx, &cr,
 			resource.MustBeControllableBy(fr.GetUID()),
-			resource.AllowUpdateIf(ClusterRolesDiffer),
+			resource.AllowUpdateIf(roles.ClusterRolesDiffer),
 			resource.StoreCurrentRV(&origRV),
 		)
 		if resource.IsNotAllowed(err) {
@@ -241,48 +236,4 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 
 	// There's no need to requeue explicitly - we're watching all FRs.
 	return reconcile.Result{Requeue: false}, nil
-}
-
-// DefinedResources returns the resources defined by the supplied references.
-func DefinedResources(refs []xpv1.TypedReference) []Resource {
-	out := make([]Resource, 0, len(refs))
-	for _, ref := range refs {
-		// This would only return an error if the APIVersion contained more than
-		// one "/". This should be impossible, but if it somehow happens we'll
-		// just skip this resource since it can't be a CRD.
-		gv, _ := schema.ParseGroupVersion(ref.APIVersion)
-
-		// We're only concerned with CRDs or MRDs.
-		switch {
-		case gv.Group == apiextensions.GroupName && ref.Kind == "CustomResourceDefinition":
-		// Do the work!
-		case gv.Group == v1alpha1.Group && ref.Kind == v1alpha1.ManagedResourceDefinitionKind:
-		// Do the work!
-		default:
-			// Filter out the non CRD or MRD.
-			continue
-		}
-
-		p, g, valid := strings.Cut(ref.Name, ".")
-		if !valid {
-			// This shouldn't be possible - CRDs must be named <plural>.<group>.
-			continue
-		}
-
-		out = append(out, Resource{Group: g, Plural: p})
-	}
-
-	return out
-}
-
-// ClusterRolesDiffer returns true if the supplied objects are different
-// ClusterRoles. We consider ClusterRoles to be different if their labels and
-// rules do not match.
-func ClusterRolesDiffer(current, desired runtime.Object) bool {
-	// Calling this with anything but ClusterRoles is a programming error. If it
-	// happens, we probably do want to panic.
-	c := current.(*rbacv1.ClusterRole) //nolint:forcetypeassert // See above.
-	d := desired.(*rbacv1.ClusterRole) //nolint:forcetypeassert // See above.
-
-	return !cmp.Equal(c.GetLabels(), d.GetLabels()) || !cmp.Equal(c.Rules, d.Rules)
 }

--- a/internal/controller/rbac/function/roles/reconciler.go
+++ b/internal/controller/rbac/function/roles/reconciler.go
@@ -44,7 +44,7 @@ import (
 const (
 	timeout = 2 * time.Minute
 
-	errGetFR         = "cannot get FunctionRevision"
+	errGetFR        = "cannot get FunctionRevision"
 	errFmtApplyRole = "cannot apply ClusterRole %q"
 )
 

--- a/internal/controller/rbac/function/roles/reconciler_test.go
+++ b/internal/controller/rbac/function/roles/reconciler_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 The Crossplane Authors.
+Copyright 2025 The Crossplane Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -39,6 +39,7 @@ import (
 	"github.com/crossplane/crossplane-runtime/v2/pkg/test"
 
 	v1 "github.com/crossplane/crossplane/v2/apis/pkg/v1"
+	"github.com/crossplane/crossplane/v2/internal/controller/rbac/roles"
 )
 
 func TestReconcile(t *testing.T) {
@@ -149,7 +150,7 @@ func TestReconcile(t *testing.T) {
 							return errBoom
 						}),
 					}),
-					WithClusterRoleRenderer(ClusterRoleRenderFn(func(*v1.FunctionRevision, []Resource) []rbacv1.ClusterRole {
+					WithClusterRoleRenderer(ClusterRoleRenderFn(func(*v1.FunctionRevision, []roles.Resource) []rbacv1.ClusterRole {
 						return []rbacv1.ClusterRole{{}}
 					})),
 				},
@@ -173,7 +174,7 @@ func TestReconcile(t *testing.T) {
 							return resource.AllowUpdateIf(func(_, _ runtime.Object) bool { return false })(ctx, o, o)
 						}),
 					}),
-					WithClusterRoleRenderer(ClusterRoleRenderFn(func(*v1.FunctionRevision, []Resource) []rbacv1.ClusterRole {
+					WithClusterRoleRenderer(ClusterRoleRenderFn(func(*v1.FunctionRevision, []roles.Resource) []rbacv1.ClusterRole {
 						return []rbacv1.ClusterRole{{}}
 					})),
 				},
@@ -198,7 +199,7 @@ func TestReconcile(t *testing.T) {
 							return nil
 						}),
 					}),
-					WithClusterRoleRenderer(ClusterRoleRenderFn(func(*v1.FunctionRevision, []Resource) []rbacv1.ClusterRole {
+					WithClusterRoleRenderer(ClusterRoleRenderFn(func(*v1.FunctionRevision, []roles.Resource) []rbacv1.ClusterRole {
 						return []rbacv1.ClusterRole{{
 							ObjectMeta: metav1.ObjectMeta{
 								Name: "test-role",

--- a/internal/controller/rbac/function/roles/reconciler_test.go
+++ b/internal/controller/rbac/function/roles/reconciler_test.go
@@ -34,6 +34,7 @@ import (
 
 	"github.com/crossplane/crossplane-runtime/v2/pkg/errors"
 	"github.com/crossplane/crossplane-runtime/v2/pkg/logging"
+	"github.com/crossplane/crossplane-runtime/v2/pkg/meta"
 	"github.com/crossplane/crossplane-runtime/v2/pkg/resource"
 	"github.com/crossplane/crossplane-runtime/v2/pkg/resource/fake"
 	"github.com/crossplane/crossplane-runtime/v2/pkg/test"
@@ -124,7 +125,7 @@ func TestReconcile(t *testing.T) {
 							MockGet: test.NewMockGetFn(nil, func(o client.Object) error {
 								fr := o.(*v1.FunctionRevision)
 								fr.SetAnnotations(map[string]string{
-									"crossplane.io/paused": "true",
+									meta.AnnotationKeyReconciliationPaused: "true",
 								})
 								return nil
 							}),
@@ -156,7 +157,7 @@ func TestReconcile(t *testing.T) {
 				},
 			},
 			want: want{
-				err: errors.Wrap(errBoom, errApplyRole),
+				err: errors.Wrapf(errBoom, errFmtApplyRole, ""),
 			},
 		},
 		"SuccessfulNoOp": {

--- a/internal/controller/rbac/function/roles/reconciler_test.go
+++ b/internal/controller/rbac/function/roles/reconciler_test.go
@@ -1,0 +1,230 @@
+/*
+Copyright 2020 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package roles
+
+import (
+	"context"
+	"io"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	rbacv1 "k8s.io/api/rbac/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"github.com/crossplane/crossplane-runtime/v2/pkg/errors"
+	"github.com/crossplane/crossplane-runtime/v2/pkg/logging"
+	"github.com/crossplane/crossplane-runtime/v2/pkg/resource"
+	"github.com/crossplane/crossplane-runtime/v2/pkg/resource/fake"
+	"github.com/crossplane/crossplane-runtime/v2/pkg/test"
+
+	v1 "github.com/crossplane/crossplane/v2/apis/pkg/v1"
+)
+
+func TestReconcile(t *testing.T) {
+	errBoom := errors.New("boom")
+	testLog := logging.NewLogrLogger(zap.New(zap.UseDevMode(true), zap.WriteTo(io.Discard)).WithName("testlog"))
+	now := metav1.Now()
+
+	type args struct {
+		mgr  manager.Manager
+		opts []ReconcilerOption
+	}
+
+	type want struct {
+		r   reconcile.Result
+		err error
+	}
+
+	cases := map[string]struct {
+		reason string
+		args   args
+		want   want
+	}{
+		"FunctionRevisionNotFound": {
+			reason: "We should not return an error if the FunctionRevision was not found.",
+			args: args{
+				mgr: &fake.Manager{},
+				opts: []ReconcilerOption{
+					WithClientApplicator(resource.ClientApplicator{
+						Client: &test.MockClient{
+							MockGet: test.NewMockGetFn(kerrors.NewNotFound(schema.GroupResource{}, "")),
+						},
+					}),
+				},
+			},
+			want: want{
+				r: reconcile.Result{},
+			},
+		},
+		"GetFunctionRevisionError": {
+			reason: "We should return any other error encountered while getting a FunctionRevision.",
+			args: args{
+				mgr: &fake.Manager{},
+				opts: []ReconcilerOption{
+					WithClientApplicator(resource.ClientApplicator{
+						Client: &test.MockClient{
+							MockGet: test.NewMockGetFn(errBoom),
+						},
+					}),
+				},
+			},
+			want: want{
+				err: errors.Wrap(errBoom, errGetFR),
+			},
+		},
+		"FunctionRevisionDeleted": {
+			reason: "We should return early if the FunctionRevision was deleted.",
+			args: args{
+				mgr: &fake.Manager{},
+				opts: []ReconcilerOption{
+					WithClientApplicator(resource.ClientApplicator{
+						Client: &test.MockClient{
+							MockGet: test.NewMockGetFn(nil, func(o client.Object) error {
+								d := o.(*v1.FunctionRevision)
+								d.SetDeletionTimestamp(&now)
+								return nil
+							}),
+						},
+					}),
+				},
+			},
+			want: want{
+				r: reconcile.Result{Requeue: false},
+			},
+		},
+		"PauseReconcile": {
+			reason: "We should not reconcile a paused FunctionRevision.",
+			args: args{
+				mgr: &fake.Manager{},
+				opts: []ReconcilerOption{
+					WithClientApplicator(resource.ClientApplicator{
+						Client: &test.MockClient{
+							MockGet: test.NewMockGetFn(nil, func(o client.Object) error {
+								fr := o.(*v1.FunctionRevision)
+								fr.SetAnnotations(map[string]string{
+									"crossplane.io/paused": "true",
+								})
+								return nil
+							}),
+						},
+					}),
+				},
+			},
+			want: want{
+				r: reconcile.Result{},
+			},
+		},
+		"ApplyClusterRoleError": {
+			reason: "We should return an error encountered applying a ClusterRole.",
+			args: args{
+				mgr: &fake.Manager{},
+				opts: []ReconcilerOption{
+					WithLogger(testLog),
+					WithClientApplicator(resource.ClientApplicator{
+						Client: &test.MockClient{
+							MockGet: test.NewMockGetFn(nil),
+						},
+						Applicator: resource.ApplyFn(func(context.Context, client.Object, ...resource.ApplyOption) error {
+							return errBoom
+						}),
+					}),
+					WithClusterRoleRenderer(ClusterRoleRenderFn(func(*v1.FunctionRevision, []Resource) []rbacv1.ClusterRole {
+						return []rbacv1.ClusterRole{{}}
+					})),
+				},
+			},
+			want: want{
+				err: errors.Wrap(errBoom, errApplyRole),
+			},
+		},
+		"SuccessfulNoOp": {
+			reason: "We should not requeue when no ClusterRoles need applying.",
+			args: args{
+				mgr: &fake.Manager{},
+				opts: []ReconcilerOption{
+					WithLogger(testLog),
+					WithClientApplicator(resource.ClientApplicator{
+						Client: &test.MockClient{
+							MockGet: test.NewMockGetFn(nil),
+						},
+						Applicator: resource.ApplyFn(func(ctx context.Context, o client.Object, _ ...resource.ApplyOption) error {
+							// Simulate a no-op change by not allowing the update.
+							return resource.AllowUpdateIf(func(_, _ runtime.Object) bool { return false })(ctx, o, o)
+						}),
+					}),
+					WithClusterRoleRenderer(ClusterRoleRenderFn(func(*v1.FunctionRevision, []Resource) []rbacv1.ClusterRole {
+						return []rbacv1.ClusterRole{{}}
+					})),
+				},
+			},
+			want: want{
+				r: reconcile.Result{Requeue: false},
+			},
+		},
+		"SuccessfulApply": {
+			reason: "We should not requeue when we successfully apply our ClusterRoles.",
+			args: args{
+				mgr: &fake.Manager{},
+				opts: []ReconcilerOption{
+					WithLogger(testLog),
+					WithClientApplicator(resource.ClientApplicator{
+						Client: &test.MockClient{
+							MockGet: test.NewMockGetFn(nil),
+						},
+						Applicator: resource.ApplyFn(func(_ context.Context, o client.Object, _ ...resource.ApplyOption) error {
+							// Simulate a successful apply by setting a resource version.
+							o.SetResourceVersion("1")
+							return nil
+						}),
+					}),
+					WithClusterRoleRenderer(ClusterRoleRenderFn(func(*v1.FunctionRevision, []Resource) []rbacv1.ClusterRole {
+						return []rbacv1.ClusterRole{{
+							ObjectMeta: metav1.ObjectMeta{
+								Name: "test-role",
+							},
+						}}
+					})),
+				},
+			},
+			want: want{
+				r: reconcile.Result{Requeue: false},
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			r := NewReconciler(tc.args.mgr, tc.args.opts...)
+			got, err := r.Reconcile(context.Background(), reconcile.Request{})
+
+			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
+				t.Errorf("\n%s\nr.Reconcile(...): -want error, +got error:\n%s", tc.reason, diff)
+			}
+
+			if diff := cmp.Diff(tc.want.r, got); diff != "" {
+				t.Errorf("\n%s\nr.Reconcile(...): -want, +got:\n%s", tc.reason, diff)
+			}
+		})
+	}
+}

--- a/internal/controller/rbac/function/roles/roles.go
+++ b/internal/controller/rbac/function/roles/roles.go
@@ -60,7 +60,7 @@ func RenderClusterRoles(fr *v1.FunctionRevision, rs []roles.Resource) []rbacv1.C
 		resources[r.Group] = append(resources[r.Group], r.Plural, r.Plural+roles.SuffixStatus)
 	}
 
-	rules := []rbacv1.PolicyRule{}
+	var rules []rbacv1.PolicyRule
 	for _, g := range groups {
 		rules = append(rules, rbacv1.PolicyRule{
 			APIGroups: []string{g},

--- a/internal/controller/rbac/function/roles/roles.go
+++ b/internal/controller/rbac/function/roles/roles.go
@@ -60,7 +60,7 @@ func RenderClusterRoles(fr *v1.FunctionRevision, rs []roles.Resource) []rbacv1.C
 		resources[r.Group] = append(resources[r.Group], r.Plural, r.Plural+roles.SuffixStatus)
 	}
 
-	var rules []rbacv1.PolicyRule
+	rules := make([]rbacv1.PolicyRule, 0, len(groups))
 	for _, g := range groups {
 		rules = append(rules, rbacv1.PolicyRule{
 			APIGroups: []string{g},

--- a/internal/controller/rbac/function/roles/roles.go
+++ b/internal/controller/rbac/function/roles/roles.go
@@ -1,0 +1,142 @@
+/*
+Copyright 2020 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package roles
+
+import (
+	"sort"
+
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/crossplane/crossplane-runtime/v2/pkg/meta"
+
+	v1 "github.com/crossplane/crossplane/v2/apis/pkg/v1"
+)
+
+const (
+	namePrefix     = "crossplane:function:"
+	nameSuffixEdit = ":aggregate-to-edit"
+	nameSuffixView = ":aggregate-to-view"
+
+	keyAggregateToCrossplane = "rbac.crossplane.io/aggregate-to-crossplane"
+	keyAggregateToAdmin      = "rbac.crossplane.io/aggregate-to-admin"
+	keyAggregateToEdit       = "rbac.crossplane.io/aggregate-to-edit"
+	keyAggregateToView       = "rbac.crossplane.io/aggregate-to-view"
+
+	valTrue = "true"
+
+	suffixStatus = "/status"
+)
+
+//nolint:gochecknoglobals // We treat these as constants.
+var (
+	verbsEdit = []string{rbacv1.VerbAll}
+	verbsView = []string{"get", "list", "watch"}
+)
+
+// A Resource is a Kubernetes API resource.
+type Resource struct {
+	// Group is the unversioned API group of this resource.
+	Group string
+
+	// Plural is the plural name of this resource.
+	Plural string
+}
+
+// RenderClusterRoles returns ClusterRoles for the supplied FunctionRevision.
+// Functions are invoked via gRPC and don't need direct Kubernetes API access,
+// so we only create aggregated roles for human users to interact with the
+// resources defined by the function.
+func RenderClusterRoles(fr *v1.FunctionRevision, rs []Resource) []rbacv1.ClusterRole {
+	// Return early if we have no resources to render roles for.
+	if len(rs) == 0 {
+		return nil
+	}
+
+	// Our list of resources has no guaranteed order, so we sort them in order
+	// to ensure we don't reorder our RBAC rules on each update.
+	sort.Slice(rs, func(i, j int) bool {
+		return rs[i].Plural+rs[i].Group < rs[j].Plural+rs[j].Group
+	})
+
+	groups := make([]string, 0) // Allows deterministic iteration over groups.
+
+	resources := make(map[string][]string) // Resources by group.
+	for _, r := range rs {
+		if _, ok := resources[r.Group]; !ok {
+			resources[r.Group] = make([]string, 0)
+			groups = append(groups, r.Group)
+		}
+
+		resources[r.Group] = append(resources[r.Group], r.Plural, r.Plural+suffixStatus)
+	}
+
+	rules := []rbacv1.PolicyRule{}
+	for _, g := range groups {
+		rules = append(rules, rbacv1.PolicyRule{
+			APIGroups: []string{g},
+			Resources: resources[g],
+		})
+	}
+
+	edit := &rbacv1.ClusterRole{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: namePrefix + fr.GetName() + nameSuffixEdit,
+			Labels: map[string]string{
+				// Edit rules aggregate to the Crossplane ClusterRole too.
+				// Crossplane needs access to reconcile all composite resources
+				// and composite resource claims.
+				keyAggregateToCrossplane: valTrue,
+
+				// Edit rules aggregate to admin too. Currently edit and admin
+				// differ only in their base roles.
+				keyAggregateToAdmin: valTrue,
+
+				keyAggregateToEdit: valTrue,
+			},
+		},
+		Rules: withVerbs(rules, verbsEdit),
+	}
+
+	view := &rbacv1.ClusterRole{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: namePrefix + fr.GetName() + nameSuffixView,
+			Labels: map[string]string{
+				keyAggregateToView: valTrue,
+			},
+		},
+		Rules: withVerbs(rules, verbsView),
+	}
+
+	roles := []rbacv1.ClusterRole{*edit, *view}
+	for i := range roles {
+		ref := meta.AsController(meta.TypedReferenceTo(fr, v1.FunctionRevisionGroupVersionKind))
+		roles[i].SetOwnerReferences([]metav1.OwnerReference{ref})
+	}
+
+	return roles
+}
+
+func withVerbs(r []rbacv1.PolicyRule, verbs []string) []rbacv1.PolicyRule {
+	verbal := make([]rbacv1.PolicyRule, len(r))
+	for i := range r {
+		verbal[i] = r[i]
+		verbal[i].Verbs = verbs
+	}
+
+	return verbal
+}

--- a/internal/controller/rbac/function/roles/roles_test.go
+++ b/internal/controller/rbac/function/roles/roles_test.go
@@ -1,0 +1,484 @@
+/*
+Copyright 2020 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package roles
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+
+	xpv1 "github.com/crossplane/crossplane-runtime/v2/apis/common/v1"
+
+	v1 "github.com/crossplane/crossplane/v2/apis/pkg/v1"
+)
+
+func TestRenderClusterRoles(t *testing.T) {
+	frName := "revised"
+	frUID := types.UID("no-you-id")
+
+	ctrl := true
+	crCtrlr := metav1.OwnerReference{
+		APIVersion:         v1.FunctionRevisionGroupVersionKind.GroupVersion().String(),
+		Kind:               v1.FunctionRevisionKind,
+		Name:               frName,
+		UID:                frUID,
+		Controller:         &ctrl,
+		BlockOwnerDeletion: &ctrl,
+	}
+
+	nameEdit := namePrefix + frName + nameSuffixEdit
+	nameView := namePrefix + frName + nameSuffixView
+
+	groupA := "example.org"
+	groupB := "example.org"
+	groupC := "example.net"
+
+	pluralA := "demonstrations"
+	pluralB := "examples"
+	pluralC := "examples"
+
+	type args struct {
+		fr        *v1.FunctionRevision
+		resources []Resource
+	}
+
+	cases := map[string]struct {
+		reason string
+		args   args
+		want   []rbacv1.ClusterRole
+	}{
+		"EmptyResources": {
+			reason: "If there are no resources (yet) we should not produce any ClusterRoles.",
+			args: args{
+				fr:        &v1.FunctionRevision{ObjectMeta: metav1.ObjectMeta{Name: frName, UID: frUID}},
+				resources: []Resource{},
+			},
+		},
+		"SingleResource": {
+			reason: "A FunctionRevision with a single resource should produce edit and view ClusterRoles.",
+			args: args{
+				fr: &v1.FunctionRevision{ObjectMeta: metav1.ObjectMeta{Name: frName, UID: frUID}},
+				resources: []Resource{
+					{
+						Group:  groupA,
+						Plural: pluralA,
+					},
+				},
+			},
+			want: []rbacv1.ClusterRole{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            nameEdit,
+						OwnerReferences: []metav1.OwnerReference{crCtrlr},
+						Labels: map[string]string{
+							keyAggregateToCrossplane: valTrue,
+							keyAggregateToAdmin:      valTrue,
+							keyAggregateToEdit:       valTrue,
+						},
+					},
+					Rules: []rbacv1.PolicyRule{
+						{
+							APIGroups: []string{groupA},
+							Resources: []string{pluralA, pluralA + suffixStatus},
+							Verbs:     verbsEdit,
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            nameView,
+						OwnerReferences: []metav1.OwnerReference{crCtrlr},
+						Labels: map[string]string{
+							keyAggregateToView: valTrue,
+						},
+					},
+					Rules: []rbacv1.PolicyRule{
+						{
+							APIGroups: []string{groupA},
+							Resources: []string{pluralA, pluralA + suffixStatus},
+							Verbs:     verbsView,
+						},
+					},
+				},
+			},
+		},
+		"MergeGroups": {
+			reason: "A FunctionRevision should merge resources by group to produce the fewest rules possible.",
+			args: args{
+				fr: &v1.FunctionRevision{ObjectMeta: metav1.ObjectMeta{Name: frName, UID: frUID}},
+				resources: []Resource{
+					{
+						Group:  groupA,
+						Plural: pluralA,
+					},
+					{
+						Group:  groupB,
+						Plural: pluralB,
+					},
+					{
+						Group:  groupC,
+						Plural: pluralC,
+					},
+				},
+			},
+			want: []rbacv1.ClusterRole{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            nameEdit,
+						OwnerReferences: []metav1.OwnerReference{crCtrlr},
+						Labels: map[string]string{
+							keyAggregateToCrossplane: valTrue,
+							keyAggregateToAdmin:      valTrue,
+							keyAggregateToEdit:       valTrue,
+						},
+					},
+					Rules: []rbacv1.PolicyRule{
+						{
+							APIGroups: []string{groupA},
+							Resources: []string{pluralA, pluralA + suffixStatus, pluralB, pluralB + suffixStatus},
+							Verbs:     verbsEdit,
+						},
+						{
+							APIGroups: []string{groupC},
+							Resources: []string{pluralC, pluralC + suffixStatus},
+							Verbs:     verbsEdit,
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            nameView,
+						OwnerReferences: []metav1.OwnerReference{crCtrlr},
+						Labels: map[string]string{
+							keyAggregateToView: valTrue,
+						},
+					},
+					Rules: []rbacv1.PolicyRule{
+						{
+							APIGroups: []string{groupA},
+							Resources: []string{pluralA, pluralA + suffixStatus, pluralB, pluralB + suffixStatus},
+							Verbs:     verbsView,
+						},
+						{
+							APIGroups: []string{groupC},
+							Resources: []string{pluralC, pluralC + suffixStatus},
+							Verbs:     verbsView,
+						},
+					},
+				},
+			},
+		},
+		"SortResources": {
+			reason: "Resources should be sorted deterministically to avoid spurious diffs.",
+			args: args{
+				fr: &v1.FunctionRevision{ObjectMeta: metav1.ObjectMeta{Name: frName, UID: frUID}},
+				resources: []Resource{
+					{
+						Group:  groupC,
+						Plural: pluralC,
+					},
+					{
+						Group:  groupA,
+						Plural: pluralB,
+					},
+					{
+						Group:  groupA,
+						Plural: pluralA,
+					},
+				},
+			},
+			want: []rbacv1.ClusterRole{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            nameEdit,
+						OwnerReferences: []metav1.OwnerReference{crCtrlr},
+						Labels: map[string]string{
+							keyAggregateToCrossplane: valTrue,
+							keyAggregateToAdmin:      valTrue,
+							keyAggregateToEdit:       valTrue,
+						},
+					},
+					Rules: []rbacv1.PolicyRule{
+						{
+							APIGroups: []string{groupA},
+							Resources: []string{pluralA, pluralA + suffixStatus, pluralB, pluralB + suffixStatus},
+							Verbs:     verbsEdit,
+						},
+						{
+							APIGroups: []string{groupC},
+							Resources: []string{pluralC, pluralC + suffixStatus},
+							Verbs:     verbsEdit,
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            nameView,
+						OwnerReferences: []metav1.OwnerReference{crCtrlr},
+						Labels: map[string]string{
+							keyAggregateToView: valTrue,
+						},
+					},
+					Rules: []rbacv1.PolicyRule{
+						{
+							APIGroups: []string{groupA},
+							Resources: []string{pluralA, pluralA + suffixStatus, pluralB, pluralB + suffixStatus},
+							Verbs:     verbsView,
+						},
+						{
+							APIGroups: []string{groupC},
+							Resources: []string{pluralC, pluralC + suffixStatus},
+							Verbs:     verbsView,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got := RenderClusterRoles(tc.args.fr, tc.args.resources)
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("\n%s\nRenderClusterRoles(...): -want, +got:\n%s", tc.reason, diff)
+			}
+		})
+	}
+}
+
+func TestClusterRolesDiffer(t *testing.T) {
+	cases := map[string]struct {
+		reason  string
+		current *rbacv1.ClusterRole
+		desired *rbacv1.ClusterRole
+		want    bool
+	}{
+		"Equal": {
+			reason: "Two ClusterRoles with the same labels and rules should not differ.",
+			current: &rbacv1.ClusterRole{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{"cool": "true"},
+				},
+				Rules: []rbacv1.PolicyRule{
+					{
+						APIGroups: []string{"example.org"},
+						Resources: []string{"examples"},
+						Verbs:     []string{"*"},
+					},
+				},
+			},
+			desired: &rbacv1.ClusterRole{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{"cool": "true"},
+				},
+				Rules: []rbacv1.PolicyRule{
+					{
+						APIGroups: []string{"example.org"},
+						Resources: []string{"examples"},
+						Verbs:     []string{"*"},
+					},
+				},
+			},
+			want: false,
+		},
+		"LabelsDiffer": {
+			reason: "Two ClusterRoles with different labels should differ.",
+			current: &rbacv1.ClusterRole{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{"cool": "true"},
+				},
+				Rules: []rbacv1.PolicyRule{
+					{
+						APIGroups: []string{"example.org"},
+						Resources: []string{"examples"},
+						Verbs:     []string{"*"},
+					},
+				},
+			},
+			desired: &rbacv1.ClusterRole{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{"cool": "false"},
+				},
+				Rules: []rbacv1.PolicyRule{
+					{
+						APIGroups: []string{"example.org"},
+						Resources: []string{"examples"},
+						Verbs:     []string{"*"},
+					},
+				},
+			},
+			want: true,
+		},
+		"RulesDiffer": {
+			reason: "Two ClusterRoles with different rules should differ.",
+			current: &rbacv1.ClusterRole{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{"cool": "true"},
+				},
+				Rules: []rbacv1.PolicyRule{
+					{
+						APIGroups: []string{"example.org"},
+						Resources: []string{"examples"},
+						Verbs:     []string{"*"},
+					},
+				},
+			},
+			desired: &rbacv1.ClusterRole{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{"cool": "true"},
+				},
+				Rules: []rbacv1.PolicyRule{
+					{
+						APIGroups: []string{"example.com"},
+						Resources: []string{"examples"},
+						Verbs:     []string{"get"},
+					},
+				},
+			},
+			want: true,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got := ClusterRolesDiffer(tc.current, tc.desired)
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("\n%s\nClusterRolesDiffer(...): -want, +got:\n%s", tc.reason, diff)
+			}
+		})
+	}
+}
+
+func TestWithVerbs(t *testing.T) {
+	rules := []rbacv1.PolicyRule{
+		{
+			APIGroups: []string{"example.org"},
+			Resources: []string{"examples"},
+		},
+	}
+
+	verbs := []string{"get", "list", "watch"}
+	got := withVerbs(rules, verbs)
+
+	want := []rbacv1.PolicyRule{
+		{
+			APIGroups: []string{"example.org"},
+			Resources: []string{"examples"},
+			Verbs:     verbs,
+		},
+	}
+
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("withVerbs(...): -want, +got:\n%s", diff)
+	}
+
+	// Ensure original rules are not modified
+	if len(rules[0].Verbs) != 0 {
+		t.Errorf("withVerbs should not modify original rules")
+	}
+}
+
+func TestDefinedResources(t *testing.T) {
+	cases := map[string]struct {
+		reason string
+		refs   []runtime.Object
+		want   []Resource
+	}{
+		"CRD": {
+			reason: "A CRD reference should be converted to a Resource.",
+			refs: []runtime.Object{
+				&metav1.PartialObjectMetadata{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "apiextensions.k8s.io/v1",
+						Kind:       "CustomResourceDefinition",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "examples.example.org",
+					},
+				},
+			},
+			want: []Resource{
+				{
+					Group:  "example.org",
+					Plural: "examples",
+				},
+			},
+		},
+		"InvalidName": {
+			reason: "A CRD reference with an invalid name should be ignored.",
+			refs: []runtime.Object{
+				&metav1.PartialObjectMetadata{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "apiextensions.k8s.io/v1",
+						Kind:       "CustomResourceDefinition",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "invalid",
+					},
+				},
+			},
+			want: []Resource{},
+		},
+		"NonCRD": {
+			reason: "A non-CRD reference should be ignored.",
+			refs: []runtime.Object{
+				&metav1.PartialObjectMetadata{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+						Kind:       "ConfigMap",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test",
+					},
+				},
+			},
+			want: []Resource{},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			// Convert runtime.Objects to TypedReferences
+			refs := make([]metav1.PartialObjectMetadata, 0, len(tc.refs))
+			for _, obj := range tc.refs {
+				refs = append(refs, *obj.(*metav1.PartialObjectMetadata))
+			}
+
+			got := DefinedResources(convertToTypedRefs(refs))
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("\n%s\nDefinedResources(...): -want, +got:\n%s", tc.reason, diff)
+			}
+		})
+	}
+}
+
+// Helper function to convert PartialObjectMetadata to TypedReferences.
+func convertToTypedRefs(objs []metav1.PartialObjectMetadata) []xpv1.TypedReference {
+	refs := make([]xpv1.TypedReference, 0, len(objs))
+	for _, obj := range objs {
+		refs = append(refs, xpv1.TypedReference{
+			APIVersion: obj.APIVersion,
+			Kind:       obj.Kind,
+			Name:       obj.Name,
+		})
+	}
+	return refs
+}

--- a/internal/controller/rbac/function/roles/roles_test.go
+++ b/internal/controller/rbac/function/roles/roles_test.go
@@ -423,6 +423,26 @@ func TestDefinedResources(t *testing.T) {
 				},
 			},
 		},
+		"MRD": {
+			reason: "An MRD reference should be converted to a Resource.",
+			refs: []runtime.Object{
+				&metav1.PartialObjectMetadata{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "apiextensions.crossplane.io/v1alpha1",
+						Kind:       "ManagedResourceDefinition",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "buckets.storage.example.org",
+					},
+				},
+			},
+			want: []roles.Resource{
+				{
+					Group:  "storage.example.org",
+					Plural: "buckets",
+				},
+			},
+		},
 		"InvalidName": {
 			reason: "A CRD reference with an invalid name should be ignored.",
 			refs: []runtime.Object{

--- a/internal/controller/rbac/function/roles/roles_test.go
+++ b/internal/controller/rbac/function/roles/roles_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 The Crossplane Authors.
+Copyright 2025 The Crossplane Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -28,6 +28,7 @@ import (
 	xpv1 "github.com/crossplane/crossplane-runtime/v2/apis/common/v1"
 
 	v1 "github.com/crossplane/crossplane/v2/apis/pkg/v1"
+	"github.com/crossplane/crossplane/v2/internal/controller/rbac/roles"
 )
 
 func TestRenderClusterRoles(t *testing.T) {
@@ -44,8 +45,8 @@ func TestRenderClusterRoles(t *testing.T) {
 		BlockOwnerDeletion: &ctrl,
 	}
 
-	nameEdit := namePrefix + frName + nameSuffixEdit
-	nameView := namePrefix + frName + nameSuffixView
+	nameEdit := namePrefix + frName + roles.NameSuffixEdit
+	nameView := namePrefix + frName + roles.NameSuffixView
 
 	groupA := "example.org"
 	groupB := "example.org"
@@ -57,7 +58,7 @@ func TestRenderClusterRoles(t *testing.T) {
 
 	type args struct {
 		fr        *v1.FunctionRevision
-		resources []Resource
+		resources []roles.Resource
 	}
 
 	cases := map[string]struct {
@@ -69,14 +70,14 @@ func TestRenderClusterRoles(t *testing.T) {
 			reason: "If there are no resources (yet) we should not produce any ClusterRoles.",
 			args: args{
 				fr:        &v1.FunctionRevision{ObjectMeta: metav1.ObjectMeta{Name: frName, UID: frUID}},
-				resources: []Resource{},
+				resources: []roles.Resource{},
 			},
 		},
 		"SingleResource": {
 			reason: "A FunctionRevision with a single resource should produce edit and view ClusterRoles.",
 			args: args{
 				fr: &v1.FunctionRevision{ObjectMeta: metav1.ObjectMeta{Name: frName, UID: frUID}},
-				resources: []Resource{
+				resources: []roles.Resource{
 					{
 						Group:  groupA,
 						Plural: pluralA,
@@ -89,16 +90,16 @@ func TestRenderClusterRoles(t *testing.T) {
 						Name:            nameEdit,
 						OwnerReferences: []metav1.OwnerReference{crCtrlr},
 						Labels: map[string]string{
-							keyAggregateToCrossplane: valTrue,
-							keyAggregateToAdmin:      valTrue,
-							keyAggregateToEdit:       valTrue,
+							roles.KeyAggregateToCrossplane: roles.ValTrue,
+							roles.KeyAggregateToAdmin:      roles.ValTrue,
+							roles.KeyAggregateToEdit:       roles.ValTrue,
 						},
 					},
 					Rules: []rbacv1.PolicyRule{
 						{
 							APIGroups: []string{groupA},
-							Resources: []string{pluralA, pluralA + suffixStatus},
-							Verbs:     verbsEdit,
+							Resources: []string{pluralA, pluralA + roles.SuffixStatus},
+							Verbs:     roles.VerbsEdit,
 						},
 					},
 				},
@@ -107,14 +108,14 @@ func TestRenderClusterRoles(t *testing.T) {
 						Name:            nameView,
 						OwnerReferences: []metav1.OwnerReference{crCtrlr},
 						Labels: map[string]string{
-							keyAggregateToView: valTrue,
+							roles.KeyAggregateToView: roles.ValTrue,
 						},
 					},
 					Rules: []rbacv1.PolicyRule{
 						{
 							APIGroups: []string{groupA},
-							Resources: []string{pluralA, pluralA + suffixStatus},
-							Verbs:     verbsView,
+							Resources: []string{pluralA, pluralA + roles.SuffixStatus},
+							Verbs:     roles.VerbsView,
 						},
 					},
 				},
@@ -124,7 +125,7 @@ func TestRenderClusterRoles(t *testing.T) {
 			reason: "A FunctionRevision should merge resources by group to produce the fewest rules possible.",
 			args: args{
 				fr: &v1.FunctionRevision{ObjectMeta: metav1.ObjectMeta{Name: frName, UID: frUID}},
-				resources: []Resource{
+				resources: []roles.Resource{
 					{
 						Group:  groupA,
 						Plural: pluralA,
@@ -145,21 +146,21 @@ func TestRenderClusterRoles(t *testing.T) {
 						Name:            nameEdit,
 						OwnerReferences: []metav1.OwnerReference{crCtrlr},
 						Labels: map[string]string{
-							keyAggregateToCrossplane: valTrue,
-							keyAggregateToAdmin:      valTrue,
-							keyAggregateToEdit:       valTrue,
+							roles.KeyAggregateToCrossplane: roles.ValTrue,
+							roles.KeyAggregateToAdmin:      roles.ValTrue,
+							roles.KeyAggregateToEdit:       roles.ValTrue,
 						},
 					},
 					Rules: []rbacv1.PolicyRule{
 						{
 							APIGroups: []string{groupA},
-							Resources: []string{pluralA, pluralA + suffixStatus, pluralB, pluralB + suffixStatus},
-							Verbs:     verbsEdit,
+							Resources: []string{pluralA, pluralA + roles.SuffixStatus, pluralB, pluralB + roles.SuffixStatus},
+							Verbs:     roles.VerbsEdit,
 						},
 						{
 							APIGroups: []string{groupC},
-							Resources: []string{pluralC, pluralC + suffixStatus},
-							Verbs:     verbsEdit,
+							Resources: []string{pluralC, pluralC + roles.SuffixStatus},
+							Verbs:     roles.VerbsEdit,
 						},
 					},
 				},
@@ -168,19 +169,19 @@ func TestRenderClusterRoles(t *testing.T) {
 						Name:            nameView,
 						OwnerReferences: []metav1.OwnerReference{crCtrlr},
 						Labels: map[string]string{
-							keyAggregateToView: valTrue,
+							roles.KeyAggregateToView: roles.ValTrue,
 						},
 					},
 					Rules: []rbacv1.PolicyRule{
 						{
 							APIGroups: []string{groupA},
-							Resources: []string{pluralA, pluralA + suffixStatus, pluralB, pluralB + suffixStatus},
-							Verbs:     verbsView,
+							Resources: []string{pluralA, pluralA + roles.SuffixStatus, pluralB, pluralB + roles.SuffixStatus},
+							Verbs:     roles.VerbsView,
 						},
 						{
 							APIGroups: []string{groupC},
-							Resources: []string{pluralC, pluralC + suffixStatus},
-							Verbs:     verbsView,
+							Resources: []string{pluralC, pluralC + roles.SuffixStatus},
+							Verbs:     roles.VerbsView,
 						},
 					},
 				},
@@ -190,7 +191,7 @@ func TestRenderClusterRoles(t *testing.T) {
 			reason: "Resources should be sorted deterministically to avoid spurious diffs.",
 			args: args{
 				fr: &v1.FunctionRevision{ObjectMeta: metav1.ObjectMeta{Name: frName, UID: frUID}},
-				resources: []Resource{
+				resources: []roles.Resource{
 					{
 						Group:  groupC,
 						Plural: pluralC,
@@ -211,21 +212,21 @@ func TestRenderClusterRoles(t *testing.T) {
 						Name:            nameEdit,
 						OwnerReferences: []metav1.OwnerReference{crCtrlr},
 						Labels: map[string]string{
-							keyAggregateToCrossplane: valTrue,
-							keyAggregateToAdmin:      valTrue,
-							keyAggregateToEdit:       valTrue,
+							roles.KeyAggregateToCrossplane: roles.ValTrue,
+							roles.KeyAggregateToAdmin:      roles.ValTrue,
+							roles.KeyAggregateToEdit:       roles.ValTrue,
 						},
 					},
 					Rules: []rbacv1.PolicyRule{
 						{
 							APIGroups: []string{groupA},
-							Resources: []string{pluralA, pluralA + suffixStatus, pluralB, pluralB + suffixStatus},
-							Verbs:     verbsEdit,
+							Resources: []string{pluralA, pluralA + roles.SuffixStatus, pluralB, pluralB + roles.SuffixStatus},
+							Verbs:     roles.VerbsEdit,
 						},
 						{
 							APIGroups: []string{groupC},
-							Resources: []string{pluralC, pluralC + suffixStatus},
-							Verbs:     verbsEdit,
+							Resources: []string{pluralC, pluralC + roles.SuffixStatus},
+							Verbs:     roles.VerbsEdit,
 						},
 					},
 				},
@@ -234,19 +235,19 @@ func TestRenderClusterRoles(t *testing.T) {
 						Name:            nameView,
 						OwnerReferences: []metav1.OwnerReference{crCtrlr},
 						Labels: map[string]string{
-							keyAggregateToView: valTrue,
+							roles.KeyAggregateToView: roles.ValTrue,
 						},
 					},
 					Rules: []rbacv1.PolicyRule{
 						{
 							APIGroups: []string{groupA},
-							Resources: []string{pluralA, pluralA + suffixStatus, pluralB, pluralB + suffixStatus},
-							Verbs:     verbsView,
+							Resources: []string{pluralA, pluralA + roles.SuffixStatus, pluralB, pluralB + roles.SuffixStatus},
+							Verbs:     roles.VerbsView,
 						},
 						{
 							APIGroups: []string{groupC},
-							Resources: []string{pluralC, pluralC + suffixStatus},
-							Verbs:     verbsView,
+							Resources: []string{pluralC, pluralC + roles.SuffixStatus},
+							Verbs:     roles.VerbsView,
 						},
 					},
 				},
@@ -359,7 +360,7 @@ func TestClusterRolesDiffer(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			got := ClusterRolesDiffer(tc.current, tc.desired)
+			got := roles.ClusterRolesDiffer(tc.current, tc.desired)
 			if diff := cmp.Diff(tc.want, got); diff != "" {
 				t.Errorf("\n%s\nClusterRolesDiffer(...): -want, +got:\n%s", tc.reason, diff)
 			}
@@ -376,7 +377,7 @@ func TestWithVerbs(t *testing.T) {
 	}
 
 	verbs := []string{"get", "list", "watch"}
-	got := withVerbs(rules, verbs)
+	got := roles.WithVerbs(rules, verbs)
 
 	want := []rbacv1.PolicyRule{
 		{
@@ -387,12 +388,12 @@ func TestWithVerbs(t *testing.T) {
 	}
 
 	if diff := cmp.Diff(want, got); diff != "" {
-		t.Errorf("withVerbs(...): -want, +got:\n%s", diff)
+		t.Errorf("roles.WithVerbs(...): -want, +got:\n%s", diff)
 	}
 
 	// Ensure original rules are not modified
 	if len(rules[0].Verbs) != 0 {
-		t.Errorf("withVerbs should not modify original rules")
+		t.Errorf("roles.WithVerbs should not modify original rules")
 	}
 }
 
@@ -400,7 +401,7 @@ func TestDefinedResources(t *testing.T) {
 	cases := map[string]struct {
 		reason string
 		refs   []runtime.Object
-		want   []Resource
+		want   []roles.Resource
 	}{
 		"CRD": {
 			reason: "A CRD reference should be converted to a Resource.",
@@ -415,7 +416,7 @@ func TestDefinedResources(t *testing.T) {
 					},
 				},
 			},
-			want: []Resource{
+			want: []roles.Resource{
 				{
 					Group:  "example.org",
 					Plural: "examples",
@@ -435,7 +436,7 @@ func TestDefinedResources(t *testing.T) {
 					},
 				},
 			},
-			want: []Resource{},
+			want: []roles.Resource{},
 		},
 		"NonCRD": {
 			reason: "A non-CRD reference should be ignored.",
@@ -450,7 +451,7 @@ func TestDefinedResources(t *testing.T) {
 					},
 				},
 			},
-			want: []Resource{},
+			want: []roles.Resource{},
 		},
 	}
 
@@ -462,7 +463,7 @@ func TestDefinedResources(t *testing.T) {
 				refs = append(refs, *obj.(*metav1.PartialObjectMetadata))
 			}
 
-			got := DefinedResources(convertToTypedRefs(refs))
+			got := roles.DefinedResources(convertToTypedRefs(refs))
 			if diff := cmp.Diff(tc.want, got); diff != "" {
 				t.Errorf("\n%s\nDefinedResources(...): -want, +got:\n%s", tc.reason, diff)
 			}

--- a/internal/controller/rbac/provider/roles/reconciler.go
+++ b/internal/controller/rbac/provider/roles/reconciler.go
@@ -46,14 +46,15 @@ import (
 const (
 	timeout = 2 * time.Minute
 
-	errGetPR     = "cannot get ProviderRevision"
-	errListPRs   = "cannot list ProviderRevisions"
-	errApplyRole = "cannot apply ClusterRole"
+	errGetPR         = "cannot get ProviderRevision"
+	errListPRs       = "cannot list ProviderRevisions"
+	errFmtApplyRole = "cannot apply ClusterRole %q"
 )
 
 // Event reasons.
 const (
-	reasonApplyRoles event.Reason = "ApplyClusterRoles"
+	reasonApplyRoles       event.Reason = "ApplyClusterRoles"
+	reasonApplyRolesFailed event.Reason = "ApplyClusterRolesFailed"
 )
 
 // A ClusterRoleRenderer renders ClusterRoles for the given resources.
@@ -243,7 +244,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 			}
 
 			err = errors.Wrap(err, errListPRs)
-			r.record.Event(pr, event.Warning(reasonApplyRoles, err))
+			r.record.Event(pr, event.Warning(reasonApplyRolesFailed, err))
 
 			return reconcile.Result{}, err
 		}
@@ -305,8 +306,8 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 				return reconcile.Result{Requeue: true}, nil
 			}
 
-			err = errors.Wrap(err, errApplyRole)
-			r.record.Event(pr, event.Warning(reasonApplyRoles, err))
+			err = errors.Wrapf(err, errFmtApplyRole, cr.GetName())
+			r.record.Event(pr, event.Warning(reasonApplyRolesFailed, err))
 
 			return reconcile.Result{}, err
 		}

--- a/internal/controller/rbac/provider/roles/reconciler.go
+++ b/internal/controller/rbac/provider/roles/reconciler.go
@@ -272,6 +272,18 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 		}
 	}
 
+	// Deduplicate resources aggregated from provider family members.
+	seen := make(map[roles.Resource]struct{}, len(resources))
+	dedup := resources[:0]
+	for _, rsrc := range resources {
+		if _, ok := seen[rsrc]; ok {
+			continue
+		}
+		seen[rsrc] = struct{}{}
+		dedup = append(dedup, rsrc)
+	}
+	resources = dedup
+
 	applied := make([]string, 0)
 
 	for _, cr := range r.rbac.RenderClusterRoles(pr, resources) {

--- a/internal/controller/rbac/provider/roles/reconciler_test.go
+++ b/internal/controller/rbac/provider/roles/reconciler_test.go
@@ -43,6 +43,7 @@ import (
 	"github.com/crossplane/crossplane-runtime/v2/pkg/test"
 
 	v1 "github.com/crossplane/crossplane/v2/apis/pkg/v1"
+	"github.com/crossplane/crossplane/v2/internal/controller/rbac/roles"
 )
 
 func TestReconcile(t *testing.T) {
@@ -156,7 +157,7 @@ func TestReconcile(t *testing.T) {
 							return errBoom
 						}),
 					}),
-					WithClusterRoleRenderer(ClusterRoleRenderFn(func(*v1.ProviderRevision, []Resource) []rbacv1.ClusterRole {
+					WithClusterRoleRenderer(ClusterRoleRenderFn(func(*v1.ProviderRevision, []roles.Resource) []rbacv1.ClusterRole {
 						return []rbacv1.ClusterRole{{}}
 					})),
 				},
@@ -180,7 +181,7 @@ func TestReconcile(t *testing.T) {
 							return resource.AllowUpdateIf(func(_, _ runtime.Object) bool { return false })(ctx, o, o)
 						}),
 					}),
-					WithClusterRoleRenderer(ClusterRoleRenderFn(func(*v1.ProviderRevision, []Resource) []rbacv1.ClusterRole {
+					WithClusterRoleRenderer(ClusterRoleRenderFn(func(*v1.ProviderRevision, []roles.Resource) []rbacv1.ClusterRole {
 						return []rbacv1.ClusterRole{{}}
 					})),
 				},
@@ -222,7 +223,7 @@ func TestReconcile(t *testing.T) {
 							return nil
 						}),
 					}),
-					WithClusterRoleRenderer(ClusterRoleRenderFn(func(*v1.ProviderRevision, []Resource) []rbacv1.ClusterRole {
+					WithClusterRoleRenderer(ClusterRoleRenderFn(func(*v1.ProviderRevision, []roles.Resource) []rbacv1.ClusterRole {
 						return []rbacv1.ClusterRole{{}}
 					})),
 				},
@@ -250,7 +251,7 @@ func TestReconcile(t *testing.T) {
 							}),
 						},
 					}),
-					WithClusterRoleRenderer(ClusterRoleRenderFn(func(*v1.ProviderRevision, []Resource) []rbacv1.ClusterRole {
+					WithClusterRoleRenderer(ClusterRoleRenderFn(func(*v1.ProviderRevision, []roles.Resource) []rbacv1.ClusterRole {
 						return []rbacv1.ClusterRole{{}}
 					})),
 				},
@@ -280,27 +281,27 @@ func TestReconcile(t *testing.T) {
 func TestDefinedResources(t *testing.T) {
 	cases := map[string]struct {
 		refs []xpv1.TypedReference
-		want []Resource
+		want []roles.Resource
 	}{
 		"UnparseableAPIVersion": {
 			refs: []xpv1.TypedReference{{
 				APIVersion: "too/many/slashes",
 			}},
-			want: []Resource{},
+			want: []roles.Resource{},
 		},
 		"WrongGroup": {
 			refs: []xpv1.TypedReference{{
 				APIVersion: "example.org/v1",
 				Kind:       "CustomResourceDefinition",
 			}},
-			want: []Resource{},
+			want: []roles.Resource{},
 		},
 		"WrongKind": {
 			refs: []xpv1.TypedReference{{
 				APIVersion: extv1.SchemeGroupVersion.String(),
 				Kind:       "ConversionReview",
 			}},
-			want: []Resource{},
+			want: []roles.Resource{},
 		},
 		"InvalidName": {
 			refs: []xpv1.TypedReference{{
@@ -308,7 +309,7 @@ func TestDefinedResources(t *testing.T) {
 				Kind:       "CustomResourceDefinition",
 				Name:       "I'm different!",
 			}},
-			want: []Resource{},
+			want: []roles.Resource{},
 		},
 		"DefinedResource": {
 			refs: []xpv1.TypedReference{{
@@ -316,7 +317,7 @@ func TestDefinedResources(t *testing.T) {
 				Kind:       "CustomResourceDefinition",
 				Name:       "pinballs.example.org",
 			}},
-			want: []Resource{{
+			want: []roles.Resource{{
 				Group:  "example.org",
 				Plural: "pinballs",
 			}},
@@ -325,7 +326,7 @@ func TestDefinedResources(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			got := DefinedResources(tc.refs)
+			got := roles.DefinedResources(tc.refs)
 			if diff := cmp.Diff(tc.want, got); diff != "" {
 				t.Errorf("DefinedResources(...): -want, +got:\n%s", diff)
 			}
@@ -387,7 +388,7 @@ func TestClusterRolesDiffer(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			got := ClusterRolesDiffer(tc.current, tc.desired)
+			got := roles.ClusterRolesDiffer(tc.current, tc.desired)
 			if diff := cmp.Diff(tc.want, got); diff != "" {
 				t.Errorf("ClusterRolesDiffer(...): -want, +got\n:%s", diff)
 			}

--- a/internal/controller/rbac/provider/roles/reconciler_test.go
+++ b/internal/controller/rbac/provider/roles/reconciler_test.go
@@ -163,7 +163,7 @@ func TestReconcile(t *testing.T) {
 				},
 			},
 			want: want{
-				err: errors.Wrap(errBoom, errApplyRole),
+				err: errors.Wrapf(errBoom, errFmtApplyRole, ""),
 			},
 		},
 		"SuccessfulNoOp": {

--- a/internal/controller/rbac/provider/roles/roles.go
+++ b/internal/controller/rbac/provider/roles/roles.go
@@ -99,7 +99,7 @@ func RenderClusterRoles(pr *v1.ProviderRevision, rs []roles.Resource) []rbacv1.C
 		resources[r.Group] = append(resources[r.Group], r.Plural, r.Plural+roles.SuffixStatus)
 	}
 
-	rules := []rbacv1.PolicyRule{}
+	var rules []rbacv1.PolicyRule
 	for _, g := range groups {
 		rules = append(rules, rbacv1.PolicyRule{
 			APIGroups: []string{g},

--- a/internal/controller/rbac/provider/roles/roles.go
+++ b/internal/controller/rbac/provider/roles/roles.go
@@ -99,7 +99,7 @@ func RenderClusterRoles(pr *v1.ProviderRevision, rs []roles.Resource) []rbacv1.C
 		resources[r.Group] = append(resources[r.Group], r.Plural, r.Plural+roles.SuffixStatus)
 	}
 
-	var rules []rbacv1.PolicyRule
+	rules := make([]rbacv1.PolicyRule, 0, len(groups))
 	for _, g := range groups {
 		rules = append(rules, rbacv1.PolicyRule{
 			APIGroups: []string{g},

--- a/internal/controller/rbac/provider/roles/roles_test.go
+++ b/internal/controller/rbac/provider/roles/roles_test.go
@@ -27,6 +27,7 @@ import (
 
 	pkgmetav1 "github.com/crossplane/crossplane/v2/apis/pkg/meta/v1"
 	v1 "github.com/crossplane/crossplane/v2/apis/pkg/v1"
+	"github.com/crossplane/crossplane/v2/internal/controller/rbac/roles"
 )
 
 func TestRenderClusterRoles(t *testing.T) {
@@ -43,8 +44,8 @@ func TestRenderClusterRoles(t *testing.T) {
 		BlockOwnerDeletion: &ctrl,
 	}
 
-	nameEdit := namePrefix + prName + nameSuffixEdit
-	nameView := namePrefix + prName + nameSuffixView
+	nameEdit := namePrefix + prName + roles.NameSuffixEdit
+	nameView := namePrefix + prName + roles.NameSuffixView
 	nameSystem := SystemClusterRoleName(prName)
 
 	groupA := "example.org"
@@ -57,7 +58,7 @@ func TestRenderClusterRoles(t *testing.T) {
 
 	type args struct {
 		pr        *v1.ProviderRevision
-		resources []Resource
+		resources []roles.Resource
 	}
 
 	cases := map[string]struct {
@@ -69,14 +70,14 @@ func TestRenderClusterRoles(t *testing.T) {
 			reason: "If there are no resources (yet) we should not produce any ClusterRoles.",
 			args: args{
 				pr:        &v1.ProviderRevision{ObjectMeta: metav1.ObjectMeta{Name: prName, UID: prUID}},
-				resources: []Resource{},
+				resources: []roles.Resource{},
 			},
 		},
 		"MergeGroups": {
 			reason: "A ProviderRevision should merge resources by group to produce the fewest rules possible.",
 			args: args{
 				pr: &v1.ProviderRevision{ObjectMeta: metav1.ObjectMeta{Name: prName, UID: prUID}},
-				resources: []Resource{
+				resources: []roles.Resource{
 					{
 						Group:  groupA,
 						Plural: pluralA,
@@ -97,21 +98,21 @@ func TestRenderClusterRoles(t *testing.T) {
 						Name:            nameEdit,
 						OwnerReferences: []metav1.OwnerReference{crCtrlr},
 						Labels: map[string]string{
-							keyAggregateToCrossplane: valTrue,
-							keyAggregateToAdmin:      valTrue,
-							keyAggregateToEdit:       valTrue,
+							roles.KeyAggregateToCrossplane: roles.ValTrue,
+							roles.KeyAggregateToAdmin:      roles.ValTrue,
+							roles.KeyAggregateToEdit:       roles.ValTrue,
 						},
 					},
 					Rules: []rbacv1.PolicyRule{
 						{
 							APIGroups: []string{groupA},
-							Resources: []string{pluralA, pluralA + suffixStatus, pluralB, pluralB + suffixStatus},
-							Verbs:     verbsEdit,
+							Resources: []string{pluralA, pluralA + roles.SuffixStatus, pluralB, pluralB + roles.SuffixStatus},
+							Verbs:     roles.VerbsEdit,
 						},
 						{
 							APIGroups: []string{groupC},
-							Resources: []string{pluralC, pluralC + suffixStatus},
-							Verbs:     verbsEdit,
+							Resources: []string{pluralC, pluralC + roles.SuffixStatus},
+							Verbs:     roles.VerbsEdit,
 						},
 					},
 				},
@@ -120,19 +121,19 @@ func TestRenderClusterRoles(t *testing.T) {
 						Name:            nameView,
 						OwnerReferences: []metav1.OwnerReference{crCtrlr},
 						Labels: map[string]string{
-							keyAggregateToView: valTrue,
+							roles.KeyAggregateToView: roles.ValTrue,
 						},
 					},
 					Rules: []rbacv1.PolicyRule{
 						{
 							APIGroups: []string{groupA},
-							Resources: []string{pluralA, pluralA + suffixStatus, pluralB, pluralB + suffixStatus},
-							Verbs:     verbsView,
+							Resources: []string{pluralA, pluralA + roles.SuffixStatus, pluralB, pluralB + roles.SuffixStatus},
+							Verbs:     roles.VerbsView,
 						},
 						{
 							APIGroups: []string{groupC},
-							Resources: []string{pluralC, pluralC + suffixStatus},
-							Verbs:     verbsView,
+							Resources: []string{pluralC, pluralC + roles.SuffixStatus},
+							Verbs:     roles.VerbsView,
 						},
 					},
 				},
@@ -145,12 +146,12 @@ func TestRenderClusterRoles(t *testing.T) {
 					Rules: append([]rbacv1.PolicyRule{
 						{
 							APIGroups: []string{groupA},
-							Resources: []string{pluralA, pluralA + suffixStatus, pluralB, pluralB + suffixStatus},
+							Resources: []string{pluralA, pluralA + roles.SuffixStatus, pluralB, pluralB + roles.SuffixStatus},
 							Verbs:     verbsSystem,
 						},
 						{
 							APIGroups: []string{groupC},
-							Resources: []string{pluralC, pluralC + suffixStatus},
+							Resources: []string{pluralC, pluralC + roles.SuffixStatus},
 							Verbs:     verbsSystem,
 						},
 						{
@@ -173,7 +174,7 @@ func TestRenderClusterRoles(t *testing.T) {
 						},
 					},
 				},
-				resources: []Resource{
+				resources: []roles.Resource{
 					{
 						Group:  groupA,
 						Plural: pluralA,
@@ -186,16 +187,16 @@ func TestRenderClusterRoles(t *testing.T) {
 						Name:            nameEdit,
 						OwnerReferences: []metav1.OwnerReference{crCtrlr},
 						Labels: map[string]string{
-							keyAggregateToCrossplane: valTrue,
-							keyAggregateToAdmin:      valTrue,
-							keyAggregateToEdit:       valTrue,
+							roles.KeyAggregateToCrossplane: roles.ValTrue,
+							roles.KeyAggregateToAdmin:      roles.ValTrue,
+							roles.KeyAggregateToEdit:       roles.ValTrue,
 						},
 					},
 					Rules: []rbacv1.PolicyRule{
 						{
 							APIGroups: []string{groupA},
-							Resources: []string{pluralA, pluralA + suffixStatus},
-							Verbs:     verbsEdit,
+							Resources: []string{pluralA, pluralA + roles.SuffixStatus},
+							Verbs:     roles.VerbsEdit,
 						},
 					},
 				},
@@ -204,14 +205,14 @@ func TestRenderClusterRoles(t *testing.T) {
 						Name:            nameView,
 						OwnerReferences: []metav1.OwnerReference{crCtrlr},
 						Labels: map[string]string{
-							keyAggregateToView: valTrue,
+							roles.KeyAggregateToView: roles.ValTrue,
 						},
 					},
 					Rules: []rbacv1.PolicyRule{
 						{
 							APIGroups: []string{groupA},
-							Resources: []string{pluralA, pluralA + suffixStatus},
-							Verbs:     verbsView,
+							Resources: []string{pluralA, pluralA + roles.SuffixStatus},
+							Verbs:     roles.VerbsView,
 						},
 					},
 				},
@@ -224,7 +225,7 @@ func TestRenderClusterRoles(t *testing.T) {
 					Rules: []rbacv1.PolicyRule{
 						{
 							APIGroups: []string{groupA},
-							Resources: []string{pluralA, pluralA + suffixStatus},
+							Resources: []string{pluralA, pluralA + roles.SuffixStatus},
 							Verbs:     verbsSystem,
 						},
 						{
@@ -235,10 +236,10 @@ func TestRenderClusterRoles(t *testing.T) {
 						{
 							APIGroups: []string{"", coordinationv1.GroupName},
 							Resources: []string{pluralSecrets, pluralConfigmaps, pluralEvents, pluralLeases},
-							Verbs:     verbsEdit,
+							Verbs:     roles.VerbsEdit,
 						},
 						{
-							Verbs:     verbsView,
+							Verbs:     roles.VerbsView,
 							APIGroups: []string{"apiextensions.k8s.io"},
 							Resources: []string{"customresourcedefinitions"},
 						},

--- a/internal/controller/rbac/rbac.go
+++ b/internal/controller/rbac/rbac.go
@@ -22,8 +22,9 @@ import (
 
 	"github.com/crossplane/crossplane/v2/internal/controller/rbac/controller"
 	"github.com/crossplane/crossplane/v2/internal/controller/rbac/definition"
+	functionroles "github.com/crossplane/crossplane/v2/internal/controller/rbac/function/roles"
 	"github.com/crossplane/crossplane/v2/internal/controller/rbac/provider/binding"
-	"github.com/crossplane/crossplane/v2/internal/controller/rbac/provider/roles"
+	providerroles "github.com/crossplane/crossplane/v2/internal/controller/rbac/provider/roles"
 )
 
 // Setup RBAC manager controllers.
@@ -31,7 +32,8 @@ func Setup(mgr ctrl.Manager, o controller.Options) error {
 	for _, setup := range []func(ctrl.Manager, controller.Options) error{
 		definition.Setup,
 		binding.Setup,
-		roles.Setup,
+		providerroles.Setup,
+		functionroles.Setup,
 	} {
 		if err := setup(mgr, o); err != nil {
 			return err

--- a/internal/controller/rbac/roles/roles.go
+++ b/internal/controller/rbac/roles/roles.go
@@ -1,0 +1,131 @@
+/*
+Copyright 2025 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package roles provides shared utilities for RBAC role management.
+package roles
+
+import (
+	"strings"
+
+	"github.com/google/go-cmp/cmp"
+	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	xpv1 "github.com/crossplane/crossplane-runtime/v2/apis/common/v1"
+
+	"github.com/crossplane/crossplane/v2/apis/apiextensions/v1alpha1"
+)
+
+const (
+	// NameSuffixEdit is the suffix for edit aggregate roles.
+	NameSuffixEdit = ":aggregate-to-edit"
+
+	// NameSuffixView is the suffix for view aggregate roles.
+	NameSuffixView = ":aggregate-to-view"
+
+	// KeyAggregateToCrossplane is the label key for aggregating to crossplane role.
+	KeyAggregateToCrossplane = "rbac.crossplane.io/aggregate-to-crossplane"
+
+	// KeyAggregateToAdmin is the label key for aggregating to admin role.
+	KeyAggregateToAdmin = "rbac.crossplane.io/aggregate-to-admin"
+
+	// KeyAggregateToEdit is the label key for aggregating to edit role.
+	KeyAggregateToEdit = "rbac.crossplane.io/aggregate-to-edit"
+
+	// KeyAggregateToView is the label key for aggregating to view role.
+	KeyAggregateToView = "rbac.crossplane.io/aggregate-to-view"
+
+	// ValTrue is the value for true labels.
+	ValTrue = "true"
+
+	// SuffixStatus is the suffix for status subresources.
+	SuffixStatus = "/status"
+)
+
+//nolint:gochecknoglobals // We treat these as constants.
+var (
+	// VerbsEdit are the verbs for edit permissions.
+	VerbsEdit = []string{rbacv1.VerbAll}
+
+	// VerbsView are the verbs for view permissions.
+	VerbsView = []string{"get", "list", "watch"}
+)
+
+// A Resource is a Kubernetes API resource.
+type Resource struct {
+	// Group is the unversioned API group of this resource.
+	Group string
+
+	// Plural is the plural name of this resource.
+	Plural string
+}
+
+// DefinedResources returns the resources defined by the supplied references.
+func DefinedResources(refs []xpv1.TypedReference) []Resource {
+	out := make([]Resource, 0, len(refs))
+	for _, ref := range refs {
+		// This would only return an error if the APIVersion contained more than
+		// one "/". This should be impossible, but if it somehow happens we'll
+		// just skip this resource since it can't be a CRD.
+		gv, _ := schema.ParseGroupVersion(ref.APIVersion)
+
+		// We're only concerned with CRDs or MRDs.
+		switch {
+		case gv.Group == apiextensions.GroupName && ref.Kind == "CustomResourceDefinition":
+		// Do the work!
+		case gv.Group == v1alpha1.Group && ref.Kind == v1alpha1.ManagedResourceDefinitionKind:
+		// Do the work!
+		default:
+			// Filter out the non CRD or MRD.
+			continue
+		}
+
+		p, g, valid := strings.Cut(ref.Name, ".")
+		if !valid {
+			// This shouldn't be possible - CRDs must be named <plural>.<group>.
+			continue
+		}
+
+		out = append(out, Resource{Group: g, Plural: p})
+	}
+
+	return out
+}
+
+// ClusterRolesDiffer returns true if the supplied objects are different
+// ClusterRoles. We consider ClusterRoles to be different if their labels and
+// rules do not match.
+func ClusterRolesDiffer(current, desired runtime.Object) bool {
+	// Calling this with anything but ClusterRoles is a programming error. If it
+	// happens, we probably do want to panic.
+	c := current.(*rbacv1.ClusterRole) //nolint:forcetypeassert // See above.
+	d := desired.(*rbacv1.ClusterRole) //nolint:forcetypeassert // See above.
+
+	return !cmp.Equal(c.GetLabels(), d.GetLabels()) || !cmp.Equal(c.Rules, d.Rules)
+}
+
+// WithVerbs returns a copy of the supplied rules with the supplied verbs.
+func WithVerbs(r []rbacv1.PolicyRule, verbs []string) []rbacv1.PolicyRule {
+	verbal := make([]rbacv1.PolicyRule, len(r))
+	for i := range r {
+		verbal[i] = r[i]
+		verbal[i].Verbs = verbs
+	}
+
+	return verbal
+}


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane! Please read the contribution docs
(linked below) if this is your first Crossplane pull request.
-->

### Description of your changes

<!--
Briefly describe what this pull request does, and how it is covered by tests.
Be proactive - direct your reviewers' attention to anything that needs special
consideration.

We love pull requests that fix an open issue. If yours does, use the below line
to indicate which issue it fixes, for example "Fixes #500".
-->

This PR implements RBAC role management for FunctionRevisions, mirroring the existing ProviderRevision RBAC support. The RBAC manager now automatically creates ClusterRoles for resources defined by Functions.

This is needed because we currently deploy inputs CRDs, so tooling relying on CRDs to understand what's a crossplane resource could still try to get those resources and fail due to the lack of permissions, we could have just omitted CRDs owned by functions, but some Functions come with proper CRDs intended for human consumption, e.g. https://github.com/upbound/function-claude-status-transformer/blob/main/package/input/function-claude-status-transformer.fn.crossplane.io_functionconfigs.yaml, I didn't go as far as setting up RBAC for functions to be able to directly access those, that would be against the spec and they should go through extra-resources.

Key differences from Provider RBAC:
- Creates only edit and view aggregated roles (no system role)
- Functions are invoked via gRPC and don't need direct Kubernetes API access

Changes:
1. New controller in internal/controller/rbac/function/roles/ watches FunctionRevisions and creates ClusterRoles
2. Extracted shared RBAC utilities to internal/controller/rbac/roles/ to reduce duplication
3. Updated Helm chart to grant RBAC manager permissions for FunctionRevisions

Test coverage includes unit tests, fuzz testing, and verification on live cluster with function-patch-and-transform.
```
 # Spin up cluster
earthly +hack

# Install function
kubectl apply -f - <<EOF
apiVersion: pkg.crossplane.io/v1beta1
kind: Function
metadata:
  name: upbound-function-patch-and-transform
spec:
  package: xpkg.upbound.io/upbound/function-patch-and-transform:v0.9.1
EOF

# Wait for function to be healthy
kubectl wait --for=condition=Healthy --timeout=2m function/upbound-function-patch-and-transform

# Verify ClusterRoles were created
kubectl get clusterroles | grep "crossplane:function"
# Check their content manually.
```
I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `earthly +reviewable` to ensure this PR is ready for review.
- [x] Added or updated unit tests.
- [x] Added or updated e2e tests.
- [x] Linked a PR or a [docs tracking issue] to [document this change].
- [x] Added `backport release-x.y` labels to auto-backport this PR.
- [x] Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md