### PR TITLE
docs: add RELEASE.md and links to crossplane/release for better discoverability of release process

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ documentation].
 You can subscribe to the [community calendar] to track all release dates, and
 find the most recent releases on the [releases] page.
 
+The release process is fully documented in the [`crossplane/release`] repo.
+
 ## Roadmap
 
 The public roadmap for Crossplane is published as a GitHub project board. Issues
@@ -144,6 +146,7 @@ Crossplane is under the Apache 2.0 license.
 [Get Started Docs]: https://docs.crossplane.io/latest/get-started/get-started-with-composition
 [community calendar]: https://zoom-lfx.platform.linuxfoundation.org/meetings/crossplane?view=month
 [releases]: https://github.com/crossplane/crossplane/releases
+[`crossplane/release`]: https://github.com/crossplane/release
 [ADOPTERS.md]: ADOPTERS.md
 [regular community meetings]: https://github.com/crossplane/crossplane/blob/main/README.md#get-involved
 [Crossplane Roadmap]: https://github.com/orgs/crossplane/projects/20/views/9?pane=info

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,10 @@
+# Crossplane Releases
+
+The release process for the Crossplane project is fully documented in the
+[`crossplane/release`] repo.
+
+Tracking issues with complete process checklists
+for past and upcoming releases can be found there as well.
+
+<!-- Named links -->
+[`crossplane/release`]: https://github.com/crossplane/release


### PR DESCRIPTION
### Description of your changes

This PR adds a new RELEASE.md file at the root of the repo for better discoverability of our Crossplane release processes documented in https://github.com/crossplane/release.

The main README is also updated with this link.

This update is related to graduation due diligence.

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `earthly +reviewable` to ensure this PR is ready for review.
- [ ] ~Added or updated unit tests.~
- [ ] ~Added or updated e2e tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~
- [ ] ~Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md