### PR TITLE
fix(xrd): Use per-field validation rules

### DIFF
--- a/apis/apiextensions/v1/xrd_types.go
+++ b/apis/apiextensions/v1/xrd_types.go
@@ -47,7 +47,10 @@ type CompositeResourceDefinitionSpec struct {
 
 	// Names specifies the resource and kind names of the defined composite
 	// resource.
-	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="Value is immutable"
+	// +kubebuilder:validation:XValidation:rule="self.plural == oldSelf.plural",message="plural is immutable"
+	// +kubebuilder:validation:XValidation:rule="self.singular == oldSelf.singular",message="singular is immutable"
+	// +kubebuilder:validation:XValidation:rule="self.kind == oldSelf.kind",message="kind is immutable"
+	// +kubebuilder:validation:XValidation:rule="self.listKind == oldSelf.listKind",message="listKind is immutable"
 	// +kubebuilder:validation:XValidation:rule="self.plural == self.plural.lowerAscii()",message="Plural name must be lowercase"
 	// +kubebuilder:validation:XValidation:rule="!has(self.singular) || self.singular == self.singular.lowerAscii()",message="Singular name must be lowercase"
 	Names extv1.CustomResourceDefinitionNames `json:"names"`
@@ -72,7 +75,10 @@ type CompositeResourceDefinitionSpec struct {
 	// claim names to an existing CompositeResourceDefinition, but they cannot
 	// be changed or removed once they have been set.
 	// +optional
-	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="Value is immutable"
+	// +kubebuilder:validation:XValidation:rule="self.plural == oldSelf.plural",message="plural is immutable"
+	// +kubebuilder:validation:XValidation:rule="self.singular == oldSelf.singular",message="singular is immutable"
+	// +kubebuilder:validation:XValidation:rule="self.kind == oldSelf.kind",message="kind is immutable"
+	// +kubebuilder:validation:XValidation:rule="self.listKind == oldSelf.listKind",message="listKind is immutable"
 	// +kubebuilder:validation:XValidation:rule="self.plural == self.plural.lowerAscii()",message="Plural name must be lowercase"
 	// +kubebuilder:validation:XValidation:rule="!has(self.singular) || self.singular == self.singular.lowerAscii()",message="Singular name must be lowercase"
 	ClaimNames *extv1.CustomResourceDefinitionNames `json:"claimNames,omitempty"`
@@ -99,7 +105,6 @@ type CompositeResourceDefinitionSpec struct {
 	// EnforcedCompositionRef refers to the Composition resource that will be used
 	// by all composite instances whose schema is defined by this definition.
 	// +optional
-	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="Value is immutable"
 	EnforcedCompositionRef *CompositionReference `json:"enforcedCompositionRef,omitempty"`
 
 	// DefaultCompositionUpdatePolicy is the policy used when updating composites after a new

--- a/cluster/crds/apiextensions.crossplane.io_compositeresourcedefinitions.yaml
+++ b/cluster/crds/apiextensions.crossplane.io_compositeresourcedefinitions.yaml
@@ -117,8 +117,14 @@ spec:
                 - plural
                 type: object
                 x-kubernetes-validations:
-                - message: Value is immutable
-                  rule: self == oldSelf
+                - message: plural is immutable
+                  rule: self.plural == oldSelf.plural
+                - message: singular is immutable
+                  rule: self.singular == oldSelf.singular
+                - message: kind is immutable
+                  rule: self.kind == oldSelf.kind
+                - message: listKind is immutable
+                  rule: self.listKind == oldSelf.listKind
                 - message: Plural name must be lowercase
                   rule: self.plural == self.plural.lowerAscii()
                 - message: Singular name must be lowercase
@@ -281,9 +287,6 @@ spec:
                 required:
                 - name
                 type: object
-                x-kubernetes-validations:
-                - message: Value is immutable
-                  rule: self == oldSelf
               group:
                 description: |-
                   Group specifies the API group of the defined composite resource.
@@ -366,8 +369,14 @@ spec:
                 - plural
                 type: object
                 x-kubernetes-validations:
-                - message: Value is immutable
-                  rule: self == oldSelf
+                - message: plural is immutable
+                  rule: self.plural == oldSelf.plural
+                - message: singular is immutable
+                  rule: self.singular == oldSelf.singular
+                - message: kind is immutable
+                  rule: self.kind == oldSelf.kind
+                - message: listKind is immutable
+                  rule: self.listKind == oldSelf.listKind
                 - message: Plural name must be lowercase
                   rule: self.plural == self.plural.lowerAscii()
                 - message: Singular name must be lowercase


### PR DESCRIPTION
### Description of your changes

Replace property-wide `self == oldSef` validation rule with validation of individual properties to allow chainging the value of properties that do not affect the naming or behaviour of CRDs/XRDs, like categories and shortnames.

Also, remove the validation rule for enforcedCompositionRef as this should be able to be changed in the future if, say, the ops teams decides to enforce a newer composition. With the rule enabled it would be impossible to change the enforced composition ever again without deleting the whole XRD and risk deleting all underlying claims and composite resources.

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `earthly +reviewable` to ensure this PR is ready for review.
- [x] Added or updated unit tests.
- [x] Added or updated e2e tests.
- [x] Linked a PR or a [docs tracking issue] to [document this change].
- [x] Added `backport release-x.y` labels to auto-backport this PR.
- [x] Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Validation errors for CompositeResourceDefinition names are now granular, clearly indicating which field (plural, singular, kind, listKind) is immutable.
  * The same granular validation applies to claim names, improving error clarity.
  * Enforced composition reference is now editable (no longer treated as immutable).
  * Lowercase checks for plural and singular names are retained to prevent invalid values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->