### PR TITLE
build: update releases/charts bucket names

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -489,7 +489,7 @@ ci-push-build-artifacts:
   ARG --required CROSSPLANE_VERSION
   ARG --required BUILD_DIR
   ARG ARTIFACTS_DIR=_output
-  ARG BUCKET_RELEASES=crossplane.releases
+  ARG BUCKET_RELEASES=crossplane-releases
   ARG AWS_DEFAULT_REGION
   FROM amazon/aws-cli:2.15.61
   COPY --dir ${ARTIFACTS_DIR} artifacts
@@ -503,8 +503,8 @@ ci-promote-build-artifacts:
   ARG --required BUILD_DIR
   ARG --required CHANNEL
   ARG HELM_REPO_URL=https://charts.crossplane.io
-  ARG BUCKET_RELEASES=crossplane.releases
-  ARG BUCKET_CHARTS=crossplane.charts
+  ARG BUCKET_RELEASES=crossplane-releases
+  ARG BUCKET_CHARTS=crossplane-helm-charts
   ARG PRERELEASE=false
   ARG AWS_DEFAULT_REGION
   FROM amazon/aws-cli:2.15.61


### PR DESCRIPTION
### Description of your changes

This PR simply updates the build scripts to publish to the new S3 artifacts buckets. The data has already been migrated, but we need to switch the build to actually publish there too.

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `earthly +reviewable` to ensure this PR is ready for review.
- [ ] ~Added or updated unit tests.~
- [ ] ~Added or updated e2e tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~
- [ ] ~Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md