### PR TITLE
fix: update CompositionRevision migrator for v1.20 to upgrade from v1beta1 to current (v1)

### DIFF
--- a/cmd/crossplane/core/init.go
+++ b/cmd/crossplane/core/init.go
@@ -95,7 +95,7 @@ func (c *initCommand) Run(s *runtime.Scheme, log logging.Logger) error {
 	// CRD migrator steps are done after core CRDs are applied/updated, so we
 	// are always migrating to the most current storage version
 	steps = append(steps,
-		initializer.NewCoreCRDsMigrator("compositionrevisions.apiextensions.crossplane.io", "v1alpha1"),
+		initializer.NewCoreCRDsMigrator("compositionrevisions.apiextensions.crossplane.io", "v1beta1"),
 		initializer.NewCoreCRDsMigrator("environmentconfigs.apiextensions.crossplane.io", "v1alpha1"),
 		initializer.NewCoreCRDsMigrator("usages.apiextensions.crossplane.io", "v1beta1"),
 		initializer.NewCoreCRDsMigrator("functions.pkg.crossplane.io", "v1beta1"),


### PR DESCRIPTION
### Description of your changes

This PR updates the `CompositionRevision` migrator for v1.20 to upgrade from `v1beta1` to the current storage version in that release, which is v1. The current code in v1.20 is migrating incorrectly from `v1alpha1`, which was removed way back in v1.13. There is no need to keep migrating from that version that no longer exists.

v1.20 is the last version that `v1beta1` exists in, so this is the perfect time to migrate away from it and ensure all resources are stored as `v1`.

The root cause, repro steps, and testing workflow are demonstrated in the following gist:

* https://gist.github.com/jbw976/246eda39c96a6e14926178a5f757d1c7 

Fixes https://github.com/crossplane/crossplane/issues/6717

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `earthly +reviewable` to ensure this PR is ready for review.
- [ ] ~Added or updated unit tests.~
- [ ] ~Added or updated e2e tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~
- [x] Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md