### PR TITLE
Refactor circuit breaker metrics to match Crossplane patterns

### DIFF
--- a/internal/circuit/circuit_metrics.go
+++ b/internal/circuit/circuit_metrics.go
@@ -20,20 +20,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
-const (
-	// CircuitBreakerResultAllowed indicates the event was processed while the circuit
-	// was closed.
-	CircuitBreakerResultAllowed = "allowed"
-
-	// CircuitBreakerResultDropped indicates the event was dropped while the circuit
-	// was open.
-	CircuitBreakerResultDropped = "dropped"
-
-	// CircuitBreakerResultHalfOpenAllowed indicates the event was processed while
-	// probing a half-open circuit.
-	CircuitBreakerResultHalfOpenAllowed = "halfopen_allowed"
-)
-
 var (
 	_ Metrics              = &NopMetrics{}
 	_ Metrics              = &PrometheusMetrics{}

--- a/internal/circuit/mapfunc.go
+++ b/internal/circuit/mapfunc.go
@@ -28,11 +28,7 @@ import (
 // NewMapFunc wraps a handler.MapFunc with circuit breaker functionality.
 // It records events for each target resource and filters out requests when the
 // circuit breaker is open, allowing occasional requests through in half-open state.
-func NewMapFunc(wrapped handler.MapFunc, breaker Breaker, m Metrics, controller string) handler.MapFunc {
-	if m == nil {
-		m = &NopMetrics{}
-	}
-
+func NewMapFunc(wrapped handler.MapFunc, b Breaker) handler.MapFunc {
 	return func(ctx context.Context, obj client.Object) []reconcile.Request {
 		// Get the original requests
 		requests := wrapped(ctx, obj)
@@ -47,39 +43,40 @@ func NewMapFunc(wrapped handler.MapFunc, breaker Breaker, m Metrics, controller 
 		// Filter out requests for resources with open circuit breakers
 		keep := make([]reconcile.Request, 0, len(requests))
 		for _, req := range requests {
-			// If object is marked for deletion, always allow the
-			// event through without affecting circuit breaker
-			// timing. This ensures deletion events (which are
-			// MODIFIED events with deletionTimestamp set) can reach
-			// the reconciler to remove finalizers.
+			// If object is marked for deletion, always allow the event through
+			// without any circuit breaker interaction. This ensures deletion
+			// events (which are MODIFIED events with deletionTimestamp set) can
+			// reach the reconciler to remove finalizers. Unlike normal events,
+			// deletion is a one-way operation - if we drop this event the
+			// resource will be stuck until the next cache resync (default 1
+			// hour), since no further updates will occur once deletionTimestamp
+			// is set. We don't record these events in circuit breaker state or
+			// metrics since they bypass circuit breaker logic entirely for
+			// correctness, not as a circuit breaker decision.
 			if obj.GetDeletionTimestamp() != nil {
-				m.IncEvent(controller, CircuitBreakerResultAllowed)
 				keep = append(keep, req)
 				continue
 			}
 
-			// Always record the event for tracking
-			breaker.RecordEvent(ctx, req.NamespacedName, source)
-
 			// Get current state
-			state := breaker.GetState(ctx, req.NamespacedName)
+			state := b.GetState(ctx, req.NamespacedName)
 
 			// If breaker is closed, allow the request
 			if !state.IsOpen {
+				b.RecordEvent(ctx, req.NamespacedName, source, EventAllowed)
 				keep = append(keep, req)
-				m.IncEvent(controller, CircuitBreakerResultAllowed)
 				continue
 			}
 
 			// Breaker is open - check if we should allow in half-open state
 			if time.Now().After(state.NextAllowedAt) {
+				b.RecordEvent(ctx, req.NamespacedName, source, EventHalfOpenAllowed)
 				keep = append(keep, req)
-				breaker.RecordAllowed(ctx, req.NamespacedName)
-				m.IncEvent(controller, CircuitBreakerResultHalfOpenAllowed)
 				continue
 			}
+
 			// Otherwise filter out - fully open state
-			m.IncEvent(controller, CircuitBreakerResultDropped)
+			b.RecordEvent(ctx, req.NamespacedName, source, EventDropped)
 		}
 
 		return keep

--- a/internal/controller/apiextensions/composite/reconciler_test.go
+++ b/internal/controller/apiextensions/composite/reconciler_test.go
@@ -1357,9 +1357,8 @@ func TestReconcile(t *testing.T) {
 
 // MockCircuitBreaker is a mock implementation of circuit.Breaker for testing.
 type MockCircuitBreaker struct {
-	MockGetState      func(ctx context.Context, target types.NamespacedName) circuit.State
-	MockRecordEvent   func(ctx context.Context, target types.NamespacedName, source circuit.EventSource)
-	MockRecordAllowed func(ctx context.Context, target types.NamespacedName)
+	MockGetState    func(ctx context.Context, target types.NamespacedName) circuit.State
+	MockRecordEvent func(ctx context.Context, target types.NamespacedName, es circuit.EventSource, et circuit.EventType)
 }
 
 // GetState calls MockGetState if set, otherwise returns a closed circuit.
@@ -1371,16 +1370,9 @@ func (m *MockCircuitBreaker) GetState(ctx context.Context, target types.Namespac
 }
 
 // RecordEvent calls MockRecordEvent if set.
-func (m *MockCircuitBreaker) RecordEvent(ctx context.Context, target types.NamespacedName, source circuit.EventSource) {
+func (m *MockCircuitBreaker) RecordEvent(ctx context.Context, target types.NamespacedName, es circuit.EventSource, et circuit.EventType) {
 	if m.MockRecordEvent != nil {
-		m.MockRecordEvent(ctx, target, source)
-	}
-}
-
-// RecordAllowed calls MockRecordAllowed if set.
-func (m *MockCircuitBreaker) RecordAllowed(ctx context.Context, target types.NamespacedName) {
-	if m.MockRecordAllowed != nil {
-		m.MockRecordAllowed(ctx, target)
+		m.MockRecordEvent(ctx, target, es, et)
 	}
 }
 

--- a/internal/controller/apiextensions/definition/reconciler.go
+++ b/internal/controller/apiextensions/definition/reconciler.go
@@ -570,7 +570,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 		}
 
 		cmf := CompositeResourcesMapFunc(d.GetCompositeGroupVersionKind(), r.engine.GetCached(), r.log)
-		h := handler.EnqueueRequestsFromMapFunc(circuit.NewMapFunc(cmf, cb, r.options.CircuitBreakerMetrics, controllerName))
+		h := handler.EnqueueRequestsFromMapFunc(circuit.NewMapFunc(cmf, cb))
 		ro = append(ro,
 			composite.WithWatchStarter(controllerName, h, r.engine),
 			composite.WithPollInterval(0), // Disable polling.
@@ -619,9 +619,9 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 	xr.SetGroupVersionKind(gvk)
 
 	crmf := CompositionRevisionMapFunc(gvk, schema, r.engine.GetCached(), log)
-	crh := handler.EnqueueRequestsFromMapFunc(circuit.NewMapFunc(crmf, cb, r.options.CircuitBreakerMetrics, controllerName))
+	crh := handler.EnqueueRequestsFromMapFunc(circuit.NewMapFunc(crmf, cb))
 
-	h := handler.EnqueueRequestsFromMapFunc(circuit.NewMapFunc(SelfMapFunc(), cb, r.options.CircuitBreakerMetrics, controllerName))
+	h := handler.EnqueueRequestsFromMapFunc(circuit.NewMapFunc(SelfMapFunc(), cb))
 
 	if err := r.engine.StartWatches(ctx, name,
 		engine.WatchFor(xr, engine.WatchTypeCompositeResource, h),


### PR DESCRIPTION
### Description of your changes

This PR refactors the circuit breaker metrics implementation from #6854 to follow Crossplane's established patterns and simplify the architecture.

The metrics implementation now matches the pattern in `internal/engine/engine_metrics.go` by using `Subsystem` instead of `Namespace` in Prometheus metric definitions and passing metrics via `WithMetrics()` option instead of a constructor parameter. This changes metric names from `crossplane_circuit_breaker_*` to `circuit_breaker_*`, which is fine since these metrics haven't been released yet.

The more significant change moves metrics recording into the circuit breaker implementation itself. The breaker's `RecordEvent()` method now takes an `EventType` parameter (`EventAllowed`, `EventDropped`, `EventHalfOpenAllowed`) and records metrics internally. This simplifies MapFunc's signature from `NewMapFunc(wrapped, breaker, metrics, controller)` to `NewMapFunc(wrapped, breaker)`. MapFunc now just tells the breaker what happened, and the breaker handles both state management and metrics recording.

During review I also noticed that deletion events were being counted in metrics even though they bypass circuit breaker logic (they must always be allowed to prevent resources from getting stuck waiting for finalizer removal). Deletion events now skip metrics recording entirely and the comment explaining this behavior has been expanded.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `earthly +reviewable` to ensure this PR is ready for review.
- [x] Added or updated unit tests.
- [ ] ~Added or updated e2e tests~.
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change]~.
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR~.
- [ ] ~Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API~.

[contribution process]: https://git.io/fj2m9
[docs tracking issue]: https://github.com/crossplane/docs/issues
[document this change]: https://docs.crossplane.io/contribute/contribute/#documenting-changes
[API promotion workflow]: https://docs.crossplane.io/contribute/feature-lifecycle/#api-promotion-workflow
[cheat sheet]: https://crossplane.io/contribute/cheat-sheet/