### PR TITLE
feat(helm): Set automountServiceAccountToken on service accounts

### DIFF
--- a/cluster/charts/crossplane/templates/rbac-manager-serviceaccount.yaml
+++ b/cluster/charts/crossplane/templates/rbac-manager-serviceaccount.yaml
@@ -13,4 +13,5 @@ imagePullSecrets:
 - name: {{ $secret }}
 {{- end }}
 {{- end }}
+automountServiceAccountToken: true
 {{- end}}

--- a/cluster/charts/crossplane/templates/serviceaccount.yaml
+++ b/cluster/charts/crossplane/templates/serviceaccount.yaml
@@ -16,4 +16,5 @@ imagePullSecrets:
 - name: {{ $secret }}
 {{- end }}
 {{ end }}
+automountServiceAccountToken: true
 {{- end }}


### PR DESCRIPTION
### Description of your changes

It is considered best practice (see: CIS EKS Benchmark 4.1.6) to only mount the service account token when necessary. In the case of the crossplane charts, the API token is needed as there is are RBAC role bindings to the service accounts. Since `automountServiceAccountToken` defaults to `true`, there is no functional change - this only adds clarity to the chart.

Fixes #6874

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `earthly +reviewable` to ensure this PR is ready for review.
- [ ] ~Added or updated unit tests.~
- [ ] ~Added or updated e2e tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [ ] Added `backport release-x.y` labels to auto-backport this PR.
- [ ] ~Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md