### PR TITLE
chore(deps): bump crossplane-runtime to v2.2.0-rc.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/Masterminds/semver v1.5.0
 	github.com/alecthomas/kong v1.4.0
 	github.com/containerd/errdefs v1.0.0
-	github.com/crossplane/crossplane-runtime/v2 v2.1.0-rc.0.0.20251007191542-756e2d041413
+	github.com/crossplane/crossplane-runtime/v2 v2.2.0-rc.0
 	github.com/docker/docker v28.3.3+incompatible
 	github.com/docker/go-connections v0.5.0
 	github.com/emicklei/dot v1.8.0

--- a/go.sum
+++ b/go.sum
@@ -207,8 +207,8 @@ github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSV
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/creack/pty v1.1.18 h1:n56/Zwd5o6whRC5PMGretI4IdRLlmBXYNjScPaBgsbY=
 github.com/creack/pty v1.1.18/go.mod h1:MOBLtS5ELjhRRrroQr9kyvTxUAFNvYEK993ew/Vr4O4=
-github.com/crossplane/crossplane-runtime/v2 v2.1.0-rc.0.0.20251007191542-756e2d041413 h1:8de5Hbfz6d5DPoIwjsrhUCcvsTl3WyDFLteoBg0JMD4=
-github.com/crossplane/crossplane-runtime/v2 v2.1.0-rc.0.0.20251007191542-756e2d041413/go.mod h1:Hn1U4BazS6qzGeBOfAWJLfuI1CnFofPS9dCUcAlc93A=
+github.com/crossplane/crossplane-runtime/v2 v2.2.0-rc.0 h1:06kaL2nnBdaXU+fMGR8Nfl8JGYBKz9iJ2w+GWzlfNs8=
+github.com/crossplane/crossplane-runtime/v2 v2.2.0-rc.0/go.mod h1:j78pmk0qlI//Ur7zHhqTr8iePHFcwJKrZnzZB+Fg4t0=
 github.com/cyberphone/json-canonicalization v0.0.0-20231011164504-785e29786b46 h1:2Dx4IHfC1yHWI12AxQDJM1QbRCDfk6M+blLzlZCXdrc=
 github.com/cyberphone/json-canonicalization v0.0.0-20231011164504-785e29786b46/go.mod h1:uzvlm1mxhHkdfqitSA92i7Se+S9ksOn3a3qmv/kyOCw=
 github.com/cyphar/filepath-securejoin v0.3.6 h1:4d9N5ykBnSp5Xn2JkhocYDkOpURL/18CYMpo6xB9uWM=


### PR DESCRIPTION
### Description of your changes

As per https://github.com/crossplane/release/issues/51: 

> (On the Main Branch) created and merged a PR bumping the Crossplane Runtime dependency to the release candidate tag on main, v2.2.0-rc.0.

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `earthly +reviewable` to ensure this PR is ready for review.
- [ ] ~Added or updated unit tests.~
- [ ] ~Added or updated e2e tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.`
- [ ] ~Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.`

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md