### PR TITLE
Fix Docker port binding race condition on macOS by using HostPort "0"

### DIFF
--- a/cmd/crank/render/runtime_docker.go
+++ b/cmd/crank/render/runtime_docker.go
@@ -264,7 +264,7 @@ func (r *RuntimeDocker) createContainer(ctx context.Context, cli *client.Client)
 		PortBindings: nat.PortMap{
 			port: []nat.PortBinding{{
 				HostIP:   r.BindAddress,
-				HostPort: "", // empty => engine allocates an ephemeral port
+				HostPort: "0", // "0" => engine allocates an ephemeral port
 			}},
 		},
 	}


### PR DESCRIPTION
### Description of your changes

PR #6799 introduced a race condition on macOS by changing from nat.ParsePortSpecs() (which returns HostPort: "0") to manual construction (HostPort: "").

Docker's behavior on macOS differs between these two values:
- HostPort: "0" → NetworkSettings.Ports populated synchronously
- HostPort: "" → NetworkSettings.Ports populated asynchronously

This caused intermittent failures when inspecting containers immediately after ContainerStart() on macOS because the port bindings array would be empty.

The fix uses HostPort: "0" instead of "" to ensure port bindings are available immediately after container start, matching the behavior of the original nat.ParsePortSpecs() implementation.

<!--
Thank you for helping to improve Crossplane! Please read the contribution docs
(linked below) if this is your first Crossplane pull request.
-->

<!--
Briefly describe what this pull request does, and how it is covered by tests.
Be proactive - direct your reviewers' attention to anything that needs special
consideration.

We love pull requests that fix an open issue. If yours does, use the below line
to indicate which issue it fixes, for example "Fixes #500".
-->

Fixes #

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `earthly +reviewable` to ensure this PR is ready for review.
- [ ] ~Added or updated unit tests.~
- [ ] ~Added or updated e2e tests.~
- [x] Linked a PR or a [docs tracking issue] to [document this change].
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~
- [ ] ~Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md