### PR TITLE
Fix XR circuit breaker to account for double token consumption

### DIFF
--- a/internal/controller/apiextensions/controller/options.go
+++ b/internal/controller/apiextensions/controller/options.go
@@ -18,6 +18,8 @@ limitations under the License.
 package controller
 
 import (
+	"time"
+
 	"github.com/crossplane/crossplane-runtime/v2/pkg/controller"
 
 	"github.com/crossplane/crossplane/v2/internal/circuit"
@@ -37,4 +39,13 @@ type Options struct {
 
 	// CircuitBreakerMetrics records XR circuit breaker activity.
 	CircuitBreakerMetrics *circuit.PrometheusMetrics
+
+	// CircuitBreakerBurst is the token bucket capacity for XR circuit breakers.
+	CircuitBreakerBurst float64
+
+	// CircuitBreakerRefillRate is the token refill rate (tokens/second) for XR circuit breakers.
+	CircuitBreakerRefillRate float64
+
+	// CircuitBreakerCooldown is how long XR circuit breakers stay open after triggering.
+	CircuitBreakerCooldown time.Duration
 }

--- a/internal/controller/apiextensions/definition/reconciler.go
+++ b/internal/controller/apiextensions/definition/reconciler.go
@@ -518,8 +518,13 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 	)
 
 	controllerName := composite.ControllerName(d.GetName())
-	cb := circuit.NewTokenBucketBreaker(controllerName, circuit.WithMetrics(r.options.CircuitBreakerMetrics))
 	gvk := d.GetCompositeGroupVersionKind()
+	cb := circuit.NewTokenBucketBreaker(controllerName,
+		circuit.WithMetrics(r.options.CircuitBreakerMetrics),
+		circuit.WithBurst(r.options.CircuitBreakerBurst),
+		circuit.WithRefillRatePerSecond(r.options.CircuitBreakerRefillRate),
+		circuit.WithOpenDuration(r.options.CircuitBreakerCooldown),
+	)
 
 	// All XRs have modern schema unless their XRD's scope is LegacyCluster.
 	schema := ucomposite.SchemaModern


### PR DESCRIPTION

<!--
Thank you for helping to improve Crossplane! Please read the contribution docs
(linked below) if this is your first Crossplane pull request.
-->

### Description of your changes

<!--
Briefly describe what this pull request does, and how it is covered by tests.
Be proactive - direct your reviewers' attention to anything that needs special
consideration.

We love pull requests that fix an open issue. If yours does, use the below line
to indicate which issue it fixes, for example "Fixes #500".
-->

Fixes https://github.com/crossplane/crossplane/issues/6910

The XR circuit breaker was opening during normal XR initialization, even with --max-concurrent-reconciles=1. XRs typically go through 25-30 rapid updates during initialization (adding finalizers, refs, status updates as composed resources become ready). This was exhausting the 50-token burst capacity and opening the circuit.

Controller-runtime's Update event handler calls MapFunc twice - once with the old object, once with the new object - to allow handlers to react to both states before deduplicating the reconcile requests. The circuit breaker wraps MapFunc, so it records events before deduplication happens. This means Update events consume 2 tokens instead of 1.

This commit doubles the default burst capacity (50 -> 100 tokens) and refill rate (0.5 -> 1.0 tokens/second) to compensate. The effective limits for Update events remain at 50-event burst and 1 event per 2 seconds sustained. Create and Delete events get more headroom, which is acceptable since they're rarer.

This commit also adds three CLI flags to make the circuit breaker tunable without recompiling: --circuit-breaker-burst, --circuit-breaker-refill-rate, and --circuit-breaker-cooldown. The half-open interval and garbage collection duration remain hardcoded as internal implementation details.

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `earthly +reviewable` to ensure this PR is ready for review.
- [ ] ~Added or updated unit tests.~
- [ ] ~Added or updated e2e tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~
- [ ] ~Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md