### PR TITLE
fix(mrd): update CRDs when ownerReferences change

### DIFF
--- a/internal/controller/apiextensions/managed/reconciler_test.go
+++ b/internal/controller/apiextensions/managed/reconciler_test.go
@@ -549,7 +549,6 @@ func TestReconcile(t *testing.T) {
 									Kind:       "ManagedResourceDefinition",
 									Name:       "test-mrd",
 									UID:        "test-uid",
-									Controller: ptr.To(false),
 								},
 								{
 									APIVersion: "pkg.crossplane.io/v1",
@@ -602,7 +601,7 @@ func TestReconcile(t *testing.T) {
 									},
 									{
 										APIVersion: "pkg.crossplane.io/v1",
-										Controller: ptr.To(false), // old provider revision should not be a controller anymore
+										Controller: nil, // old provider revision should not be a controller anymore
 										Kind:       "ProviderRevision",
 										Name:       "old-provider-revision",
 										UID:        "old-provider-revision-uid",


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane! Please read the contribution docs
(linked below) if this is your first Crossplane pull request.
-->

### Description of your changes

- Ensure MRD controller updates the CRDs when the spec is unchanged, but `ownerReferences` change.
- In MRD controller, when a new `ProviderRevision` becomes active, handle `ownerReferences` changes for an existing CRD by releasing the old controller reference and setting the new active `ProviderRevision`.

Context:
With Crossplane v2  `features.EnableBetaCustomToManagedResourceConversion` is enabled by default. CRDs in a provider package are converted to MRDs. This means `ProviderRevision` controls and has object refs to MRDs, not the CRDs. Therefore, during deactivation of a `ProviderRevision/foo-1111aaaa` releases control of MRDs, but not the corresponding CRDs. 

When a new `ProviderRevision/foo-2222bbbb` becomes active, MRD controller tries to set the `ProviderRevision` `foo-2222bbbb` as a new controller reference to the CRD. However, `ProviderRevision/foo-1111aaaa` still there as a controller reference, therefore the staged change is invalid, as it contains two controller refs in the ownerReferences.

This PR ensures that the `ProviderRevision/foo-1111aaaa` becomes a non-controller ownerRef first, and sets ProviderRevision/foo-2222bbbb` as the new controller ref, resulting a valid CRD update and controller transfer.

Background:

Some prior discussions regarding the ownership graph and why it was needed like this:
https://github.com/crossplane/crossplane/pull/6639#issuecomment-3119380618
https://github.com/crossplane/crossplane/pull/6639#issuecomment-3119868889

We still keep the ownership graph as is.
```
          +--------------------+ 
          |                    v 
ProviderRevision -->  MRD --> CRD
```

So, the ownerRefs at a CRD will look like:

before provider upgrade (omitted fields for brevity)
```yaml
kind: CustomResourceDefinition
metadata:
  ownerReferences:
  - kind: ManagedResourceDefinition
    name: some-mrd
    controller: false # mrd is always a non-controlling owner
  - kind: ProviderRevision
    name: provider-foo-1111aaaa
    controller: true # providerrevision is the controlling owner
```
after a provider upgrade:
```yaml
kind: CustomResourceDefinition
metadata:
  ownerReferences:
  - kind: ManagedResourceDefinition
    name: some-mrd
    controller: false # mrd is always a non-controlling owner
  - kind: ProviderRevision
    name: provider-foo-1111aaaa
    controller: false # old revision is now a non-controlling owner
  - kind: ProviderRevision
    name: provider-foo-2222bbbb
    controller: true # new active revision is the controlling owner
```

Fixes #6804 #6761

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `earthly +reviewable` to ensure this PR is ready for review.
- [x] Added or updated unit tests.
- [x] ~Added or updated e2e tests.~
- [x] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [x] Added `backport release-x.y` labels to auto-backport this PR.
- [ ] ~Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md