### PR TITLE
Allow configuring custom annotations on Crossplane helm chart secret resources

### DIFF
--- a/cluster/charts/crossplane/README.md
+++ b/cluster/charts/crossplane/README.md
@@ -125,6 +125,7 @@ and their default values.
 | `resourcesRBACManager.requests.memory` | Memory resource requests for the RBAC Manager pod. | `"256Mi"` |
 | `revisionHistoryLimit` | The number of Crossplane ReplicaSets to retain. | `nil` |
 | `runtimeClassName` | The runtimeClassName name to apply to the Crossplane and RBAC Manager pods. | `""` |
+| `secrets.customAnnotations` | Add custom annotations to Crossplane Secret resources. | `{}` |
 | `securityContextCrossplane.allowPrivilegeEscalation` | Enable `allowPrivilegeEscalation` for the Crossplane pod. | `false` |
 | `securityContextCrossplane.readOnlyRootFilesystem` | Set the Crossplane pod root file system as read-only. | `true` |
 | `securityContextCrossplane.runAsGroup` | The group ID used by the Crossplane pod. | `65532` |

--- a/cluster/charts/crossplane/templates/secret.yaml
+++ b/cluster/charts/crossplane/templates/secret.yaml
@@ -9,6 +9,9 @@ kind: Secret
 metadata:
   name: ess-server-certs
   namespace: {{ .Release.Namespace }}
+  {{- with .Values.secrets.customAnnotations }}
+  annotations: {{ toYaml . | nindent 4 }}
+  {{- end }}
 type: Opaque
 {{- end }}
 ---
@@ -20,6 +23,9 @@ kind: Secret
 metadata:
   name: crossplane-root-ca
   namespace: {{ .Release.Namespace }}
+  {{- with .Values.secrets.customAnnotations }}
+  annotations: {{ toYaml . | nindent 4 }}
+  {{- end }}
 type: Opaque
 ---
 # The reason this is created empty and filled by the init container is we want
@@ -30,6 +36,9 @@ kind: Secret
 metadata:
   name: crossplane-tls-server
   namespace: {{ .Release.Namespace }}
+  {{- with .Values.secrets.customAnnotations }}
+  annotations: {{ toYaml . | nindent 4 }}
+  {{- end }}
 type: Opaque
 ---
 # The reason this is created empty and filled by the init container is we want
@@ -40,4 +49,7 @@ kind: Secret
 metadata:
   name: crossplane-tls-client
   namespace: {{ .Release.Namespace }}
+  {{- with .Values.secrets.customAnnotations }}
+  annotations: {{ toYaml . | nindent 4 }}
+  {{- end }}
 type: Opaque

--- a/cluster/charts/crossplane/values.yaml
+++ b/cluster/charts/crossplane/values.yaml
@@ -81,6 +81,10 @@ service:
   # -- Configure annotations on the service object. Only enabled when webhooks.enabled = true
   customAnnotations: {}
 
+secrets:
+  # -- Add custom annotations to Crossplane Secret resources.
+  customAnnotations: {}
+
 webhooks:
   # -- Enable webhooks for Crossplane and installed Provider packages.
   enabled: true


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane! Please read the contribution docs
(linked below) if this is your first Crossplane pull request.
-->

### Description of your changes

<!--
Briefly describe what this pull request does, and how it is covered by tests.
Be proactive - direct your reviewers' attention to anything that needs special
consideration.

We love pull requests that fix an open issue. If yours does, use the below line
to indicate which issue it fixes, for example "Fixes #500".
-->

- This adds the helm chart values configuration to be able to specify `metadata.annotations` on Secret resources rendered by the crossplane helm chart.

This will be useful in scenarios where the crossplane helm chart would have to be uninstalled and then reinstalled, while keeping the crossplane core generated root-ca certificate intact/retained from the previous install: 

```
secrets:
  # Instruct helm to not uninstall the resources
  # https://helm.sh/docs/howto/charts_tips_and_tricks/#tell-helm-not-to-uninstall-a-resource
  customAnnotations:
    helm.sh/resource-policy: keep
```

UXP Crossplane chart name has changed from `universal-crossplane` in UXP-1.x chart to `crossplane` in UXP-2.x chart. When upgrading from uxp-1.20 to UXP-2.0 version, managed using a  FluxCD HelmRelease, despite having the same `spec.releaseName`, it leads to uninstall of `universal-crossplane` chart and install of `crossplane` chart and regeneration of crossplane-root-ca secret. All the running function pkgs server certificates remain issued by the old/previous root-ca, resulting in ca trust errors with crossplane -> functions grpc endpoint communications, as already reported in https://github.com/crossplane/crossplane/issues/5456#issuecomment-1980992787

we need this to be backported to crossplane release-1.20.

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [X] Read and followed Crossplane's [contribution process].
- [X] Run `earthly +reviewable` to ensure this PR is ready for review.
- ~~[ ] Added or updated unit tests.~~
- ~~[ ] Added or updated e2e tests.~~
- ~~[ ] Linked a PR or a [docs tracking issue] to [document this change].~~
- [ ] Added `backport release-x.y` labels to auto-backport this PR.
- ~~[ ] Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md