### PR TITLE
Fix claim controller watch startup after transient failures

### DIFF
--- a/internal/controller/apiextensions/offered/reconciler.go
+++ b/internal/controller/apiextensions/offered/reconciler.go
@@ -489,13 +489,6 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 			"desired-version", desired.APIVersion)
 	}
 
-	if r.engine.IsRunning(claim.ControllerName(d.GetName())) {
-		log.Debug("Composite resource claim controller is running")
-		status.MarkConditions(v1.WatchingClaim())
-
-		return reconcile.Result{Requeue: false}, errors.Wrap(r.client.Status().Update(ctx, d), errUpdateStatus)
-	}
-
 	// Add an index to the controller engine's client.
 	if indexer := r.engine.GetFieldIndexer(); indexer != nil {
 		if err := indexer.IndexField(ctx, &v1.CompositeResourceDefinition{}, claim.XRDByCompositeGVKIndex(), claim.IndexXRDByCompositeGVK()); err != nil {
@@ -503,30 +496,41 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 		}
 	}
 
-	cr := claim.NewReconciler(r.engine.GetCached(), d.GetClaimGroupVersionKind(), d.GetCompositeGroupVersionKind(), o...)
+	controllerName := claim.ControllerName(d.GetName())
+	gvkClaim := d.GetClaimGroupVersionKind()
+	gvkXR := d.GetCompositeGroupVersionKind()
+
+	cr := claim.NewReconciler(r.engine.GetCached(), gvkClaim, gvkXR, o...)
 
 	ko := r.options.ForControllerRuntime()
 	ko.Reconciler = errors.WithSilentRequeueOnConflict(cr)
 
-	if err := r.engine.Start(claim.ControllerName(d.GetName()), engine.WithRuntimeOptions(ko)); err != nil {
+	// Start is idempotent - it's a no-op if the controller is already running.
+	// We call it every reconcile to ensure the controller is started, even after
+	// transient failures.
+	if !r.engine.IsRunning(controllerName) {
+		log.Debug("Starting composite resource claim controller")
+	}
+	if err := r.engine.Start(controllerName, engine.WithRuntimeOptions(ko)); err != nil {
 		err = errors.Wrap(err, errStartController)
 		r.record.Event(d, event.Warning(reasonOfferXRC, err))
 
 		return reconcile.Result{}, err
 	}
 
-	log.Debug("Started composite resource claim controller")
-
 	// These must be *unstructured.Unstructured, not e.g. *claim.Unstructured.
 	// controller-runtime doesn't support watching types that satisfy the
 	// runtime.Unstructured interface - only *unstructured.Unstructured.
 	cm := &kunstructured.Unstructured{}
-	cm.SetGroupVersionKind(d.GetClaimGroupVersionKind())
+	cm.SetGroupVersionKind(gvkClaim)
 
 	xr := &kunstructured.Unstructured{}
-	xr.SetGroupVersionKind(d.GetCompositeGroupVersionKind())
+	xr.SetGroupVersionKind(gvkXR)
 
-	if err := r.engine.StartWatches(ctx, claim.ControllerName(d.GetName()),
+	// StartWatches is idempotent - it only starts watches that don't already
+	// exist. We call it every reconcile to ensure watches are started, even if
+	// they failed transiently on a previous attempt.
+	if err := r.engine.StartWatches(ctx, controllerName,
 		engine.WatchFor(cm, engine.WatchTypeClaim, &handler.EnqueueRequestForObject{}),
 		engine.WatchFor(xr, engine.WatchTypeCompositeResource, &EnqueueRequestForClaim{}),
 	); err != nil {
@@ -536,7 +540,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 		return reconcile.Result{}, err
 	}
 
-	d.Status.Controllers.CompositeResourceClaimTypeRef = v1.TypeReferenceTo(d.GetClaimGroupVersionKind())
+	d.Status.Controllers.CompositeResourceClaimTypeRef = v1.TypeReferenceTo(gvkClaim)
 	status.MarkConditions(v1.WatchingClaim())
 
 	return reconcile.Result{Requeue: false}, errors.Wrap(r.client.Status().Update(ctx, d), errUpdateStatus)

--- a/internal/controller/apiextensions/offered/reconciler_test.go
+++ b/internal/controller/apiextensions/offered/reconciler_test.go
@@ -901,9 +901,13 @@ func TestReconcile(t *testing.T) {
 					WithControllerEngine(&MockEngine{
 						MockIsRunning: func(_ string) bool { return true },
 						MockStart: func(_ string, _ ...engine.ControllerOption) error {
-							t.Errorf("MockStart should not be called")
+							// Start is idempotent, so it's fine to call it when already running.
 							return nil
 						},
+						MockStartWatches: func(_ context.Context, _ string, _ ...engine.Watch) error {
+							return nil
+						},
+						MockGetClient:       func() client.Client { return test.NewMockClient() },
 						MockGetFieldIndexer: func() client.FieldIndexer { return nil },
 					}),
 				},


### PR DESCRIPTION
### Description of your changes

Fixes #6884

The claim controller could fail to start watches after a transient watch startup failure. When `engine.Start()` succeeded but `engine.StartWatches()` failed with a transient error, the reconciler would requeue. On retry, it checked if the engine was already running and returned early without calling `StartWatches()` again. The controller would run indefinitely without watches, never reconciling claims.

The fix leverages that both `engine.Start()` and `engine.StartWatches()` are idempotent. The reconciler now calls both on every reconcile, removing the early return check. `Start()` is a no-op if the controller is already running. `StartWatches()` only starts watches that don't already exist. This ensures watches are established even after transient failures.

This fix mirrors the XR controller fix from #6885 and addresses the same bug reported in #6884 for the claim (offered) controller.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `earthly +reviewable` to ensure this PR is ready for review.
- [x] Added or updated unit tests.
- [ ] ~Added or updated e2e tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [x] Added `backport release-x.y` labels to auto-backport this PR.
- [ ] ~Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md