### PR TITLE
[Backport release-1.20] Fix XRD controller watch startup after transient failures

### DIFF
--- a/internal/controller/apiextensions/definition/reconciler_test.go
+++ b/internal/controller/apiextensions/definition/reconciler_test.go
@@ -887,7 +887,16 @@ func TestReconcile(t *testing.T) {
 					WithControllerEngine(&MockEngine{
 						MockIsRunning: func(_ string) bool { return true },
 						MockStart: func(_ string, _ ...engine.ControllerOption) error {
-							t.Errorf("MockStart should not be called")
+							// Start is idempotent, so it's fine to call it when already running.
+							return nil
+						},
+						MockGetCached: func() client.Client {
+							return &test.MockClient{}
+						},
+						MockGetUncached: func() client.Client {
+							return &test.MockClient{}
+						},
+						MockStartWatches: func(_ context.Context, _ string, _ ...engine.Watch) error {
 							return nil
 						},
 					}),


### PR DESCRIPTION
### Description of your changes

Backport of #6885 to `release-1.20`.

The XRD controller could fail to start watches after a transient watch startup failure. This fix makes both `engine.Start()` and `engine.StartWatches()` calls happen on every reconcile, leveraging their idempotency to ensure watches are established even after transient failures.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] ~Run `earthly +reviewable` to ensure this PR is ready for review.~
- [x] ~Added or updated unit tests.~
- [ ] ~Added or updated e2e tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~
- [ ] ~Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md