### PR TITLE
design: Propose a new approach to controlled rollout of composition functions

### DIFF
--- a/design/defunct/one-pager-controlled-rollout-of-composition-functions.md
+++ b/design/defunct/one-pager-controlled-rollout-of-composition-functions.md
@@ -2,7 +2,7 @@
 
 * Owner: Adam Wolfe Gordon (@adamwg)
 * Reviewers: Crossplane Maintainers
-* Status: Accepted
+* Status: Superseded by [v2]
 
 ## Background
 
@@ -221,3 +221,4 @@ condition on the XR and raise an event.
 
 [crossplane#6139]: https://github.com/crossplane/crossplane/issues/6139
 [crossplane#5294]: https://github.com/crossplane/crossplane/issues/5294
+[v2]: ../one-pager-controlled-rollout-of-composition-functions-v2.md

--- a/design/one-pager-controlled-rollout-of-composition-functions-v2.md
+++ b/design/one-pager-controlled-rollout-of-composition-functions-v2.md
@@ -13,6 +13,15 @@ possible for multiple revisions of a function to be active at once. The
 background section of the original design describes the problem we wish to
 solve.
 
+Though it's not called out explicitly in the original design doc, the underlying
+problem that prevents controlled rollout of composition functions is that both
+compositions and functions can have revisions, and these revisions interact
+(composition revisions call function revisions), but the coupling is loose
+(composition revisions don't refer directly to function revisions). The previous
+design solved the problem by tightening the coupling (allowing composition
+revisions to refer to function revisions explicitly), while this design instead
+removes the coupling altogether (removing the need for function revisions).
+
 This document proposes a new, simpler design to solve the problem, based on the
 following observations:
 

--- a/design/one-pager-controlled-rollout-of-composition-functions-v2.md
+++ b/design/one-pager-controlled-rollout-of-composition-functions-v2.md
@@ -1,0 +1,198 @@
+# Controlled Rollout of Composition Functions (v2)
+
+* Owner: Adam Wolfe Gordon (@adamwg)
+* Reviewers: @negz, @bobh66
+* Status: Draft
+
+## Background
+
+Previously, we proposed [a design][v1] that would allow changes to composition
+functions to be rolled out to composite resources in a controlled fashion by
+allowing compositions to reference a specific function revision and making it
+possible for multiple revisions of a function to be active at once. The
+background section of the original design describes the problem we wish to
+solve.
+
+This document proposes a new, simpler design to solve the problem, based on the
+following observations:
+
+1. Unlike other package types, functions do not package resources that should be
+   installed in the cluster (their input types do get installed today, but this
+   is not a desired behavior).
+2. Unlike providers (the other current package type with a runtime component),
+   functions are stateless gRPC servers, not controllers. Multiple instances (of
+   the same or different revisions) will not interfere with one another.
+3. It is uncommon for functions to have dependencies.
+
+## Goals
+
+From the original design:
+
+* Allow users to progressively roll out changes to functions that compose
+  resources. This solves [crossplane#6139].
+* Maintain current behavior for users who do not wish to roll out function
+  changes progressively.
+
+New for this design:
+
+* Allow users to use arbitrary function packages in their compositions without
+  the need to pre-install the functions (as dependencies or otherwise).
+* Allow mixing of function installation modes without duplicate runtime
+  resources being created.
+
+## Proposal
+
+This document proposes three changes in Crossplane to allow for progressive
+rollout of composition functions:
+
+1. Allow composition pipeline steps to reference functions by OCI reference
+   rather than by Function resource name.
+2. Have the composition revision controller manage functions referenced by OCI
+   reference, avoiding the need to pre-install such functions.
+3. Introduce dedicated resource types for the package runtime controllers,
+   providing a common substrate for functions managed by the composition
+   revision controller and those installed the traditional way using the package
+   manager. This also makes the package manager conceptually simpler, since each
+   resource type will be reconciled by only one controller.
+
+To limit risk, these changes will be introduced behind a feature flag, which
+will initially be off by default.
+
+Note that while this design addresses only composition functions, the pipeline
+and package manager changes apply also to operation functions. Operations do not
+have revisions, so controlled rollout of them is not relevant, but the other
+simplifications in this design are applicable.
+
+### Composition Changes
+
+We will add a `package` field to the `functionRef` field in pipeline steps such
+that functions can be referenced by OCI reference rather than name:
+
+```yaml
+apiVersion: apiextensions.crossplane.io/v1
+kind: Composition
+metadata:
+  name: example
+spec:
+  compositeTypeRef:
+    apiVersion: custom-api.example.org/v1alpha1
+    kind: AcmeBucket
+  mode: Pipeline
+  pipeline:
+  - step: patch-and-transform
+    functionRef:
+      package: xpkg.crossplane.io/crossplane-contrib/function-patch-and-transform:v0.8.2
+    input:
+      # Removed for brevity
+```
+
+The `package` field, if given, must contain a fully-qualified OCI reference
+(i.e., include a registry, repository, and tag or digest). It is invalid to
+provide both `name` and `package`.
+
+When `package` is provided, the composition revision controller will ensure that
+the specified function is running by creating a `FunctionRuntime` resource for
+it (see the package manager section below). If a `FunctionRuntime` already
+exists, the composition revision will be added as an owner reference.
+
+A user wishing to roll out a new version of `function-patch-and-transform`
+simply updates their composition to reference the new version, resulting in
+creation of a new composition revision and runtime creation for the new function
+version. The existing `compositionUpdatePolicy` and
+`compositionRevisionSelector` mechanisms on XRs can be used to progressively
+roll out the change:
+
+```yaml
+apiVersion: custom-api.example.org/v1alpha1
+kind: AcmeBucket
+metadata:
+  name: my-bucket
+spec:
+  compositionUpdatePolicy: Manual
+  compositionRevisionSelector:
+    matchLabels:
+      release-channel: alpha
+```
+
+In addition to allowing for progressive rollout, this new way of specifying
+functions is simpler and safer to use than the existing method. Users don't need
+to specify all their functions as dependencies or otherwise pre-install
+them. They also don't need to know how the package manager names dependency
+packages to construct the right `functionRef.name` in their composition. They
+are also guaranteed to get exactly the version they specify regardless of what
+other changes happen in the cluster; pacakges can be specified by digest for
+further safety.
+
+### Package Manager Changes
+
+Currently, both the package revision controller and the package runtime
+controller operate on package revision resources (`FunctionRevision` and
+`ProviderRevision`). The revision controller installs resources (CRDs, etc.)
+from the package, while the runtime controller creates runtime resources
+(deployments, services, etc.) for active revisions of packages that have a
+runtime component.
+
+In order to allow runtime-only packages, we will introduce new `FunctionRuntime`
+and `ProviderRuntime` resources, which will be reconciled by the package runtime
+controller. The revision controller will be changed to create a runtime resource
+corresponding to the active revision; the runtime controller will no longer
+operate on revisions directly.
+
+This allows the composition revision controller to create its own
+`FunctionRuntime` resources to run functions without creating `Function`s or
+`FunctionRevision`s. The package revision and composition revision controllers
+will use the same scheme to name their `FunctionRevision`s, ensuring that a
+particular version of a function runs only once even if it's installed multiple
+ways. I.e., a `FunctionRuntime` may be shared between a `FunctionRevision` and
+one or more `CompositionRevision`s.
+
+Note that this change has two side effects for functions installed by the
+composition revision controller:
+
+1. Their dependencies will not be installed, as there will be no revision
+   inserted into the `Lock`.
+2. They will not have corresponding package or package revision resources,
+   meaning they will not show up in `kubectl get pkg` or similar commands.
+
+### Function Runner Changes
+
+Today, the function runner invoked by the composite controller finds the
+function endpoint for a pipeline step by first listing all function revisions
+with the `pkg.crossplane.io/package` label set to the function's name, then
+finding the single active revision in the list. This logic will change as
+follows:
+
+1. If `functionRef.package` is specified, the relevant `FunctionRuntime`
+   resource will be looked up directly using the `pkg.crossplane.io/source`
+   label.
+2. If `functionRef.name` is specified, the existing logic to find the active
+   revision is unchanged, but the endpoint will be read from the
+   `FunctionRuntime`'s status.
+
+The signature of the `FunctionRunner` in `internal/xfn` will change such that
+functions are called by their OCI ref, since there is no longer always a
+Function resource name to use as a key. Internally, the runner's gRPC connection
+pool will likewise be keyed by OCI ref.
+
+## Alternatives Considered
+
+* Do nothing. For functions that don't take input, users can work around the
+  limitation today by installing multiple versions of a function with unique
+  names and referencing these names in their compositions. This workaround
+  effectively simulates what is proposed in this design without support from
+  Crossplane itself. However, it does not work for functions that take input due
+  to [crossplane#5294], and does not work well with the package manager's
+  dependency resolution system when using Configurations.
+* Make it easier for composition functions to take input from external sources
+  such as OCI images or git repositories. This would allow function input to be
+  versioned separately from both functions and compositions, with new
+  composition revisions being created to reference new input versions. However,
+  this change would introduce significant additional complexity to the
+  composition controller, and would not solve the problem for functions that
+  don't take input.
+* The [previous design][v1], which had the package manager allow for multiple
+  active revisions of a package and added revision selectors in compositions.
+
+[crossplane#6139]: https://github.com/crossplane/crossplane/issues/6139
+[crossplane#5294]: https://github.com/crossplane/crossplane/issues/5294
+[v1]: ./defunct/one-pager-controlled-rollout-of-composition-functions.md

--- a/design/one-pager-controlled-rollout-of-composition-functions-v2.md
+++ b/design/one-pager-controlled-rollout-of-composition-functions-v2.md
@@ -65,8 +65,9 @@ simplifications in this design are applicable.
 
 ### Composition Changes
 
-We will add a `package` field to the `functionRef` field in pipeline steps such
-that functions can be referenced by OCI reference rather than name:
+We will add a `function` field alongside the `functionRef` field in pipeline
+steps such that functions can be called by supplying an OCI reference rather
+than a reference to an installed `Function` resource:
 
 ```yaml
 apiVersion: apiextensions.crossplane.io/v1
@@ -80,19 +81,18 @@ spec:
   mode: Pipeline
   pipeline:
   - step: patch-and-transform
-    functionRef:
-      package: xpkg.crossplane.io/crossplane-contrib/function-patch-and-transform:v0.8.2
+    function: xpkg.crossplane.io/crossplane-contrib/function-patch-and-transform:v0.8.2
     input:
       # Removed for brevity
 ```
 
-The `package` field, if given, must contain a fully-qualified OCI reference
+The `function` field, if given, must contain a fully-qualified OCI reference
 (i.e., include a registry, repository, and tag or digest). It is invalid to
-provide both `name` and `package`.
+provide both `function` and `functionRef`.
 
-When `package` is provided, the composition revision controller will ensure that
-the specified function is running by creating a `FunctionRuntime` resource for
-it (see the package manager section below). If a `FunctionRuntime` already
+When `function` is provided, the composition revision controller will ensure
+that the specified function is running by creating a `FunctionRuntime` resource
+for it (see the package manager section below). If a `FunctionRuntime` already
 exists, the composition revision will be added as an owner reference.
 
 A user wishing to roll out a new version of `function-patch-and-transform`
@@ -162,12 +162,11 @@ with the `pkg.crossplane.io/package` label set to the function's name, then
 finding the single active revision in the list. This logic will change as
 follows:
 
-1. If `functionRef.package` is specified, the relevant `FunctionRuntime`
-   resource will be looked up directly using the `pkg.crossplane.io/source`
-   label.
-2. If `functionRef.name` is specified, the existing logic to find the active
-   revision is unchanged, but the endpoint will be read from the
-   `FunctionRuntime`'s status.
+1. If `function` is specified, the relevant `FunctionRuntime` resource will be
+   looked up directly using the `pkg.crossplane.io/source` label.
+2. If `functionRef` is specified, the existing logic to find the active revision
+   is unchanged, but the endpoint will be read from the `FunctionRuntime`'s
+   status.
 
 The signature of the `FunctionRunner` in `internal/xfn` will change such that
 functions are called by their OCI ref, since there is no longer always a

--- a/design/one-pager-controlled-rollout-of-composition-functions-v2.md
+++ b/design/one-pager-controlled-rollout-of-composition-functions-v2.md
@@ -72,7 +72,7 @@ and package manager changes apply also to operation functions. Operations do not
 have revisions, so controlled rollout of them is not relevant, but the other
 simplifications in this design are applicable.
 
-### Composition Changes
+### Composition and Operation Changes
 
 We will add a `function` field alongside the `functionRef` field in pipeline
 steps such that functions can be called by supplying an OCI reference rather
@@ -102,7 +102,9 @@ provide both `function` and `functionRef`.
 When `function` is provided, the composition revision controller will ensure
 that the specified function is running by creating a `FunctionRuntime` resource
 for it (see the package manager section below). If a `FunctionRuntime` already
-exists, the composition revision will be added as an owner reference.
+exists, the composition revision will be added as an owner reference. The same
+applies to the operation controller (operations execute in a one-shot manner,
+and as such do not have revisions).
 
 A user wishing to roll out a new version of `function-patch-and-transform`
 simply updates their composition to reference the new version, resulting in

--- a/design/one-pager-controlled-rollout-of-composition-functions-v2.md
+++ b/design/one-pager-controlled-rollout-of-composition-functions-v2.md
@@ -25,13 +25,11 @@ removes the coupling altogether (removing the need for function revisions).
 This document proposes a new, simpler design to solve the problem, based on the
 following observations:
 
-1. Unlike other package types, functions do not package resources that should be
-   installed in the cluster (their input types do get installed today, but this
-   is not a desired behavior).
+1. Unlike other package types, functions do not contain resources that get
+   installed in the cluster.
 2. Unlike providers (the other current package type with a runtime component),
    functions are stateless gRPC servers, not controllers. Multiple instances (of
    the same or different revisions) will not interfere with one another.
-3. It is uncommon for functions to have dependencies.
 
 ## Goals
 
@@ -46,8 +44,7 @@ New for this design:
 
 * Allow users to use arbitrary function packages in their compositions without
   the need to pre-install the functions (as dependencies or otherwise).
-* Allow mixing of function installation modes without duplicate runtime
-  resources being created.
+* Allow mixing of function installation modes.
 
 ## Proposal
 
@@ -56,16 +53,11 @@ rollout of composition functions:
 
 1. Allow composition pipeline steps to reference functions by OCI reference
    rather than by Function resource name.
-2. Have the composition revision controller manage functions referenced by OCI
-   reference, avoiding the need to pre-install such functions.
-3. Introduce dedicated resource types for the package runtime controllers,
-   providing a common substrate for functions managed by the composition
-   revision controller and those installed the traditional way using the package
-   manager. This also makes the package manager conceptually simpler, since each
-   resource type will be reconciled by only one controller.
-
-To limit risk, these changes will be introduced behind a feature flag, which
-will initially be off by default.
+2. Have the composition revision controller manage functions and function
+   revisions referenced by OCI reference, avoiding the need to pre-install such
+   functions.
+3. To accommodate (2), introduce the concept of "external revisions" for
+   functions.
 
 Note that while this design addresses only composition functions, the pipeline
 and package manager changes apply also to operation functions. Operations do not
@@ -100,18 +92,20 @@ The `function` field, if given, must contain a fully-qualified OCI reference
 provide both `function` and `functionRef`.
 
 When `function` is provided, the composition revision controller will ensure
-that the specified function is running by creating a `FunctionRuntime` resource
-for it (see the package manager section below). If a `FunctionRuntime` already
-exists, the composition revision will be added as an owner reference. The same
+that the specified function is running by creating a `FunctionRevision` resource
+for it and a `Function` resource with the revision included in
+`spec.externalRevisions` (see the package manager section below). If a matching
+`FunctionRevision` already exists, the composition revision will be added as an
+owner reference. Similarly, if a matching `Function` already exists, it gets an
+owner reference and the revision added to its `externalRevisions`. The same
 applies to the operation controller (operations execute in a one-shot manner,
 and as such do not have revisions).
 
 A user wishing to roll out a new version of `function-patch-and-transform`
 simply updates their composition to reference the new version, resulting in
-creation of a new composition revision and runtime creation for the new function
-version. The existing `compositionUpdatePolicy` and
-`compositionRevisionSelector` mechanisms on XRs can be used to progressively
-roll out the change:
+creation of a new composition revision and function revision. The existing
+`compositionUpdatePolicy` and `compositionRevisionSelector` mechanisms on XRs
+can be used to progressively roll out the change:
 
 ```yaml
 apiVersion: custom-api.example.org/v1alpha1
@@ -136,34 +130,24 @@ further safety.
 
 ### Package Manager Changes
 
-Currently, both the package revision controller and the package runtime
-controller operate on package revision resources (`FunctionRevision` and
-`ProviderRevision`). The revision controller installs resources (CRDs, etc.)
-from the package, while the runtime controller creates runtime resources
-(deployments, services, etc.) for active revisions of packages that have a
-runtime component.
+In order to allow for `FunctionRevision`s that are not controlled by the package
+manager, we will make two backward-compatible API changes for package resources:
 
-In order to allow runtime-only packages, we will introduce new `FunctionRuntime`
-and `ProviderRuntime` resources, which will be reconciled by the package runtime
-controller. The revision controller will be changed to create a runtime resource
-corresponding to the active revision; the runtime controller will no longer
-operate on revisions directly.
+1. Make `spec.package` optional.
+2. Add `spec.externalRevisionRefs`.
 
-This allows the composition revision controller to create its own
-`FunctionRuntime` resources to run functions without creating `Function`s or
-`FunctionRevision`s. The package revision and composition revision controllers
-will use the same scheme to name their `FunctionRevision`s, ensuring that a
-particular version of a function runs only once even if it's installed multiple
-ways. I.e., a `FunctionRuntime` may be shared between a `FunctionRevision` and
-one or more `CompositionRevision`s.
+A package with an empty `spec.package` does not have revisions managed by the
+package manager. The status of the package is computed from the revisions
+referenced in `externalRevisionRefs`. A package may have both `package` and
+`externalRevisionRefs` (e.g., if it was installed as a dependency and also by
+being referenced in a composition); in this case, the package manager ignores
+`externalRevisionRefs`, but they are still present for visibility.
 
-Note that this change has two side effects for functions installed by the
-composition revision controller:
-
-1. Their dependencies will not be installed, as there will be no revision
-   inserted into the `Lock`.
-2. They will not have corresponding package or package revision resources,
-   meaning they will not show up in `kubectl get pkg` or similar commands.
+The package manager's resolver controller (which controls the `Lock` resource)
+will be updated to allow multiple versions of a package to be installed at
+once. This lets composition-controlled functions participate in dependency
+resolution, meaning that a function version referred to in a composition and
+also depended upon by another package will be installed only once.
 
 ### Function Runner Changes
 
@@ -173,10 +157,10 @@ with the `pkg.crossplane.io/package` label set to the function's name, then
 finding the single active revision in the list. This logic will change as
 follows:
 
-1. If `function` is specified, the relevant `FunctionRuntime` resource will be
+1. If `function` is specified, the relevant `FunctionRevision` resource will be
    looked up directly using the `pkg.crossplane.io/source` label.
 2. If `functionRef` is specified, the existing logic to find the active revision
-   is unchanged, but the endpoint will be read from the `FunctionRuntime`'s
+   is unchanged, but the endpoint will be read from the `FunctionRevision`'s
    status.
 
 The signature of the `FunctionRunner` in `internal/xfn` will change such that
@@ -200,6 +184,12 @@ pool will likewise be keyed by OCI ref.
   this change would introduce significant additional complexity to the
   composition controller, and would not solve the problem for functions that
   don't take input.
+* Introduce a new `FunctionRuntime` API to allow the composition controller to
+  spin up functions without interacting with existing package manager types at
+  all. This is somewhat simpler than the current proposal, but has two confusing
+  side-effects: composition-controlled functions don't participate in dependency
+  resolution, and users can't see composition-controlled functions in `kubectl
+  get pkg`.
 * The [previous design][v1], which had the package manager allow for multiple
   active revisions of a package and added revision selectors in compositions.
 

--- a/design/one-pager-controlled-rollout-of-composition-functions-v2.md
+++ b/design/one-pager-controlled-rollout-of-composition-functions-v2.md
@@ -82,14 +82,16 @@ spec:
   mode: Pipeline
   pipeline:
   - step: patch-and-transform
-    function: xpkg.crossplane.io/crossplane-contrib/function-patch-and-transform:v0.8.2
+    function: xpkg.crossplane.io/crossplane-contrib/function-patch-and-transform@sha256:c14068f64cfb2088eec75b1c5cc43425383211b75380b9891f1253b57b3c4fe6
     input:
       # Removed for brevity
 ```
 
 The `function` field, if given, must contain a fully-qualified OCI reference
-(i.e., include a registry, repository, and tag or digest). It is invalid to
-provide both `function` and `functionRef`.
+with the version specified by digest. We require digests here rather than tags
+because it makes composition revisions truly immutable: installing the same
+composition revision later or on a different cluster is guaranteed to run the
+same function. It is invalid to provide both `function` and `functionRef`.
 
 When `function` is provided, the composition revision controller will ensure
 that the specified function is running by creating a `FunctionRevision` resource
@@ -99,7 +101,9 @@ for it and a `Function` resource with the revision included in
 owner reference. Similarly, if a matching `Function` already exists, it gets an
 owner reference and the revision added to its `externalRevisions`. The same
 applies to the operation controller (operations execute in a one-shot manner,
-and as such do not have revisions).
+and as such do not have revisions). This means the composition revision and
+operation controllers will adopt an existing `Function` created by the user or
+package manager if needed.
 
 A user wishing to roll out a new version of `function-patch-and-transform`
 simply updates their composition to reference the new version, resulting in
@@ -125,8 +129,7 @@ to specify all their functions as dependencies or otherwise pre-install
 them. They also don't need to know how the package manager names dependency
 packages to construct the right `functionRef.name` in their composition. They
 are also guaranteed to get exactly the version they specify regardless of what
-other changes happen in the cluster; pacakges can be specified by digest for
-further safety.
+other changes happen in the cluster or registry.
 
 ### Package Manager Changes
 
@@ -141,7 +144,10 @@ package manager. The status of the package is computed from the revisions
 referenced in `externalRevisionRefs`. A package may have both `package` and
 `externalRevisionRefs` (e.g., if it was installed as a dependency and also by
 being referenced in a composition); in this case, the package manager ignores
-`externalRevisionRefs`, but they are still present for visibility.
+revisions listed in `externalRevisionRefs` when managing its own revisions, to
+avoid competing with other controllers. Note that in this specific case there
+could be two active revisions with the same OCI ref (i.e., same version of the
+function).
 
 The package manager's resolver controller (which controls the `Lock` resource)
 will be updated to allow multiple versions of a package to be installed at
@@ -190,6 +196,16 @@ pool will likewise be keyed by OCI ref.
   side-effects: composition-controlled functions don't participate in dependency
   resolution, and users can't see composition-controlled functions in `kubectl
   get pkg`.
+* Make multiple sources explicit in the package API (i.e., add a plural
+  `spec.packages` to the `Function` resource) and have the package manager
+  manage and activate revisions for all specified sources. This keeps revision
+  management entirely in the package manager, which is nice. However, it makes
+  it impossible to determine the provenance of a particular revision: whether it
+  was requested by the user, the dependency resolver, the composition revision
+  controller, or multiple of these. This lack of provenance makes it difficult
+  to clean up revisions that are no longer needed. The proposed design allows us
+  to take advantage of built-in Kubernetes garbage collection for cleanup by
+  setting owner references directly on the revisions.
 * The [previous design][v1], which had the package manager allow for multiple
   active revisions of a package and added revision selectors in compositions.
 


### PR DESCRIPTION
### Description of your changes

In #6398, we accepted a design that allowed for controlled rollout of composition functions by enabling multiple function revisions to be active at once and adding revision selectors to composition pipeline steps. Further thinking and discussion has led us to a new, simpler design. Move the old design to defunct and introduce the new one.

Toward #6139

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `earthly +reviewable` to ensure this PR is ready for review.
~- [ ] Added or updated unit tests.~
~- [ ] Added or updated e2e tests.~
~- [ ] Linked a PR or a [docs tracking issue] to [document this change].~
~- [ ] Added `backport release-x.y` labels to auto-backport this PR.~
~- [ ] Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~

[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md
