### PR TITLE
tests: add error handling test for printPodsTable

### DIFF
--- a/cmd/crank/beta/top/top_test.go
+++ b/cmd/crank/beta/top/top_test.go
@@ -12,13 +12,14 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	v1 "github.com/crossplane/crossplane/v2/apis/pkg/v1"
 )
 
 type errorWriter struct{}
 
-func (w *errorWriter) Write(p []byte) (n int, err error) {
-    return 0, fmt.Errorf("write error")
+func (w *errorWriter) Write(_ []byte) (n int, err error) {
+	return 0, fmt.Errorf("write error")
 }
 
 func TestGetCrossplanePods(t *testing.T) {
@@ -177,7 +178,7 @@ func TestPrintPodsTable(t *testing.T) {
 		"NoPodsFound": {
 			reason:         "Should return header when no pods are found",
 			crossplanePods: []topMetrics{},
-			writer:         &bytes.Buffer{},   
+			writer:         &bytes.Buffer{},
 			want: want{
 				results: `
 TYPE   NAMESPACE   NAME   CPU(cores)   MEMORY
@@ -196,7 +197,7 @@ TYPE   NAMESPACE   NAME   CPU(cores)   MEMORY
 					MemoryUsage:  resource.MustParse("512Mi"),
 				},
 			},
-			writer:         &bytes.Buffer{},
+			writer: &bytes.Buffer{},
 			want: want{
 				results: `
 TYPE         NAMESPACE           NAME             CPU(cores)   MEMORY
@@ -223,7 +224,7 @@ crossplane   crossplane-system   crossplane-123   100m         512Mi
 					MemoryUsage:  resource.MustParse("1024Mi"),
 				},
 			},
-			writer:         &bytes.Buffer{},
+			writer: &bytes.Buffer{},
 			want: want{
 				results: `
 TYPE         NAMESPACE           NAME             CPU(cores)   MEMORY
@@ -244,13 +245,12 @@ function     crossplane-system   function-123     200m         1024Mi
 					MemoryUsage:  resource.MustParse("512Mi"),
 				},
 			},
-			writer:         &errorWriter{},
+			writer: &errorWriter{},
 			want: want{
 				results: "",
 				err:     cmpopts.AnyError,
 			},
 		},
-
 	}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
@@ -266,7 +266,6 @@ function     crossplane-system   function-123     200m         1024Mi
 					t.Errorf("%s\nprintPodsTable(): -want, +got:\n%s", tt.reason, diff)
 				}
 			}
-
 		})
 	}
 }


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane! Please read the contribution docs
(linked below) if this is your first Crossplane pull request.
-->

### Description

This pull request adds an error-handling test case for the `printPodsTable` function 
using a custom `errorWriter`. It resolves the previous TODO for verifying behavior 
when writing to the writer fails. 

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `earthly +reviewable` to ensure this PR is ready for review.
- [x] Added or updated unit tests.
~- [ ] Added or updated e2e tests.~
~- [ ] Linked a PR or a [docs tracking issue] to [document this change].~
~- [ ] Added `backport release-x.y` labels to auto-backport this PR.~
~- [ ] Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md