### PR TITLE
[Backport release-1.20] fix: Add TLS as app protocol to function service

### DIFF
--- a/internal/controller/pkg/revision/runtime.go
+++ b/internal/controller/pkg/revision/runtime.go
@@ -65,6 +65,7 @@ var (
 	allowPrivilegeEscalation = false
 	privileged               = false
 	runAsNonRoot             = true
+	appProtocolTLS           = "tls"
 )
 
 // ManifestBuilder builds the runtime manifests for a package revision.

--- a/internal/controller/pkg/revision/runtime_function.go
+++ b/internal/controller/pkg/revision/runtime_function.go
@@ -203,10 +203,11 @@ func functionServiceOverrides() []ServiceOverride {
 		ServiceWithClusterIP(corev1.ClusterIPNone),
 		ServiceWithAdditionalPorts([]corev1.ServicePort{
 			{
-				Name:       grpcPortName,
-				Protocol:   corev1.ProtocolTCP,
-				Port:       grpcPort,
-				TargetPort: intstr.FromString(grpcPortName),
+				Name:        grpcPortName,
+				Protocol:    corev1.ProtocolTCP,
+				Port:        grpcPort,
+				TargetPort:  intstr.FromString(grpcPortName),
+				AppProtocol: &appProtocolTLS,
 			},
 		}),
 	}


### PR DESCRIPTION
# Description
Backport of #6943 to `release-1.20`.