### PR TITLE
feat(webhook): add webhook for provider deletion

### DIFF
--- a/cluster/charts/crossplane/README.md
+++ b/cluster/charts/crossplane/README.md
@@ -142,6 +142,7 @@ and their default values.
 | `topologySpreadConstraints` | Add `topologySpreadConstraints` to the Crossplane pod deployment. | `[]` |
 | `webhooks.enabled` | Enable webhooks for Crossplane and installed Provider packages. | `true` |
 | `webhooks.port` | The port the webhook server listens on. | `""` |
+| `webhooks.providerDeletionProtection.enabled` | Enable provider deletion protection webhook that prevents deletion of providers with active managed resources. | `true` |
 
 ### Command Line
 

--- a/cluster/charts/crossplane/templates/deployment.yaml
+++ b/cluster/charts/crossplane/templates/deployment.yaml
@@ -82,6 +82,9 @@ spec:
           - --activation
           - "{{ $arg }}"
           {{- end }}
+          {{- if not .Values.webhooks.providerDeletionProtection.enabled }}
+          - --disable-provider-deletion-protection
+          {{- end }}
           resources:
             {{- toYaml .Values.resourcesCrossplane | nindent 12 }}
           {{- with .Values.securityContextCrossplane }}
@@ -144,6 +147,9 @@ spec:
         - start
         {{- range $arg := .Values.args }}
         - {{ $arg }}
+        {{- end }}
+        {{- if not .Values.webhooks.providerDeletionProtection.enabled }}
+        - --disable-provider-deletion-protection
         {{- end }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         resources:

--- a/cluster/charts/crossplane/values.yaml
+++ b/cluster/charts/crossplane/values.yaml
@@ -90,6 +90,9 @@ webhooks:
   enabled: true
   # -- The port the webhook server listens on.
   port: ""
+  providerDeletionProtection:
+    # -- Enable provider deletion protection webhook that prevents deletion of providers with active managed resources.
+    enabled: true
 
 rbacManager:
   # -- Deploy the RBAC Manager pod and its required roles.

--- a/cluster/webhookconfigurations/provider-deletion.yaml
+++ b/cluster/webhookconfigurations/provider-deletion.yaml
@@ -1,0 +1,27 @@
+---
+# Provider deletion validation webhook
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: crossplane-provider-deletion
+webhooks:
+  - admissionReviewVersions:
+      - v1
+    clientConfig:
+      service:
+        name: webhook-service
+        namespace: system
+        path: /validate-provider-deletion
+    failurePolicy: Fail
+    name: providerdeletion.pkg.crossplane.io
+    rules:
+      - apiGroups:
+          - pkg.crossplane.io
+        apiVersions:
+          - v1
+          - v1beta1
+        operations:
+          - DELETE
+        resources:
+          - providers
+    sideEffects: None

--- a/cmd/crossplane/core/core.go
+++ b/cmd/crossplane/core/core.go
@@ -142,7 +142,8 @@ type startCommand struct {
 	EnableRealtimeCompositions              bool `default:"true" group:"Beta Features:" help:"Enable support for realtime compositions, i.e. watching composed resources and reconciling compositions immediately when any of the composed resources is updated."`
 	EnableCustomToManagedResourceConversion bool `default:"true" group:"Beta Features:" help:"Enable support CRD to MRD conversion when installing a package."`
 
-	RestrictNamespacedEvents bool `default:"false" help:"Prevent events from being produced on resources that are not namespaced. Useful when crossplane does not have permissions in the default namespace."`
+	DisableProviderDeletionProtection bool `default:"false" help:"Disable provider deletion protection webhook that prevents deletion of providers with active managed resources."`
+	RestrictNamespacedEvents          bool `default:"false" help:"Prevent events from being produced on resources that are not namespaced. Useful when crossplane does not have permissions in the default namespace."`
 
 	// These are features that we've removed support for. Crossplane returns an
 	// error when you enable them. This ensures you'll see an explicit and
@@ -344,6 +345,11 @@ func (c *startCommand) Run(s *runtime.Scheme, log logging.Logger) error { //noli
 	if c.EnableOperations {
 		o.Features.Enable(features.EnableAlphaOperations)
 		log.Info("Alpha feature enabled", "flag", features.EnableAlphaOperations)
+	}
+
+	if c.DisableProviderDeletionProtection {
+		o.Features.Enable(features.DisableProviderDeletionProtection)
+		log.Info("Provider deletion protection disabled", "flag", features.DisableProviderDeletionProtection)
 	}
 
 	// Claim and XR controllers are started and stopped dynamically by the

--- a/internal/features/features.go
+++ b/internal/features/features.go
@@ -70,4 +70,10 @@ const (
 	// custom resource definition to managed resource definition conversion.
 	// Conversion happens at provider install time.
 	EnableBetaCustomToManagedResourceConversion feature.Flag = "EnableBetaCustomToManagedResourceConversion"
+
+	// DisableProviderDeletionProtection disables the provider deletion
+	// protection webhook that prevents deletion of providers with active
+	// managed resources. When disabled, deleting a provider may result in
+	// orphaned managed resources.
+	DisableProviderDeletionProtection feature.Flag = "DisableProviderDeletionProtection"
 )

--- a/internal/initializer/webhook_configurations_test.go
+++ b/internal/initializer/webhook_configurations_test.go
@@ -264,7 +264,7 @@ apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
   creationTimestamp: null
-  name: validating-webhook-configuration
+  name: mutating-webhook-configuration
 webhooks:
 - admissionReviewVersions:
   - v1

--- a/internal/initializer/webhook_configurations_test.go
+++ b/internal/initializer/webhook_configurations_test.go
@@ -183,6 +183,37 @@ func TestWebhookConfigurations(t *testing.T) {
 				err: errors.Errorf("only MutatingWebhookConfiguration and ValidatingWebhookConfiguration kinds are accepted, got %s", "*v1.CustomResourceDefinition"),
 			},
 		},
+		"SkipWebhookByName": {
+			reason: "Webhooks in the skip list should not be applied",
+			args: args{
+				opts: []WebhookConfigurationsOption{
+					WithWebhookConfigurationsFs(fs),
+					WithWebhookConfigurationsSkipNames("validating-webhook-configuration"),
+				},
+				svc: svc,
+				kube: &test.MockClient{
+					MockGet: func(_ context.Context, _ client.ObjectKey, obj client.Object) error {
+						if s, ok := obj.(*corev1.Secret); ok {
+							secret.DeepCopyInto(s)
+							return nil
+						}
+						return kerrors.NewNotFound(schema.GroupResource{}, "")
+					},
+					MockCreate: func(_ context.Context, obj client.Object, _ ...client.CreateOption) error {
+						// Validating webhook should be skipped, only mutating should be applied
+						switch obj.(type) {
+						case *admv1.ValidatingWebhookConfiguration:
+							t.Error("ValidatingWebhookConfiguration should have been skipped")
+						case *admv1.MutatingWebhookConfiguration:
+							// Expected - mutating webhook should still be applied
+						default:
+							t.Error("unexpected type")
+						}
+						return nil
+					},
+				},
+			},
+		},
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {

--- a/internal/webhook/protection/provider/handler.go
+++ b/internal/webhook/protection/provider/handler.go
@@ -1,0 +1,249 @@
+/*
+Copyright 2024 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package provider contains the Handler for the provider deletion webhook.
+package provider
+
+import (
+	"context"
+	"net/http"
+
+	admissionv1 "k8s.io/api/admission/v1"
+	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	xpv1 "github.com/crossplane/crossplane-runtime/v2/apis/common/v1"
+	"github.com/crossplane/crossplane-runtime/v2/pkg/controller"
+	"github.com/crossplane/crossplane-runtime/v2/pkg/errors"
+	"github.com/crossplane/crossplane-runtime/v2/pkg/logging"
+
+	v1alpha1 "github.com/crossplane/crossplane/v2/apis/apiextensions/v1alpha1"
+	v1 "github.com/crossplane/crossplane/v2/apis/pkg/v1"
+)
+
+// Error strings.
+const (
+	errFmtUnexpectedOp        = "unexpected operation %q, expected \"DELETE\""
+	errFmtGetProviderRevision = "cannot get provider revision %q"
+	errFmtGetMRD              = "cannot get ManagedResourceDefinition %q"
+	errFmtGetCRD              = "cannot get CustomResourceDefinition %q"
+	errFmtListCRs             = "cannot list custom resources for CRD %q"
+	errCRsExist               = "Cannot delete provider: custom resources still exist. Please delete all custom resources before deleting the provider."
+	errUnmarshalProvider      = "cannot unmarshal provider from admission request"
+	errExtractMRDNames        = "cannot extract CRD names from MRDs"
+)
+
+// SetupWebhookWithManager sets up the webhook with the manager.
+func SetupWebhookWithManager(mgr ctrl.Manager, options controller.Options) {
+	h := NewHandler(mgr.GetClient(), WithLogger(options.Logger.WithValues("webhook", "provider-deletion")))
+	mgr.GetWebhookServer().Register("/validate-provider-deletion", &webhook.Admission{Handler: h})
+}
+
+// Handler implements the admission Handler for Provider deletion.
+type Handler struct {
+	client client.Client
+	log    logging.Logger
+}
+
+// HandlerOption is used to configure the Handler.
+type HandlerOption func(*Handler)
+
+// WithLogger configures the logger for the Handler.
+func WithLogger(l logging.Logger) HandlerOption {
+	return func(h *Handler) {
+		h.log = l
+	}
+}
+
+// NewHandler returns a new Handler.
+func NewHandler(client client.Client, opts ...HandlerOption) *Handler {
+	h := &Handler{
+		client: client,
+		log:    logging.NewNopLogger(),
+	}
+
+	for _, opt := range opts {
+		opt(h)
+	}
+
+	return h
+}
+
+// Handle handles the admission request, validating that no custom resources
+// exist for the provider's CRDs before allowing deletion.
+func (h *Handler) Handle(ctx context.Context, request admission.Request) admission.Response {
+	switch request.Operation {
+	case admissionv1.Create, admissionv1.Update, admissionv1.Connect:
+		return admission.Errored(http.StatusBadRequest, errors.Errorf(errFmtUnexpectedOp, request.Operation))
+	case admissionv1.Delete:
+		u := &unstructured.Unstructured{}
+		if err := u.UnmarshalJSON(request.OldObject.Raw); err != nil {
+			return admission.Errored(http.StatusBadRequest, errors.Wrap(err, errUnmarshalProvider))
+		}
+
+		provider := &v1.Provider{}
+		if err := runtime.DefaultUnstructuredConverter.FromUnstructured(u.Object, provider); err != nil {
+			return admission.Errored(http.StatusBadRequest, errors.Wrap(err, errUnmarshalProvider))
+		}
+
+		log := h.log.WithValues(
+			"provider", provider.GetName(),
+			"currentRevision", provider.Status.CurrentRevision,
+		)
+
+		log.Debug("Validating provider deletion")
+
+		// Check if provider has a current revision
+		if provider.Status.CurrentRevision == "" {
+			log.Debug("Provider has no current revision, allowing deletion")
+			return admission.Allowed("")
+		}
+
+		// Get the current provider revision
+		revision := &v1.ProviderRevision{}
+		if err := h.client.Get(ctx, types.NamespacedName{Name: provider.Status.CurrentRevision}, revision); err != nil {
+			if kerrors.IsNotFound(err) {
+				log.Debug("Provider revision not found, allowing deletion", "err", err)
+				// If revision is gone, allow provider deletion
+				return admission.Allowed("")
+			}
+			log.Debug("Error getting provider revision", "err", err)
+			return admission.Errored(http.StatusInternalServerError, errors.Wrapf(err, errFmtGetProviderRevision, provider.Status.CurrentRevision))
+		}
+
+		// Extract CRD names from MRDs in the revision's ObjectRefs
+		// This checks if MRDs are Active and only returns CRD names for Active MRDs
+		crdNames, err := h.extractActiveMRDNames(ctx, revision.Status.ObjectRefs)
+		if err != nil {
+			log.Debug("Error extracting active MRD names", "err", err)
+			return admission.Errored(http.StatusInternalServerError, errors.Wrap(err, errExtractMRDNames))
+		}
+		if len(crdNames) == 0 {
+			log.Debug("No active MRDs found in provider revision, allowing deletion")
+			return admission.Allowed("")
+		}
+
+		log.Debug("Checking for existing custom resources", "crdCount", len(crdNames))
+
+		// Check each CRD for existing custom resources
+		// Return early as soon as we find any instance to minimize API calls
+		for _, crdName := range crdNames {
+			hasInstances, err := h.hasCustomResources(ctx, crdName)
+			if err != nil {
+				log.Debug("Error checking for custom resources", "crd", crdName, "err", err)
+				return admission.Errored(http.StatusInternalServerError, errors.Wrapf(err, errFmtListCRs, crdName))
+			}
+			if hasInstances {
+				log.Debug("Custom resources found, blocking deletion", "crd", crdName)
+				return admission.Response{
+					AdmissionResponse: admissionv1.AdmissionResponse{
+						Allowed: false,
+						Result: &metav1.Status{
+							Code:   int32(http.StatusConflict),
+							Reason: metav1.StatusReason(errCRsExist),
+						},
+					},
+				}
+			}
+		}
+
+		log.Debug("No custom resources found, allowing deletion")
+		return admission.Allowed("")
+	default:
+		return admission.Errored(http.StatusBadRequest, errors.Errorf(errFmtUnexpectedOp, request.Operation))
+	}
+}
+
+// extractActiveMRDNames extracts CRD names from Active MRDs in ObjectRefs.
+// Providers track their CRDs via ManagedResourceDefinitions (MRDs).
+// This function:
+// 1. Finds MRD references in ObjectRefs
+// 2. Fetches each MRD resource
+// 3. Checks if the MRD is Active (spec.state == "Active")
+// 4. Only returns CRD names for Active MRDs (inactive MRDs don't have CRDs).
+func (h *Handler) extractActiveMRDNames(ctx context.Context, refs []xpv1.TypedReference) ([]string, error) {
+	crdNames := []string{}
+	for _, ref := range refs {
+		if ref.Kind != v1alpha1.ManagedResourceDefinitionKind {
+			continue
+		}
+
+		// Fetch the MRD to check its state
+		mrd := &v1alpha1.ManagedResourceDefinition{}
+		if err := h.client.Get(ctx, types.NamespacedName{Name: ref.Name}, mrd); err != nil {
+			if kerrors.IsNotFound(err) {
+				// MRD doesn't exist anymore, skip it (no CRD to check)
+				continue
+			}
+			return nil, errors.Wrapf(err, errFmtGetMRD, ref.Name)
+		}
+
+		// Only include Active MRDs - Inactive MRDs don't create CRDs
+		if mrd.Spec.State.IsActive() {
+			crdNames = append(crdNames, mrd.Name)
+		}
+	}
+	return crdNames, nil
+}
+
+// hasCustomResources checks if any custom resource instances exist for a given CRD.
+// It returns early after finding the first instance to minimize API calls.
+func (h *Handler) hasCustomResources(ctx context.Context, crdName string) (bool, error) {
+	// Get the CRD to extract GVK information
+	crd := &extv1.CustomResourceDefinition{}
+	if err := h.client.Get(ctx, types.NamespacedName{Name: crdName}, crd); err != nil {
+		if kerrors.IsNotFound(err) {
+			// CRD doesn't exist, so no instances can exist
+			return false, nil
+		}
+		return false, errors.Wrapf(err, errFmtGetCRD, crdName)
+	}
+
+	// Find the storage version
+	var storageVersion string
+	for _, version := range crd.Spec.Versions {
+		if version.Storage {
+			storageVersion = version.Name
+			break
+		}
+	}
+
+	// Build GVK for listing
+	gvk := schema.GroupVersionKind{
+		Group:   crd.Spec.Group,
+		Version: storageVersion,
+		Kind:    crd.Spec.Names.ListKind,
+	}
+
+	// List custom resources using unstructured with Limit(1) to check existence
+	list := &unstructured.UnstructuredList{}
+	list.SetGroupVersionKind(gvk)
+
+	if err := h.client.List(ctx, list, client.Limit(1)); err != nil {
+		return false, errors.Wrapf(err, errFmtListCRs, crdName)
+	}
+
+	return len(list.Items) > 0, nil
+}

--- a/internal/webhook/protection/provider/handler_test.go
+++ b/internal/webhook/protection/provider/handler_test.go
@@ -1,0 +1,601 @@
+/*
+Copyright 2024 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package provider
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	admissionv1 "k8s.io/api/admission/v1"
+	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	xpv1 "github.com/crossplane/crossplane-runtime/v2/apis/common/v1"
+	"github.com/crossplane/crossplane-runtime/v2/pkg/errors"
+	"github.com/crossplane/crossplane-runtime/v2/pkg/test"
+
+	v1alpha1 "github.com/crossplane/crossplane/v2/apis/apiextensions/v1alpha1"
+	v1 "github.com/crossplane/crossplane/v2/apis/pkg/v1"
+)
+
+var _ admission.Handler = &Handler{}
+
+var errBoom = errors.New("boom")
+
+func TestHandle(t *testing.T) {
+	type args struct {
+		client  client.Client
+		request admission.Request
+	}
+
+	type want struct {
+		resp admission.Response
+	}
+
+	cases := map[string]struct {
+		reason string
+		args   args
+		want   want
+	}{
+		"UnexpectedCreate": {
+			reason: "We should return an error if the request is a create (not a delete).",
+			args: args{
+				request: admission.Request{
+					AdmissionRequest: admissionv1.AdmissionRequest{
+						Operation: admissionv1.Create,
+					},
+				},
+			},
+			want: want{
+				resp: admission.Errored(http.StatusBadRequest, errors.Errorf(errFmtUnexpectedOp, admissionv1.Create)),
+			},
+		},
+		"UnexpectedUpdate": {
+			reason: "We should return an error if the request is an update (not a delete).",
+			args: args{
+				request: admission.Request{
+					AdmissionRequest: admissionv1.AdmissionRequest{
+						Operation: admissionv1.Update,
+					},
+				},
+			},
+			want: want{
+				resp: admission.Errored(http.StatusBadRequest, errors.Errorf(errFmtUnexpectedOp, admissionv1.Update)),
+			},
+		},
+		"DeleteWithoutOldObj": {
+			reason: "We should return an error if delete request does not have the old object.",
+			args: args{
+				request: admission.Request{
+					AdmissionRequest: admissionv1.AdmissionRequest{
+						Operation: admissionv1.Delete,
+					},
+				},
+			},
+			want: want{
+				resp: admission.Errored(http.StatusBadRequest, errors.Wrap(errors.New("unexpected end of JSON input"), errUnmarshalProvider)),
+			},
+		},
+		"DeleteAllowedNoRevision": {
+			reason: "We should allow deletion if provider has no current revision.",
+			args: args{
+				request: admission.Request{
+					AdmissionRequest: admissionv1.AdmissionRequest{
+						Operation: admissionv1.Delete,
+						OldObject: runtime.RawExtension{
+							Raw: []byte(`{
+								"apiVersion": "pkg.crossplane.io/v1",
+								"kind": "Provider",
+								"metadata": {
+									"name": "test-provider"
+								},
+								"status": {
+									"currentRevision": ""
+								}
+							}`),
+						},
+					},
+				},
+			},
+			want: want{
+				resp: admission.Allowed(""),
+			},
+		},
+		"DeleteAllowedRevisionNotFound": {
+			reason: "We should allow deletion if the provider revision is not found.",
+			args: args{
+				client: &test.MockClient{
+					MockGet: func(_ context.Context, key client.ObjectKey, obj client.Object) error {
+						if _, ok := obj.(*v1.ProviderRevision); ok {
+							return kerrors.NewNotFound(schema.GroupResource{Group: "pkg.crossplane.io", Resource: "providerrevisions"}, key.Name)
+						}
+						return nil
+					},
+				},
+				request: admission.Request{
+					AdmissionRequest: admissionv1.AdmissionRequest{
+						Operation: admissionv1.Delete,
+						OldObject: runtime.RawExtension{
+							Raw: []byte(`{
+								"apiVersion": "pkg.crossplane.io/v1",
+								"kind": "Provider",
+								"metadata": {
+									"name": "test-provider"
+								},
+								"status": {
+									"currentRevision": "test-provider-abc123"
+								}
+							}`),
+						},
+					},
+				},
+			},
+			want: want{
+				resp: admission.Allowed(""),
+			},
+		},
+		"DeleteAllowedNoCRDs": {
+			reason: "We should allow deletion if the provider revision has no CRDs.",
+			args: args{
+				client: &test.MockClient{
+					MockGet: func(_ context.Context, _ client.ObjectKey, obj client.Object) error {
+						if pr, ok := obj.(*v1.ProviderRevision); ok {
+							*pr = v1.ProviderRevision{
+								Status: v1.ProviderRevisionStatus{
+									PackageRevisionStatus: v1.PackageRevisionStatus{
+										ObjectRefs: []xpv1.TypedReference{
+											{
+												APIVersion: "v1",
+												Kind:       "ServiceAccount",
+												Name:       "test-sa",
+											},
+										},
+									},
+								},
+							}
+							return nil
+						}
+						return nil
+					},
+				},
+				request: admission.Request{
+					AdmissionRequest: admissionv1.AdmissionRequest{
+						Operation: admissionv1.Delete,
+						OldObject: runtime.RawExtension{
+							Raw: []byte(`{
+								"apiVersion": "pkg.crossplane.io/v1",
+								"kind": "Provider",
+								"metadata": {
+									"name": "test-provider"
+								},
+								"status": {
+									"currentRevision": "test-provider-abc123"
+								}
+							}`),
+						},
+					},
+				},
+			},
+			want: want{
+				resp: admission.Allowed(""),
+			},
+		},
+		"DeleteAllowedNoCRsExist": {
+			reason: "We should allow deletion if no custom resources exist for the provider's MRDs.",
+			args: args{
+				client: &test.MockClient{
+					MockGet: func(_ context.Context, key client.ObjectKey, obj client.Object) error {
+						switch o := obj.(type) {
+						case *v1.ProviderRevision:
+							*o = v1.ProviderRevision{
+								Status: v1.ProviderRevisionStatus{
+									PackageRevisionStatus: v1.PackageRevisionStatus{
+										ObjectRefs: []xpv1.TypedReference{
+											{
+												APIVersion: "apiextensions.crossplane.io/v1alpha1",
+												Kind:       v1alpha1.ManagedResourceDefinitionKind,
+												Name:       "tests.example.com",
+											},
+										},
+									},
+								},
+							}
+							return nil
+						case *v1alpha1.ManagedResourceDefinition:
+							*o = v1alpha1.ManagedResourceDefinition{
+								ObjectMeta: metav1.ObjectMeta{
+									Name: key.Name,
+								},
+								Spec: v1alpha1.ManagedResourceDefinitionSpec{
+									State: v1alpha1.ManagedResourceDefinitionActive,
+								},
+							}
+							return nil
+						case *extv1.CustomResourceDefinition:
+							*o = extv1.CustomResourceDefinition{
+								Spec: extv1.CustomResourceDefinitionSpec{
+									Group: "example.com",
+									Names: extv1.CustomResourceDefinitionNames{
+										Kind:     "Test",
+										ListKind: "TestList",
+									},
+									Scope: extv1.ClusterScoped,
+									Versions: []extv1.CustomResourceDefinitionVersion{
+										{
+											Name:    "v1alpha1",
+											Storage: true,
+										},
+									},
+								},
+							}
+							return nil
+						}
+						return nil
+					},
+					MockList: func(_ context.Context, list client.ObjectList, _ ...client.ListOption) error {
+						if ul, ok := list.(*unstructured.UnstructuredList); ok {
+							ul.Items = []unstructured.Unstructured{} // No instances
+							return nil
+						}
+						return nil
+					},
+				},
+				request: admission.Request{
+					AdmissionRequest: admissionv1.AdmissionRequest{
+						Operation: admissionv1.Delete,
+						OldObject: runtime.RawExtension{
+							Raw: []byte(`{
+								"apiVersion": "pkg.crossplane.io/v1",
+								"kind": "Provider",
+								"metadata": {
+									"name": "test-provider"
+								},
+								"status": {
+									"currentRevision": "test-provider-abc123"
+								}
+							}`),
+						},
+					},
+				},
+			},
+			want: want{
+				resp: admission.Allowed(""),
+			},
+		},
+		"DeleteBlockedCRsExist": {
+			reason: "We should block deletion if custom resources exist for the provider's MRDs.",
+			args: args{
+				client: &test.MockClient{
+					MockGet: func(_ context.Context, key client.ObjectKey, obj client.Object) error {
+						switch o := obj.(type) {
+						case *v1.ProviderRevision:
+							*o = v1.ProviderRevision{
+								Status: v1.ProviderRevisionStatus{
+									PackageRevisionStatus: v1.PackageRevisionStatus{
+										ObjectRefs: []xpv1.TypedReference{
+											{
+												APIVersion: "apiextensions.crossplane.io/v1alpha1",
+												Kind:       v1alpha1.ManagedResourceDefinitionKind,
+												Name:       "buckets.s3.aws.upbound.io",
+											},
+										},
+									},
+								},
+							}
+							return nil
+						case *v1alpha1.ManagedResourceDefinition:
+							*o = v1alpha1.ManagedResourceDefinition{
+								ObjectMeta: metav1.ObjectMeta{
+									Name: key.Name,
+								},
+								Spec: v1alpha1.ManagedResourceDefinitionSpec{
+									State: v1alpha1.ManagedResourceDefinitionActive,
+								},
+							}
+							return nil
+						case *extv1.CustomResourceDefinition:
+							*o = extv1.CustomResourceDefinition{
+								Spec: extv1.CustomResourceDefinitionSpec{
+									Group: "s3.aws.upbound.io",
+									Names: extv1.CustomResourceDefinitionNames{
+										Kind:     "Bucket",
+										ListKind: "BucketList",
+									},
+									Scope: extv1.ClusterScoped,
+									Versions: []extv1.CustomResourceDefinitionVersion{
+										{
+											Name:    "v1beta1",
+											Storage: true,
+										},
+									},
+								},
+							}
+							return nil
+						}
+						return nil
+					},
+					MockList: func(_ context.Context, list client.ObjectList, _ ...client.ListOption) error {
+						if ul, ok := list.(*unstructured.UnstructuredList); ok {
+							// Return 1 instance (only need 1 to block)
+							ul.Items = []unstructured.Unstructured{
+								{},
+							}
+							return nil
+						}
+						return nil
+					},
+				},
+				request: admission.Request{
+					AdmissionRequest: admissionv1.AdmissionRequest{
+						Operation: admissionv1.Delete,
+						OldObject: runtime.RawExtension{
+							Raw: []byte(`{
+								"apiVersion": "pkg.crossplane.io/v1",
+								"kind": "Provider",
+								"metadata": {
+									"name": "provider-aws-s3"
+								},
+								"status": {
+									"currentRevision": "provider-aws-s3-abc123"
+								}
+							}`),
+						},
+					},
+				},
+			},
+			want: want{
+				resp: admission.Response{
+					AdmissionResponse: admissionv1.AdmissionResponse{
+						Allowed: false,
+						Result: &metav1.Status{
+							Code:   int32(http.StatusConflict),
+							Reason: metav1.StatusReason(errCRsExist),
+						},
+					},
+				},
+			},
+		},
+		"DeleteBlockedMultipleCRDsWithCRs": {
+			reason: "We should block deletion if multiple MRDs have custom resources (returns early on first match).",
+			args: args{
+				client: &test.MockClient{
+					MockGet: func(_ context.Context, key client.ObjectKey, obj client.Object) error {
+						switch o := obj.(type) {
+						case *v1.ProviderRevision:
+							*o = v1.ProviderRevision{
+								Status: v1.ProviderRevisionStatus{
+									PackageRevisionStatus: v1.PackageRevisionStatus{
+										ObjectRefs: []xpv1.TypedReference{
+											{
+												APIVersion: "apiextensions.crossplane.io/v1alpha1",
+												Kind:       v1alpha1.ManagedResourceDefinitionKind,
+												Name:       "buckets.s3.aws.upbound.io",
+											},
+											{
+												APIVersion: "apiextensions.crossplane.io/v1alpha1",
+												Kind:       v1alpha1.ManagedResourceDefinitionKind,
+												Name:       "roles.iam.aws.upbound.io",
+											},
+										},
+									},
+								},
+							}
+							return nil
+						case *v1alpha1.ManagedResourceDefinition:
+							*o = v1alpha1.ManagedResourceDefinition{
+								ObjectMeta: metav1.ObjectMeta{
+									Name: key.Name,
+								},
+								Spec: v1alpha1.ManagedResourceDefinitionSpec{
+									State: v1alpha1.ManagedResourceDefinitionActive,
+								},
+							}
+							return nil
+						case *extv1.CustomResourceDefinition:
+							if key.Name == "buckets.s3.aws.upbound.io" {
+								*o = extv1.CustomResourceDefinition{
+									Spec: extv1.CustomResourceDefinitionSpec{
+										Group: "s3.aws.upbound.io",
+										Names: extv1.CustomResourceDefinitionNames{
+											Kind:     "Bucket",
+											ListKind: "BucketList",
+										},
+										Scope: extv1.ClusterScoped,
+										Versions: []extv1.CustomResourceDefinitionVersion{
+											{
+												Name:    "v1beta1",
+												Storage: true,
+											},
+										},
+									},
+								}
+							} else {
+								*o = extv1.CustomResourceDefinition{
+									Spec: extv1.CustomResourceDefinitionSpec{
+										Group: "iam.aws.upbound.io",
+										Names: extv1.CustomResourceDefinitionNames{
+											Kind:     "Role",
+											ListKind: "RoleList",
+										},
+										Scope: extv1.ClusterScoped,
+										Versions: []extv1.CustomResourceDefinitionVersion{
+											{
+												Name:    "v1beta1",
+												Storage: true,
+											},
+										},
+									},
+								}
+							}
+							return nil
+						}
+						return nil
+					},
+					MockList: func(_ context.Context, list client.ObjectList, _ ...client.ListOption) error {
+						if ul, ok := list.(*unstructured.UnstructuredList); ok {
+							// First CRD has instances, so it will return early
+							ul.Items = []unstructured.Unstructured{
+								{},
+							}
+							return nil
+						}
+						return nil
+					},
+				},
+				request: admission.Request{
+					AdmissionRequest: admissionv1.AdmissionRequest{
+						Operation: admissionv1.Delete,
+						OldObject: runtime.RawExtension{
+							Raw: []byte(`{
+								"apiVersion": "pkg.crossplane.io/v1",
+								"kind": "Provider",
+								"metadata": {
+									"name": "provider-aws"
+								},
+								"status": {
+									"currentRevision": "provider-aws-abc123"
+								}
+							}`),
+						},
+					},
+				},
+			},
+			want: want{
+				resp: admission.Response{
+					AdmissionResponse: admissionv1.AdmissionResponse{
+						Allowed: false,
+						Result: &metav1.Status{
+							Code:   int32(http.StatusConflict),
+							Reason: metav1.StatusReason(errCRsExist),
+						},
+					},
+				},
+			},
+		},
+		"DeleteRejectedCannotGetRevision": {
+			reason: "We should reject a delete request if we cannot get the provider revision.",
+			args: args{
+				client: &test.MockClient{
+					MockGet: func(_ context.Context, _ client.ObjectKey, obj client.Object) error {
+						if _, ok := obj.(*v1.ProviderRevision); ok {
+							return errBoom
+						}
+						return nil
+					},
+				},
+				request: admission.Request{
+					AdmissionRequest: admissionv1.AdmissionRequest{
+						Operation: admissionv1.Delete,
+						OldObject: runtime.RawExtension{
+							Raw: []byte(`{
+								"apiVersion": "pkg.crossplane.io/v1",
+								"kind": "Provider",
+								"metadata": {
+									"name": "test-provider"
+								},
+								"status": {
+									"currentRevision": "test-provider-abc123"
+								}
+							}`),
+						},
+					},
+				},
+			},
+			want: want{
+				resp: admission.Errored(http.StatusInternalServerError, errors.Wrapf(errBoom, errFmtGetProviderRevision, "test-provider-abc123")),
+			},
+		},
+		"DeleteRejectedCannotGetCRD": {
+			reason: "We should reject a delete request if we cannot get a CRD for an MRD.",
+			args: args{
+				client: &test.MockClient{
+					MockGet: func(_ context.Context, key client.ObjectKey, obj client.Object) error {
+						switch o := obj.(type) {
+						case *v1.ProviderRevision:
+							*o = v1.ProviderRevision{
+								Status: v1.ProviderRevisionStatus{
+									PackageRevisionStatus: v1.PackageRevisionStatus{
+										ObjectRefs: []xpv1.TypedReference{
+											{
+												APIVersion: "apiextensions.crossplane.io/v1alpha1",
+												Kind:       v1alpha1.ManagedResourceDefinitionKind,
+												Name:       "tests.example.com",
+											},
+										},
+									},
+								},
+							}
+							return nil
+						case *v1alpha1.ManagedResourceDefinition:
+							*o = v1alpha1.ManagedResourceDefinition{
+								ObjectMeta: metav1.ObjectMeta{
+									Name: key.Name,
+								},
+								Spec: v1alpha1.ManagedResourceDefinitionSpec{
+									State: v1alpha1.ManagedResourceDefinitionActive,
+								},
+							}
+							return nil
+						case *extv1.CustomResourceDefinition:
+							return errBoom
+						}
+						return nil
+					},
+				},
+				request: admission.Request{
+					AdmissionRequest: admissionv1.AdmissionRequest{
+						Operation: admissionv1.Delete,
+						OldObject: runtime.RawExtension{
+							Raw: []byte(`{
+								"apiVersion": "pkg.crossplane.io/v1",
+								"kind": "Provider",
+								"metadata": {
+									"name": "test-provider"
+								},
+								"status": {
+									"currentRevision": "test-provider-abc123"
+								}
+							}`),
+						},
+					},
+				},
+			},
+			want: want{
+				resp: admission.Errored(http.StatusInternalServerError, errors.Wrapf(errors.Wrapf(errBoom, errFmtGetCRD, "tests.example.com"), errFmtListCRs, "tests.example.com")),
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			h := NewHandler(tc.args.client)
+
+			got := h.Handle(context.Background(), tc.args.request)
+			if diff := cmp.Diff(tc.want.resp, got); diff != "" {
+				t.Errorf("%s\nHandle(...): -want response, +got:\n%s", tc.reason, diff)
+			}
+		})
+	}
+}

--- a/test/e2e/protection_provider_deletion_test.go
+++ b/test/e2e/protection_provider_deletion_test.go
@@ -1,0 +1,62 @@
+/*
+Copyright 2024 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/e2e-framework/pkg/features"
+
+	xpv1 "github.com/crossplane/crossplane-runtime/v2/apis/common/v1"
+
+	pkgv1 "github.com/crossplane/crossplane/v2/apis/pkg/v1"
+	"github.com/crossplane/crossplane/v2/test/e2e/config"
+	"github.com/crossplane/crossplane/v2/test/e2e/funcs"
+)
+
+func TestProviderDeletionProtection(t *testing.T) {
+	manifests := "test/e2e/manifests/pkg/provider"
+
+	environment.Test(t,
+		features.NewWithDescription(t.Name(), "Tests that provider deletion is blocked when custom resources exist for the provider's CRDs.").
+			WithLabel(LabelArea, LabelAreaProtection).
+			WithLabel(LabelSize, LabelSizeSmall).
+			WithLabel(config.LabelTestSuite, config.TestSuiteDefault).
+			WithSetup("ApplyProvider", funcs.AllOf(
+				funcs.ApplyResources(FieldManager, manifests, "provider-initial.yaml"),
+				funcs.ResourcesCreatedWithin(1*time.Minute, manifests, "provider-initial.yaml"),
+				funcs.ResourcesHaveConditionWithin(2*time.Minute, manifests, "provider-initial.yaml", pkgv1.Healthy(), pkgv1.Active()),
+			)).
+			WithSetup("CreateManagedResource", funcs.AllOf(
+				funcs.ApplyResources(FieldManager, manifests, "mr-initial.yaml"),
+				funcs.ResourcesCreatedWithin(1*time.Minute, manifests, "mr-initial.yaml"),
+				funcs.ResourcesHaveConditionWithin(1*time.Minute, manifests, "mr-initial.yaml", xpv1.Available()),
+			)).
+			Assess("ProviderDeletionBlocked", funcs.DeletionBlockedByProviderWebhook(manifests, "provider-initial.yaml")).
+			WithTeardown("DeleteManagedResource", funcs.AllOf(
+				funcs.DeleteResources(manifests, "mr-initial.yaml"),
+				funcs.ResourcesDeletedWithin(1*time.Minute, manifests, "mr-initial.yaml"),
+			)).
+			WithTeardown("DeleteProviderAfterMRDeleted", funcs.AllOf(
+				funcs.DeleteResourcesWithPropagationPolicy(manifests, "provider-initial.yaml", metav1.DeletePropagationForeground),
+				funcs.ResourcesDeletedWithin(1*time.Minute, manifests, "provider-initial.yaml"),
+			)).
+			Feature(),
+	)
+}


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane! Please read the contribution docs
(linked below) if this is your first Crossplane pull request.
-->

### Description of your changes
Adding a dedicated webhook to prevent accidental deletion of Providers that still have active managed resources. While Crossplane already has deletion protection mechanisms like `ProviderConfigUsage` and the `Usage / ClusterUsage` resource, this webhook addresses a specific gap where users can delete a Provider package without realizing they have managed resources that depend on the CRDs defined by that Provider. 

The existing protection mechanisms operate at different layers. `ProviderConfigUsage` tracks dependencies between `ProviderConfigs` and managed resources, while `Usage / ClusterUsage` provide a generic mechanism for enforcing deletion order across Crossplane resources. However, neither mechanism directly safeguards against the scenario where a Provider is deleted while managed resources created from its CRDs still exist. In that case, those resources could be orphaned, leaving underlying infrastructure in an unmanaged state.

While it is technically possible for users to define `User / ClusterUsage` resources on top of Provider manifests to mitigate this risk, doing so requires prior knowledge and explicit action. Without that awareness, the default behavior can be dangerous.

This webhook acts as a final safety net by checking for any custom resource instances across all CRDs owned by the Provider before allowing deletion. _The webhook is enabled by default when webhooks are active_, providing safe defaults for users who may not be aware of the cascading effects of Provider deletion. _Users who understand the implications and want to allow Provider deletion regardless of existing managed resources can opt out_ by setting the `DisableProviderDeletionProtection` feature flag. This approach prioritizes safety while maintaining flexibility for advanced use cases. 

- returns early upon finding the first managed resource instance across all CRDs (minimizing API server load and providing fast webhook responses)
- error message is intentionally generic that deletion is blocked due to existing custom resources. 
 
We acknowledge that having multiple deletion protection patterns in the ecosystem represents an architectural tradeoff. The pragmatic choice here is to ship a targeted solution that prevents a specific dangerous operation.

Looking forward, the same deletion protection pattern could be valuable for `Configurations`, as they also define XRDs that may have active instances when users attempt to delete the Configuration package. Applying this safety net to Configurations would provide consistent protection across both package types and prevent similar scenarios where deleting a Configuration could orphan composite resources.

<!--
Briefly describe what this pull request does, and how it is covered by tests.
Be proactive - direct your reviewers' attention to anything that needs special
consideration.

We love pull requests that fix an open issue. If yours does, use the below line
to indicate which issue it fixes, for example "Fixes #500".
-->

Fixes #6001
Fixes #4251
Fixes #6268

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `earthly +reviewable` to ensure this PR is ready for review.
- [x] Added or updated unit tests.
- [x] Added or updated e2e tests.
- [x] Linked a PR or a [docs tracking issue] to [document this change].
- [x] Added `backport release-x.y` labels to auto-backport this PR.
- [x] Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md


```
kubectl apply -f ./test/e2e/manifests/pkg/provider/provider-initial.yaml
provider.pkg.crossplane.io/provider-nop-pkg-provider-upgrade created

kubectl apply -f ./test/e2e/manifests/pkg/provider/mr-initial.yaml      
nopresource.nop.crossplane.io/pkg-provider-upgrade created

kubectl delete -f ./test/e2e/manifests/pkg/provider/provider-initial.yaml
Error from server (Cannot delete provider: custom resources still exist. Please delete all custom resources before deleting the provider.): error when deleting "./test/e2e/manifests/pkg/provider/provider-initial.yaml": admission webhook "providerdeletion.pkg.crossplane.io" denied the request: Cannot delete provider: custom resources still exist. Please delete all custom resources before deleting the provider.

kubectl delete -f ./test/e2e/manifests/pkg/provider/mr-initial.yaml      
nopresource.nop.crossplane.io "pkg-provider-upgrade" deleted

kubectl delete -f ./test/e2e/manifests/pkg/provider/provider-initial.yaml
provider.pkg.crossplane.io "provider-nop-pkg-provider-upgrade" deleted
```