### PR TITLE
Make Earthly +image load locally unless PUSH=true ( +go-build | failed: Canceled: grpc: the client connection is closing #6989 )

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -273,6 +273,7 @@ go-lint:
 
 # image builds the Crossplane OCI image for your native architecture.
 image:
+  ARG PUSH=false
   ARG EARTHLY_GIT_BRANCH
   ARG EARTHLY_GIT_SHORT_HASH
   ARG EARTHLY_GIT_COMMIT_TIMESTAMP


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane! Please read the contribution docs
(linked below) if this is your first Crossplane pull request.
-->

### Description of your changes

<!--
This PR makes the +image Earthly target more suitable for local development by loading images into the local Docker daemon by default, and only pushing images when explicitly requested.

This keeps CI and release behavior unchanged while improving developer experience and reducing flaky local build failures.

We love pull requests that fix an open issue. If yours does, use the below line
to indicate which issue it fixes, for example "Fixes #6989 ".
-->

Fixes #

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `earthly +reviewable` to ensure this PR is ready for review.
- [ ] Added or updated unit tests.
- [ ] Added or updated e2e tests.
- [ ] Linked a PR or a [docs tracking issue] to [document this change].
- [ ] Added `backport release-x.y` labels to auto-backport this PR.
- [ ] Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md