### PR TITLE
chore: update run function proto comments for v2 connection details

### DIFF
--- a/proto/fn/v1/run_function.pb.go
+++ b/proto/fn/v1/run_function.pb.go
@@ -1093,7 +1093,7 @@ type Resource struct {
 	// the observed connection details of a composite or composed resource.
 	//
 	// * A function should set this field in a RunFunctionResponse to indicate the
-	// desired connection details of the XR.
+	// desired connection details of legacy XRs. For modern XRs, this will be ignored.
 	//
 	// * A function should not set this field in a RunFunctionResponse to indicate
 	// the desired connection details of a composed resource. This will be

--- a/proto/fn/v1/run_function.proto
+++ b/proto/fn/v1/run_function.proto
@@ -247,7 +247,7 @@ message Resource {
   // the observed connection details of a composite or composed resource.
   //
   // * A function should set this field in a RunFunctionResponse to indicate the
-  // desired connection details of the XR.
+  // desired connection details of legacy XRs. For modern XRs, this will be ignored.
   //
   // * A function should not set this field in a RunFunctionResponse to indicate
   // the desired connection details of a composed resource. This will be

--- a/proto/fn/v1beta1/zz_generated_run_function.pb.go
+++ b/proto/fn/v1beta1/zz_generated_run_function.pb.go
@@ -1095,7 +1095,7 @@ type Resource struct {
 	// the observed connection details of a composite or composed resource.
 	//
 	// * A function should set this field in a RunFunctionResponse to indicate the
-	// desired connection details of the XR.
+	// desired connection details of legacy XRs. For modern XRs, this will be ignored.
 	//
 	// * A function should not set this field in a RunFunctionResponse to indicate
 	// the desired connection details of a composed resource. This will be

--- a/proto/fn/v1beta1/zz_generated_run_function.proto
+++ b/proto/fn/v1beta1/zz_generated_run_function.proto
@@ -249,7 +249,7 @@ message Resource {
   // the observed connection details of a composite or composed resource.
   //
   // * A function should set this field in a RunFunctionResponse to indicate the
-  // desired connection details of the XR.
+  // desired connection details of legacy XRs. For modern XRs, this will be ignored.
   //
   // * A function should not set this field in a RunFunctionResponse to indicate
   // the desired connection details of a composed resource. This will be


### PR DESCRIPTION
### Description of your changes

This PR just adds simple clarification to the `RunFunction*` protobufs to make it clear that setting an XR's connection details will be ignored in v2.

This is part of the overall effort to reduce confusion in this area for https://github.com/crossplane/docs/issues/1001. 

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `earthly +reviewable` to ensure this PR is ready for review.
- [ ] ~Added or updated unit tests.~
- [ ] ~Added or updated e2e tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~
- [ ] ~Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md