### PR TITLE
Disable CodeRabbit issue enrichment beta feature

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -260,6 +260,15 @@ reviews:
       enabled: false
 
 # =============================================================================
+# ISSUE ENRICHMENT
+# Disable automatic issue enrichment (beta feature) - we only want PR reviews
+# =============================================================================
+
+issue_enrichment:
+  auto_enrich:
+    enabled: false
+
+# =============================================================================
 # CHAT
 # Interactive chat with CodeRabbit in PR comments. You can ask questions like:
 # - @coderabbitai explain this error handling approach


### PR DESCRIPTION
### Description of your changes

CodeRabbit recently enabled an "issue enrichment" beta that comments on every new issue. The comments suggest related issues and possible duplicates, and offer to generate LLM implementation plans for fixing the issue.

Looking at recent issues, the related issue suggestions appear low value. They match on surface-level signals (e.g. suggesting unrelated CI failures as duplicates because both mention "build") rather than understanding the actual problem being reported.

The "Create Plan" feature is also undesirable. We don't want to encourage contributors to ask an LLM to generate implementation plans for issues they're working on.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [ ] ~Run `earthly +reviewable` to ensure this PR is ready for review.~
- [ ] ~Added or updated unit tests.~
- [ ] ~Added or updated e2e tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~
- [ ] ~Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md