### PR TITLE
chore: Fix Render copylocks error by changing Requirements map to store pointer

### DIFF
--- a/cmd/crank/render/render.go
+++ b/cmd/crank/render/render.go
@@ -91,7 +91,7 @@ type Outputs struct {
 	// The Crossplane context object
 	Context *unstructured.Unstructured
 	// The Function requirements
-	Requirements map[string]fnv1.Requirements
+	Requirements map[string]*fnv1.Requirements
 
 	// TODO(negz): Allow returning desired XR connection details. Maybe as a
 	// Secret? Should we honor writeConnectionSecretToRef? What if secret stores
@@ -228,7 +228,7 @@ func Render(ctx context.Context, log logging.Logger, in Inputs) (Outputs, error)
 
 	results := make([]unstructured.Unstructured, 0)
 	conditions := make([]xpv1.Condition, 0)
-	requirements := make(map[string]fnv1.Requirements)
+	requirements := make(map[string]*fnv1.Requirements)
 
 	// The Function context starts empty.
 	fctx := &structpb.Struct{Fields: map[string]*structpb.Value{}}
@@ -334,9 +334,7 @@ func Render(ctx context.Context, log logging.Logger, in Inputs) (Outputs, error)
 			})
 		}
 
-		if rsp.GetRequirements() != nil {
-			requirements[fn.Step] = *rsp.GetRequirements()
-		}
+		requirements[fn.Step] = rsp.GetRequirements()
 
 		// Results of fatal severity stop the Composition process.
 		for _, rs := range rsp.GetResults() {

--- a/cmd/crank/render/render_test.go
+++ b/cmd/crank/render/render_test.go
@@ -200,7 +200,7 @@ name: test
 			},
 			want: want{
 				out: Outputs{
-					Requirements: map[string]fnv1.Requirements{},
+					Requirements: map[string]*fnv1.Requirements{},
 				},
 				err: cmpopts.AnyError,
 			},
@@ -258,7 +258,7 @@ name: test
 			},
 			want: want{
 				out: Outputs{
-					Requirements: map[string]fnv1.Requirements{
+					Requirements: map[string]*fnv1.Requirements{
 						"test": {
 							Resources: map[string]*fnv1.ResourceSelector{
 								"required-resource": {
@@ -469,7 +469,7 @@ name: test
 							},
 						},
 					},
-					Requirements: map[string]fnv1.Requirements{
+					Requirements: map[string]*fnv1.Requirements{
 						"test": {
 							Resources: map[string]*fnv1.ResourceSelector{
 								"example-resource": {
@@ -859,7 +859,7 @@ object:
 							},
 						},
 					},
-					Requirements: map[string]fnv1.Requirements{
+					Requirements: map[string]*fnv1.Requirements{
 						"test": {
 							Resources: map[string]*fnv1.ResourceSelector{
 								"ready-resource": {
@@ -1090,7 +1090,7 @@ object:
 							},
 						},
 					},
-					Requirements: map[string]fnv1.Requirements{
+					Requirements: map[string]*fnv1.Requirements{
 						"test": {
 							ExtraResources: map[string]*fnv1.ResourceSelector{
 								"extra-resource-by-name": {


### PR DESCRIPTION
The Outputs.Requirements field was defined as map[string]fnv1.Requirements (value type). Because fnv1.Requirements is a Protobuf message containing a sync.Mutex, accessing this map copies the struct and the lock, which triggers go vet copylocks errors.

I discovered this while writing a custom resource fetcher. Simply iterating over the Requirements map caused linter failures because Go map access copies the value. This made it annoying to read the data without copylock warnings.

Changed Outputs.Requirements to map[string]*fnv1.Requirements and updated Render() to assign pointers directly.

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `earthly +reviewable` to ensure this PR is ready for review.
- [x] Added or updated unit tests.
~- [] Added or updated e2e tests.~
~- [ ] Linked a PR or a [docs tracking issue] to [document this change].~
~- [ ] Added `backport release-x.y` labels to auto-backport this PR.~
~- [ ] Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~
