### PR TITLE
Allow XRDs to configure x-kubernetes-validations outside of spec

### DIFF
--- a/internal/xcrd/crd.go
+++ b/internal/xcrd/crd.go
@@ -189,6 +189,7 @@ func genCrdVersion(vr v1.CompositeResourceDefinitionVersion, maxNameLength int64
 	}
 
 	crdv.Schema.OpenAPIV3Schema.Description = s.Description
+	crdv.Schema.OpenAPIV3Schema.XValidations = s.XValidations
 
 	maxLength := maxNameLength
 	if old := s.Properties["metadata"].Properties["name"].MaxLength; old != nil && *old < maxLength {

--- a/internal/xcrd/crd_test.go
+++ b/internal/xcrd/crd_test.go
@@ -1998,6 +1998,259 @@ func TestForCompositeResource(t *testing.T) {
 				},
 			},
 		},
+		"PreserveTopLevelXValidations": {
+			reason: "A CRD should be generated with top-level x-kubernetes-validations outside of spec.",
+			args: args{
+				xrd: &v1.CompositeResourceDefinition{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:        name,
+						Labels:      labels,
+						Annotations: annotations,
+						UID:         types.UID("you-you-eye-dee"),
+					},
+					Spec: v1.CompositeResourceDefinitionSpec{
+						Scope: ptr.To(v1.CompositeResourceScopeNamespaced),
+						Group: group,
+						Names: extv1.CustomResourceDefinitionNames{
+							Plural:   plural,
+							Singular: singular,
+							Kind:     kind,
+							ListKind: listKind,
+						},
+						Versions: []v1.CompositeResourceDefinitionVersion{{
+							Name:          version,
+							Referenceable: true,
+							Served:        true,
+						}},
+					},
+				},
+				v: &v1.CompositeResourceValidation{
+					OpenAPIV3Schema: runtime.RawExtension{Raw: []byte(strings.Replace(schema, `"properties":`, `"x-kubernetes-validations":[{"rule":"self.metadata.name == ('database-' + self.spec.engineVersion)","message":"metadata.name must be database-spec.engineVersion"}],"properties":`, 1))},
+				},
+			},
+			want: want{
+				c: &extv1.CustomResourceDefinition{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:   name,
+						Labels: labels,
+						OwnerReferences: []metav1.OwnerReference{
+							meta.AsController(meta.TypedReferenceTo(d, v1.CompositeResourceDefinitionGroupVersionKind)),
+						},
+					},
+					Spec: extv1.CustomResourceDefinitionSpec{
+						Group: group,
+						Names: extv1.CustomResourceDefinitionNames{
+							Plural:     plural,
+							Singular:   singular,
+							Kind:       kind,
+							ListKind:   listKind,
+							Categories: []string{CategoryComposite},
+						},
+						Scope: extv1.NamespaceScoped,
+						Versions: []extv1.CustomResourceDefinitionVersion{{
+							Name:    version,
+							Served:  true,
+							Storage: true,
+							Subresources: &extv1.CustomResourceSubresources{
+								Status: &extv1.CustomResourceSubresourceStatus{},
+							},
+							AdditionalPrinterColumns: []extv1.CustomResourceColumnDefinition{
+								{
+									Name:     "SYNCED",
+									Type:     "string",
+									JSONPath: ".status.conditions[?(@.type=='Synced')].status",
+								},
+								{
+									Name:     "READY",
+									Type:     "string",
+									JSONPath: ".status.conditions[?(@.type=='Ready')].status",
+								},
+								{
+									Name:     "COMPOSITION",
+									Type:     "string",
+									JSONPath: ".spec.crossplane.compositionRef.name",
+								},
+								{
+									Name:     "COMPOSITIONREVISION",
+									Type:     "string",
+									JSONPath: ".spec.crossplane.compositionRevisionRef.name",
+									Priority: 1,
+								},
+								{
+									Name:     "AGE",
+									Type:     "date",
+									JSONPath: ".metadata.creationTimestamp",
+								},
+							},
+							Schema: &extv1.CustomResourceValidation{
+								OpenAPIV3Schema: &extv1.JSONSchemaProps{
+									Type:        "object",
+									Description: "What the resource is for.",
+									Required:    []string{"spec"},
+									XValidations: extv1.ValidationRules{
+										{
+											Rule:    "self.metadata.name == ('database-' + self.spec.engineVersion)",
+											Message: "metadata.name must be database-spec.engineVersion",
+										},
+									},
+									Properties: map[string]extv1.JSONSchemaProps{
+										"apiVersion": {
+											Type: "string",
+										},
+										"kind": {
+											Type: "string",
+										},
+										"metadata": {
+											Type: "object",
+											Properties: map[string]extv1.JSONSchemaProps{
+												"name": {
+													Type:      "string",
+													MaxLength: ptr.To[int64](63),
+												},
+											},
+										},
+										"spec": {
+											Type:        "object",
+											Required:    []string{"storageGB", "engineVersion"},
+											Description: "Specification of the resource.",
+											Properties: map[string]extv1.JSONSchemaProps{
+												"storageGB": {Type: "integer", Description: "Pretend this is useful."},
+												"engineVersion": {
+													Type: "string",
+													Enum: []extv1.JSON{
+														{Raw: []byte(`"5.6"`)},
+														{Raw: []byte(`"5.7"`)},
+													},
+												},
+												"someField":      {Type: "string", Description: "Pretend this is useful."},
+												"someOtherField": {Type: "string", Description: "Pretend this is useful."},
+												"crossplane": {
+													Type:        "object",
+													Description: "Configures how Crossplane will reconcile this composite resource",
+													Properties: map[string]extv1.JSONSchemaProps{
+														"compositionRef": {
+															Type:     "object",
+															Required: []string{"name"},
+															Properties: map[string]extv1.JSONSchemaProps{
+																"name": {Type: "string"},
+															},
+														},
+														"compositionSelector": {
+															Type:     "object",
+															Required: []string{"matchLabels"},
+															Properties: map[string]extv1.JSONSchemaProps{
+																"matchLabels": {
+																	Type: "object",
+																	AdditionalProperties: &extv1.JSONSchemaPropsOrBool{
+																		Allows: true,
+																		Schema: &extv1.JSONSchemaProps{Type: "string"},
+																	},
+																},
+															},
+														},
+														"compositionRevisionRef": {
+															Type:     "object",
+															Required: []string{"name"},
+															Properties: map[string]extv1.JSONSchemaProps{
+																"name": {Type: "string"},
+															},
+														},
+														"compositionRevisionSelector": {
+															Type:     "object",
+															Required: []string{"matchLabels"},
+															Properties: map[string]extv1.JSONSchemaProps{
+																"matchLabels": {
+																	Type: "object",
+																	AdditionalProperties: &extv1.JSONSchemaPropsOrBool{
+																		Allows: true,
+																		Schema: &extv1.JSONSchemaProps{Type: "string"},
+																	},
+																},
+															},
+														},
+														"compositionUpdatePolicy": {
+															Type: "string",
+															Enum: []extv1.JSON{
+																{Raw: []byte(`"Automatic"`)},
+																{Raw: []byte(`"Manual"`)},
+															},
+														},
+														"resourceRefs": {
+															Type: "array",
+															Items: &extv1.JSONSchemaPropsOrArray{
+																Schema: &extv1.JSONSchemaProps{
+																	Type: "object",
+																	Properties: map[string]extv1.JSONSchemaProps{
+																		"apiVersion": {Type: "string"},
+																		"name":       {Type: "string"},
+																		"kind":       {Type: "string"},
+																	},
+																	Required: []string{"apiVersion", "kind"},
+																},
+															},
+															XListType: ptr.To("atomic"),
+														},
+													},
+												},
+											},
+											XValidations: extv1.ValidationRules{
+												{
+													Message: "Cannot change engine version",
+													Rule:    "self.engineVersion == oldSelf.engineVersion",
+												},
+											},
+											OneOf: []extv1.JSONSchemaProps{
+												{Required: []string{"someField"}},
+												{Required: []string{"someOtherField"}},
+											},
+										},
+										"status": {
+											Type:        "object",
+											Description: "Status of the resource.",
+											Properties: map[string]extv1.JSONSchemaProps{
+												"phase":     {Type: "string"},
+												"something": {Type: "string"},
+
+												"conditions": {
+													Description:  "Conditions of the resource.",
+													Type:         "array",
+													XListType:    ptr.To("map"),
+													XListMapKeys: []string{"type"},
+													Items: &extv1.JSONSchemaPropsOrArray{
+														Schema: &extv1.JSONSchemaProps{
+															Type:     "object",
+															Required: []string{"lastTransitionTime", "reason", "status", "type"},
+															Properties: map[string]extv1.JSONSchemaProps{
+																"lastTransitionTime": {Type: "string", Format: "date-time"},
+																"message":            {Type: "string"},
+																"reason":             {Type: "string"},
+																"status":             {Type: "string"},
+																"type":               {Type: "string"},
+																"observedGeneration": {Type: "integer", Format: "int64"},
+															},
+														},
+													},
+												},
+											},
+											XValidations: extv1.ValidationRules{
+												{
+													Message: "Phase is required once set",
+													Rule:    "!has(oldSelf.phase) || has(self.phase)",
+												},
+											},
+											OneOf: []extv1.JSONSchemaProps{
+												{Required: []string{"phase"}},
+												{Required: []string{"something"}},
+											},
+										},
+									},
+								},
+							},
+						}},
+					},
+				},
+			},
+		},
 	}
 
 	for name, tc := range cases {


### PR DESCRIPTION
### Description of your changes
This PR allows users to configure `x-kubernetes-validations` outside of the `spec.versions[].schema.openAPIV3Schema.properties.spec."x-kubernetes-validations"` on level `spec.versions[].schema.openAPIV3Schema."x-kubernetes-validations"`.
This may be used to validate the metadata object to contain certain labels, enforcing naming conventions etc.

Fixes #4993
Fixes #6832

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [X] Read and followed Crossplane's [contribution process].
- [X] Run `earthly +reviewable` to ensure this PR is ready for review.
- [X] Added or updated unit tests.
~- [ ] Added or updated e2e tests.~
- [X] Linked a PR or a [docs tracking issue] to [document this change].
~- [ ] Added `backport release-x.y` labels to auto-backport this PR.~
~- [ ] Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md