### PR TITLE
Handle CronOperation and WatchOperation in alpha render op

### DIFF
--- a/cmd/crank/alpha/render/op/cmd.go
+++ b/cmd/crank/alpha/render/op/cmd.go
@@ -143,8 +143,18 @@ func (c *Cmd) Run(k *kong.Context, log logging.Logger) error {
 	ctx, cancel := context.WithTimeout(context.Background(), c.Timeout)
 	defer cancel()
 
+	// Load required resources
+	rrs := []unstructured.Unstructured{}
+	var err error
+	if c.RequiredResources != "" {
+		rrs, err = render.LoadRequiredResources(c.fs, c.RequiredResources)
+		if err != nil {
+			return errors.Wrapf(err, "cannot load required resources from %q", c.RequiredResources)
+		}
+	}
+
 	// Load operation
-	op, err := LoadOperation(c.fs, c.Operation)
+	op, err := LoadOperation(c.fs, c.Operation, rrs)
 	if err != nil {
 		return err
 	}
@@ -166,15 +176,6 @@ func (c *Cmd) Run(k *kong.Context, log logging.Logger) error {
 		fcreds, err = render.LoadCredentials(c.fs, c.FunctionCredentials)
 		if err != nil {
 			return errors.Wrapf(err, "cannot load function credentials from %q", c.FunctionCredentials)
-		}
-	}
-
-	// Load required resources
-	rrs := []unstructured.Unstructured{}
-	if c.RequiredResources != "" {
-		rrs, err = render.LoadRequiredResources(c.fs, c.RequiredResources)
-		if err != nil {
-			return errors.Wrapf(err, "cannot load required resources from %q", c.RequiredResources)
 		}
 	}
 

--- a/cmd/crank/alpha/render/op/load.go
+++ b/cmd/crank/alpha/render/op/load.go
@@ -18,7 +18,10 @@ package op
 
 import (
 	"github.com/spf13/afero"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/util/yaml"
+	"k8s.io/utils/ptr"
 
 	"github.com/crossplane/crossplane-runtime/v2/pkg/errors"
 
@@ -26,7 +29,7 @@ import (
 )
 
 // LoadOperation loads an Operation from a YAML file.
-func LoadOperation(fs afero.Fs, path string) (*opsv1alpha1.Operation, error) {
+func LoadOperation(fs afero.Fs, path string, rrs []unstructured.Unstructured) (*opsv1alpha1.Operation, error) {
 	data, err := afero.ReadFile(fs, path)
 	if err != nil {
 		return nil, errors.Wrapf(err, "cannot read operation file %q", path)
@@ -41,7 +44,73 @@ func LoadOperation(fs afero.Fs, path string) (*opsv1alpha1.Operation, error) {
 	switch gvk := op.GroupVersionKind(); gvk {
 	case opsv1alpha1.OperationGroupVersionKind:
 		return op, nil
+	case opsv1alpha1.CronOperationGroupVersionKind:
+		cop := opsv1alpha1.CronOperation{}
+		if err := yaml.Unmarshal(data, &cop); err != nil {
+			return nil, errors.Wrapf(err, "cannot unmarshal operation from %q", path)
+		}
+		op.Kind = opsv1alpha1.OperationKind
+		op.Spec = cop.Spec.OperationTemplate.Spec
+		return op, nil
+	case opsv1alpha1.WatchOperationGroupVersionKind:
+		wop := opsv1alpha1.WatchOperation{}
+		if err := yaml.Unmarshal(data, &wop); err != nil {
+			return nil, errors.Wrapf(err, "cannot unmarshal operation from %q", path)
+		}
+		return newOperationFromWatchOperation(&wop, rrs)
+
 	default:
-		return nil, errors.Errorf("not an operation: %s/%s", gvk.Kind, op.GetName())
+		return nil, errors.Errorf("not an operation type: %s/%s", gvk.Kind, op.GetName())
 	}
+}
+
+// newOperationFromWatchOperation creates a new Operation from a WatchOperation's template,
+// injecting the watched resource selector into all pipeline steps.
+func newOperationFromWatchOperation(wo *opsv1alpha1.WatchOperation, requiredResources []unstructured.Unstructured) (*opsv1alpha1.Operation, error) {
+	// Find the watched resource (marked with annotation ops.crossplane.io/watched-resource: "True")
+	var watched *unstructured.Unstructured
+	for i := range requiredResources {
+		res := &requiredResources[i]
+		annotations := res.GetAnnotations()
+		if annotations != nil && annotations[opsv1alpha1.RequirementNameWatchedResource] == "True" {
+			watched = res
+			break
+		}
+	}
+
+	// If no watched resource found, return error
+	if watched == nil {
+		return nil, errors.New("no watched resource found in required resources - expected resource with annotation ops.crossplane.io/watched-resource: \"True\"")
+	}
+
+	// Build the selector for the watched resource
+	sel := opsv1alpha1.RequiredResourceSelector{
+		RequirementName: opsv1alpha1.RequirementNameWatchedResource,
+		APIVersion:      watched.GetAPIVersion(),
+		Kind:            watched.GetKind(),
+		Name:            ptr.To(watched.GetName()),
+	}
+	if watched.GetNamespace() != "" {
+		sel.Namespace = ptr.To(watched.GetNamespace())
+	}
+
+	// Create operation from template and inject selector into each pipeline step
+	op := &opsv1alpha1.Operation{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: opsv1alpha1.SchemeGroupVersion.String(),
+			Kind:       opsv1alpha1.OperationKind,
+		},
+		ObjectMeta: wo.ObjectMeta,
+		Spec:       *wo.Spec.OperationTemplate.Spec.DeepCopy(),
+	}
+
+	for i := range op.Spec.Pipeline {
+		step := &op.Spec.Pipeline[i]
+		if step.Requirements == nil {
+			step.Requirements = &opsv1alpha1.FunctionRequirements{}
+		}
+		step.Requirements.RequiredResources = append(step.Requirements.RequiredResources, sel)
+	}
+
+	return op, nil
 }


### PR DESCRIPTION
### Description of your changes

Update `crossplane alpha render op` to accept `CronOperation` and `WatchOperation` manifests and extract
the `Operation` from the `operationTemplate`.

Fixes #7020

- [X] Read and followed Crossplane's [contribution process].
- [X] Run `earthly +reviewable` to ensure this PR is ready for review.
- [X] Added or updated unit tests.
~- [ ] Added or updated e2e tests.~
~- [ ] Linked a PR or a [docs tracking issue] to [document this change].~
~- [ ] Added `backport release-x.y` labels to auto-backport this PR.~
-~ [ ] Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md