### PR TITLE
chore: add adamwg as maintainer, move turkenh to emeritus

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -5,7 +5,7 @@
 #
 # The goal of this file is for most PRs to automatically and fairly have 1 to 2
 # maintainers set as PR reviewers. All maintainers have permission to approve
-# and merge PRs. PRs only need 
+# and merge PRs. PRs only need
 #
 # Most lines in this file will assign one subject matter expert and one random
 # maintainer. PRs only need to be approved by one of these people to be merged.
@@ -43,10 +43,10 @@
 /contributing/                       @crossplane/crossplane-maintainers @negz
 
 # Package manager
-/apis/pkg/                           @crossplane/crossplane-maintainers @turkenh
-/internal/xpkg/                      @crossplane/crossplane-maintainers @turkenh
-/internal/dag/                       @crossplane/crossplane-maintainers @turkenh
-/internal/controller/pkg/            @crossplane/crossplane-maintainers @turkenh
+/apis/pkg/                           @crossplane/crossplane-maintainers @adamwg
+/internal/xpkg/                      @crossplane/crossplane-maintainers @adamwg
+/internal/dag/                       @crossplane/crossplane-maintainers @adamwg
+/internal/controller/pkg/            @crossplane/crossplane-maintainers @adamwg
 
 # Composition
 /apis/apiextensions/                 @crossplane/crossplane-maintainers @negz
@@ -63,5 +63,4 @@
 /cmd/crank/                          @crossplane/crossplane-maintainers @phisco
 
 # Misc
-/apis/secrets/                       @crossplane/crossplane-maintainers @turkenh
 /internal/features/                  @crossplane/crossplane-maintainers @negz

--- a/OWNERS.md
+++ b/OWNERS.md
@@ -12,10 +12,10 @@ See [CODEOWNERS](CODEOWNERS) for automatic PR assignment.
 ## Maintainers
 
 * Nic Cope <negz@upbound.io> ([negz](https://github.com/negz))
-* Hasan Turken <hasan@upbound.io> ([turkenh](https://github.com/turkenh))
 * Bob Haddleton <bob.haddleton@nokia.com> ([bobh66](https://github.com/bobh66))
 * Philippe Scorsolini <philippe.scorsolini@upbound.io> ([phisco](https://github.com/phisco))
 * Jared Watts <jared@upbound.io> ([jbw976](https://github.com/jbw976))
+* Adam Wolfe Gordon <adam.wolfegordon@upbound.io> ([adamwg](https://github.com/adamwg))
 
 ## Emeritus Maintainers
 
@@ -23,3 +23,4 @@ See [CODEOWNERS](CODEOWNERS) for automatic PR assignment.
 * Illya Chekrygin <illya.chekrygin@gmail.com> ([ichekrygin](https://github.com/ichekrygin))
 * Daniel Mangum <georgedanielmangum@gmail.com> ([hasheddan](https://github.com/hasheddan))
 * Muvaffak Onus <me@muvaf.com> ([muvaf](https://github.com/muvaf))
+* Hasan Turken <hasan@upbound.io> ([turkenh](https://github.com/turkenh))


### PR DESCRIPTION
### Description of your changes

This PR makes the following updates to the maintainers list of this repo:

* adds @adamwg as a new maintainer
* moves @turkenh to emeritus status

@adamwg has been successfully driving large features recently, providing thoughtful reviews, and engaging effectively with the community (especially around `#sig-cli` efforts).  Welcome to the maintainer team!

@turkenh, thank you so very much for the incredible impact you've had on the project with all your contributions over the years. It has been very appreciated! 🙇‍♂️ 

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `earthly +reviewable` to ensure this PR is ready for review.
- [ ] ~Added or updated unit tests.~
- [ ] ~Added or updated e2e tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~
- [ ] ~Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md