### PR TITLE
docs: fix typo in comments

### DIFF
--- a/proto/fn/v1/run_function.pb.go
+++ b/proto/fn/v1/run_function.pb.go
@@ -1112,7 +1112,7 @@ type Resource struct {
 	// * A function should set this field to READY_TRUE in a RunFunctionResponse
 	// to indicate that a desired XR is ready. This overwrites the standard
 	// readiness detection that determines the ready state of the composite by the
-	// ready state of the the composed resources.
+	// ready state of the composed resources.
 	//
 	// Ready is only used for composition. It's ignored by Operations.
 	Ready         Ready `protobuf:"varint,3,opt,name=ready,proto3,enum=apiextensions.fn.proto.v1.Ready" json:"ready,omitempty"`

--- a/proto/fn/v1/run_function.proto
+++ b/proto/fn/v1/run_function.proto
@@ -267,7 +267,7 @@ message Resource {
   // * A function should set this field to READY_TRUE in a RunFunctionResponse
   // to indicate that a desired XR is ready. This overwrites the standard
   // readiness detection that determines the ready state of the composite by the
-  // ready state of the the composed resources.
+  // ready state of the composed resources.
   //
   // Ready is only used for composition. It's ignored by Operations.
   Ready ready = 3;

--- a/proto/fn/v1beta1/zz_generated_run_function.pb.go
+++ b/proto/fn/v1beta1/zz_generated_run_function.pb.go
@@ -1114,7 +1114,7 @@ type Resource struct {
 	// * A function should set this field to READY_TRUE in a RunFunctionResponse
 	// to indicate that a desired XR is ready. This overwrites the standard
 	// readiness detection that determines the ready state of the composite by the
-	// ready state of the the composed resources.
+	// ready state of the composed resources.
 	//
 	// Ready is only used for composition. It's ignored by Operations.
 	Ready         Ready `protobuf:"varint,3,opt,name=ready,proto3,enum=apiextensions.fn.proto.v1beta1.Ready" json:"ready,omitempty"`

--- a/proto/fn/v1beta1/zz_generated_run_function.proto
+++ b/proto/fn/v1beta1/zz_generated_run_function.proto
@@ -269,7 +269,7 @@ message Resource {
   // * A function should set this field to READY_TRUE in a RunFunctionResponse
   // to indicate that a desired XR is ready. This overwrites the standard
   // readiness detection that determines the ready state of the composite by the
-  // ready state of the the composed resources.
+  // ready state of the composed resources.
   //
   // Ready is only used for composition. It's ignored by Operations.
   Ready ready = 3;


### PR DESCRIPTION
### Description of your changes

Fix a typo in proto comment: "the the composed resources" → "the composed resources"

This is a documentation-only change in a proto file comment. The fix was made in the source `.proto` file and regenerated using `earthly +generate`.

I have:
- [x] Read and followed Crossplane's [contribution process].
- [x] Run `earthly +reviewable` to ensure this PR is ready for review.
- [ ] ~Added or updated unit tests.~ (not applicable - typo fix only)
- [ ] ~Added or updated e2e tests.~ (not applicable - typo fix only)
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~ (not applicable - typo fix only)
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~ (not applicable)
- [ ] ~Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~ (not applicable)

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing