### PR TITLE
fix(cli/beta/validate): support dependency semantic version range

### DIFF
--- a/cmd/crank/beta/validate/cache.go
+++ b/cmd/crank/beta/validate/cache.go
@@ -122,6 +122,7 @@ func (c *LocalCache) Exists(image string) (string, error) {
 
 // getCachePath transforms an image name to a validate folder path that store schemas.
 func (c *LocalCache) getCachePath(image string) string {
-	cacheImagePath := strings.ReplaceAll(image, ":", "@")
+	replacer := strings.NewReplacer(":", "@", ",", " ")
+	cacheImagePath := replacer.Replace(image)
 	return filepath.Join(c.cacheDir, cacheImagePath)
 }

--- a/cmd/crank/beta/validate/cache.go
+++ b/cmd/crank/beta/validate/cache.go
@@ -122,7 +122,6 @@ func (c *LocalCache) Exists(image string) (string, error) {
 
 // getCachePath transforms an image name to a validate folder path that store schemas.
 func (c *LocalCache) getCachePath(image string) string {
-	replacer := strings.NewReplacer(":", "@", ",", " ")
-	cacheImagePath := replacer.Replace(image)
+	cacheImagePath := strings.ReplaceAll(image, ":", "@")
 	return filepath.Join(c.cacheDir, cacheImagePath)
 }

--- a/cmd/crank/beta/validate/cache.go
+++ b/cmd/crank/beta/validate/cache.go
@@ -93,7 +93,7 @@ func (c *LocalCache) Flush() error {
 func (c *LocalCache) Load(img string) ([]*unstructured.Unstructured, error) {
 	image, err := findImageTagForVersionConstraint(img)
 	if err != nil {
-		return nil, errors.Wrapf(err, "cannot resolve image tag for %s", image)
+		return nil, errors.Wrapf(err, "cannot resolve image tag for %s", img)
 	}
 
 	cacheImagePath := c.getCachePath(image)
@@ -115,7 +115,7 @@ func (c *LocalCache) Load(img string) ([]*unstructured.Unstructured, error) {
 func (c *LocalCache) Exists(img string) (string, error) {
 	image, err := findImageTagForVersionConstraint(img)
 	if err != nil {
-		return "", errors.Wrapf(err, "cannot resolve image tag for %s", image)
+		return "", errors.Wrapf(err, "cannot resolve image tag for %s", img)
 	}
 
 	path := c.getCachePath(image)

--- a/cmd/crank/beta/validate/cache.go
+++ b/cmd/crank/beta/validate/cache.go
@@ -90,7 +90,12 @@ func (c *LocalCache) Flush() error {
 
 // Load loads schemas from the cache directory.
 // image should be a validate image name with the format: <registry>/<image>:<tag>.
-func (c *LocalCache) Load(image string) ([]*unstructured.Unstructured, error) {
+func (c *LocalCache) Load(img string) ([]*unstructured.Unstructured, error) {
+	image, err := findImageTagForVersionConstraint(img)
+	if err != nil {
+		return nil, errors.Wrapf(err, "cannot resolve image tag for %s", image)
+	}
+
 	cacheImagePath := c.getCachePath(image)
 
 	loader, err := load.NewLoader(cacheImagePath)
@@ -107,10 +112,15 @@ func (c *LocalCache) Load(image string) ([]*unstructured.Unstructured, error) {
 }
 
 // Exists checks if the cache contains the image and returns the path if it doesn't exist.
-func (c *LocalCache) Exists(image string) (string, error) {
+func (c *LocalCache) Exists(img string) (string, error) {
+	image, err := findImageTagForVersionConstraint(img)
+	if err != nil {
+		return "", errors.Wrapf(err, "cannot resolve image tag for %s", image)
+	}
+
 	path := c.getCachePath(image)
 
-	_, err := os.Stat(path)
+	_, err = os.Stat(path)
 	if err != nil && os.IsNotExist(err) {
 		return path, nil
 	} else if err != nil {

--- a/cmd/crank/beta/validate/cache.go
+++ b/cmd/crank/beta/validate/cache.go
@@ -17,10 +17,15 @@ limitations under the License.
 package validate
 
 import (
+	"fmt"
+	"io/fs"
 	"os"
+	"path"
 	"path/filepath"
+	"sort"
 	"strings"
 
+	"github.com/Masterminds/semver/v3"
 	"github.com/spf13/afero"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
@@ -112,19 +117,69 @@ func (c *LocalCache) Load(img string) ([]*unstructured.Unstructured, error) {
 }
 
 // Exists checks if the cache contains the image and returns the path if it doesn't exist.
+// If the image tag is a version constraint,
+// check cache for latest version that matches the constraint
 func (c *LocalCache) Exists(img string) (string, error) {
-	image, err := findImageTagForVersionConstraint(img)
+	isConstraint := true
+	imageBase, imageTag := separateImageTag(img)
+
+	constraint, err := semver.NewConstraint(imageTag)
 	if err != nil {
-		return "", errors.Wrapf(err, "cannot resolve image tag for %s", img)
+		isConstraint = false
 	}
 
-	path := c.getCachePath(image)
+	cachePath := c.getCachePath(img)
 
-	_, err = os.Stat(path)
+	if isConstraint {
+		// search cache-directory for tags
+		cacheDir := filepath.Dir(cachePath)
+
+		tags := []string{}
+		err := filepath.WalkDir(cacheDir, func(p string, d fs.DirEntry, err error) error {
+			if d.IsDir() && strings.HasPrefix(d.Name(), path.Base(imageBase)) {
+				i := strings.Index(d.Name(), "@")
+				if i == -1 {
+					return errors.New(fmt.Sprintf("the cache entry '%s' does not contain a tag", d.Name()))
+				}
+
+				tags = append(tags, d.Name()[i+1:])
+			}
+
+			return nil
+		})
+		if err != nil {
+			return "", errors.Wrapf(err, "failed to search cache-directory %s for existing tag", cacheDir)
+		}
+
+		if len(tags) == 0 {
+			return "", nil
+		}
+
+		vs := convertToSemver(tags)
+
+		sort.Sort(sort.Reverse(semver.Collection(vs)))
+
+		var latestVersionInConstraint string
+		for _, v := range vs {
+			if constraint.Check(v) {
+				latestVersionInConstraint = v.Original()
+			}
+		}
+
+		if latestVersionInConstraint == "" {
+			// no version that is valid for constraint exist
+			return "", nil
+		}
+
+		// replace the constraint with latest version
+		return strings.Replace(cachePath, imageTag, latestVersionInConstraint, 0), nil
+	}
+
+	_, err = os.Stat(cachePath)
 	if err != nil && os.IsNotExist(err) {
-		return path, nil
+		return cachePath, nil
 	} else if err != nil {
-		return "", errors.Wrapf(err, "cannot stat file %s", path)
+		return "", errors.Wrapf(err, "cannot stat file %s", cachePath)
 	}
 
 	return "", nil

--- a/cmd/crank/beta/validate/cache.go
+++ b/cmd/crank/beta/validate/cache.go
@@ -95,12 +95,7 @@ func (c *LocalCache) Flush() error {
 
 // Load loads schemas from the cache directory.
 // image should be a validate image name with the format: <registry>/<image>:<tag>.
-func (c *LocalCache) Load(img string) ([]*unstructured.Unstructured, error) {
-	image, err := findImageTagForVersionConstraint(img)
-	if err != nil {
-		return nil, errors.Wrapf(err, "cannot resolve image tag for %s", img)
-	}
-
+func (c *LocalCache) Load(image string) ([]*unstructured.Unstructured, error) {
 	cacheImagePath := c.getCachePath(image)
 
 	loader, err := load.NewLoader(cacheImagePath)
@@ -117,69 +112,14 @@ func (c *LocalCache) Load(img string) ([]*unstructured.Unstructured, error) {
 }
 
 // Exists checks if the cache contains the image and returns the path if it doesn't exist.
-// If the image tag is a version constraint,
-// check cache for latest version that matches the constraint
-func (c *LocalCache) Exists(img string) (string, error) {
-	isConstraint := true
-	imageBase, imageTag := separateImageTag(img)
+func (c *LocalCache) Exists(image string) (string, error) {
+	path := c.getCachePath(image)
 
-	constraint, err := semver.NewConstraint(imageTag)
-	if err != nil {
-		isConstraint = false
-	}
-
-	cachePath := c.getCachePath(img)
-
-	if isConstraint {
-		// search cache-directory for tags
-		cacheDir := filepath.Dir(cachePath)
-
-		tags := []string{}
-		err := filepath.WalkDir(cacheDir, func(p string, d fs.DirEntry, err error) error {
-			if d.IsDir() && strings.HasPrefix(d.Name(), path.Base(imageBase)) {
-				i := strings.Index(d.Name(), "@")
-				if i == -1 {
-					return errors.New(fmt.Sprintf("the cache entry '%s' does not contain a tag", d.Name()))
-				}
-
-				tags = append(tags, d.Name()[i+1:])
-			}
-
-			return nil
-		})
-		if err != nil {
-			return "", errors.Wrapf(err, "failed to search cache-directory %s for existing tag", cacheDir)
-		}
-
-		if len(tags) == 0 {
-			return "", nil
-		}
-
-		vs := convertToSemver(tags)
-
-		sort.Sort(sort.Reverse(semver.Collection(vs)))
-
-		var latestVersionInConstraint string
-		for _, v := range vs {
-			if constraint.Check(v) {
-				latestVersionInConstraint = v.Original()
-			}
-		}
-
-		if latestVersionInConstraint == "" {
-			// no version that is valid for constraint exist
-			return "", nil
-		}
-
-		// replace the constraint with latest version
-		return strings.Replace(cachePath, imageTag, latestVersionInConstraint, 0), nil
-	}
-
-	_, err = os.Stat(cachePath)
+	_, err := os.Stat(path)
 	if err != nil && os.IsNotExist(err) {
-		return cachePath, nil
+		return path, nil
 	} else if err != nil {
-		return "", errors.Wrapf(err, "cannot stat file %s", cachePath)
+		return "", errors.Wrapf(err, "cannot stat file %s", path)
 	}
 
 	return "", nil
@@ -189,4 +129,62 @@ func (c *LocalCache) Exists(img string) (string, error) {
 func (c *LocalCache) getCachePath(image string) string {
 	cacheImagePath := strings.ReplaceAll(image, ":", "@")
 	return filepath.Join(c.cacheDir, cacheImagePath)
+}
+
+// getLatestSemanticVersionCachePath scans the cache for an entry with the latest tag that matches the image version constraint
+// and if found, returns the cache-path to it.
+// image must be a valid image name with the format: <registry>/<image>:<tag>, where tag can be a semantic version constraint
+func (c *LocalCache) findCachedVersionForConstraint(image string) (string, error) {
+	imageBase, imageTag := separateImageTag(image)
+
+	constraint, err := semver.NewConstraint(imageTag)
+	if err != nil {
+		// silently fail
+		return "", nil
+	}
+
+	cachePath := c.getCachePath(image)
+
+	// search cache-directory for tags
+	cacheDir := filepath.Dir(cachePath)
+
+	tags := []string{}
+	err = filepath.WalkDir(cacheDir, func(p string, d fs.DirEntry, err error) error {
+		if d.IsDir() && strings.HasPrefix(d.Name(), path.Base(imageBase)) {
+			i := strings.Index(d.Name(), "@")
+			if i == -1 {
+				return errors.New(fmt.Sprintf("the cache entry '%s' does not contain a tag", d.Name()))
+			}
+
+			tags = append(tags, d.Name()[i+1:])
+		}
+
+		return nil
+	})
+	if err != nil {
+		return "", errors.Wrapf(err, "failed to search cache-directory %s for existing tag", cacheDir)
+	}
+
+	if len(tags) == 0 {
+		return "", nil
+	}
+
+	vs := convertToSemver(tags)
+
+	sort.Sort(sort.Reverse(semver.Collection(vs)))
+
+	var latestVersionInConstraint string
+	for _, v := range vs {
+		if constraint.Check(v) {
+			latestVersionInConstraint = v.Original()
+		}
+	}
+
+	if latestVersionInConstraint == "" {
+		// no version that is valid for constraint exist
+		return "", nil
+	}
+
+	// return the cache-path with the latest valid version instead of the constraint
+	return strings.Replace(cachePath, imageTag, latestVersionInConstraint, 0), nil
 }

--- a/cmd/crank/beta/validate/cache.go
+++ b/cmd/crank/beta/validate/cache.go
@@ -169,7 +169,7 @@ func (c *LocalCache) getCachePath(image string) string {
 	return filepath.Join(c.cacheDir, cacheImagePath)
 }
 
-// isConstraint checks if a string is a semantic version constraint, but not an exact version.
+// isRangedConstraint checks if a string is a semantic version constraint, but not an exact version.
 func isRangedConstraint(tag string) bool {
 	if _, err := semver.NewVersion(tag); err == nil {
 		return false

--- a/cmd/crank/beta/validate/cache.go
+++ b/cmd/crank/beta/validate/cache.go
@@ -232,6 +232,8 @@ func (c *LocalCache) findLatestCachedVersionForConstraint(image string) (string,
 	for _, v := range vs {
 		if constraint.Check(v) {
 			latestVersionInConstraint = v.Original()
+
+			break
 		}
 	}
 

--- a/cmd/crank/beta/validate/cache.go
+++ b/cmd/crank/beta/validate/cache.go
@@ -17,8 +17,7 @@ limitations under the License.
 package validate
 
 import (
-	"fmt"
-	"io/fs"
+	iofs "io/fs"
 	"os"
 	"path"
 	"path/filepath"
@@ -51,6 +50,8 @@ type LocalCache struct {
 
 // Store stores the schemas in the directory.
 func (c *LocalCache) Store(schemas [][]byte, path string) error {
+	path = c.getCachePath(path)
+
 	if err := c.fs.MkdirAll(path, os.ModePerm); err != nil {
 		return errors.Wrapf(err, "cannot create directory %s", path)
 	}
@@ -94,9 +95,26 @@ func (c *LocalCache) Flush() error {
 }
 
 // Load loads schemas from the cache directory.
-// image should be a validate image name with the format: <registry>/<image>:<tag>.
+// image should be a validated image name with the format: <registry>/<image>:<tag>.
+// <tag> can be a constraint, in which case the latest version of the schema that satisfies this constraint
+// is loaded from the cache.
 func (c *LocalCache) Load(image string) ([]*unstructured.Unstructured, error) {
 	cacheImagePath := c.getCachePath(image)
+	imageBase, imageTag := separateImageTag(image)
+
+	if isRangedConstraint(imageTag) {
+		var err error
+		cacheImagePath, err = c.findLatestCachedVersionForConstraint(image)
+		if err != nil {
+			return nil, errors.Wrapf(err,
+				"failed to scan cache for entries that matches image %s with the constraint %s",
+				imageBase, imageTag)
+		}
+
+		if cacheImagePath == "" {
+			return []*unstructured.Unstructured{}, nil
+		}
+	}
 
 	loader, err := load.NewLoader(cacheImagePath)
 	if err != nil {
@@ -112,8 +130,28 @@ func (c *LocalCache) Load(image string) ([]*unstructured.Unstructured, error) {
 }
 
 // Exists checks if the cache contains the image and returns the path if it doesn't exist.
+// If the image contains a semantic version constraint, the returned cache-path will include it on cache miss,
+// as it can not be resolved by the cache.
 func (c *LocalCache) Exists(image string) (string, error) {
 	path := c.getCachePath(image)
+
+	_, imageTag := separateImageTag(image)
+
+	// if the image-tag is a ranged constraint we need to try to find the latest cached version that satisfies that constraint
+	if isRangedConstraint(imageTag) {
+		v, err := c.findLatestCachedVersionForConstraint(image)
+		if err != nil {
+			return "", errors.Wrapf(err, "failed to scan cache for constraint")
+		}
+
+		if v == "" {
+			// valid version for constraint not found
+			return path, nil
+		}
+
+		// valid version for constraint was found
+		return "", nil
+	}
 
 	_, err := os.Stat(path)
 	if err != nil && os.IsNotExist(err) {
@@ -131,16 +169,24 @@ func (c *LocalCache) getCachePath(image string) string {
 	return filepath.Join(c.cacheDir, cacheImagePath)
 }
 
-// getLatestSemanticVersionCachePath scans the cache for an entry with the latest tag that matches the image version constraint
-// and if found, returns the cache-path to it.
-// image must be a valid image name with the format: <registry>/<image>:<tag>, where tag can be a semantic version constraint
-func (c *LocalCache) findCachedVersionForConstraint(image string) (string, error) {
+// isConstraint checks if a string is a semantic version constraint, but not an exact version.
+func isRangedConstraint(tag string) bool {
+	if _, err := semver.NewVersion(tag); err == nil {
+		return false
+	}
+	_, err := semver.NewConstraint(tag)
+	return err == nil
+}
+
+// findLatestCachedVersionForConstraint returns the cache-path for the latest tag that matches the image version constraint.
+// On cache miss, an empty string is returned.
+// The image must be a valid image name with the format: <registry>/<image>:<tag>.
+func (c *LocalCache) findLatestCachedVersionForConstraint(image string) (string, error) {
 	imageBase, imageTag := separateImageTag(image)
 
 	constraint, err := semver.NewConstraint(imageTag)
 	if err != nil {
-		// silently fail
-		return "", nil
+		return "", errors.Wrapf(err, "%s is not a valid constraint", imageTag)
 	}
 
 	cachePath := c.getCachePath(image)
@@ -149,11 +195,20 @@ func (c *LocalCache) findCachedVersionForConstraint(image string) (string, error
 	cacheDir := filepath.Dir(cachePath)
 
 	tags := []string{}
-	err = filepath.WalkDir(cacheDir, func(p string, d fs.DirEntry, err error) error {
+	err = filepath.WalkDir(cacheDir, func(_ string, d iofs.DirEntry, err error) error {
+		if err != nil {
+			if errors.Is(err, iofs.ErrNotExist) {
+				// the walk will fail on first run (directories dont exist) - ignore it
+				return nil
+			}
+
+			return err
+		}
+
 		if d.IsDir() && strings.HasPrefix(d.Name(), path.Base(imageBase)) {
 			i := strings.Index(d.Name(), "@")
 			if i == -1 {
-				return errors.New(fmt.Sprintf("the cache entry '%s' does not contain a tag", d.Name()))
+				return errors.Errorf("the cache entry '%s' does not contain a tag", d.Name())
 			}
 
 			tags = append(tags, d.Name()[i+1:])
@@ -186,5 +241,5 @@ func (c *LocalCache) findCachedVersionForConstraint(image string) (string, error
 	}
 
 	// return the cache-path with the latest valid version instead of the constraint
-	return strings.Replace(cachePath, imageTag, latestVersionInConstraint, 0), nil
+	return strings.ReplaceAll(cachePath, imageTag, latestVersionInConstraint), nil
 }

--- a/cmd/crank/beta/validate/cache.go
+++ b/cmd/crank/beta/validate/cache.go
@@ -228,20 +228,13 @@ func (c *LocalCache) findLatestCachedVersionForConstraint(image string) (string,
 
 	sort.Sort(sort.Reverse(semver.Collection(vs)))
 
-	var latestVersionInConstraint string
 	for _, v := range vs {
 		if constraint.Check(v) {
-			latestVersionInConstraint = v.Original()
-
-			break
+			// return the cache-path with the latest valid semantic version
+			return strings.ReplaceAll(cachePath, imageTag, v.Original()), nil
 		}
 	}
 
-	if latestVersionInConstraint == "" {
-		// no version that is valid for constraint exist
-		return "", nil
-	}
+	return "", nil
 
-	// return the cache-path with the latest valid version instead of the constraint
-	return strings.ReplaceAll(cachePath, imageTag, latestVersionInConstraint), nil
 }

--- a/cmd/crank/beta/validate/cache.go
+++ b/cmd/crank/beta/validate/cache.go
@@ -195,7 +195,7 @@ func (c *LocalCache) findLatestCachedVersionForConstraint(image string) (string,
 	cacheDir := filepath.Dir(cachePath)
 
 	tags := []string{}
-	err = filepath.WalkDir(cacheDir, func(_ string, d iofs.DirEntry, err error) error {
+	err = iofs.WalkDir(afero.NewIOFS(c.fs), cacheDir, func(_ string, d iofs.DirEntry, err error) error {
 		if err != nil {
 			if errors.Is(err, iofs.ErrNotExist) {
 				// the walk will fail on first run (directories dont exist) - ignore it

--- a/cmd/crank/beta/validate/cache.go
+++ b/cmd/crank/beta/validate/cache.go
@@ -194,34 +194,26 @@ func (c *LocalCache) findLatestCachedVersionForConstraint(image string) (string,
 	// search cache-directory for tags
 	cacheDir := filepath.Dir(cachePath)
 
-	tags := []string{}
-	err = iofs.WalkDir(afero.NewIOFS(c.fs), cacheDir, func(_ string, d iofs.DirEntry, err error) error {
-		if err != nil {
-			if errors.Is(err, iofs.ErrNotExist) {
-				// the walk will fail on first run (directories dont exist) - ignore it
-				return nil
-			}
-
-			return err
-		}
-
-		if d.IsDir() && strings.HasPrefix(d.Name(), path.Base(imageBase)) {
-			i := strings.Index(d.Name(), "@")
-			if i == -1 {
-				return errors.Errorf("the cache entry '%s' does not contain a tag", d.Name())
-			}
-
-			tags = append(tags, d.Name()[i+1:])
-		}
-
-		return nil
-	})
+	dirEntries, err := afero.ReadDir(c.fs, cacheDir)
 	if err != nil {
-		return "", errors.Wrapf(err, "failed to search cache-directory %s for existing tag", cacheDir)
+		if errors.Is(err, iofs.ErrNotExist) {
+			// the directory wont exist if it hasnt been cached yet, in which case its a normal cache miss
+			return "", nil
+		}
+
+		return "", err
 	}
 
-	if len(tags) == 0 {
-		return "", nil
+	tags := []string{}
+	for _, entry := range dirEntries {
+		if entry.IsDir() && strings.HasPrefix(entry.Name(), path.Base(imageBase)) {
+			i := strings.Index(entry.Name(), "@")
+			if i == -1 {
+				return "", errors.Errorf("the cache entry '%s' does not contain a tag", entry.Name())
+			}
+
+			tags = append(tags, entry.Name()[i+1:])
+		}
 	}
 
 	vs := convertToSemver(tags)
@@ -236,5 +228,4 @@ func (c *LocalCache) findLatestCachedVersionForConstraint(image string) (string,
 	}
 
 	return "", nil
-
 }

--- a/cmd/crank/beta/validate/cache_test.go
+++ b/cmd/crank/beta/validate/cache_test.go
@@ -270,3 +270,74 @@ func TestLocalCacheStore(t *testing.T) {
 		})
 	}
 }
+
+func TestIsRangedConstraint(t *testing.T) {
+	type args struct {
+		in string
+	}
+
+	type want struct {
+		result bool
+	}
+
+	cases := map[string]struct {
+		reason string
+		args   args
+		want   want
+	}{
+		"ValidConstraint": {
+			reason: "A valid constraint should return true",
+			args: args{
+				in: ">v2.0.0",
+			},
+			want: want{
+				result: true,
+			},
+		},
+		"ValidRangedConstraint": {
+			reason: "A valid ranged constraint should return true",
+			args: args{
+				in: ">v2.0.0, <v3.0.0",
+			},
+			want: want{
+				result: true,
+			},
+		},
+		"ValidExactVersion": {
+			reason: "A valid exact version should return false",
+			args: args{
+				in: "v2.0.0",
+			},
+			want: want{
+				result: false,
+			},
+		},
+		"InvalidString": {
+			reason: "A string that is not a semantic version version should return false",
+			args: args{
+				in: "v2abc",
+			},
+			want: want{
+				result: false,
+			},
+		},
+		"ValidExactVersionWithDigest": {
+			reason: "A valid exact version with digest should return false",
+			args: args{
+				in: "v0.6.3@sha256:a37a591901b6718b2f160b64b4e172bb4eb5a7cde03e30f1967df987c7bf64ae",
+			},
+			want: want{
+				result: false,
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got := isRangedConstraint(tc.args.in)
+			if got != tc.want.result {
+				t.Errorf("isRangedConstraint(...): %s\n -want: '%v', +got '%v'", tc.reason, got, tc.want.result)
+			}
+		})
+	}
+}

--- a/cmd/crank/beta/validate/cache_test.go
+++ b/cmd/crank/beta/validate/cache_test.go
@@ -313,7 +313,7 @@ func TestIsRangedConstraint(t *testing.T) {
 			},
 		},
 		"InvalidString": {
-			reason: "A string that is not a semantic version version should return false",
+			reason: "A string that is not a semantic version should return false",
 			args: args{
 				in: "v2abc",
 			},

--- a/cmd/crank/beta/validate/cmd.go
+++ b/cmd/crank/beta/validate/cmd.go
@@ -46,6 +46,7 @@ type Cmd struct {
 	CrossplaneImage       string `help:"Specify the Crossplane image to be used for validating the built-in schemas."`
 	ErrorOnMissingSchemas bool   `default:"false"                                                                     help:"Return non zero exit code if not all schemas are provided."`
 	SkipSuccessResults    bool   `help:"Skip printing success results."`
+	UpdateCache           bool   `default:"false" help:"Update cached schemas by downloading the latest version that satisfies a constraint. May be useful if you are using semantic version constraints and want to get the latest version, but this will slow down the cache lookup due to the required network calls."`
 
 	fs afero.Fs
 }
@@ -131,7 +132,7 @@ func (c *Cmd) Run(k *kong.Context, _ logging.Logger) error {
 		c.CacheDir = filepath.Join(homeDir, c.CacheDir[2:])
 	}
 
-	m := NewManager(c.CacheDir, c.fs, k.Stdout, WithCrossplaneImage(c.CrossplaneImage))
+	m := NewManager(c.CacheDir, c.fs, k.Stdout, WithCrossplaneImage(c.CrossplaneImage), WithUpdateCache(c.UpdateCache))
 
 	// Convert XRDs/CRDs to CRDs and add package dependencies
 	if err := m.PrepExtensions(extensions); err != nil {

--- a/cmd/crank/beta/validate/cmd.go
+++ b/cmd/crank/beta/validate/cmd.go
@@ -41,12 +41,12 @@ type Cmd struct {
 	Resources  string `arg:"" help:"Resource sources as a comma-separated list of files, directories, or '-' for standard input."`
 
 	// Flags. Keep them in alphabetical order.
-	CacheDir              string `default:"~/.crossplane/cache"                                                       help:"Absolute path to the cache directory where downloaded schemas are stored." predictor:"directory"`
+	CacheDir              string `default:"~/.crossplane/cache"                                                       help:"Absolute path to the cache directory where downloaded schemas are stored."                                                                                                                                                                                        predictor:"directory"`
 	CleanCache            bool   `help:"Clean the cache directory before downloading package schemas."`
 	CrossplaneImage       string `help:"Specify the Crossplane image to be used for validating the built-in schemas."`
 	ErrorOnMissingSchemas bool   `default:"false"                                                                     help:"Return non zero exit code if not all schemas are provided."`
 	SkipSuccessResults    bool   `help:"Skip printing success results."`
-	UpdateCache           bool   `default:"false" help:"Update cached schemas by downloading the latest version that satisfies a constraint. May be useful if you are using semantic version constraints and want to get the latest version, but this will slow down the cache lookup due to the required network calls."`
+	UpdateCache           bool   `default:"false"                                                                     help:"Update cached schemas by downloading the latest version that satisfies a constraint. May be useful if you are using semantic version constraints and want to get the latest version, but this will slow down the cache lookup due to the required network calls."`
 
 	fs afero.Fs
 }

--- a/cmd/crank/beta/validate/cmd.go
+++ b/cmd/crank/beta/validate/cmd.go
@@ -43,10 +43,11 @@ type Cmd struct {
 	// Flags. Keep them in alphabetical order.
 	CacheDir              string `default:"~/.crossplane/cache"                                                       help:"Absolute path to the cache directory where downloaded schemas are stored." predictor:"directory"`
 	CleanCache            bool   `help:"Clean the cache directory before downloading package schemas."`
-	SkipSuccessResults    bool   `help:"Skip printing success results."`
 	CrossplaneImage       string `help:"Specify the Crossplane image to be used for validating the built-in schemas."`
 	ErrorOnMissingSchemas bool   `default:"false"                                                                     help:"Return non zero exit code if not all schemas are provided."`
-	fs                    afero.Fs
+	SkipSuccessResults    bool   `help:"Skip printing success results."`
+
+	fs afero.Fs
 }
 
 // Help prints out the help for the validate command.

--- a/cmd/crank/beta/validate/image.go
+++ b/cmd/crank/beta/validate/image.go
@@ -26,7 +26,7 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/Masterminds/semver"
+	"github.com/Masterminds/semver/v3"
 	"github.com/google/go-containerregistry/pkg/crane"
 	"github.com/google/go-containerregistry/pkg/name"
 	conregv1 "github.com/google/go-containerregistry/pkg/v1"

--- a/cmd/crank/beta/validate/image.go
+++ b/cmd/crank/beta/validate/image.go
@@ -150,16 +150,22 @@ func findImageTagForVersionConstraint(image string) (string, error) {
 	imageBase := strings.Join(parts[0:lastPart], ":")
 	imageTag := parts[lastPart]
 
-	// Check if the tag is a constraint
+	// Check if the tag is a constraint or already a valid semantic version
 	isConstraint := true
+	isExactVersion := true
 
 	c, err := semver.NewConstraint(imageTag)
 	if err != nil {
 		isConstraint = false
 	}
 
-	// Return original image if no constraint was detected
-	if !isConstraint {
+	_, err = semver.NewVersion(imageTag)
+	if err != nil {
+		isExactVersion = false
+	}
+
+	// Return original image if no constraint was detected or the tag is already an exact version
+	if !isConstraint || isExactVersion {
 		return image, nil
 	}
 

--- a/cmd/crank/beta/validate/image.go
+++ b/cmd/crank/beta/validate/image.go
@@ -41,33 +41,33 @@ const maxDecompressedSize = 200 * 1024 * 1024 // 200 MB
 
 // ImageFetcher defines an interface for fetching images.
 type ImageFetcher interface {
-	FetchBaseLayer(image string) (*conregv1.Layer, error)
-	FetchImage(image string) ([]conregv1.Layer, error)
+	FetchBaseLayer(image string) (string, *conregv1.Layer, error)
+	FetchImage(image string) (string, []conregv1.Layer, error)
 }
 
 // Fetcher implements the ImageFetcher interface.
 type Fetcher struct{}
 
 // FetchImage pulls the full image and extracts the CRDs folder to fetch .yaml files.
-func (f *Fetcher) FetchImage(image string) ([]conregv1.Layer, error) {
+func (f *Fetcher) FetchImage(image string) (string, []conregv1.Layer, error) {
 	image, err := prepareImageReference(image)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to prepare image reference")
+		return "", nil, errors.Wrap(err, "failed to prepare image reference")
 	}
 
 	// Pull the image
 	img, err := crane.Pull(image)
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to pull image")
+		return "", nil, errors.Wrapf(err, "failed to pull image")
 	}
 
 	// Extract the layers of the image into the temporary directory
 	layers, err := img.Layers()
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to get image layers")
+		return "", nil, errors.Wrapf(err, "failed to get image layers")
 	}
 
-	return layers, nil
+	return image, layers, nil
 }
 
 // BaseLayerNotFoundError is returned when the base layer of the image could not be found.
@@ -92,32 +92,32 @@ func IsErrBaseLayerNotFound(err error) bool {
 }
 
 // FetchBaseLayer fetches the base layer of the image which contains the 'package.yaml' file.
-func (f *Fetcher) FetchBaseLayer(image string) (*conregv1.Layer, error) {
+func (f *Fetcher) FetchBaseLayer(image string) (string, *conregv1.Layer, error) {
 	image, err := prepareImageReference(image)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to prepare image reference")
+		return "", nil, errors.Wrap(err, "failed to prepare image reference")
 	}
 
 	ref, err := name.ParseReference(image)
 	if err != nil {
-		return nil, errors.Wrapf(err, "invalid image reference: %s", image)
+		return "", nil, errors.Wrapf(err, "invalid image reference: %s", image)
 	}
 
 	repoName := ref.Context().Name()
 
 	cBytes, err := crane.Config(image)
 	if err != nil {
-		return nil, errors.Wrapf(err, "cannot get config")
+		return image, nil, errors.Wrapf(err, "cannot get config")
 	}
 
 	cfg := &conregv1.ConfigFile{}
 	if err := yaml.Unmarshal(cBytes, cfg); err != nil {
-		return nil, errors.Wrapf(err, "cannot unmarshal image config")
+		return image, nil, errors.Wrapf(err, "cannot unmarshal image config")
 	}
 
 	// TODO(ezgidemirel): consider using the annotations instead of labels to find out the base layer like package managed
 	if cfg.Config.Labels == nil {
-		return nil, errors.New("cannot get image labels")
+		return image, nil, errors.New("cannot get image labels")
 	}
 
 	var label string
@@ -130,25 +130,46 @@ func (f *Fetcher) FetchBaseLayer(image string) (*conregv1.Layer, error) {
 	}
 
 	if label == "" {
-		return nil, NewBaseLayerNotFoundError(image)
+		return image, nil, NewBaseLayerNotFoundError(image)
 	}
 
 	lDigest := strings.SplitN(label, ":", 2)[1] // e.g.: sha256:0158764f65dc2a68728fdffa6ee6f2c9ef158f2dfed35abbd4f5bef8973e4b59
 
 	ll, err := crane.PullLayer(fmt.Sprintf(refFmt, repoName, lDigest))
 	if err != nil {
-		return nil, errors.Wrapf(err, "cannot pull base layer %s", lDigest)
+		return image, nil, errors.Wrapf(err, "cannot pull base layer %s", lDigest)
 	}
 
-	return &ll, nil
+	return image, &ll, nil
+}
+
+// Separate the image base and the image tag
+func separateImageTag(image string) (imageBase, imageTag string) {
+	parts := strings.Split(image, ":")
+	lastPart := len(parts) - 1
+
+	return strings.Join(parts[0:lastPart], ":"), parts[lastPart]
+}
+
+// Convert tags to semver versions.
+// Silently skips tags that are not valid semantic versions
+func convertToSemver(tags []string) []*semver.Version {
+	vs := []*semver.Version{}
+	for _, r := range tags {
+		v, err := semver.NewVersion(r)
+		if err != nil {
+			// We skip any tags that are not valid semantic versions
+			continue
+		}
+
+		vs = append(vs, v)
+	}
+
+	return vs
 }
 
 func findImageTagForVersionConstraint(image string) (string, error) {
-	// Separate the image base and the image tag
-	parts := strings.Split(image, ":")
-	lastPart := len(parts) - 1
-	imageBase := strings.Join(parts[0:lastPart], ":")
-	imageTag := parts[lastPart]
+	imageBase, imageTag := separateImageTag(image)
 
 	// Check if the tag is a constraint or already a valid semantic version
 	isConstraint := true
@@ -175,17 +196,7 @@ func findImageTagForVersionConstraint(image string) (string, error) {
 		return "", errors.Wrapf(err, "cannot fetch tags for the image %s", imageBase)
 	}
 
-	// Convert tags to semver versions
-	vs := []*semver.Version{}
-	for _, r := range tags {
-		v, err := semver.NewVersion(r)
-		if err != nil {
-			// We skip any tags that are not valid semantic versions
-			continue
-		}
-
-		vs = append(vs, v)
-	}
+	vs := convertToSemver(tags)
 
 	// Sort all versions and find the last version complient with the constraint
 	sort.Sort(sort.Reverse(semver.Collection(vs)))

--- a/cmd/crank/beta/validate/image.go
+++ b/cmd/crank/beta/validate/image.go
@@ -143,16 +143,15 @@ func (f *Fetcher) FetchBaseLayer(image string) (string, *conregv1.Layer, error) 
 	return image, &ll, nil
 }
 
-// Separate the image base and the image tag
+// Separate the image base and the image tag based on ':'.
 func separateImageTag(image string) (imageBase, imageTag string) {
 	parts := strings.Split(image, ":")
 	lastPart := len(parts) - 1
-
 	return strings.Join(parts[0:lastPart], ":"), parts[lastPart]
 }
 
 // Convert tags to semver versions.
-// Silently skips tags that are not valid semantic versions
+// Silently skips tags that are not valid semantic versions.
 func convertToSemver(tags []string) []*semver.Version {
 	vs := []*semver.Version{}
 	for _, r := range tags {
@@ -168,6 +167,10 @@ func convertToSemver(tags []string) []*semver.Version {
 	return vs
 }
 
+// findImageTagForVersionConstraint fetches the latest tag for an image with a version constraint.
+// image should be a validated image name with the format: <registry>/<image>:<tag>.
+// where <tag> can be a version constraint.
+// if <tag> is already an exact version, the same image string is returned back.
 func findImageTagForVersionConstraint(image string) (string, error) {
 	imageBase, imageTag := separateImageTag(image)
 

--- a/cmd/crank/beta/validate/image_test.go
+++ b/cmd/crank/beta/validate/image_test.go
@@ -65,6 +65,16 @@ func TestFindImageTagForVersionConstraint(t *testing.T) {
 			constraint:   ">4.5.6",
 			expectError:  true,
 		},
+		"RangedConstraint": {
+			responseBody:  responseTags,
+			constraint:    ">=v2.0.0 <v5.0.0",
+			expectedImage: "ubuntu:4.5.6",
+		},
+		"CommaSeparatedRangedConstraint": {
+			responseBody:  responseTags,
+			constraint:    ">=v2.0.0,<v5.0.0",
+			expectedImage: "ubuntu:4.5.6",
+		},
 	}
 
 	for name, tc := range cases {

--- a/cmd/crank/beta/validate/image_test.go
+++ b/cmd/crank/beta/validate/image_test.go
@@ -156,3 +156,68 @@ func TestIsErrBaseLayerNotFound(t *testing.T) {
 		})
 	}
 }
+
+func TestSeparateImageTag(t *testing.T) {
+	type args struct {
+		image string
+	}
+
+	type want struct {
+		imageBase string
+		imageTag  string
+	}
+
+	tests := map[string]struct {
+		args args
+		want want
+	}{
+		"ImageWithDigest": {
+			args: args{
+				image: "my-registry:1234/crossplane/crossplane:v2.0.0@sha256:abc1234",
+			},
+			want: want{
+				imageBase: "my-registry:1234/crossplane/crossplane:v2.0.0@sha256",
+				imageTag:  "abc1234",
+			},
+		},
+		"RegistryWithPort": {
+			args: args{
+				image: "my-registry:1234/crossplane/crossplane:v2.0.0",
+			},
+			want: want{
+				imageBase: "my-registry:1234/crossplane/crossplane",
+				imageTag:  "v2.0.0",
+			},
+		},
+		"ColonSeparatedImage": {
+			args: args{
+				image: "ghcr.io/crossplane/crossplane:v2.0.0",
+			},
+			want: want{
+				imageBase: "ghcr.io/crossplane/crossplane",
+				imageTag:  "v2.0.0",
+			},
+		},
+		"EmptyTag": {
+			args: args{
+				image: "ghcr.io/crossplane/crossplane:",
+			},
+			want: want{
+				imageBase: "ghcr.io/crossplane/crossplane",
+				imageTag:  "",
+			},
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			imageBase, imageTag := separateImageTag(tt.args.image)
+			if imageBase != tt.want.imageBase || imageTag != tt.want.imageTag {
+				t.Errorf("separateImageTag() want %v got %v", tt.want, want{
+					imageBase: imageBase,
+					imageTag:  imageTag,
+				})
+			}
+		})
+	}
+}

--- a/cmd/crank/beta/validate/manager.go
+++ b/cmd/crank/beta/validate/manager.go
@@ -144,7 +144,12 @@ func (m *Manager) PrepExtensions(extensions []*unstructured.Unstructured) error 
 				return errors.Wrapf(err, "cannot get provider package image")
 			}
 
-			m.deps[image] = true
+			resolvedImage, err := findImageTagForVersionConstraint(image)
+			if err != nil {
+				return errors.Wrapf(err, "cannot resolve image tag for: %s", image)
+			}
+
+			m.deps[resolvedImage] = true
 
 		case schema.GroupKind{Group: "pkg.crossplane.io", Kind: "Function"}:
 			paved := fieldpath.Pave(e.Object)
@@ -154,7 +159,12 @@ func (m *Manager) PrepExtensions(extensions []*unstructured.Unstructured) error 
 				return errors.Wrapf(err, "cannot get function package image")
 			}
 
-			m.deps[image] = true
+			resolvedImage, err := findImageTagForVersionConstraint(image)
+			if err != nil {
+				return errors.Wrapf(err, "cannot resolve image tag for: %s", image)
+			}
+
+			m.deps[resolvedImage] = true
 
 		case schema.GroupKind{Group: "pkg.crossplane.io", Kind: "Configuration"}:
 			paved := fieldpath.Pave(e.Object)
@@ -164,7 +174,12 @@ func (m *Manager) PrepExtensions(extensions []*unstructured.Unstructured) error 
 				return errors.Wrapf(err, "cannot get package image")
 			}
 
-			m.confs[image] = nil
+			resolvedImage, err := findImageTagForVersionConstraint(image)
+			if err != nil {
+				return errors.Wrapf(err, "cannot resolve image tag for: %s", image)
+			}
+
+			m.confs[resolvedImage] = nil
 
 		case schema.GroupKind{Group: "meta.pkg.crossplane.io", Kind: "Configuration"}:
 			meta, err := e.MarshalJSON()

--- a/cmd/crank/beta/validate/manager.go
+++ b/cmd/crank/beta/validate/manager.go
@@ -225,7 +225,7 @@ func (m *Manager) addDependencies(confs map[string]*metav1.Configuration) error 
 	for img := range confs {
 		image, err := findImageTagForVersionConstraint(img)
 		if err != nil {
-			return errors.Wrapf(err, "cannot resolve image tag for %s", image)
+			return errors.Wrapf(err, "cannot resolve image tag for %s", img)
 		}
 
 		cfg := m.confs[image]
@@ -295,7 +295,7 @@ func (m *Manager) cacheDependencies() error {
 	for img := range m.deps {
 		image, err := findImageTagForVersionConstraint(img)
 		if err != nil {
-			return errors.Wrapf(err, "cannot resolve image tag for %s", image)
+			return errors.Wrapf(err, "cannot resolve image tag for %s", img)
 		}
 
 		path, err := m.cache.Exists(image) // returns the path if the image is not cached

--- a/cmd/crank/beta/validate/manager.go
+++ b/cmd/crank/beta/validate/manager.go
@@ -362,12 +362,7 @@ func (m *Manager) loadDependencies() ([]*unstructured.Unstructured, error) {
 	schemas := make([]*unstructured.Unstructured, 0)
 
 	for dep := range m.deps {
-		image, err := findImageTagForVersionConstraint(dep)
-		if err != nil {
-			return nil, errors.Wrapf(err, "cannot resolve image tag for %s", dep)
-		}
-
-		cachedSchema, err := m.cache.Load(image)
+		cachedSchema, err := m.cache.Load(dep)
 		if err != nil {
 			return nil, errors.Wrapf(err, "cannot load cache for %s", dep)
 		}

--- a/cmd/crank/beta/validate/manager.go
+++ b/cmd/crank/beta/validate/manager.go
@@ -45,9 +45,10 @@ const (
 
 // Manager defines a Manager for preparing Crossplane packages for validation.
 type Manager struct {
-	fetcher ImageFetcher
-	cache   Cache
-	writer  io.Writer
+	fetcher     ImageFetcher
+	cache       Cache
+	writer      io.Writer
+	updateCache bool
 
 	crds  []*extv1.CustomResourceDefinition
 	deps  map[string]bool                  // Dependency images
@@ -65,6 +66,14 @@ func WithCrossplaneImage(image string) Option {
 		}
 
 		m.deps[image] = true
+	}
+}
+
+// WithUpdateCache forces re-downloading packages with ranged semver
+// constraints even when a matching version is already cached.
+func WithUpdateCache(update bool) Option {
+	return func(m *Manager) {
+		m.updateCache = update
 	}
 }
 
@@ -293,11 +302,19 @@ func (m *Manager) cacheDependencies() error {
 			return errors.Wrapf(err, "cannot check if cache exists for %s", image)
 		}
 
+		// cache hit -> skip unless the image contains a ranged version constraint and update-cache option is enabled
 		if path == "" {
-			continue
+			_, imageTag := separateImageTag(image)
+			if !isRangedConstraint(imageTag) || !m.updateCache {
+				continue
+			}
 		}
 
-		if _, err := fmt.Fprintln(m.writer, "schemas does not exist, downloading: ", image); err != nil {
+		msg := "schemas does not exist, downloading: "
+		if path == "" {
+			msg = "updating cached schemas: "
+		}
+		if _, err := fmt.Fprintln(m.writer, msg, image); err != nil {
 			return errors.Wrapf(err, errWriteOutput)
 		}
 

--- a/cmd/crank/beta/validate/manager.go
+++ b/cmd/crank/beta/validate/manager.go
@@ -307,12 +307,7 @@ func (m *Manager) cacheDependencies() error {
 		return errors.Wrapf(err, "cannot initialize cache directory")
 	}
 
-	for img := range m.deps {
-		image, err := findImageTagForVersionConstraint(img)
-		if err != nil {
-			return errors.Wrapf(err, "cannot resolve image tag for %s", img)
-		}
-
+	for image := range m.deps {
 		path, err := m.cache.Exists(image) // returns the path if the image is not cached
 		if err != nil {
 			return errors.Wrapf(err, "cannot check if cache exists for %s", image)
@@ -328,11 +323,11 @@ func (m *Manager) cacheDependencies() error {
 
 		var schemas [][]byte
 		// handling for packages
-		layer, err := m.fetcher.FetchBaseLayer(image)
+		resolvedImage, layer, err := m.fetcher.FetchBaseLayer(image)
 		switch {
 		case IsErrBaseLayerNotFound(err):
 			// We fall back to fetching the image if the base layer is not found
-			layers, err := m.fetcher.FetchImage(image)
+			_, layers, err := m.fetcher.FetchImage(image)
 			if err != nil {
 				return errors.Wrapf(err, "cannot extract crds")
 			}

--- a/cmd/crank/beta/validate/manager.go
+++ b/cmd/crank/beta/validate/manager.go
@@ -144,12 +144,7 @@ func (m *Manager) PrepExtensions(extensions []*unstructured.Unstructured) error 
 				return errors.Wrapf(err, "cannot get provider package image")
 			}
 
-			resolvedImage, err := findImageTagForVersionConstraint(image)
-			if err != nil {
-				return errors.Wrapf(err, "cannot resolve image tag for: %s", image)
-			}
-
-			m.deps[resolvedImage] = true
+			m.deps[image] = true
 
 		case schema.GroupKind{Group: "pkg.crossplane.io", Kind: "Function"}:
 			paved := fieldpath.Pave(e.Object)
@@ -159,12 +154,7 @@ func (m *Manager) PrepExtensions(extensions []*unstructured.Unstructured) error 
 				return errors.Wrapf(err, "cannot get function package image")
 			}
 
-			resolvedImage, err := findImageTagForVersionConstraint(image)
-			if err != nil {
-				return errors.Wrapf(err, "cannot resolve image tag for: %s", image)
-			}
-
-			m.deps[resolvedImage] = true
+			m.deps[image] = true
 
 		case schema.GroupKind{Group: "pkg.crossplane.io", Kind: "Configuration"}:
 			paved := fieldpath.Pave(e.Object)
@@ -174,12 +164,7 @@ func (m *Manager) PrepExtensions(extensions []*unstructured.Unstructured) error 
 				return errors.Wrapf(err, "cannot get package image")
 			}
 
-			resolvedImage, err := findImageTagForVersionConstraint(image)
-			if err != nil {
-				return errors.Wrapf(err, "cannot resolve image tag for: %s", image)
-			}
-
-			m.confs[resolvedImage] = nil
+			m.confs[image] = nil
 
 		case schema.GroupKind{Group: "meta.pkg.crossplane.io", Kind: "Configuration"}:
 			meta, err := e.MarshalJSON()

--- a/cmd/crank/beta/validate/manager.go
+++ b/cmd/crank/beta/validate/manager.go
@@ -237,18 +237,13 @@ func (m *Manager) addDependencies(confs map[string]*metav1.Configuration) error 
 
 	deepConfs := make(map[string]*metav1.Configuration)
 
-	for img := range confs {
-		image, err := findImageTagForVersionConstraint(img)
-		if err != nil {
-			return errors.Wrapf(err, "cannot resolve image tag for %s", img)
-		}
-
+	for image := range confs {
 		cfg := m.confs[image]
 
 		if cfg == nil {
 			m.deps[image] = true // we need to download the configuration package for the XRDs
 
-			layer, err := m.fetcher.FetchBaseLayer(image)
+			_, layer, err := m.fetcher.FetchBaseLayer(image)
 			if err != nil {
 				return errors.Wrapf(err, "cannot download package %s", image)
 			}
@@ -327,7 +322,9 @@ func (m *Manager) cacheDependencies() error {
 		switch {
 		case IsErrBaseLayerNotFound(err):
 			// We fall back to fetching the image if the base layer is not found
-			_, layers, err := m.fetcher.FetchImage(image)
+			var layers []regv1.Layer
+			var err error
+			resolvedImage, layers, err = m.fetcher.FetchImage(image)
 			if err != nil {
 				return errors.Wrapf(err, "cannot extract crds")
 			}
@@ -345,7 +342,7 @@ func (m *Manager) cacheDependencies() error {
 			}
 		}
 
-		if err := m.cache.Store(schemas, path); err != nil {
+		if err := m.cache.Store(schemas, resolvedImage); err != nil {
 			return errors.Wrapf(err, "cannot store base layer")
 		}
 	}

--- a/cmd/crank/beta/validate/manager.go
+++ b/cmd/crank/beta/validate/manager.go
@@ -302,12 +302,9 @@ func (m *Manager) cacheDependencies() error {
 			return errors.Wrapf(err, "cannot check if cache exists for %s", image)
 		}
 
-		// cache hit -> skip unless the image contains a ranged version constraint and update-cache option is enabled
-		if path == "" {
-			_, imageTag := separateImageTag(image)
-			if !isRangedConstraint(imageTag) || !m.updateCache {
-				continue
-			}
+		// cache hit, skip unless update-cache option is enabled
+		if path == "" && !m.updateCache {
+			continue
 		}
 
 		msg := "schemas does not exist, downloading: "

--- a/cmd/crank/beta/validate/manager_test.go
+++ b/cmd/crank/beta/validate/manager_test.go
@@ -117,27 +117,26 @@ func TestConfigurationTypeSupport(t *testing.T) {
 	fd := static.NewLayer(funcYaml, types.OCILayer)
 	f2 := static.NewLayer(func2Yaml, types.OCILayer)
 
-	fetchMockFunc := func(image string) (*conregv1.Layer, error) {
+	fetchMockFunc := func(image string) (string, *conregv1.Layer, error) {
 		switch image {
 		case "config-pkg:v1.3.0":
-			return &confpkg, nil
+			return "config-pkg:v1.3.0", &confpkg, nil
 		case "provider-dep-1:v1.3.0":
-			return &pd, nil
+			return "provider-dep-1-:v1.3.0", &pd, nil
 		case "provider-test:v1.3.0":
-			return &p2, nil
+			return "provider-test:v1.3.0", &p2, nil
 		case "function-dep-1:v1.3.0":
-			return &fd, nil
+			return "function-dep-1:v1.3.0", &fd, nil
 		case "function-test:v1.3.0":
-			return &f2, nil
-
+			return "function-test:v1.3.0", &f2, nil
 		default:
-			return nil, fmt.Errorf("unknown image: %s", image)
+			return "", nil, fmt.Errorf("unknown image: %s", image)
 		}
 	}
 
 	type args struct {
 		extensions []*unstructured.Unstructured
-		fetchMock  func(image string) (*conregv1.Layer, error)
+		fetchMock  func(image string) (string, *conregv1.Layer, error)
 	}
 
 	type want struct {
@@ -366,29 +365,29 @@ func TestAddDependencies(t *testing.T) {
 	fd1 := static.NewLayer(funcYaml, types.OCILayer)
 	crossplaneLayer := static.NewLayer([]byte("crossplane content"), types.OCILayer)
 
-	fetchMockFunc := func(image string) (*conregv1.Layer, error) {
+	fetchMockFunc := func(image string) (string, *conregv1.Layer, error) {
 		switch image {
 		case "config-dep-1:v1.3.0":
-			return &cd1, nil
+			return image, &cd1, nil
 		case "config-dep-2:v1.3.0":
-			return &cd2, nil
+			return image, &cd2, nil
 		case "provider-dep-1:v1.3.0":
-			return &pd1, nil
+			return image, &pd1, nil
 		case "function-dep-1:v1.3.0":
-			return &fd1, nil
+			return image, &fd1, nil
 		case "xpkg.crossplane.io/crossplane/crossplane:v1.16.0":
-			return &crossplaneLayer, nil
+			return "xpkg.crossplane.io/crossplane/crossplane:v1.16.0", &crossplaneLayer, nil
 		default:
-			return nil, fmt.Errorf("unknown image: %s", image)
+			return "", nil, fmt.Errorf("unknown image: %s", image)
 		}
 	}
 
-	fetchImageMockFunc := func(image string) ([]conregv1.Layer, error) {
+	fetchImageMockFunc := func(image string) (string, []conregv1.Layer, error) {
 		switch image {
 		case "xpkg.crossplane.io/crossplane/crossplane:v1.16.0":
-			return []conregv1.Layer{crossplaneLayer}, nil
+			return "xpkg.crossplane.io/crossplane/crossplane:v1.16.0", []conregv1.Layer{crossplaneLayer}, nil
 		default:
-			return nil, fmt.Errorf("unknown image: %s", image)
+			return "", nil, fmt.Errorf("unknown image: %s", image)
 		}
 	}
 
@@ -501,18 +500,18 @@ func TestAddDependencies(t *testing.T) {
 }
 
 type MockFetcher struct {
-	fetchBaseLayer func(image string) (*conregv1.Layer, error)
-	fetchImage     func(image string) ([]conregv1.Layer, error)
+	fetchBaseLayer func(image string) (string, *conregv1.Layer, error)
+	fetchImage     func(image string) (string, []conregv1.Layer, error)
 }
 
-func (m *MockFetcher) FetchBaseLayer(image string) (*conregv1.Layer, error) {
+func (m *MockFetcher) FetchBaseLayer(image string) (string, *conregv1.Layer, error) {
 	return m.fetchBaseLayer(image)
 }
 
-func (m *MockFetcher) FetchImage(image string) ([]conregv1.Layer, error) {
+func (m *MockFetcher) FetchImage(image string) (string, []conregv1.Layer, error) {
 	if m.fetchImage != nil {
 		return m.fetchImage(image)
 	}
 
-	return nil, nil // or a sensible default/mock behavior
+	return "", nil, nil // or a sensible default/mock behavior
 }

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	dario.cat/mergo v1.0.2
 	github.com/AdaLogics/go-fuzz-headers v0.0.0-20240806141605-e8a1dd7889d6
 	github.com/Masterminds/semver v1.5.0
+	github.com/Masterminds/semver/v3 v3.4.0
 	github.com/alecthomas/kong v1.14.0
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/containerd/errdefs v1.0.0

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,6 @@ replace github.com/crossplane/crossplane/apis/v2 => ./apis
 require (
 	dario.cat/mergo v1.0.2
 	github.com/AdaLogics/go-fuzz-headers v0.0.0-20240806141605-e8a1dd7889d6
-	github.com/Masterminds/semver v1.5.0
 	github.com/Masterminds/semver/v3 v3.4.0
 	github.com/alecthomas/kong v1.14.0
 	github.com/charmbracelet/bubbletea v1.3.10
@@ -46,7 +45,6 @@ require (
 )
 
 require (
-	github.com/Masterminds/semver/v3 v3.4.0 // indirect
 	github.com/go-json-experiment/json v0.0.0-20240815175050-ebd3a8989ca1 // indirect
 	github.com/google/go-containerregistry/pkg/authn/k8schain v0.0.0-20230919002926-dbcd01c402b2 // indirect
 	github.com/in-toto/in-toto-golang v0.10.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -66,8 +66,6 @@ github.com/AzureAD/microsoft-authentication-library-for-go v1.6.0 h1:XRzhVemXdgv
 github.com/AzureAD/microsoft-authentication-library-for-go v1.6.0/go.mod h1:HKpQxkWaGLJ+D/5H8QRpyQXA1eKjxkFlOMwck5+33Jk=
 github.com/MakeNowJust/heredoc v1.0.0 h1:cXCdzVdstXyiTqTvfqk9SDHpKNjxuom+DOlyEeQ4pzQ=
 github.com/MakeNowJust/heredoc v1.0.0/go.mod h1:mG5amYoWBHf8vpLOuehzbGGw0EHxpZZ6lCpQ4fNJ8LE=
-github.com/Masterminds/semver v1.5.0 h1:H65muMkzWKEuNDnfl9d70GUjFniHKHRbFPGBuZ3QEww=
-github.com/Masterminds/semver v1.5.0/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
 github.com/Masterminds/semver/v3 v3.4.0 h1:Zog+i5UMtVoCU8oKka5P7i9q9HgrJeGzI9SA1Xbatp0=
 github.com/Masterminds/semver/v3 v3.4.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
 github.com/Microsoft/go-winio v0.5.2/go.mod h1:WpS1mjBmmwHBEWmogvA2mj8546UReBk4v8QkMxJ6pZY=

--- a/internal/controller/pkg/resolver/reconciler.go
+++ b/internal/controller/pkg/resolver/reconciler.go
@@ -25,7 +25,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/Masterminds/semver"
+	"github.com/Masterminds/semver/v3"
 	"github.com/google/go-containerregistry/pkg/name"
 	conregv1 "github.com/google/go-containerregistry/pkg/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"

--- a/internal/controller/pkg/revision/dependency.go
+++ b/internal/controller/pkg/revision/dependency.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/Masterminds/semver"
+	"github.com/Masterminds/semver/v3"
 	"github.com/google/go-containerregistry/pkg/name"
 	conregv1 "github.com/google/go-containerregistry/pkg/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"

--- a/internal/dag/upgrading_dag.go
+++ b/internal/dag/upgrading_dag.go
@@ -17,7 +17,7 @@ limitations under the License.
 package dag
 
 import (
-	"github.com/Masterminds/semver"
+	"github.com/Masterminds/semver/v3"
 
 	"github.com/crossplane/crossplane-runtime/v2/pkg/errors"
 )


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane! Please read the contribution docs
(linked below) if this is your first Crossplane pull request.
-->

### Description of your changes

This PR:
  -  updates semver package to v3  (this adds support for correctly detecting ranged semantic version constraints)
     -  added version constraint ranges as test cases in TestFindImageTagForVersionConstraint
  - refactors cache, image and manager to support caching of semantic version ranges with  behavior as described by Adam in https://github.com/crossplane/crossplane/pull/7050#pullrequestreview-4108715670.
  - Adds an `--update-cache` flag that optionally always checks if there are newer versions of a tag/version constraint upstream
 
#### Background

Currently caching of dependencies with ranged version constraints are not working properly.

Example `./apis/package.yaml` can look like this:

```yaml
---
apiVersion: meta.pkg.crossplane.io/v1
kind: Configuration
metadata:
  name: example
spec:
  dependsOn:
    - apiVersion: pkg.crossplane.io/v1
      kind: Function
      package: xpkg.crossplane.io/crossplane-contrib/function-auto-ready
      version: ">=v0.6.0,<v1.0.0"
    - apiVersion: pkg.crossplane.io/v1
      kind: Function
      package: xpkg.crossplane.io/crossplane-contrib/function-environment-configs
      version: ">=v0.0.0,<v1.0.0"
    - apiVersion: pkg.crossplane.io/v1
      kind: Function
      package: xpkg.crossplane.io/crossplane-contrib/function-go-templating
      version: ">=v0.11.0,<v1.0.0"
    - apiVersion: pkg.crossplane.io/v1
      kind: Provider
      package: xpkg.crossplane.io/crossplane-contrib/provider-azuread
      version: ">=v2.0.0,<v3.0.0"
    - apiVersion: pkg.crossplane.io/v1
      kind: Function
      package: ghcr.io/sn-atmos/function-entraid-password-rotation
      version: ">=v0.0.0,<v1.0.0"
  crossplane:
    version: ">=v2.0.2,<v3.0.0"
```

Trying to run `go run ./cmd/crank  beta validate apis/ tests/app-observed/expected.yaml --clean-cache --cache-dir .cache --verbose --crossplane-image=xpkg.crossplane.io/crossplane/crossplane:v2.1.3`:


Results in error: 

```sh
crossplane: error: cannot download and load cache: cannot load cache: cannot load cache for xpkg.crossplane.io/crossplane-contrib/function-environment-configs:>=v0.0.0,<v1.0.0: cannot create loader from .cache/xpkg.crossplane.io/crossplane-contrib/function-environment-configs@>=v0.0.0,<v1.0.0: cannot create loader for ".cache/xpkg.crossplane.io/crossplane-contrib/function-environment-configs@>=v0.0.0": cannot stat input source: stat .cache/xpkg.crossplane.io/crossplane-contrib/function-environment-configs@>=v0.0.0: no such file or directory
exit status 1`
```

As seen in the error message, the cache path is invalid because the second part of the comma separated semantic range is cut off.

This PR adds support for semantic ranges by resolving it correctly before caching:

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `earthly +reviewable` to ensure this PR is ready for review. 
- [x] Added or updated unit tests.
~~- [ ] Added or updated e2e tests.~~
- [x] Linked a PR or a [docs tracking issue] to [document this change].
~~- [ ] Added `backport release-x.y` labels to auto-backport this PR.~~
~~- [ ] Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md