### PR TITLE
Fix Renovate local preset syntax to use owner/repo//path format

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -5,9 +5,12 @@
   // - renovate-base.json5: Common configuration for all branches
   // - renovate-earthly.json5: Earthly-specific config for release branches
   // - renovate-nix.json5: Nix-specific config for main branch
+  //
+  // The local> syntax requires owner/repo format with // for paths.
+  // See: https://docs.renovatebot.com/config-presets/#local-presets
   extends: [
-    'local>.github/renovate-base.json5',
-    'local>.github/renovate-earthly.json5',
-    'local>.github/renovate-nix.json5',
+    'local>crossplane/crossplane//.github/renovate-base.json5',
+    'local>crossplane/crossplane//.github/renovate-earthly.json5',
+    'local>crossplane/crossplane//.github/renovate-nix.json5',
   ],
 }


### PR DESCRIPTION
### Description of your changes

The Renovate config refactoring in #6999 used incorrect `local>` preset syntax. It used paths like `local>.github/renovate-base.json5`, which Renovate interpreted as a repository named ".github/renovate-base.json5" rather than a file path within the current repository.

This caused the error:
```
Cannot find preset's package (local>.github/renovate-base.json5)
```

See https://github.com/crossplane/crossplane/actions/runs/21501331745/job/61948107511

(I think) the correct syntax requires `owner/repo//path` format per https://docs.renovatebot.com/config-presets/#local-presets

I have:

- [x] Read and followed Crossplane's [contribution process].
- [ ] ~Run `./nix.sh flake check` to ensure this PR is ready for review.~
- [ ] ~Added or updated unit tests.~
- [ ] ~Added or updated e2e tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~
- [ ] ~Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md