### PR TITLE
Fix Nix config for Renovate post-upgrade tasks

### DIFF
--- a/.github/renovate-entrypoint.sh
+++ b/.github/renovate-entrypoint.sh
@@ -12,13 +12,14 @@ chmod +x /usr/local/bin/earthly
 echo "Installing Nix..."
 apt-get update && apt-get install -y nix-bin
 
-# Configure Nix via environment variable
-export NIX_CONFIG="
+# Configure Nix
+mkdir -p /etc/nix
+cat > /etc/nix/nix.conf << 'EOF'
 experimental-features = nix-command flakes
 max-jobs = auto
 extra-substituters = https://crossplane.cachix.org
 extra-trusted-public-keys = crossplane.cachix.org-1:NJluVUN9TX0rY/zAxHYaT19Y5ik4ELH4uFuxje+62d4=
-"
+EOF
 
 echo "Nix $(nix --version) installed successfully"
 


### PR DESCRIPTION
### Description of your changes

Fixes the "experimental Nix feature 'nix-command' is disabled" error seen in https://github.com/crossplane/crossplane/pull/7047#issuecomment-3821750129

Renovate runs post-upgrade tasks (`nix run .#tidy`, `nix run .#generate`) in subprocesses that don't inherit the `NIX_CONFIG` environment variable set in the entrypoint script.

This PR writes to `/etc/nix/nix.conf` instead, which Nix reads regardless of how it's invoked.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `./nix.sh flake check` to ensure this PR is ready for review.
- [ ] ~Added or updated unit tests.~
- [ ] ~Added or updated e2e tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~
- [ ] ~Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md