### PR TITLE
Disable Nix build-users-group for Renovate

### DIFF
--- a/.github/renovate-entrypoint.sh
+++ b/.github/renovate-entrypoint.sh
@@ -15,8 +15,17 @@ apt-get update && apt-get install -y nix-bin
 # Configure Nix
 mkdir -p /etc/nix
 cat > /etc/nix/nix.conf << 'EOF'
+# Enable flakes and the nix command (e.g. nix run, nix build).
 experimental-features = nix-command flakes
+
+# Run builds as the calling user, not dedicated nixbld users. This avoids
+# needing to create the nixbld group and users in this ephemeral container.
+build-users-group =
+
+# Build derivations in parallel, one per CPU core.
 max-jobs = auto
+
+# Use the Crossplane Cachix cache to download pre-built binaries from CI.
 extra-substituters = https://crossplane.cachix.org
 extra-trusted-public-keys = crossplane.cachix.org-1:NJluVUN9TX0rY/zAxHYaT19Y5ik4ELH4uFuxje+62d4=
 EOF


### PR DESCRIPTION
### Description of your changes

Fixes the "the group 'nixbld' specified in 'build-users-group' does not exist" error seen in https://github.com/crossplane/crossplane/pull/7047

Nix normally runs builds as dedicated users in the `nixbld` group for isolation. The Renovate container doesn't have this group, causing errors when running post-upgrade tasks like `nix run .#tidy`.

Setting `build-users-group =` (empty) makes Nix run builds as the calling user (root) instead. This is fine for an ephemeral CI container.

Also adds comments documenting each nix.conf setting.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `./nix.sh flake check` to ensure this PR is ready for review.
- [ ] ~Added or updated unit tests.~
- [ ] ~Added or updated e2e tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~
- [ ] ~Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md