### PR TITLE
Filter Nix source to avoid unnecessary Go rebuilds

### DIFF
--- a/nix/build.nix
+++ b/nix/build.nix
@@ -7,8 +7,13 @@
 #   pkgs.buildGoApplication - gomod2nix's Go builder (https://github.com/nix-community/gomod2nix)
 #   pkgs.dockerTools        - Build OCI images without Docker (https://nixos.org/manual/nixpkgs/stable/#sec-pkgs-dockerTools)
 #   pkgs.runCommand         - Run a shell script, capture output directory as $out
-{ pkgs, self }:
+{
+  pkgs,
+  self,
+  src,
+}:
 let
+
   # Build a Go binary for a specific platform.
   goBinary =
     {
@@ -22,10 +27,9 @@ let
     in
     pkgs.buildGoApplication {
       pname = "${pname}-${platform.os}-${platform.arch}";
-      inherit version;
-      src = self;
-      pwd = self;
-      modules = "${self}/gomod2nix.toml";
+      inherit version src;
+      pwd = src;
+      modules = "${src}/gomod2nix.toml";
       subPackages = [ subPackage ];
 
       # Cross-compile by merging GOOS/GOARCH into Go's attrset (// merges attrsets).
@@ -199,10 +203,9 @@ in
     { version }:
     pkgs.buildGoApplication {
       pname = "crossplane-e2e";
-      inherit version;
-      src = self;
-      pwd = self;
-      modules = "${self}/gomod2nix.toml";
+      inherit version src;
+      pwd = src;
+      modules = "${src}/gomod2nix.toml";
 
       CGO_ENABLED = "0";
 

--- a/nix/checks.nix
+++ b/nix/checks.nix
@@ -9,16 +9,19 @@
 #
 # All checks are builder functions that take an attrset of arguments and return
 # a derivation. The actual check definitions live in flake.nix.
-{ pkgs, self }:
+{
+  pkgs,
+  self,
+  src,
+}:
 {
   # Run Go unit tests with coverage
   test =
     { version }:
     pkgs.buildGoApplication {
       pname = "crossplane-test";
-      inherit version;
-      src = self;
-      pwd = self;
+      inherit version src;
+      pwd = src;
       modules = ../gomod2nix.toml;
 
       CGO_ENABLED = "0";
@@ -43,9 +46,8 @@
     { version }:
     pkgs.buildGoApplication {
       pname = "crossplane-go-lint";
-      inherit version;
-      src = self;
-      pwd = self;
+      inherit version src;
+      pwd = src;
       modules = ../gomod2nix.toml;
 
       CGO_ENABLED = "0";


### PR DESCRIPTION
### Description of your changes

When using `nix build`, any file change in the repository triggered a full Go rebuild, even for unrelated files like `README.md` or Helm charts. This made iterative development slower than necessary.

This PR adds source filtering using `lib.sources.cleanSourceWith` to create a filtered source containing only Go-related files (`*.go`, `go.mod`, `go.sum`, `gomod2nix.toml`), test fixtures (`testdata/`), and lint config
(`.golangci.yml`). The filtered source is passed to `build.nix` and `checks.nix` for use in `buildGoApplication` calls.

With this change, rebuilding after editing a non-Go file is 6-7x faster. Only images and charts rebuild; Go binaries are cached. Go builds still trigger normally when Go files change.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `./nix.sh flake check` to ensure this PR is ready for review.
- [ ] ~Added or updated unit tests.~
- [ ] ~Added or updated e2e tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~
- [ ] ~Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md