### PR TITLE
Use lockFileMaintenance to update flake.lock

### DIFF
--- a/.github/renovate-nix.json5
+++ b/.github/renovate-nix.json5
@@ -2,21 +2,19 @@
   // Nix-specific configuration for main branch.
   // Release branches use Earthly - see renovate-earthly.json5.
 
-  // Enable the nix manager to update flake.lock when flake inputs change.
+  // Enable the nix manager to detect flake.nix/flake.lock files.
   nix: {
     enabled: true,
   },
 
+  // Update flake.lock weekly by running 'nix flake update'.
+  // This also affects other lock files, so we disable it for gomod below.
+  lockFileMaintenance: {
+    enabled: true,
+    extends: ['schedule:weekly'],
+  },
+
   packageRules: [
-    {
-      description: 'Update flake.lock monthly',
-      matchManagers: [
-        'nix',
-      ],
-      extends: [
-        'schedule:monthly',
-      ],
-    },
     {
       description: 'Regenerate gomod2nix.toml and generated code after upgrading go dependencies (Nix)',
       matchDatasources: [


### PR DESCRIPTION
### Description of your changes

Renovate's nix manager was failing to update flake.lock with errors like "Digest is not updated" and "Value is not updated". The manager tried to do text replacement in flake.nix, but digests live in flake.lock, not flake.nix. It also incorrectly suggested updating from nixos-25.11 to ancient tags like v208 (from 2015) that don't match the nixpkgs versioning scheme.

This commit switches to lockFileMaintenance, which runs `nix flake update` directly. As far as I can tell this is what most Nix projects using Renovate have configured.

It also switches nixpkgs updates to weekly, which'll make sure we get updates to all development tools (e.g. Go) within a week.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [ ] ~Run `./nix.sh flake check` to ensure this PR is ready for review.~
- [ ] ~Added or updated unit tests.~
- [ ] ~Added or updated e2e tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~
- [ ] ~Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md