### PR TITLE
Set distinct app.kubernetes.io/component labels for rbac-manager (issue #6965)

### DIFF
--- a/cluster/charts/crossplane/templates/_helpers.tpl
+++ b/cluster/charts/crossplane/templates/_helpers.tpl
@@ -12,14 +12,21 @@ Create chart name and version as used by the chart label.
 {{- define "crossplane.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
-
+{{/*
+This helper allows setting app.kubernetes.io/component dynamically.
+instead of hardcoding it for all Deployments.
+Usage:
+  {{- include "crossplane.componentLabel" "rbac-manager" | nindent 4 }}
+*/}}
+{{- define "crossplane.componentLabel" -}}
+app.kubernetes.io/component: {{ . | quote }}
+{{- end -}}
 {{/*
 Generate basic labels
 */}}
 {{- define "crossplane.labels" }}
 helm.sh/chart: {{ include "crossplane.chart" . }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
-app.kubernetes.io/component: cloud-infrastructure-controller
 app.kubernetes.io/part-of: {{ template "crossplane.name" . }}
 app.kubernetes.io/name: {{ include "crossplane.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}

--- a/cluster/charts/crossplane/templates/deployment.yaml
+++ b/cluster/charts/crossplane/templates/deployment.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "crossplane.name" . }}
+    {{- include "crossplane.componentLabel" "cloud-infrastructure-controller" | nindent 4 }}
     release: {{ .Release.Name }}
     {{- include "crossplane.labels" . | indent 4 }}
   {{- with .Values.customAnnotations }}
@@ -36,6 +37,7 @@ spec:
       {{- end }}
       labels:
         app: {{ template "crossplane.name" . }}
+        {{- include "crossplane.componentLabel" "cloud-infrastructure-controller" | nindent 8 }}
         release: {{ .Release.Name }}
         {{- include "crossplane.labels" . | indent 8 }}
     spec:

--- a/cluster/charts/crossplane/templates/rbac-manager-deployment.yaml
+++ b/cluster/charts/crossplane/templates/rbac-manager-deployment.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "crossplane.name" . }}-rbac-manager
+    {{- include "crossplane.componentLabel" "rbac-manager" | nindent 4 }}
     release: {{ .Release.Name }}
     {{- include "crossplane.labels" . | indent 4 }}
   {{- with .Values.customAnnotations }}
@@ -37,6 +38,7 @@ spec:
       {{- end }}
       labels:
         app: {{ template "crossplane.name" . }}-rbac-manager
+        {{- include "crossplane.componentLabel" "rbac-manager" | nindent 8 }}
         release: {{ .Release.Name }}
         {{- include "crossplane.labels" . | indent 8 }}
     spec:


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane! Please read the contribution docs
(linked below) if this is your first Crossplane pull request.
-->

### Description of your changes

<!--
Fixes an issue where both the Crossplane controller and RBAC manager
Deployments were labeled with the same app.kubernetes.io/component.

The component label is no longer hardcoded in the shared labels helper.
Each Deployment now sets its own component explicitly, preserving Helm
upgrade safety.


-->

Fixes #6965

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `./nix.sh flake check` to ensure this PR is ready for review.
- [ ] Added or updated unit tests.
- [ ] Added or updated e2e tests.
- [ ] Linked a PR or a [docs tracking issue] to [document this change].
- [ ] Added `backport release-x.y` labels to auto-backport this PR.
- [x] Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md
