### PR TITLE
build: add values file support for hack target

### DIFF
--- a/nix/apps.nix
+++ b/nix/apps.nix
@@ -203,6 +203,7 @@
           text = ''
             CLUSTER_NAME="crossplane-hack"
             CROSSPLANE_ARGS="''${HACK_CROSSPLANE_ARGS:---debug}"
+            HELM_VALUES="''${HACK_CROSSPLANE_VALUES:-}"
 
             if ! docker ps --format '{{.Names}}' | grep -q "^$CLUSTER_NAME-control-plane$"; then
               kind delete cluster --name "$CLUSTER_NAME" 2>/dev/null || true
@@ -224,6 +225,7 @@
               --set image.repository=crossplane/crossplane \
               --set image.tag=${version} \
               --set "args={''${CROSSPLANE_ARGS}}" \
+              ''${HELM_VALUES:+-f "$HELM_VALUES"} \
               --wait
 
             echo ""


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane! Please read the contribution docs
(linked below) if this is your first Crossplane pull request.
-->

### Description of your changes

Add support for an optional `HACK_CROSSPLANE_VALUES` environment variable to the nix hack target, allowing users to pass additional Helm values files when deploying Crossplane.

Example:
```
HACK_CROSSPLANE_VALUES=inspector-values.yaml nix run .#hack
```

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `./nix.sh flake check` to ensure this PR is ready for review.
- [ ] ~Added or updated unit tests.~
- [ ] ~Added or updated e2e tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~
- [ ] ~Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md

