### PR TITLE
Use `--watched-resource` flag for WatchOperations

### DIFF
--- a/cmd/crank/alpha/render/op/load.go
+++ b/cmd/crank/alpha/render/op/load.go
@@ -28,62 +28,69 @@ import (
 	opsv1alpha1 "github.com/crossplane/crossplane/v2/apis/ops/v1alpha1"
 )
 
-// LoadOperation loads an Operation from a YAML file.
-func LoadOperation(fs afero.Fs, path string, rrs []unstructured.Unstructured) (*opsv1alpha1.Operation, error) {
+// LoadOperation loads an Operation from a YAML file. If the file contains a
+// CronOperation or WatchOperation, the Operation template is extracted.
+func LoadOperation(fs afero.Fs, path string) (*opsv1alpha1.Operation, error) {
 	data, err := afero.ReadFile(fs, path)
 	if err != nil {
 		return nil, errors.Wrapf(err, "cannot read operation file %q", path)
 	}
 
-	op := &opsv1alpha1.Operation{}
-	if err := yaml.Unmarshal(data, op); err != nil {
-		return nil, errors.Wrapf(err, "cannot unmarshal operation from %q", path)
+	// Peek at the GVK to determine which type to unmarshal into.
+	var meta metav1.TypeMeta
+	if err := yaml.Unmarshal(data, &meta); err != nil {
+		return nil, errors.Wrapf(err, "cannot unmarshal type metadata from %q", path)
 	}
 
-	// Validate that it's an Operation by checking the GVK
-	switch gvk := op.GroupVersionKind(); gvk {
+	switch gvk := meta.GroupVersionKind(); gvk {
 	case opsv1alpha1.OperationGroupVersionKind:
+		op := &opsv1alpha1.Operation{}
+		if err := yaml.Unmarshal(data, op); err != nil {
+			return nil, errors.Wrapf(err, "cannot unmarshal Operation from %q", path)
+		}
 		return op, nil
+
 	case opsv1alpha1.CronOperationGroupVersionKind:
-		cop := opsv1alpha1.CronOperation{}
-		if err := yaml.Unmarshal(data, &cop); err != nil {
-			return nil, errors.Wrapf(err, "cannot unmarshal operation from %q", path)
+		cop := &opsv1alpha1.CronOperation{}
+		if err := yaml.Unmarshal(data, cop); err != nil {
+			return nil, errors.Wrapf(err, "cannot unmarshal CronOperation from %q", path)
 		}
-		op.Kind = opsv1alpha1.OperationKind
-		op.Spec = cop.Spec.OperationTemplate.Spec
+		// Use the template's metadata (labels, annotations) like the real
+		// controller does. The real controller always overwrites the name with
+		// a generated one; we use the parent's name for simplicity.
+		op := &opsv1alpha1.Operation{
+			TypeMeta:   metav1.TypeMeta{APIVersion: meta.APIVersion, Kind: opsv1alpha1.OperationKind},
+			ObjectMeta: cop.Spec.OperationTemplate.ObjectMeta,
+			Spec:       cop.Spec.OperationTemplate.Spec,
+		}
+		op.SetName(cop.GetName())
 		return op, nil
+
 	case opsv1alpha1.WatchOperationGroupVersionKind:
-		wop := opsv1alpha1.WatchOperation{}
-		if err := yaml.Unmarshal(data, &wop); err != nil {
-			return nil, errors.Wrapf(err, "cannot unmarshal operation from %q", path)
+		wop := &opsv1alpha1.WatchOperation{}
+		if err := yaml.Unmarshal(data, wop); err != nil {
+			return nil, errors.Wrapf(err, "cannot unmarshal WatchOperation from %q", path)
 		}
-		return newOperationFromWatchOperation(&wop, rrs)
+		// Use the template's metadata (labels, annotations) like the real
+		// controller does. The real controller always overwrites the name with
+		// a generated one; we use the parent's name for simplicity.
+		op := &opsv1alpha1.Operation{
+			TypeMeta:   metav1.TypeMeta{APIVersion: meta.APIVersion, Kind: opsv1alpha1.OperationKind},
+			ObjectMeta: wop.Spec.OperationTemplate.ObjectMeta,
+			Spec:       *wop.Spec.OperationTemplate.Spec.DeepCopy(),
+		}
+		op.SetName(wop.GetName())
+		return op, nil
 
 	default:
-		return nil, errors.Errorf("not an operation type: %s/%s", gvk.Kind, op.GetName())
+		return nil, errors.Errorf("not an operation type: %s/%s", gvk.Kind, meta.GetObjectKind().GroupVersionKind().GroupVersion())
 	}
 }
 
-// newOperationFromWatchOperation creates a new Operation from a WatchOperation's template,
-// injecting the watched resource selector into all pipeline steps.
-func newOperationFromWatchOperation(wo *opsv1alpha1.WatchOperation, requiredResources []unstructured.Unstructured) (*opsv1alpha1.Operation, error) {
-	// Find the watched resource (marked with annotation ops.crossplane.io/watched-resource: "True")
-	var watched *unstructured.Unstructured
-	for i := range requiredResources {
-		res := &requiredResources[i]
-		annotations := res.GetAnnotations()
-		if annotations != nil && annotations[opsv1alpha1.RequirementNameWatchedResource] == "True" {
-			watched = res
-			break
-		}
-	}
-
-	// If no watched resource found, return error
-	if watched == nil {
-		return nil, errors.New("no watched resource found in required resources - expected resource with annotation ops.crossplane.io/watched-resource: \"True\"")
-	}
-
-	// Build the selector for the watched resource
+// InjectWatchedResource adds a RequiredResourceSelector for the watched resource
+// to every pipeline step. This replicates what the WatchOperation controller does
+// when creating an Operation from a WatchOperation.
+func InjectWatchedResource(op *opsv1alpha1.Operation, watched *unstructured.Unstructured) {
 	sel := opsv1alpha1.RequiredResourceSelector{
 		RequirementName: opsv1alpha1.RequirementNameWatchedResource,
 		APIVersion:      watched.GetAPIVersion(),
@@ -94,16 +101,6 @@ func newOperationFromWatchOperation(wo *opsv1alpha1.WatchOperation, requiredReso
 		sel.Namespace = ptr.To(watched.GetNamespace())
 	}
 
-	// Create operation from template and inject selector into each pipeline step
-	op := &opsv1alpha1.Operation{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: opsv1alpha1.SchemeGroupVersion.String(),
-			Kind:       opsv1alpha1.OperationKind,
-		},
-		ObjectMeta: wo.ObjectMeta,
-		Spec:       *wo.Spec.OperationTemplate.Spec.DeepCopy(),
-	}
-
 	for i := range op.Spec.Pipeline {
 		step := &op.Spec.Pipeline[i]
 		if step.Requirements == nil {
@@ -111,6 +108,4 @@ func newOperationFromWatchOperation(wo *opsv1alpha1.WatchOperation, requiredReso
 		}
 		step.Requirements.RequiredResources = append(step.Requirements.RequiredResources, sel)
 	}
-
-	return op, nil
 }


### PR DESCRIPTION
### Description of your changes

Follow-up to #7021.

We recently added support for `crossplane alpha render` to accept WatchOperations and CronOperations as well as Operations. When presented with one of these wrapper types, it extracts the resulting Operation.

WatchOperations must inject the watched resource (the resource that triggered the watch) selector into the templated operation. The initial implementation used a special annotation on a required resource to do
this. This annotation doesn't exist in the 'real' implementation. It also meant the LoadOperation function needed all required resources as an argument (to find the one annotated as watched).

This commit removes the special annotation and instead adds a `--watched-resource` flag that specifies the watched resource file. I think this is more easily discoverable than an annotation.

The commit also matches the real controller a little more closely when forming Operations from CronOperations and WatchOperations. Namely it honors templated metadata.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `./nix.sh flake check` to ensure this PR is ready for review.
- [x] Added or updated unit tests.
- [ ] ~Added or updated e2e tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~
- [ ] ~Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md