### PR TITLE
Validate RunFunctionRequests in basic composition E2E tests

### DIFF
--- a/test/e2e/apiextensions_compositions_test.go
+++ b/test/e2e/apiextensions_compositions_test.go
@@ -105,7 +105,7 @@ func TestCompositionRevisionSelection(t *testing.T) {
 func TestBasicCompositionNamespaced(t *testing.T) {
 	manifests := "test/e2e/manifests/apiextensions/composition/basic-namespaced"
 	environment.Test(t,
-		features.NewWithDescription(t.Name(), "Tests the correct functioning of a namespaced XR ensuring that the composed resources are created, conditions are met, fields are patched, and resources are properly cleaned up when deleted.").
+		features.NewWithDescription(t.Name(), "Tests the correct functioning of a namespaced XR ensuring that the composed resources are created, conditions are met, fields are patched, and resources are properly cleaned up when deleted. Uses function-python to validate that Crossplane sends the observed composite, credentials, and observed composed resources to the function.").
 			WithLabel(LabelArea, LabelAreaAPIExtensions).
 			WithLabel(LabelSize, LabelSizeSmall).
 			WithLabel(config.LabelTestSuite, config.TestSuiteDefault).
@@ -113,6 +113,7 @@ func TestBasicCompositionNamespaced(t *testing.T) {
 				funcs.ApplyResources(FieldManager, manifests, "setup/*.yaml"),
 				funcs.ResourcesCreatedWithin(30*time.Second, manifests, "setup/*.yaml"),
 				funcs.ResourcesHaveConditionWithin(1*time.Minute, manifests, "setup/definition.yaml", apiextensionsv1.WatchingComposite()),
+				funcs.ResourcesHaveConditionWithin(2*time.Minute, manifests, "setup/functions.yaml", pkgv1.Healthy(), pkgv1.Active()),
 			)).
 			Assess("CreateXR", funcs.AllOf(
 				funcs.ApplyResources(FieldManager, manifests, "xr.yaml"),
@@ -122,6 +123,18 @@ func TestBasicCompositionNamespaced(t *testing.T) {
 				funcs.ResourcesHaveConditionWithin(1*time.Minute, manifests, "xr.yaml", xpv1.Available(), xpv1.ReconcileSuccess())).
 			Assess("XRHasStatusField",
 				funcs.ResourcesHaveFieldValueWithin(1*time.Minute, manifests, "xr.yaml", "status.coolerField", "I'M COOLER!"),
+			).
+			Assess("FunctionReceivedObservedComposite",
+				funcs.ResourcesHaveFieldValueWithin(1*time.Minute, manifests, "xr.yaml", "status.observedCompositeReceived", true),
+			).
+			Assess("FunctionReceivedObservedCompositeWithCoolField",
+				funcs.ResourcesHaveFieldValueWithin(1*time.Minute, manifests, "xr.yaml", "status.observedCompositeHasCoolField", true),
+			).
+			Assess("FunctionReceivedCredentials",
+				funcs.ResourcesHaveFieldValueWithin(1*time.Minute, manifests, "xr.yaml", "status.credentialsReceived", true),
+			).
+			Assess("FunctionReceivedObservedComposedResources",
+				funcs.ResourcesHaveFieldValueWithin(2*time.Minute, manifests, "xr.yaml", "status.observedComposedResourcesReceived", true),
 			).
 			WithTeardown("DeleteXR", funcs.AllOf(
 				funcs.DeleteResourcesWithPropagationPolicy(manifests, "xr.yaml", metav1.DeletePropagationForeground),
@@ -170,7 +183,7 @@ func TestLackOfRightsNamespaced(t *testing.T) {
 func TestBasicCompositionCluster(t *testing.T) {
 	manifests := "test/e2e/manifests/apiextensions/composition/basic-cluster"
 	environment.Test(t,
-		features.NewWithDescription(t.Name(), "Tests the correct functioning of cluster-scoped XR ensuring that the composed resources are created, conditions are met, fields are patched, and resources are properly cleaned up when deleted.").
+		features.NewWithDescription(t.Name(), "Tests the correct functioning of cluster-scoped XR ensuring that the composed resources are created, conditions are met, fields are patched, and resources are properly cleaned up when deleted. Uses function-python to validate that Crossplane sends the observed composite, credentials, and observed composed resources to the function.").
 			WithLabel(LabelArea, LabelAreaAPIExtensions).
 			WithLabel(LabelSize, LabelSizeSmall).
 			WithLabel(config.LabelTestSuite, config.TestSuiteDefault).
@@ -178,6 +191,7 @@ func TestBasicCompositionCluster(t *testing.T) {
 				funcs.ApplyResources(FieldManager, manifests, "setup/*.yaml"),
 				funcs.ResourcesCreatedWithin(30*time.Second, manifests, "setup/*.yaml"),
 				funcs.ResourcesHaveConditionWithin(1*time.Minute, manifests, "setup/definition.yaml", apiextensionsv1.WatchingComposite()),
+				funcs.ResourcesHaveConditionWithin(2*time.Minute, manifests, "setup/functions.yaml", pkgv1.Healthy(), pkgv1.Active()),
 			)).
 			Assess("CreateXR", funcs.AllOf(
 				funcs.ApplyResources(FieldManager, manifests, "xr.yaml"),
@@ -193,6 +207,18 @@ func TestBasicCompositionCluster(t *testing.T) {
 			).
 			Assess("XRHasStatusField",
 				funcs.ResourcesHaveFieldValueWithin(1*time.Minute, manifests, "xr.yaml", "status.coolerField", "I'M COOLER!"),
+			).
+			Assess("FunctionReceivedObservedComposite",
+				funcs.ResourcesHaveFieldValueWithin(1*time.Minute, manifests, "xr.yaml", "status.observedCompositeReceived", true),
+			).
+			Assess("FunctionReceivedObservedCompositeWithCoolField",
+				funcs.ResourcesHaveFieldValueWithin(1*time.Minute, manifests, "xr.yaml", "status.observedCompositeHasCoolField", true),
+			).
+			Assess("FunctionReceivedCredentials",
+				funcs.ResourcesHaveFieldValueWithin(1*time.Minute, manifests, "xr.yaml", "status.credentialsReceived", true),
+			).
+			Assess("FunctionReceivedObservedComposedResources",
+				funcs.ResourcesHaveFieldValueWithin(2*time.Minute, manifests, "xr.yaml", "status.observedComposedResourcesReceived", true),
 			).
 			WithTeardown("DeleteXR", funcs.AllOf(
 				funcs.DeleteResourcesWithPropagationPolicy(manifests, "xr.yaml", metav1.DeletePropagationForeground),

--- a/test/e2e/manifests/apiextensions/composition/basic-cluster/setup/composition.yaml
+++ b/test/e2e/manifests/apiextensions/composition/basic-cluster/setup/composition.yaml
@@ -8,53 +8,78 @@ spec:
     kind: ClusterTest
   mode: Pipeline
   pipeline:
-  - step: be-a-dummy
+  - step: validate-and-compose
     functionRef:
-      name: function-dummy-ext-basic
+      name: function-python-ext-basic
     input:
-      apiVersion: dummy.fn.crossplane.io/v1beta1
-      kind: Response
-      # This is a YAML-serialized RunFunctionResponse. function-dummy will
-      # overlay the desired state on any that was passed into it.
-      response:
-        desired:
-          composite:
-            resource:
-              status:
-                coolerField: "I'M COOLER!"
-          resources:
-            configmap:
-              resource:
-                apiVersion: v1
-                kind: ConfigMap
-                metadata:
-                  namespace: default
-                data:
-                  coolData: "I'm cool!"
-              ready: READY_TRUE
-            crd:
-              resource:
-                apiVersion: apiextensions.k8s.io/v1
-                kind: CustomResourceDefinition
-                metadata:
-                  name: controllers.test.example.org
-                spec:
-                  group: test.example.org
-                  names:
-                    kind: Controller
-                    plural: controllers
-                  scope: Cluster
-                  versions:
-                  - name: v1alpha1
-                    served: true
-                    storage: true
-                    schema:
-                      openAPIV3Schema:
-                       type: object
-              ready: READY_TRUE
-        results:
-         - severity: SEVERITY_NORMAL
-           message: "I am doing a compose!"
+      apiVersion: python.fn.crossplane.io/v1beta1
+      kind: Script
+      script: |
+        from crossplane.function import request, response
+        from crossplane.function.proto.v1 import run_function_pb2 as fnv1
+
+        def compose(req: fnv1.RunFunctionRequest, rsp: fnv1.RunFunctionResponse):
+            observed_xr = req.observed.composite.resource
+
+            observed_composite_received = "spec" in observed_xr
+            observed_composite_has_cool_field = False
+            if observed_composite_received and "coolField" in observed_xr["spec"]:
+                observed_composite_has_cool_field = observed_xr["spec"]["coolField"] == "I'm cool!"
+
+            credentials_received = "important-secret" in req.credentials
+
+            observed_composed_resources_received = len(req.observed.resources) > 0
+
+            rsp.desired.composite.resource.update({
+                "status": {
+                    "coolerField": "I'M COOLER!",
+                    "observedCompositeReceived": observed_composite_received,
+                    "observedCompositeHasCoolField": observed_composite_has_cool_field,
+                    "credentialsReceived": credentials_received,
+                    "observedComposedResourcesReceived": observed_composed_resources_received,
+                }
+            })
+
+            rsp.desired.resources["configmap"].resource.update({
+                "apiVersion": "v1",
+                "kind": "ConfigMap",
+                "metadata": {
+                    "namespace": "default",
+                },
+                "data": {
+                    "coolData": "I'm cool!",
+                }
+            })
+            rsp.desired.resources["configmap"].ready = fnv1.READY_TRUE
+
+            rsp.desired.resources["crd"].resource.update({
+                "apiVersion": "apiextensions.k8s.io/v1",
+                "kind": "CustomResourceDefinition",
+                "metadata": {
+                    "name": "controllers.test.example.org",
+                },
+                "spec": {
+                    "group": "test.example.org",
+                    "names": {
+                        "kind": "Controller",
+                        "plural": "controllers",
+                    },
+                    "scope": "Cluster",
+                    "versions": [{
+                        "name": "v1alpha1",
+                        "served": True,
+                        "storage": True,
+                        "schema": {
+                            "openAPIV3Schema": {
+                                "type": "object",
+                            },
+                        },
+                    }],
+                },
+            })
+            rsp.desired.resources["crd"].ready = fnv1.READY_TRUE
+
+            response.normal(rsp, "I am doing a compose!")
     credentials:
     - name: important-secret
       source: Secret

--- a/test/e2e/manifests/apiextensions/composition/basic-cluster/setup/definition.yaml
+++ b/test/e2e/manifests/apiextensions/composition/basic-cluster/setup/definition.yaml
@@ -28,3 +28,11 @@ spec:
           properties:
             coolerField:
               type: string
+            observedCompositeReceived:
+              type: boolean
+            observedCompositeHasCoolField:
+              type: boolean
+            credentialsReceived:
+              type: boolean
+            observedComposedResourcesReceived:
+              type: boolean

--- a/test/e2e/manifests/apiextensions/composition/basic-cluster/setup/functions.yaml
+++ b/test/e2e/manifests/apiextensions/composition/basic-cluster/setup/functions.yaml
@@ -1,8 +1,6 @@
----
-# We intentionally use v1beta1 here, to make sure it still works.
-apiVersion: pkg.crossplane.io/v1beta1
+apiVersion: pkg.crossplane.io/v1
 kind: Function
 metadata:
-  name: function-dummy-ext-basic
+  name: function-python-ext-basic
 spec:
-  package: xpkg.crossplane.io/crossplane-contrib/function-dummy:v0.4.1
+  package: xpkg.crossplane.io/crossplane-contrib/function-python:v0.4.0

--- a/test/e2e/manifests/apiextensions/composition/basic-namespaced/setup/composition.yaml
+++ b/test/e2e/manifests/apiextensions/composition/basic-namespaced/setup/composition.yaml
@@ -8,31 +8,48 @@ spec:
     kind: Test
   mode: Pipeline
   pipeline:
-  - step: be-a-dummy
+  - step: validate-and-compose
     functionRef:
-      name: function-dummy-ext-basic
+      name: function-python-ext-basic
     input:
-      apiVersion: dummy.fn.crossplane.io/v1beta1
-      kind: Response
-      # This is a YAML-serialized RunFunctionResponse. function-dummy will
-      # overlay the desired state on any that was passed into it.
-      response:
-        desired:
-          composite:
-            resource:
-              status:
-                coolerField: "I'M COOLER!"
-          resources:
-            configmap:
-              resource:
-                apiVersion: v1
-                kind: ConfigMap
-                data:
-                  coolData: "I'm cool!"
-              ready: READY_TRUE
-        results:
-         - severity: SEVERITY_NORMAL
-           message: "I am doing a compose!"
+      apiVersion: python.fn.crossplane.io/v1beta1
+      kind: Script
+      script: |
+        from crossplane.function import request, response
+        from crossplane.function.proto.v1 import run_function_pb2 as fnv1
+
+        def compose(req: fnv1.RunFunctionRequest, rsp: fnv1.RunFunctionResponse):
+            observed_xr = req.observed.composite.resource
+
+            observed_composite_received = "spec" in observed_xr
+            observed_composite_has_cool_field = False
+            if observed_composite_received and "coolField" in observed_xr["spec"]:
+                observed_composite_has_cool_field = observed_xr["spec"]["coolField"] == "I'm cool!"
+
+            credentials_received = "important-secret" in req.credentials
+
+            observed_composed_resources_received = len(req.observed.resources) > 0
+
+            rsp.desired.composite.resource.update({
+                "status": {
+                    "coolerField": "I'M COOLER!",
+                    "observedCompositeReceived": observed_composite_received,
+                    "observedCompositeHasCoolField": observed_composite_has_cool_field,
+                    "credentialsReceived": credentials_received,
+                    "observedComposedResourcesReceived": observed_composed_resources_received,
+                }
+            })
+
+            rsp.desired.resources["configmap"].resource.update({
+                "apiVersion": "v1",
+                "kind": "ConfigMap",
+                "data": {
+                    "coolData": "I'm cool!",
+                }
+            })
+            rsp.desired.resources["configmap"].ready = fnv1.READY_TRUE
+
+            response.normal(rsp, "I am doing a compose!")
     credentials:
     - name: important-secret
       source: Secret

--- a/test/e2e/manifests/apiextensions/composition/basic-namespaced/setup/definition.yaml
+++ b/test/e2e/manifests/apiextensions/composition/basic-namespaced/setup/definition.yaml
@@ -28,3 +28,11 @@ spec:
           properties:
             coolerField:
               type: string
+            observedCompositeReceived:
+              type: boolean
+            observedCompositeHasCoolField:
+              type: boolean
+            credentialsReceived:
+              type: boolean
+            observedComposedResourcesReceived:
+              type: boolean

--- a/test/e2e/manifests/apiextensions/composition/basic-namespaced/setup/functions.yaml
+++ b/test/e2e/manifests/apiextensions/composition/basic-namespaced/setup/functions.yaml
@@ -1,8 +1,6 @@
----
-# We intentionally use v1beta1 here, to make sure it still works.
-apiVersion: pkg.crossplane.io/v1beta1
+apiVersion: pkg.crossplane.io/v1
 kind: Function
 metadata:
-  name: function-dummy-ext-basic
+  name: function-python-ext-basic
 spec:
-  package: xpkg.crossplane.io/crossplane-contrib/function-dummy:v0.4.1
+  package: xpkg.crossplane.io/crossplane-contrib/function-python:v0.4.0

--- a/test/e2e/manifests/apiextensions/composition/required-resources/setup/composition.yaml
+++ b/test/e2e/manifests/apiextensions/composition/required-resources/setup/composition.yaml
@@ -48,13 +48,9 @@ spec:
                 }
             })
 
-            # Add a result for observability.
-            result = fnv1.Result()
-            result.severity = fnv1.SEVERITY_NORMAL
             if resource_has_expected_data:
-                result.message = "Successfully received ConfigMap with expected data"
+                response.normal(rsp, "Successfully received ConfigMap with expected data")
             elif resource_received:
-                result.message = "Received ConfigMap but it was missing expected data"
+                response.normal(rsp, "Received ConfigMap but it was missing expected data")
             else:
-                result.message = "Waiting for ConfigMap"
-            rsp.results.append(result)
+                response.normal(rsp, "Waiting for ConfigMap")

--- a/test/e2e/manifests/apiextensions/composition/required-schemas/setup/composition.yaml
+++ b/test/e2e/manifests/apiextensions/composition/required-schemas/setup/composition.yaml
@@ -49,15 +49,11 @@ spec:
                 }
             })
 
-            # Add a result for observability.
-            result = fnv1.Result()
-            result.severity = fnv1.SEVERITY_NORMAL
             if schema_has_flattened_refs:
-                result.message = "Successfully received ConfigMap schema with properties and flattened refs"
+                response.normal(rsp, "Successfully received ConfigMap schema with properties and flattened refs")
             elif schema_has_properties:
-                result.message = "Received ConfigMap schema with properties but refs not flattened"
+                response.normal(rsp, "Received ConfigMap schema with properties but refs not flattened")
             elif schema_received:
-                result.message = "Received ConfigMap schema but it was empty or missing expected properties"
+                response.normal(rsp, "Received ConfigMap schema but it was empty or missing expected properties")
             else:
-                result.message = "Waiting for ConfigMap schema"
-            rsp.results.append(result)
+                response.normal(rsp, "Waiting for ConfigMap schema")


### PR DESCRIPTION
### Description of your changes

The basic composition E2E tests (`TestBasicCompositionNamespaced` and `TestBasicCompositionCluster`) used function-dummy, which returns a canned RunFunctionResponse regardless of what Crossplane sends it. A regression in how Crossplane populates the RunFunctionRequest — for example broken credential passthrough or missing observed state — would go undetected.

This PR replaces function-dummy with function-python in both tests. The inline Python script inspects the RunFunctionRequest and writes pass/fail booleans to XR status fields, which the Go test asserts. The function validates that:

- The observed composite resource is present with the expected spec.
- Credentials configured on the pipeline step are delivered.
- Observed composed resources appear on subsequent reconcile iterations.

The function still returns the same desired state as the old function-dummy configuration, so the tests continue to validate everything they did before.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `./nix.sh flake check` to ensure this PR is ready for review.
- [ ] ~Added or updated unit tests.~
- [x] Added or updated e2e tests.
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~
- [ ] ~Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md