### PR TITLE
chore: clean up lingering refs to HACK_CROSSPLANE_ARGS

### DIFF
--- a/contributing/README.md
+++ b/contributing/README.md
@@ -129,7 +129,7 @@ Use your editor or IDE to write code, then validate with `nix.sh`:
 ./nix.sh run .#lint         # Run linters (with --fix)
 ./nix.sh run .#generate     # Run code generators
 ./nix.sh run .#e2e          # Run E2E tests (starts a kind cluster)
-./nix.sh run .#hack         # Start kind cluster with your local changes. Args can be passed as needed, e.g. HACK_CROSSPLANE_ARGS="--debug" ./nix.sh run .#hack
+./nix.sh run .#hack         # Start kind cluster with your local changes
 ./nix.sh build              # Build binaries and images (see the result/ dir)
 ./nix.sh flake check        # Run checks hermetically, like CI
 

--- a/nix.sh
+++ b/nix.sh
@@ -119,6 +119,5 @@ docker run --rm --privileged --cgroupns=host ${INTERACTIVE_FLAGS} \
 	-e "HOST_UID=$(id -u)" \
 	-e "HOST_GID=$(id -g)" \
 	-e "TERM=${TERM:-xterm}" \
-	-e "HACK_CROSSPLANE_ARGS=${HACK_CROSSPLANE_ARGS:-}" \
 	nixos/nix \
 	/crossplane/nix.sh "${@}"


### PR DESCRIPTION
### Description of your changes

Follow up to #7111. The `HACK_CROSSPLANE_ARGS` are no longer used or supported, so this cleans up remaining references to them.

Tested with `nix.sh` to make sure the hack target still works OK, e.g.:
```
❯ ./nix.sh run .#hack -- --args="--debug,--circuit-breaker-burst=500.0"
```

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `./nix.sh flake check` to ensure this PR is ready for review.
- [ ] ~Added or updated unit tests.~
- [ ] ~Added or updated e2e tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~
- [ ] ~Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md
