### PR TITLE
Update renovate config for v2.2 release

### DIFF
--- a/.github/renovate-base.json5
+++ b/.github/renovate-base.json5
@@ -17,6 +17,7 @@
     'release-1.20',
     'release-2.0',
     'release-2.1',
+    'release-2.2',
   ],
   ignorePaths: [
     'design/**',

--- a/.github/renovate-earthly.json5
+++ b/.github/renovate-earthly.json5
@@ -130,7 +130,9 @@
         'go',
       ],
       matchBaseBranches: [
-        '/^release-.*/',
+        // Release 2.1 and older use earthly.
+        '/^release-1\..*/',
+        '/^release-2\.[0-1]$/',
       ],
       postUpgradeTasks: {
         commands: [
@@ -148,7 +150,9 @@
         'golangci/golangci-lint',
       ],
       matchBaseBranches: [
-        '/^release-.*/',
+        // Release 2.1 and older use earthly.
+        '/^release-1\..*/',
+        '/^release-2\.[0-1]$/',
       ],
       postUpgradeTasks: {
         commands: [

--- a/.github/renovate-nix.json5
+++ b/.github/renovate-nix.json5
@@ -22,6 +22,8 @@
       ],
       matchBaseBranches: [
         'main',
+        // Release 2.2 and newer use nix.
+        '/'^release-2\.([2-9]|..+)$/',
       ],
       postUpgradeTasks: {
         commands: [
@@ -41,6 +43,8 @@
       ],
       matchBaseBranches: [
         'main',
+        // Release 2.2 and newer use nix.
+        '/'^release-2\.([2-9]|..+)$/',
       ],
       postUpgradeTasks: {
         commands: [


### PR DESCRIPTION
### Description of your changes

Add release-2.2 to the branches for renovate, and update the branch patterns so that v2.2 and newer will use the nix build while v2.1 and earlier continue to use earthly.

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
~- [ ] Run `./nix.sh flake check` to ensure this PR is ready for review.~
~- [ ] Added or updated unit tests.~
~- [ ] Added or updated e2e tests.~
~- [ ] Linked a PR or a [docs tracking issue] to [document this change].~
~- [ ] Added `backport release-x.y` labels to auto-backport this PR.~
~- [ ] Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md
