### PR TITLE
fix: get all resources when requiredResources matchLabels is empty

### DIFF
--- a/internal/xfn/selector.go
+++ b/internal/xfn/selector.go
@@ -46,7 +46,7 @@ func ToProtobufResourceSelector(r RequiredResourceSelector) *fnv1.ResourceSelect
 		return selector
 	}
 
-	if len(r.GetMatchLabels()) > 0 {
+	if r.GetMatchLabels() != nil {
 		selector.Match = &fnv1.ResourceSelector_MatchLabels{
 			MatchLabels: &fnv1.MatchLabels{
 				Labels: r.GetMatchLabels(),

--- a/internal/xfn/selector_test.go
+++ b/internal/xfn/selector_test.go
@@ -241,6 +241,26 @@ func TestToProtobufResourceSelector(t *testing.T) {
 				},
 			},
 		},
+		"OperationSelectorWithEmptyLabels": {
+			reason: "Empty matchLabels should select all resources of the kind, similar to kubectl get --selector",
+			args: args{
+				selector: &apiextensionsv1.RequiredResourceSelector{
+					RequirementName: "test-req",
+					APIVersion:      "v1",
+					Kind:            "ConfigMap",
+					MatchLabels:     map[string]string{},
+				},
+			},
+			want: want{
+				result: &fnv1.ResourceSelector{
+					ApiVersion: "v1",
+					Kind:       "ConfigMap",
+					Match: &fnv1.ResourceSelector_MatchLabels{
+						MatchLabels: &fnv1.MatchLabels{},
+					},
+				},
+			},
+		},
 	}
 
 	for name, tc := range cases {


### PR DESCRIPTION
When specifying `matchLabels: {}` in a composition's requiredResources to fetch all resources of a kind, no resources were returned.

```yaml
requirements:
  requiredResources:
    - requirementName: all-vpcs
      apiVersion: ec2.aws.upbound.io/v1beta1
      kind: VPC
      matchLabels: {}
```


The issue was that ToProtobufResourceSelector  checked len(r.GetMatchLabels()) > 0 before setting the MatchLabels field on the protobuf selector,  causing the fetcher to skip all resources if `matchLabels: {}`

I changed the check to r.GetMatchLabels() != nil so that an explicitly set but empty matchLabels map is preserved. This matches kubectl behavior where an empty label selector matches all resources. 

---

I added a unit-test for this, and also tested this "manually" with crossplane render.

<details>
<summary>files</summary>

Composition:

```yaml
---
apiVersion: apiextensions.crossplane.io/v1
kind: Composition
metadata:
  name: templates.api-group.domain.com 
spec:
  compositeTypeRef:
    apiVersion: api-group.domain.com/v1alpha1
    kind: template 
  mode: Pipeline
  pipeline:
    - step: get-all-resources-example
      functionRef:
        name: crossplane-contrib-function-python
      requirements:
        requiredResources:
          - requirementName: all-firewallrulesetes
            apiVersion: azure.domain.io/v1
            kind: FirewallRuleSet
            matchLabels: {}
      input:
        apiVersion: python.fn.crossplane.io/v1beta1
        kind: Script
        script: |
          from crossplane.function import request, response, resource

          def compose(req, rsp):
            xr = resource.struct_to_dict(req.observed.composite.resource)
            
            allFirewallRuleSets = request.get_required_resources(req, "all-firewallrulesets")

            if not allFirewallRuleSets:
              return

            for i, firewallRuleSet in enumerate(allFirewallRuleSets):
              rsp.desired.resources[f"firewallruleset-{i}"].resource.update(firewallRuleSet)
```

XRD:

```yaml
---
apiVersion: apiextensions.crossplane.io/v2
kind: CompositeResourceDefinition
metadata:
  name: templates.api-group.domain.com 
spec:
  group: api-group.domain.com
  names:
    kind: template
    plural: templates
  scope: Namespaced
  versions:
    - name: v1alpha1
      served: true
      referenceable: true
      schema:
        openAPIV3Schema:
          type: object
          properties: {}

```

Required resources:
```yaml
---
apiVersion: azure.domain.io/v1
kind: FirewallRuleSet
metadata:
  name: baz
  namespace: teama
  labels:
    test: hi
spec:
  applicationrules:
    - fqdn: google.com
    - fqdn: yahoo.com
---
apiVersion: azure.domain.io/v1
kind: FirewallRuleSet
metadata:
  name: foo
  namespace: teamb
spec:
  applicationrules:
    - fqdn: vg.no
    - fqdn: kode24.no
```

test-XR:

```yaml
---
apiVersion: api-group.domain.com/v1alpha1 
kind: template 
metadata:
  name: example
  namespace: example
spec:
  crossplane:
    compositionRef:
      name: templates.api-group.domain.com
```
</details>