### PR TITLE
Fix reconciliation loop from stale cached XR conditions

### DIFF
--- a/internal/controller/apiextensions/composite/composition_functions.go
+++ b/internal/controller/apiextensions/composite/composition_functions.go
@@ -635,6 +635,7 @@ func (c *FunctionComposer) Compose(ctx context.Context, xr *composite.Unstructur
 	n := xr.GetName()
 	u := xr.GetUID()
 	cs := xr.GetConditions()
+	gen := xr.GetGeneration()
 
 	if err := xfn.FromStruct(xr, d.GetComposite().GetResource()); err != nil {
 		return CompositionResult{}, errors.Wrap(err, errUnmarshalDesiredXRStatus)
@@ -650,7 +651,19 @@ func (c *FunctionComposer) Compose(ctx context.Context, xr *composite.Unstructur
 	// will set conditions to nil if it's not passed any arguments. SSA
 	// interprets this as null and rejects it, so we only set them if
 	// there's actually some to set.
+	//
+	// We also update each condition's ObservedGeneration to match the XR's
+	// current generation. When the XR is read from an informer cache, its
+	// conditions may have a stale ObservedGeneration from a previous
+	// generation. Without this update, applying stale conditions via SSA
+	// followed by the reconciler setting conditions with the current
+	// generation would create a reconciliation loop, as each update would
+	// trigger another reconcile that re-applies the stale cached
+	// conditions.
 	if len(cs) > 0 {
+		for i := range cs {
+			cs[i].ObservedGeneration = gen
+		}
 		xr.SetConditions(cs...)
 	}
 


### PR DESCRIPTION
Fixes #7062

When an XR is patched, the `Compose` method in `composition_functions.go` reads its conditions from the informer cache. These cached conditions can have an `ObservedGeneration` from a previous generation of the XR. The conditions are saved before `FromStruct` replaces the XR's backing data, then set back onto the XR and applied via SSA.

After that SSA patch, the reconciler updates conditions again with the current generation via `MarkConditions` (which uses `ObservedGenerationPropagationManager`). This status update triggers another reconcile, which reads the still-stale conditions from cache, creating a rapid loop that only stops when the circuit breaker kicks in (20-50+ reconciles).

The fix updates the `ObservedGeneration` on cached conditions to match the XR's current generation before setting them back. This way the SSA patch and the subsequent `MarkConditions` write the same `ObservedGeneration`, so no unnecessary status update occurs and no reconcile loop is triggered.

Tested with existing unit tests - all pass.