### PR TITLE
build: mitigate potential script injection in promote workflow

### DIFF
--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -62,14 +62,23 @@ jobs:
 
       - name: Promote Images to DockerHub
         if: env.DOCKER_USR != ''
-        run: nix run .#promote-images -- crossplane/crossplane ${{ inputs.version }} ${{ inputs.channel }}
+        env:
+          VERSION: ${{ inputs.version }}
+          CHANNEL: ${{ inputs.channel }}
+        run: nix run .#promote-images -- crossplane/crossplane "$VERSION" "$CHANNEL"
 
       - name: Promote Images to Upbound
         if: env.UPBOUND_MARKETPLACE_PUSH_ROBOT_USR != ''
-        run: nix run .#promote-images -- xpkg.upbound.io/crossplane/crossplane ${{ inputs.version }} ${{ inputs.channel }}
+        env:
+          VERSION: ${{ inputs.version }}
+          CHANNEL: ${{ inputs.channel }}
+        run: nix run .#promote-images -- xpkg.upbound.io/crossplane/crossplane "$VERSION" "$CHANNEL"
 
       - name: Promote Images to GitHub Container Registry
-        run: nix run .#promote-images -- ghcr.io/crossplane/crossplane ${{ inputs.version }} ${{ inputs.channel }}
+        env:
+          VERSION: ${{ inputs.version }}
+          CHANNEL: ${{ inputs.channel }}
+        run: nix run .#promote-images -- ghcr.io/crossplane/crossplane "$VERSION" "$CHANNEL"
 
       - name: Promote Artifacts to S3
         if: env.AWS_USR != ''
@@ -77,9 +86,12 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_USR }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_PSW }}
           AWS_DEFAULT_REGION: us-east-1
+          VERSION: ${{ inputs.version }}
+          CHANNEL: ${{ inputs.channel }}
+          PRE_RELEASE: ${{ inputs.pre-release }}
         run: |
           PRERELEASE_FLAG=""
-          if [ "${{ inputs.pre-release }}" = "true" ]; then
+          if [ "$PRE_RELEASE" = "true" ]; then
             PRERELEASE_FLAG="--prerelease"
           fi
-          nix run .#promote-artifacts -- "${GITHUB_REF##*/}" ${{ inputs.version }} ${{ inputs.channel }} $PRERELEASE_FLAG
+          nix run .#promote-artifacts -- "${GITHUB_REF##*/}" "$VERSION" "$CHANNEL" $PRERELEASE_FLAG


### PR DESCRIPTION
### Description of your changes

We did some repo auditing after @ytsarev shared this article about other CNCF projects github actions workflows being exploited: https://www.stepsecurity.io/blog/hackerbot-claw-github-actions-exploitation

Most of the findings for improvements are related to setting default minimal permissions for workflows, which is covered in this ongoing PR:
* #7131 

This PR updates the `promote.yml` workflow to minimize a potential script injection attack.

We now pass promote workflow inputs through environment variables instead of interpolating them directly into shell commands with `${{ }}`. Direct interpolation allows shell metacharacters in input values to be evaluated, which is a script injection risk in a workflow that has access to publishing credentials.

Note that this was not a readily exploitable vector, because the promote workflow can only be manually executed by maintainers. This path would be viable only if a maintainer's credential first became compromised.

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `./nix.sh flake check` to ensure this PR is ready for review.
- [ ] ~Added or updated unit tests.~
- [ ] ~Added or updated e2e tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~
- [ ] ~Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md
