### PR TITLE
build: mitigate potential script injection in promote workflow (release-2.1)

### DIFF
--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -44,38 +44,51 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           version: ${{ env.EARTHLY_VERSION }}
 
-      - name: Promote Image to docker.io/crossplane/crossplane:${{ inputs.channel }}
+      - name: Promote Image to docker.io/crossplane/crossplane
         if: env.DOCKER_USR != ''
+        env:
+          VERSION: ${{ inputs.version }}
+          CHANNEL: ${{ inputs.channel }}
         run: |
           earthly --strict \
             --push \
             --secret DOCKER_USER=${{ secrets.DOCKER_USR }} \
             --secret DOCKER_PASSWORD=${{ secrets.DOCKER_PSW }} \
-            +ci-promote-image --CHANNEL=${{ inputs.channel }} --CROSSPLANE_VERSION=${{ inputs.version }} --CROSSPLANE_REPO=docker.io/crossplane/crossplane
+            +ci-promote-image --CHANNEL="$CHANNEL" --CROSSPLANE_VERSION="$VERSION" --CROSSPLANE_REPO=docker.io/crossplane/crossplane
 
-      - name: Promote Image to ghcr.io/crossplane/crossplane:${{ inputs.channel }}
+      - name: Promote Image to ghcr.io/crossplane/crossplane
         if: env.GHCR_USR != ''
+        env:
+          VERSION: ${{ inputs.version }}
+          CHANNEL: ${{ inputs.channel }}
         run: |
           earthly --strict \
             --push \
             --secret DOCKER_USER=${{ github.actor }} \
             --secret DOCKER_PASSWORD=${{ secrets.GITHUB_TOKEN }} \
-            +ci-promote-image --CHANNEL=${{ inputs.channel }} --CROSSPLANE_VERSION=${{ inputs.version }} --CROSSPLANE_REPO=ghcr.io/crossplane/crossplane
+            +ci-promote-image --CHANNEL="$CHANNEL" --CROSSPLANE_VERSION="$VERSION" --CROSSPLANE_REPO=ghcr.io/crossplane/crossplane
 
-      - name: Promote Image to xpkg.upbound.io/crossplane/crossplane:${{ inputs.channel }}
+      - name: Promote Image to xpkg.upbound.io/crossplane/crossplane
         if: env.UPBOUND_MARKETPLACE_PUSH_ROBOT_USR != ''
+        env:
+          VERSION: ${{ inputs.version }}
+          CHANNEL: ${{ inputs.channel }}
         run: |
           earthly --strict \
           --push \
           --secret DOCKER_USER=${{ secrets.UPBOUND_MARKETPLACE_PUSH_ROBOT_USR }} \
           --secret DOCKER_PASSWORD=${{ secrets.UPBOUND_MARKETPLACE_PUSH_ROBOT_PSW }} \
-          +ci-promote-image --CHANNEL=${{ inputs.channel }} --CROSSPLANE_VERSION=${{ inputs.version }} --CROSSPLANE_REPO=xpkg.upbound.io/crossplane/crossplane
+          +ci-promote-image --CHANNEL="$CHANNEL" --CROSSPLANE_VERSION="$VERSION" --CROSSPLANE_REPO=xpkg.upbound.io/crossplane/crossplane
 
-      - name: Promote Build Artifacts to https://releases.crossplane.io/${{ inputs.channel }}
+      - name: Promote Build Artifacts
         if: env.AWS_USR != ''
+        env:
+          VERSION: ${{ inputs.version }}
+          CHANNEL: ${{ inputs.channel }}
+          PRE_RELEASE: ${{ inputs.pre-release }}
         run: |
           earthly --strict \
             --push \
             --secret=AWS_ACCESS_KEY_ID=${{ secrets.AWS_USR }} \
             --secret=AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_PSW }} \
-            +ci-promote-build-artifacts --AWS_DEFAULT_REGION=us-east-1 --CHANNEL=${{ inputs.channel }} --BUILD_DIR=${GITHUB_REF##*/} --PRERELEASE=${{ inputs.pre-release }} --CROSSPLANE_VERSION=${{ inputs.version }}
+            +ci-promote-build-artifacts --AWS_DEFAULT_REGION=us-east-1 --CHANNEL="$CHANNEL" --BUILD_DIR=${GITHUB_REF##*/} --PRERELEASE="$PRE_RELEASE" --CROSSPLANE_VERSION="$VERSION"


### PR DESCRIPTION
### Description of your changes

Similar to https://github.com/crossplane/crossplane/pull/7166, but for earthly based promote workflows (pre v2.2 branches).

This PR updates the `promote.yml` workflow to minimize a potential script injection attack.

We now pass promote workflow inputs through environment variables instead of interpolating them directly into shell commands with `${{ }}`. Direct interpolation allows shell metacharacters in input values to be evaluated, which is a script injection risk in a workflow that has access to publishing credentials.

Note that this was not a readily exploitable vector, because the promote workflow can only be manually executed by maintainers. This path would be viable only if a maintainer's credential first became compromised.

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `./nix.sh flake check` to ensure this PR is ready for review.
- [ ] ~Added or updated unit tests.~
- [ ] ~Added or updated e2e tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [x] Added `backport release-x.y` labels to auto-backport this PR.
- [ ] ~Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md
