### PR TITLE
Allow MRD deactivation and clean up CRD

### DIFF
--- a/apis/apiextensions/v1alpha1/conditions.go
+++ b/apis/apiextensions/v1alpha1/conditions.go
@@ -41,8 +41,9 @@ const (
 	ReasonPendingManaged              xpv2.ConditionReason = "PendingManagedResource"
 	ReasonInactiveManaged             xpv2.ConditionReason = "InactiveManagedResource"
 	ReasonBlockedActivationPolicy     xpv2.ConditionReason = "BlockedManagedResourceActivationPolicy"
-	ReasonTerminatingManaged          xpv2.ConditionReason = "TerminatingManagedResource"
-	ReasonTerminatingActivationPolicy xpv2.ConditionReason = "TerminatingManagedResourceActivationPolicy"
+	ReasonTerminatingManaged                xpv2.ConditionReason = "TerminatingManagedResource"
+	ReasonTerminatingActivationPolicy       xpv2.ConditionReason = "TerminatingManagedResourceActivationPolicy"
+	ReasonWaitingForManagedResourceDeletion xpv2.ConditionReason = "WaitingForManagedResourceDeletion"
 )
 
 // EstablishedManaged indicates that Crossplane has defined new kind of managed resource.
@@ -62,6 +63,17 @@ func InactiveManaged() xpv2.Condition {
 		Status:             corev1.ConditionFalse,
 		LastTransitionTime: metav1.Now(),
 		Reason:             ReasonInactiveManaged,
+	}
+}
+
+// WaitingForInstanceDeletion indicates that the MRD is inactive but its CRD
+// cannot be deleted because managed resource instances still exist.
+func WaitingForInstanceDeletion() xpv2.Condition {
+	return xpv2.Condition{
+		Type:               TypeEstablished,
+		Status:             corev1.ConditionFalse,
+		LastTransitionTime: metav1.Now(),
+		Reason:             ReasonWaitingForManagedResourceDeletion,
 	}
 }
 

--- a/apis/apiextensions/v1alpha1/mrd_types.go
+++ b/apis/apiextensions/v1alpha1/mrd_types.go
@@ -33,7 +33,6 @@ type ManagedResourceDefinitionSpec struct {
 	// State toggles whether the underlying CRD is created or not.
 	// +kubebuilder:validation:Enum=Active;Inactive
 	// +kubebuilder:default=Inactive
-	// +kubebuilder:validation:XValidation:rule="self == oldSelf || oldSelf != 'Active'",message="state cannot be changed once it becomes Active"
 	State ManagedResourceDefinitionState `json:"state,omitempty"`
 }
 

--- a/cluster/crds/apiextensions.crossplane.io_managedresourcedefinitions.yaml
+++ b/cluster/crds/apiextensions.crossplane.io_managedresourcedefinitions.yaml
@@ -267,9 +267,6 @@ spec:
                 - Active
                 - Inactive
                 type: string
-                x-kubernetes-validations:
-                - message: state cannot be changed once it becomes Active
-                  rule: self == oldSelf || oldSelf != 'Active'
               versions:
                 description: |-
                   Versions is the list of all API versions of the defined custom resource.

--- a/internal/controller/apiextensions/managed/reconciler.go
+++ b/internal/controller/apiextensions/managed/reconciler.go
@@ -22,7 +22,12 @@ import (
 	"time"
 
 	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	kmeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kunstructured "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -48,6 +53,7 @@ const (
 	reasonReconcile event.Reason = "Reconcile"
 	reasonPaused    event.Reason = "ReconciliationPaused"
 	reasonApplyCRD  event.Reason = "ApplyCustomResourceDefinition"
+	reasonDeleteCRD event.Reason = "DeleteCustomResourceDefinition"
 )
 
 // FieldOwnerMRD is the field manager name used when applying CRDs.
@@ -102,8 +108,7 @@ func (r *Reconciler) Reconcile(ogctx context.Context, req reconcile.Request) (re
 	}
 
 	if !mrd.Spec.State.IsActive() {
-		status.MarkConditions(v1alpha1.InactiveManaged())
-		return reconcile.Result{}, errors.Wrap(r.client.Status().Update(ogctx, mrd), "cannot update status of ManagedResourceDefinition")
+		return r.reconcileInactive(ogctx, ctx, mrd, status, log)
 	}
 
 	// Read the CRD to upgrade its managed fields if needed.
@@ -170,4 +175,91 @@ func (r *Reconciler) Reconcile(ogctx context.Context, req reconcile.Request) (re
 
 	status.MarkConditions(v1alpha1.EstablishedManaged())
 	return reconcile.Result{}, errors.Wrap(r.client.Status().Update(ogctx, mrd), "cannot update status of ManagedResourceDefinition")
+}
+
+// reconcileInactive handles MRD deactivation by cleaning up the CRD when no
+// managed resource instances exist.
+func (r *Reconciler) reconcileInactive(ogctx, ctx context.Context, mrd *v1alpha1.ManagedResourceDefinition, status conditions.ConditionSet, log logging.Logger) (reconcile.Result, error) {
+	// Check if the CRD exists.
+	crd := &extv1.CustomResourceDefinition{}
+	if err := r.client.Get(ctx, types.NamespacedName{Name: mrd.GetName()}, crd); err != nil {
+		if kerrors.IsNotFound(err) {
+			// CRD doesn't exist — was never active, or already cleaned up.
+			status.MarkConditions(v1alpha1.InactiveManaged())
+			return reconcile.Result{}, errors.Wrap(r.client.Status().Update(ogctx, mrd), "cannot update status of ManagedResourceDefinition")
+		}
+		log.Debug("cannot get CustomResourceDefinition", "error", err)
+		r.record.Event(mrd, event.Warning(reasonReconcile, err))
+		status.MarkConditions(v1alpha1.BlockedManaged().WithMessage("unable to get CustomResourceDefinition, see events"))
+		_ = r.client.Status().Update(ogctx, mrd)
+		return reconcile.Result{}, errors.Wrap(err, "cannot get CustomResourceDefinition")
+	}
+
+	// CRD exists but is not controlled by this MRD — don't delete it.
+	if !metav1.IsControlledBy(crd, mrd) {
+		status.MarkConditions(v1alpha1.InactiveManaged())
+		return reconcile.Result{}, errors.Wrap(r.client.Status().Update(ogctx, mrd), "cannot update status of ManagedResourceDefinition")
+	}
+
+	// CRD exists — check if any managed resource instances exist.
+	ver := storageVersion(mrd)
+	if ver == "" {
+		log.Debug("MRD has no versions defined, cannot list managed resources")
+		r.record.Event(mrd, event.Warning(reasonReconcile, errors.New("MRD has no versions defined")))
+		status.MarkConditions(v1alpha1.BlockedManaged().WithMessage("MRD has no versions defined"))
+		_ = r.client.Status().Update(ogctx, mrd)
+		return reconcile.Result{}, errors.New("MRD has no versions defined, cannot list managed resources")
+	}
+	gvk := schema.GroupVersionKind{
+		Group:   mrd.Spec.Group,
+		Version: ver,
+		Kind:    mrd.Spec.Names.ListKind,
+	}
+
+	l := &kunstructured.UnstructuredList{}
+	l.SetGroupVersionKind(gvk)
+
+	if err := r.client.List(ctx, l, client.Limit(1)); resource.Ignore(kmeta.IsNoMatchError, err) != nil {
+		log.Debug("cannot list managed resources", "error", err, "gvk", gvk.String())
+		r.record.Event(mrd, event.Warning(reasonReconcile, errors.Wrap(err, "cannot list managed resources")))
+		status.MarkConditions(v1alpha1.BlockedManaged().WithMessage("unable to list managed resources, see events"))
+		_ = r.client.Status().Update(ogctx, mrd)
+		return reconcile.Result{}, errors.Wrap(err, "cannot list managed resources")
+	}
+
+	if len(l.Items) > 0 {
+		log.Debug("waiting for managed resource instances to be deleted before removing CRD")
+		r.record.Event(mrd, event.Normal(reasonDeleteCRD, "Waiting for managed resource instances to be deleted"))
+		status.MarkConditions(v1alpha1.WaitingForInstanceDeletion().WithMessage("waiting for managed resource instances to be deleted"))
+		_ = r.client.Status().Update(ogctx, mrd)
+		return reconcile.Result{Requeue: true}, nil
+	}
+
+	// No instances — delete the CRD.
+	if err := r.client.Delete(ctx, crd); resource.IgnoreNotFound(err) != nil {
+		log.Debug("cannot delete CustomResourceDefinition", "error", err)
+		r.record.Event(mrd, event.Warning(reasonDeleteCRD, err))
+		status.MarkConditions(v1alpha1.BlockedManaged().WithMessage("unable to delete CustomResourceDefinition, see events"))
+		_ = r.client.Status().Update(ogctx, mrd)
+		return reconcile.Result{}, errors.Wrap(err, "cannot delete CustomResourceDefinition")
+	}
+
+	log.Debug("Deleted CustomResourceDefinition for inactive MRD")
+	r.record.Event(mrd, event.Normal(reasonDeleteCRD, "Deleted CustomResourceDefinition"))
+	status.MarkConditions(v1alpha1.InactiveManaged())
+	return reconcile.Result{}, errors.Wrap(r.client.Status().Update(ogctx, mrd), "cannot update status of ManagedResourceDefinition")
+}
+
+// storageVersion returns the name of the storage version from the MRD spec.
+func storageVersion(mrd *v1alpha1.ManagedResourceDefinition) string {
+	for _, v := range mrd.Spec.Versions {
+		if v.Storage {
+			return v.Name
+		}
+	}
+	// Fall back to the first version if no storage version is marked.
+	if len(mrd.Spec.Versions) > 0 {
+		return mrd.Spec.Versions[0].Name
+	}
+	return ""
 }

--- a/internal/controller/apiextensions/managed/reconciler_test.go
+++ b/internal/controller/apiextensions/managed/reconciler_test.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -131,13 +132,22 @@ func TestReconcile(t *testing.T) {
 				r: reconcile.Result{},
 			},
 		},
-		"MRDInactiveState": {
-			reason: "We should mark MRD as inactive when state is not active",
+		"MRDInactiveNoCRD": {
+			reason: "We should mark MRD as inactive when state is not active and no CRD exists",
 			args: args{
 				c: &test.MockClient{
-					MockGet: withMRD(t, newMRD(func(mrd *v1alpha1.ManagedResourceDefinition) {
-						mrd.Spec.State = v1alpha1.ManagedResourceDefinitionInactive
-					})),
+					MockGet: func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
+						switch obj.(type) {
+						case *v1alpha1.ManagedResourceDefinition:
+							return withMRD(t, newMRD(func(mrd *v1alpha1.ManagedResourceDefinition) {
+								mrd.Spec.State = v1alpha1.ManagedResourceDefinitionInactive
+							}))(ctx, key, obj)
+						case *extv1.CustomResourceDefinition:
+							return kerrors.NewNotFound(schema.GroupResource{}, "")
+						default:
+							return kerrors.NewNotFound(schema.GroupResource{}, "")
+						}
+					},
 					MockStatusUpdate: wantMRD(t, newMRD(func(mrd *v1alpha1.ManagedResourceDefinition) {
 						mrd.Spec.State = v1alpha1.ManagedResourceDefinitionInactive
 						mrd.SetConditions(v1alpha1.InactiveManaged())
@@ -146,6 +156,344 @@ func TestReconcile(t *testing.T) {
 			},
 			want: want{
 				r: reconcile.Result{},
+			},
+		},
+		"MRDInactiveCRDExistsInstancesExist": {
+			reason: "We should set WaitingForInstanceDeletion when CRD exists and MR instances exist",
+			args: args{
+				c: &test.MockClient{
+					MockGet: func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
+						switch o := obj.(type) {
+						case *v1alpha1.ManagedResourceDefinition:
+							return withMRD(t, newMRD(func(mrd *v1alpha1.ManagedResourceDefinition) {
+								mrd.Spec.State = v1alpha1.ManagedResourceDefinitionInactive
+								mrd.Spec.CustomResourceDefinitionSpec = v1alpha1.CustomResourceDefinitionSpec{
+									Group: "example.com",
+									Names: extv1.CustomResourceDefinitionNames{
+										Plural:   "databases",
+										Kind:     "Database",
+										ListKind: "DatabaseList",
+									},
+									Versions: []v1alpha1.CustomResourceDefinitionVersion{
+										{Name: "v1", Served: true, Storage: true},
+									},
+								}
+							}))(ctx, key, obj)
+						case *extv1.CustomResourceDefinition:
+							o.OwnerReferences = []metav1.OwnerReference{{
+								UID:        "test-uid",
+								Controller: ptr.To(true),
+							}}
+							return nil
+						default:
+							return kerrors.NewNotFound(schema.GroupResource{}, "")
+						}
+					},
+					MockList: func(_ context.Context, list client.ObjectList, _ ...client.ListOption) error {
+						l := list.(*unstructured.UnstructuredList)
+						l.Items = []unstructured.Unstructured{{}}
+						return nil
+					},
+					MockStatusUpdate: wantMRD(t, newMRD(func(mrd *v1alpha1.ManagedResourceDefinition) {
+						mrd.Spec.State = v1alpha1.ManagedResourceDefinitionInactive
+						mrd.Spec.CustomResourceDefinitionSpec = v1alpha1.CustomResourceDefinitionSpec{
+							Group: "example.com",
+							Names: extv1.CustomResourceDefinitionNames{
+								Plural:   "databases",
+								Kind:     "Database",
+								ListKind: "DatabaseList",
+							},
+							Versions: []v1alpha1.CustomResourceDefinitionVersion{
+								{Name: "v1", Served: true, Storage: true},
+							},
+						}
+						mrd.SetConditions(v1alpha1.WaitingForInstanceDeletion().WithMessage("waiting for managed resource instances to be deleted"))
+					})),
+				},
+				opts: []ReconcilerOption{
+					WithRecorder(&testRecorder{}),
+				},
+			},
+			want: want{
+				r: reconcile.Result{Requeue: true},
+			},
+		},
+		"MRDInactiveCRDExistsNoInstances": {
+			reason: "We should delete the CRD when no MR instances exist",
+			args: args{
+				c: &test.MockClient{
+					MockGet: func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
+						switch o := obj.(type) {
+						case *v1alpha1.ManagedResourceDefinition:
+							return withMRD(t, newMRD(func(mrd *v1alpha1.ManagedResourceDefinition) {
+								mrd.Spec.State = v1alpha1.ManagedResourceDefinitionInactive
+								mrd.Spec.CustomResourceDefinitionSpec = v1alpha1.CustomResourceDefinitionSpec{
+									Group: "example.com",
+									Names: extv1.CustomResourceDefinitionNames{
+										Plural:   "databases",
+										Kind:     "Database",
+										ListKind: "DatabaseList",
+									},
+									Versions: []v1alpha1.CustomResourceDefinitionVersion{
+										{Name: "v1", Served: true, Storage: true},
+									},
+								}
+							}))(ctx, key, obj)
+						case *extv1.CustomResourceDefinition:
+							o.OwnerReferences = []metav1.OwnerReference{{
+								UID:        "test-uid",
+								Controller: ptr.To(true),
+							}}
+							return nil
+						default:
+							return kerrors.NewNotFound(schema.GroupResource{}, "")
+						}
+					},
+					MockList:   test.NewMockListFn(nil),
+					MockDelete: test.NewMockDeleteFn(nil),
+					MockStatusUpdate: wantMRD(t, newMRD(func(mrd *v1alpha1.ManagedResourceDefinition) {
+						mrd.Spec.State = v1alpha1.ManagedResourceDefinitionInactive
+						mrd.Spec.CustomResourceDefinitionSpec = v1alpha1.CustomResourceDefinitionSpec{
+							Group: "example.com",
+							Names: extv1.CustomResourceDefinitionNames{
+								Plural:   "databases",
+								Kind:     "Database",
+								ListKind: "DatabaseList",
+							},
+							Versions: []v1alpha1.CustomResourceDefinitionVersion{
+								{Name: "v1", Served: true, Storage: true},
+							},
+						}
+						mrd.SetConditions(v1alpha1.InactiveManaged())
+					})),
+				},
+				opts: []ReconcilerOption{
+					WithRecorder(&testRecorder{}),
+				},
+			},
+			want: want{
+				r: reconcile.Result{},
+			},
+		},
+		"MRDInactiveCRDExistsDeleteFails": {
+			reason: "We should return error when CRD deletion fails",
+			args: args{
+				c: &test.MockClient{
+					MockGet: func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
+						switch o := obj.(type) {
+						case *v1alpha1.ManagedResourceDefinition:
+							return withMRD(t, newMRD(func(mrd *v1alpha1.ManagedResourceDefinition) {
+								mrd.Spec.State = v1alpha1.ManagedResourceDefinitionInactive
+								mrd.Spec.CustomResourceDefinitionSpec = v1alpha1.CustomResourceDefinitionSpec{
+									Group: "example.com",
+									Names: extv1.CustomResourceDefinitionNames{
+										Plural:   "databases",
+										Kind:     "Database",
+										ListKind: "DatabaseList",
+									},
+									Versions: []v1alpha1.CustomResourceDefinitionVersion{
+										{Name: "v1", Served: true, Storage: true},
+									},
+								}
+							}))(ctx, key, obj)
+						case *extv1.CustomResourceDefinition:
+							o.OwnerReferences = []metav1.OwnerReference{{
+								UID:        "test-uid",
+								Controller: ptr.To(true),
+							}}
+							return nil
+						default:
+							return kerrors.NewNotFound(schema.GroupResource{}, "")
+						}
+					},
+					MockList:   test.NewMockListFn(nil),
+					MockDelete: test.NewMockDeleteFn(errBoom),
+					MockStatusUpdate: wantMRD(t, newMRD(func(mrd *v1alpha1.ManagedResourceDefinition) {
+						mrd.Spec.State = v1alpha1.ManagedResourceDefinitionInactive
+						mrd.Spec.CustomResourceDefinitionSpec = v1alpha1.CustomResourceDefinitionSpec{
+							Group: "example.com",
+							Names: extv1.CustomResourceDefinitionNames{
+								Plural:   "databases",
+								Kind:     "Database",
+								ListKind: "DatabaseList",
+							},
+							Versions: []v1alpha1.CustomResourceDefinitionVersion{
+								{Name: "v1", Served: true, Storage: true},
+							},
+						}
+						mrd.SetConditions(v1alpha1.BlockedManaged().WithMessage("unable to delete CustomResourceDefinition, see events"))
+					})),
+				},
+				opts: []ReconcilerOption{
+					WithRecorder(&testRecorder{}),
+				},
+			},
+			want: want{
+				err: cmpopts.AnyError,
+			},
+		},
+		"MRDInactiveCRDExistsListFails": {
+			reason: "We should return error when listing MR instances fails",
+			args: args{
+				c: &test.MockClient{
+					MockGet: func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
+						switch o := obj.(type) {
+						case *v1alpha1.ManagedResourceDefinition:
+							return withMRD(t, newMRD(func(mrd *v1alpha1.ManagedResourceDefinition) {
+								mrd.Spec.State = v1alpha1.ManagedResourceDefinitionInactive
+								mrd.Spec.CustomResourceDefinitionSpec = v1alpha1.CustomResourceDefinitionSpec{
+									Group: "example.com",
+									Names: extv1.CustomResourceDefinitionNames{
+										Plural:   "databases",
+										Kind:     "Database",
+										ListKind: "DatabaseList",
+									},
+									Versions: []v1alpha1.CustomResourceDefinitionVersion{
+										{Name: "v1", Served: true, Storage: true},
+									},
+								}
+							}))(ctx, key, obj)
+						case *extv1.CustomResourceDefinition:
+							o.OwnerReferences = []metav1.OwnerReference{{
+								UID:        "test-uid",
+								Controller: ptr.To(true),
+							}}
+							return nil
+						default:
+							return kerrors.NewNotFound(schema.GroupResource{}, "")
+						}
+					},
+					MockList: test.NewMockListFn(errBoom),
+					MockStatusUpdate: wantMRD(t, newMRD(func(mrd *v1alpha1.ManagedResourceDefinition) {
+						mrd.Spec.State = v1alpha1.ManagedResourceDefinitionInactive
+						mrd.Spec.CustomResourceDefinitionSpec = v1alpha1.CustomResourceDefinitionSpec{
+							Group: "example.com",
+							Names: extv1.CustomResourceDefinitionNames{
+								Plural:   "databases",
+								Kind:     "Database",
+								ListKind: "DatabaseList",
+							},
+							Versions: []v1alpha1.CustomResourceDefinitionVersion{
+								{Name: "v1", Served: true, Storage: true},
+							},
+						}
+						mrd.SetConditions(v1alpha1.BlockedManaged().WithMessage("unable to list managed resources, see events"))
+					})),
+				},
+				opts: []ReconcilerOption{
+					WithRecorder(&testRecorder{}),
+				},
+			},
+			want: want{
+				err: cmpopts.AnyError,
+			},
+		},
+		"MRDInactiveCRDGetError": {
+			reason: "We should return error when getting CRD fails with non-NotFound error during inactive reconciliation",
+			args: args{
+				c: &test.MockClient{
+					MockGet: func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
+						switch obj.(type) {
+						case *v1alpha1.ManagedResourceDefinition:
+							return withMRD(t, newMRD(func(mrd *v1alpha1.ManagedResourceDefinition) {
+								mrd.Spec.State = v1alpha1.ManagedResourceDefinitionInactive
+							}))(ctx, key, obj)
+						case *extv1.CustomResourceDefinition:
+							return errBoom
+						default:
+							return kerrors.NewNotFound(schema.GroupResource{}, "")
+						}
+					},
+					MockStatusUpdate: wantMRD(t, newMRD(func(mrd *v1alpha1.ManagedResourceDefinition) {
+						mrd.Spec.State = v1alpha1.ManagedResourceDefinitionInactive
+						mrd.SetConditions(v1alpha1.BlockedManaged().WithMessage("unable to get CustomResourceDefinition, see events"))
+					})),
+				},
+				opts: []ReconcilerOption{
+					WithRecorder(&testRecorder{}),
+				},
+			},
+			want: want{
+				err: cmpopts.AnyError,
+			},
+		},
+		"MRDInactiveCRDNotControlledByMRD": {
+			reason: "We should mark inactive without deleting CRD when it is not controlled by this MRD",
+			args: args{
+				c: &test.MockClient{
+					MockGet: func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
+						switch o := obj.(type) {
+						case *v1alpha1.ManagedResourceDefinition:
+							return withMRD(t, newMRD(func(mrd *v1alpha1.ManagedResourceDefinition) {
+								mrd.Spec.State = v1alpha1.ManagedResourceDefinitionInactive
+							}))(ctx, key, obj)
+						case *extv1.CustomResourceDefinition:
+							// CRD exists but has no owner references pointing to the MRD.
+							o.Name = key.Name
+							return nil
+						default:
+							return kerrors.NewNotFound(schema.GroupResource{}, "")
+						}
+					},
+					MockStatusUpdate: wantMRD(t, newMRD(func(mrd *v1alpha1.ManagedResourceDefinition) {
+						mrd.Spec.State = v1alpha1.ManagedResourceDefinitionInactive
+						mrd.SetConditions(v1alpha1.InactiveManaged())
+					})),
+				},
+			},
+			want: want{
+				r: reconcile.Result{},
+			},
+		},
+		"MRDInactiveNoVersions": {
+			reason: "We should return error when MRD has no versions defined",
+			args: args{
+				c: &test.MockClient{
+					MockGet: func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
+						switch o := obj.(type) {
+						case *v1alpha1.ManagedResourceDefinition:
+							return withMRD(t, newMRD(func(mrd *v1alpha1.ManagedResourceDefinition) {
+								mrd.Spec.State = v1alpha1.ManagedResourceDefinitionInactive
+								mrd.Spec.CustomResourceDefinitionSpec = v1alpha1.CustomResourceDefinitionSpec{
+									Group: "example.com",
+									Names: extv1.CustomResourceDefinitionNames{
+										Plural:   "databases",
+										Kind:     "Database",
+										ListKind: "DatabaseList",
+									},
+								}
+							}))(ctx, key, obj)
+						case *extv1.CustomResourceDefinition:
+							// CRD exists and is controlled by the MRD.
+							o.Name = key.Name
+							o.OwnerReferences = []metav1.OwnerReference{{
+								UID:        "test-uid",
+								Controller: ptr.To(true),
+							}}
+							return nil
+						default:
+							return kerrors.NewNotFound(schema.GroupResource{}, "")
+						}
+					},
+					MockStatusUpdate: wantMRD(t, newMRD(func(mrd *v1alpha1.ManagedResourceDefinition) {
+						mrd.Spec.State = v1alpha1.ManagedResourceDefinitionInactive
+						mrd.Spec.CustomResourceDefinitionSpec = v1alpha1.CustomResourceDefinitionSpec{
+							Group: "example.com",
+							Names: extv1.CustomResourceDefinitionNames{
+								Plural:   "databases",
+								Kind:     "Database",
+								ListKind: "DatabaseList",
+							},
+						}
+						mrd.SetConditions(v1alpha1.BlockedManaged().WithMessage("MRD has no versions defined"))
+					})),
+				},
+				opts: []ReconcilerOption{
+					WithRecorder(&testRecorder{}),
+				},
+			},
+			want: want{
+				err: cmpopts.AnyError,
 			},
 		},
 		"MRDActiveCRDGetError": {
@@ -189,8 +537,9 @@ func TestReconcile(t *testing.T) {
 								mrd.Spec.CustomResourceDefinitionSpec = v1alpha1.CustomResourceDefinitionSpec{
 									Group: "example.com",
 									Names: extv1.CustomResourceDefinitionNames{
-										Plural: "databases",
-										Kind:   "Database",
+										Plural:   "databases",
+										Kind:     "Database",
+										ListKind: "DatabaseList",
 									},
 									Scope: extv1.ClusterScoped,
 									Versions: []v1alpha1.CustomResourceDefinitionVersion{
@@ -219,8 +568,9 @@ func TestReconcile(t *testing.T) {
 						mrd.Spec.CustomResourceDefinitionSpec = v1alpha1.CustomResourceDefinitionSpec{
 							Group: "example.com",
 							Names: extv1.CustomResourceDefinitionNames{
-								Plural: "databases",
-								Kind:   "Database",
+								Plural:   "databases",
+								Kind:     "Database",
+								ListKind: "DatabaseList",
 							},
 							Scope: extv1.ClusterScoped,
 							Versions: []v1alpha1.CustomResourceDefinitionVersion{
@@ -259,8 +609,9 @@ func TestReconcile(t *testing.T) {
 								mrd.Spec.CustomResourceDefinitionSpec = v1alpha1.CustomResourceDefinitionSpec{
 									Group: "example.com",
 									Names: extv1.CustomResourceDefinitionNames{
-										Plural: "databases",
-										Kind:   "Database",
+										Plural:   "databases",
+										Kind:     "Database",
+										ListKind: "DatabaseList",
 									},
 									Scope: extv1.ClusterScoped,
 									Versions: []v1alpha1.CustomResourceDefinitionVersion{
@@ -289,8 +640,9 @@ func TestReconcile(t *testing.T) {
 						mrd.Spec.CustomResourceDefinitionSpec = v1alpha1.CustomResourceDefinitionSpec{
 							Group: "example.com",
 							Names: extv1.CustomResourceDefinitionNames{
-								Plural: "databases",
-								Kind:   "Database",
+								Plural:   "databases",
+								Kind:     "Database",
+								ListKind: "DatabaseList",
 							},
 							Scope: extv1.ClusterScoped,
 							Versions: []v1alpha1.CustomResourceDefinitionVersion{
@@ -329,8 +681,9 @@ func TestReconcile(t *testing.T) {
 								mrd.Spec.CustomResourceDefinitionSpec = v1alpha1.CustomResourceDefinitionSpec{
 									Group: "example.com",
 									Names: extv1.CustomResourceDefinitionNames{
-										Plural: "databases",
-										Kind:   "Database",
+										Plural:   "databases",
+										Kind:     "Database",
+										ListKind: "DatabaseList",
 									},
 									Scope: extv1.ClusterScoped,
 									Versions: []v1alpha1.CustomResourceDefinitionVersion{
@@ -352,8 +705,9 @@ func TestReconcile(t *testing.T) {
 							o.Spec = extv1.CustomResourceDefinitionSpec{
 								Group: "example.com",
 								Names: extv1.CustomResourceDefinitionNames{
-									Plural: "databases",
-									Kind:   "Database",
+									Plural:   "databases",
+									Kind:     "Database",
+									ListKind: "DatabaseList",
 								},
 								Scope: extv1.ClusterScoped,
 								Versions: []extv1.CustomResourceDefinitionVersion{
@@ -391,8 +745,9 @@ func TestReconcile(t *testing.T) {
 						mrd.Spec.CustomResourceDefinitionSpec = v1alpha1.CustomResourceDefinitionSpec{
 							Group: "example.com",
 							Names: extv1.CustomResourceDefinitionNames{
-								Plural: "databases",
-								Kind:   "Database",
+								Plural:   "databases",
+								Kind:     "Database",
+								ListKind: "DatabaseList",
 							},
 							Scope: extv1.ClusterScoped,
 							Versions: []v1alpha1.CustomResourceDefinitionVersion{
@@ -441,9 +796,18 @@ func TestReconcile(t *testing.T) {
 			reason: "We should handle status update errors when marking MRD as inactive",
 			args: args{
 				c: &test.MockClient{
-					MockGet: withMRD(t, newMRD(func(mrd *v1alpha1.ManagedResourceDefinition) {
-						mrd.Spec.State = v1alpha1.ManagedResourceDefinitionInactive
-					})),
+					MockGet: func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
+						switch obj.(type) {
+						case *v1alpha1.ManagedResourceDefinition:
+							return withMRD(t, newMRD(func(mrd *v1alpha1.ManagedResourceDefinition) {
+								mrd.Spec.State = v1alpha1.ManagedResourceDefinitionInactive
+							}))(ctx, key, obj)
+						case *extv1.CustomResourceDefinition:
+							return kerrors.NewNotFound(schema.GroupResource{}, "")
+						default:
+							return kerrors.NewNotFound(schema.GroupResource{}, "")
+						}
+					},
 					MockStatusUpdate: test.NewMockSubResourceUpdateFn(errBoom),
 				},
 			},

--- a/test/e2e/apiextensions_mrds_test.go
+++ b/test/e2e/apiextensions_mrds_test.go
@@ -80,10 +80,13 @@ func TestMRDValidation(t *testing.T) {
 			Assessment:  funcs.ResourcesFailToApply(FieldManager, manifests, "mrd-invalid.yaml"),
 		},
 		{
-			// An attempt to deactivate an active MRD should be rejected.
-			Name:        "ActiveMRDCannotBeDeactivated",
-			Description: "An attempt to change an active MRD to inactive should be rejected.",
-			Assessment:  funcs.ResourcesFailToApply(FieldManager, manifests, "mrd-active-to-inactive.yaml"),
+			// An active MRD can be deactivated.
+			Name:        "ActiveMRDCanBeDeactivated",
+			Description: "An active MRD should be allowed to transition to inactive and clean up its CRD.",
+			Assessment: funcs.AllOf(
+				funcs.ApplyResources(FieldManager, manifests, "mrd-active-to-inactive.yaml"),
+				funcs.ResourcesHaveConditionWithin(1*time.Minute, manifests, "mrd-active-to-inactive.yaml", v1alpha1.InactiveManaged()),
+			),
 		},
 	}
 	environment.Test(t,


### PR DESCRIPTION
## Summary

- Remove CEL validation rule that prevents `spec.state` from transitioning `Active → Inactive`
- When deactivated, reconciler checks for existing MR instances before deleting the CRD
  - No CRD exists → mark `InactiveManaged`
  - Instances exist → set `WaitingForManagedResourceDeletion`, requeue
  - No instances → delete CRD, mark `InactiveManaged`
- Fully reversible: user can set state back to `Active` at any time, even while waiting for instance deletion

## Context

Users upgrading to Crossplane v2 get all CRDs installed via the default `*` MRAP. Once MRDs are Active, the CEL rule blocks `Active → Inactive`, so thousands of unwanted CRDs can never be cleaned up.

## Test plan

### Unit tests
- [x] MRD Inactive, no CRD exists → `InactiveManaged()`
- [x] MRD Inactive, CRD exists, MR instances exist → `WaitingForInstanceDeletion()`, `Requeue: true`
- [x] MRD Inactive, CRD exists, no instances → Delete CRD, `InactiveManaged()`
- [x] MRD Inactive, CRD exists, Delete fails → `BlockedManaged()`, error
- [x] MRD Inactive, CRD exists, List fails → `BlockedManaged()`, error
- [x] MRD Inactive, status update error → error

### Manual kind cluster verification

```bash
# Create cluster and build/install Crossplane from this branch
kind create cluster --name mrd-test
nix --extra-experimental-features 'nix-command flakes' run .#hack

# Apply updated MRD CRD (removes CEL rule)
kubectl --context kind-crossplane-hack apply -f   cluster/crds/apiextensions.crossplane.io_managedresourcedefinitions.yaml

# Install provider with ignoreCrossplaneConstraints (dev build version)
kubectl --context kind-crossplane-hack apply -f - <<YAML
apiVersion: pkg.crossplane.io/v1
kind: Provider
metadata:
  name: upbound-provider-family-aws
spec:
  package: xpkg.upbound.io/upbound/provider-family-aws:v2.4.0
  ignoreCrossplaneConstraints: true
YAML
kubectl --context kind-crossplane-hack apply -f - <<YAML
apiVersion: pkg.crossplane.io/v1
kind: Provider
metadata:
  name: upbound-provider-aws-ec2
spec:
  package: xpkg.upbound.io/upbound/provider-aws-ec2:v2.4.0
  ignoreCrossplaneConstraints: true
YAML
kubectl --context kind-crossplane-hack wait --for=condition=Healthy   provider/upbound-provider-family-aws --timeout=5m
kubectl --context kind-crossplane-hack wait --for=condition=Healthy   provider/upbound-provider-aws-ec2 --timeout=5m

# Wait for MRDs to become Active, then patch MRAP to stop interference
kubectl --context kind-crossplane-hack get mrds | head -20
kubectl --context kind-crossplane-hack patch managedresourceactivationpolicy   default --type=merge -p '{"spec":{"activate":["nothing.example.com"]}}'

# Test 1: Deactivate with no instances → CRD deleted
kubectl --context kind-crossplane-hack patch mrd vpcs.ec2.aws.upbound.io   --type=merge -p '{"spec":{"state":"Inactive"}}'
sleep 3
kubectl --context kind-crossplane-hack get mrd vpcs.ec2.aws.upbound.io
# STATE=Inactive, ESTABLISHED=False
kubectl --context kind-crossplane-hack get crd vpcs.ec2.aws.upbound.io
# NotFound

# Test 2: Re-activate → CRD recreated
kubectl --context kind-crossplane-hack patch mrd vpcs.ec2.aws.upbound.io   --type=merge -p '{"spec":{"state":"Active"}}'
sleep 5
kubectl --context kind-crossplane-hack get mrd vpcs.ec2.aws.upbound.io
# STATE=Active, ESTABLISHED=True
kubectl --context kind-crossplane-hack get crd vpcs.ec2.aws.upbound.io
# Exists

# Test 3: Deactivate with instances → WaitingForInstanceDeletion
kubectl --context kind-crossplane-hack apply -f - <<YAML
apiVersion: ec2.aws.upbound.io/v1beta1
kind: VPC
metadata:
  name: test-vpc
spec:
  forProvider:
    region: us-east-1
    cidrBlock: "10.0.0.0/16"
YAML
kubectl --context kind-crossplane-hack patch mrd vpcs.ec2.aws.upbound.io   --type=merge -p '{"spec":{"state":"Inactive"}}'
sleep 3
kubectl --context kind-crossplane-hack get mrd vpcs.ec2.aws.upbound.io   -o jsonpath='{.status.conditions}' | python3 -m json.tool
# reason: WaitingForManagedResourceDeletion
kubectl --context kind-crossplane-hack get crd vpcs.ec2.aws.upbound.io
# Still exists

# Test 4: Change mind while waiting → re-activate aborts deactivation
kubectl --context kind-crossplane-hack patch mrd vpcs.ec2.aws.upbound.io   --type=merge -p '{"spec":{"state":"Active"}}'
sleep 5
kubectl --context kind-crossplane-hack get mrd vpcs.ec2.aws.upbound.io
# STATE=Active, ESTABLISHED=True — CRD and instance preserved

# Test 5: Deactivate again, then delete instance → CRD cleaned up
kubectl --context kind-crossplane-hack patch mrd vpcs.ec2.aws.upbound.io   --type=merge -p '{"spec":{"state":"Inactive"}}'
sleep 3
kubectl --context kind-crossplane-hack delete vpc.ec2.aws.upbound.io test-vpc
sleep 5
kubectl --context kind-crossplane-hack get mrd vpcs.ec2.aws.upbound.io
# STATE=Inactive, ESTABLISHED=False
kubectl --context kind-crossplane-hack get crd vpcs.ec2.aws.upbound.io
# NotFound

# Cleanup
kind delete cluster --name crossplane-hack
```