### PR TITLE
fix(crank): xpkg push respects proxy environment variables

### DIFF
--- a/cmd/crank/xpkg/push.go
+++ b/cmd/crank/xpkg/push.go
@@ -124,10 +124,11 @@ func (c *pushCmd) Run(logger logging.Logger) error {
 		images = append(images, packageImage{Image: img, Path: cleanPath})
 	}
 
-	t := &http.Transport{
-		TLSClientConfig: &tls.Config{
-			InsecureSkipVerify: c.InsecureSkipTLSVerify, //nolint:gosec // we need to support insecure connections if requested
-		},
+	t := http.DefaultTransport.(*http.Transport).Clone() //nolint:forcetypeassert // http.DefaultTransport is always *http.Transport
+	if c.InsecureSkipTLSVerify {
+		t.TLSClientConfig = &tls.Config{
+			InsecureSkipVerify: true, //nolint:gosec // we need to support insecure connections if requested
+		}
 	}
 
 	options := []remote.Option{


### PR DESCRIPTION
Dear maintainers,

### Description of your changes

This PR fixes an issue where the `crossplane xpkg push` command does not respect HTTP proxy environment variables (HTTP_PROXY, HTTPS_PROXY, NO_PROXY), which blocks users in enterprise environments where internet access is restricted and must go through corporate proxies.

Fixes #7207

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
~- [ ] Run `./nix.sh flake check` to ensure this PR is ready for review.~
~- [ ] Added or updated unit tests.~
~- [ ] Added or updated e2e tests.~
~- [ ] Linked a PR or a [docs tracking issue] to [document this change].~
~- [ ] Added `backport release-x.y` labels to auto-backport this PR.~
~- [ ] Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md
