### PR TITLE
Make check-diff CI verify generated files are committed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,17 @@ jobs:
       - name: Verify Generated Code
         run: nix build .#checks.x86_64-linux.generate .#checks.x86_64-linux.generate-apis --print-build-logs
 
+      - name: Check Diff
+        run: |
+          nix run .#generate
+          nix run .#tidy
+          echo "Checking that branch is clean..."
+          if [ -n "$(git status --porcelain)" ]; then
+            git status --short
+            echo "ERROR: Generated files are out of date. Run 'nix run .#generate' and 'nix run .#tidy' and commit."
+            exit 1
+          fi
+
   lint:
     runs-on: ubuntu-24.04
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,12 +40,11 @@ jobs:
 
       - name: Check Diff
         run: |
-          nix run .#generate
           nix run .#tidy
           echo "Checking that branch is clean..."
           if [ -n "$(git status --porcelain)" ]; then
             git status --short
-            echo "ERROR: Generated files are out of date. Run 'nix run .#generate' and 'nix run .#tidy' and commit."
+            echo "ERROR: go.mod/go.sum or vendor hashes are out of date. Run 'nix run .#tidy' and commit."
             exit 1
           fi
 


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane! Please read the contribution docs
(linked below) if this is your first Crossplane pull request.
-->

### Description of your changes

<!--
Briefly describe what this pull request does, and how it is covered by tests.
Be proactive - direct your reviewers' attention to anything that needs special
consideration.

We love pull requests that fix an open issue. If yours does, use the below line
to indicate which issue it fixes, for example "Fixes #500".
-->

The `check-diff` job should fail when running the repository's generation
workflow would leave uncommitted changes. The hermetic Nix generated-code check
verifies generated code, but it cannot run `go mod tidy` or refresh the Go
vendor hashes in `nix/vendor-hashes.nix`, because both need network access.

Generated code is verified by the hermetic `Verify Generated Code` step, which
runs `go generate` for the root and `apis` modules, the CRD patch, and
helm-docs, then diffs against the committed tree. This PR adds a `Check Diff`
step that covers what the sandbox can't: it runs `nix run .#tidy` and fails if
`git status --porcelain` reports any changes, catching untidied
`go.mod`/`go.sum` files and stale vendor hashes with an actionable message
instead of the raw hash-mismatch errors the sandboxed checks would otherwise
fail with.

I did not add unit or e2e tests for this change. The behavior is covered by the
CI workflow itself: `Verify Generated Code` enforces that generated files are
committed, and the new `Check Diff` step enforces that `go.mod`/`go.sum` and
vendor hashes are tidy and committed.

Fixes #

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `./nix.sh flake check` to ensure this PR is ready for review.
- [ ] ~Added or updated unit tests.~
- [ ] ~Added or updated e2e tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~
- [ ] ~Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md

