### PR TITLE
fix: skip digest references in dependency version upgrade

### DIFF
--- a/internal/controller/pkg/resolver/reconciler.go
+++ b/internal/controller/pkg/resolver/reconciler.go
@@ -522,6 +522,10 @@ func (r *Reconciler) findDependencyVersionToUpdate(ctx context.Context, ref name
 		return digest, nil
 	}
 
+	if strings.HasPrefix(insVer, "sha256:") {
+		return "", errors.Errorf("installed version is a digest reference, cannot upgrade using semantic versioning")
+	}
+
 	// ListVersions handles ImageConfig path rewriting and pull secrets.
 	versions, err := r.pkg.ListVersions(ctx, ref.String())
 	if err != nil {

--- a/internal/controller/pkg/resolver/reconciler_test.go
+++ b/internal/controller/pkg/resolver/reconciler_test.go
@@ -1208,6 +1208,30 @@ func TestReconcilerFindDependencyVersionToUpgrade(t *testing.T) {
 				err: errors.Errorf(errFmtDiffConstraintTypes, fmt.Sprintf("[%s v0.0.1]", digest1)),
 			},
 		},
+		"ErrorInstalledVersionDigest": {
+			reason: "We should return an error if the installed version is a digest (and not call ListVersions).",
+			args: args{
+				mgr:    &fake.Manager{Client: test.NewMockClient()},
+				insVer: digest1,
+				dep: &dag.DependencyNode{
+					Dependency: v1beta1.Dependency{
+						Package: "xpkg.crossplane.io/cool-repo/cool-image",
+						ParentConstraints: []string{
+							">=v1.0.0",
+							"v2.0.0",
+						},
+					},
+				},
+				rec: []ReconcilerOption{
+					WithClient(&fakexpkg.MockClient{
+						MockListVersions: fakexpkg.NewMockListVersionsFn(nil, errors.New("ListVersions should not be called")),
+					}),
+				},
+			},
+			want: want{
+				err: errors.Errorf("installed version is a digest reference, cannot upgrade using semantic versioning"),
+			},
+		},
 		"SuccessReturnVersion": {
 			reason: "We should be able to find the version to update.",
 			args: args{


### PR DESCRIPTION
## Summary
Fixes #7006.
**Root cause:** `findDependencyVersionToUpdate` called `semver.MustParse()` on digest references (e.g. `sha256:...`) which panics because digests are not valid semver strings.
**Fix:** Added a check to skip digest references before attempting semver parsing.
## Changes
- Updated dependency version resolution to skip digest references
## Testing
- Verified fix prevents panic when installed packages use digest references
- Change is minimal and follows existing code patterns

Made with [Cursor](https://cursor.com)