### PR TITLE
pkg: Correctly handle dependency upgrades with ImageConfig prefix rewriting

### DIFF
--- a/internal/controller/pkg/resolver/reconciler.go
+++ b/internal/controller/pkg/resolver/reconciler.go
@@ -338,15 +338,11 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 		}
 
 		for _, p := range l.Items {
-			// Start with spec.package, which should always be set.
+			// Packages in the lock are always referred to by their original
+			// sources, without any ImageConfig rewriting applied, so we need to
+			// match find packages using spec.package rather than
+			// status.resolvedPackage.
 			source, _ := fieldpath.Pave(p.Object).GetString("spec.package")
-
-			// If status.resolvedPackage is set, use that. This is
-			// the "real" package, as resolved by applying any
-			// ImageConfigs that might rewrite spec.package.
-			if resolved, err := fieldpath.Pave(p.Object).GetString("status.resolvedPackage"); err == nil && resolved != "" {
-				source = resolved
-			}
 
 			pref, err := name.ParseReference(source, name.StrictValidation)
 			if err != nil {
@@ -356,6 +352,14 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 			if pref.Context().Name() == ref.Context().Name() {
 				pkg = &p
 				installedVersion = pref.Identifier()
+				// Use the resolved package for the installed version if it is
+				// set, since the version could have been rewritten by an
+				// ImageConfig.
+				if resolved, err := fieldpath.Pave(p.Object).GetString("status.resolvedPackage"); err == nil && resolved != "" {
+					if rref, err := name.ParseReference(resolved, name.StrictValidation); err == nil {
+						installedVersion = rref.Identifier()
+					}
+				}
 			}
 		}
 	}

--- a/internal/controller/pkg/resolver/reconciler_test.go
+++ b/internal/controller/pkg/resolver/reconciler_test.go
@@ -924,7 +924,10 @@ func TestReconcile(t *testing.T) {
 						MockList: test.NewMockListFn(nil, func(obj client.ObjectList) error {
 							p := &unstructured.Unstructured{}
 							p.SetName("this-is-a-cool-image")
+							// spec.package uses the original ref.
 							_ = fieldpath.Pave(p.Object).SetString("spec.package", "xpkg.crossplane.io/cool-repo/cool-image:v0.0.1")
+							// status.resolvedPackage uses the rewritten ref.
+							_ = fieldpath.Pave(p.Object).SetString("status.resolvedPackage", "registry.example.com/cool-repo/cool-image:v0.0.1")
 							l := obj.(*unstructured.UnstructuredList)
 							l.Items = []unstructured.Unstructured{*p}
 							return nil
@@ -934,11 +937,7 @@ func TestReconcile(t *testing.T) {
 				rec: []ReconcilerOption{
 					WithFeatures(upgradesEnabled),
 					WithClient(&fakexpkg.MockClient{
-						MockListVersions: func(_ context.Context, _ string, _ ...xpkg.GetOption) ([]string, error) {
-							// Client handles ImageConfig rewriting internally.
-							// This test verifies versions are returned correctly.
-							return []string{"v0.2.0", "v0.3.0", "v1.0.0", "v1.2.0"}, nil
-						},
+						MockListVersions: fakexpkg.NewMockListVersionsFn([]string{"v0.0.1", "v1.0.0", "v1.0.1", "v2.0.0"}, nil),
 					}),
 					WithNewDagFn(func() dag.DAG {
 						return &fakedag.MockDag{


### PR DESCRIPTION
### Description of your changes

The package upgrade logic in the resolver reconciler needs to find existing packages that match a given `LockPackage`. Previously, it was matching packages based on their `status.resolvedPackage`, which reflects where the package was pulled from after applying any `ImageConfig` rewrites. However, `LockPackage`s are always identified by the original source. This meant that dependencies installed with a rewrite would never get upgraded, since the resolver would not find a matching package and would therefore attempt to create a new package, which fails silently with an `AlreadyExists` error.

Update the matching logic to use the pre-rewrite `spec.package` field, even when `status.resolvedPackage` is non-empty. We still take the installed version from `resolvedPackage` since `ImageConfig` rewrites can change versions.

While we're here, update the relevant test case to properly fill in the `status.resolvedPackage` for the mocked rewritten package. It appears that when image rewriting was centralized into `xpkg.Client`, this test case was updated such that it tests exactly the same case as the non-rewrite version.

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `./nix.sh flake check` to ensure this PR is ready for review.
- [x] Added or updated unit tests.
~- [ ] Added or updated e2e tests.~
~- [ ] Linked a PR or a [docs tracking issue] to [document this change].~
- [x] Added `backport release-x.y` labels to auto-backport this PR.
~- [ ] Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md
