### PR TITLE
fix(webhook): avoid panic for selector-only Usage.by

### DIFF
--- a/internal/webhook/protection/usage/handler.go
+++ b/internal/webhook/protection/usage/handler.go
@@ -171,7 +171,13 @@ func inUseMessage(u []protection.Usage) string {
 	}
 
 	if by != nil {
-		return fmt.Sprintf("This resource is in-use by %d usage(s), including the %T %s by resource %s/%s.", len(u), uu, id, by.Kind, by.ResourceRef.Name)
+		if by.ResourceRef != nil && by.ResourceRef.Name != "" {
+			return fmt.Sprintf("This resource is in-use by %d usage(s), including the %T %s by resource %s/%s.", len(u), uu, id, by.Kind, by.ResourceRef.Name)
+		}
+		if by.ResourceSelector != nil {
+			return fmt.Sprintf("This resource is in-use by %d usage(s), including the %T %s by resource selector %s.", len(u), uu, id, by.Kind)
+		}
+		return fmt.Sprintf("This resource is in-use by %d usage(s), including the %T %s by resource %s.", len(u), uu, id, by.Kind)
 	}
 
 	if r := ptr.Deref(first.GetReason(), ""); r != "" {

--- a/internal/webhook/protection/usage/handler_test.go
+++ b/internal/webhook/protection/usage/handler_test.go
@@ -251,6 +251,71 @@ func TestHandle(t *testing.T) {
 				},
 			},
 		},
+		"DeleteBlockedWithUsageBySelector": {
+			reason: "We should reject a delete request if there are usages for the given object with \"by.resourceSelector\" defined.",
+			params: params{
+				client: &test.MockClient{
+					MockPatch: func(_ context.Context, _ client.Object, _ client.Patch, _ ...client.PatchOption) error {
+						return nil
+					},
+				},
+				f: FinderFn(func(_ context.Context, _ usage.Object) ([]protection.Usage, error) {
+					usages := []protection.Usage{
+						&protection.InternalUsage{
+							Usage: v1beta1.Usage{
+								ObjectMeta: metav1.ObjectMeta{
+									Namespace: "default",
+									Name:      "used-by-selector",
+								},
+								Spec: v1beta1.UsageSpec{
+									Of: v1beta1.NamespacedResource{
+										APIVersion: "nop.crossplane.io/v1alpha1",
+										Kind:       "NopResource",
+										ResourceRef: &v1beta1.NamespacedResourceRef{
+											Name: "used-resource",
+										},
+									},
+									By: &v1beta1.Resource{
+										APIVersion: "nop.crossplane.io/v1alpha1",
+										Kind:       "NopResource",
+										ResourceSelector: &v1beta1.ResourceSelector{
+											MatchLabels: map[string]string{"app": "selector"},
+										},
+									},
+								},
+							},
+						},
+					}
+					return usages, nil
+				}),
+			},
+			args: args{
+				request: admission.Request{
+					AdmissionRequest: admissionv1.AdmissionRequest{
+						Operation: admissionv1.Delete,
+						OldObject: runtime.RawExtension{
+							Raw: []byte(`{
+								"apiVersion": "nop.crossplane.io/v1alpha1",
+								"kind": "NopResource",
+								"metadata": {
+									"name": "used-resource"
+								}}`),
+						},
+					},
+				},
+			},
+			want: want{
+				resp: admission.Response{
+					AdmissionResponse: admissionv1.AdmissionResponse{
+						Allowed: false,
+						Result: &metav1.Status{
+							Code:   int32(http.StatusConflict),
+							Reason: metav1.StatusReason("This resource is in-use by 1 usage(s), including the *v1beta1.Usage \"used-by-selector\" (in namespace \"default\") by resource selector NopResource."),
+						},
+					},
+				},
+			},
+		},
 		"DeleteBlockedWithUsageReason": {
 			reason: "We should reject a delete request if there are usages for the given object with \"reason\" defined.",
 			params: params{


### PR DESCRIPTION
## Summary
- handle `spec.by` entries that use `resourceSelector` but do not yet have `resourceRef` in the no-usages admission webhook message path
- avoid nil-pointer dereference when formatting denial messages
- add regression coverage for selector-only `spec.by`

Fixes #7243.

## Test plan
- [x] `go test ./internal/webhook/protection/usage`
- [x] Confirm new test case covers `by.resourceSelector` without `by.resourceRef`