### PR TITLE
fix(pkg-runtime): clean up stale deployments after runtime-config renames

### DIFF
--- a/internal/controller/pkg/runtime/migration.go
+++ b/internal/controller/pkg/runtime/migration.go
@@ -21,6 +21,7 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -92,30 +93,53 @@ func (m *DeletingDeploymentSelectorMigrator) MigrateDeploymentSelector(ctx conte
 	sa := builder.ServiceAccount()
 	expectedDeploy := builder.Deployment(sa.Name)
 
-	// Check if there's an existing deployment
-	existingDeploy := &appsv1.Deployment{}
+	// Check if there's an existing deployment with the current expected name.
+	currentDeploy := &appsv1.Deployment{}
 
 	err := m.client.Get(ctx, types.NamespacedName{
 		Name:      expectedDeploy.Name,
 		Namespace: expectedDeploy.Namespace,
-	}, existingDeploy)
-	if kerrors.IsNotFound(err) {
-		// No existing deployment, no migration needed
-		return nil
+	}, currentDeploy)
+	if err != nil && !kerrors.IsNotFound(err) {
+		return errors.Wrap(err, "cannot get existing deployment")
 	}
 
-	if err != nil {
-		return errors.Wrap(err, "cannot get existing deployment")
+	deployments := &appsv1.DeploymentList{}
+	if err := m.client.List(ctx, deployments, client.InNamespace(expectedDeploy.Namespace)); err != nil {
+		return errors.Wrap(err, "cannot list existing deployments")
+	}
+
+	for i := range deployments.Items {
+		d := &deployments.Items[i]
+		if !deploymentBelongsToRevision(d, pr) || d.Name == expectedDeploy.Name {
+			continue
+		}
+
+		m.log.Info("Deleting stale provider deployment after runtime config change",
+			"deployment", d.Name,
+			"expected-deployment", expectedDeploy.Name,
+			"revision", pr.GetName())
+
+		if err := m.client.Delete(ctx, d); err != nil {
+			return errors.Wrap(err, "cannot delete existing deployment for name migration")
+		}
+	}
+
+	if kerrors.IsNotFound(err) {
+		// No deployment exists with the current expected name. Any stale
+		// deployments have already been deleted, and the post hook will render
+		// the current deployment after this migration step.
+		return nil
 	}
 
 	existing := providerRev.GetLabels()[v1.LabelParentPackage]
 
-	if existingDeploy.Spec.Selector == nil || existingDeploy.Spec.Selector.MatchLabels == nil {
+	if currentDeploy.Spec.Selector == nil || currentDeploy.Spec.Selector.MatchLabels == nil {
 		// No selector or match labels, no migration needed
 		return nil
 	}
 
-	expected := existingDeploy.Spec.Selector.MatchLabels[v1.LabelProvider]
+	expected := currentDeploy.Spec.Selector.MatchLabels[v1.LabelProvider]
 
 	// Check if the provider label needs migration
 	if expected == existing {
@@ -131,9 +155,17 @@ func (m *DeletingDeploymentSelectorMigrator) MigrateDeploymentSelector(ctx conte
 
 	// If the provider label is different, we need to delete the old deployment.
 	// The new deployment will be created in the Post hook.
-	if err := m.client.Delete(ctx, existingDeploy); err != nil {
+	if err := m.client.Delete(ctx, currentDeploy); err != nil {
 		return errors.Wrap(err, "cannot delete existing deployment for selector migration")
 	}
 
 	return nil
+}
+
+func deploymentBelongsToRevision(d *appsv1.Deployment, pr v1.PackageRevisionWithRuntime) bool {
+	if controller := metav1.GetControllerOf(d); controller != nil && controller.UID != "" && controller.UID == pr.GetUID() {
+		return true
+	}
+
+	return d.Spec.Selector != nil && d.Spec.Selector.MatchLabels[v1.LabelRevision] == pr.GetName()
 }

--- a/internal/controller/pkg/runtime/migration.go
+++ b/internal/controller/pkg/runtime/migration.go
@@ -120,8 +120,8 @@ func (m *DeletingDeploymentSelectorMigrator) MigrateDeploymentSelector(ctx conte
 			"expected-deployment", expectedDeploy.Name,
 			"revision", pr.GetName())
 
-		if err := m.client.Delete(ctx, d); err != nil {
-			return errors.Wrap(err, "cannot delete existing deployment for name migration")
+		if err := m.client.Delete(ctx, d); err != nil && !kerrors.IsNotFound(err) {
+			return errors.Wrapf(err, "cannot delete stale deployment %q in namespace %q while migrating provider revision %q", d.GetName(), d.GetNamespace(), pr.GetName())
 		}
 	}
 
@@ -155,8 +155,8 @@ func (m *DeletingDeploymentSelectorMigrator) MigrateDeploymentSelector(ctx conte
 
 	// If the provider label is different, we need to delete the old deployment.
 	// The new deployment will be created in the Post hook.
-	if err := m.client.Delete(ctx, currentDeploy); err != nil {
-		return errors.Wrap(err, "cannot delete existing deployment for selector migration")
+	if err := m.client.Delete(ctx, currentDeploy); err != nil && !kerrors.IsNotFound(err) {
+		return errors.Wrapf(err, "cannot delete deployment %q in namespace %q while migrating provider revision %q", currentDeploy.GetName(), currentDeploy.GetNamespace(), pr.GetName())
 	}
 
 	return nil

--- a/internal/controller/pkg/runtime/migration_test.go
+++ b/internal/controller/pkg/runtime/migration_test.go
@@ -511,7 +511,7 @@ func TestDeletingDeploymentSelectorMigrator_MigrateDeploymentSelector(t *testing
 				builder: mockBuilder,
 			},
 			want: want{
-				err: errors.Wrap(errBoom, "cannot delete existing deployment for selector migration"),
+				err: errors.Wrapf(errBoom, "cannot delete deployment %q in namespace %q while migrating provider revision %q", testDeploymentName, testNamespaceName, ""),
 			},
 		},
 	}

--- a/internal/controller/pkg/runtime/migration_test.go
+++ b/internal/controller/pkg/runtime/migration_test.go
@@ -126,7 +126,8 @@ func TestDeletingDeploymentSelectorMigrator_MigrateDeploymentSelector(t *testing
 			reason: "Should return nil when no existing deployment is found.",
 			args: args{
 				client: &test.MockClient{
-					MockGet: test.NewMockGetFn(kerrors.NewNotFound(schema.GroupResource{}, "")),
+					MockGet:  test.NewMockGetFn(kerrors.NewNotFound(schema.GroupResource{}, "")),
+					MockList: test.NewMockListFn(nil),
 				},
 				pr: &v1.ProviderRevision{
 					ObjectMeta: metav1.ObjectMeta{
@@ -170,6 +171,159 @@ func TestDeletingDeploymentSelectorMigrator_MigrateDeploymentSelector(t *testing
 				err: errors.Wrap(errBoom, "cannot get existing deployment"),
 			},
 		},
+		"ErrorListingDeployments": {
+			reason: "Should return an error when listing existing deployments fails.",
+			args: args{
+				client: &test.MockClient{
+					MockGet: test.NewMockGetFn(kerrors.NewNotFound(schema.GroupResource{}, "")),
+					MockList: test.NewMockListFn(nil, func(_ client.ObjectList) error {
+						return errBoom
+					}),
+				},
+				pr: &v1.ProviderRevision{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "provider-nop-v1.0.0",
+						Labels: map[string]string{
+							v1.LabelParentPackage: "crossplane-provider-nop",
+						},
+					},
+					Spec: v1.ProviderRevisionSpec{
+						PackageRevisionSpec: v1.PackageRevisionSpec{
+							DesiredState: v1.PackageRevisionActive,
+						},
+					},
+				},
+				builder: mockBuilder,
+			},
+			want: want{
+				err: errors.Wrap(errBoom, "cannot list existing deployments"),
+			},
+		},
+		"DeleteStaleDeploymentWhenExpectedNameChanges": {
+			reason: "Should delete a stale deployment owned by the same revision when the runtime config changes the deployment name.",
+			args: args{
+				client: &test.MockClient{
+					MockGet: test.NewMockGetFn(kerrors.NewNotFound(schema.GroupResource{}, "")),
+					MockList: test.NewMockListFn(nil, func(obj client.ObjectList) error {
+						l := obj.(*appsv1.DeploymentList)
+						l.Items = []appsv1.Deployment{
+							{
+								ObjectMeta: metav1.ObjectMeta{
+									Name:      "old-deployment",
+									Namespace: testNamespaceName,
+								},
+								Spec: appsv1.DeploymentSpec{
+									Selector: &metav1.LabelSelector{
+										MatchLabels: map[string]string{
+											v1.LabelRevision: "provider-nop-v1.0.0",
+										},
+									},
+								},
+							},
+						}
+						return nil
+					}),
+					MockDelete: test.NewMockDeleteFn(nil, func(o client.Object) error {
+						deploy := o.(*appsv1.Deployment)
+						if deploy.GetName() != "old-deployment" {
+							t.Errorf("expected stale deployment to be deleted, got %q", deploy.GetName())
+						}
+						return nil
+					}),
+				},
+				pr: &v1.ProviderRevision{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "provider-nop-v1.0.0",
+						Labels: map[string]string{
+							v1.LabelParentPackage: "crossplane-provider-nop",
+						},
+					},
+					Spec: v1.ProviderRevisionSpec{
+						PackageRevisionSpec: v1.PackageRevisionSpec{
+							DesiredState: v1.PackageRevisionActive,
+						},
+					},
+				},
+				builder: mockBuilder,
+			},
+			want: want{
+				err: nil,
+			},
+		},
+		"DeleteStaleDeploymentWhenExpectedDeploymentExists": {
+			reason: "Should delete stale deployments owned by the same revision even when the current deployment already exists.",
+			args: args{
+				client: &test.MockClient{
+					MockGet: test.NewMockGetFn(nil, func(o client.Object) error {
+						deploy := o.(*appsv1.Deployment)
+						deploy.Name = testDeploymentName
+						deploy.Namespace = testNamespaceName
+						deploy.Spec.Selector = &metav1.LabelSelector{
+							MatchLabels: map[string]string{
+								v1.LabelProvider: "crossplane-provider-nop",
+							},
+						}
+						return nil
+					}),
+					MockList: test.NewMockListFn(nil, func(obj client.ObjectList) error {
+						l := obj.(*appsv1.DeploymentList)
+						l.Items = []appsv1.Deployment{
+							{
+								ObjectMeta: metav1.ObjectMeta{
+									Name:      testDeploymentName,
+									Namespace: testNamespaceName,
+								},
+								Spec: appsv1.DeploymentSpec{
+									Selector: &metav1.LabelSelector{
+										MatchLabels: map[string]string{
+											v1.LabelRevision: "provider-nop-v1.0.0",
+										},
+									},
+								},
+							},
+							{
+								ObjectMeta: metav1.ObjectMeta{
+									Name:      "old-deployment",
+									Namespace: testNamespaceName,
+								},
+								Spec: appsv1.DeploymentSpec{
+									Selector: &metav1.LabelSelector{
+										MatchLabels: map[string]string{
+											v1.LabelRevision: "provider-nop-v1.0.0",
+										},
+									},
+								},
+							},
+						}
+						return nil
+					}),
+					MockDelete: test.NewMockDeleteFn(nil, func(o client.Object) error {
+						deploy := o.(*appsv1.Deployment)
+						if deploy.GetName() != "old-deployment" {
+							t.Errorf("expected stale deployment to be deleted, got %q", deploy.GetName())
+						}
+						return nil
+					}),
+				},
+				pr: &v1.ProviderRevision{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "provider-nop-v1.0.0",
+						Labels: map[string]string{
+							v1.LabelParentPackage: "crossplane-provider-nop",
+						},
+					},
+					Spec: v1.ProviderRevisionSpec{
+						PackageRevisionSpec: v1.PackageRevisionSpec{
+							DesiredState: v1.PackageRevisionActive,
+						},
+					},
+				},
+				builder: mockBuilder,
+			},
+			want: want{
+				err: nil,
+			},
+		},
 		"NoSelectorInDeployment": {
 			reason: "Should return nil when deployment has no selector.",
 			args: args{
@@ -181,6 +335,7 @@ func TestDeletingDeploymentSelectorMigrator_MigrateDeploymentSelector(t *testing
 						deploy.Spec.Selector = nil
 						return nil
 					}),
+					MockList: test.NewMockListFn(nil),
 				},
 				pr: &v1.ProviderRevision{
 					ObjectMeta: metav1.ObjectMeta{
@@ -213,6 +368,7 @@ func TestDeletingDeploymentSelectorMigrator_MigrateDeploymentSelector(t *testing
 						}
 						return nil
 					}),
+					MockList: test.NewMockListFn(nil),
 				},
 				pr: &v1.ProviderRevision{
 					ObjectMeta: metav1.ObjectMeta{
@@ -247,6 +403,7 @@ func TestDeletingDeploymentSelectorMigrator_MigrateDeploymentSelector(t *testing
 						}
 						return nil
 					}),
+					MockList: test.NewMockListFn(nil),
 				},
 				pr: &v1.ProviderRevision{
 					ObjectMeta: metav1.ObjectMeta{
@@ -281,6 +438,7 @@ func TestDeletingDeploymentSelectorMigrator_MigrateDeploymentSelector(t *testing
 						}
 						return nil
 					}),
+					MockList: test.NewMockListFn(nil),
 					MockDelete: test.NewMockDeleteFn(nil, func(o client.Object) error {
 						want := &appsv1.Deployment{
 							ObjectMeta: metav1.ObjectMeta{
@@ -335,6 +493,7 @@ func TestDeletingDeploymentSelectorMigrator_MigrateDeploymentSelector(t *testing
 						}
 						return nil
 					}),
+					MockList:   test.NewMockListFn(nil),
 					MockDelete: test.NewMockDeleteFn(errBoom),
 				},
 				pr: &v1.ProviderRevision{


### PR DESCRIPTION
### Description of your changes

Changing a `DeploymentRuntimeConfig` deployment name can currently leave the old provider deployment behind. The runtime reconciler renders the new deployment, but the migration hook only checks the current expected deployment name and never cleans up stale deployments owned by the same provider revision.

This PR teaches the provider runtime migration hook to scan deployments in the revision namespace and remove stale deployments that still belong to the same revision but no longer match the currently rendered deployment name. The existing selector-migration behavior stays in place for the current deployment.

Fixes #7210

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `./nix.sh flake check` to ensure this PR is ready for review.
- [x] Added or updated unit tests.
- [ ] ~Added or updated e2e tests.~ (the migration hook behavior is covered directly with unit tests)
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~ (bug fix for existing runtime behavior)
- [ ] Added `backport release-x.y` labels to auto-backport this PR.
- [ ] ~Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~ (no API changes)

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md
