### PR TITLE
Skip no-op status updates in revision and composite reconcilers

### DIFF
--- a/internal/controller/apiextensions/composite/reconciler.go
+++ b/internal/controller/apiextensions/composite/reconciler.go
@@ -34,6 +34,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
+	"github.com/google/go-cmp/cmp"
+
 	"github.com/crossplane/crossplane-runtime/v2/pkg/conditions"
 	"github.com/crossplane/crossplane-runtime/v2/pkg/errors"
 	"github.com/crossplane/crossplane-runtime/v2/pkg/event"
@@ -554,6 +556,8 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 		return reconcile.Result{}, errors.Wrap(resource.IgnoreNotFound(err), errGet)
 	}
 
+	xrBefore := xr.DeepCopyObject()
+
 	log = log.WithValues(
 		"uid", xr.GetUID(),
 		"version", xr.GetResourceVersion(),
@@ -870,7 +874,10 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 		result = reconcile.Result{RequeueAfter: jitter(res.TTL)}
 	}
 
-	return result, errors.Wrap(r.client.Status().Update(updateCtx, xr), errUpdateStatus)
+	if !cmp.Equal(xr, xrBefore) {
+		return result, errors.Wrap(r.client.Status().Update(updateCtx, xr), errUpdateStatus)
+	}
+	return result, nil
 }
 
 type compositionResultMeta struct {

--- a/internal/controller/apiextensions/composite/reconciler.go
+++ b/internal/controller/apiextensions/composite/reconciler.go
@@ -556,7 +556,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 		return reconcile.Result{}, errors.Wrap(resource.IgnoreNotFound(err), errGet)
 	}
 
-	xrBefore := xr.DeepCopyObject()
+	statusBefore, _, _ := kunstructured.NestedFieldCopy(xr.Object, "status")
 
 	log = log.WithValues(
 		"uid", xr.GetUID(),
@@ -874,7 +874,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 		result = reconcile.Result{RequeueAfter: jitter(res.TTL)}
 	}
 
-	if !cmp.Equal(xr, xrBefore) {
+	if !cmp.Equal(statusBefore, xr.Object["status"]) {
 		return result, errors.Wrap(r.client.Status().Update(updateCtx, xr), errUpdateStatus)
 	}
 	return result, nil

--- a/internal/controller/apiextensions/composite/reconciler.go
+++ b/internal/controller/apiextensions/composite/reconciler.go
@@ -24,6 +24,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
 	corev1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -33,8 +34,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
-
-	"github.com/google/go-cmp/cmp"
 
 	"github.com/crossplane/crossplane-runtime/v2/pkg/conditions"
 	"github.com/crossplane/crossplane-runtime/v2/pkg/errors"

--- a/internal/controller/apiextensions/revision/reconciler.go
+++ b/internal/controller/apiextensions/revision/reconciler.go
@@ -27,6 +27,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
+	"github.com/google/go-cmp/cmp"
+
 	"github.com/crossplane/crossplane-runtime/v2/pkg/conditions"
 	"github.com/crossplane/crossplane-runtime/v2/pkg/errors"
 	"github.com/crossplane/crossplane-runtime/v2/pkg/event"
@@ -135,6 +137,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 		return reconcile.Result{}, errors.Wrap(resource.IgnoreNotFound(err), "cannot get CompositionRevision")
 	}
 
+	statusBefore := rev.Status.DeepCopy()
 	status := r.conditions.For(rev)
 
 	if meta.WasDeleted(rev) {
@@ -161,12 +164,18 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 		status.MarkConditions(xpv2.ReconcileSuccess(), v1.MissingCapabilities(err.Error()))
 
 		// Update status but don't return the error - capability failures are informational
-		return reconcile.Result{}, errors.Wrap(r.client.Status().Update(ctx, rev), "cannot update CompositionRevision status")
+		if !cmp.Equal(statusBefore, &rev.Status) {
+			return reconcile.Result{}, errors.Wrap(r.client.Status().Update(ctx, rev), "cannot update CompositionRevision status")
+		}
+		return reconcile.Result{}, nil
 	}
 
 	log.Debug("All functions have required composition capability")
 	r.record.Event(rev, event.Normal(reasonCheckCapabilities, "All functions have required composition capability"))
 	status.MarkConditions(xpv2.ReconcileSuccess(), v1.ValidPipeline())
 
-	return reconcile.Result{}, errors.Wrap(r.client.Status().Update(ctx, rev), "cannot update CompositionRevision status")
+	if !cmp.Equal(statusBefore, &rev.Status) {
+		return reconcile.Result{}, errors.Wrap(r.client.Status().Update(ctx, rev), "cannot update CompositionRevision status")
+	}
+	return reconcile.Result{}, nil
 }

--- a/internal/controller/apiextensions/revision/reconciler.go
+++ b/internal/controller/apiextensions/revision/reconciler.go
@@ -22,12 +22,11 @@ import (
 	"strings"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
-
-	"github.com/google/go-cmp/cmp"
 
 	"github.com/crossplane/crossplane-runtime/v2/pkg/conditions"
 	"github.com/crossplane/crossplane-runtime/v2/pkg/errors"


### PR DESCRIPTION
## Summary
- CompositionRevision and composite resource reconcilers call `Status().Update()` 
  unconditionally on every reconcile pass, even when status hasn't changed. This 
  produces unnecessary API server writes, watch events, and re-enqueues — causing 
  an infinite reconcile loop that never converges to steady state.
- Snapshot the object before reconciliation and skip `Status().Update()` when 
  nothing changed, following the existing pattern in the usage protection reconciler.

Fixes #7221

## Test plan
- [x] Existing unit tests pass for both `revision` and `composite` packages
- [x] Create a Composition + XR, watch CompositionRevision with `kubectl get compositionrevision -w`, 
      and confirm `resourceVersion` stops incrementing once steady state is reached