### PR TITLE
test(e2e): add missing poll intervals to wait.For calls

### DIFF
--- a/test/e2e/funcs/feature.go
+++ b/test/e2e/funcs/feature.go
@@ -854,7 +854,7 @@ func ClaimUnderTestMustNotChangeWithin(d time.Duration) features.Func {
 
 		t.Logf("Ensuring claim %s does not change within %s", identifier(cm), d.String())
 
-		if err := wait.For(conditions.New(c.Client().Resources()).ResourcesMatch(list, m), wait.WithTimeout(d)); err != nil {
+		if err := wait.For(conditions.New(c.Client().Resources()).ResourcesMatch(list, m), wait.WithTimeout(d), wait.WithInterval(DefaultPollInterval)); err != nil {
 			if deadlineExceed(err) {
 				t.Logf("Claim %s did not change within %s", identifier(cm), d.String())
 				return ctx
@@ -909,7 +909,7 @@ func CompositeUnderTestMustNotChangeWithin(d time.Duration) features.Func {
 
 		t.Logf("Ensuring composite resource %s does not change within %s", identifier(cp), d.String())
 
-		if err := wait.For(conditions.New(c.Client().Resources()).ResourcesMatch(list, m), wait.WithTimeout(d)); err != nil {
+		if err := wait.For(conditions.New(c.Client().Resources()).ResourcesMatch(list, m), wait.WithTimeout(d), wait.WithInterval(DefaultPollInterval)); err != nil {
 			if deadlineExceed(err) {
 				t.Logf("Composite resource %s did not change within %s", identifier(cp), d.String())
 				return ctx
@@ -963,7 +963,7 @@ func CompositeResourceMustMatchWithin(d time.Duration, dir, claimFile string, ma
 			return match(&composite.Unstructured{Unstructured: *u})
 		}
 
-		if err := wait.For(conditions.New(c.Client().Resources()).ResourcesMatch(list, m), wait.WithTimeout(d)); err != nil && count.Load() > 0 {
+		if err := wait.For(conditions.New(c.Client().Resources()).ResourcesMatch(list, m), wait.WithTimeout(d), wait.WithInterval(DefaultPollInterval)); err != nil && count.Load() > 0 {
 			t.Errorf("composite %s did not match the condition before timeout (%s): %s\n\n", identifier(&uxr), d.String(), err)
 			return ctx
 		}


### PR DESCRIPTION
### Description of your changes

Three `wait.For` calls in `test/e2e/funcs/feature.go` were missing
`wait.WithInterval(DefaultPollInterval)`, unlike all other `wait.For` calls in
the file. Without an explicit interval, these calls use the e2e-framework's
default polling behavior, which is inconsistent and can contribute to flaky test
results.

This adds the missing interval option to:
- `ClaimUnderTestMustNotChangeWithin`
- `CompositeUnderTestMustNotChangeWithin`
- `CompositeResourceMustMatchWithin`

Refs #5671

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `./nix.sh flake check` to ensure this PR is ready for review.
- [x] ~Added or updated unit tests.~
- [ ] ~Added or updated e2e tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~
- [ ] ~Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md
