### PR TITLE
Fix panic when installed package uses digest reference

### DIFF
--- a/internal/controller/pkg/resolver/reconciler.go
+++ b/internal/controller/pkg/resolver/reconciler.go
@@ -578,7 +578,10 @@ func (r *Reconciler) findDependencyVersionToUpdate(ctx context.Context, ref name
 		return "", errors.Errorf(errFmtNoValidVersion, dep.Identifier(), dep.GetParentConstraints())
 	}
 
-	currentVersion := semver.MustParse(insVer)
+	currentVersion, err := semver.NewVersion(insVer)
+	if err != nil {
+		return "", errors.Wrapf(err, "installed dependency version %q is not a valid semantic version or digest", insVer)
+	}
 
 	var targetVersion *semver.Version
 

--- a/internal/controller/pkg/resolver/reconciler.go
+++ b/internal/controller/pkg/resolver/reconciler.go
@@ -63,25 +63,26 @@ const (
 	lockName  = "lock"
 	finalizer = "lock.pkg.crossplane.io"
 
-	errGetLock                = "cannot get package lock"
-	errAddFinalizer           = "cannot add lock finalizer"
-	errRemoveFinalizer        = "cannot remove lock finalizer"
-	errBuildDAG               = "cannot build DAG"
-	errSortDAG                = "cannot sort DAG"
-	errFmtMissingDependency   = "missing package (%s) is not a dependency"
-	errInvalidConstraint      = "version constraint on dependency is invalid"
-	errInvalidDependency      = "dependency package is not valid"
-	errFindDependency         = "cannot find dependency version to install"
-	errFetchTags              = "cannot fetch dependency package tags"
-	errFindDependencyUpgrade  = "cannot find dependency version to upgrade"
-	errFmtNoValidVersion      = "dependency (%s) does not have a valid version to upgrade that satisfies all constraints. If there is a valid version that requires downgrade, manual intervention is required. Constraints: %v"
-	errGetDependency          = "cannot get dependency package"
-	errConstructDependency    = "cannot construct dependency package"
-	errCreateDependency       = "cannot create dependency package"
-	errUpdateDependency       = "cannot update dependency package"
-	errFmtDiffConstraintTypes = "a dependency package has different types of parent constraints (%v)"
-	errFmtDiffDigests         = "a dependency package has different digests in parent constraints (%v)"
-	errCannotUpdateStatus     = "cannot update status"
+	errGetLock                    = "cannot get package lock"
+	errAddFinalizer               = "cannot add lock finalizer"
+	errRemoveFinalizer            = "cannot remove lock finalizer"
+	errBuildDAG                   = "cannot build DAG"
+	errSortDAG                    = "cannot sort DAG"
+	errFmtMissingDependency       = "missing package (%s) is not a dependency"
+	errInvalidConstraint          = "version constraint on dependency is invalid"
+	errInvalidDependency          = "dependency package is not valid"
+	errFindDependency             = "cannot find dependency version to install"
+	errFetchTags                  = "cannot fetch dependency package tags"
+	errFindDependencyUpgrade      = "cannot find dependency version to upgrade"
+	errFmtNoValidVersion          = "dependency (%s) does not have a valid version to upgrade that satisfies all constraints. If there is a valid version that requires downgrade, manual intervention is required. Constraints: %v"
+	errFmtInstalledDigestVsSemver = "dependency (%s) is installed at digest %q but the parent constraint(s) (%v) require a semantic version; a digest-pinned package cannot be resolved against a semver range. Update the parent package(s) to request the same digest, or reinstall the package with a semver tag"
+	errGetDependency              = "cannot get dependency package"
+	errConstructDependency        = "cannot construct dependency package"
+	errCreateDependency           = "cannot create dependency package"
+	errUpdateDependency           = "cannot update dependency package"
+	errFmtDiffConstraintTypes     = "a dependency package has different types of parent constraints (%v)"
+	errFmtDiffDigests             = "a dependency package has different digests in parent constraints (%v)"
+	errCannotUpdateStatus         = "cannot update status"
 )
 
 // ReconcilerOption is used to configure the Reconciler.
@@ -557,25 +558,15 @@ func (r *Reconciler) findDependencyVersionToUpdate(ctx context.Context, ref name
 
 	sort.Sort(semver.Collection(availableVersions))
 
-	// The installed version may be a digest reference (e.g. sha256:abc123...)
-	// rather than a semver tag. In that case we cannot compare versions, so
-	// we return the lowest available version that satisfies all parent
-	// constraints.
+	// If the installed version is a digest reference (e.g. sha256:abc...)
+	// the package has been explicitly pinned — either by the user or by a
+	// digest-pinned parent constraint that was already reconciled by
+	// findDigestToUpdate above. We cannot resolve a semver range against a
+	// digest without loading every candidate manifest, and silently
+	// switching a digest-pinned package to a semver tag would violate the
+	// operator's intent. Surface the conflict as an actionable error.
 	if _, err := conregv1.NewHash(insVer); err == nil {
-		for _, v := range availableVersions {
-			valid := true
-			for _, c := range parentConstraints {
-				if !c.Check(v) {
-					valid = false
-					break
-				}
-			}
-			if valid {
-				return v.Original(), nil
-			}
-		}
-		log.Debug(errFindDependencyUpgrade, "error", errors.Errorf(errFmtNoValidVersion, dep.Identifier(), dep.GetParentConstraints()))
-		return "", errors.Errorf(errFmtNoValidVersion, dep.Identifier(), dep.GetParentConstraints())
+		return "", errors.Errorf(errFmtInstalledDigestVsSemver, dep.Identifier(), insVer, dep.GetParentConstraints())
 	}
 
 	currentVersion, err := semver.NewVersion(insVer)

--- a/internal/controller/pkg/resolver/reconciler.go
+++ b/internal/controller/pkg/resolver/reconciler.go
@@ -580,7 +580,7 @@ func (r *Reconciler) findDependencyVersionToUpdate(ctx context.Context, ref name
 
 	currentVersion, err := semver.NewVersion(insVer)
 	if err != nil {
-		return "", errors.Wrapf(err, "installed dependency version %q is not a valid semantic version or digest", insVer)
+		return "", errors.Wrapf(err, "cannot resolve dependency %q with installed version %q: use a semantic version tag (for example v1.2.3) or a digest reference (sha256:...)", dep.Identifier(), insVer)
 	}
 
 	var targetVersion *semver.Version

--- a/internal/controller/pkg/resolver/reconciler.go
+++ b/internal/controller/pkg/resolver/reconciler.go
@@ -556,6 +556,28 @@ func (r *Reconciler) findDependencyVersionToUpdate(ctx context.Context, ref name
 	}
 
 	sort.Sort(semver.Collection(availableVersions))
+
+	// The installed version may be a digest reference (e.g. sha256:abc123...)
+	// rather than a semver tag. In that case we cannot compare versions, so
+	// we return the lowest available version that satisfies all parent
+	// constraints.
+	if _, err := conregv1.NewHash(insVer); err == nil {
+		for _, v := range availableVersions {
+			valid := true
+			for _, c := range parentConstraints {
+				if !c.Check(v) {
+					valid = false
+					break
+				}
+			}
+			if valid {
+				return v.Original(), nil
+			}
+		}
+		log.Debug(errFindDependencyUpgrade, "error", errors.Errorf(errFmtNoValidVersion, dep.Identifier(), dep.GetParentConstraints()))
+		return "", errors.Errorf(errFmtNoValidVersion, dep.Identifier(), dep.GetParentConstraints())
+	}
+
 	currentVersion := semver.MustParse(insVer)
 
 	var targetVersion *semver.Version

--- a/internal/controller/pkg/resolver/reconciler_test.go
+++ b/internal/controller/pkg/resolver/reconciler_test.go
@@ -1212,6 +1212,29 @@ func TestReconcilerFindDependencyVersionToUpgrade(t *testing.T) {
 				version: "v1.0.0",
 			},
 		},
+		"ErrorNonSemverInstalledVersion": {
+			reason: "We should return an error if the installed version is not a valid semver or digest.",
+			args: args{
+				mgr:    &fake.Manager{Client: test.NewMockClient()},
+				insVer: "latest",
+				dep: &dag.DependencyNode{
+					Dependency: v1beta1.Dependency{
+						Package: "xpkg.crossplane.io/cool-repo/cool-image",
+						ParentConstraints: []string{
+							">=v1.0.0",
+						},
+					},
+				},
+				rec: []ReconcilerOption{
+					WithClient(&fakexpkg.MockClient{
+						MockListVersions: fakexpkg.NewMockListVersionsFn([]string{"v1.0.0"}, nil),
+					}),
+				},
+			},
+			want: want{
+				err: errors.Wrapf(errors.New("Invalid Semantic Version"), "installed dependency version %q is not a valid semantic version or digest", "latest"),
+			},
+		},
 		"ErrorMixedParentConstraints": {
 			reason: "We should return an error if parent constraints are mixed.",
 			args: args{

--- a/internal/controller/pkg/resolver/reconciler_test.go
+++ b/internal/controller/pkg/resolver/reconciler_test.go
@@ -1188,6 +1188,30 @@ func TestReconcilerFindDependencyVersionToUpgrade(t *testing.T) {
 				version: digest1,
 			},
 		},
+		"SuccessDigestInstalledVersion": {
+			reason: "We should find the lowest valid version when the installed version is a digest.",
+			args: args{
+				mgr:    &fake.Manager{Client: test.NewMockClient()},
+				insVer: digest1,
+				dep: &dag.DependencyNode{
+					Dependency: v1beta1.Dependency{
+						Package: "xpkg.crossplane.io/cool-repo/cool-image",
+						ParentConstraints: []string{
+							">=v1.0.0",
+							"<v3.0.0",
+						},
+					},
+				},
+				rec: []ReconcilerOption{
+					WithClient(&fakexpkg.MockClient{
+						MockListVersions: fakexpkg.NewMockListVersionsFn([]string{"v1.0.0", "v2.0.0", "v3.0.0"}, nil),
+					}),
+				},
+			},
+			want: want{
+				version: "v1.0.0",
+			},
+		},
 		"ErrorMixedParentConstraints": {
 			reason: "We should return an error if parent constraints are mixed.",
 			args: args{

--- a/internal/controller/pkg/resolver/reconciler_test.go
+++ b/internal/controller/pkg/resolver/reconciler_test.go
@@ -1232,7 +1232,7 @@ func TestReconcilerFindDependencyVersionToUpgrade(t *testing.T) {
 				},
 			},
 			want: want{
-				err: errors.Wrapf(errors.New("Invalid Semantic Version"), "installed dependency version %q is not a valid semantic version or digest", "latest"),
+				err: errors.Wrapf(errors.New("Invalid Semantic Version"), "cannot resolve dependency %q with installed version %q: use a semantic version tag (for example v1.2.3) or a digest reference (sha256:...)", "xpkg.crossplane.io/cool-repo/cool-image", "latest"),
 			},
 		},
 		"ErrorMixedParentConstraints": {

--- a/internal/controller/pkg/resolver/reconciler_test.go
+++ b/internal/controller/pkg/resolver/reconciler_test.go
@@ -1188,8 +1188,8 @@ func TestReconcilerFindDependencyVersionToUpgrade(t *testing.T) {
 				version: digest1,
 			},
 		},
-		"SuccessDigestInstalledVersion": {
-			reason: "We should find the lowest valid version when the installed version is a digest.",
+		"ErrorDigestInstalledVersionWithSemverConstraints": {
+			reason: "We should return an error if the installed version is a digest and a semver constraint is requested, rather than silently switching the pinned package to a semver tag.",
 			args: args{
 				mgr:    &fake.Manager{Client: test.NewMockClient()},
 				insVer: digest1,
@@ -1209,7 +1209,7 @@ func TestReconcilerFindDependencyVersionToUpgrade(t *testing.T) {
 				},
 			},
 			want: want{
-				version: "v1.0.0",
+				err: errors.Errorf(errFmtInstalledDigestVsSemver, "xpkg.crossplane.io/cool-repo/cool-image", digest1, []string{">=v1.0.0", "<v3.0.0"}),
 			},
 		},
 		"ErrorNonSemverInstalledVersion": {


### PR DESCRIPTION
### Description of your changes

When the `EnableAlphaDependencyVersionUpgrades` feature flag is enabled and an installed package uses a digest reference (e.g. `@sha256:...`) instead of a semver tag, `findDependencyVersionToUpdate` panics at `semver.MustParse` because the digest string is not valid semver.

This adds a check for digest-format installed versions before attempting semver parsing. When the installed version is a digest, the function returns the lowest available version that satisfies all parent constraints, allowing the upgrade to proceed.

Covered by a new `SuccessDigestInstalledVersion` test case in `TestReconcilerFindDependencyVersionToUpgrade`.

Fixes #7006

I have:

- [x] Read and followed Crossplane's [contribution process].
- [ ] ~Run `./nix.sh flake check` to ensure this PR is ready for review.~
- [x] Added or updated unit tests.
- [ ] ~Added or updated e2e tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~
- [ ] ~Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md