### PR TITLE
fix(composite): skip composed-resource refs whose CRD no longer exists

### DIFF
--- a/internal/controller/apiextensions/composite/composition_functions.go
+++ b/internal/controller/apiextensions/composite/composition_functions.go
@@ -28,6 +28,7 @@ import (
 	"google.golang.org/protobuf/types/known/structpb"
 	corev1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	kmeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
@@ -794,6 +795,16 @@ func (g *ExistingComposedResourceObserver) ObserveComposedResources(ctx context.
 				// We believe we created this resource, but it no longer exists.
 				continue
 			}
+		}
+
+		// If the CRD backing the reference no longer exists (e.g. an API
+		// version was dropped during an operator upgrade) we can never
+		// observe the resource — and because the ref is stale the compose
+		// pipeline has no way to reconcile it away either. Skip it so the
+		// function pipeline gets a chance to run and produce a corrected
+		// desired state. See crossplane/crossplane#7284.
+		if kmeta.IsNoMatchError(err) {
+			continue
 		}
 
 		if err != nil {

--- a/internal/controller/apiextensions/composite/composition_functions_test.go
+++ b/internal/controller/apiextensions/composite/composition_functions_test.go
@@ -30,6 +30,7 @@ import (
 	"google.golang.org/protobuf/types/known/structpb"
 	corev1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	kmeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -1573,6 +1574,34 @@ func TestGetComposedResources(t *testing.T) {
 					ComposedResourcesReferencer: fake.ComposedResourcesReferencer{
 						Refs: []corev1.ObjectReference{
 							{Name: "cool-resource"},
+						},
+					},
+				},
+			},
+		},
+		"ComposedResourceCRDMissing": {
+			reason: "We should skip resources whose CRD no longer exists (NoMatchError) rather than abort the reconciliation. See crossplane/crossplane#7284.",
+			params: params{
+				c: &test.MockClient{
+					MockGet: test.NewMockGetFn(&kmeta.NoKindMatchError{
+						GroupKind: schema.GroupKind{Group: "external-secrets.io", Kind: "ExternalSecret"},
+					}),
+				},
+				uc: &test.MockClient{
+					MockGet: test.NewMockGetFn(&kmeta.NoKindMatchError{
+						GroupKind: schema.GroupKind{Group: "external-secrets.io", Kind: "ExternalSecret"},
+					}),
+				},
+			},
+			args: args{
+				xr: &fake.Composite{
+					ComposedResourcesReferencer: fake.ComposedResourcesReferencer{
+						Refs: []corev1.ObjectReference{
+							{
+								APIVersion: "external-secrets.io/v1beta1",
+								Kind:       "ExternalSecret",
+								Name:       "stale-ref",
+							},
 						},
 					},
 				},


### PR DESCRIPTION
## Summary

`ObserveComposedResources` already tolerates a composed resource returning `NotFound` — we assume we created it but it was deleted underneath us. The same logic was missing when the underlying CRD itself is gone (for example when an operator upgrade drops a prior API version): the API server returns a `NoKindMatchError` from the REST mapper, which fell through to the generic error path and aborted the entire reconciliation loop.

That stranded the XR indefinitely — the compose pipeline could never run to produce a corrected desired state and prune the stale ref. The reporter in #7284 had a `v1beta1 ExternalSecret` ref blocking reconciliation for 9 days after upgrading External Secrets Operator.

Add a `kmeta.IsNoMatchError` check next to the existing `NotFound` branches: if the CRD is gone the composed resource cannot exist, so skipping is both safe and desirable — it lets the function pipeline run and emit a corrected set of `resourceRefs`.

Fixes #7284

## Test plan

- [x] `go test ./internal/controller/apiextensions/...`
- [x] `gofmt` clean
- [x] New case `TestGetComposedResources/ComposedResourceCRDMissing` seeds a `NoKindMatchError` from both cached and uncached clients and asserts no error is returned.

Signed-off-by: Ali <alliasgher123@gmail.com>