### PR TITLE
fix(crank/beta/validate/manager): add exported CRDs function

### DIFF
--- a/cmd/crank/beta/validate/manager.go
+++ b/cmd/crank/beta/validate/manager.go
@@ -347,3 +347,8 @@ func (m *Manager) loadDependencies() ([]*unstructured.Unstructured, error) {
 
 	return schemas, nil
 }
+
+// Returns crds loaded by the manager
+func (m *Manager) CRDs() []*extv1.CustomResourceDefinition {
+	return m.crds
+}


### PR DESCRIPTION
### Description of your changes

In crank/beta/validate/manager, i've added an exported function that will allow other modules to get the crds loaded by the manager.

This will allow me (and others) to for example use [SchemaValidation()](https://github.com/sn-atmos/crossplane/blob/88ef2c87716f038e16cd4e3d5be3b06e95143ffb/cmd/crank/beta/validate/validate.go#L99) which accepts `crds` as an argument, without having to reinvent the loading/caching/dependency resolving part.

Me and my team are currently working on an alternative testing framework, and want to add validation to it too, and use existing validation logic where we can. I'm aware there will be some changes (cli functionality being moved out), but i think this is a small reasonable change in the meantime.

But maybe there's a reason this field is unexported?

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [ ] Run `./nix.sh flake check` to ensure this PR is ready for review.
- [ ] Added or updated unit tests.
- [ ] Added or updated e2e tests.
- [ ] Linked a PR or a [docs tracking issue] to [document this change].
- [ ] Added `backport release-x.y` labels to auto-backport this PR.
- [ ] Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md
