### PR TITLE
chore(deps): bump Go to 1.25.9 [security] (release-2.0)

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -3,7 +3,7 @@ VERSION --try --raw-output 0.8
 
 PROJECT crossplane/crossplane
 
-ARG --global GO_VERSION=1.25.6
+ARG --global GO_VERSION=1.25.9
 
 # reviewable checks that a branch is ready for review. Run it before opening a
 # pull request. It will catch a lot of the things our CI workflow will catch.

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/crossplane/crossplane/v2
 
-go 1.25.6
+go 1.25.9
 
 require (
 	dario.cat/mergo v1.0.2


### PR DESCRIPTION
### Description of your changes

Bump the Go toolchain from 1.25.6 to 1.25.9 to address multiple stdlib CVEs:

- **Critical**: CVE-2025-68121
- **High**: CVE-2026-25679, CVE-2026-32280, CVE-2026-27140, CVE-2026-32283, CVE-2026-32281, CVE-2025-61732
- **Medium**: CVE-2026-27142, CVE-2026-32289, CVE-2026-32282, CVE-2026-32288
- **Low**: CVE-2026-27139

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `earthly +reviewable` to ensure this PR is ready for review.
- [ ] ~Added or updated unit tests.~
- [ ] ~Added or updated e2e tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~
- [ ] ~Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md