### PR TITLE
chore(deps): bump Go to 1.25.9 [security] (release-2.2)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -56,10 +56,27 @@
         "type": "github"
       }
     },
+    "nixpkgs-unstable": {
+      "locked": {
+        "lastModified": 1775888245,
+        "narHash": "sha256-nwASzrRDD1JBEu/o8ekKYEXm/oJW6EMCzCRdrwcLe90=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "13043924aaa7375ce482ebe2494338e058282925",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "gomod2nix": "gomod2nix",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "nixpkgs-unstable": "nixpkgs-unstable"
       }
     },
     "systems": {

--- a/flake.nix
+++ b/flake.nix
@@ -6,6 +6,7 @@
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.11";
+    nixpkgs-unstable.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
 
     # TODO(negz): Unpin once https://github.com/nix-community/gomod2nix/pull/231 is released.
     gomod2nix = {
@@ -18,6 +19,7 @@
     {
       self,
       nixpkgs,
+      nixpkgs-unstable,
       gomod2nix,
     }:
     let
@@ -87,7 +89,13 @@
           inherit system;
           pkgs = import nixpkgs {
             inherit system;
-            overlays = [ gomod2nix.overlays.default ];
+            overlays = [
+              gomod2nix.overlays.default
+              (final: prev: {
+                go = nixpkgs-unstable.legacyPackages.${system}.go_1_25;
+                go_1_25 = nixpkgs-unstable.legacyPackages.${system}.go_1_25;
+              })
+            ];
           };
         };
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/crossplane/crossplane/v2
 
-go 1.25.5
+go 1.25.9
 
 require (
 	dario.cat/mergo v1.0.2


### PR DESCRIPTION
### Description of your changes

Bump the Go toolchain from 1.25.5 to 1.25.9 to address multiple stdlib CVEs:

- **Critical**: CVE-2025-68121
- **High**: CVE-2026-25679, CVE-2026-32280, CVE-2026-27140, CVE-2026-32283, CVE-2026-32281, CVE-2025-61732
- **Medium**: CVE-2026-27142, CVE-2026-32289, CVE-2026-32282, CVE-2026-32288
- **Low**: CVE-2026-27139

Since `nixos-25.11` currently only provides Go 1.25.8, a dedicated `nixpkgs-go` input pointing to `nixpkgs-unstable` is added with an overlay that pins `pkgs.go` and `pkgs.go_1_25` to Go 1.25.9.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] ~Run `earthly +reviewable` to ensure this PR is ready for review.~
- [ ] ~Added or updated unit tests.~
- [ ] ~Added or updated e2e tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~
- [ ] ~Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md