### PR TITLE
Fix nix lint errors

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -91,9 +91,9 @@
             inherit system;
             overlays = [
               gomod2nix.overlays.default
-              (final: prev: {
+              (_final: _prev: {
                 go = nixpkgs-unstable.legacyPackages.${system}.go_1_25;
-                go_1_25 = nixpkgs-unstable.legacyPackages.${system}.go_1_25;
+                inherit (nixpkgs-unstable.legacyPackages.${system}) go_1_25;
               })
             ];
           };


### PR DESCRIPTION
### Description of your changes

After the new Go 1.25 overlay was added, I started seeing the following nix lint error in `nix flake check`:

```
crossplane-nix-lint> [W04] Warning: Assignment instead of inherit from
crossplane-nix-lint>     ╭─[/nix/store/8kj6883id251yccyq51zl1yc7163x43k-source/flake.nix:96:17]
crossplane-nix-lint>     │
crossplane-nix-lint>  96 │                 go_1_25 = nixpkgs-unstable.legacyPackages.${system}.go_1_25;
crossplane-nix-lint>     ·                 ──────────────────────────────┬─────────────────────────────
crossplane-nix-lint>     ·                                               ╰─────────────────────────────── This assignment is better written with inherit
crossplane-nix-lint> ────╯
```

I'm not sure why we don't see this issue in CI; could be a different nix version? This commit contains nix-lint's automated changes, generated by `nix run .#lint`.

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `./nix.sh flake check` to ensure this PR is ready for review.
~- [ ] Added or updated unit tests.~
~- [ ] Added or updated e2e tests.~
~- [ ] Linked a PR or a [docs tracking issue] to [document this change].~
- [x] Added `backport release-x.y` labels to auto-backport this PR.
~- [ ] Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md
