### PR TITLE
Backport #7323 to release-2.2

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -89,23 +89,22 @@
           inherit system;
           pkgs = import nixpkgs {
             inherit system;
-            overlays = [
-              gomod2nix.overlays.default
-              (_final: _prev: {
-                go = nixpkgs-unstable.legacyPackages.${system}.go_1_25;
-                inherit (nixpkgs-unstable.legacyPackages.${system}) go_1_25;
-              })
-            ];
+            overlays = [ gomod2nix.overlays.default ];
           };
+          # We use the go toolchain from unstable because it's been updated to
+          # v1.25.9. However, we thread this through only to our build targets
+          # rather than add it to the global overlay so that we can still use
+          # pre-built binaries for Go-based tools from nixpkgs.
+          unstableGo = nixpkgs-unstable.legacyPackages.${system}.go_1_25;
         };
 
     in
     {
       # Build outputs (nix build).
       packages = forAllSystems (
-        { pkgs, ... }:
+        { pkgs, unstableGo, ... }:
         let
-          build = import ./nix/build.nix { inherit pkgs self; };
+          build = import ./nix/build.nix { inherit pkgs self unstableGo; };
         in
         {
           default = build.release {
@@ -120,9 +119,9 @@
 
       # CI checks (nix flake check).
       checks = forAllSystems (
-        { pkgs, ... }:
+        { pkgs, unstableGo, ... }:
         let
-          checks = import ./nix/checks.nix { inherit pkgs self; };
+          checks = import ./nix/checks.nix { inherit pkgs self unstableGo; };
         in
         {
           test = checks.test { inherit version; };
@@ -136,10 +135,10 @@
 
       # Development commands (nix run .#<app>).
       apps = forAllSystems (
-        { pkgs, ... }:
+        { pkgs, unstableGo, ... }:
         let
-          build = import ./nix/build.nix { inherit pkgs self; };
-          apps = import ./nix/apps.nix { inherit pkgs; };
+          build = import ./nix/build.nix { inherit pkgs self unstableGo; };
+          apps = import ./nix/apps.nix { inherit pkgs unstableGo; };
           nativeArch = if pkgs.stdenv.hostPlatform.isAarch64 then "arm64" else "amd64";
           images = build.images {
             inherit version;
@@ -186,14 +185,14 @@
 
       # Development shell (nix develop).
       devShells = forAllSystems (
-        { pkgs, ... }:
+        { pkgs, unstableGo, ... }:
         {
           default = pkgs.mkShell {
             buildInputs = [
               pkgs.coreutils
               pkgs.gnused
               pkgs.ncurses
-              pkgs.go
+              unstableGo
               pkgs.golangci-lint
               pkgs.kubectl
               pkgs.kubernetes-helm

--- a/flake.nix
+++ b/flake.nix
@@ -89,22 +89,27 @@
           inherit system;
           pkgs = import nixpkgs {
             inherit system;
-            overlays = [ gomod2nix.overlays.default ];
+            overlays = [
+              gomod2nix.overlays.default
+              (_final: _prev: {
+                # We use the go toolchain from unstable because it's been
+                # updated to fix some CVEs. However, we explicitly use this only
+                # in our build targets rather than replace Go in the global
+                # overlay so that we can still use pre-built binaries for
+                # Go-based tools from nixpkgs.
+                go-unstable = nixpkgs-unstable.legacyPackages.${system}.go_1_25;
+              })
+            ];
           };
-          # We use the go toolchain from unstable because it's been updated to
-          # v1.25.9. However, we thread this through only to our build targets
-          # rather than add it to the global overlay so that we can still use
-          # pre-built binaries for Go-based tools from nixpkgs.
-          unstableGo = nixpkgs-unstable.legacyPackages.${system}.go_1_25;
         };
 
     in
     {
       # Build outputs (nix build).
       packages = forAllSystems (
-        { pkgs, unstableGo, ... }:
+        { pkgs, ... }:
         let
-          build = import ./nix/build.nix { inherit pkgs self unstableGo; };
+          build = import ./nix/build.nix { inherit pkgs self; };
         in
         {
           default = build.release {
@@ -119,9 +124,9 @@
 
       # CI checks (nix flake check).
       checks = forAllSystems (
-        { pkgs, unstableGo, ... }:
+        { pkgs, ... }:
         let
-          checks = import ./nix/checks.nix { inherit pkgs self unstableGo; };
+          checks = import ./nix/checks.nix { inherit pkgs self; };
         in
         {
           test = checks.test { inherit version; };
@@ -135,10 +140,10 @@
 
       # Development commands (nix run .#<app>).
       apps = forAllSystems (
-        { pkgs, unstableGo, ... }:
+        { pkgs, ... }:
         let
-          build = import ./nix/build.nix { inherit pkgs self unstableGo; };
-          apps = import ./nix/apps.nix { inherit pkgs unstableGo; };
+          build = import ./nix/build.nix { inherit pkgs self; };
+          apps = import ./nix/apps.nix { inherit pkgs; };
           nativeArch = if pkgs.stdenv.hostPlatform.isAarch64 then "arm64" else "amd64";
           images = build.images {
             inherit version;
@@ -185,14 +190,14 @@
 
       # Development shell (nix develop).
       devShells = forAllSystems (
-        { pkgs, unstableGo, ... }:
+        { pkgs, ... }:
         {
           default = pkgs.mkShell {
             buildInputs = [
               pkgs.coreutils
               pkgs.gnused
               pkgs.ncurses
-              unstableGo
+              pkgs.go-unstable
               pkgs.golangci-lint
               pkgs.kubectl
               pkgs.kubernetes-helm

--- a/nix/apps.nix
+++ b/nix/apps.nix
@@ -12,7 +12,7 @@
 #
 # Each app declares its tool dependencies via runtimeInputs, with inheritPath
 # set to false. This ensures apps only use explicitly declared tools.
-{ pkgs, unstableGo }:
+{ pkgs }:
 {
   # Run Go unit tests.
   test = _: {
@@ -21,7 +21,7 @@
     program = pkgs.lib.getExe (
       pkgs.writeShellApplication {
         name = "crossplane-test";
-        runtimeInputs = [ unstableGo ];
+        runtimeInputs = [ pkgs.go-unstable ];
         inheritPath = false;
         text = ''
           export CGO_ENABLED=0
@@ -40,7 +40,7 @@
         name = "crossplane-lint";
         runtimeInputs = [
           pkgs.findutils
-          unstableGo
+          pkgs.go-unstable
           pkgs.golangci-lint
           pkgs.statix
           pkgs.deadnix
@@ -83,7 +83,7 @@
         runtimeInputs = [
           pkgs.coreutils
           pkgs.gnused
-          unstableGo
+          pkgs.go-unstable
           pkgs.kubectl
           pkgs.helm-docs
 
@@ -125,7 +125,7 @@
       pkgs.writeShellApplication {
         name = "crossplane-tidy";
         runtimeInputs = [
-          unstableGo
+          pkgs.go-unstable
           pkgs.gomod2nix
         ];
         inheritPath = false;
@@ -165,7 +165,7 @@
           name = "crossplane-e2e";
           runtimeInputs = [
             pkgs.coreutils
-            unstableGo
+            pkgs.go-unstable
             pkgs.docker-client
             pkgs.gotestsum
             pkgs.kind

--- a/nix/apps.nix
+++ b/nix/apps.nix
@@ -12,7 +12,7 @@
 #
 # Each app declares its tool dependencies via runtimeInputs, with inheritPath
 # set to false. This ensures apps only use explicitly declared tools.
-{ pkgs }:
+{ pkgs, unstableGo }:
 {
   # Run Go unit tests.
   test = _: {
@@ -21,7 +21,7 @@
     program = pkgs.lib.getExe (
       pkgs.writeShellApplication {
         name = "crossplane-test";
-        runtimeInputs = [ pkgs.go ];
+        runtimeInputs = [ unstableGo ];
         inheritPath = false;
         text = ''
           export CGO_ENABLED=0
@@ -40,7 +40,7 @@
         name = "crossplane-lint";
         runtimeInputs = [
           pkgs.findutils
-          pkgs.go
+          unstableGo
           pkgs.golangci-lint
           pkgs.statix
           pkgs.deadnix
@@ -83,7 +83,7 @@
         runtimeInputs = [
           pkgs.coreutils
           pkgs.gnused
-          pkgs.go
+          unstableGo
           pkgs.kubectl
           pkgs.helm-docs
 
@@ -125,7 +125,7 @@
       pkgs.writeShellApplication {
         name = "crossplane-tidy";
         runtimeInputs = [
-          pkgs.go
+          unstableGo
           pkgs.gomod2nix
         ];
         inheritPath = false;
@@ -165,7 +165,7 @@
           name = "crossplane-e2e";
           runtimeInputs = [
             pkgs.coreutils
-            pkgs.go
+            unstableGo
             pkgs.docker-client
             pkgs.gotestsum
             pkgs.kind

--- a/nix/build.nix
+++ b/nix/build.nix
@@ -7,11 +7,7 @@
 #   pkgs.buildGoApplication - gomod2nix's Go builder (https://github.com/nix-community/gomod2nix)
 #   pkgs.dockerTools        - Build OCI images without Docker (https://nixos.org/manual/nixpkgs/stable/#sec-pkgs-dockerTools)
 #   pkgs.runCommand         - Run a shell script, capture output directory as $out
-{
-  pkgs,
-  self,
-  unstableGo,
-}:
+{ pkgs, self }:
 let
   # Build a Go binary for a specific platform.
   goBinary =
@@ -33,7 +29,7 @@ let
       subPackages = [ subPackage ];
 
       # Cross-compile by merging GOOS/GOARCH into Go's attrset (// merges attrsets).
-      go = unstableGo // {
+      go = pkgs.go-unstable // {
         GOOS = platform.os;
         GOARCH = platform.arch;
       };
@@ -207,7 +203,7 @@ in
       src = self;
       pwd = self;
       modules = "${self}/gomod2nix.toml";
-      go = unstableGo;
+      go = pkgs.go-unstable;
 
       CGO_ENABLED = "0";
 

--- a/nix/build.nix
+++ b/nix/build.nix
@@ -7,7 +7,11 @@
 #   pkgs.buildGoApplication - gomod2nix's Go builder (https://github.com/nix-community/gomod2nix)
 #   pkgs.dockerTools        - Build OCI images without Docker (https://nixos.org/manual/nixpkgs/stable/#sec-pkgs-dockerTools)
 #   pkgs.runCommand         - Run a shell script, capture output directory as $out
-{ pkgs, self }:
+{
+  pkgs,
+  self,
+  unstableGo,
+}:
 let
   # Build a Go binary for a specific platform.
   goBinary =
@@ -29,7 +33,7 @@ let
       subPackages = [ subPackage ];
 
       # Cross-compile by merging GOOS/GOARCH into Go's attrset (// merges attrsets).
-      go = pkgs.go // {
+      go = unstableGo // {
         GOOS = platform.os;
         GOARCH = platform.arch;
       };
@@ -203,6 +207,7 @@ in
       src = self;
       pwd = self;
       modules = "${self}/gomod2nix.toml";
+      go = unstableGo;
 
       CGO_ENABLED = "0";
 

--- a/nix/checks.nix
+++ b/nix/checks.nix
@@ -9,7 +9,11 @@
 #
 # All checks are builder functions that take an attrset of arguments and return
 # a derivation. The actual check definitions live in flake.nix.
-{ pkgs, self }:
+{
+  pkgs,
+  self,
+  unstableGo,
+}:
 {
   # Run Go unit tests with coverage
   test =
@@ -20,6 +24,7 @@
       src = self;
       pwd = self;
       modules = ../gomod2nix.toml;
+      go = unstableGo;
 
       CGO_ENABLED = "0";
 
@@ -47,6 +52,7 @@
       src = self;
       pwd = self;
       modules = ../gomod2nix.toml;
+      go = unstableGo;
 
       CGO_ENABLED = "0";
 
@@ -90,6 +96,7 @@
       src = self;
       pwd = self;
       modules = ../gomod2nix.toml;
+      go = unstableGo;
 
       CGO_ENABLED = "0";
 

--- a/nix/checks.nix
+++ b/nix/checks.nix
@@ -9,11 +9,7 @@
 #
 # All checks are builder functions that take an attrset of arguments and return
 # a derivation. The actual check definitions live in flake.nix.
-{
-  pkgs,
-  self,
-  unstableGo,
-}:
+{ pkgs, self }:
 {
   # Run Go unit tests with coverage
   test =
@@ -24,7 +20,7 @@
       src = self;
       pwd = self;
       modules = ../gomod2nix.toml;
-      go = unstableGo;
+      go = pkgs.go-unstable;
 
       CGO_ENABLED = "0";
 
@@ -52,7 +48,7 @@
       src = self;
       pwd = self;
       modules = ../gomod2nix.toml;
-      go = unstableGo;
+      go = pkgs.go-unstable;
 
       CGO_ENABLED = "0";
 
@@ -96,7 +92,7 @@
       src = self;
       pwd = self;
       modules = ../gomod2nix.toml;
-      go = unstableGo;
+      go = pkgs.go-unstable;
 
       CGO_ENABLED = "0";
 


### PR DESCRIPTION
### Description of your changes

Manual backport of #7323 to release-2.2, resolving conflicts related to the apis module.

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `./nix.sh flake check` to ensure this PR is ready for review.
~- [ ] Added or updated unit tests.~
~- [ ] Added or updated e2e tests.~
~- [ ] Linked a PR or a [docs tracking issue] to [document this change].~
~- [ ] Added `backport release-x.y` labels to auto-backport this PR.~
~- [ ] Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md
