### PR TITLE
fix: preserve accumulated events when a composed resource apply fails

### DIFF
--- a/internal/controller/apiextensions/composite/composition_functions.go
+++ b/internal/controller/apiextensions/composite/composition_functions.go
@@ -627,7 +627,13 @@ func (c *FunctionComposer) Compose(ctx context.Context, xr *composite.Unstructur
 				continue
 			}
 
-			return CompositionResult{}, xerrors.ComposedResourceError{
+			// Include events and resources accumulated so far (e.g. from
+			// IsInvalid errors on other resources) so they're not lost when
+			// the caller handles this error.
+			return CompositionResult{
+				Events:   events,
+				Composed: resources,
+			}, xerrors.ComposedResourceError{
 				Message:  fmt.Sprintf(errFmtApplyCD, name),
 				Composed: cd.Resource,
 				Err:      err,

--- a/internal/controller/apiextensions/composite/composition_functions_test.go
+++ b/internal/controller/apiextensions/composite/composition_functions_test.go
@@ -1084,6 +1084,100 @@ func TestFunctionCompose(t *testing.T) {
 				},
 			},
 		},
+		"ApplyComposedResourceErrorPreservesEvents": {
+			reason: "When applying a composed resource fails with a non-invalid error, previously accumulated events (e.g. from function pipeline warnings) should be preserved in the returned result.",
+			params: params{
+				c: &test.MockClient{
+					MockGet: test.NewMockGetFn(kerrors.NewNotFound(schema.GroupResource{Resource: "UncoolComposed"}, "")),
+					MockPatch: test.NewMockPatchFn(nil, func(obj client.Object) error {
+						switch obj.(type) {
+						case *composed.Unstructured:
+							return errBoom
+						default:
+						}
+						return nil
+					}),
+					MockStatusPatch: test.NewMockSubResourcePatchFn(nil),
+				},
+				uc: &test.MockClient{
+					MockGet: test.NewMockGetFn(errBoom),
+				},
+				r: FunctionRunnerFn(func(_ context.Context, _ string, _ *fnv1.RunFunctionRequest) (rsp *fnv1.RunFunctionResponse, err error) {
+					d := &fnv1.State{
+						Resources: map[string]*fnv1.Resource{
+							"uncool-resource": {
+								Resource: MustStruct(map[string]any{
+									"apiVersion": "test.crossplane.io/v1",
+									"kind":       "UncoolComposed",
+								}),
+							},
+						},
+					}
+					return &fnv1.RunFunctionResponse{
+						Desired: d,
+						Results: []*fnv1.Result{
+							{
+								Severity: fnv1.Severity_SEVERITY_WARNING,
+								Message:  "something went wrong in the pipeline",
+							},
+						},
+					}, nil
+				}),
+				o: []FunctionComposerOption{
+					WithCompositeConnectionDetailsFetcher(ConnectionDetailsFetcherFn(func(_ context.Context, _ ConnectionSecretOwner) (managed.ConnectionDetails, error) {
+						return nil, nil
+					})),
+					WithComposedResourceObserver(ComposedResourceObserverFn(func(_ context.Context, _ resource.Composite) (ComposedResourceStates, error) {
+						return nil, nil
+					})),
+					WithComposedResourceGarbageCollector(ComposedResourceGarbageCollectorFn(func(_ context.Context, _ metav1.Object, _, _ ComposedResourceStates) error {
+						return nil
+					})),
+				},
+			},
+			args: args{
+				xr: WithParentLabel(),
+				req: CompositionRequest{
+					Revision: &v1.CompositionRevision{
+						Spec: v1.CompositionRevisionSpec{
+							Pipeline: []v1.PipelineStep{
+								{
+									Step:        "run-cool-function",
+									FunctionRef: v1.FunctionReference{Name: "cool-function"},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: want{
+				res: CompositionResult{
+					Events: []TargetedEvent{
+						{
+							Event: event.Event{
+								Type:    "Warning",
+								Reason:  "ComposeResources",
+								Message: "something went wrong in the pipeline",
+							},
+							Detail: `Pipeline step "run-cool-function"`,
+							Target: CompositionTargetComposite,
+						},
+					},
+				},
+				err: xerrors.ComposedResourceError{
+					Message: fmt.Sprintf(errFmtApplyCD, "uncool-resource"),
+					Composed: &composed.Unstructured{
+						Unstructured: unstructured.Unstructured{
+							Object: map[string]any{
+								"apiVersion": "test.crossplane.io/v1",
+								"kind":       "UncoolComposed",
+							},
+						},
+					},
+					Err: errBoom,
+				},
+			},
+		},
 		"BootstrapRequirementsError": {
 			reason: "We should return an error if we can't fetch bootstrap requirements",
 			params: params{


### PR DESCRIPTION
### Description of your changes

  When applying a composed resource fails with a non-invalid error (e.g. namespace not found), the early return previously dropped all events accumulated before that point — including `IsInvalid` warnings from other resources and warnings from
  the function pipeline. This caused the root cause error to be hidden from users behind a less informative downstream error.

  Fix by including the accumulated `events` and `resources` in the `CompositionResult` returned alongside the error, so `handleCommonCompositionResult` still emits them.

  Fixes #7335

  I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

  - [x] Read and followed Crossplane's [contribution process].
  - [ ] ~Run `./nix.sh flake check` to ensure this PR is ready for review.~
  - [x] Added or updated unit tests.
  - [ ] ~Added or updated e2e tests.~
  - [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
  - [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~
  - [ ] ~Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~

  [contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
  [docs tracking issue]: https://github.com/crossplane/docs/issues/new
  [document this change]: https://docs.crossplane.io/contribute/contribute
  [cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
  [API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md