### PR TITLE
fix(webhook/usage): nil-guard ResourceRef in inUseMessage for selector-only Usage

### DIFF
--- a/internal/webhook/protection/usage/handler.go
+++ b/internal/webhook/protection/usage/handler.go
@@ -171,7 +171,16 @@ func inUseMessage(u []protection.Usage) string {
 	}
 
 	if by != nil {
-		return fmt.Sprintf("This resource is in-use by %d usage(s), including the %T %s by resource %s/%s.", len(u), uu, id, by.Kind, by.ResourceRef.Name)
+		// spec.by validates as "either resourceRef or resourceSelector
+		// should be set", so ResourceRef can legitimately be nil on a
+		// selector-based reference (#7243). Only format the referenced
+		// object when we actually have a name - otherwise fall back to
+		// the kind-only form so the webhook does not nil-deref and
+		// panic under recover.
+		if by.ResourceRef != nil {
+			return fmt.Sprintf("This resource is in-use by %d usage(s), including the %T %s by resource %s/%s.", len(u), uu, id, by.Kind, by.ResourceRef.Name)
+		}
+		return fmt.Sprintf("This resource is in-use by %d usage(s), including the %T %s by a %s selected via resourceSelector.", len(u), uu, id, by.Kind)
 	}
 
 	if r := ptr.Deref(first.GetReason(), ""); r != "" {


### PR DESCRIPTION
## What

Fixes #7243.

The no-usages admission webhook's `inUseMessage` formatted the `by` reference as `%s/%s, by.Kind, by.ResourceRef.Name` whenever `by != nil`. `spec.by` is validated at the API level as 'either resourceRef or resourceSelector should be set', so a legitimately configured `Usage` / `ClusterUsage` can carry a selector-only reference (no `resourceRef`). Deleting the referenced resource then dereferenced a nil `by.ResourceRef` and tripped a recovered panic that surfaced to the client as:

```
admission webhook 'nousages.protection.crossplane.io' denied the request:
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
```

## Fix

Check `by.ResourceRef` before touching `.Name`. When the reference is name-based, keep the existing message verbatim. When it is selector-based, fall back to `by a <kind> selected via resourceSelector.` so the user still gets a meaningful denial message. No change for the selector-less happy path.

## Verification

Locally on macOS, go 1.26.2:
- `gofmt -s -l internal/webhook/protection/usage/`: clean
- `go vet ./internal/webhook/protection/usage/...`: clean
- `go test -race -count=1 ./internal/webhook/protection/usage/...`: pass

Closes #7243