### PR TITLE
fix empty secret name behavior and allow reading PKI from disk

### DIFF
--- a/cmd/crossplane/core/core.go
+++ b/cmd/crossplane/core/core.go
@@ -130,6 +130,13 @@ type startCommand struct {
 	TLSClientSecretName string `env:"TLS_CLIENT_SECRET_NAME" help:"The name of the TLS Secret that will be store Crossplane's client certificate."`
 	TLSClientCertsDir   string `env:"TLS_CLIENT_CERTS_DIR"   help:"The path of the folder which will store TLS client certificate of Crossplane."`
 
+	TLSClientCACertFileName string `env:"TLS_CLIENT_CA_CERT_FILENAME" help:"The filename of the CA certificate in the TLS client certs directory."`
+	TLSClientCertFileName   string `env:"TLS_CLIENT_CERT_FILENAME"    help:"The filename of the client certificate in the TLS client certs directory."`
+	TLSClientKeyFileName    string `env:"TLS_CLIENT_KEY_FILENAME"     help:"The filename of the client private key in the TLS client certs directory."`
+
+	TLSServerCertFileName string `env:"TLS_SERVER_CERT_FILENAME" help:"The filename of the server certificate in the TLS server certs directory."`
+	TLSServerKeyFileName  string `env:"TLS_SERVER_KEY_FILENAME"  help:"The filename of the server private key in the TLS server certs directory."`
+
 	EnableDependencyVersionUpgrades   bool `group:"Alpha Features:" help:"Enable support for upgrading dependency versions when the parent package is updated."`
 	EnableDependencyVersionDowngrades bool `group:"Alpha Features:" help:"Enable support for upgrading and downgrading dependency versions when a dependent package is updated."`
 	EnableSignatureVerification       bool `group:"Alpha Features:" help:"Enable support for package signature verification via ImageConfig API."`
@@ -161,6 +168,22 @@ type startCommand struct {
 
 // Run core Crossplane controllers.
 func (c *startCommand) Run(s *runtime.Scheme, log logging.Logger) error { //nolint:gocognit // Only slightly over.
+	if c.TLSClientCACertFileName == "" {
+		c.TLSClientCACertFileName = initializer.SecretKeyCACert
+	}
+	if c.TLSClientCertFileName == "" {
+		c.TLSClientCertFileName = corev1.TLSCertKey
+	}
+	if c.TLSClientKeyFileName == "" {
+		c.TLSClientKeyFileName = corev1.TLSPrivateKeyKey
+	}
+	if c.TLSServerCertFileName == "" {
+		c.TLSServerCertFileName = corev1.TLSCertKey
+	}
+	if c.TLSServerKeyFileName == "" {
+		c.TLSServerKeyFileName = corev1.TLSPrivateKeyKey
+	}
+
 	if c.EnableCompositionWebhookSchemaValidation {
 		//nolint:revive // This is long and easier to read with punctuation.
 		return errors.New("Crossplane now uses CEL to validate Compositions. The --enable-composition-webhook-schema-validation flag will be removed in a future release.")
@@ -208,7 +231,9 @@ func (c *startCommand) Run(s *runtime.Scheme, log logging.Logger) error { //noli
 		Scheme: s,
 		Cache:  cacheOptions,
 		WebhookServer: webhook.NewServer(webhook.Options{
-			CertDir: c.TLSServerCertsDir,
+			CertDir:  c.TLSServerCertsDir,
+			CertName: c.TLSServerCertFileName,
+			KeyName:  c.TLSServerKeyFileName,
 			TLSOpts: []func(*tls.Config){
 				func(t *tls.Config) {
 					t.MinVersion = tls.VersionTLS13
@@ -274,9 +299,9 @@ func (c *startCommand) Run(s *runtime.Scheme, log logging.Logger) error { //noli
 	}
 
 	clienttls, err := certificates.LoadMTLSConfig(
-		filepath.Join(c.TLSClientCertsDir, initializer.SecretKeyCACert),
-		filepath.Join(c.TLSClientCertsDir, corev1.TLSCertKey),
-		filepath.Join(c.TLSClientCertsDir, corev1.TLSPrivateKeyKey),
+		filepath.Join(c.TLSClientCertsDir, c.TLSClientCACertFileName),
+		filepath.Join(c.TLSClientCertsDir, c.TLSClientCertFileName),
+		filepath.Join(c.TLSClientCertsDir, c.TLSClientKeyFileName),
 		false)
 	if err != nil {
 		return errors.Wrap(err, "cannot load client TLS certificates")

--- a/cmd/crossplane/core/init.go
+++ b/cmd/crossplane/core/init.go
@@ -19,6 +19,7 @@ package core
 import (
 	"context"
 	"fmt"
+	"path/filepath"
 
 	admv1 "k8s.io/api/admissionregistration/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -53,6 +54,9 @@ type initCommand struct {
 	TLSCASecretName         string `env:"TLS_CA_SECRET_NAME"        help:"The name of the Secret that the initializer will fill with TLS CA certificate."`
 	TLSServerSecretName     string `env:"TLS_SERVER_SECRET_NAME"    help:"The name of the Secret that the initializer will fill with TLS server certificates."`
 	TLSClientSecretName     string `env:"TLS_CLIENT_SECRET_NAME"    help:"The name of the Secret that the initializer will fill with TLS client certificates."`
+
+	WebhookTLSCertDir string `env:"WEBHOOK_TLS_CERT_DIR" help:"Directory containing TLS certificates for webhooks. When set, certificates are read from files instead of Secrets."`
+	WebhookTLSCACert  string `env:"WEBHOOK_TLS_CA_CERT"  help:"Filename of the CA certificate within the TLS cert directory."`
 }
 
 // Run starts the initialization process.
@@ -65,6 +69,10 @@ func (c *initCommand) Run(s *runtime.Scheme, log logging.Logger) error {
 	cl, err := client.New(cfg, client.Options{Scheme: s})
 	if err != nil {
 		return errors.Wrap(err, "cannot create new kubernetes client")
+	}
+
+	if c.WebhookTLSCACert == "" {
+		c.WebhookTLSCACert = initializer.SecretKeyCACert
 	}
 
 	var steps []initializer.Step
@@ -91,18 +99,28 @@ func (c *initCommand) Run(s *runtime.Scheme, log logging.Logger) error {
 			),
 		)
 
-		nn := types.NamespacedName{
-			Name:      c.TLSServerSecretName,
-			Namespace: c.Namespace,
-		}
 		svc := admv1.ServiceReference{
 			Name:      c.WebhookServiceName,
 			Namespace: c.WebhookServiceNamespace,
 			Port:      &c.WebhookServicePort,
 		}
-		steps = append(steps,
-			initializer.NewCoreCRDs(c.CRDsPath, s, initializer.WithWebhookTLSSecretRef(nn)),
-			initializer.NewWebhookConfigurations(c.WebhookConfigurationsPath, s, nn, svc))
+
+		var caProvider initializer.WebhookCAProvider
+		if c.WebhookTLSCertDir != "" {
+			caProvider = &initializer.FileCAProvider{Path: filepath.Join(c.WebhookTLSCertDir, c.WebhookTLSCACert)}
+			steps = append(steps,
+				initializer.NewCoreCRDs(c.CRDsPath, s),
+				initializer.NewWebhookConfigurations(c.WebhookConfigurationsPath, s, caProvider, svc))
+		} else {
+			nn := types.NamespacedName{
+				Name:      c.TLSServerSecretName,
+				Namespace: c.Namespace,
+			}
+			caProvider = &initializer.SecretCAProvider{SecretRef: nn}
+			steps = append(steps,
+				initializer.NewCoreCRDs(c.CRDsPath, s, initializer.WithWebhookTLSSecretRef(nn)),
+				initializer.NewWebhookConfigurations(c.WebhookConfigurationsPath, s, caProvider, svc))
+		}
 	} else {
 		log.Info("Warning: Webhooks are disabled, so deprecated ValidatingWebhookConfigurations will not be automatically deleted.")
 		steps = append(steps,

--- a/internal/initializer/tls.go
+++ b/internal/initializer/tls.go
@@ -89,16 +89,24 @@ func TLSCertificateGeneratorWithOwner(owner []metav1.OwnerReference) TLSCertific
 }
 
 // TLSCertificateGeneratorWithServerSecretName returns an TLSCertificateGeneratorOption that sets server secret name.
+// If the secret name is empty, the option is a no-op.
 func TLSCertificateGeneratorWithServerSecretName(s string, dnsNames []string) TLSCertificateGeneratorOption {
 	return func(g *TLSCertificateGenerator) {
+		if s == "" {
+			return
+		}
 		g.tlsServerSecretName = &s
 		g.tlsServerDNSNames = dnsNames
 	}
 }
 
 // TLSCertificateGeneratorWithClientSecretName returns an TLSCertificateGeneratorOption that sets client secret name.
+// If the secret name is empty, the option is a no-op.
 func TLSCertificateGeneratorWithClientSecretName(s string, subjects []string) TLSCertificateGeneratorOption {
 	return func(g *TLSCertificateGenerator) {
+		if s == "" {
+			return
+		}
 		g.tlsClientSecretName = &s
 		g.tlsClientDNSNames = subjects
 	}

--- a/internal/initializer/tls_test.go
+++ b/internal/initializer/tls_test.go
@@ -707,6 +707,37 @@ func TestTLSCertificateGeneratorRun(t *testing.T) {
 			},
 			want: want{err: nil},
 		},
+		"EmptyServerSecretNameIsNoOp": {
+			reason: "Passing an empty server secret name should not set tlsServerSecretName, so Run returns nil immediately.",
+			args: args{
+				kube: &test.MockClient{},
+				opts: []TLSCertificateGeneratorOption{
+					TLSCertificateGeneratorWithServerSecretName("", []string{subject}),
+				},
+			},
+			want: want{err: nil},
+		},
+		"EmptyClientSecretNameIsNoOp": {
+			reason: "Passing an empty client secret name should not set tlsClientSecretName, so Run returns nil immediately.",
+			args: args{
+				kube: &test.MockClient{},
+				opts: []TLSCertificateGeneratorOption{
+					TLSCertificateGeneratorWithClientSecretName("", []string{subject}),
+				},
+			},
+			want: want{err: nil},
+		},
+		"EmptyBothSecretNamesIsNoOp": {
+			reason: "Passing empty secret names for both server and client should result in no work done.",
+			args: args{
+				kube: &test.MockClient{},
+				opts: []TLSCertificateGeneratorOption{
+					TLSCertificateGeneratorWithServerSecretName("", []string{subject}),
+					TLSCertificateGeneratorWithClientSecretName("", []string{subject}),
+				},
+			},
+			want: want{err: nil},
+		},
 		"OnlyClientCertificateSuccessfulGeneratedClientCert": {
 			reason: "It should be successful if the client certificate is generated and put into the Secret.",
 			args: args{

--- a/internal/initializer/webhook_configurations.go
+++ b/internal/initializer/webhook_configurations.go
@@ -18,6 +18,7 @@ package initializer
 
 import (
 	"context"
+	"os"
 
 	"github.com/spf13/afero"
 	admv1 "k8s.io/api/admissionregistration/v1"
@@ -35,7 +36,52 @@ import (
 const (
 	errApplyWebhookConfiguration = "cannot apply webhook configuration"
 	errGetWebhookSecret          = "cannot get webhook secret"
+	errReadCABundleFile          = "cannot read CA bundle file"
+	errEmptyCABundleFile         = "CA bundle file is empty"
 )
+
+// WebhookCAProvider provides a CA bundle for webhook configurations.
+type WebhookCAProvider interface {
+	GetCABundle(ctx context.Context, kube client.Client) ([]byte, error)
+}
+
+// SecretCAProvider loads the CA bundle from a Kubernetes Secret.
+type SecretCAProvider struct {
+	SecretRef types.NamespacedName
+}
+
+// GetCABundle returns the CA bundle from a Kubernetes Secret.
+func (p *SecretCAProvider) GetCABundle(ctx context.Context, kube client.Client) ([]byte, error) {
+	s := &corev1.Secret{}
+	if err := kube.Get(ctx, p.SecretRef, s); err != nil {
+		return nil, errors.Wrap(err, errGetWebhookSecret)
+	}
+
+	if len(s.Data["tls.crt"]) == 0 {
+		return nil, errors.Errorf(errFmtNoTLSCrtInSecret, p.SecretRef.String())
+	}
+
+	return s.Data["tls.crt"], nil
+}
+
+// FileCAProvider loads the CA bundle from a file.
+type FileCAProvider struct {
+	Path string
+}
+
+// GetCABundle returns the CA bundle from a file on disk.
+func (p *FileCAProvider) GetCABundle(_ context.Context, _ client.Client) ([]byte, error) {
+	data, err := os.ReadFile(p.Path)
+	if err != nil {
+		return nil, errors.Wrap(err, errReadCABundleFile)
+	}
+
+	if len(data) == 0 {
+		return nil, errors.New(errEmptyCABundleFile)
+	}
+
+	return data, nil
+}
 
 // WithWebhookConfigurationsFs is used to configure the filesystem the CRDs will
 // be read from. Its default is afero.OsFs.
@@ -45,15 +91,22 @@ func WithWebhookConfigurationsFs(fs afero.Fs) WebhookConfigurationsOption {
 	}
 }
 
+// WithWebhookCAProvider sets the CA provider for webhook configurations.
+func WithWebhookCAProvider(provider WebhookCAProvider) WebhookConfigurationsOption {
+	return func(c *WebhookConfigurations) {
+		c.caProvider = provider
+	}
+}
+
 // WebhookConfigurationsOption configures WebhookConfigurations step.
 type WebhookConfigurationsOption func(*WebhookConfigurations)
 
 // NewWebhookConfigurations returns a new *WebhookConfigurations.
-func NewWebhookConfigurations(path string, s *runtime.Scheme, tlsSecretRef types.NamespacedName, svc admv1.ServiceReference, opts ...WebhookConfigurationsOption) *WebhookConfigurations {
+func NewWebhookConfigurations(path string, s *runtime.Scheme, caProvider WebhookCAProvider, svc admv1.ServiceReference, opts ...WebhookConfigurationsOption) *WebhookConfigurations {
 	c := &WebhookConfigurations{
 		Path:             path,
 		Scheme:           s,
-		TLSSecretRef:     tlsSecretRef,
+		caProvider:       caProvider,
 		ServiceReference: svc,
 		fs:               afero.NewOsFs(),
 	}
@@ -69,7 +122,7 @@ func NewWebhookConfigurations(path string, s *runtime.Scheme, tlsSecretRef types
 type WebhookConfigurations struct {
 	Path             string
 	Scheme           *runtime.Scheme
-	TLSSecretRef     types.NamespacedName
+	caProvider       WebhookCAProvider
 	ServiceReference admv1.ServiceReference
 
 	fs afero.Fs
@@ -78,16 +131,10 @@ type WebhookConfigurations struct {
 // Run applies all webhook ValidatingWebhookConfigurations and
 // MutatingWebhookConfiguration in the given directory.
 func (c *WebhookConfigurations) Run(ctx context.Context, kube client.Client) error {
-	s := &corev1.Secret{}
-	if err := kube.Get(ctx, c.TLSSecretRef, s); err != nil {
-		return errors.Wrap(err, errGetWebhookSecret)
+	caBundle, err := c.caProvider.GetCABundle(ctx, kube)
+	if err != nil {
+		return err
 	}
-
-	if len(s.Data["tls.crt"]) == 0 {
-		return errors.Errorf(errFmtNoTLSCrtInSecret, c.TLSSecretRef.String())
-	}
-
-	caBundle := s.Data["tls.crt"]
 
 	r, err := parser.NewFsBackend(c.fs,
 		parser.FsDir(c.Path),

--- a/internal/initializer/webhook_configurations_test.go
+++ b/internal/initializer/webhook_configurations_test.go
@@ -19,6 +19,7 @@ package initializer
 import (
 	"bytes"
 	"context"
+	"os"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -37,11 +38,136 @@ import (
 	"github.com/crossplane/crossplane-runtime/v2/pkg/test"
 )
 
-func TestWebhookConfigurations(t *testing.T) {
+func TestSecretCAProvider(t *testing.T) {
 	type args struct {
 		kube client.Client
-		svc  admv1.ServiceReference
-		opts []WebhookConfigurationsOption
+		ref  types.NamespacedName
+	}
+
+	type want struct {
+		ca  []byte
+		err error
+	}
+
+	cases := map[string]struct {
+		reason string
+		args   args
+		want   want
+	}{
+		"Success": {
+			reason: "It should return the CA bundle from the secret.",
+			args: args{
+				ref: types.NamespacedName{Name: "my-secret", Namespace: "ns"},
+				kube: &test.MockClient{
+					MockGet: func(_ context.Context, _ client.ObjectKey, obj client.Object) error {
+						s := &corev1.Secret{
+							Data: map[string][]byte{"tls.crt": []byte("CABUNDLE")},
+						}
+						s.DeepCopyInto(obj.(*corev1.Secret))
+						return nil
+					},
+				},
+			},
+			want: want{
+				ca: []byte("CABUNDLE"),
+			},
+		},
+		"GetError": {
+			reason: "It should return an error if the secret cannot be retrieved.",
+			args: args{
+				ref:  types.NamespacedName{Name: "my-secret", Namespace: "ns"},
+				kube: &test.MockClient{MockGet: test.NewMockGetFn(errBoom)},
+			},
+			want: want{
+				err: errors.Wrap(errBoom, errGetWebhookSecret),
+			},
+		},
+		"EmptyCert": {
+			reason: "It should return an error if the secret has no tls.crt data.",
+			args: args{
+				ref:  types.NamespacedName{Name: "my-secret", Namespace: "ns"},
+				kube: &test.MockClient{MockGet: test.NewMockGetFn(nil)},
+			},
+			want: want{
+				err: errors.Errorf(errFmtNoTLSCrtInSecret, "ns/my-secret"),
+			},
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			p := &SecretCAProvider{SecretRef: tc.args.ref}
+			ca, err := p.GetCABundle(context.TODO(), tc.args.kube)
+			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
+				t.Errorf("\n%s\nGetCABundle(...): -want err, +got err:\n%s", tc.reason, diff)
+			}
+			if diff := cmp.Diff(tc.want.ca, ca); diff != "" {
+				t.Errorf("\n%s\nGetCABundle(...): -want ca, +got ca:\n%s", tc.reason, diff)
+			}
+		})
+	}
+}
+
+func TestFileCAProvider(t *testing.T) {
+	type want struct {
+		ca  []byte
+		err error
+	}
+
+	validDir := t.TempDir()
+	validPath := validDir + "/ca.crt"
+	_ = os.WriteFile(validPath, []byte("CABUNDLE"), 0o644)
+
+	emptyDir := t.TempDir()
+	emptyPath := emptyDir + "/ca.crt"
+	_ = os.WriteFile(emptyPath, []byte{}, 0o644)
+
+	cases := map[string]struct {
+		reason string
+		path   string
+		want   want
+	}{
+		"Success": {
+			reason: "It should return the CA bundle from the file.",
+			path:   validPath,
+			want: want{
+				ca: []byte("CABUNDLE"),
+			},
+		},
+		"FileNotFound": {
+			reason: "It should return an error if the file does not exist.",
+			path:   "/nonexistent/ca.crt",
+			want: want{
+				err: errors.Wrap(errors.New("open /nonexistent/ca.crt: no such file or directory"), errReadCABundleFile),
+			},
+		},
+		"EmptyFile": {
+			reason: "It should return an error if the file is empty.",
+			path:   emptyPath,
+			want: want{
+				err: errors.New(errEmptyCABundleFile),
+			},
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			p := &FileCAProvider{Path: tc.path}
+			ca, err := p.GetCABundle(context.TODO(), nil)
+			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
+				t.Errorf("\n%s\nGetCABundle(...): -want err, +got err:\n%s", tc.reason, diff)
+			}
+			if diff := cmp.Diff(tc.want.ca, ca); diff != "" {
+				t.Errorf("\n%s\nGetCABundle(...): -want ca, +got ca:\n%s", tc.reason, diff)
+			}
+		})
+	}
+}
+
+func TestWebhookConfigurations(t *testing.T) {
+	type args struct {
+		kube       client.Client
+		caProvider WebhookCAProvider
+		svc        admv1.ServiceReference
+		opts       []WebhookConfigurationsOption
 	}
 
 	type want struct {
@@ -71,14 +197,23 @@ func TestWebhookConfigurations(t *testing.T) {
 		Port:      &p,
 	}
 
+	caDir := t.TempDir()
+	caFilePath := caDir + "/ca.crt"
+	_ = os.WriteFile(caFilePath, []byte("CABUNDLE"), 0o644)
+
+	emptyCADir := t.TempDir()
+	emptyCAPath := emptyCADir + "/ca.crt"
+	_ = os.WriteFile(emptyCAPath, []byte{}, 0o644)
+
 	cases := map[string]struct {
 		reason string
 		args
 		want
 	}{
-		"Success": {
-			reason: "If a proper webhook TLS is given, then webhook configurations should have the configs injected and operations should succeed",
+		"SecretCAProviderSuccess": {
+			reason: "If a proper webhook TLS secret is given, then webhook configurations should have the configs injected and operations should succeed",
 			args: args{
+				caProvider: &SecretCAProvider{SecretRef: types.NamespacedName{}},
 				opts: []WebhookConfigurationsOption{
 					WithWebhookConfigurationsFs(fs),
 				},
@@ -113,9 +248,10 @@ func TestWebhookConfigurations(t *testing.T) {
 				},
 			},
 		},
-		"CertNotFound": {
+		"SecretCAProviderCertNotFound": {
 			reason: "If TLS Secret cannot be found, then it should not proceed",
 			args: args{
+				caProvider: &SecretCAProvider{SecretRef: types.NamespacedName{}},
 				opts: []WebhookConfigurationsOption{
 					WithWebhookConfigurationsFs(fs),
 				},
@@ -127,9 +263,10 @@ func TestWebhookConfigurations(t *testing.T) {
 				err: errors.Wrap(errBoom, errGetWebhookSecret),
 			},
 		},
-		"CertKeyEmpty": {
+		"SecretCAProviderCertKeyEmpty": {
 			reason: "If the TLS Secret does not have a CA bundle, then it should not proceed",
 			args: args{
+				caProvider: &SecretCAProvider{SecretRef: types.NamespacedName{}},
 				opts: []WebhookConfigurationsOption{
 					WithWebhookConfigurationsFs(fs),
 				},
@@ -141,9 +278,10 @@ func TestWebhookConfigurations(t *testing.T) {
 				err: errors.Errorf(errFmtNoTLSCrtInSecret, "/"),
 			},
 		},
-		"ApplyFailed": {
+		"SecretCAProviderApplyFailed": {
 			reason: "If it cannot apply webhook configurations, then it should not proceed",
 			args: args{
+				caProvider: &SecretCAProvider{SecretRef: types.NamespacedName{}},
 				opts: []WebhookConfigurationsOption{
 					WithWebhookConfigurationsFs(fs),
 				},
@@ -165,6 +303,7 @@ func TestWebhookConfigurations(t *testing.T) {
 		"NonWebhookType": {
 			reason: "Only webhook configuration types can be processed",
 			args: args{
+				caProvider: &SecretCAProvider{SecretRef: types.NamespacedName{}},
 				opts: []WebhookConfigurationsOption{
 					WithWebhookConfigurationsFs(fsWithMixedTypes),
 				},
@@ -183,13 +322,73 @@ func TestWebhookConfigurations(t *testing.T) {
 				err: errors.Errorf("only MutatingWebhookConfiguration and ValidatingWebhookConfiguration kinds are accepted, got %s", "*v1.CustomResourceDefinition"),
 			},
 		},
+		"FileCAProviderSuccess": {
+			reason: "If a valid CA file is given via FileCAProvider, webhook configurations should be injected successfully",
+			args: args{
+				caProvider: &FileCAProvider{Path: caFilePath},
+				opts: []WebhookConfigurationsOption{
+					WithWebhookConfigurationsFs(fs),
+				},
+				svc: svc,
+				kube: &test.MockClient{
+					MockGet: func(_ context.Context, _ client.ObjectKey, _ client.Object) error {
+						return kerrors.NewNotFound(schema.GroupResource{}, "")
+					},
+					MockCreate: func(_ context.Context, obj client.Object, _ ...client.CreateOption) error {
+						switch c := obj.(type) {
+						case *admv1.ValidatingWebhookConfiguration:
+							for _, w := range c.Webhooks {
+								if !bytes.Equal(w.ClientConfig.CABundle, []byte("CABUNDLE")) {
+									t.Errorf("unexpected certificate bundle content: %s", string(w.ClientConfig.CABundle))
+								}
+							}
+						case *admv1.MutatingWebhookConfiguration:
+							for _, w := range c.Webhooks {
+								if !bytes.Equal(w.ClientConfig.CABundle, []byte("CABUNDLE")) {
+									t.Errorf("unexpected certificate bundle content: %s", string(w.ClientConfig.CABundle))
+								}
+							}
+						default:
+							t.Error("unexpected type")
+						}
+						return nil
+					},
+				},
+			},
+		},
+		"FileCAProviderFileNotFound": {
+			reason: "If the CA file does not exist, it should return an error",
+			args: args{
+				caProvider: &FileCAProvider{Path: "/nonexistent/ca.crt"},
+				opts: []WebhookConfigurationsOption{
+					WithWebhookConfigurationsFs(fs),
+				},
+				kube: &test.MockClient{},
+			},
+			want: want{
+				err: errors.Wrap(errors.New("open /nonexistent/ca.crt: no such file or directory"), errReadCABundleFile),
+			},
+		},
+		"FileCAProviderEmptyFile": {
+			reason: "If the CA file is empty, it should return an error",
+			args: args{
+				caProvider: &FileCAProvider{Path: emptyCAPath},
+				opts: []WebhookConfigurationsOption{
+					WithWebhookConfigurationsFs(fs),
+				},
+				kube: &test.MockClient{},
+			},
+			want: want{
+				err: errors.New(errEmptyCABundleFile),
+			},
+		},
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			err := NewWebhookConfigurations(
 				"/webhooks",
 				sch,
-				&SecretCAProvider{SecretRef: types.NamespacedName{}},
+				tc.args.caProvider,
 				tc.args.svc,
 				tc.opts...).Run(context.TODO(), tc.kube)
 			if diff := cmp.Diff(tc.err, err, test.EquateErrors()); diff != "" {

--- a/internal/initializer/webhook_configurations_test.go
+++ b/internal/initializer/webhook_configurations_test.go
@@ -189,7 +189,7 @@ func TestWebhookConfigurations(t *testing.T) {
 			err := NewWebhookConfigurations(
 				"/webhooks",
 				sch,
-				types.NamespacedName{},
+				&SecretCAProvider{SecretRef: types.NamespacedName{}},
 				tc.args.svc,
 				tc.opts...).Run(context.TODO(), tc.kube)
 			if diff := cmp.Diff(tc.err, err, test.EquateErrors()); diff != "" {


### PR DESCRIPTION
### Description of your changes

Fixes #7008

- We can see [here](https://github.com/crossplane/crossplane/blob/84a9d6cd05181eee4d081aa8c4422a48c756cb6f/internal/initializer/tls.go#L317-L319) that the intention is for empty secret names to return nil, but given the envvar default is `""` and this is always assigned as the pointer, the `== nil` will never evaluate as true. This fixes that behavior so the controller does not attempt to generate the bundle and populate the secrets if those values are not configured as envvars
- Add functionality to allow reading PKI materials from disk, breaks out previous functionality into `SecretCAProvider`, adds new functionality under `FileCAProvider`
- Allows for overriding the filenames of the client and webhook server PKI materials
- TLS filename overrides fall back to the original constants (`initializer.SecretKeyCACert`, `corev1.TLSCertKey`, `corev1.TLSPrivateKeyKey`)

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `./nix.sh flake check` to ensure this PR is ready for review.
- [x] Added or updated unit tests.
- [ ] ~Added or updated e2e tests.~
- [ ] Linked a PR or a [docs tracking issue] to [document this change].
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~
- [ ] ~Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md