### PR TITLE
fix: respect --poll-interval in package manager pull-based requeue

### DIFF
--- a/internal/controller/pkg/manager/reconciler.go
+++ b/internal/controller/pkg/manager/reconciler.go
@@ -48,17 +48,18 @@ import (
 const (
 	reconcileTimeout = 1 * time.Minute
 
-	// pullWait is the time after which the package manager will check for
-	// updated content for the given package reference. This behavior is only
-	// enabled when the packagePullPolicy is Always.
-	pullWait = 1 * time.Minute
+	// defaultPollInterval is the default interval after which the package
+	// manager will check for updated content for the given package reference,
+	// when no --poll-interval is configured. This behavior is only enabled
+	// when the packagePullPolicy is Always.
+	defaultPollInterval = 1 * time.Minute
 
 	reconcilePausedMsg = "Reconciliation (including deletion) is paused via the pause annotation"
 )
 
-func pullBasedRequeue(p *corev1.PullPolicy) reconcile.Result {
+func (r *Reconciler) pullBasedRequeue(p *corev1.PullPolicy) reconcile.Result {
 	if p != nil && *p == corev1.PullAlways {
-		return reconcile.Result{RequeueAfter: pullWait}
+		return reconcile.Result{RequeueAfter: r.pollInterval}
 	}
 
 	return reconcile.Result{Requeue: false}
@@ -130,6 +131,14 @@ func WithRecorder(er event.Recorder) ReconcilerOption {
 	}
 }
 
+// WithPollInterval specifies how often the Reconciler should requeue after a
+// successful reconcile when the package's pull policy is Always.
+func WithPollInterval(d time.Duration) ReconcilerOption {
+	return func(r *Reconciler) {
+		r.pollInterval = d
+	}
+}
+
 // WithManagingRevisionRuntimeSpec will allow this reconciler to propagate the
 // runtime spec fields to revisions.
 func WithManagingRevisionRuntimeSpec() ReconcilerOption {
@@ -155,6 +164,8 @@ type Reconciler struct {
 	record     event.Recorder
 	conditions conditions.Manager
 
+	pollInterval time.Duration
+
 	setPackageRuntimeManagedFields func(p v1.Package, pr v1.PackageRevision)
 
 	newPackage             func() v1.Package
@@ -177,6 +188,7 @@ func SetupProvider(mgr ctrl.Manager, o controller.Options) error {
 		WithClient(o.Client),
 		WithLogger(log),
 		WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name), o.EventFilterFunctions...)),
+		WithPollInterval(o.PollInterval),
 	}
 
 	if o.PackageRuntime.For(v1.ProviderKind) == controller.PackageRuntimeDeployment {
@@ -207,6 +219,7 @@ func SetupConfiguration(mgr ctrl.Manager, o controller.Options) error {
 		WithClient(o.Client),
 		WithLogger(log),
 		WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name), o.EventFilterFunctions...)),
+		WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).
@@ -233,6 +246,7 @@ func SetupFunction(mgr ctrl.Manager, o controller.Options) error {
 		WithClient(o.Client),
 		WithLogger(log),
 		WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name), o.EventFilterFunctions...)),
+		WithPollInterval(o.PollInterval),
 	}
 
 	if o.PackageRuntime.For(v1.FunctionKind) == controller.PackageRuntimeDeployment {
@@ -255,9 +269,10 @@ func NewReconciler(mgr ctrl.Manager, opts ...ReconcilerOption) *Reconciler {
 			Client:     mgr.GetClient(),
 			Applicator: resource.NewAPIPatchingApplicator(mgr.GetClient()),
 		},
-		log:        logging.NewNopLogger(),
-		record:     event.NewNopRecorder(),
-		conditions: conditions.ObservedGenerationPropagationManager{},
+		log:          logging.NewNopLogger(),
+		record:       event.NewNopRecorder(),
+		conditions:   conditions.ObservedGenerationPropagationManager{},
+		pollInterval: defaultPollInterval,
 	}
 
 	for _, f := range opts {
@@ -499,5 +514,5 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 	// package, the health of the package is not set until the revision reports
 	// its health. If updating from an existing revision, the package health
 	// will match the health of the old revision until the next reconcile.
-	return pullBasedRequeue(p.GetPackagePullPolicy()), errors.Wrap(r.kube.Status().Update(ctx, p), errUpdateStatus)
+	return r.pullBasedRequeue(p.GetPackagePullPolicy()), errors.Wrap(r.kube.Status().Update(ctx, p), errUpdateStatus)
 }

--- a/internal/controller/pkg/manager/reconciler_test.go
+++ b/internal/controller/pkg/manager/reconciler_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"io"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	corev1 "k8s.io/api/core/v1"
@@ -279,6 +280,7 @@ func TestReconcile(t *testing.T) {
 			args: args{
 				req: reconcile.Request{NamespacedName: types.NamespacedName{Name: "test"}},
 				rec: &Reconciler{
+					pollInterval:           defaultPollInterval,
 					newPackage:             func() v1.Package { return &v1.Configuration{} },
 					newPackageRevision:     func() v1.PackageRevision { return &v1.ConfigurationRevision{} },
 					newPackageRevisionList: func() v1.PackageRevisionList { return &v1.ConfigurationRevisionList{} },
@@ -328,7 +330,7 @@ func TestReconcile(t *testing.T) {
 				},
 			},
 			want: want{
-				r: reconcile.Result{RequeueAfter: pullWait},
+				r: reconcile.Result{RequeueAfter: defaultPollInterval},
 			},
 		},
 		"SuccessfulNoExistingRevisionsManualActivate": {
@@ -981,6 +983,52 @@ func TestReconcile(t *testing.T) {
 
 			if diff := cmp.Diff(tc.want.r, got, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\nr.Reconcile(...): -want, +got:\n%s", tc.reason, diff)
+			}
+		})
+	}
+}
+
+func TestPullBasedRequeue(t *testing.T) {
+	pullAlways := corev1.PullAlways
+	pullIfNotPresent := corev1.PullIfNotPresent
+
+	cases := map[string]struct {
+		reason       string
+		pollInterval time.Duration
+		policy       *corev1.PullPolicy
+		want         reconcile.Result
+	}{
+		"PullAlwaysHonorsConfiguredInterval": {
+			reason:       "When pull policy is Always, the requeue interval should match the configured pollInterval.",
+			pollInterval: 5 * time.Minute,
+			policy:       &pullAlways,
+			want:         reconcile.Result{RequeueAfter: 5 * time.Minute},
+		},
+		"PullAlwaysWithDefaultInterval": {
+			reason:       "When pull policy is Always and no override is set, the default pollInterval is used.",
+			pollInterval: defaultPollInterval,
+			policy:       &pullAlways,
+			want:         reconcile.Result{RequeueAfter: defaultPollInterval},
+		},
+		"PullIfNotPresentDoesNotRequeue": {
+			reason:       "When pull policy is not Always, no requeue is scheduled regardless of pollInterval.",
+			pollInterval: 5 * time.Minute,
+			policy:       &pullIfNotPresent,
+			want:         reconcile.Result{Requeue: false},
+		},
+		"NilPolicyDoesNotRequeue": {
+			reason:       "When pull policy is nil, no requeue is scheduled regardless of pollInterval.",
+			pollInterval: 5 * time.Minute,
+			policy:       nil,
+			want:         reconcile.Result{Requeue: false},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			r := &Reconciler{pollInterval: tc.pollInterval}
+			if diff := cmp.Diff(tc.want, r.pullBasedRequeue(tc.policy)); diff != "" {
+				t.Errorf("\n%s\nr.pullBasedRequeue(...): -want, +got:\n%s", tc.reason, diff)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary
- Wires the `--poll-interval` flag (already plumbed through `controller.Options.PollInterval`) to the package manager's pull-based requeue path, so `Provider`, `Configuration`, and `Function` packages with `packagePullPolicy: Always` honor the operator-configured interval.
- Removes the hardcoded `pullWait = 1 * time.Minute` constant; preserves the previous 1-minute value as `defaultPollInterval` so unchanged deployments keep their current behavior.
- Adds `TestPullBasedRequeue` covering: `PullAlways` with overridden interval, `PullAlways` with default, non-`Always` policy, and nil policy.

## Problem
The reporter on #7245 deploys Crossplane with `--poll-interval=5m` and observes reconciliation continuing at 1m. Tracing the flag through the codebase:

1. `cmd/crossplane/core/core.go` parses `--poll-interval` into `c.PollInterval` and forwards it via `controller.Options{PollInterval: c.PollInterval}` (verified — works correctly).
2. `internal/controller/apiextensions/composite/reconciler.go` and `internal/controller/protection/usage/reconciler.go` consume `o.PollInterval` and use it for their `RequeueAfter` (verified — works correctly).
3. `internal/controller/pkg/manager/reconciler.go` had a module-level `pullWait = 1 * time.Minute` constant used directly in `pullBasedRequeue` — the option was **never threaded into this reconciler**, so the package manager re-pulled every 60s regardless of `--poll-interval`.

This particularly affects users running with `imagePullPolicy: Always` (which the help text for `pullPolicy` makes the natural choice for tracking floating tags), and exactly matches the symptom in the issue.

## Fix
- Add `pollInterval time.Duration` field to `Reconciler`.
- Add `WithPollInterval(d time.Duration)` `ReconcilerOption`, following the existing `WithLogger` / `WithRecorder` pattern.
- Default `r.pollInterval = defaultPollInterval` (`1 * time.Minute`) in `NewReconciler` so reconcilers built without the option keep the prior behavior.
- Convert `pullBasedRequeue` from a free function to a method on `*Reconciler` so it can read `r.pollInterval`. Single existing caller updated.
- Wire `WithPollInterval(o.PollInterval)` into `SetupProvider`, `SetupConfiguration`, and `SetupFunction`.

The change is intentionally minimal: it does not introduce per-resource `crossplane.io/poll-interval` annotation handling for packages (that's a follow-up if maintainers want symmetry with the recently merged #7239).

## Test plan
- [x] `go build ./...` passes.
- [x] `go vet ./internal/controller/pkg/manager/...` passes.
- [x] `go test ./internal/controller/pkg/manager/...` passes — both the existing `TestReconcile` (updated to use `defaultPollInterval`) and the new `TestPullBasedRequeue`.
- [ ] Verify on a live cluster that starting Crossplane with `--poll-interval=5m` and a `Provider` using `packagePullPolicy: Always` results in reconciliation logs ~5m apart instead of ~1m.

Fixes #7245