### PR TITLE
feat(xpkg): add --annotation flag and crossplane.yaml propagation to xpkg build/push

### DIFF
--- a/cmd/crank/xpkg/annotations.go
+++ b/cmd/crank/xpkg/annotations.go
@@ -1,0 +1,54 @@
+/*
+Copyright 2025 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package xpkg
+
+import (
+	"strings"
+
+	"github.com/crossplane/crossplane-runtime/v2/pkg/errors"
+)
+
+// parseAnnotations parses a slice of "key=value" strings into a map. Returns
+// an error if any entry is not in key=value format.
+func parseAnnotations(kvs []string) (map[string]string, error) {
+	anns := make(map[string]string, len(kvs))
+	for _, kv := range kvs {
+		k, v, ok := strings.Cut(kv, "=")
+		if !ok {
+			return nil, errors.Errorf("invalid annotation %q: must be in key=value format", kv)
+		}
+		anns[k] = v
+	}
+	return anns, nil
+}
+
+// mergeAnnotations merges metadata annotations with flag annotations. Flag
+// annotations take precedence over metadata annotations when keys overlap.
+func mergeAnnotations(metaAnnotations map[string]string, flagAnnotations []string) (map[string]string, error) {
+	anns := make(map[string]string)
+	for k, v := range metaAnnotations {
+		anns[k] = v
+	}
+	flagAnns, err := parseAnnotations(flagAnnotations)
+	if err != nil {
+		return nil, err
+	}
+	for k, v := range flagAnns {
+		anns[k] = v
+	}
+	return anns, nil
+}

--- a/cmd/crank/xpkg/annotations_test.go
+++ b/cmd/crank/xpkg/annotations_test.go
@@ -1,0 +1,164 @@
+/*
+Copyright 2025 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package xpkg
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+)
+
+func TestParseAnnotations(t *testing.T) {
+	type args struct {
+		kvs []string
+	}
+	type want struct {
+		anns map[string]string
+		err  error
+	}
+
+	cases := map[string]struct {
+		reason string
+		args   args
+		want   want
+	}{
+		"EmptySlice": {
+			reason: "Empty input should return an empty map with no error.",
+			args:   args{kvs: []string{}},
+			want:   want{anns: map[string]string{}},
+		},
+		"SingleEntry": {
+			reason: "A single valid key=value entry should be parsed correctly.",
+			args:   args{kvs: []string{"org.example/key=value"}},
+			want:   want{anns: map[string]string{"org.example/key": "value"}},
+		},
+		"MultipleEntries": {
+			reason: "Multiple valid key=value entries should all be parsed.",
+			args: args{kvs: []string{
+				"org.opencontainers.image.source=https://github.com/example/pkg",
+				"org.opencontainers.image.version=v1.0.0",
+			}},
+			want: want{anns: map[string]string{
+				"org.opencontainers.image.source":  "https://github.com/example/pkg",
+				"org.opencontainers.image.version": "v1.0.0",
+			}},
+		},
+		"ValueContainsEquals": {
+			reason: "Values that contain '=' characters should be preserved intact.",
+			args:   args{kvs: []string{"key=val=ue"}},
+			want:   want{anns: map[string]string{"key": "val=ue"}},
+		},
+		"MissingEquals": {
+			reason: "An entry without '=' should return an error.",
+			args:   args{kvs: []string{"invalid-no-equals"}},
+			want:   want{err: cmpopts.AnyError},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got, err := parseAnnotations(tc.args.kvs)
+
+			if diff := cmp.Diff(tc.want.err, err, cmpopts.EquateErrors()); diff != "" {
+				t.Errorf("\n%s\nparseAnnotations(...): -want error, +got error:\n%s", tc.reason, diff)
+			}
+
+			if diff := cmp.Diff(tc.want.anns, got); diff != "" {
+				t.Errorf("\n%s\nparseAnnotations(...): -want, +got:\n%s", tc.reason, diff)
+			}
+		})
+	}
+}
+
+func TestMergeAnnotations(t *testing.T) {
+	type args struct {
+		metaAnnotations map[string]string
+		flagAnnotations []string
+	}
+	type want struct {
+		anns map[string]string
+		err  error
+	}
+
+	cases := map[string]struct {
+		reason string
+		args   args
+		want   want
+	}{
+		"FlagOnly": {
+			reason: "Flag annotations alone should appear in the result.",
+			args: args{
+				metaAnnotations: nil,
+				flagAnnotations: []string{"org.example/env=production"},
+			},
+			want: want{anns: map[string]string{"org.example/env": "production"}},
+		},
+		"MetadataOnly": {
+			reason: "Metadata annotations alone should appear in the result.",
+			args: args{
+				metaAnnotations: map[string]string{"org.example/team": "platform"},
+				flagAnnotations: []string{},
+			},
+			want: want{anns: map[string]string{"org.example/team": "platform"}},
+		},
+		"FlagOverridesMetadata": {
+			reason: "Flag annotation should override a metadata annotation with the same key.",
+			args: args{
+				metaAnnotations: map[string]string{
+					"org.example/env":  "staging",
+					"org.example/team": "platform",
+				},
+				flagAnnotations: []string{"org.example/env=production"},
+			},
+			want: want{anns: map[string]string{
+				"org.example/env":  "production",
+				"org.example/team": "platform",
+			}},
+		},
+		"BothEmpty": {
+			reason: "Empty metadata and no flags should produce an empty map.",
+			args: args{
+				metaAnnotations: nil,
+				flagAnnotations: []string{},
+			},
+			want: want{anns: map[string]string{}},
+		},
+		"MalformedFlag": {
+			reason: "A malformed flag annotation (missing '=') should return an error.",
+			args: args{
+				metaAnnotations: map[string]string{"org.example/key": "val"},
+				flagAnnotations: []string{"bad-annotation"},
+			},
+			want: want{err: cmpopts.AnyError},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got, err := mergeAnnotations(tc.args.metaAnnotations, tc.args.flagAnnotations)
+
+			if diff := cmp.Diff(tc.want.err, err, cmpopts.EquateErrors()); diff != "" {
+				t.Errorf("\n%s\nmergeAnnotations(...): -want error, +got error:\n%s", tc.reason, diff)
+			}
+
+			if diff := cmp.Diff(tc.want.anns, got); diff != "" {
+				t.Errorf("\n%s\nmergeAnnotations(...): -want, +got:\n%s", tc.reason, diff)
+			}
+		})
+	}
+}

--- a/cmd/crank/xpkg/batch.go
+++ b/cmd/crank/xpkg/batch.go
@@ -274,7 +274,7 @@ func (c *batchCmd) pushWithRetry(logger logging.Logger, imgs []packageImage, s s
 	retryMsg := ""
 	for i := range tries {
 		logger.Info(fmt.Sprintf("Pushing xpkg to %s.%s", t, retryMsg))
-		err := pushImages(logger, imgs, t)
+		err := pushImages(logger, imgs, t, nil)
 		if err == nil {
 			break
 		}

--- a/cmd/crank/xpkg/build.go
+++ b/cmd/crank/xpkg/build.go
@@ -23,6 +23,7 @@ import (
 	"github.com/google/go-containerregistry/pkg/name"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/daemon"
+	"github.com/google/go-containerregistry/pkg/v1/mutate"
 	"github.com/google/go-containerregistry/pkg/v1/tarball"
 	"github.com/spf13/afero"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -45,6 +46,7 @@ const (
 	errPullRuntimeImage        = "failed to pull runtime image"
 	errLoadRuntimeTarball      = "failed to load runtime tarball"
 	errGetRuntimeBaseImageOpts = "failed to get runtime base image options"
+	errParseAnnotations        = "failed to parse annotations"
 )
 
 // AfterApply constructs and binds context to any subcommands
@@ -94,12 +96,13 @@ func (c *buildCmd) AfterApply() error {
 // buildCmd builds a crossplane package.
 type buildCmd struct {
 	// Flags. Keep sorted alphabetically.
-	EmbedRuntimeImage        string   `help:"An OCI image to embed in the package as its runtime."                                                                                                    placeholder:"NAME"                                                     xor:"runtime-image"`
-	EmbedRuntimeImageTarball string   `help:"An OCI image tarball to embed in the package as its runtime."                                                                                            placeholder:"PATH"                                                     predictor:"file"      type:"existingfile" xor:"runtime-image"`
-	ExamplesRoot             string   `default:"./examples"                                                                                                                                           help:"A directory of example YAML files to include in the package."    predictor:"directory" short:"e"           type:"path"`
+	Annotation               []string `help:"An OCI manifest annotation to add to the package in key=value format. Repeatable. Overrides matching keys from the package's crossplane.yaml metadata.annotations." placeholder:"KEY=VALUE" short:"a"`
+	EmbedRuntimeImage        string   `help:"An OCI image to embed in the package as its runtime."                                                                                                placeholder:"NAME"      xor:"runtime-image"`
+	EmbedRuntimeImageTarball string   `help:"An OCI image tarball to embed in the package as its runtime."                                                                                        placeholder:"PATH"      predictor:"file"      type:"existingfile" xor:"runtime-image"`
+	ExamplesRoot             string   `default:"./examples"                                                                                                                                       help:"A directory of example YAML files to include in the package." predictor:"directory" short:"e"           type:"path"`
 	Ignore                   []string `help:"Comma-separated file paths, specified relative to --package-root, to exclude from the package. Wildcards are supported. Directories cannot be excluded." placeholder:"PATH"`
-	PackageFile              string   `help:"The file to write the package to. Defaults to a generated filename in --package-root."                                                                   placeholder:"PATH"                                                     predictor:"xpkg_file" short:"o"           type:"path"`
-	PackageRoot              string   `default:"."                                                                                                                                                    help:"The directory that contains the package's crossplane.yaml file." predictor:"directory" short:"f"           type:"existingdir"`
+	PackageFile              string   `help:"The file to write the package to. Defaults to a generated filename in --package-root."                                                               placeholder:"PATH"      predictor:"xpkg_file" short:"o"           type:"path"`
+	PackageRoot              string   `default:"."                                                                                                                                                help:"The directory that contains the package's crossplane.yaml file." predictor:"directory" short:"f"           type:"existingdir"`
 
 	// Internal state. These aren't part of the user-exposed CLI structure.
 	fs      afero.Fs
@@ -184,6 +187,20 @@ func (c *buildCmd) Run(logger logging.Logger) error {
 	img, meta, err := c.builder.Build(context.Background(), buildOpts...)
 	if err != nil {
 		return errors.Wrap(err, errBuildPackage)
+	}
+
+	// Collect OCI manifest annotations from crossplane.yaml metadata.annotations
+	// first, then from --annotation flags (flags take precedence).
+	var metaAnnotations map[string]string
+	if pkgMeta, ok := meta.(metav1.Object); ok {
+		metaAnnotations = pkgMeta.GetAnnotations()
+	}
+	anns, err := mergeAnnotations(metaAnnotations, c.Annotation)
+	if err != nil {
+		return errors.Wrap(err, errParseAnnotations)
+	}
+	if len(anns) > 0 {
+		img = mutate.Annotations(img, anns).(v1.Image)
 	}
 
 	hash, err := img.Digest()

--- a/cmd/crank/xpkg/push.go
+++ b/cmd/crank/xpkg/push.go
@@ -60,6 +60,7 @@ type pushCmd struct {
 	Package string `arg:"" help:"Where to push the package. Must be a fully qualified OCI tag, including the registry, repository, and tag." placeholder:"REGISTRY/REPOSITORY:TAG"`
 
 	// Flags. Keep sorted alphabetically.
+	Annotation            []string `help:"An OCI manifest annotation to add to the package in key=value format. Repeatable. Merged with any annotations already in the package file." placeholder:"KEY=VALUE" short:"a"`
 	InsecureSkipTLSVerify bool     `help:"[INSECURE] Skip verifying TLS certificates."`
 	PackageFiles          []string `help:"A comma-separated list of xpkg files to push." placeholder:"PATH" predictor:"xpkg_file" short:"f" type:"existingfile"`
 
@@ -135,7 +136,12 @@ func (c *pushCmd) Run(logger logging.Logger) error {
 		remote.WithTransport(t),
 	}
 
-	return pushImages(logger, images, c.Package, options...)
+	anns, err := parseAnnotations(c.Annotation)
+	if err != nil {
+		return errors.Wrap(err, errParseAnnotations)
+	}
+
+	return pushImages(logger, images, c.Package, anns, options...)
 }
 
 // packageImage describes a package image that will be pushed.
@@ -149,7 +155,7 @@ type packageImage struct {
 }
 
 // pushImages pushes package images to the given URL using the provided options.
-func pushImages(logger logging.Logger, images []packageImage, url string, options ...remote.Option) error {
+func pushImages(logger logging.Logger, images []packageImage, url string, annotations map[string]string, options ...remote.Option) error {
 	if len(options) == 0 {
 		options = []remote.Option{
 			remote.WithAuthFromKeychain(authn.DefaultKeychain),
@@ -168,6 +174,10 @@ func pushImages(logger logging.Logger, images []packageImage, url string, option
 		img, err := xpkg.AnnotateLayers(pi.Image)
 		if err != nil {
 			return errors.Wrapf(err, errAnnotateLayers)
+		}
+
+		if len(annotations) > 0 {
+			img = mutate.Annotations(img, annotations).(v1.Image)
 		}
 
 		if err := remote.Write(tag, img, options...); err != nil {
@@ -190,6 +200,10 @@ func pushImages(logger logging.Logger, images []packageImage, url string, option
 			img, err := xpkg.AnnotateLayers(pi.Image)
 			if err != nil {
 				return errors.Wrapf(err, errAnnotateLayers)
+			}
+
+			if len(annotations) > 0 {
+				img = mutate.Annotations(img, annotations).(v1.Image)
 			}
 
 			d, err := img.Digest()


### PR DESCRIPTION
## What this does

Adds OCI manifest annotation support to `crossplane xpkg build` and
`crossplane xpkg push`, addressing #7282.

### `--annotation` flag (`-a`)

Both commands now accept repeatable `--annotation key=value` flags:

```sh
# Build with static annotations
crossplane xpkg build -a org.opencontainers.image.source=https://github.com/org/repo

# Push with dynamic (CI-injected) annotations
crossplane xpkg push -f pkg.xpkg \
  -a org.opencontainers.image.revision=$(git rev-parse HEAD) \
  xpkg.example.io/org/pkg:v1.0.0
