### PR TITLE
fix(mrd): prevent duplicate controller ownerRefs on CRD during provider upgrades

### DIFF
--- a/internal/controller/apiextensions/managed/crd.go
+++ b/internal/controller/apiextensions/managed/crd.go
@@ -21,7 +21,6 @@ import (
 	"slices"
 	"strings"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	"github.com/crossplane/crossplane-runtime/v2/pkg/errors"
@@ -95,11 +94,13 @@ func CRDAsUnstructured(mrd *v1alpha1.ManagedResourceDefinition) (*unstructured.U
 	// Build the Unstructured from the Paved content
 	u := &unstructured.Unstructured{Object: p.UnstructuredContent()}
 
-	// Add owner references
-	meta.AddOwnerReference(u, meta.AsOwner(meta.TypedReferenceTo(mrd, v1alpha1.ManagedResourceDefinitionGroupVersionKind)))
-	if owner := metav1.GetControllerOf(mrd); owner != nil {
-		meta.AddOwnerReference(u, *owner)
-	}
+	// Set the MRD as the controller of the CRD. The ProviderRevision that
+	// controls the MRD is not propagated here: doing so caused "only one
+	// reference can have Controller set to true" errors during provider
+	// upgrades, when the old and new revisions both transiently appeared as
+	// controllers of the same CRD. The GC chain PR → MRD → CRD means the
+	// CRD is still garbage-collected when the provider is removed.
+	meta.AddOwnerReference(u, meta.AsController(meta.TypedReferenceTo(mrd, v1alpha1.ManagedResourceDefinitionGroupVersionKind)))
 
 	return u, nil
 }

--- a/internal/controller/apiextensions/managed/crd_test.go
+++ b/internal/controller/apiextensions/managed/crd_test.go
@@ -84,10 +84,12 @@ func TestCRDAsUnstructured(t *testing.T) {
 							"name": "databases.example.com",
 							"ownerReferences": []any{
 								map[string]any{
-									"apiVersion": "apiextensions.crossplane.io/v1alpha1",
-									"kind":       "ManagedResourceDefinition",
-									"name":       "databases.example.com",
-									"uid":        mrdUID,
+									"apiVersion":         "apiextensions.crossplane.io/v1alpha1",
+									"kind":               "ManagedResourceDefinition",
+									"name":               "databases.example.com",
+									"uid":                mrdUID,
+									"controller":         true,
+									"blockOwnerDeletion": true,
 								},
 							},
 						},
@@ -178,10 +180,12 @@ func TestCRDAsUnstructured(t *testing.T) {
 							"name": "databases.example.com",
 							"ownerReferences": []any{
 								map[string]any{
-									"apiVersion": "apiextensions.crossplane.io/v1alpha1",
-									"kind":       "ManagedResourceDefinition",
-									"name":       "databases.example.com",
-									"uid":        mrdUID,
+									"apiVersion":         "apiextensions.crossplane.io/v1alpha1",
+									"kind":               "ManagedResourceDefinition",
+									"name":               "databases.example.com",
+									"uid":                mrdUID,
+									"controller":         true,
+									"blockOwnerDeletion": true,
 								},
 							},
 						},
@@ -289,10 +293,12 @@ func TestCRDAsUnstructured(t *testing.T) {
 							"name": "databases.example.com",
 							"ownerReferences": []any{
 								map[string]any{
-									"apiVersion": "apiextensions.crossplane.io/v1alpha1",
-									"kind":       "ManagedResourceDefinition",
-									"name":       "databases.example.com",
-									"uid":        mrdUID,
+									"apiVersion":         "apiextensions.crossplane.io/v1alpha1",
+									"kind":               "ManagedResourceDefinition",
+									"name":               "databases.example.com",
+									"uid":                mrdUID,
+									"controller":         true,
+									"blockOwnerDeletion": true,
 								},
 							},
 						},
@@ -327,7 +333,7 @@ func TestCRDAsUnstructured(t *testing.T) {
 		},
 
 		"MRDWithControllerOwner": {
-			reason: "Should propagate controller owner from MRD to CRD",
+			reason: "Should set MRD as controller of CRD; ProviderRevision is not propagated to avoid controller conflicts during upgrades",
 			args: args{
 				mrd: &v1alpha1.ManagedResourceDefinition{
 					ObjectMeta: metav1.ObjectMeta{
@@ -372,16 +378,10 @@ func TestCRDAsUnstructured(t *testing.T) {
 							"name": "databases.example.com",
 							"ownerReferences": []any{
 								map[string]any{
-									"apiVersion": "apiextensions.crossplane.io/v1alpha1",
-									"kind":       "ManagedResourceDefinition",
-									"name":       "databases.example.com",
-									"uid":        mrdUID,
-								},
-								map[string]any{
-									"apiVersion":         "pkg.crossplane.io/v1",
-									"kind":               "ProviderRevision",
-									"name":               "provider-example-abc123",
-									"uid":                providerRevisionUID,
+									"apiVersion":         "apiextensions.crossplane.io/v1alpha1",
+									"kind":               "ManagedResourceDefinition",
+									"name":               "databases.example.com",
+									"uid":                mrdUID,
 									"controller":         true,
 									"blockOwnerDeletion": true,
 								},

--- a/internal/controller/apiextensions/managed/reconciler.go
+++ b/internal/controller/apiextensions/managed/reconciler.go
@@ -24,6 +24,7 @@ import (
 	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -48,6 +49,10 @@ const (
 	reasonReconcile event.Reason = "Reconcile"
 	reasonPaused    event.Reason = "ReconciliationPaused"
 	reasonApplyCRD  event.Reason = "ApplyCustomResourceDefinition"
+)
+
+const (
+	errDemoteControllerRefs = "cannot demote stale controller ownerReferences on CRD"
 )
 
 // FieldOwnerMRD is the field manager name used when applying CRDs.
@@ -116,6 +121,31 @@ func (r *Reconciler) Reconcile(ogctx context.Context, req reconcile.Request) (re
 		return reconcile.Result{}, errors.Wrap(err, "cannot get CustomResourceDefinition")
 	}
 
+	// Demote any stale controller ownerReferences that are not from the
+	// ManagedResourceDefinition. Previously, the ProviderRevision controlling
+	// the MRD was propagated as controller:true on the CRD. During provider
+	// upgrades the old and new revisions both transiently had controller:true,
+	// causing Kubernetes to reject the update. This migration step demotes
+	// those stale refs so the MRD can safely claim controller ownership.
+	if meta.WasCreated(crd) && demoteStaleControllerRefs(crd) {
+		if err := r.client.Update(ctx, crd); err != nil {
+			log.Debug("cannot demote stale controller references on CRD", "error", err)
+			r.record.Event(mrd, event.Warning(reasonReconcile, err))
+			status.MarkConditions(v1alpha1.BlockedManaged().WithMessage("unable to fix CRD controller references, see events"))
+			_ = r.client.Status().Update(ogctx, mrd)
+			return reconcile.Result{}, errors.Wrap(err, errDemoteControllerRefs)
+		}
+		// Re-read to pick up the new resourceVersion before the managed
+		// fields upgrade, which uses the resource version for its patch.
+		if err := r.client.Get(ctx, types.NamespacedName{Name: mrd.GetName()}, crd); resource.IgnoreNotFound(err) != nil {
+			log.Debug("cannot get CustomResourceDefinition", "error", err)
+			r.record.Event(mrd, event.Warning(reasonReconcile, err))
+			status.MarkConditions(v1alpha1.BlockedManaged().WithMessage("unable to get CustomResourceDefinition, see events"))
+			_ = r.client.Status().Update(ogctx, mrd)
+			return reconcile.Result{}, errors.Wrap(err, "cannot get CustomResourceDefinition")
+		}
+	}
+
 	// Upgrade the CRD's managed fields from client-side to server-side
 	// apply. This is necessary when a CRD was previously managed using
 	// client-side apply, but should now be managed using server-side apply.
@@ -170,4 +200,21 @@ func (r *Reconciler) Reconcile(ogctx context.Context, req reconcile.Request) (re
 
 	status.MarkConditions(v1alpha1.EstablishedManaged())
 	return reconcile.Result{}, errors.Wrap(r.client.Status().Update(ogctx, mrd), "cannot update status of ManagedResourceDefinition")
+}
+
+// demoteStaleControllerRefs sets controller:false on any ownerReference that
+// claims controller status but is not from a ManagedResourceDefinition. This
+// is a migration step: older Crossplane versions propagated the controlling
+// ProviderRevision as controller:true on the CRD, which caused "only one
+// reference can have Controller set to true" errors when the revision changed.
+// Returns true if any references were modified.
+func demoteStaleControllerRefs(crd *extv1.CustomResourceDefinition) bool {
+	changed := false
+	for i := range crd.OwnerReferences {
+		if ptr.Deref(crd.OwnerReferences[i].Controller, false) && crd.OwnerReferences[i].Kind != v1alpha1.ManagedResourceDefinitionKind {
+			crd.OwnerReferences[i].Controller = ptr.To(false)
+			changed = true
+		}
+	}
+	return changed
 }

--- a/internal/controller/apiextensions/managed/reconciler.go
+++ b/internal/controller/apiextensions/managed/reconciler.go
@@ -19,6 +19,7 @@ package managed
 
 import (
 	"context"
+	"strings"
 	"time"
 
 	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -211,10 +212,16 @@ func (r *Reconciler) Reconcile(ogctx context.Context, req reconcile.Request) (re
 func demoteStaleControllerRefs(crd *extv1.CustomResourceDefinition) bool {
 	changed := false
 	for i := range crd.OwnerReferences {
-		if ptr.Deref(crd.OwnerReferences[i].Controller, false) && crd.OwnerReferences[i].Kind != v1alpha1.ManagedResourceDefinitionKind {
-			crd.OwnerReferences[i].Controller = ptr.To(false)
-			changed = true
+		ref := &crd.OwnerReferences[i]
+		if !ptr.Deref(ref.Controller, false) {
+			continue
 		}
+		group, _, _ := strings.Cut(ref.APIVersion, "/")
+		if ref.Kind == v1alpha1.ManagedResourceDefinitionKind && group == v1alpha1.Group {
+			continue
+		}
+		ref.Controller = ptr.To(false)
+		changed = true
 	}
 	return changed
 }

--- a/internal/controller/apiextensions/managed/reconciler_test.go
+++ b/internal/controller/apiextensions/managed/reconciler_test.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -451,6 +452,119 @@ func TestReconcile(t *testing.T) {
 				err: cmpopts.AnyError,
 			},
 		},
+		"StaleCRDControllerRefDemoteError": {
+			reason: "We should return an error and set BlockedManaged when demoting stale controller ownerReferences fails",
+			args: args{
+				c: &test.MockClient{
+					MockGet: func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
+						switch o := obj.(type) {
+						case *v1alpha1.ManagedResourceDefinition:
+							return withMRD(t, newMRD(func(mrd *v1alpha1.ManagedResourceDefinition) {
+								mrd.Spec.State = v1alpha1.ManagedResourceDefinitionActive
+							}))(ctx, key, o)
+						case *extv1.CustomResourceDefinition:
+							o.CreationTimestamp = metav1.Now()
+							o.OwnerReferences = []metav1.OwnerReference{{
+								APIVersion: "pkg.crossplane.io/v1",
+								Kind:       "ProviderRevision",
+								Controller: ptr.To(true),
+							}}
+							return nil
+						default:
+							return kerrors.NewNotFound(schema.GroupResource{}, "")
+						}
+					},
+					MockUpdate: test.NewMockUpdateFn(errBoom),
+					MockStatusUpdate: wantMRD(t, newMRD(func(mrd *v1alpha1.ManagedResourceDefinition) {
+						mrd.Spec.State = v1alpha1.ManagedResourceDefinitionActive
+						mrd.SetConditions(v1alpha1.BlockedManaged().WithMessage("unable to fix CRD controller references, see events"))
+					})),
+				},
+				opts: []ReconcilerOption{
+					WithRecorder(&testRecorder{}),
+				},
+			},
+			want: want{
+				err: cmpopts.AnyError,
+			},
+		},
+		"StaleCRDControllerRefDemoted": {
+			reason: "We should demote stale controller ownerReferences, re-read the CRD, and continue to reconcile successfully",
+			args: args{
+				c: &test.MockClient{
+					MockGet: func() func(context.Context, client.ObjectKey, client.Object) error {
+						crdGetCall := 0
+						return func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
+							switch o := obj.(type) {
+							case *v1alpha1.ManagedResourceDefinition:
+								return withMRD(t, newMRD(func(mrd *v1alpha1.ManagedResourceDefinition) {
+									mrd.Spec.State = v1alpha1.ManagedResourceDefinitionActive
+									mrd.Spec.CustomResourceDefinitionSpec = v1alpha1.CustomResourceDefinitionSpec{
+										Group: "example.com",
+										Names: extv1.CustomResourceDefinitionNames{
+											Plural: "databases",
+											Kind:   "Database",
+										},
+										Scope:    extv1.ClusterScoped,
+										Versions: []v1alpha1.CustomResourceDefinitionVersion{{Name: "v1", Served: true, Storage: true}},
+									}
+								}))(ctx, key, o)
+							case *extv1.CustomResourceDefinition:
+								crdGetCall++
+								if crdGetCall == 1 {
+									// First Get: CRD exists with a stale ProviderRevision controller ownerRef.
+									o.CreationTimestamp = metav1.Now()
+									o.OwnerReferences = []metav1.OwnerReference{{
+										APIVersion: "pkg.crossplane.io/v1",
+										Kind:       "ProviderRevision",
+										Controller: ptr.To(true),
+									}}
+								}
+								// Second Get (after Update): clean CRD, no stale refs.
+								return nil
+							default:
+								return kerrors.NewNotFound(schema.GroupResource{}, "")
+							}
+						}
+					}(),
+					MockUpdate: test.NewMockUpdateFn(nil),
+					MockPatch: func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) error {
+						u, ok := obj.(*unstructured.Unstructured)
+						if !ok {
+							return nil
+						}
+						u.Object["status"] = map[string]any{
+							"conditions": []any{
+								map[string]any{
+									"type":   string(extv1.Established),
+									"status": string(extv1.ConditionTrue),
+								},
+							},
+						}
+						return nil
+					},
+					MockStatusUpdate: wantMRD(t, newMRD(func(mrd *v1alpha1.ManagedResourceDefinition) {
+						mrd.Spec.State = v1alpha1.ManagedResourceDefinitionActive
+						mrd.Spec.CustomResourceDefinitionSpec = v1alpha1.CustomResourceDefinitionSpec{
+							Group: "example.com",
+							Names: extv1.CustomResourceDefinitionNames{
+								Plural: "databases",
+								Kind:   "Database",
+							},
+							Scope:    extv1.ClusterScoped,
+							Versions: []v1alpha1.CustomResourceDefinitionVersion{{Name: "v1", Served: true, Storage: true}},
+						}
+						mrd.SetConditions(v1alpha1.EstablishedManaged())
+					})),
+				},
+				opts: []ReconcilerOption{
+					WithRecorder(&testRecorder{}),
+				},
+			},
+			want: want{
+				r: reconcile.Result{},
+			},
+		},
 	}
 
 	for name, tc := range cases {
@@ -537,9 +651,6 @@ func (r *testRecorder) WithAnnotations(_ ...string) event.Recorder {
 }
 
 func TestDemoteStaleControllerRefs(t *testing.T) {
-	trueVal := true
-	falseVal := false
-
 	cases := map[string]struct {
 		reason  string
 		crd     *extv1.CustomResourceDefinition
@@ -557,26 +668,38 @@ func TestDemoteStaleControllerRefs(t *testing.T) {
 			crd: &extv1.CustomResourceDefinition{
 				ObjectMeta: metav1.ObjectMeta{
 					OwnerReferences: []metav1.OwnerReference{
-						{Kind: "ManagedResourceDefinition", Controller: &trueVal},
+						{APIVersion: "apiextensions.crossplane.io/v1alpha1", Kind: "ManagedResourceDefinition", Controller: ptr.To(true)},
 					},
 				},
 			},
-			want:    []metav1.OwnerReference{{Kind: "ManagedResourceDefinition", Controller: &trueVal}},
+			want:    []metav1.OwnerReference{{APIVersion: "apiextensions.crossplane.io/v1alpha1", Kind: "ManagedResourceDefinition", Controller: ptr.To(true)}},
 			changed: false,
+		},
+		"SameKindDifferentGroup": {
+			reason: "Should demote an ownerRef with Kind=ManagedResourceDefinition but a different group",
+			crd: &extv1.CustomResourceDefinition{
+				ObjectMeta: metav1.ObjectMeta{
+					OwnerReferences: []metav1.OwnerReference{
+						{APIVersion: "other.io/v1", Kind: "ManagedResourceDefinition", Controller: ptr.To(true)},
+					},
+				},
+			},
+			want:    []metav1.OwnerReference{{APIVersion: "other.io/v1", Kind: "ManagedResourceDefinition", Controller: ptr.To(false)}},
+			changed: true,
 		},
 		"ProviderRevisionController": {
 			reason: "Should demote a ProviderRevision with controller:true",
 			crd: &extv1.CustomResourceDefinition{
 				ObjectMeta: metav1.ObjectMeta{
 					OwnerReferences: []metav1.OwnerReference{
-						{Kind: "ProviderRevision", Controller: &trueVal},
-						{Kind: "ManagedResourceDefinition", Controller: &falseVal},
+						{APIVersion: "pkg.crossplane.io/v1", Kind: "ProviderRevision", Controller: ptr.To(true)},
+						{APIVersion: "apiextensions.crossplane.io/v1alpha1", Kind: "ManagedResourceDefinition", Controller: ptr.To(false)},
 					},
 				},
 			},
 			want: []metav1.OwnerReference{
-				{Kind: "ProviderRevision", Controller: &falseVal},
-				{Kind: "ManagedResourceDefinition", Controller: &falseVal},
+				{APIVersion: "pkg.crossplane.io/v1", Kind: "ProviderRevision", Controller: ptr.To(false)},
+				{APIVersion: "apiextensions.crossplane.io/v1alpha1", Kind: "ManagedResourceDefinition", Controller: ptr.To(false)},
 			},
 			changed: true,
 		},
@@ -585,29 +708,41 @@ func TestDemoteStaleControllerRefs(t *testing.T) {
 			crd: &extv1.CustomResourceDefinition{
 				ObjectMeta: metav1.ObjectMeta{
 					OwnerReferences: []metav1.OwnerReference{
-						{Kind: "ProviderRevision", Name: "old", Controller: &trueVal},
-						{Kind: "ProviderRevision", Name: "older", Controller: &trueVal},
-						{Kind: "ManagedResourceDefinition", Controller: &trueVal},
+						{APIVersion: "pkg.crossplane.io/v1", Kind: "ProviderRevision", Name: "old", Controller: ptr.To(true)},
+						{APIVersion: "pkg.crossplane.io/v1", Kind: "ProviderRevision", Name: "older", Controller: ptr.To(true)},
+						{APIVersion: "apiextensions.crossplane.io/v1alpha1", Kind: "ManagedResourceDefinition", Controller: ptr.To(true)},
 					},
 				},
 			},
 			want: []metav1.OwnerReference{
-				{Kind: "ProviderRevision", Name: "old", Controller: &falseVal},
-				{Kind: "ProviderRevision", Name: "older", Controller: &falseVal},
-				{Kind: "ManagedResourceDefinition", Controller: &trueVal},
+				{APIVersion: "pkg.crossplane.io/v1", Kind: "ProviderRevision", Name: "old", Controller: ptr.To(false)},
+				{APIVersion: "pkg.crossplane.io/v1", Kind: "ProviderRevision", Name: "older", Controller: ptr.To(false)},
+				{APIVersion: "apiextensions.crossplane.io/v1alpha1", Kind: "ManagedResourceDefinition", Controller: ptr.To(true)},
 			},
 			changed: true,
+		},
+		"NilControllerPointer": {
+			reason: "Should treat Controller==nil as non-controller and leave the ref unchanged",
+			crd: &extv1.CustomResourceDefinition{
+				ObjectMeta: metav1.ObjectMeta{
+					OwnerReferences: []metav1.OwnerReference{
+						{APIVersion: "pkg.crossplane.io/v1", Kind: "ProviderRevision", Controller: nil},
+					},
+				},
+			},
+			want:    []metav1.OwnerReference{{APIVersion: "pkg.crossplane.io/v1", Kind: "ProviderRevision", Controller: nil}},
+			changed: false,
 		},
 		"NonControllerProviderRevision": {
 			reason: "Should not modify a ProviderRevision that is already controller:false",
 			crd: &extv1.CustomResourceDefinition{
 				ObjectMeta: metav1.ObjectMeta{
 					OwnerReferences: []metav1.OwnerReference{
-						{Kind: "ProviderRevision", Controller: &falseVal},
+						{APIVersion: "pkg.crossplane.io/v1", Kind: "ProviderRevision", Controller: ptr.To(false)},
 					},
 				},
 			},
-			want:    []metav1.OwnerReference{{Kind: "ProviderRevision", Controller: &falseVal}},
+			want:    []metav1.OwnerReference{{APIVersion: "pkg.crossplane.io/v1", Kind: "ProviderRevision", Controller: ptr.To(false)}},
 			changed: false,
 		},
 	}

--- a/internal/controller/apiextensions/managed/reconciler_test.go
+++ b/internal/controller/apiextensions/managed/reconciler_test.go
@@ -535,3 +535,92 @@ func (r *testRecorder) Event(_ runtime.Object, e event.Event) {
 func (r *testRecorder) WithAnnotations(_ ...string) event.Recorder {
 	return r
 }
+
+func TestDemoteStaleControllerRefs(t *testing.T) {
+	trueVal := true
+	falseVal := false
+
+	cases := map[string]struct {
+		reason  string
+		crd     *extv1.CustomResourceDefinition
+		want    []metav1.OwnerReference
+		changed bool
+	}{
+		"NoOwnerRefs": {
+			reason:  "Should return false when there are no ownerReferences",
+			crd:     &extv1.CustomResourceDefinition{},
+			want:    nil,
+			changed: false,
+		},
+		"MRDControllerOnly": {
+			reason: "Should return false when the only controller is the ManagedResourceDefinition",
+			crd: &extv1.CustomResourceDefinition{
+				ObjectMeta: metav1.ObjectMeta{
+					OwnerReferences: []metav1.OwnerReference{
+						{Kind: "ManagedResourceDefinition", Controller: &trueVal},
+					},
+				},
+			},
+			want:    []metav1.OwnerReference{{Kind: "ManagedResourceDefinition", Controller: &trueVal}},
+			changed: false,
+		},
+		"ProviderRevisionController": {
+			reason: "Should demote a ProviderRevision with controller:true",
+			crd: &extv1.CustomResourceDefinition{
+				ObjectMeta: metav1.ObjectMeta{
+					OwnerReferences: []metav1.OwnerReference{
+						{Kind: "ProviderRevision", Controller: &trueVal},
+						{Kind: "ManagedResourceDefinition", Controller: &falseVal},
+					},
+				},
+			},
+			want: []metav1.OwnerReference{
+				{Kind: "ProviderRevision", Controller: &falseVal},
+				{Kind: "ManagedResourceDefinition", Controller: &falseVal},
+			},
+			changed: true,
+		},
+		"MultipleStaleControllers": {
+			reason: "Should demote all non-MRD controller refs",
+			crd: &extv1.CustomResourceDefinition{
+				ObjectMeta: metav1.ObjectMeta{
+					OwnerReferences: []metav1.OwnerReference{
+						{Kind: "ProviderRevision", Name: "old", Controller: &trueVal},
+						{Kind: "ProviderRevision", Name: "older", Controller: &trueVal},
+						{Kind: "ManagedResourceDefinition", Controller: &trueVal},
+					},
+				},
+			},
+			want: []metav1.OwnerReference{
+				{Kind: "ProviderRevision", Name: "old", Controller: &falseVal},
+				{Kind: "ProviderRevision", Name: "older", Controller: &falseVal},
+				{Kind: "ManagedResourceDefinition", Controller: &trueVal},
+			},
+			changed: true,
+		},
+		"NonControllerProviderRevision": {
+			reason: "Should not modify a ProviderRevision that is already controller:false",
+			crd: &extv1.CustomResourceDefinition{
+				ObjectMeta: metav1.ObjectMeta{
+					OwnerReferences: []metav1.OwnerReference{
+						{Kind: "ProviderRevision", Controller: &falseVal},
+					},
+				},
+			},
+			want:    []metav1.OwnerReference{{Kind: "ProviderRevision", Controller: &falseVal}},
+			changed: false,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got := demoteStaleControllerRefs(tc.crd)
+			if diff := cmp.Diff(tc.changed, got); diff != "" {
+				t.Errorf("\n%s\ndemoteStaleControllerRefs(...): -want changed, +got changed:\n%s", tc.reason, diff)
+			}
+			if diff := cmp.Diff(tc.want, tc.crd.OwnerReferences); diff != "" {
+				t.Errorf("\n%s\ndemoteStaleControllerRefs(...): -want refs, +got refs:\n%s", tc.reason, diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What this does

Fixes #7311 — CRD updates fail during provider upgrades with:
> `metadata.ownerReferences: Invalid value: [...]: Only one reference can
> have Controller set to true`

## Root cause

`CRDAsUnstructured` propagated the MRD's controlling `ProviderRevision`
as `controller: true` onto the CRD's `ownerReferences`. During a
provider upgrade the old revision's `controller: true` entry was never
cleaned up — it became an unmanaged field after the SSA managed-fields
migration, so server-side apply left it in place. When the new revision
was then applied as controller, Kubernetes rejected the update because
two entries simultaneously claimed `controller: true`.

## Fix

**`CRDAsUnstructured` (`crd.go`)** — the MRD itself is now set as
`controller: true` on the CRD instead of propagating the
`ProviderRevision`. The GC chain `ProviderRevision → MRD → CRD` already
handles cascading deletion, so the revision does not need to appear
directly on the CRD.

**Migration step (`reconciler.go`)** — before each SSA apply, if the
CRD already exists with stale `controller: true` ownerReferences from
non-MRD sources (ProviderRevisions left over from Crossplane 1.x or
pre-fix 2.x), they are demoted to `controller: false` via a regular
Update. Without this step the first reconciliation on an affected cluster
would still conflict.

## Testing

- `TestCRDAsUnstructured` updated to assert the MRD is the sole
  controller ownerRef and the ProviderRevision is no longer propagated.
- `TestDemoteStaleControllerRefs` added: covers no-op (no refs,
  MRD-only, already-demoted) and mutation (single stale ref, multiple
  stale refs) cases.
- All unit tests pass (`go test ./...`; e2e skipped — requires a live
  kind cluster).
