### PR TITLE
design: Add a one-pager regarding versioning and releasing the CLI

### DIFF
--- a/design/one-pager-cli-releases.md
+++ b/design/one-pager-cli-releases.md
@@ -1,0 +1,93 @@
+# Decoupling CLI Releases from Crossplane Core Releases
+
+* Owner: Adam Wolfe Gordon (@adamwg)
+* Reviewers: Jared Watts (@jbw976), Nic Cope (@negz)
+* Status: Proposed
+
+## Background
+
+As part of the project to add developer experience tooling to the Crossplane
+CLI, we have decided to move the CLI to its own repository,
+`crossplane/cli`. This move has a few motivations:
+
+1. Decouple the feature development and release cadence of the CLI from
+   Crossplane core, with the intent that CLI development can move faster.
+2. Make it simpler for the CLI to have its own set of maintainers, who are not
+   necessarily all core Crossplane maintainers.
+3. Enforce architectural boundaries between the CLI and Crossplane core (since
+   the CLI can no longer import `internal/` packages from core).
+
+The first motivation being the primary and most compelling one, we must now
+define how CLI releases will relate to Crossplane core releases and by what
+mechanism they will be made available for installation.
+
+## Proposal
+
+### Versioning
+
+I propose that the initial CLI release from its new repository coincide with the
+v2.3.0 release of Crossplane, and carry the version number v2.3.0. This makes it
+clear that CLI development has continued in a new location and that users should
+update from v2.2.x or older releases.
+
+I propose that after the initial release, we allow the CLI's version to diverge
+from that of Crossplane core. In keeping with semantic versioning, the next
+bugfix release of the CLI following v2.3.0 will be v2.3.1, and the next release
+containing new features will be v2.4.0, regardless of whether its release date
+coincides with Crossplane v2.4.0.
+
+### Compatibility
+
+Given that the Crossplane CLI version number will no longer correspond to the
+Crossplane core version, we must define a policy for backward compatibility.
+
+In practice, I expect this will be largely a non-issue: going forward, all
+interactions between the CLI and Crossplane core will be across API boundaries,
+and Crossplane's APIs are relatively stable. We will, of course, introduce new
+CLI features that require new APIs and work only on newer versions of
+Crossplane, but existing features are unlikely to break.
+
+That being said, we still need a policy. I propose that:
+
+1. Pre-existing features in a new minor version of the Crossplane CLI will
+   maintain support for all Crossplane minor versions that are supported at
+   release time. For example, if we released CLI v2.4.0 in June, 2026 we would
+   support Crossplane v2.3, v2.2, and v2.1.
+2. Patch releases of the CLI will not break compatibility with any Crossplane
+   releases that were supported when their minor version was initially released,
+   even if it has since become EOL. I.e., changes to the compatibility matrix
+   will happen only in new minor versions of the CLI.
+
+### Artifact Location
+
+I propose that the CLI, going forward, will be distributed via a new S3 bucket
+called `crossplane-cli-releases` (separate from the existing
+`crossplane-releases` bucket used for Crossplane core artifacts). This new
+bucket will have the same layout as `crossplane-releases`, but contain only the
+CLI binaries and bundles.
+
+We do not currently distribute OCI images for the CLI, and will not start doing
+so immediately. If we do, they will be uploaded to the release bucket as
+tarballs and also pushed to GHCR, as the Crossplane core images are today.
+
+## Necessary Changes
+
+When we move the CLI into `crossplane/cli`, that repository will be bootstrapped
+with its own Nix-based build infrastructure configured to upload to the
+`crossplane-cli-releases` bucket. We should set up a new CloudFront
+distribution, `cli.crossplane.io`, to serve CLI releases as
+`releases.crossplane.io` does for Crossplane core.
+
+The `install.sh` script can be uploaded to the new bucket, so that users are
+able to install the CLI by running:
+
+```console
+curl -sL https://cli.crossplane.io | sh
+```
+
+The install script will need to be updated to reflect the new bucket
+location. For the time being, the install script can continue to also be
+available in the Crossplane core repository, but updated to point at the new
+bucket, so that any scripts relying on the current instructions (getting the
+script directly from the repository via `raw.githubusercontent.com`) continue to
+work.

--- a/design/one-pager-cli-releases.md
+++ b/design/one-pager-cli-releases.md
@@ -12,8 +12,8 @@ CLI, we have decided to move the CLI to its own repository,
 
 1. Decouple the feature development and release cadence of the CLI from
    Crossplane core, with the intent that CLI development can move faster.
-2. Make it simpler for the CLI to have its own set of maintainers, who are not
-   necessarily all core Crossplane maintainers.
+2. Make it possible for the CLI to have additional maintainers on top of the 
+   core Crossplane ones. 
 3. Enforce architectural boundaries between the CLI and Crossplane core (since
    the CLI can no longer import `internal/` packages from core).
 

--- a/design/one-pager-cli-releases.md
+++ b/design/one-pager-cli-releases.md
@@ -74,6 +74,34 @@ That being said, we still need a policy. I propose that:
    major versions of Crossplane. I.e., features in CLI v3.0 may be incompatible
    with non-EOL versions of Crossplane v2.x.
 
+The support matrix will be documented in the CLI's README file and on the CLI
+overview page on docs.crossplane.io. It will also be encoded into the CLI itself
+so that cluster-facing commands can print a warning if the CLI version is not
+officially compatible with the observed Crossplane version.
+
+### Release Cadence
+
+For now, I propose that the CLI will not have a fixed release cadence. Rather,
+we will cut a new minor release whenever we have substantial new features merged
+to `main`. In order to meet the compatibility guarantees described above, we
+will also do a minor release to coincide with each new minor release of
+Crossplane core.
+
+As we settle into the rhythm of development in the new CLI repository, we may
+revisit this decision and set a fixed release cadence.
+
+### Support Window
+
+With the CLI being simpler and less risky to upgrade than core Crossplane, we
+expect that users will upgrade to new CLI releases relatively frequently. Given
+this, it is reasonable to offer a shorter support window for CLI releases than
+the 9 months / 3 minor versions we offer for core Crossplane.
+
+I propose that we support the two most recent minor versions of the CLI,
+regardless of their release date. This provides a supported trailing release for
+users who prefer not to take up larger changes right away, while minimizing
+release toil for the CLI maintainers.
+
 ### Artifact Location
 
 I propose that the CLI, going forward, will be distributed via a new S3 bucket

--- a/design/one-pager-cli-releases.md
+++ b/design/one-pager-cli-releases.md
@@ -36,10 +36,19 @@ bugfix release of the CLI following v2.3.0 will be v2.3.1, and the next release
 containing new features will be v2.4.0, regardless of whether its release date
 coincides with Crossplane v2.4.0.
 
+A v3.0 version of the CLI will be developed and released along with Crossplane
+v3.0.
+
 ### Compatibility
 
 Given that the Crossplane CLI version number will no longer correspond to the
-Crossplane core version, we must define a policy for backward compatibility.
+Crossplane core version, we must define a policy for backward compatibility. CLI
+release `X` being compatible with Crossplane release `Y` means that:
+
+1. Commands in CLI version `X` that interact with a Crossplane cluster work
+   correctly when the cluster is running version `Y`.
+2. Artifacts produced by CLI version `X` (e.g., packages) work correctly on a
+   cluster running version `Y`.
 
 In practice, I expect this will be largely a non-issue: going forward, all
 interactions between the CLI and Crossplane core will be across API boundaries,
@@ -51,12 +60,19 @@ That being said, we still need a policy. I propose that:
 
 1. Pre-existing features in a new minor version of the Crossplane CLI will
    maintain support for all Crossplane minor versions that are supported at
-   release time. For example, if we released CLI v2.4.0 in June, 2026 we would
+   release time. For example, if we release CLI v2.4.0 before August, 2026 (when
+   Crossplane v2.4 is release and v2.1 reaches EOL) all existing features will
    support Crossplane v2.3, v2.2, and v2.1.
-2. Patch releases of the CLI will not break compatibility with any Crossplane
+2. New features released in a minor version of the Crossplane CLI may be
+   compatible with only a subset of the supported Crossplane versions at the
+   time. This allows for CLI features that depend on new core functionality.
+3. Patch releases of the CLI will not break compatibility with any Crossplane
    releases that were supported when their minor version was initially released,
    even if it has since become EOL. I.e., changes to the compatibility matrix
    will happen only in new minor versions of the CLI.
+4. New major versions of the CLI will guarantee compatibility only with matching
+   major versions of Crossplane. I.e., features in CLI v3.0 may be incompatible
+   with non-EOL versions of Crossplane v2.x.
 
 ### Artifact Location
 

--- a/design/one-pager-cli-releases.md
+++ b/design/one-pager-cli-releases.md
@@ -82,6 +82,16 @@ called `crossplane-cli-releases` (separate from the existing
 bucket will have the same layout as `crossplane-releases`, but contain only the
 CLI binaries and bundles.
 
+To provide a smooth transition period, we will do two things:
+
+1. Update the `install.sh` script to parse versions and choose the appropriate
+   bucket based on the version, so that it can continue to be used to install
+   any available version.
+2. Manually upload v2.3.x releases of the CLI to the core `crossplane-releases`
+   bucket so that anyone relying on them to be available there can get
+   them. This means that for the lifetime of the v2.3 release branch, we will
+   create CLI patch releases to match core patch releases.
+
 We do not currently distribute OCI images for the CLI, and will not start doing
 so immediately. If we do, they will be uploaded to the release bucket as
 tarballs and also pushed to GHCR, as the Crossplane core images are today.
@@ -98,7 +108,7 @@ The `install.sh` script can be uploaded to the new bucket, so that users are
 able to install the CLI by running:
 
 ```console
-curl -sL https://cli.crossplane.io | sh
+curl -sfL https://cli.crossplane.io/install.sh | sh
 ```
 
 The install script will need to be updated to reflect the new bucket


### PR DESCRIPTION
### Description of your changes

With the CLI being moved into a separate repository as part of the developer experience work, we need to define how it will be versioned and released.

Fixes #4850 

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `./nix.sh flake check` to ensure this PR is ready for review.
~- [ ] Added or updated unit tests.~
~- [ ] Added or updated e2e tests.~
~- [ ] Linked a PR or a [docs tracking issue] to [document this change].~
~- [ ] Added `backport release-x.y` labels to auto-backport this PR.~
~- [ ] Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md
