### PR TITLE
Add ReconcilePending condition for async operations

### DIFF
--- a/apis/core/v2/condition.go
+++ b/apis/core/v2/condition.go
@@ -68,6 +68,7 @@ const (
 	ReasonReconcileSuccess ConditionReason = "ReconcileSuccess"
 	ReasonReconcileError   ConditionReason = "ReconcileError"
 	ReasonReconcilePaused  ConditionReason = "ReconcilePaused"
+	ReasonReconcilePending ConditionReason = "ReconcilePending"
 )
 
 // Reasons a resource is or is not up to date.
@@ -323,6 +324,19 @@ func ReconcilePaused() Condition {
 		Status:             corev1.ConditionFalse,
 		LastTransitionTime: metav1.Now(),
 		Reason:             ReasonReconcilePaused,
+	}
+}
+
+// ReconcilePending returns a condition indicating that reconciliation is
+// deferred pending an in-flight async operation. Unlike ReconcileError, this
+// does not trigger exponential backoff.
+func ReconcilePending(msg string) Condition {
+	return Condition{
+		Type:               TypeSynced,
+		Status:             corev1.ConditionFalse,
+		LastTransitionTime: metav1.Now(),
+		Reason:             ReasonReconcilePending,
+		Message:            msg,
 	}
 }
 


### PR DESCRIPTION
## Description

Add a `ReconcilePending` condition constructor and `ReasonReconcilePending` constant to the core condition types. This enables the managed reconciler to express "reconciliation is deferred pending an in-flight async operation" without triggering exponential backoff (unlike `ReconcileError`) or falsely reporting success (unlike `ReconcileSuccess`).

### What this adds

- `ReasonReconcilePending` — new `ConditionReason` constant
- `ReconcilePending(msg string) Condition` — sets `Synced=False` with reason `ReconcilePending` and a caller-provided message

### Why

When an upjet-based provider has a long-running async operation in progress (e.g. an MSK cluster instance type change taking 60+ minutes), the `Synced` condition remains `True` for the entire duration. The existing condition constructors (`ReconcileSuccess`, `ReconcileError`, `ReconcilePaused`) cannot model this state:

- `ReconcileSuccess` — incorrect, reconciliation has not succeeded
- `ReconcileError` — triggers exponential backoff, the opposite of what is needed
- `ReconcilePaused` — semantically wrong, reconciliation is not paused

`ReconcilePending` fills this gap.

### Related

- Companion crossplane-runtime PR: https://github.com/crossplane/crossplane-runtime/pull/984
- Companion upjet PR: https://github.com/crossplane/upjet/pull/638
- crossplane-runtime issue: https://github.com/crossplane/crossplane-runtime/issues/941
- upjet issue: https://github.com/crossplane/upjet/issues/609