### PR TITLE
Use pkgs.unstable overlay instead of single pkgs.go-unstable attribute

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -91,13 +91,12 @@
             inherit system;
             overlays = [
               gomod2nix.overlays.default
-              (_final: _prev: {
-                # We use the go toolchain from unstable because it's been
-                # updated to fix some CVEs. However, we explicitly use this only
-                # in our build targets rather than replace Go in the global
-                # overlay so that we can still use pre-built binaries for
-                # Go-based tools from nixpkgs.
-                go-unstable = nixpkgs-unstable.legacyPackages.${system}.go_1_25;
+              (_final: prev: {
+                # Allow use of pkgs.unstable.<package-name> to pull individual
+                # packages from nixpkgs-unstable.
+                unstable = import nixpkgs-unstable {
+                  system = prev.stdenv.hostPlatform.system;
+                };
               })
             ];
           };
@@ -200,7 +199,7 @@
               pkgs.coreutils
               pkgs.gnused
               pkgs.ncurses
-              pkgs.go-unstable
+              pkgs.unstable.go_1_25
               pkgs.golangci-lint
               pkgs.kubectl
               pkgs.kubernetes-helm

--- a/nix/apps.nix
+++ b/nix/apps.nix
@@ -21,7 +21,7 @@
     program = pkgs.lib.getExe (
       pkgs.writeShellApplication {
         name = "crossplane-test";
-        runtimeInputs = [ pkgs.go-unstable ];
+        runtimeInputs = [ pkgs.unstable.go_1_25 ];
         inheritPath = false;
         text = ''
           export CGO_ENABLED=0
@@ -41,7 +41,7 @@
         name = "crossplane-lint";
         runtimeInputs = [
           pkgs.findutils
-          pkgs.go-unstable
+          pkgs.unstable.go_1_25
           pkgs.golangci-lint
           pkgs.statix
           pkgs.deadnix
@@ -85,7 +85,7 @@
         runtimeInputs = [
           pkgs.coreutils
           pkgs.gnused
-          pkgs.go-unstable
+          pkgs.unstable.go_1_25
           pkgs.kubectl
           pkgs.helm-docs
 
@@ -130,7 +130,7 @@
       pkgs.writeShellApplication {
         name = "crossplane-tidy";
         runtimeInputs = [
-          pkgs.go-unstable
+          pkgs.unstable.go_1_25
           pkgs.gomod2nix
         ];
         inheritPath = false;
@@ -178,7 +178,7 @@
           name = "crossplane-e2e";
           runtimeInputs = [
             pkgs.coreutils
-            pkgs.go-unstable
+            pkgs.unstable.go_1_25
             pkgs.docker-client
             pkgs.gotestsum
             pkgs.kind

--- a/nix/build.nix
+++ b/nix/build.nix
@@ -29,7 +29,7 @@ let
       subPackages = [ subPackage ];
 
       # Cross-compile by merging GOOS/GOARCH into Go's attrset (// merges attrsets).
-      go = pkgs.go-unstable // {
+      go = pkgs.unstable.go_1_25 // {
         GOOS = platform.os;
         GOARCH = platform.arch;
       };
@@ -205,7 +205,7 @@ in
       src = self;
       pwd = self;
       modules = "${self}/gomod2nix.toml";
-      go = pkgs.go-unstable;
+      go = pkgs.unstable.go_1_25;
 
       CGO_ENABLED = "0";
 

--- a/nix/checks.nix
+++ b/nix/checks.nix
@@ -20,7 +20,7 @@
       src = self;
       pwd = self;
       modules = ../gomod2nix.toml;
-      go = pkgs.go-unstable;
+      go = pkgs.unstable.go_1_25;
 
       CGO_ENABLED = "0";
 
@@ -48,7 +48,7 @@
       src = "${self}/apis";
       pwd = "${self}/apis";
       modules = "${self}/apis/gomod2nix.toml";
-      go = pkgs.go-unstable;
+      go = pkgs.unstable.go_1_25;
 
       CGO_ENABLED = "0";
 
@@ -76,7 +76,7 @@
       src = self;
       pwd = self;
       modules = ../gomod2nix.toml;
-      go = pkgs.go-unstable;
+      go = pkgs.unstable.go_1_25;
 
       CGO_ENABLED = "0";
 
@@ -107,7 +107,7 @@
       src = "${self}/apis";
       pwd = "${self}/apis";
       modules = "${self}/apis/gomod2nix.toml";
-      go = pkgs.go-unstable;
+      go = pkgs.unstable.go_1_25;
 
       CGO_ENABLED = "0";
 
@@ -151,7 +151,7 @@
       src = self;
       pwd = self;
       modules = ../gomod2nix.toml;
-      go = pkgs.go-unstable;
+      go = pkgs.unstable.go_1_25;
 
       CGO_ENABLED = "0";
 
@@ -206,7 +206,7 @@
       src = "${self}/apis";
       pwd = "${self}/apis";
       modules = "${self}/apis/gomod2nix.toml";
-      go = pkgs.go-unstable;
+      go = pkgs.unstable.go_1_25;
 
       CGO_ENABLED = "0";
 


### PR DESCRIPTION
### Description of your changes

The Nix overlay previously exported only a single package from nixpkgs-unstable as `pkgs.go-unstable`. This works, but it's a one-off pattern that doesn't scale if we need other packages from unstable.

This PR replaces the single-attribute overlay with one that imports the entire nixpkgs-unstable package set as `pkgs.unstable`, and updates all references to use `pkgs.unstable.go_1_25`. This allows any package to be pulled from unstable using `pkgs.unstable.<name>`.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `./nix.sh flake check` to ensure this PR is ready for review.
- [ ] ~Added or updated unit tests.~
- [ ] ~Added or updated e2e tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~
- [ ] ~Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md