### PR TITLE
feat(helm): add podMonitor to helm chart and adjust values

### DIFF
--- a/cluster/charts/crossplane/templates/podmonitor.yaml
+++ b/cluster/charts/crossplane/templates/podmonitor.yaml
@@ -1,0 +1,46 @@
+{{- if and .Values.metrics.enabled .Values.metrics.podMonitor.enabled }}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: {{ template "crossplane.name" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "crossplane.name" . }}
+    release: {{ .Release.Name }}
+    {{- include "crossplane.labels" . | indent 4 }}
+spec:
+  jobLabel: app.kubernetes.io/name
+  selector:
+    matchLabels:
+      app: {{ template "crossplane.name" . }}
+      release: {{ .Release.Name }}
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  podMetricsEndpoints:
+    - port: metrics
+      path: {{ .Values.metrics.podMonitor.path }}
+      {{- with .Values.metrics.podMonitor.interval }}
+      interval: {{ . }}
+      {{- end }}
+      {{- with .Values.metrics.podMonitor.scrapeTimeout }}
+      scrapeTimeout: {{ . }}
+      {{- end }}
+      {{- with .Values.metrics.podMonitor.scheme }}
+      scheme: {{ . }}
+      {{- end }}
+      {{- with .Values.metrics.podMonitor.tlsConfig }}
+      tlsConfig:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.metrics.podMonitor.relabelings }}
+      relabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.metrics.podMonitor.metricRelabelings }}
+      metricRelabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      honorLabels: {{ .Values.metrics.podMonitor.honorLabels }}
+{{- end }}

--- a/cluster/charts/crossplane/templates/rbac-manager-podmonitor.yaml
+++ b/cluster/charts/crossplane/templates/rbac-manager-podmonitor.yaml
@@ -1,0 +1,46 @@
+{{- if and .Values.rbacManager.deploy .Values.metrics.enabled .Values.metrics.podMonitor.enabled }}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: {{ template "crossplane.name" . }}-rbac-manager
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "crossplane.name" . }}-rbac-manager
+    release: {{ .Release.Name }}
+    {{- include "crossplane.labels" . | indent 4 }}
+spec:
+  jobLabel: app.kubernetes.io/name
+  selector:
+    matchLabels:
+      app: {{ template "crossplane.name" . }}-rbac-manager
+      release: {{ .Release.Name }}
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  podMetricsEndpoints:
+    - port: metrics
+      path: {{ .Values.metrics.podMonitor.path }}
+      {{- with .Values.metrics.podMonitor.interval }}
+      interval: {{ . }}
+      {{- end }}
+      {{- with .Values.metrics.podMonitor.scrapeTimeout }}
+      scrapeTimeout: {{ . }}
+      {{- end }}
+      {{- with .Values.metrics.podMonitor.scheme }}
+      scheme: {{ . }}
+      {{- end }}
+      {{- with .Values.metrics.podMonitor.tlsConfig }}
+      tlsConfig:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.metrics.podMonitor.relabelings }}
+      relabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.metrics.podMonitor.metricRelabelings }}
+      metricRelabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      honorLabels: {{ .Values.metrics.podMonitor.honorLabels }}
+{{- end }}

--- a/cluster/charts/crossplane/values.yaml
+++ b/cluster/charts/crossplane/values.yaml
@@ -186,6 +186,29 @@ metrics:
   enabled: false
   # -- The port the metrics server listens on.
   port: ""
+ 
+  podMonitor:
+    # -- If true, PodMonitor CRs are created for the Prometheus Operator.
+    # Creates one PodMonitor for the Crossplane deployment and one for
+    # the RBAC Manager (when `rbacManager.deploy` is also true).
+    # Requires `metrics.enabled: true`.
+    enabled: false
+    # -- The path to scrape for metrics.
+    path: /metrics
+    # -- The scrape interval. Falls back to the Prometheus default if unset. example: 30s
+    interval: ""
+    # -- The scrape timeout. Falls back to the Prometheus default if unset. example: 10s
+    scrapeTimeout: ""
+    # -- HTTP scheme to use for scraping (http or https). Omit or leave empty to let the Prometheus Operator use its default.
+    scheme: ""
+    # -- If true, labels from scraped data are honored over labels attached to the PodMonitor
+    honorLabels: false
+    # -- TLS configuration for the scrape endpoint.
+    tlsConfig: {}
+    # -- RelabelConfigs to apply to samples before scraping.
+    relabelings: []
+    # -- MetricRelabelConfigs to apply to samples after scraping, before ingestion.
+    metricRelabelings: []
 
 readiness:
   # -- The port the readyz server listens on.


### PR DESCRIPTION
### Description of your changes

This change introduces a configurable podMonitor for the rbac manager as well as the crossplane pod itself. The podMonitor will only be created if metrics are created - the rbac-manager one only when that is also enabled. 

It adds the option to utilize prometheus-operator ressources out-of-the-values-file

Fixes #7358 

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [X] Read and followed Crossplane's [contribution process].
- [X] Run `./nix.sh flake check` to ensure this PR is ready for review.
~- [ ] Added or updated unit tests.~
~- [ ] Added or updated e2e tests.~
- [X] Linked a PR or a [docs tracking issue] to [document this change].
~- [ ] Added `backport release-x.y` labels to auto-backport this PR.~
~- [ ] Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md
