### PR TITLE
feat(provider-deletion): protect Providers from deletion via ClusterUsage

### DIFF
--- a/cmd/crossplane/core/core.go
+++ b/cmd/crossplane/core/core.go
@@ -136,6 +136,7 @@ type startCommand struct {
 	EnableFunctionResponseCache       bool `group:"Alpha Features:" help:"Enable support for caching composition function responses."`
 	EnableOperations                  bool `group:"Alpha Features:" help:"Enable support for Operations."`
 	EnablePipelineInspector           bool `group:"Alpha Features:" help:"Enable support for emitting function pipeline execution data to a sidecar."`
+	EnableProviderDeletionProtection  bool `group:"Alpha Features:" help:"Enable automatic protection of Providers from deletion when they have active managed resources. Requires --enable-usages."`
 
 	XfnCacheDir             string        `default:"/cache/xfn"                         env:"XFN_CACHE_DIR"             group:"Alpha Features:" help:"Directory used for caching function responses. Requires --enable-function-response-cache."`
 	XfnCacheMaxTTL          time.Duration `default:"24h"                                env:"XFN_CACHE_MAX_TTL"         group:"Alpha Features:" help:"Maximum TTL for cached function responses. Set to 0 to disable. Requires --enable-function-response-cache."`
@@ -350,6 +351,11 @@ func (c *startCommand) Run(s *runtime.Scheme, log logging.Logger) error { //noli
 	if c.EnableOperations {
 		o.Features.Enable(features.EnableAlphaOperations)
 		log.Info("Alpha feature enabled", "flag", features.EnableAlphaOperations)
+	}
+
+	if c.EnableProviderDeletionProtection {
+		o.Features.Enable(features.EnableAlphaProviderDeletionProtection)
+		log.Info("Alpha feature enabled", "flag", features.EnableAlphaProviderDeletionProtection)
 	}
 
 	cacheOptionsAPIExt := cache.Options{

--- a/flake.nix
+++ b/flake.nix
@@ -95,7 +95,7 @@
                 # Allow use of pkgs.unstable.<package-name> to pull individual
                 # packages from nixpkgs-unstable.
                 unstable = import nixpkgs-unstable {
-                  system = prev.stdenv.hostPlatform.system;
+                  inherit (prev.stdenv.hostPlatform) system;
                 };
               })
             ];

--- a/internal/controller/apiextensions/managed/protection.go
+++ b/internal/controller/apiextensions/managed/protection.go
@@ -1,0 +1,218 @@
+/*
+Copyright 2025 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package managed
+
+import (
+	"context"
+	"crypto/sha256"
+	"fmt"
+	"time"
+
+	kmeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kunstructured "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"github.com/crossplane/crossplane-runtime/v2/pkg/errors"
+	"github.com/crossplane/crossplane-runtime/v2/pkg/logging"
+	"github.com/crossplane/crossplane-runtime/v2/pkg/resource"
+
+	"github.com/crossplane/crossplane/apis/v2/apiextensions/v1alpha1"
+	pkgv1 "github.com/crossplane/crossplane/apis/v2/pkg/v1"
+	protectionv1beta1 "github.com/crossplane/crossplane/apis/v2/protection/v1beta1"
+)
+
+// FieldOwnerMRDProtection is the field manager name used when applying
+// ClusterUsage objects for provider deletion protection.
+const FieldOwnerMRDProtection = "apiextensions.crossplane.io/managed-protection"
+
+// Error strings for the protection reconciler.
+const (
+	errListMRs             = "cannot list managed resources"
+	errGetMRDForProtection = "cannot get ManagedResourceDefinition for protection"
+	errGetProviderRevision = "cannot get ProviderRevision"
+	errResolveProvider     = "cannot resolve Provider from ProviderRevision"
+	errApplyClusterUsage   = "cannot apply ClusterUsage"
+	errDeleteClusterUsage  = "cannot delete ClusterUsage"
+)
+
+// ProtectionControllerName returns the name of the protection controller
+// for the given MRD name.
+func ProtectionControllerName(mrdName string) string {
+	return "protection/" + mrdName
+}
+
+// ClusterUsageName returns a deterministic name for a ClusterUsage
+// protecting a Provider due to the given MRD. It uses a SHA-256 hash
+// to avoid exceeding the Kubernetes 253-character name limit.
+func ClusterUsageName(mrdName string) string {
+	h := sha256.Sum256([]byte(mrdName))
+	return fmt.Sprintf("provider-protection-%x", h[:26])
+}
+
+// ResourceMapFunc returns a handler.MapFunc that enqueues a fixed
+// reconcile request for the protection controller whenever any managed
+// resource of the watched type changes.
+func ResourceMapFunc(mrdName string) handler.MapFunc {
+	return func(_ context.Context, _ client.Object) []reconcile.Request {
+		return []reconcile.Request{{
+			NamespacedName: types.NamespacedName{Name: mrdName},
+		}}
+	}
+}
+
+// A ProtectionReconciler manages a ClusterUsage that protects a Provider from
+// deletion when managed resources of the given type exist.
+type ProtectionReconciler struct {
+	cached  client.Client // engine's cached client, for reading MR instances
+	writer  client.Client // main client, for writing ClusterUsage objects
+	mrdName string
+	gvk     schema.GroupVersionKind
+	log     logging.Logger
+}
+
+// Reconcile checks whether any managed resources of the watched type exist.
+// If they do, it ensures a ClusterUsage exists to protect the owning Provider.
+// If none exist, it deletes the ClusterUsage.
+func (r *ProtectionReconciler) Reconcile(ctx context.Context, _ reconcile.Request) (reconcile.Result, error) {
+	log := r.log.WithValues("gvk", r.gvk.String())
+	log.Debug("Reconciling provider deletion protection")
+
+	list := &kunstructured.UnstructuredList{}
+	list.SetGroupVersionKind(r.gvk.GroupVersion().WithKind(r.gvk.Kind + "List"))
+
+	if err := r.cached.List(ctx, list, client.Limit(1)); err != nil {
+		// If the CRD doesn't exist (yet or anymore), treat as no MRs.
+		if kmeta.IsNoMatchError(err) {
+			log.Debug("CRD not found, ensuring no ClusterUsage")
+			return r.ensureNoClusterUsage(ctx)
+		}
+		return reconcile.Result{}, errors.Wrap(err, errListMRs)
+	}
+
+	if len(list.Items) > 0 {
+		return r.ensureClusterUsage(ctx)
+	}
+
+	return r.ensureNoClusterUsage(ctx)
+}
+
+func (r *ProtectionReconciler) ensureClusterUsage(ctx context.Context) (reconcile.Result, error) {
+	mrd := &v1alpha1.ManagedResourceDefinition{}
+	if err := r.cached.Get(ctx, types.NamespacedName{Name: r.mrdName}, mrd); err != nil {
+		return reconcile.Result{}, errors.Wrap(err, errGetMRDForProtection)
+	}
+
+	providerName, err := resolveProviderName(ctx, r.cached, mrd)
+	if err != nil {
+		r.log.Debug("Cannot resolve Provider name, will retry", "error", err)
+		return reconcile.Result{RequeueAfter: 30 * time.Second}, nil
+	}
+
+	mrType := fmt.Sprintf("%s.%s", mrd.Spec.Names.Kind, mrd.Spec.Group)
+	cu := buildClusterUsage(r.mrdName, providerName, mrType)
+
+	//nolint:staticcheck // TODO(adamwg): Stop using client.Apply after the v2.2 release.
+	if err := r.writer.Patch(ctx, cu, client.Apply,
+		client.ForceOwnership,
+		client.FieldOwner(FieldOwnerMRDProtection),
+	); err != nil {
+		return reconcile.Result{}, errors.Wrap(err, errApplyClusterUsage)
+	}
+
+	r.log.Debug("ClusterUsage applied for provider protection", "provider", providerName, "mrType", mrType)
+	return reconcile.Result{}, nil
+}
+
+func (r *ProtectionReconciler) ensureNoClusterUsage(ctx context.Context) (reconcile.Result, error) {
+	cu := &protectionv1beta1.ClusterUsage{}
+	cu.SetName(ClusterUsageName(r.mrdName))
+	if err := r.writer.Delete(ctx, cu); resource.IgnoreNotFound(err) != nil {
+		return reconcile.Result{}, errors.Wrap(err, errDeleteClusterUsage)
+	}
+	r.log.Debug("ClusterUsage removed for provider protection")
+	return reconcile.Result{}, nil
+}
+
+// resolveProviderName follows the owner chain from MRD -> ProviderRevision ->
+// Provider to determine the name of the Provider that owns the given MRD.
+func resolveProviderName(ctx context.Context, c client.Client, mrd *v1alpha1.ManagedResourceDefinition) (string, error) {
+	owner := metav1.GetControllerOf(mrd)
+	if owner == nil {
+		return "", errors.New("MRD has no controller owner")
+	}
+
+	rev := &pkgv1.ProviderRevision{}
+	if err := c.Get(ctx, types.NamespacedName{Name: owner.Name}, rev); err != nil {
+		return "", errors.Wrap(err, errGetProviderRevision)
+	}
+
+	providerName := rev.GetLabels()[pkgv1.LabelParentPackage]
+	if providerName == "" {
+		return "", errors.Errorf("ProviderRevision %q has no %s label", rev.GetName(), pkgv1.LabelParentPackage)
+	}
+
+	return providerName, nil
+}
+
+// buildClusterUsage constructs a ClusterUsage that protects a Provider from
+// deletion due to the existence of managed resources of the given type.
+func buildClusterUsage(mrdName, providerName, mrTypeDescription string) *protectionv1beta1.ClusterUsage {
+	return &protectionv1beta1.ClusterUsage{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: protectionv1beta1.SchemeGroupVersion.String(),
+			Kind:       protectionv1beta1.ClusterUsageKind,
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: ClusterUsageName(mrdName),
+			Labels: map[string]string{
+				"crossplane.io/provider-protection": "true",
+				pkgv1.LabelParentPackage:            providerName,
+				"apiextensions.crossplane.io/mrd":   mrdName,
+			},
+		},
+		Spec: protectionv1beta1.ClusterUsageSpec{
+			Of: protectionv1beta1.Resource{
+				APIVersion: pkgv1.SchemeGroupVersion.String(),
+				Kind:       pkgv1.ProviderKind,
+				ResourceRef: &protectionv1beta1.ResourceRef{
+					Name: providerName,
+				},
+			},
+			Reason: ptr.To(fmt.Sprintf(
+				"Provider has active managed resources of type %s",
+				mrTypeDescription,
+			)),
+		},
+	}
+}
+
+// storageVersion returns the storage version name from the MRD.
+func storageVersion(mrd *v1alpha1.ManagedResourceDefinition) string {
+	for _, v := range mrd.Spec.Versions {
+		if v.Storage {
+			return v.Name
+		}
+	}
+	// This should never be reached as the MRD API requires a storage version.
+	return ""
+}

--- a/internal/controller/apiextensions/managed/protection.go
+++ b/internal/controller/apiextensions/managed/protection.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"crypto/sha256"
 	"fmt"
-	"time"
 
 	kmeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -44,16 +43,6 @@ import (
 // FieldOwnerMRDProtection is the field manager name used when applying
 // ClusterUsage objects for provider deletion protection.
 const FieldOwnerMRDProtection = "apiextensions.crossplane.io/managed-protection"
-
-// Error strings for the protection reconciler.
-const (
-	errListMRs             = "cannot list managed resources"
-	errGetMRDForProtection = "cannot get ManagedResourceDefinition for protection"
-	errGetProviderRevision = "cannot get ProviderRevision"
-	errResolveProvider     = "cannot resolve Provider from ProviderRevision"
-	errApplyClusterUsage   = "cannot apply ClusterUsage"
-	errDeleteClusterUsage  = "cannot delete ClusterUsage"
-)
 
 // ProtectionControllerName returns the name of the protection controller
 // for the given MRD name.
@@ -106,7 +95,7 @@ func (r *ProtectionReconciler) Reconcile(ctx context.Context, _ reconcile.Reques
 			log.Debug("CRD not found, ensuring no ClusterUsage")
 			return r.ensureNoClusterUsage(ctx)
 		}
-		return reconcile.Result{}, errors.Wrap(err, errListMRs)
+		return reconcile.Result{}, errors.Wrap(err, "cannot list managed resources")
 	}
 
 	if len(list.Items) > 0 {
@@ -119,13 +108,12 @@ func (r *ProtectionReconciler) Reconcile(ctx context.Context, _ reconcile.Reques
 func (r *ProtectionReconciler) ensureClusterUsage(ctx context.Context) (reconcile.Result, error) {
 	mrd := &v1alpha1.ManagedResourceDefinition{}
 	if err := r.cached.Get(ctx, types.NamespacedName{Name: r.mrdName}, mrd); err != nil {
-		return reconcile.Result{}, errors.Wrap(err, errGetMRDForProtection)
+		return reconcile.Result{}, errors.Wrap(err, "cannot get ManagedResourceDefinition for protection")
 	}
 
 	providerName, err := resolveProviderName(ctx, r.cached, mrd)
 	if err != nil {
-		r.log.Debug("Cannot resolve Provider name, will retry", "error", err)
-		return reconcile.Result{RequeueAfter: 30 * time.Second}, nil
+		return reconcile.Result{}, errors.Wrap(err, "cannot resolve Provider name")
 	}
 
 	mrType := fmt.Sprintf("%s.%s", mrd.Spec.Names.Kind, mrd.Spec.Group)
@@ -136,7 +124,7 @@ func (r *ProtectionReconciler) ensureClusterUsage(ctx context.Context) (reconcil
 		client.ForceOwnership,
 		client.FieldOwner(FieldOwnerMRDProtection),
 	); err != nil {
-		return reconcile.Result{}, errors.Wrap(err, errApplyClusterUsage)
+		return reconcile.Result{}, errors.Wrap(err, "cannot apply ClusterUsage")
 	}
 
 	r.log.Debug("ClusterUsage applied for provider protection", "provider", providerName, "mrType", mrType)
@@ -147,7 +135,7 @@ func (r *ProtectionReconciler) ensureNoClusterUsage(ctx context.Context) (reconc
 	cu := &protectionv1beta1.ClusterUsage{}
 	cu.SetName(ClusterUsageName(r.mrdName))
 	if err := r.writer.Delete(ctx, cu); resource.IgnoreNotFound(err) != nil {
-		return reconcile.Result{}, errors.Wrap(err, errDeleteClusterUsage)
+		return reconcile.Result{}, errors.Wrap(err, "cannot delete ClusterUsage")
 	}
 	r.log.Debug("ClusterUsage removed for provider protection")
 	return reconcile.Result{}, nil
@@ -163,7 +151,7 @@ func resolveProviderName(ctx context.Context, c client.Client, mrd *v1alpha1.Man
 
 	rev := &pkgv1.ProviderRevision{}
 	if err := c.Get(ctx, types.NamespacedName{Name: owner.Name}, rev); err != nil {
-		return "", errors.Wrap(err, errGetProviderRevision)
+		return "", errors.Wrap(err, "cannot get ProviderRevision")
 	}
 
 	providerName := rev.GetLabels()[pkgv1.LabelParentPackage]

--- a/internal/controller/apiextensions/managed/protection_test.go
+++ b/internal/controller/apiextensions/managed/protection_test.go
@@ -18,6 +18,7 @@ package managed
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -28,6 +29,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kunstructured "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -341,36 +343,103 @@ func TestProtectionReconcilerReconcile(t *testing.T) {
 }
 
 func TestClusterUsageName(t *testing.T) {
-	cases := map[string]struct {
+	type args struct {
 		mrdName string
+	}
+	type want struct {
+		prefix        string
+		deterministic bool
+		maxLen        int
+	}
+
+	cases := map[string]struct {
+		reason string
+		args   args
+		want   want
 	}{
-		"Short": {mrdName: "test-mrd"},
-		"Long":  {mrdName: "very-long-managed-resource-definition-name-that-could-potentially-exceed-kubernetes-limits.some-group.example.com"},
+		"ShortName": {
+			reason: "A short MRD name should produce a deterministic name within Kubernetes limits",
+			args: args{
+				mrdName: "test-mrd",
+			},
+			want: want{
+				prefix:        "provider-protection-",
+				deterministic: true,
+				maxLen:        253,
+			},
+		},
+		"LongName": {
+			reason: "A long MRD name should produce a deterministic name within Kubernetes limits",
+			args: args{
+				mrdName: "very-long-managed-resource-definition-name-that-could-potentially-exceed-kubernetes-limits.some-group.example.com",
+			},
+			want: want{
+				prefix:        "provider-protection-",
+				deterministic: true,
+				maxLen:        253,
+			},
+		},
 	}
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			got := ClusterUsageName(tc.mrdName)
-			if len(got) > 253 {
-				t.Errorf("ClusterUsageName(%q) = %q (len %d), want len <= 253", tc.mrdName, got, len(got))
+			got := ClusterUsageName(tc.args.mrdName)
+
+			if len(got) > tc.want.maxLen {
+				t.Errorf("\n%s\nClusterUsageName(%q) length = %d, want <= %d", tc.reason, tc.args.mrdName, len(got), tc.want.maxLen)
 			}
-			// Should be deterministic
-			if got != ClusterUsageName(tc.mrdName) {
-				t.Errorf("ClusterUsageName(%q) is not deterministic", tc.mrdName)
+			if tc.want.deterministic {
+				if diff := cmp.Diff(got, ClusterUsageName(tc.args.mrdName)); diff != "" {
+					t.Errorf("\n%s\nClusterUsageName(%q) is not deterministic: -want, +got:\n%s", tc.reason, tc.args.mrdName, diff)
+				}
 			}
-			// Should start with provider-protection-
-			const prefix = "provider-protection-"
-			if len(got) < len(prefix) || got[:len(prefix)] != prefix {
-				t.Errorf("ClusterUsageName(%q) = %q, want prefix %q", tc.mrdName, got, prefix)
+			if !strings.HasPrefix(got, tc.want.prefix) {
+				t.Errorf("\n%s\nClusterUsageName(%q) = %q, want prefix %q", tc.reason, tc.args.mrdName, got, tc.want.prefix)
 			}
 		})
 	}
 }
 
 func TestProtectionControllerName(t *testing.T) {
-	got := ProtectionControllerName("test-mrd")
-	if got != "protection/test-mrd" {
-		t.Errorf("ProtectionControllerName(%q) = %q, want %q", "test-mrd", got, "protection/test-mrd")
+	type args struct {
+		mrdName string
+	}
+	type want struct {
+		name string
+	}
+
+	cases := map[string]struct {
+		reason string
+		args   args
+		want   want
+	}{
+		"StandardName": {
+			reason: "The controller name should be prefixed with protection/",
+			args: args{
+				mrdName: "test-mrd",
+			},
+			want: want{
+				name: "protection/test-mrd",
+			},
+		},
+		"FullyQualifiedName": {
+			reason: "The controller name should include the full MRD name",
+			args: args{
+				mrdName: "databases.example.com",
+			},
+			want: want{
+				name: "protection/databases.example.com",
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got := ProtectionControllerName(tc.args.mrdName)
+			if diff := cmp.Diff(tc.want.name, got); diff != "" {
+				t.Errorf("\n%s\nProtectionControllerName(...): -want, +got:\n%s", tc.reason, diff)
+			}
+		})
 	}
 }
 
@@ -501,46 +570,99 @@ func TestResolveProviderName(t *testing.T) {
 }
 
 func TestBuildClusterUsage(t *testing.T) {
-	want := &protectionv1beta1.ClusterUsage{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: protectionv1beta1.SchemeGroupVersion.String(),
-			Kind:       protectionv1beta1.ClusterUsageKind,
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name: ClusterUsageName("test-mrd"),
-			Labels: map[string]string{
-				"crossplane.io/provider-protection": "true",
-				pkgv1.LabelParentPackage:            "my-provider",
-				"apiextensions.crossplane.io/mrd":   "test-mrd",
+	type args struct {
+		mrdName           string
+		providerName      string
+		mrTypeDescription string
+	}
+	type want struct {
+		cu *protectionv1beta1.ClusterUsage
+	}
+
+	cases := map[string]struct {
+		reason string
+		args   args
+		want   want
+	}{
+		"StandardUsage": {
+			reason: "A ClusterUsage should be built with the correct metadata, labels, and spec",
+			args: args{
+				mrdName:           "test-mrd",
+				providerName:      "my-provider",
+				mrTypeDescription: "Database.example.com",
 			},
-		},
-		Spec: protectionv1beta1.ClusterUsageSpec{
-			Of: protectionv1beta1.Resource{
-				APIVersion: pkgv1.SchemeGroupVersion.String(),
-				Kind:       pkgv1.ProviderKind,
-				ResourceRef: &protectionv1beta1.ResourceRef{
-					Name: "my-provider",
+			want: want{
+				cu: &protectionv1beta1.ClusterUsage{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: protectionv1beta1.SchemeGroupVersion.String(),
+						Kind:       protectionv1beta1.ClusterUsageKind,
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: ClusterUsageName("test-mrd"),
+						Labels: map[string]string{
+							"crossplane.io/provider-protection": "true",
+							pkgv1.LabelParentPackage:            "my-provider",
+							"apiextensions.crossplane.io/mrd":   "test-mrd",
+						},
+					},
+					Spec: protectionv1beta1.ClusterUsageSpec{
+						Of: protectionv1beta1.Resource{
+							APIVersion: pkgv1.SchemeGroupVersion.String(),
+							Kind:       pkgv1.ProviderKind,
+							ResourceRef: &protectionv1beta1.ResourceRef{
+								Name: "my-provider",
+							},
+						},
+						Reason: ptr.To("Provider has active managed resources of type Database.example.com"),
+					},
 				},
 			},
-			Reason: ptr.To("Provider has active managed resources of type Database.example.com"),
 		},
 	}
 
-	got := buildClusterUsage("test-mrd", "my-provider", "Database.example.com")
-
-	if diff := cmp.Diff(want, got); diff != "" {
-		t.Errorf("buildClusterUsage(...): -want, +got:\n%s", diff)
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got := buildClusterUsage(tc.args.mrdName, tc.args.providerName, tc.args.mrTypeDescription)
+			if diff := cmp.Diff(tc.want.cu, got); diff != "" {
+				t.Errorf("\n%s\nbuildClusterUsage(...): -want, +got:\n%s", tc.reason, diff)
+			}
+		})
 	}
 }
 
 func TestResourceMapFunc(t *testing.T) {
-	fn := ResourceMapFunc("test-mrd")
-	reqs := fn(context.Background(), nil)
-
-	if len(reqs) != 1 {
-		t.Fatalf("ResourceMapFunc returned %d requests, want 1", len(reqs))
+	type args struct {
+		mrdName string
 	}
-	if reqs[0].Name != "test-mrd" {
-		t.Errorf("ResourceMapFunc request name = %q, want %q", reqs[0].Name, "test-mrd")
+	type want struct {
+		reqs []reconcile.Request
+	}
+
+	cases := map[string]struct {
+		reason string
+		args   args
+		want   want
+	}{
+		"EnqueuesFixedRequest": {
+			reason: "ResourceMapFunc should return a single reconcile request for the MRD name",
+			args: args{
+				mrdName: "test-mrd",
+			},
+			want: want{
+				reqs: []reconcile.Request{{
+					NamespacedName: types.NamespacedName{Name: "test-mrd"},
+				}},
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			fn := ResourceMapFunc(tc.args.mrdName)
+			got := fn(context.Background(), nil)
+			if diff := cmp.Diff(tc.want.reqs, got); diff != "" {
+				t.Errorf("\n%s\nResourceMapFunc(...): -want, +got:\n%s", tc.reason, diff)
+			}
+		})
 	}
 }

--- a/internal/controller/apiextensions/managed/protection_test.go
+++ b/internal/controller/apiextensions/managed/protection_test.go
@@ -39,6 +39,7 @@ import (
 
 	"github.com/crossplane/crossplane/apis/v2/apiextensions/v1alpha1"
 	pkgv1 "github.com/crossplane/crossplane/apis/v2/pkg/v1"
+	protectionv1beta1 "github.com/crossplane/crossplane/apis/v2/protection/v1beta1"
 )
 
 func TestProtectionReconcilerReconcile(t *testing.T) {
@@ -501,28 +502,35 @@ func TestResolveProviderName(t *testing.T) {
 }
 
 func TestBuildClusterUsage(t *testing.T) {
-	cu := buildClusterUsage("test-mrd", "my-provider", "Database.example.com")
+	want := &protectionv1beta1.ClusterUsage{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: protectionv1beta1.SchemeGroupVersion.String(),
+			Kind:       protectionv1beta1.ClusterUsageKind,
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: ClusterUsageName("test-mrd"),
+			Labels: map[string]string{
+				"crossplane.io/provider-protection": "true",
+				pkgv1.LabelParentPackage:            "my-provider",
+				"apiextensions.crossplane.io/mrd":   "test-mrd",
+			},
+		},
+		Spec: protectionv1beta1.ClusterUsageSpec{
+			Of: protectionv1beta1.Resource{
+				APIVersion: pkgv1.SchemeGroupVersion.String(),
+				Kind:       pkgv1.ProviderKind,
+				ResourceRef: &protectionv1beta1.ResourceRef{
+					Name: "my-provider",
+				},
+			},
+			Reason: ptr.To("Provider has active managed resources of type Database.example.com"),
+		},
+	}
 
-	if cu.Name != ClusterUsageName("test-mrd") {
-		t.Errorf("buildClusterUsage name = %q, want %q", cu.Name, ClusterUsageName("test-mrd"))
-	}
-	if cu.Spec.Of.Kind != pkgv1.ProviderKind {
-		t.Errorf("buildClusterUsage of.kind = %q, want %q", cu.Spec.Of.Kind, pkgv1.ProviderKind)
-	}
-	if cu.Spec.Of.ResourceRef.Name != "my-provider" {
-		t.Errorf("buildClusterUsage of.resourceRef.name = %q, want %q", cu.Spec.Of.ResourceRef.Name, "my-provider")
-	}
-	if cu.Labels["crossplane.io/provider-protection"] != "true" {
-		t.Errorf("buildClusterUsage missing provider-protection label")
-	}
-	if cu.Labels[pkgv1.LabelParentPackage] != "my-provider" {
-		t.Errorf("buildClusterUsage missing parent package label")
-	}
-	if cu.Labels["apiextensions.crossplane.io/mrd"] != "test-mrd" {
-		t.Errorf("buildClusterUsage missing mrd label")
-	}
-	if cu.Spec.Reason == nil || *cu.Spec.Reason != "Provider has active managed resources of type Database.example.com" {
-		t.Errorf("buildClusterUsage reason = %v, want non-nil with correct text", cu.Spec.Reason)
+	got := buildClusterUsage("test-mrd", "my-provider", "Database.example.com")
+
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("buildClusterUsage(...): -want, +got:\n%s", diff)
 	}
 }
 

--- a/internal/controller/apiextensions/managed/protection_test.go
+++ b/internal/controller/apiextensions/managed/protection_test.go
@@ -1,0 +1,539 @@
+/*
+Copyright 2025 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package managed
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	kmeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kunstructured "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"github.com/crossplane/crossplane-runtime/v2/pkg/errors"
+	"github.com/crossplane/crossplane-runtime/v2/pkg/logging"
+	"github.com/crossplane/crossplane-runtime/v2/pkg/test"
+
+	"github.com/crossplane/crossplane/apis/v2/apiextensions/v1alpha1"
+	pkgv1 "github.com/crossplane/crossplane/apis/v2/pkg/v1"
+)
+
+func TestProtectionReconcilerReconcile(t *testing.T) {
+	errBoom := errors.New("boom")
+
+	testGVK := schema.GroupVersionKind{
+		Group:   "example.com",
+		Version: "v1",
+		Kind:    "Database",
+	}
+
+	type args struct {
+		cached  client.Client
+		writer  client.Client
+		mrdName string
+		gvk     schema.GroupVersionKind
+	}
+	type want struct {
+		r   reconcile.Result
+		err error
+	}
+
+	cases := map[string]struct {
+		reason string
+		args   args
+		want   want
+	}{
+		"ListMRsError": {
+			reason: "We should return an error if listing managed resources fails",
+			args: args{
+				cached: &test.MockClient{
+					MockList: test.NewMockListFn(errBoom),
+				},
+				writer:  &test.MockClient{},
+				mrdName: "test-mrd",
+				gvk:     testGVK,
+			},
+			want: want{
+				err: cmpopts.AnyError,
+			},
+		},
+		"ListMRsNoMatchDeletesClusterUsage": {
+			reason: "When the CRD doesn't exist (NoMatch), we should delete the ClusterUsage",
+			args: args{
+				cached: &test.MockClient{
+					MockList: func(_ context.Context, _ client.ObjectList, _ ...client.ListOption) error {
+						return &kmeta.NoKindMatchError{GroupKind: schema.GroupKind{Group: "example.com", Kind: "Database"}}
+					},
+				},
+				writer: &test.MockClient{
+					MockDelete: test.NewMockDeleteFn(nil),
+				},
+				mrdName: "test-mrd",
+				gvk:     testGVK,
+			},
+			want: want{
+				r: reconcile.Result{},
+			},
+		},
+		"NoMRsDeletesClusterUsage": {
+			reason: "When no managed resources exist, we should delete the ClusterUsage",
+			args: args{
+				cached: &test.MockClient{
+					MockList: test.NewMockListFn(nil),
+				},
+				writer: &test.MockClient{
+					MockDelete: test.NewMockDeleteFn(nil),
+				},
+				mrdName: "test-mrd",
+				gvk:     testGVK,
+			},
+			want: want{
+				r: reconcile.Result{},
+			},
+		},
+		"NoMRsDeleteClusterUsageNotFound": {
+			reason: "When no managed resources exist and ClusterUsage is already gone, we should succeed",
+			args: args{
+				cached: &test.MockClient{
+					MockList: test.NewMockListFn(nil),
+				},
+				writer: &test.MockClient{
+					MockDelete: test.NewMockDeleteFn(kerrors.NewNotFound(schema.GroupResource{}, "")),
+				},
+				mrdName: "test-mrd",
+				gvk:     testGVK,
+			},
+			want: want{
+				r: reconcile.Result{},
+			},
+		},
+		"NoMRsDeleteClusterUsageError": {
+			reason: "We should return an error if deleting the ClusterUsage fails",
+			args: args{
+				cached: &test.MockClient{
+					MockList: test.NewMockListFn(nil),
+				},
+				writer: &test.MockClient{
+					MockDelete: test.NewMockDeleteFn(errBoom),
+				},
+				mrdName: "test-mrd",
+				gvk:     testGVK,
+			},
+			want: want{
+				err: cmpopts.AnyError,
+			},
+		},
+		"MRsExistGetMRDError": {
+			reason: "We should return an error if we can't get the MRD when MRs exist",
+			args: args{
+				cached: &test.MockClient{
+					MockList: func(_ context.Context, list client.ObjectList, _ ...client.ListOption) error {
+						u := list.(*kunstructured.UnstructuredList)
+						u.Items = []kunstructured.Unstructured{{}}
+						return nil
+					},
+					MockGet: test.NewMockGetFn(errBoom),
+				},
+				writer:  &test.MockClient{},
+				mrdName: "test-mrd",
+				gvk:     testGVK,
+			},
+			want: want{
+				err: cmpopts.AnyError,
+			},
+		},
+		"MRsExistNoControllerOwner": {
+			reason: "When MRD has no controller owner, we should requeue after delay",
+			args: args{
+				cached: &test.MockClient{
+					MockList: func(_ context.Context, list client.ObjectList, _ ...client.ListOption) error {
+						u := list.(*kunstructured.UnstructuredList)
+						u.Items = []kunstructured.Unstructured{{}}
+						return nil
+					},
+					MockGet: func(_ context.Context, key client.ObjectKey, obj client.Object) error {
+						if mrd, ok := obj.(*v1alpha1.ManagedResourceDefinition); ok {
+							mrd.Name = key.Name
+							mrd.Spec.Group = "example.com"
+							mrd.Spec.Names = extv1.CustomResourceDefinitionNames{Kind: "Database"}
+							// No owner references
+							return nil
+						}
+						return kerrors.NewNotFound(schema.GroupResource{}, "")
+					},
+				},
+				writer:  &test.MockClient{},
+				mrdName: "test-mrd",
+				gvk:     testGVK,
+			},
+			want: want{
+				r: reconcile.Result{RequeueAfter: 30 * time.Second},
+			},
+		},
+		"MRsExistProviderRevisionNotFound": {
+			reason: "When ProviderRevision is not found, we should requeue after delay",
+			args: args{
+				cached: &test.MockClient{
+					MockList: func(_ context.Context, list client.ObjectList, _ ...client.ListOption) error {
+						u := list.(*kunstructured.UnstructuredList)
+						u.Items = []kunstructured.Unstructured{{}}
+						return nil
+					},
+					MockGet: func(_ context.Context, key client.ObjectKey, obj client.Object) error {
+						switch o := obj.(type) {
+						case *v1alpha1.ManagedResourceDefinition:
+							o.Name = key.Name
+							o.Spec.Group = "example.com"
+							o.Spec.Names = extv1.CustomResourceDefinitionNames{Kind: "Database"}
+							o.OwnerReferences = []metav1.OwnerReference{{
+								APIVersion: pkgv1.SchemeGroupVersion.String(),
+								Kind:       pkgv1.ProviderRevisionKind,
+								Name:       "test-provider-revision",
+								Controller: ptr.To(true),
+							}}
+							return nil
+						case *pkgv1.ProviderRevision:
+							return kerrors.NewNotFound(schema.GroupResource{}, key.Name)
+						default:
+							return kerrors.NewNotFound(schema.GroupResource{}, "")
+						}
+					},
+				},
+				writer:  &test.MockClient{},
+				mrdName: "test-mrd",
+				gvk:     testGVK,
+			},
+			want: want{
+				r: reconcile.Result{RequeueAfter: 30 * time.Second},
+			},
+		},
+		"MRsExistClusterUsageApplied": {
+			reason: "When MRs exist and Provider can be resolved, we should apply a ClusterUsage",
+			args: args{
+				cached: &test.MockClient{
+					MockList: func(_ context.Context, list client.ObjectList, _ ...client.ListOption) error {
+						u := list.(*kunstructured.UnstructuredList)
+						u.Items = []kunstructured.Unstructured{{}}
+						return nil
+					},
+					MockGet: func(_ context.Context, key client.ObjectKey, obj client.Object) error {
+						switch o := obj.(type) {
+						case *v1alpha1.ManagedResourceDefinition:
+							o.Name = key.Name
+							o.Spec.Group = "example.com"
+							o.Spec.Names = extv1.CustomResourceDefinitionNames{Kind: "Database"}
+							o.OwnerReferences = []metav1.OwnerReference{{
+								APIVersion: pkgv1.SchemeGroupVersion.String(),
+								Kind:       pkgv1.ProviderRevisionKind,
+								Name:       "test-provider-revision",
+								Controller: ptr.To(true),
+							}}
+							return nil
+						case *pkgv1.ProviderRevision:
+							o.Name = key.Name
+							o.SetLabels(map[string]string{
+								pkgv1.LabelParentPackage: "test-provider",
+							})
+							return nil
+						default:
+							return kerrors.NewNotFound(schema.GroupResource{}, "")
+						}
+					},
+				},
+				writer: &test.MockClient{
+					MockPatch: test.NewMockPatchFn(nil),
+				},
+				mrdName: "test-mrd",
+				gvk:     testGVK,
+			},
+			want: want{
+				r: reconcile.Result{},
+			},
+		},
+		"MRsExistClusterUsageApplyError": {
+			reason: "We should return an error if applying the ClusterUsage fails",
+			args: args{
+				cached: &test.MockClient{
+					MockList: func(_ context.Context, list client.ObjectList, _ ...client.ListOption) error {
+						u := list.(*kunstructured.UnstructuredList)
+						u.Items = []kunstructured.Unstructured{{}}
+						return nil
+					},
+					MockGet: func(_ context.Context, key client.ObjectKey, obj client.Object) error {
+						switch o := obj.(type) {
+						case *v1alpha1.ManagedResourceDefinition:
+							o.Name = key.Name
+							o.Spec.Group = "example.com"
+							o.Spec.Names = extv1.CustomResourceDefinitionNames{Kind: "Database"}
+							o.OwnerReferences = []metav1.OwnerReference{{
+								APIVersion: pkgv1.SchemeGroupVersion.String(),
+								Kind:       pkgv1.ProviderRevisionKind,
+								Name:       "test-provider-revision",
+								Controller: ptr.To(true),
+							}}
+							return nil
+						case *pkgv1.ProviderRevision:
+							o.Name = key.Name
+							o.SetLabels(map[string]string{
+								pkgv1.LabelParentPackage: "test-provider",
+							})
+							return nil
+						default:
+							return kerrors.NewNotFound(schema.GroupResource{}, "")
+						}
+					},
+				},
+				writer: &test.MockClient{
+					MockPatch: test.NewMockPatchFn(errBoom),
+				},
+				mrdName: "test-mrd",
+				gvk:     testGVK,
+			},
+			want: want{
+				err: cmpopts.AnyError,
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			r := &ProtectionReconciler{
+				cached:  tc.args.cached,
+				writer:  tc.args.writer,
+				mrdName: tc.args.mrdName,
+				gvk:     tc.args.gvk,
+				log:     logging.NewNopLogger(),
+			}
+
+			got, err := r.Reconcile(context.Background(), reconcile.Request{})
+
+			if diff := cmp.Diff(tc.want.err, err, cmpopts.EquateErrors()); diff != "" {
+				t.Errorf("\n%s\nr.Reconcile(...): -want error, +got error:\n%s", tc.reason, diff)
+			}
+			if diff := cmp.Diff(tc.want.r, got); diff != "" {
+				t.Errorf("\n%s\nr.Reconcile(...): -want, +got:\n%s", tc.reason, diff)
+			}
+		})
+	}
+}
+
+func TestClusterUsageName(t *testing.T) {
+	cases := map[string]struct {
+		mrdName string
+	}{
+		"Short": {mrdName: "test-mrd"},
+		"Long":  {mrdName: "very-long-managed-resource-definition-name-that-could-potentially-exceed-kubernetes-limits.some-group.example.com"},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got := ClusterUsageName(tc.mrdName)
+			if len(got) > 253 {
+				t.Errorf("ClusterUsageName(%q) = %q (len %d), want len <= 253", tc.mrdName, got, len(got))
+			}
+			// Should be deterministic
+			if got != ClusterUsageName(tc.mrdName) {
+				t.Errorf("ClusterUsageName(%q) is not deterministic", tc.mrdName)
+			}
+			// Should start with provider-protection-
+			const prefix = "provider-protection-"
+			if len(got) < len(prefix) || got[:len(prefix)] != prefix {
+				t.Errorf("ClusterUsageName(%q) = %q, want prefix %q", tc.mrdName, got, prefix)
+			}
+		})
+	}
+}
+
+func TestProtectionControllerName(t *testing.T) {
+	got := ProtectionControllerName("test-mrd")
+	if got != "protection/test-mrd" {
+		t.Errorf("ProtectionControllerName(%q) = %q, want %q", "test-mrd", got, "protection/test-mrd")
+	}
+}
+
+func TestStorageVersion(t *testing.T) {
+	cases := map[string]struct {
+		mrd  *v1alpha1.ManagedResourceDefinition
+		want string
+	}{
+		"StorageVersionFound": {
+			mrd: &v1alpha1.ManagedResourceDefinition{
+				Spec: v1alpha1.ManagedResourceDefinitionSpec{
+					CustomResourceDefinitionSpec: v1alpha1.CustomResourceDefinitionSpec{
+						Versions: []v1alpha1.CustomResourceDefinitionVersion{
+							{Name: "v1alpha1", Storage: false},
+							{Name: "v1", Storage: true},
+						},
+					},
+				},
+			},
+			want: "v1",
+		},
+		"SingleStorageVersion": {
+			mrd: &v1alpha1.ManagedResourceDefinition{
+				Spec: v1alpha1.ManagedResourceDefinitionSpec{
+					CustomResourceDefinitionSpec: v1alpha1.CustomResourceDefinitionSpec{
+						Versions: []v1alpha1.CustomResourceDefinitionVersion{
+							{Name: "v1beta1", Storage: true},
+						},
+					},
+				},
+			},
+			want: "v1beta1",
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got := storageVersion(tc.mrd)
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("storageVersion(...): -want, +got:\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestResolveProviderName(t *testing.T) {
+	errBoom := errors.New("boom")
+
+	cases := map[string]struct {
+		reason string
+		c      client.Client
+		mrd    *v1alpha1.ManagedResourceDefinition
+		want   string
+		err    error
+	}{
+		"NoControllerOwner": {
+			reason: "An MRD with no controller owner should return an error",
+			c:      &test.MockClient{},
+			mrd:    &v1alpha1.ManagedResourceDefinition{},
+			err:    cmpopts.AnyError,
+		},
+		"GetProviderRevisionError": {
+			reason: "An error getting the ProviderRevision should be returned",
+			c: &test.MockClient{
+				MockGet: test.NewMockGetFn(errBoom),
+			},
+			mrd: &v1alpha1.ManagedResourceDefinition{
+				ObjectMeta: metav1.ObjectMeta{
+					OwnerReferences: []metav1.OwnerReference{{
+						Name:       "test-rev",
+						Controller: ptr.To(true),
+					}},
+				},
+			},
+			err: cmpopts.AnyError,
+		},
+		"NoParentPackageLabel": {
+			reason: "A ProviderRevision without the parent package label should return an error",
+			c: &test.MockClient{
+				MockGet: test.NewMockGetFn(nil),
+			},
+			mrd: &v1alpha1.ManagedResourceDefinition{
+				ObjectMeta: metav1.ObjectMeta{
+					OwnerReferences: []metav1.OwnerReference{{
+						Name:       "test-rev",
+						Controller: ptr.To(true),
+					}},
+				},
+			},
+			err: cmpopts.AnyError,
+		},
+		"Success": {
+			reason: "We should return the provider name from the ProviderRevision label",
+			c: &test.MockClient{
+				MockGet: func(_ context.Context, _ client.ObjectKey, obj client.Object) error {
+					if rev, ok := obj.(*pkgv1.ProviderRevision); ok {
+						rev.SetLabels(map[string]string{
+							pkgv1.LabelParentPackage: "my-provider",
+						})
+					}
+					return nil
+				},
+			},
+			mrd: &v1alpha1.ManagedResourceDefinition{
+				ObjectMeta: metav1.ObjectMeta{
+					OwnerReferences: []metav1.OwnerReference{{
+						Name:       "test-rev",
+						Controller: ptr.To(true),
+					}},
+				},
+			},
+			want: "my-provider",
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got, err := resolveProviderName(context.Background(), tc.c, tc.mrd)
+
+			if diff := cmp.Diff(tc.err, err, cmpopts.EquateErrors()); diff != "" {
+				t.Errorf("\n%s\nresolveProviderName(...): -want error, +got error:\n%s", tc.reason, diff)
+			}
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("\n%s\nresolveProviderName(...): -want, +got:\n%s", tc.reason, diff)
+			}
+		})
+	}
+}
+
+func TestBuildClusterUsage(t *testing.T) {
+	cu := buildClusterUsage("test-mrd", "my-provider", "Database.example.com")
+
+	if cu.Name != ClusterUsageName("test-mrd") {
+		t.Errorf("buildClusterUsage name = %q, want %q", cu.Name, ClusterUsageName("test-mrd"))
+	}
+	if cu.Spec.Of.Kind != pkgv1.ProviderKind {
+		t.Errorf("buildClusterUsage of.kind = %q, want %q", cu.Spec.Of.Kind, pkgv1.ProviderKind)
+	}
+	if cu.Spec.Of.ResourceRef.Name != "my-provider" {
+		t.Errorf("buildClusterUsage of.resourceRef.name = %q, want %q", cu.Spec.Of.ResourceRef.Name, "my-provider")
+	}
+	if cu.Labels["crossplane.io/provider-protection"] != "true" {
+		t.Errorf("buildClusterUsage missing provider-protection label")
+	}
+	if cu.Labels[pkgv1.LabelParentPackage] != "my-provider" {
+		t.Errorf("buildClusterUsage missing parent package label")
+	}
+	if cu.Labels["apiextensions.crossplane.io/mrd"] != "test-mrd" {
+		t.Errorf("buildClusterUsage missing mrd label")
+	}
+	if cu.Spec.Reason == nil || *cu.Spec.Reason != "Provider has active managed resources of type Database.example.com" {
+		t.Errorf("buildClusterUsage reason = %v, want non-nil with correct text", cu.Spec.Reason)
+	}
+}
+
+func TestResourceMapFunc(t *testing.T) {
+	fn := ResourceMapFunc("test-mrd")
+	reqs := fn(context.Background(), nil)
+
+	if len(reqs) != 1 {
+		t.Fatalf("ResourceMapFunc returned %d requests, want 1", len(reqs))
+	}
+	if reqs[0].Name != "test-mrd" {
+		t.Errorf("ResourceMapFunc request name = %q, want %q", reqs[0].Name, "test-mrd")
+	}
+}

--- a/internal/controller/apiextensions/managed/protection_test.go
+++ b/internal/controller/apiextensions/managed/protection_test.go
@@ -19,7 +19,6 @@ package managed
 import (
 	"context"
 	"testing"
-	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -167,7 +166,7 @@ func TestProtectionReconcilerReconcile(t *testing.T) {
 			},
 		},
 		"MRsExistNoControllerOwner": {
-			reason: "When MRD has no controller owner, we should requeue after delay",
+			reason: "When MRD has no controller owner, we should return an error",
 			args: args{
 				cached: &test.MockClient{
 					MockList: func(_ context.Context, list client.ObjectList, _ ...client.ListOption) error {
@@ -191,11 +190,11 @@ func TestProtectionReconcilerReconcile(t *testing.T) {
 				gvk:     testGVK,
 			},
 			want: want{
-				r: reconcile.Result{RequeueAfter: 30 * time.Second},
+				err: cmpopts.AnyError,
 			},
 		},
 		"MRsExistProviderRevisionNotFound": {
-			reason: "When ProviderRevision is not found, we should requeue after delay",
+			reason: "When ProviderRevision is not found, we should return an error",
 			args: args{
 				cached: &test.MockClient{
 					MockList: func(_ context.Context, list client.ObjectList, _ ...client.ListOption) error {
@@ -228,7 +227,7 @@ func TestProtectionReconcilerReconcile(t *testing.T) {
 				gvk:     testGVK,
 			},
 			want: want{
-				r: reconcile.Result{RequeueAfter: 30 * time.Second},
+				err: cmpopts.AnyError,
 			},
 		},
 		"MRsExistClusterUsageApplied": {

--- a/internal/controller/apiextensions/managed/reconciler.go
+++ b/internal/controller/apiextensions/managed/reconciler.go
@@ -22,20 +22,28 @@ import (
 	"time"
 
 	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	kunstructured "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	kcontroller "sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/crossplane/crossplane-runtime/v2/pkg/conditions"
 	"github.com/crossplane/crossplane-runtime/v2/pkg/errors"
 	"github.com/crossplane/crossplane-runtime/v2/pkg/event"
+	"github.com/crossplane/crossplane-runtime/v2/pkg/feature"
 	"github.com/crossplane/crossplane-runtime/v2/pkg/logging"
 	"github.com/crossplane/crossplane-runtime/v2/pkg/meta"
 	"github.com/crossplane/crossplane-runtime/v2/pkg/resource"
 	"github.com/crossplane/crossplane-runtime/v2/pkg/xcrd"
 
 	"github.com/crossplane/crossplane/apis/v2/apiextensions/v1alpha1"
+	protectionv1beta1 "github.com/crossplane/crossplane/apis/v2/protection/v1beta1"
+	"github.com/crossplane/crossplane/v2/internal/engine"
+	"github.com/crossplane/crossplane/v2/internal/features"
 	"github.com/crossplane/crossplane/v2/internal/ssa"
 )
 
@@ -58,6 +66,12 @@ type Reconciler struct {
 	client client.Client
 
 	managedFields ssa.ManagedFieldsUpgrader
+
+	// engine is used to dynamically start protection controllers that watch
+	// MR instances when provider deletion protection is enabled. It is nil
+	// when the feature is disabled.
+	engine   *engine.ControllerEngine
+	features *feature.Flags
 
 	log        logging.Logger
 	record     event.Recorder
@@ -91,6 +105,7 @@ func (r *Reconciler) Reconcile(ogctx context.Context, req reconcile.Request) (re
 	)
 
 	if meta.WasDeleted(mrd) {
+		r.cleanupProtection(ctx, log, mrd.GetName())
 		status.MarkConditions(v1alpha1.TerminatingManaged())
 		return reconcile.Result{}, errors.Wrap(r.client.Status().Update(ogctx, mrd), "cannot update status of ManagedResourceDefinition")
 	}
@@ -102,6 +117,7 @@ func (r *Reconciler) Reconcile(ogctx context.Context, req reconcile.Request) (re
 	}
 
 	if !mrd.Spec.State.IsActive() {
+		r.cleanupProtection(ctx, log, mrd.GetName())
 		status.MarkConditions(v1alpha1.InactiveManaged())
 		return reconcile.Result{}, errors.Wrap(r.client.Status().Update(ogctx, mrd), "cannot update status of ManagedResourceDefinition")
 	}
@@ -169,5 +185,84 @@ func (r *Reconciler) Reconcile(ogctx context.Context, req reconcile.Request) (re
 	}
 
 	status.MarkConditions(v1alpha1.EstablishedManaged())
+
+	// If provider deletion protection is enabled, start a protection
+	// controller that watches MR instances and manages ClusterUsage objects.
+	if r.protectionEnabled() {
+		r.startProtection(ctx, log, mrd)
+	}
+
 	return reconcile.Result{}, errors.Wrap(r.client.Status().Update(ogctx, mrd), "cannot update status of ManagedResourceDefinition")
+}
+
+// protectionEnabled returns true if provider deletion protection is enabled.
+func (r *Reconciler) protectionEnabled() bool {
+	return r.engine != nil && r.features != nil &&
+		r.features.Enabled(features.EnableAlphaProviderDeletionProtection)
+}
+
+// startProtection starts a protection controller for the given MRD that
+// watches MR instances and creates/deletes a ClusterUsage to protect the
+// owning Provider from deletion.
+func (r *Reconciler) startProtection(ctx context.Context, log logging.Logger, mrd *v1alpha1.ManagedResourceDefinition) {
+	mrGVK := schema.GroupVersionKind{
+		Group:   mrd.Spec.Group,
+		Version: storageVersion(mrd),
+		Kind:    mrd.Spec.Names.Kind,
+	}
+
+	controllerName := ProtectionControllerName(mrd.GetName())
+
+	pr := &ProtectionReconciler{
+		cached:  r.engine.GetCached(),
+		writer:  r.client,
+		mrdName: mrd.GetName(),
+		gvk:     mrGVK,
+		log:     log.WithValues("controller", controllerName),
+	}
+
+	ko := kcontroller.Options{Reconciler: pr}
+
+	//nolint:contextcheck // Start intentionally does not take a context; it creates its own so the controller outlives the caller.
+	if err := r.engine.Start(controllerName,
+		engine.WithRuntimeOptions(ko),
+	); err != nil {
+		log.Debug("Cannot start protection controller", "error", err)
+		r.record.Event(mrd, event.Warning(reasonReconcile, errors.Wrap(err, "cannot start protection controller")))
+		return
+	}
+
+	// Start a watch on MR instances. This is idempotent - it only starts
+	// watches that don't already exist.
+	mr := &kunstructured.Unstructured{}
+	mr.SetGroupVersionKind(mrGVK)
+
+	h := handler.EnqueueRequestsFromMapFunc(ResourceMapFunc(mrd.GetName()))
+
+	if err := r.engine.StartWatches(ctx, controllerName,
+		engine.WatchFor(mr, engine.WatchTypeManagedResource, h),
+	); err != nil {
+		log.Debug("Cannot start MR watch for protection", "error", err)
+		r.record.Event(mrd, event.Warning(reasonReconcile, errors.Wrap(err, "cannot start managed resource watch")))
+	}
+}
+
+// cleanupProtection stops the protection controller and deletes the
+// ClusterUsage for the given MRD. It is a no-op if provider deletion
+// protection is not enabled.
+func (r *Reconciler) cleanupProtection(ctx context.Context, log logging.Logger, mrdName string) {
+	if !r.protectionEnabled() {
+		return
+	}
+
+	controllerName := ProtectionControllerName(mrdName)
+	if err := r.engine.Stop(ctx, controllerName); err != nil {
+		log.Debug("Cannot stop protection controller", "error", err)
+	}
+
+	cu := &protectionv1beta1.ClusterUsage{}
+	cu.SetName(ClusterUsageName(mrdName))
+	if err := r.client.Delete(ctx, cu); resource.IgnoreNotFound(err) != nil {
+		log.Debug("Cannot delete ClusterUsage", "error", err)
+	}
 }

--- a/internal/controller/apiextensions/managed/reconciler.go
+++ b/internal/controller/apiextensions/managed/reconciler.go
@@ -189,7 +189,11 @@ func (r *Reconciler) Reconcile(ogctx context.Context, req reconcile.Request) (re
 	// If provider deletion protection is enabled, start a protection
 	// controller that watches MR instances and manages ClusterUsage objects.
 	if r.protectionEnabled() {
-		r.startProtection(ctx, log, mrd)
+		if err := r.startProtection(ctx, log, mrd); err != nil {
+			log.Debug("Cannot start provider deletion protection", "error", err)
+			r.record.Event(mrd, event.Warning(reasonReconcile, err))
+			return reconcile.Result{}, errors.Wrap(err, "cannot start provider deletion protection")
+		}
 	}
 
 	return reconcile.Result{}, errors.Wrap(r.client.Status().Update(ogctx, mrd), "cannot update status of ManagedResourceDefinition")
@@ -204,7 +208,7 @@ func (r *Reconciler) protectionEnabled() bool {
 // startProtection starts a protection controller for the given MRD that
 // watches MR instances and creates/deletes a ClusterUsage to protect the
 // owning Provider from deletion.
-func (r *Reconciler) startProtection(ctx context.Context, log logging.Logger, mrd *v1alpha1.ManagedResourceDefinition) {
+func (r *Reconciler) startProtection(ctx context.Context, log logging.Logger, mrd *v1alpha1.ManagedResourceDefinition) error {
 	mrGVK := schema.GroupVersionKind{
 		Group:   mrd.Spec.Group,
 		Version: storageVersion(mrd),
@@ -227,9 +231,7 @@ func (r *Reconciler) startProtection(ctx context.Context, log logging.Logger, mr
 	if err := r.engine.Start(controllerName,
 		engine.WithRuntimeOptions(ko),
 	); err != nil {
-		log.Debug("Cannot start protection controller", "error", err)
-		r.record.Event(mrd, event.Warning(reasonReconcile, errors.Wrap(err, "cannot start protection controller")))
-		return
+		return errors.Wrap(err, "cannot start protection controller")
 	}
 
 	// Start a watch on MR instances. This is idempotent - it only starts
@@ -242,9 +244,10 @@ func (r *Reconciler) startProtection(ctx context.Context, log logging.Logger, mr
 	if err := r.engine.StartWatches(ctx, controllerName,
 		engine.WatchFor(mr, engine.WatchTypeManagedResource, h),
 	); err != nil {
-		log.Debug("Cannot start MR watch for protection", "error", err)
-		r.record.Event(mrd, event.Warning(reasonReconcile, errors.Wrap(err, "cannot start managed resource watch")))
+		return errors.Wrap(err, "cannot start managed resource watch")
 	}
+
+	return nil
 }
 
 // cleanupProtection stops the protection controller and deletes the

--- a/internal/controller/apiextensions/managed/setup.go
+++ b/internal/controller/apiextensions/managed/setup.go
@@ -26,10 +26,13 @@ import (
 	"github.com/crossplane/crossplane-runtime/v2/pkg/conditions"
 	"github.com/crossplane/crossplane-runtime/v2/pkg/errors"
 	"github.com/crossplane/crossplane-runtime/v2/pkg/event"
+	"github.com/crossplane/crossplane-runtime/v2/pkg/feature"
 	"github.com/crossplane/crossplane-runtime/v2/pkg/logging"
 
 	"github.com/crossplane/crossplane/apis/v2/apiextensions/v1alpha1"
 	apiextensionscontroller "github.com/crossplane/crossplane/v2/internal/controller/apiextensions/controller"
+	"github.com/crossplane/crossplane/v2/internal/engine"
+	"github.com/crossplane/crossplane/v2/internal/features"
 	"github.com/crossplane/crossplane/v2/internal/ssa"
 )
 
@@ -38,14 +41,26 @@ import (
 func Setup(mgr ctrl.Manager, o apiextensionscontroller.Options) error {
 	name := "mrd/" + strings.ToLower(v1alpha1.ManagedResourceDefinitionKind)
 
-	r := NewReconciler(mgr,
+	opts := []ReconcilerOption{
 		WithLogger(o.Logger.WithValues("controller", name)),
 		WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name), o.EventFilterFunctions...)),
 		WithManagedFieldsUpgrader(ssa.NewPatchingManagedFieldsUpgrader(
 			mgr.GetClient(),
 			ssa.ExactMatch(FieldOwnerMRD),
 		)),
-	)
+	}
+
+	if o.Features.Enabled(features.EnableAlphaProviderDeletionProtection) &&
+		o.Features.Enabled(features.EnableBetaUsages) {
+		opts = append(opts,
+			WithControllerEngine(o.ControllerEngine),
+			WithFeatures(o.Features),
+		)
+	} else if o.Features.Enabled(features.EnableAlphaProviderDeletionProtection) {
+		o.Logger.Info("Provider deletion protection requires usages to be enabled (--enable-usages). Protection is disabled.")
+	}
+
+	r := NewReconciler(mgr, opts...)
 
 	return ctrl.NewControllerManagedBy(mgr).
 		Named(name).
@@ -77,6 +92,21 @@ func WithRecorder(er event.Recorder) ReconcilerOption {
 func WithManagedFieldsUpgrader(u ssa.ManagedFieldsUpgrader) ReconcilerOption {
 	return func(r *Reconciler) {
 		r.managedFields = u
+	}
+}
+
+// WithControllerEngine specifies the engine used to dynamically start
+// protection controllers that watch MR instances.
+func WithControllerEngine(e *engine.ControllerEngine) ReconcilerOption {
+	return func(r *Reconciler) {
+		r.engine = e
+	}
+}
+
+// WithFeatures specifies the feature flags the Reconciler should use.
+func WithFeatures(f *feature.Flags) ReconcilerOption {
+	return func(r *Reconciler) {
+		r.features = f
 	}
 }
 

--- a/internal/controller/apiextensions/managed/setup.go
+++ b/internal/controller/apiextensions/managed/setup.go
@@ -57,7 +57,7 @@ func Setup(mgr ctrl.Manager, o apiextensionscontroller.Options) error {
 			WithFeatures(o.Features),
 		)
 	} else if o.Features.Enabled(features.EnableAlphaProviderDeletionProtection) {
-		o.Logger.Info("Provider deletion protection requires usages to be enabled (--enable-usages). Protection is disabled.")
+		return errors.New("provider deletion protection requires usages to be enabled (--enable-usages)")
 	}
 
 	r := NewReconciler(mgr, opts...)

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -426,6 +426,7 @@ const (
 	WatchTypeCompositeResource   WatchType = "CompositeResource"
 	WatchTypeComposedResource    WatchType = "ComposedResource"
 	WatchTypeCompositionRevision WatchType = "CompositionRevision"
+	WatchTypeManagedResource     WatchType = "ManagedResource"
 )
 
 // Watch an object.

--- a/internal/features/features.go
+++ b/internal/features/features.go
@@ -48,6 +48,11 @@ const (
 	// See the below design for more details.
 	// https://github.com/crossplane/crossplane/blob/main/design/one-pager-pipeline-inspector.md
 	EnableAlphaPipelineInspector feature.Flag = "EnableAlphaPipelineInspector"
+
+	// EnableAlphaProviderDeletionProtection enables alpha support for
+	// automatically protecting Providers from deletion when they still have
+	// active managed resources. Requires EnableBetaUsages to also be enabled.
+	EnableAlphaProviderDeletionProtection feature.Flag = "EnableAlphaProviderDeletionProtection"
 )
 
 // Beta Feature Flags.

--- a/test/e2e/funcs/env.go
+++ b/test/e2e/funcs/env.go
@@ -40,6 +40,7 @@ import (
 	apiextensionsv1alpha1 "github.com/crossplane/crossplane/apis/v2/apiextensions/v1alpha1"
 	opsv1alpha1 "github.com/crossplane/crossplane/apis/v2/ops/v1alpha1"
 	pkgv1 "github.com/crossplane/crossplane/apis/v2/pkg/v1"
+	protectionv1beta1 "github.com/crossplane/crossplane/apis/v2/protection/v1beta1"
 )
 
 type kindConfigContextKey string
@@ -100,6 +101,7 @@ func AddCrossplaneTypesToScheme() env.Func {
 		_ = opsv1alpha1.AddToScheme(c.Client().Resources().GetScheme())
 		_ = apiextensionsv1alpha1.AddToScheme(c.Client().Resources().GetScheme())
 		_ = pkgv1.AddToScheme(c.Client().Resources().GetScheme())
+		_ = protectionv1beta1.AddToScheme(c.Client().Resources().GetScheme())
 
 		return ctx, nil
 	}

--- a/test/e2e/manifests/protection/provider-deletion/mr.yaml
+++ b/test/e2e/manifests/protection/provider-deletion/mr.yaml
@@ -1,0 +1,11 @@
+apiVersion: nop.crossplane.io/v1alpha1
+kind: NopResource
+metadata:
+  name: protection-test-nop
+spec:
+  forProvider:
+    conditionAfter:
+    - conditionType: Ready
+      conditionStatus: "True"
+      conditionReason: "Available"
+      time: 0s

--- a/test/e2e/manifests/protection/provider-deletion/provider.yaml
+++ b/test/e2e/manifests/protection/provider-deletion/provider.yaml
@@ -1,0 +1,7 @@
+apiVersion: pkg.crossplane.io/v1
+kind: Provider
+metadata:
+  name: provider-nop-deletion-protection
+spec:
+  package: xpkg.upbound.io/crossplane-contrib/provider-nop:v0.4.0
+  ignoreCrossplaneConstraints: true

--- a/test/e2e/protection_provider_test.go
+++ b/test/e2e/protection_provider_test.go
@@ -1,0 +1,124 @@
+/*
+Copyright 2025 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"testing"
+	"time"
+
+	k8sapiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/e2e-framework/klient/k8s"
+	"sigs.k8s.io/e2e-framework/klient/k8s/resources"
+	"sigs.k8s.io/e2e-framework/pkg/features"
+	"sigs.k8s.io/e2e-framework/third_party/helm"
+
+	pkgv1 "github.com/crossplane/crossplane/apis/v2/pkg/v1"
+	protectionv1beta1 "github.com/crossplane/crossplane/apis/v2/protection/v1beta1"
+	"github.com/crossplane/crossplane/v2/test/e2e/config"
+	"github.com/crossplane/crossplane/v2/test/e2e/funcs"
+)
+
+// SuiteProviderDeletionProtection is the test suite for provider deletion
+// protection, which requires the --enable-provider-deletion-protection flag.
+const SuiteProviderDeletionProtection = "provider-deletion-protection"
+
+func init() {
+	environment.AddTestSuite(SuiteProviderDeletionProtection,
+		config.WithHelmInstallOpts(
+			helm.WithArgs("--set args={--debug,--enable-provider-deletion-protection}"),
+		),
+		config.WithLabelsToSelect(features.Labels{
+			config.LabelTestSuite: []string{SuiteProviderDeletionProtection, config.TestSuiteDefault},
+		}),
+	)
+}
+
+func TestProviderDeletionProtection(t *testing.T) {
+	manifests := "test/e2e/manifests/protection/provider-deletion"
+
+	environment.Test(t,
+		features.NewWithDescription(t.Name(),
+			"Tests that a Provider is automatically protected from deletion when it has active managed resources via ClusterUsage.").
+			WithLabel(LabelArea, LabelAreaProtection).
+			WithLabel(LabelStage, LabelStageAlpha).
+			WithLabel(LabelSize, LabelSizeLarge).
+			WithLabel(config.LabelTestSuite, SuiteProviderDeletionProtection).
+
+			// Setup: Install the provider and wait for it to be healthy.
+			WithSetup("InstallProvider", funcs.AllOf(
+				funcs.ApplyResources(FieldManager, manifests, "provider.yaml"),
+				funcs.ResourcesCreatedWithin(1*time.Minute, manifests, "provider.yaml"),
+				funcs.ResourcesHaveConditionWithin(3*time.Minute, manifests, "provider.yaml", pkgv1.Healthy(), pkgv1.Active()),
+			)).
+
+			// Create a managed resource so the protection controller creates a
+			// ClusterUsage protecting the Provider.
+			Assess("CreateManagedResource", funcs.AllOf(
+				funcs.ApplyResources(FieldManager, manifests, "mr.yaml"),
+				funcs.ResourcesCreatedWithin(1*time.Minute, manifests, "mr.yaml"),
+			)).
+
+			// Verify that a ClusterUsage with the provider-protection label was
+			// created automatically by the protection controller.
+			Assess("ClusterUsageCreatedForProvider",
+				funcs.ListedResourcesValidatedWithin(2*time.Minute,
+					&protectionv1beta1.ClusterUsageList{},
+					1,
+					func(o k8s.Object) bool {
+						cu, ok := o.(*protectionv1beta1.ClusterUsage)
+						if !ok {
+							return false
+						}
+						return cu.Spec.Of.Kind == "Provider"
+					},
+					resources.WithLabelSelector("crossplane.io/provider-protection=true"),
+				),
+			).
+
+			// Attempt to delete the Provider. The usage webhook should block it.
+			Assess("ProviderDeletionBlockedByUsage",
+				funcs.DeletionBlockedByUsageWebhook(manifests, "provider.yaml"),
+			).
+
+			// Delete the managed resource so the protection controller removes
+			// the ClusterUsage.
+			Assess("DeleteManagedResource", funcs.AllOf(
+				funcs.DeleteResources(manifests, "mr.yaml"),
+				funcs.ResourcesDeletedWithin(1*time.Minute, manifests, "mr.yaml"),
+			)).
+
+			// Verify that the ClusterUsage is removed after the managed
+			// resource is deleted.
+			Assess("ClusterUsageRemovedAfterMRDeletion",
+				funcs.ListedResourcesDeletedWithin(2*time.Minute,
+					&protectionv1beta1.ClusterUsageList{},
+					resources.WithLabelSelector("crossplane.io/provider-protection=true"),
+				),
+			).
+
+			// Cleanup: Delete the Provider and ensure the CRD is removed.
+			WithTeardown("DeleteProvider", funcs.AllOf(
+				funcs.DeleteResourcesWithPropagationPolicy(manifests, "provider.yaml", metav1.DeletePropagationForeground),
+				funcs.ResourcesDeletedWithin(2*time.Minute, manifests, "provider.yaml"),
+				funcs.ResourceDeletedWithin(2*time.Minute, &k8sapiextensionsv1.CustomResourceDefinition{
+					ObjectMeta: metav1.ObjectMeta{Name: "nopresources.nop.crossplane.io"},
+				}),
+			)).
+			Feature(),
+	)
+}


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane! Please read the contribution docs
(linked below) if this is your first Crossplane pull request.
-->

### Description of your changes

stacked on: https://github.com/crossplane/crossplane/pull/7361 

Implements automatic Provider deletion protection using `ClusterUsage` resources, as discussed in #6986. Instead of the webhook approach proposed in the original PR, this follows the direction agreed upon by maintainers: the MRD reconciler dynamically starts per-MRD protection controllers that watch managed resource instances and manage `ClusterUsage` objects to leverage the existing Usage webhook.

#### How it works
1. When `--enable-provider-deletion-protection` (and --enable-usages, its enabled by default) is enabled, the MRD reconciler starts a protection controller for each active MRD using the ControllerEngine.
2. Each protection controller watches MR instances via the engine's shared informer cache (no additional watch cost for MRs already composed by XR controllers).
3. When MRs exist, the controller creates a ClusterUsage protecting the owning Provider (resolved via MRD -> ProviderRevision -> Provider owner chain).
4. When all MRs of that type are deleted, the ClusterUsage is removed.
5. The existing Usage webhook blocks Provider deletion as long as any ClusterUsage references it.


#### Key design decisions
- Reuses existing Usage infrastructure rather than introducing a new webhook, keeping Crossplane's deletion protection story on a single consistent concept (per maintainer feedback on #6986).
- One `ClusterUsage` per MRD with a descriptive reason field (e.g. "Provider has active managed resources of type VPC.ec2.aws.upbound.io"), making it self-documenting and easy to inspect.
- Alpha feature flag (-`-enable-provider-deletion-protection`) gated behind `--enable-usages`.
- Leverages ControllerEngine for dynamic controller lifecycle, sharing watches/caches with existing XR controllers.
<!--
Briefly describe what this pull request does, and how it is covered by tests.
Be proactive - direct your reviewers' attention to anything that needs special
consideration.

We love pull requests that fix an open issue. If yours does, use the below line
to indicate which issue it fixes, for example "Fixes #500".
-->

Fixes #6001
Fixes #4251
Fixes #6268

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `./nix.sh flake check` to ensure this PR is ready for review.
- [x] Added or updated unit tests.
- [x] Added or updated e2e tests.
- [x] Linked a PR or a [docs tracking issue] to [document this change].
- [x] Added `backport release-x.y` labels to auto-backport this PR.
- [x] Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md
