### PR TITLE
chart: set rbac manager component label

### DIFF
--- a/cluster/charts/crossplane/templates/_helpers.tpl
+++ b/cluster/charts/crossplane/templates/_helpers.tpl
@@ -30,3 +30,21 @@ app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{ toYaml .Values.customLabels }}
 {{- end }}
 {{- end }}
+
+{{/*
+Generate labels for the RBAC manager deployment.
+*/}}
+{{- define "crossplane.rbacManagerLabels" }}
+helm.sh/chart: {{ include "crossplane.chart" . }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/component: rbac-manager
+app.kubernetes.io/part-of: {{ template "crossplane.name" . }}
+app.kubernetes.io/name: {{ include "crossplane.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+{{- if .Values.customLabels }}
+{{ toYaml .Values.customLabels }}
+{{- end }}
+{{- end }}

--- a/cluster/charts/crossplane/templates/rbac-manager-allowed-provider-permissions.yaml
+++ b/cluster/charts/crossplane/templates/rbac-manager-allowed-provider-permissions.yaml
@@ -6,7 +6,7 @@ metadata:
   name: {{ template "crossplane.name" . }}:allowed-provider-permissions
   labels:
     app: {{ template "crossplane.name" . }}
-    {{- include "crossplane.labels" . | indent 4 }}
+    {{- include "crossplane.rbacManagerLabels" . | indent 4 }}
 aggregationRule:
   clusterRoleSelectors:
   - matchLabels:

--- a/cluster/charts/crossplane/templates/rbac-manager-clusterrole.yaml
+++ b/cluster/charts/crossplane/templates/rbac-manager-clusterrole.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ template "crossplane.name" . }}-rbac-manager
   labels:
     app: {{ template "crossplane.name" . }}
-    {{- include "crossplane.labels" . | indent 4 }}
+    {{- include "crossplane.rbacManagerLabels" . | indent 4 }}
 rules:
 - apiGroups:
   - ""

--- a/cluster/charts/crossplane/templates/rbac-manager-clusterrolebinding.yaml
+++ b/cluster/charts/crossplane/templates/rbac-manager-clusterrolebinding.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ template "crossplane.name" . }}-rbac-manager
   labels:
     app: {{ template "crossplane.name" . }}
-    {{- include "crossplane.labels" . | indent 4 }}
+    {{- include "crossplane.rbacManagerLabels" . | indent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/cluster/charts/crossplane/templates/rbac-manager-deployment.yaml
+++ b/cluster/charts/crossplane/templates/rbac-manager-deployment.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: {{ template "crossplane.name" . }}-rbac-manager
     release: {{ .Release.Name }}
-    {{- include "crossplane.labels" . | indent 4 }}
+    {{- include "crossplane.rbacManagerLabels" . | indent 4 }}
   {{- with .Values.customAnnotations }}
   annotations: {{ toYaml . | nindent 4 }}
   {{- end }}
@@ -38,7 +38,7 @@ spec:
       labels:
         app: {{ template "crossplane.name" . }}-rbac-manager
         release: {{ .Release.Name }}
-        {{- include "crossplane.labels" . | indent 8 }}
+        {{- include "crossplane.rbacManagerLabels" . | indent 8 }}
     spec:
       {{- with .Values.podSecurityContextRBACManager }}
       securityContext:

--- a/cluster/charts/crossplane/templates/rbac-manager-managed-clusterroles.yaml
+++ b/cluster/charts/crossplane/templates/rbac-manager-managed-clusterroles.yaml
@@ -6,7 +6,7 @@ metadata:
   name: {{ template "crossplane.name" . }}-admin
   labels:
     app: {{ template "crossplane.name" . }}
-    {{- include "crossplane.labels" . | indent 4 }}
+    {{- include "crossplane.rbacManagerLabels" . | indent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -22,7 +22,7 @@ metadata:
   name: {{ template "crossplane.name" . }}-admin
   labels:
     app: {{ template "crossplane.name" . }}
-    {{- include "crossplane.labels" . | indent 4 }}
+    {{- include "crossplane.rbacManagerLabels" . | indent 4 }}
 aggregationRule:
   clusterRoleSelectors:
   - matchLabels:
@@ -34,7 +34,7 @@ metadata:
   name: {{ template "crossplane.name" . }}-edit
   labels:
     app: {{ template "crossplane.name" . }}
-    {{- include "crossplane.labels" . | indent 4 }}
+    {{- include "crossplane.rbacManagerLabels" . | indent 4 }}
 aggregationRule:
   clusterRoleSelectors:
   - matchLabels:
@@ -46,7 +46,7 @@ metadata:
   name: {{ template "crossplane.name" . }}-view
   labels:
     app: {{ template "crossplane.name" . }}
-    {{- include "crossplane.labels" . | indent 4 }}
+    {{- include "crossplane.rbacManagerLabels" . | indent 4 }}
 aggregationRule:
   clusterRoleSelectors:
   - matchLabels:
@@ -58,7 +58,7 @@ metadata:
   name: {{ template "crossplane.name" . }}-browse
   labels:
     app: {{ template "crossplane.name" . }}
-    {{- include "crossplane.labels" . | indent 4 }}
+    {{- include "crossplane.rbacManagerLabels" . | indent 4 }}
 aggregationRule:
   clusterRoleSelectors:
   - matchLabels:
@@ -72,7 +72,7 @@ metadata:
   labels:
     rbac.crossplane.io/aggregate-to-admin: "true"
     app: {{ template "crossplane.name" . }}
-    {{- include "crossplane.labels" . | indent 4 }}
+    {{- include "crossplane.rbacManagerLabels" . | indent 4 }}
 rules:
 # Crossplane administrators have access to view events.
 - apiGroups: [""]
@@ -127,7 +127,7 @@ metadata:
   labels:
     rbac.crossplane.io/aggregate-to-edit: "true"
     app: {{ template "crossplane.name" . }}
-    {{- include "crossplane.labels" . | indent 4 }}
+    {{- include "crossplane.rbacManagerLabels" . | indent 4 }}
 rules:
 # Crossplane editors have access to view events.
 - apiGroups: [""]
@@ -171,7 +171,7 @@ metadata:
   labels:
     rbac.crossplane.io/aggregate-to-view: "true"
     app: {{ template "crossplane.name" . }}
-    {{- include "crossplane.labels" . | indent 4 }}
+    {{- include "crossplane.rbacManagerLabels" . | indent 4 }}
 rules:
 # Crossplane viewers have access to view events.
 - apiGroups: [""]
@@ -210,7 +210,7 @@ metadata:
   labels:
     rbac.crossplane.io/aggregate-to-browse: "true"
     app: {{ template "crossplane.name" . }}
-    {{- include "crossplane.labels" . | indent 4 }}
+    {{- include "crossplane.rbacManagerLabels" . | indent 4 }}
 rules:
 # Crossplane browsers have access to view events.
 - apiGroups: [""]

--- a/cluster/charts/crossplane/templates/rbac-manager-serviceaccount.yaml
+++ b/cluster/charts/crossplane/templates/rbac-manager-serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "crossplane.name" . }}
-    {{- include "crossplane.labels" . | indent 4 }}
+    {{- include "crossplane.rbacManagerLabels" . | indent 4 }}
 {{- with .Values.imagePullSecrets }}
 imagePullSecrets:
 {{- range $index, $secret := . }}


### PR DESCRIPTION
### Description of your changes

Fix the Helm chart labels for the RBAC manager deployment so it does not render the same `app.kubernetes.io/component` value as the core Crossplane deployment.

The core deployment keeps `app.kubernetes.io/component: cloud-infrastructure-controller`, while the RBAC manager deployment now renders `app.kubernetes.io/component: rbac-manager` on both `metadata.labels` and `spec.template.metadata.labels`.

This does not change deployment selectors, which continue to use the existing `app` and `release` labels.

Fixes #6965.

### How has this code been tested

- `helm lint ./cluster/charts/crossplane`
- `helm template crossplane ./cluster/charts/crossplane --namespace crossplane-system > /tmp/crossplane-rendered.yaml`
- Verified rendered deployments:
  - `crossplane | cloud-infrastructure-controller | cloud-infrastructure-controller | selector-component:<none>`
  - `crossplane-rbac-manager | rbac-manager | rbac-manager | selector-component:<none>`
- `helm template crossplane ./cluster/charts/crossplane --namespace crossplane-system --set rbacManager.deploy=false > /tmp/crossplane-no-rbac-rendered.yaml`
- `git diff --check HEAD~1 HEAD`

I also attempted `./nix.sh flake check`, but it did not complete in my environment because fetching a Go module checksum from `sum.golang.org` timed out during TLS handshake.


I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [ ] ~~Run `./nix.sh flake check` to ensure this PR is ready for review.~~
- [ ] ~~Added or updated unit tests.~~
- [ ] ~~Added or updated e2e tests.~~
- [ ] ~~Linked a PR or a [docs tracking issue] to [document this change].~~
- [ ] ~~Added `backport release-x.y` labels to auto-backport this PR.~~
- [ ] ~~Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md