### PR TITLE
fix: return function cache GC cancellation errors

### DIFF
--- a/internal/xfn/cached/cached_runner.go
+++ b/internal/xfn/cached/cached_runner.go
@@ -330,7 +330,7 @@ func (r *FileBackedRunner) GarbageCollectFilesNow(ctx context.Context) (int, err
 		// Stop walking if our context is cancelled.
 		select {
 		case <-ctx.Done():
-			return nil
+			return ctx.Err()
 		default:
 		}
 

--- a/internal/xfn/cached/cached_runner_test.go
+++ b/internal/xfn/cached/cached_runner_test.go
@@ -536,3 +536,30 @@ func TestGarbageCollectFilesNow(t *testing.T) {
 		t.Errorf("\nr.GarbageCollectFilesNow(...): -want collected, +got collected:\n%s", diff)
 	}
 }
+
+func TestGarbageCollectFilesNowStopsWhenContextIsCancelled(t *testing.T) {
+	// Deadline in the past.
+	past, _ := proto.Marshal(&v1alpha1.CachedRunFunctionResponse{Deadline: timestamppb.New(time.Now().Add(-1 * time.Minute))})
+
+	fs := MockFs(map[string][]byte{
+		"/":               MockDir,
+		"/coolfn":         MockDir,
+		"/coolfn/expired": past,
+	})
+
+	r := NewFileBackedRunner(nil, "/cache",
+		WithLogger(&TestLogger{t: t}),
+		WithFilesystem(fs))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	collected, err := r.GarbageCollectFilesNow(ctx)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("r.GarbageCollectFilesNow(...): want context canceled error, got %v", err)
+	}
+
+	if diff := cmp.Diff(0, collected); diff != "" {
+		t.Errorf("\nr.GarbageCollectFilesNow(...): -want collected, +got collected:\n%s", diff)
+	}
+}


### PR DESCRIPTION
### Description of your changes

`GarbageCollectFilesNow` checked for cancellation while walking cache files, but returned `nil` from the walk callback. So cancel looked like success, ngl not great.

This returns `ctx.Err()` instead, so callers can see `context canceled` and stop cleanly.

Repro:
1. Put an expired cached function response in the cache fs.
2. Call `GarbageCollectFilesNow` with an already-canceled context.
3. Before: `collected=0, err=nil`.
4. Now: `collected=0, err=context canceled`.

This is real-world triggerable: the cache GC runs with Crossplane's process context, so normal shutdown can cancel during a walk. No cloud quota or provider API ceiling blocks this path; it's local fs work.

Related cache stuff: #6422, #6718. No direct open issue found.

Tests:
- `go test ./internal/xfn/cached`
- `go test ./internal/xfn/...`
- `./nix.sh run .#test`
- `./nix.sh flake check`

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `./nix.sh flake check` to ensure this PR is ready for review.
- [x] Added or updated unit tests.
- [ ] ~Added or updated e2e tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~
- [ ] ~Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md