### PR TITLE
feat(core): make leader election timings configurable

### DIFF
--- a/cmd/crossplane/core/core.go
+++ b/cmd/crossplane/core/core.go
@@ -99,11 +99,16 @@ func (c *Command) Run() error {
 type startCommand struct {
 	Profile string `help:"Serve runtime profiling data via HTTP at /debug/pprof." placeholder:"host:port"`
 
-	Namespace      string `default:"crossplane-system"     env:"POD_NAMESPACE"                                                      help:"Namespace used to unpack and run packages."                      short:"n"`
-	ServiceAccount string `default:"crossplane"            env:"POD_SERVICE_ACCOUNT"                                                help:"Name of the Crossplane Service Account."`
-	LeaderElection bool   `default:"false"                 env:"LEADER_ELECTION"                                                    help:"Use leader election for the controller manager."                 short:"l"`
-	CABundlePath   string `env:"CA_BUNDLE_PATH"            help:"Additional CA bundle to use when fetching packages from registry."`
-	UserAgent      string `default:"${default_user_agent}" env:"USER_AGENT"                                                         help:"The User-Agent header that will be set on all package requests."`
+	Namespace      string `default:"crossplane-system"     env:"POD_NAMESPACE"       help:"Namespace used to unpack and run packages."                      short:"n"`
+	ServiceAccount string `default:"crossplane"            env:"POD_SERVICE_ACCOUNT" help:"Name of the Crossplane Service Account."`
+
+	LeaderElection              bool          `default:"false"                 env:"LEADER_ELECTION"     help:"Use leader election for the controller manager."                 short:"l"`
+	LeaderElectionLeaseDuration time.Duration `default:"60s" env:"LEADER_ELECTION_LEASE_DURATION" help:"Duration a leader lease is valid. Must be greater than the renew deadline."`
+	LeaderElectionRenewDeadline time.Duration `default:"50s" env:"LEADER_ELECTION_RENEW_DEADLINE" help:"Duration the leader must renew the lease before it expires. Must be greater than the retry period."`
+	LeaderElectionRetryPeriod   time.Duration `default:"2s"  env:"LEADER_ELECTION_RETRY_PERIOD"   help:"How often the leader and candidates retry lease operations."`
+
+	CABundlePath string `env:"CA_BUNDLE_PATH" help:"Additional CA bundle to use when fetching packages from registry."`
+	UserAgent    string `default:"${default_user_agent}" env:"USER_AGENT" help:"The User-Agent header that will be set on all package requests."`
 
 	XpkgCacheDir string `aliases:"cache-dir" default:"/cache/xpkg" env:"XPKG_CACHE_DIR,CACHE_DIR" help:"Directory used for caching package images." short:"c"`
 
@@ -231,18 +236,17 @@ func (c *startCommand) Run(s *runtime.Scheme, log logging.Logger) error { //noli
 		},
 
 		// controller-runtime uses both ConfigMaps and Leases for leader
-		// election by default. Leases expire after 15 seconds, with a
-		// 10 second renewal deadline. We've observed leader loss due to
-		// renewal deadlines being exceeded when under high load - i.e.
-		// hundreds of reconciles per second and ~200rps to the API
-		// server. Switching to Leases only and longer leases appears to
-		// alleviate this.
+		// election by default. We use Leases only with longer durations to
+		// reduce leader loss under degraded API server connectivity. The
+		// lease duration, renew deadline, and retry period are configurable
+		// to allow tuning for different cluster conditions.
 		LeaderElection:                c.LeaderElection,
 		LeaderElectionID:              "crossplane-leader-election-core",
 		LeaderElectionResourceLock:    resourcelock.LeasesResourceLock,
 		LeaderElectionReleaseOnCancel: true,
-		LeaseDuration:                 func() *time.Duration { d := 60 * time.Second; return &d }(),
-		RenewDeadline:                 func() *time.Duration { d := 50 * time.Second; return &d }(),
+		LeaseDuration:                 &c.LeaderElectionLeaseDuration,
+		RenewDeadline:                 &c.LeaderElectionRenewDeadline,
+		RetryPeriod:                   &c.LeaderElectionRetryPeriod,
 
 		PprofBindAddress:       c.Profile,
 		HealthProbeBindAddress: fmt.Sprintf(":%d", c.HealthProbePort),

--- a/cmd/crossplane/rbac/rbac.go
+++ b/cmd/crossplane/rbac/rbac.go
@@ -50,7 +50,11 @@ type startCommand struct {
 	Profile string `help:"Serve runtime profiling data via HTTP at /debug/pprof." placeholder:"host:port"`
 
 	ProviderClusterRole string `help:"A ClusterRole enumerating the permissions provider packages may request." name:"provider-clusterrole"`
-	LeaderElection      bool   `env:"LEADER_ELECTION"                                                           help:"Use leader election for the controller manager." name:"leader-election" short:"l"`
+
+	LeaderElection              bool          `env:"LEADER_ELECTION"                  help:"Use leader election for the controller manager." name:"leader-election" short:"l"`
+	LeaderElectionLeaseDuration time.Duration `default:"60s" env:"LEADER_ELECTION_LEASE_DURATION" help:"Duration a leader lease is valid. Must be greater than the renew deadline."`
+	LeaderElectionRenewDeadline time.Duration `default:"50s" env:"LEADER_ELECTION_RENEW_DEADLINE" help:"Duration the leader must renew the lease before it expires. Must be greater than the retry period."`
+	LeaderElectionRetryPeriod   time.Duration `default:"2s"  env:"LEADER_ELECTION_RETRY_PERIOD"   help:"How often the leader and candidates retry lease operations."`
 
 	SyncInterval            time.Duration `default:"1h"                 help:"How often all resources will be double-checked for drift from the desired state." short:"s"`
 	PollInterval            time.Duration `default:"1m"                 help:"How often individual resources will be checked for drift from the desired state."`
@@ -79,6 +83,9 @@ func (c *startCommand) Run(s *runtime.Scheme, log logging.Logger) error {
 		LeaderElection:             c.LeaderElection,
 		LeaderElectionID:           "crossplane-leader-election-rbac",
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
+		LeaseDuration:              &c.LeaderElectionLeaseDuration,
+		RenewDeadline:              &c.LeaderElectionRenewDeadline,
+		RetryPeriod:                &c.LeaderElectionRetryPeriod,
 		Cache: cache.Options{
 			SyncPeriod: &c.SyncInterval,
 		},


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane! Please read the contribution docs
(linked below) if this is your first Crossplane pull request.
-->

### Description of your changes

Adds `--leader-election-lease-duration`, `--leader-election-renew-deadline`, and `--leader-election-retry-period` flags and equivalent env vars to the core and rbac manager start subcommands.

- **60s / 50s / 2s** for core, which preserves existing behaviour
- **60s / 50s / 2s** for rbac, up from the controller-runtime defaults of **15s / 10s / 2s** for consistency with core

Motivated by clusters with degraded API server connectivity where the hardcoded renew deadline is exceeded under load causing controller crashes.

Note: reformatted surrounding struct tags for consistency (gofmt).

Fixes #7376

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `./nix.sh flake check` to ensure this PR is ready for review.
~- [ ] Added or updated unit tests.~
~- [ ] Added or updated e2e tests.~
~- [ ] Linked a PR or a [docs tracking issue] to [document this change].~
~- [ ] Added `backport release-x.y` labels to auto-backport this PR.~
~- [ ] Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md