### PR TITLE
Pin Renovate config validator

### DIFF
--- a/.github/renovate-base.json5
+++ b/.github/renovate-base.json5
@@ -40,6 +40,20 @@
       '(^|/)test/e2e/.*\\.ya?ml$',
     ],
   },
+  customManagers: [
+    {
+      customType: 'regex',
+      description: 'Bump Renovate version used by the config validator',
+      fileMatch: [
+        '^\\.github/workflows/renovate\\.ya?ml$',
+      ],
+      matchStrings: [
+        'RENOVATE_VERSION: "(?<currentValue>.*?)"',
+      ],
+      datasourceTemplate: 'npm',
+      depNameTemplate: 'renovate',
+    },
+  ],
   // PackageRules disabled below should be enabled in case of vulnerabilities
   vulnerabilityAlerts: {
     enabled: true,

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -16,6 +16,7 @@ permissions:
 
 env:
   LOG_LEVEL: "info"
+  RENOVATE_VERSION: "42.99.0"
 
 jobs:
   renovate:
@@ -29,7 +30,7 @@ jobs:
 
       # Don't waste time starting Renovate if JSON is invalid
       - name: Validate Renovate JSON
-        run:  npx --yes --package renovate -- renovate-config-validator
+        run: npx --yes --package renovate@${RENOVATE_VERSION} -- renovate-config-validator
 
       - name: Get token
         id: get-github-app-token


### PR DESCRIPTION
### Description of your changes

This PR makes the Renovate config validation step use a reviewed Renovate version instead of resolving the latest package at workflow runtime.

The Renovate workflow itself is already pinned by commit SHA, but the validator package was still mutable. Pinning it keeps the full Renovate execution path more predictable: validator behavior only changes when Renovate opens a normal dependency update PR.

Validation run:

```sh
npm exec --yes --package "renovate@42.99.0" -- renovate-config-validator .github/renovate.json5
```

Fixes # <!-- none -->

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [ ] ~Run `./nix.sh flake check` to ensure this PR is ready for review.~
- [ ] ~Added or updated unit tests.~
- [ ] ~Added or updated e2e tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~
- [ ] ~Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md
