### PR TITLE
Pin Renovate Earthly download

### DIFF
--- a/.github/renovate-entrypoint.sh
+++ b/.github/renovate-entrypoint.sh
@@ -2,13 +2,7 @@
 
 set -e
 
-# Install Earthly (for release branches)
-echo "Installing Earthly..."
-curl -fsSLo /usr/local/bin/earthly https://github.com/earthly/earthly/releases/latest/download/earthly-linux-amd64
-chmod +x /usr/local/bin/earthly
-/usr/local/bin/earthly bootstrap
-
-# Install Nix (for main branch)
+# Install Nix.
 echo "Installing Nix..."
 apt-get update && apt-get install -y nix-bin
 
@@ -31,5 +25,10 @@ extra-trusted-public-keys = crossplane.cachix.org-1:NJluVUN9TX0rY/zAxHYaT19Y5ik4
 EOF
 
 echo "Nix $(nix --version) installed successfully"
+
+# Install Earthly (for release branches) from the repository flake, pinned by flake.lock.
+echo "Installing Earthly..."
+nix profile install .#earthly
+earthly bootstrap
 
 renovate

--- a/flake.nix
+++ b/flake.nix
@@ -118,6 +118,7 @@
               imagePlatforms
               ;
           };
+          earthly = pkgs.earthly;
         }
       );
 


### PR DESCRIPTION
### Description of your changes

This PR makes the Earthly binary used by self-hosted Renovate come from the repository's pinned Nix flake instead of downloading it from GitHub releases at workflow runtime.

The Renovate workflow runs a custom entrypoint that installs Earthly before running Renovate. Previously that entrypoint downloaded Earthly from the mutable `latest` release URL. This PR exposes `pkgs.earthly` as a flake package and installs it with `nix profile install .#earthly`, so the Earthly package is selected from the `nixpkgs` revision pinned in `flake.lock`.

`earthly` does not appear by name in `flake.lock`; `flake.lock` pins the `nixpkgs` input, and `.#earthly` resolves `pkgs.earthly` from that pinned input. Future Earthly updates will therefore happen through the normal Renovate-managed flake lock update path.

Validation run:

```sh
bash -n .github/renovate-entrypoint.sh
nix eval --raw .#earthly.version
npm exec --yes --package "renovate@42.99.0" -- renovate-config-validator .github/renovate.json5
```

Fixes # <!-- none -->

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [ ] ~Run `./nix.sh flake check` to ensure this PR is ready for review.~
- [ ] ~Added or updated unit tests.~
- [ ] ~Added or updated e2e tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~
- [ ] ~Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md
