### PR TITLE
Make Renovate security updates bypass throttles

### DIFF
--- a/.github/renovate-base.json5
+++ b/.github/renovate-base.json5
@@ -54,9 +54,14 @@
       depNameTemplate: 'renovate',
     },
   ],
-  // PackageRules disabled below should be enabled in case of vulnerabilities
+  // Security updates should bypass dependency dashboard approval.
   vulnerabilityAlerts: {
     enabled: true,
+    automerge: false,
+    dependencyDashboardApproval: false,
+    addLabels: [
+      'security',
+    ],
   },
   osvVulnerabilityAlerts: true,
   // Renovate evaluates all packageRules in order, so low priority rules should


### PR DESCRIPTION
### Description of your changes

This PR makes our Renovate vulnerability-alert behavior explicit and adds security-specific routing for vulnerability PRs.

Crossplane intentionally throttles some routine dependency update streams to keep Renovate manageable. Security remediation should be different: when Renovate knows an update fixes a vulnerability, it should not wait for dependency dashboard approval, and it should be easy to identify.

Behavior this PR makes explicit:

| Setting | Reason |
| --- | --- |
| `enabled: true` | Keeps vulnerability-alert PRs enabled. |
| `automerge: false` | Keeps vulnerability-alert PRs review-based. This is already Renovate's default, but setting it here makes the security posture explicit. |

Behavior this PR adds for vulnerability-alert PRs:

| Setting | Reason |
| --- | --- |
| `dependencyDashboardApproval: false` | Prevents security fixes from waiting for dependency dashboard approval. |
| `addLabels: ['security']` | Makes vulnerability-alert PRs easier to identify and route. |

Note that this PR does not set `schedule: ['at any time']` for vulnerability alerts. Crossplane runs Renovate from a scheduled GitHub Actions workflow, so repository-level Renovate schedule settings cannot make Renovate run sooner than the workflow itself.

Validation run:

```sh
npm exec --yes --package "renovate@42.99.0" -- renovate-config-validator .github/renovate.json5
```

Fixes # <!-- none -->

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [ ] ~Run `./nix.sh flake check` to ensure this PR is ready for review.~
- [ ] ~Added or updated unit tests.~
- [ ] ~Added or updated e2e tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~
- [ ] ~Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md
