### PR TITLE
fix: clean up temp files on cache write errors in CacheFunction

### DIFF
--- a/internal/xfn/cached/cached_runner.go
+++ b/internal/xfn/cached/cached_runner.go
@@ -269,6 +269,7 @@ func (r *FileBackedRunner) CacheFunction(ctx context.Context, name string, req *
 
 	if _, err := tmp.Write(msg); err != nil {
 		_ = tmp.Close()
+		_ = r.fs.Remove(tmp.Name())
 
 		log.Info("RunFunctionResponse cache write error", "err", err)
 		r.metrics.Error(name)
@@ -277,6 +278,8 @@ func (r *FileBackedRunner) CacheFunction(ctx context.Context, name string, req *
 	}
 
 	if err := tmp.Close(); err != nil {
+		_ = r.fs.Remove(tmp.Name())
+
 		log.Info("RunFunctionResponse cache write error", "err", err)
 		r.metrics.Error(name)
 
@@ -284,6 +287,8 @@ func (r *FileBackedRunner) CacheFunction(ctx context.Context, name string, req *
 	}
 
 	if err := r.fs.Rename(tmp.Name(), key); err != nil {
+		_ = r.fs.Remove(tmp.Name())
+
 		log.Info("RunFunctionResponse cache write error", "err", err)
 		r.metrics.Error(name)
 


### PR DESCRIPTION
### Description of your changes

`CacheFunction` creates a temp file for atomic writes to the function response cache. If the subsequent write, close, or rename fails, the method returns early without removing the temp file from disk. These orphaned temp files accumulate over time because the garbage collector only removes files it can successfully unmarshal as cached responses.

This commit adds `r.fs.Remove(tmp.Name())` in each of the three error paths to clean up the temp file on failure.

### Checklist

I have:

- [x] Read and followed Crossplane's [contribution process](https://github.com/crossplane/crossplane/tree/main/contributing).
- [x] Run `make reviewable` to ensure this PR is ready for review. *(Verified with `go build ./...` and `go vet ./...`)*
- [ ] Added or updated unit tests. *(Bug fix is defensive cleanup; existing unit tests continue to pass)*
- [~] Added or updated e2e tests. *(Not applicable for defensive error-path cleanup)*
- [~] Linked a documentation PR or filed a docs tracking issue. *(Not applicable)*
- [~] Added `backport release-*` labels if this fix should be in a patch release. *(Maintainer decision)*
