### PR TITLE
build: Install Earthly in Renovate container via flake URL

### DIFF
--- a/.github/renovate-entrypoint.sh
+++ b/.github/renovate-entrypoint.sh
@@ -26,9 +26,12 @@ EOF
 
 echo "Nix $(nix --version) installed successfully"
 
-# Install Earthly (for release branches) from the repository flake, pinned by flake.lock.
+# Install Earthly (for release branches) from the repository flake on main,
+# pinned by main's flake.lock. The flake is referenced by URL because this
+# entrypoint runs in the Renovate container before the target repo is checked
+# out, so the working directory does not yet contain a flake.nix.
 echo "Installing Earthly..."
-nix profile install .#earthly
+nix profile install github:crossplane/crossplane#earthly
 earthly bootstrap
 
 renovate


### PR DESCRIPTION
### Description of your changes

Since 6d7a428f the Renovate entrypoint installs Earthly via `nix profile install .#earthly`. That command resolves the flake reference relative to the container's working directory, but the entrypoint runs *before* Renovate clones the target repository into the container, so `.` doesn't contain a `flake.nix` at that point. Every scheduled Renovate run since 2026-05-14 has failed with:

```
error: could not find a flake.nix file
```

(Example failing run: https://github.com/crossplane/crossplane/actions/runs/26088202333)

This PR changes the install command to fetch the flake by URL (`github:crossplane/crossplane#earthly`) instead. Nix downloads the flake from main, reads the included `flake.lock`, and installs the pinned `pkgs.earthly` derivation. This preserves the "pinned by `flake.lock`" intent of the original commit while removing the working-directory dependency.

Verified locally that the new command resolves `pkgs.earthly` to the expected `earthly-0.8.16` from main's `flake.lock` (nixpkgs-unstable rev `13043924aaa7`):

```
$ nix profile install github:crossplane/crossplane#earthly
$ nix profile list
Name:               earthly
Flake attribute:    packages.aarch64-darwin.earthly
Original flake URL: github:crossplane/crossplane
Locked flake URL:   github:crossplane/crossplane/4e35029520dc33d85846c348262928e62a1e2e64
Store paths:        /nix/store/...-earthly-0.8.16
```

The `earthly = pkgs.earthly;` output added to `flake.nix` in 6d7a428f is unchanged; it's what the new install command resolves.

We'll definitely want to follow up after merging this to run the renovate job and make sure this works OK there too.

Fixes #7403 

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `./nix.sh flake check` to ensure this PR is ready for review.
- [ ] ~Added or updated unit tests.~
- [ ] ~Added or updated e2e tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~
- [ ] ~Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md
