### PR TITLE
build: put Nix profile bin on PATH in Renovate entrypoint

### DIFF
--- a/.github/renovate-entrypoint.sh
+++ b/.github/renovate-entrypoint.sh
@@ -32,6 +32,7 @@ echo "Nix $(nix --version) installed successfully"
 # out, so the working directory does not yet contain a flake.nix.
 echo "Installing Earthly..."
 nix profile install github:crossplane/crossplane#earthly
+export PATH="$HOME/.nix-profile/bin:$PATH"
 earthly bootstrap
 
 renovate


### PR DESCRIPTION
### Description of your changes

Follow-on to #7404. That PR fixed the `error: could not find a flake.nix file` failure but exposed a second latent bug: after `nix profile install` succeeds, the next line in the entrypoint dies with `earthly: command not found`.

Example failing run (the first scheduled run after #7404 merged): https://github.com/crossplane/crossplane/actions/runs/26119583668/job/76817709496

```
Nix nix (Nix) 2.18.1 installed successfully
Installing Earthly...
[0/1 built, 1/4/5 copied (219.8/220.6 MiB), 54.9 MiB DL] fetching earthly-0.8.16 from https://cache.nixos.org
/renovate-entrypoint.sh: line 35: earthly: command not found
Error: The process '/usr/bin/docker' failed with exit code 127
```

`nix profile install` puts the `earthly` symlink under `$HOME/.nix-profile/bin`, but the Renovate container's `PATH` doesn't include that directory. This PR prepends `$HOME/.nix-profile/bin` to `PATH` after the install and before `earthly bootstrap` so subsequent commands will find the `earthly` binary.

Verified locally in `ghcr.io/renovatebot/renovate:42.99.0` (same image and tag the workflow uses):

```bash
docker run --rm \
  --user root \
  --entrypoint /bin/bash \
  -v "$PWD/.github/renovate-entrypoint.sh:/entry.sh:ro" \
  ghcr.io/renovatebot/renovate:42.99.0 \
  -c 'sed "/^renovate$/d" /entry.sh > /tmp/test.sh && bash /tmp/test.sh && echo "OK"'
```

With this change the script reaches `Bootstrapping successful` (from `earthly`) and exits 0. There is a warning that BuildKit can't connect to a daemon locally because no Docker socket is mounted, but that should work in the real environment. Also note that test removes the call to `renovate` so it won't try to do real renovate work. The important part is that the test demonstrates `earthly` is found and invoked 😇 

Fixes #7403 

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `./nix.sh flake check` to ensure this PR is ready for review.
- [ ] ~Added or updated unit tests.~
- [ ] ~Added or updated e2e tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~
- [ ] ~Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md
