### PR TITLE
chore(deps): Bump Go to 1.25.10 to fix stdlib CVEs (release-1.20)

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -3,7 +3,7 @@ VERSION --try --raw-output 0.8
 
 PROJECT crossplane/crossplane
 
-ARG --global GO_VERSION=1.25.9
+ARG --global GO_VERSION=1.25.10
 
 # reviewable checks that a branch is ready for review. Run it before opening a
 # pull request. It will catch a lot of the things our CI workflow will catch.

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/crossplane/crossplane
 
-go 1.25.9
+go 1.25.10
 
 require (
 	dario.cat/mergo v1.0.1


### PR DESCRIPTION
### Description of your changes

Picks up the Go 1.25.10 security release announced at https://groups.google.com/g/golang-announce/c/qcCIEXso47M, which fixes 11 stdlib CVEs across net/http/httputil, cmd/go, html/template, net/mail, and others.

Updates the `go` directive in `go.mod` and the `GO_VERSION` argument in `Earthfile` to 1.25.10. No other files change on this branch (pre-Nix, Earthly-based).

**Build verification**

Locally ran `earthly +go-build` against this branch and inspected the resulting binary's embedded BuildInfo:

```
$ go version _output/bin/linux_arm64/crossplane
_output/bin/linux_arm64/crossplane: go1.25.10
```

Confirms the new `GO_VERSION` arg flows through the Earthfile to the actual compile.

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `./nix.sh flake check` to ensure this PR is ready for review.
- [ ] ~Added or updated unit tests.~
- [ ] ~Added or updated e2e tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~
- [ ] ~Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md
