### PR TITLE
chore(deps): Bump Go to 1.25.10 to fix stdlib CVEs (release-2.3)

### DIFF
--- a/apis/go.mod
+++ b/apis/go.mod
@@ -1,6 +1,6 @@
 module github.com/crossplane/crossplane/apis/v2
 
-go 1.25.9
+go 1.25.10
 
 require (
 	github.com/google/go-cmp v0.7.0

--- a/flake.lock
+++ b/flake.lock
@@ -58,11 +58,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1775888245,
-        "narHash": "sha256-nwASzrRDD1JBEu/o8ekKYEXm/oJW6EMCzCRdrwcLe90=",
+        "lastModified": 1778869304,
+        "narHash": "sha256-30sZNZoA1cqF5JNO9fVX+wgiQYjB7HJqqJ4ztCDeBZE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "13043924aaa7375ce482ebe2494338e058282925",
+        "rev": "d233902339c02a9c334e7e593de68855ad26c4cb",
         "type": "github"
       },
       "original": {

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/crossplane/crossplane/v2
 
-go 1.25.9
+go 1.25.10
 
 replace github.com/crossplane/crossplane/apis/v2 => ./apis
 


### PR DESCRIPTION
### Description of your changes

Picks up the Go 1.25.10 security release announced at https://groups.google.com/g/golang-announce/c/qcCIEXso47M, which fixes 11 stdlib CVEs across net/http/httputil, cmd/go, html/template, net/mail, and others.

Advances the `nixpkgs-unstable` flake input so `pkgs.unstable.go_1_25` resolves to 1.25.10, updates the `go` directive in both `go.mod` and `apis/go.mod`, and regenerates `gomod2nix.toml` (and `apis/gomod2nix.toml`) via `nix run .#tidy`.

**Build verification**

The structurally identical change on release-2.2 (same flake input bump, same `nix run .#tidy` regeneration) was built locally with `nix build .#`:

```
$ go version ./result/bin/darwin_amd64/crossplane
./result/bin/darwin_amd64/crossplane: go1.25.10
$ go version ./result/bin/linux_ppc64le/crossplane
./result/bin/linux_ppc64le/crossplane: go1.25.10
```

release-2.3 uses the same `nixpkgs-unstable` input mechanism, so the same outcome applies for the root module's compiled binaries. The additional `apis/go.mod` bump affects only the apis-internal module, which is a library, not a binary.


I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `./nix.sh flake check` to ensure this PR is ready for review.
- [ ] ~Added or updated unit tests.~
- [ ] ~Added or updated e2e tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~
- [ ] ~Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md
