### PR TITLE
ci: pin oss-fuzz GitHub Actions to commit SHA

### DIFF
--- a/.github/renovate-base.json5
+++ b/.github/renovate-base.json5
@@ -141,7 +141,12 @@
       ],
     },
     {
-      description: "Ignore oss-fuzz, it's not using tags, we'll stick to master",
+      // google/oss-fuzz does not publish tags. The action references in
+      // .github/workflows/ci.yml are pinned to a commit SHA per OpenSSF
+      // hardening guidance (closes #7389). Renovate is disabled here so
+      // it does not attempt to bump the pin automatically; the SHA is
+      // refreshed manually on a periodic cadence.
+      description: 'Disable Renovate for google/oss-fuzz; pin SHA is bumped manually',
       matchDepTypes: [
         'action',
       ],

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -312,13 +312,13 @@ jobs:
     steps:
       - name: Build Fuzzers
         id: build
-        uses: google/oss-fuzz/infra/cifuzz/actions/build_fuzzers@master
+        uses: google/oss-fuzz/infra/cifuzz/actions/build_fuzzers@5339266a931d07df212b58caa7bb2e45dda6bf03 # 2026-05-20
         with:
           oss-fuzz-project-name: "crossplane"
           language: go
 
       - name: Run Fuzzers
-        uses: google/oss-fuzz/infra/cifuzz/actions/run_fuzzers@master
+        uses: google/oss-fuzz/infra/cifuzz/actions/run_fuzzers@5339266a931d07df212b58caa7bb2e45dda6bf03 # 2026-05-20
         with:
           oss-fuzz-project-name: "crossplane"
           fuzz-seconds: 300


### PR DESCRIPTION
Closes #7389

## What

The CIFuzz Build Fuzzers and Run Fuzzers steps in `.github/workflows/ci.yml` referenced `google/oss-fuzz/...@master`, an unpinned branch ref. Per OpenSSF and CNCF supply-chain hardening guidance, third-party Actions should be pinned to an immutable commit SHA. This brings `google/oss-fuzz` in line with how other Actions in the same workflow are already pinned (`actions/checkout`, `cachix/install-nix-action`, etc.).

## How

- `.github/workflows/ci.yml`: pin both `google/oss-fuzz/infra/cifuzz/actions/build_fuzzers` and `.../run_fuzzers` to commit SHA `5339266a931d07df212b58caa7bb2e45dda6bf03` (HEAD of `google/oss-fuzz:master` on 2026-05-20). Trailing comment uses the date format since `google/oss-fuzz` does not publish release tags; this matches the issue's stated preference.
- `.github/renovate-base.json5`: keep the disable-Renovate rule for `google/oss-fuzz` (it still doesn't publish tags) but replace the description with a block comment documenting the manual-bump policy. This addresses the third bullet of the issue's acceptance criteria ("document manual bump policy").

## Verification

| Check | Result |
| --- | --- |
| `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"` | parses OK |
| JSON5 syntax (visual; matches existing file conventions: `//` comments, single-quoted strings, trailing commas) | conforms |

No runtime behavior change. Future SHA bumps are a manual maintainer action, as documented in the new Renovate-config comment.