### PR TITLE
chore: bump releases table and renovate baseBranches after v2.3 release

### DIFF
--- a/.github/renovate-base.json5
+++ b/.github/renovate-base.json5
@@ -15,7 +15,6 @@
   baseBranches: [
     'main',
     'release-1.20',
-    'release-2.0',
     'release-2.1',
     'release-2.2',
     'release-2.3',

--- a/README.md
+++ b/README.md
@@ -25,12 +25,12 @@ documentation].
 | Release | Release Date |   EOL    |
 |:-------:|:------------:|:--------:|
 |  v1.20  | May 21, 2025 |   TBD    |
-|  v2.0   | Aug 8, 2025  | May 2026 |
 |  v2.1   | Nov 5, 2025  | Aug 2026 |
 |  v2.2   | Feb 18, 2026 | Nov 2026 |
-|  v2.3   |   May 2026   | Feb 2027 |
+|  v2.3   | May 21, 2026 | Feb 2027 |
 |  v2.4   |   Aug 2026   | May 2027 |
 |  v2.5   |   Nov 2026   | Aug 2027 |
+|  v2.6   |   Feb 2027   | Nov 2027 |
 
 You can subscribe to the [community calendar] to track all release dates, and
 find the most recent releases on the [releases] page.


### PR DESCRIPTION
### Description of your changes

From https://github.com/crossplane/release/issues/70: 

* Updated, in a single PR, the following on main:
  * The [releases table](https://github.com/crossplane/crossplane#releases) in the README.md, removing the now old unsupported release and adding the new one.
  * The baseBranches list in .github/renovate.json5, removing the now old unsupported release.

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `./nix.sh flake check` to ensure this PR is ready for review.
- [ ] ~Added or updated unit tests.~
- [ ] ~Added or updated e2e tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~
- [ ] ~Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.`

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md
