### PR TITLE
chore(deps): bump crossplane-runtime to v2.1.6 (release-2.1)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/Masterminds/semver v1.5.0
 	github.com/alecthomas/kong v1.4.0
 	github.com/containerd/errdefs v1.0.0
-	github.com/crossplane/crossplane-runtime/v2 v2.1.5
+	github.com/crossplane/crossplane-runtime/v2 v2.1.6
 	github.com/docker/docker v28.5.2+incompatible
 	github.com/docker/go-connections v0.5.0
 	github.com/emicklei/dot v1.8.0

--- a/go.sum
+++ b/go.sum
@@ -164,8 +164,8 @@ github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSV
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/creack/pty v1.1.18 h1:n56/Zwd5o6whRC5PMGretI4IdRLlmBXYNjScPaBgsbY=
 github.com/creack/pty v1.1.18/go.mod h1:MOBLtS5ELjhRRrroQr9kyvTxUAFNvYEK993ew/Vr4O4=
-github.com/crossplane/crossplane-runtime/v2 v2.1.5 h1:9zP95ILGLjMYz1sMhQnMDK50bq1JIHBjfmjPfBcv0R8=
-github.com/crossplane/crossplane-runtime/v2 v2.1.5/go.mod h1:ZkOQK9eZAJYWJSLgaR7sVf8zE4Ppw65mAqNMxg9HL9g=
+github.com/crossplane/crossplane-runtime/v2 v2.1.6 h1:eFYUDNS4BrjSlafGBCtXU3r+utTyfpXoa8JUKulsqYM=
+github.com/crossplane/crossplane-runtime/v2 v2.1.6/go.mod h1:sKrvoljhLVTCI7bVuCEwsAyr627fs4gdPTMwRQyuQjc=
 github.com/cyberphone/json-canonicalization v0.0.0-20241213102144-19d51d7fe467 h1:uX1JmpONuD549D73r6cgnxyUu18Zb7yHAy5AYU0Pm4Q=
 github.com/cyberphone/json-canonicalization v0.0.0-20241213102144-19d51d7fe467/go.mod h1:uzvlm1mxhHkdfqitSA92i7Se+S9ksOn3a3qmv/kyOCw=
 github.com/cyphar/filepath-securejoin v0.6.1 h1:5CeZ1jPXEiYt3+Z6zqprSAgSWiggmpVyciv8syjIpVE=


### PR DESCRIPTION
### Description of your changes

Bumps `github.com/crossplane/crossplane-runtime/v2` from v2.1.5 to v2.1.6 on the release-2.1 branch to pick up the latest patch release of the runtime. Single-line change in `go.mod` plus the corresponding `go.sum` hash refresh; no other modules affected.

**Verification**

`go.sum` was refreshed via `earthly +tidy` (which also runs the `tools/` submodule's tidy target). The diff was clean, with no unrelated module churn and no `tools/` changes needed for this bump.

```
$ go list -m github.com/crossplane/crossplane-runtime/v2
github.com/crossplane/crossplane-runtime/v2 v2.1.6
$ go build ./...
(succeeds)
```

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [ ] ~Run `earthly +reviewable` to ensure this PR is ready for review.~
- [ ] ~Added or updated unit tests.~
- [ ] ~Added or updated e2e tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~
- [ ] ~Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md
