### PR TITLE
chore(deps): bump crossplane-runtime to v2.2.2 (release-2.2)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/alecthomas/kong v1.14.0
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/containerd/errdefs v1.0.0
-	github.com/crossplane/crossplane-runtime/v2 v2.2.1
+	github.com/crossplane/crossplane-runtime/v2 v2.2.2
 	github.com/docker/docker v28.5.2+incompatible
 	github.com/docker/go-connections v0.6.0
 	github.com/emicklei/dot v1.10.0

--- a/go.sum
+++ b/go.sum
@@ -180,8 +180,8 @@ github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSV
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/creack/pty v1.1.18 h1:n56/Zwd5o6whRC5PMGretI4IdRLlmBXYNjScPaBgsbY=
 github.com/creack/pty v1.1.18/go.mod h1:MOBLtS5ELjhRRrroQr9kyvTxUAFNvYEK993ew/Vr4O4=
-github.com/crossplane/crossplane-runtime/v2 v2.2.1 h1:CJXV8+1SDXLYJx67sUO4MIuLCkKEOKxCS2zg02nBqUI=
-github.com/crossplane/crossplane-runtime/v2 v2.2.1/go.mod h1:3Xq18YLf2en0BB2OZpcixTKazeX7bS3txLbQHjOR52c=
+github.com/crossplane/crossplane-runtime/v2 v2.2.2 h1:/as5jRTqT90Kd37pj8BRTlZCfu57Ys7I7E97cW942bU=
+github.com/crossplane/crossplane-runtime/v2 v2.2.2/go.mod h1:er5/a4b8fT8+wTipkLxjB+lqkX+s5vP92FGzoMbvbjE=
 github.com/cyberphone/json-canonicalization v0.0.0-20241213102144-19d51d7fe467 h1:uX1JmpONuD549D73r6cgnxyUu18Zb7yHAy5AYU0Pm4Q=
 github.com/cyberphone/json-canonicalization v0.0.0-20241213102144-19d51d7fe467/go.mod h1:uzvlm1mxhHkdfqitSA92i7Se+S9ksOn3a3qmv/kyOCw=
 github.com/cyphar/filepath-securejoin v0.6.1 h1:5CeZ1jPXEiYt3+Z6zqprSAgSWiggmpVyciv8syjIpVE=

--- a/gomod2nix.toml
+++ b/gomod2nix.toml
@@ -174,8 +174,8 @@ cachePackages = ["cel.dev/expr", "cloud.google.com/go/compute/metadata", "dario.
     version = "v3.17.0"
     hash = "sha256-b9dCq5GN5ac64UG23Rijv1qcmUZNcxb8DJQycAa96EQ="
   [mod."github.com/crossplane/crossplane-runtime/v2"]
-    version = "v2.2.1"
-    hash = "sha256-0A4GliFlbAnBWfF9rjeOuQeDx1xdOjRzTS+8ynTVkoA="
+    version = "v2.2.2"
+    hash = "sha256-Is2Ja/AhLaSyqay9ZkyotT3ekvH5IuPI9aq2I0BnrDc="
   [mod."github.com/cyberphone/json-canonicalization"]
     version = "v0.0.0-20241213102144-19d51d7fe467"
     hash = "sha256-eqH3UKAZ9eOlZjYdN7nWuJ1hFm2JAP1PVbJInQk6OLw="


### PR DESCRIPTION
### Description of your changes

Bumps `github.com/crossplane/crossplane-runtime/v2` from v2.2.1 to v2.2.2 on the release-2.2 branch to pick up the latest patch release of the runtime. Single-line change in `go.mod` plus the corresponding `go.sum` and `gomod2nix.toml` refreshes; no other modules affected.

**Verification**

`go.sum` and `gomod2nix.toml` were refreshed via `nix run .#tidy` (which runs `go mod tidy` then `gomod2nix generate --with-deps`). The diff was clean, with no unrelated module churn.

```
$ go list -m github.com/crossplane/crossplane-runtime/v2
github.com/crossplane/crossplane-runtime/v2 v2.2.2
$ go build ./...
(succeeds)
```

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [ ] ~Run `./nix.sh flake check` to ensure this PR is ready for review.~
- [ ] ~Added or updated unit tests.~
- [ ] ~Added or updated e2e tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~
- [ ] ~Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md
