### PR TITLE
fix(ci): match release tags only when computing build version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -242,7 +242,7 @@ jobs:
       # tracked files, so we set it in flake.nix before building.
       - name: Set Version
         run: |
-          VERSION=$(git describe --dirty --always --tags | sed 's/-/./2g')
+          VERSION=$(git describe --dirty --always --tags --match 'v[0-9]*' | sed 's/-/./2g')
           echo "VERSION=$VERSION" >> "$GITHUB_ENV"
           sed -i "s|buildVersion = null;|buildVersion = \"$VERSION\";|" flake.nix
 


### PR DESCRIPTION
### Description of your changes

The `build-artifacts` job has been failing on `main` since the v2.3 release ([example failure](https://github.com/crossplane/crossplane/actions/runs/26253873188/job/77271667730)).

The reason is that `git describe --tags` returns the most recent reachable tag, and the newly-created `apis/v2.4.0-rc.0` tag sits on the same commit as the existing `v2.4.0-rc.0` release tag but was tagged a week later, so it wins the tiebreaker. The version string becomes `apis/v2.4.0-rc.0-N-gSHA`, the Nix chart builder strips the leading character expecting a `v` prefix (producing `pis/v...`), and `helm package` rejects the result with `Error: invalid semantic version`.

This PR constrains `git describe` to release tags via `--match 'v[0-9]*'` so the build version always derives from a `v*` tag, regardless of submodule tags reachable from HEAD.

**Verification**

At the failing commit `68420bc9a`:

```
# old
$ git describe --dirty --always --tags | sed 's/-/./2g'
apis/v2.4.0-rc.0.17.g68420bc9a

# new
$ git describe --dirty --always --tags --match 'v[0-9]*' | sed 's/-/./2g'
v2.4.0-rc.0.17.g68420bc9a
```

`v[0-9]*` matches all 209 existing `v*` tags, so no regression on legitimate version tags.

Ran `helm package --version $CHART_VERSION` against the real `cluster/charts/crossplane` (mirroring the substring transformation in `nix/build.nix`):

- Broken version (`pis/v2.4.0-rc.0.17.g68420bc9a`) reproduces `Error: Invalid Semantic Version` from the CI log.
- Fixed version (`2.4.0-rc.0.17.g68420bc9a`) packages successfully as `crossplane-2.4.0-rc.0.17.g68420bc9a.tgz`.

**Affected branches**

- `main`: actively broken (`apis/v2.4.0-rc.0` reachable).
- `release-2.3`: actively broken. `git describe --tags upstream/release-2.3` returns `apis/v2.3.0-2-g009731d71`. Backport needed.
- `release-2.2` and older: should never get these extra apis/ tags since we are not backporting the apis module breakout. 

Fixes #7419

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `./nix.sh flake check` to ensure this PR is ready for review.
- [ ] ~~Added or updated unit tests.~~ N/A, one-line CI workflow change, no test surface.
- [ ] ~~Added or updated e2e tests.~~ N/A, one-line CI workflow change, no test surface.
- [ ] ~~Linked a PR or a [docs tracking issue] to [document this change].~~ N/A, internal CI fix, no user-facing impact.
- [ ] ~~Added `backport release-x.y` labels to auto-backport this PR.~~ `backport release-2.3` label doesn't exist in this repo yet; flagged in the affected-branches note for a maintainer to create and apply.
- [ ] ~~Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~~ N/A, no API changes.

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md