### PR TITLE
Update install.sh to point at the new CLI release bucket

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -12,7 +12,7 @@ ARCH=${ARCH:-"${arch}"}
 OS_ARCH=""
 COMPRESSED=${COMPRESSED:-"False"}
 
-BIN=${BIN:-crank}
+BIN=${BIN:-crossplane}
 
 unsupported_arch() {
 	os="$1"
@@ -25,7 +25,7 @@ case $OS in
 CYGWIN* | MINGW64* | Windows*)
 	if [ "$ARCH" = "x86_64" ]; then
 		OS_ARCH=windows_amd64
-		BIN=crank.exe
+		BIN=crossplane.exe
 	else
 		unsupported_arch "$OS" "$ARCH"
 	fi
@@ -61,11 +61,34 @@ Linux)
 	;;
 esac
 
+# v2.3.0 was the first release from the crossplane/cli repository, whose
+# artifacts go to the cli.crossplane.io bucket and uses the binary name
+# "crossplane". Use the old releases.crossplane.io hostname and "crank" binary
+# for older releases. Note we have to handle "current" specially since "current"
+# is lexically before "v2.3.0".
+
+url_host="cli.crossplane.io"
+bundle_name="crossplane-cli.tar.gz"
+if expr "${XP_VERSION}" \< "v2.3.0" >/dev/null 2>&1; then
+	if [ "${XP_VERSION}" != "current" ]; then
+		url_host="releases.crossplane.io"
+		bundle_name="crank.tar.gz"
+		case "${BIN}" in
+		crossplane)
+			BIN="crank"
+			;;
+		crossplane.exe)
+			BIN="crank.exe"
+			;;
+		esac
+	fi
+fi
+
 _compr=$(echo "$COMPRESSED" | tr '[:upper:]' '[:lower:]')
 
 if [ "${_compr}" = "true" ]; then
 	url_dir="bundle"
-	url_file="crank.tar.gz"
+	url_file="${bundle_name}"
 	url_error="a compressed file for "
 else
 	url_dir="bin"
@@ -73,7 +96,7 @@ else
 	url_error=""
 fi
 
-url="https://releases.crossplane.io/${XP_CHANNEL}/${XP_VERSION}/${url_dir}/${OS_ARCH}/${url_file}"
+url="https://${url_host}/${XP_CHANNEL}/${XP_VERSION}/${url_dir}/${OS_ARCH}/${url_file}"
 
 if ! curl -sfL "${url}" -o "${url_file}"; then
 	echo "Failed to download Crossplane CLI. Please make sure ${url_error}version ${XP_VERSION} exists on channel ${XP_CHANNEL}."
@@ -85,13 +108,13 @@ if [ "${_compr}" = "true" ]; then
 		echo "Failed to unpack the Crossplane CLI compressed file."
 		exit 1
 	fi
+	rm "${BIN}.sha256" "${url_file}"
+fi
+if [ "${BIN}" != "crossplane" ]; then
 	if ! mv "${BIN}" crossplane; then
-		echo "Failed to rename the unpacked Crossplane CLI binary: \"${BIN}\". Make sure it exists inside the compressed file."
+		echo "Failed to rename the Crossplane CLI binary: \"${BIN}\"."
 		exit 1
 	fi
-	rm "${BIN}.sha256" "${url_file}"
-else
-	mv "${url_file}" crossplane
 fi
 
 chmod +x crossplane

--- a/install.sh
+++ b/install.sh
@@ -14,6 +14,28 @@ COMPRESSED=${COMPRESSED:-"False"}
 
 BIN=${BIN:-crossplane}
 
+# v2.3.0 was the first release from the crossplane/cli repository, whose
+# artifacts go to the cli.crossplane.io bucket and uses the binary name
+# "crossplane". Use the old releases.crossplane.io hostname and "crank" binary
+# for older releases.
+
+url_host="cli.crossplane.io"
+bundle_name="crossplane-cli.tar.gz"
+
+if [ "${XP_VERSION}" != "current" ]; then
+	_ver=$(echo "${XP_VERSION}" | sed 's/^v//' | sed 's/-.*//')
+	_major=$(echo "${_ver}" | cut -d. -f1)
+	_minor=$(echo "${_ver}" | cut -d. -f2)
+
+	if [ "${_major}" -lt 2 ] 2>/dev/null ||
+		{ [ "${_major}" -eq 2 ] 2>/dev/null && [ "${_minor}" -lt 3 ] 2>/dev/null; }; then
+
+		url_host="releases.crossplane.io"
+		bundle_name="crank.tar.gz"
+		BIN="crank"
+	fi
+fi
+
 unsupported_arch() {
 	os="$1"
 	arch="$2"
@@ -25,7 +47,7 @@ case $OS in
 CYGWIN* | MINGW64* | Windows*)
 	if [ "$ARCH" = "x86_64" ]; then
 		OS_ARCH=windows_amd64
-		BIN=crossplane.exe
+		BIN="${BIN}.exe"
 	else
 		unsupported_arch "$OS" "$ARCH"
 	fi
@@ -60,35 +82,6 @@ Linux)
 	unsupported_arch "$OS" "$ARCH"
 	;;
 esac
-
-# v2.3.0 was the first release from the crossplane/cli repository, whose
-# artifacts go to the cli.crossplane.io bucket and uses the binary name
-# "crossplane". Use the old releases.crossplane.io hostname and "crank" binary
-# for older releases.
-
-url_host="cli.crossplane.io"
-bundle_name="crossplane-cli.tar.gz"
-
-if [ "${XP_VERSION}" != "current" ]; then
-	_ver=$(echo "${XP_VERSION}" | sed 's/^v//' | sed 's/-.*//')
-	_major=$(echo "${_ver}" | cut -d. -f1)
-	_minor=$(echo "${_ver}" | cut -d. -f2)
-
-	if [ "${_major}" -lt 2 ] 2>/dev/null ||
-		{ [ "${_major}" -eq 2 ] 2>/dev/null && [ "${_minor}" -lt 3 ] 2>/dev/null; }; then
-
-		url_host="releases.crossplane.io"
-		bundle_name="crank.tar.gz"
-		case "${BIN}" in
-		crossplane)
-			BIN="crank"
-			;;
-		crossplane.exe)
-			BIN="crank.exe"
-			;;
-		esac
-	fi
-fi
 
 _compr=$(echo "$COMPRESSED" | tr '[:upper:]' '[:lower:]')
 

--- a/install.sh
+++ b/install.sh
@@ -64,13 +64,19 @@ esac
 # v2.3.0 was the first release from the crossplane/cli repository, whose
 # artifacts go to the cli.crossplane.io bucket and uses the binary name
 # "crossplane". Use the old releases.crossplane.io hostname and "crank" binary
-# for older releases. Note we have to handle "current" specially since "current"
-# is lexically before "v2.3.0".
+# for older releases.
 
 url_host="cli.crossplane.io"
 bundle_name="crossplane-cli.tar.gz"
-if expr "${XP_VERSION}" \< "v2.3.0" >/dev/null 2>&1; then
-	if [ "${XP_VERSION}" != "current" ]; then
+
+if [ "${XP_VERSION}" != "current" ]; then
+	_ver=$(echo "${XP_VERSION}" | sed 's/^v//' | sed 's/-.*//')
+	_major=$(echo "${_ver}" | cut -d. -f1)
+	_minor=$(echo "${_ver}" | cut -d. -f2)
+
+	if [ "${_major}" -lt 2 ] 2>/dev/null ||
+		{ [ "${_major}" -eq 2 ] 2>/dev/null && [ "${_minor}" -lt 3 ] 2>/dev/null; }; then
+
 		url_host="releases.crossplane.io"
 		bundle_name="crank.tar.gz"
 		case "${BIN}" in


### PR DESCRIPTION
### Description of your changes

CLI releases from the new CLI repository upload artifacts to a separate bucket from core Crossplane releases, and use a different binary name (`crossplane` instead of `crank`). Update the `install.sh` script to use the new location and naming scheme by default, but revert to the old location and name when an old version is requested.

Note that this change retains the existing, possibly unintentional, behavior of renaming `crank.exe`/`crossplane.exe` to `crossplane` when the Windows release is downloaded.

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `./nix.sh flake check` to ensure this PR is ready for review.
~- [ ] Added or updated unit tests.~
~- [ ] Added or updated e2e tests.~
~- [ ] Linked a PR or a [docs tracking issue] to [document this change].~
~- [ ] Added `backport release-x.y` labels to auto-backport this PR.~
~- [ ] Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md
