### PR TITLE
feature(protection): Add XRD and Configuration deletion protection via ClusterUsage

### DIFF
--- a/cmd/crossplane/core/core.go
+++ b/cmd/crossplane/core/core.go
@@ -137,6 +137,7 @@ type startCommand struct {
 	EnableOperations                  bool `group:"Alpha Features:" help:"Enable support for Operations."`
 	EnablePipelineInspector           bool `group:"Alpha Features:" help:"Enable support for emitting function pipeline execution data to a sidecar."`
 	EnableProviderDeletionProtection  bool `group:"Alpha Features:" help:"Enable automatic protection of Providers from deletion when they have active managed resources. Requires --enable-usages."`
+	EnableXRDDeletionProtection       bool `group:"Alpha Features:" help:"Enable automatic protection of CompositeResourceDefinitions and Configurations from deletion when they have active composite resources. Requires --enable-usages."`
 
 	XfnCacheDir             string        `default:"/cache/xfn"                         env:"XFN_CACHE_DIR"             group:"Alpha Features:" help:"Directory used for caching function responses. Requires --enable-function-response-cache."`
 	XfnCacheMaxTTL          time.Duration `default:"24h"                                env:"XFN_CACHE_MAX_TTL"         group:"Alpha Features:" help:"Maximum TTL for cached function responses. Set to 0 to disable. Requires --enable-function-response-cache."`
@@ -356,6 +357,11 @@ func (c *startCommand) Run(s *runtime.Scheme, log logging.Logger) error { //noli
 	if c.EnableProviderDeletionProtection {
 		o.Features.Enable(features.EnableAlphaProviderDeletionProtection)
 		log.Info("Alpha feature enabled", "flag", features.EnableAlphaProviderDeletionProtection)
+	}
+
+	if c.EnableXRDDeletionProtection {
+		o.Features.Enable(features.EnableAlphaXRDDeletionProtection)
+		log.Info("Alpha feature enabled", "flag", features.EnableAlphaXRDDeletionProtection)
 	}
 
 	cacheOptionsAPIExt := cache.Options{

--- a/internal/controller/apiextensions/definition/protection.go
+++ b/internal/controller/apiextensions/definition/protection.go
@@ -1,0 +1,265 @@
+/*
+Copyright 2025 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package definition
+
+import (
+	"context"
+	"crypto/sha256"
+	"fmt"
+
+	kmeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kunstructured "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"github.com/crossplane/crossplane-runtime/v2/pkg/errors"
+	"github.com/crossplane/crossplane-runtime/v2/pkg/logging"
+	"github.com/crossplane/crossplane-runtime/v2/pkg/resource"
+
+	v1 "github.com/crossplane/crossplane/apis/v2/apiextensions/v1"
+	pkgv1 "github.com/crossplane/crossplane/apis/v2/pkg/v1"
+	protectionv1beta1 "github.com/crossplane/crossplane/apis/v2/protection/v1beta1"
+)
+
+// FieldOwnerXRDProtection is the field manager name used when applying
+// ClusterUsage objects for XRD and Configuration deletion protection.
+const FieldOwnerXRDProtection = "apiextensions.crossplane.io/definition-protection"
+
+// XRDProtectionControllerName returns the name of the protection controller
+// for the given XRD name.
+func XRDProtectionControllerName(xrdName string) string {
+	return "xrd-protection/" + xrdName
+}
+
+// XRDClusterUsageName returns a deterministic name for a ClusterUsage
+// protecting a CompositeResourceDefinition due to the given XRD. It uses a
+// SHA-256 hash to avoid exceeding the Kubernetes 253-character name limit.
+func XRDClusterUsageName(xrdName string) string {
+	h := sha256.Sum256([]byte(xrdName))
+	return fmt.Sprintf("xrd-protection-%x", h[:26])
+}
+
+// ConfigClusterUsageName returns a deterministic name for a ClusterUsage
+// protecting a Configuration due to the given XRD. It uses a SHA-256 hash
+// to avoid exceeding the Kubernetes 253-character name limit.
+func ConfigClusterUsageName(xrdName string) string {
+	h := sha256.Sum256([]byte(xrdName))
+	return fmt.Sprintf("config-protection-%x", h[:26])
+}
+
+// XRDResourceMapFunc returns a handler.MapFunc that enqueues a fixed
+// reconcile request for the protection controller whenever any composite
+// resource of the watched type changes.
+func XRDResourceMapFunc(xrdName string) handler.MapFunc {
+	return func(_ context.Context, _ client.Object) []reconcile.Request {
+		return []reconcile.Request{{
+			NamespacedName: types.NamespacedName{Name: xrdName},
+		}}
+	}
+}
+
+// An XRDProtectionReconciler manages ClusterUsage objects that protect a
+// CompositeResourceDefinition (and optionally its owning Configuration) from
+// deletion when composite resources of the given type exist.
+type XRDProtectionReconciler struct {
+	cached  client.Client // engine's cached client, for reading XR instances
+	writer  client.Client // main client, for writing ClusterUsage objects
+	xrdName string
+	gvk     schema.GroupVersionKind
+	log     logging.Logger
+}
+
+// Reconcile checks whether any composite resources of the watched type exist.
+// If they do, it ensures ClusterUsage objects exist to protect the owning XRD
+// (and its Configuration, if applicable). If none exist, it deletes the
+// ClusterUsages.
+func (r *XRDProtectionReconciler) Reconcile(ctx context.Context, _ reconcile.Request) (reconcile.Result, error) {
+	log := r.log.WithValues("gvk", r.gvk.String())
+	log.Debug("Reconciling XRD deletion protection")
+
+	list := &kunstructured.UnstructuredList{}
+	list.SetGroupVersionKind(r.gvk.GroupVersion().WithKind(r.gvk.Kind + "List"))
+
+	if err := r.cached.List(ctx, list, client.Limit(1)); err != nil {
+		// If the CRD doesn't exist (yet or anymore), treat as no XRs.
+		if kmeta.IsNoMatchError(err) {
+			log.Debug("CRD not found, ensuring no ClusterUsages")
+			return r.ensureNoClusterUsages(ctx)
+		}
+		return reconcile.Result{}, errors.Wrap(err, "cannot list composite resources")
+	}
+
+	if len(list.Items) > 0 {
+		return r.ensureClusterUsages(ctx)
+	}
+
+	return r.ensureNoClusterUsages(ctx)
+}
+
+func (r *XRDProtectionReconciler) ensureClusterUsages(ctx context.Context) (reconcile.Result, error) {
+	xrType := fmt.Sprintf("%s.%s", r.gvk.Kind, r.gvk.Group)
+
+	// Always apply a ClusterUsage protecting the XRD itself.
+	cu := buildXRDClusterUsage(r.xrdName, xrType)
+	//nolint:staticcheck // TODO(adamwg): Stop using client.Apply after the v2.2 release.
+	if err := r.writer.Patch(ctx, cu, client.Apply,
+		client.ForceOwnership,
+		client.FieldOwner(FieldOwnerXRDProtection),
+	); err != nil {
+		return reconcile.Result{}, errors.Wrap(err, "cannot apply XRD ClusterUsage")
+	}
+	r.log.Debug("ClusterUsage applied for XRD protection", "xrd", r.xrdName, "xrType", xrType)
+
+	// Try to resolve the owning Configuration. If the XRD is standalone
+	// (no ConfigurationRevision owner), we skip the Configuration ClusterUsage.
+	xrd := &v1.CompositeResourceDefinition{}
+	if err := r.cached.Get(ctx, types.NamespacedName{Name: r.xrdName}, xrd); err != nil {
+		return reconcile.Result{}, errors.Wrap(err, "cannot get CompositeResourceDefinition for protection")
+	}
+
+	configName, err := resolveConfigurationName(ctx, r.cached, xrd)
+	if err != nil {
+		return reconcile.Result{}, errors.Wrap(err, "cannot resolve Configuration name")
+	}
+
+	if configName != "" {
+		ccu := buildConfigClusterUsage(r.xrdName, configName, xrType)
+		//nolint:staticcheck // TODO(adamwg): Stop using client.Apply after the v2.2 release.
+		if err := r.writer.Patch(ctx, ccu, client.Apply,
+			client.ForceOwnership,
+			client.FieldOwner(FieldOwnerXRDProtection),
+		); err != nil {
+			return reconcile.Result{}, errors.Wrap(err, "cannot apply Configuration ClusterUsage")
+		}
+		r.log.Debug("ClusterUsage applied for Configuration protection", "configuration", configName, "xrType", xrType)
+	}
+
+	return reconcile.Result{}, nil
+}
+
+func (r *XRDProtectionReconciler) ensureNoClusterUsages(ctx context.Context) (reconcile.Result, error) {
+	// Delete both ClusterUsages (XRD + Configuration). If they don't exist,
+	// that's fine.
+	for _, name := range []string{XRDClusterUsageName(r.xrdName), ConfigClusterUsageName(r.xrdName)} {
+		cu := &protectionv1beta1.ClusterUsage{}
+		cu.SetName(name)
+		if err := r.writer.Delete(ctx, cu); resource.IgnoreNotFound(err) != nil {
+			return reconcile.Result{}, errors.Wrapf(err, "cannot delete ClusterUsage %q", name)
+		}
+	}
+	r.log.Debug("ClusterUsages removed for XRD protection")
+	return reconcile.Result{}, nil
+}
+
+// resolveConfigurationName follows the owner chain from XRD ->
+// ConfigurationRevision -> Configuration to determine the name of the
+// Configuration that owns the given XRD. It returns an empty string if the
+// XRD is not owned by a ConfigurationRevision (i.e. it's a standalone XRD).
+func resolveConfigurationName(ctx context.Context, c client.Client, xrd *v1.CompositeResourceDefinition) (string, error) {
+	owner := metav1.GetControllerOf(xrd)
+	if owner == nil {
+		// Standalone XRD, not owned by any ConfigurationRevision.
+		return "", nil
+	}
+
+	// Check if the owner is a ConfigurationRevision.
+	if owner.Kind != pkgv1.ConfigurationRevisionKind {
+		return "", nil
+	}
+
+	rev := &pkgv1.ConfigurationRevision{}
+	if err := c.Get(ctx, types.NamespacedName{Name: owner.Name}, rev); err != nil {
+		return "", errors.Wrap(err, "cannot get ConfigurationRevision")
+	}
+
+	configName := rev.GetLabels()[pkgv1.LabelParentPackage]
+	if configName == "" {
+		return "", errors.Errorf("ConfigurationRevision %q has no %s label", rev.GetName(), pkgv1.LabelParentPackage)
+	}
+
+	return configName, nil
+}
+
+// buildXRDClusterUsage constructs a ClusterUsage that protects a
+// CompositeResourceDefinition from deletion due to the existence of composite
+// resources of the given type.
+func buildXRDClusterUsage(xrdName, xrTypeDescription string) *protectionv1beta1.ClusterUsage {
+	return &protectionv1beta1.ClusterUsage{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: protectionv1beta1.SchemeGroupVersion.String(),
+			Kind:       protectionv1beta1.ClusterUsageKind,
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: XRDClusterUsageName(xrdName),
+			Labels: map[string]string{
+				"crossplane.io/xrd-protection":    "true",
+				"apiextensions.crossplane.io/xrd": xrdName,
+			},
+		},
+		Spec: protectionv1beta1.ClusterUsageSpec{
+			Of: protectionv1beta1.Resource{
+				APIVersion: v1.SchemeGroupVersion.String(),
+				Kind:       v1.CompositeResourceDefinitionKind,
+				ResourceRef: &protectionv1beta1.ResourceRef{
+					Name: xrdName,
+				},
+			},
+			Reason: ptr.To(fmt.Sprintf(
+				"CompositeResourceDefinition has active composite resources of type %s",
+				xrTypeDescription,
+			)),
+		},
+	}
+}
+
+// buildConfigClusterUsage constructs a ClusterUsage that protects a
+// Configuration from deletion due to the existence of composite resources
+// of the given type.
+func buildConfigClusterUsage(xrdName, configName, xrTypeDescription string) *protectionv1beta1.ClusterUsage {
+	return &protectionv1beta1.ClusterUsage{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: protectionv1beta1.SchemeGroupVersion.String(),
+			Kind:       protectionv1beta1.ClusterUsageKind,
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: ConfigClusterUsageName(xrdName),
+			Labels: map[string]string{
+				"crossplane.io/configuration-protection": "true",
+				pkgv1.LabelParentPackage:                 configName,
+				"apiextensions.crossplane.io/xrd":        xrdName,
+			},
+		},
+		Spec: protectionv1beta1.ClusterUsageSpec{
+			Of: protectionv1beta1.Resource{
+				APIVersion: pkgv1.SchemeGroupVersion.String(),
+				Kind:       pkgv1.ConfigurationKind,
+				ResourceRef: &protectionv1beta1.ResourceRef{
+					Name: configName,
+				},
+			},
+			Reason: ptr.To(fmt.Sprintf(
+				"Configuration has active composite resources of type %s",
+				xrTypeDescription,
+			)),
+		},
+	}
+}

--- a/internal/controller/apiextensions/definition/protection_test.go
+++ b/internal/controller/apiextensions/definition/protection_test.go
@@ -1,0 +1,785 @@
+/*
+Copyright 2025 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package definition
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	kmeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kunstructured "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"github.com/crossplane/crossplane-runtime/v2/pkg/errors"
+	"github.com/crossplane/crossplane-runtime/v2/pkg/logging"
+	"github.com/crossplane/crossplane-runtime/v2/pkg/test"
+
+	v1 "github.com/crossplane/crossplane/apis/v2/apiextensions/v1"
+	pkgv1 "github.com/crossplane/crossplane/apis/v2/pkg/v1"
+	protectionv1beta1 "github.com/crossplane/crossplane/apis/v2/protection/v1beta1"
+)
+
+func TestXRDProtectionReconcilerReconcile(t *testing.T) {
+	errBoom := errors.New("boom")
+
+	testGVK := schema.GroupVersionKind{
+		Group:   "example.com",
+		Version: "v1",
+		Kind:    "XDatabase",
+	}
+
+	type args struct {
+		cached  client.Client
+		writer  client.Client
+		xrdName string
+		gvk     schema.GroupVersionKind
+	}
+	type want struct {
+		r   reconcile.Result
+		err error
+	}
+
+	cases := map[string]struct {
+		reason string
+		args   args
+		want   want
+	}{
+		"ListXRsError": {
+			reason: "We should return an error if listing composite resources fails",
+			args: args{
+				cached: &test.MockClient{
+					MockList: test.NewMockListFn(errBoom),
+				},
+				writer:  &test.MockClient{},
+				xrdName: "test-xrd",
+				gvk:     testGVK,
+			},
+			want: want{
+				err: cmpopts.AnyError,
+			},
+		},
+		"ListXRsNoMatchDeletesClusterUsages": {
+			reason: "When the CRD doesn't exist (NoMatch), we should delete both ClusterUsages",
+			args: args{
+				cached: &test.MockClient{
+					MockList: func(_ context.Context, _ client.ObjectList, _ ...client.ListOption) error {
+						return &kmeta.NoKindMatchError{GroupKind: schema.GroupKind{Group: "example.com", Kind: "XDatabase"}}
+					},
+				},
+				writer: &test.MockClient{
+					MockDelete: test.NewMockDeleteFn(nil),
+				},
+				xrdName: "test-xrd",
+				gvk:     testGVK,
+			},
+			want: want{
+				r: reconcile.Result{},
+			},
+		},
+		"NoXRsDeletesClusterUsages": {
+			reason: "When no composite resources exist, we should delete both ClusterUsages",
+			args: args{
+				cached: &test.MockClient{
+					MockList: test.NewMockListFn(nil),
+				},
+				writer: &test.MockClient{
+					MockDelete: test.NewMockDeleteFn(nil),
+				},
+				xrdName: "test-xrd",
+				gvk:     testGVK,
+			},
+			want: want{
+				r: reconcile.Result{},
+			},
+		},
+		"NoXRsDeleteClusterUsageNotFound": {
+			reason: "When no composite resources exist and ClusterUsages are already gone, we should succeed",
+			args: args{
+				cached: &test.MockClient{
+					MockList: test.NewMockListFn(nil),
+				},
+				writer: &test.MockClient{
+					MockDelete: test.NewMockDeleteFn(kerrors.NewNotFound(schema.GroupResource{}, "")),
+				},
+				xrdName: "test-xrd",
+				gvk:     testGVK,
+			},
+			want: want{
+				r: reconcile.Result{},
+			},
+		},
+		"NoXRsDeleteClusterUsageError": {
+			reason: "We should return an error if deleting the ClusterUsage fails",
+			args: args{
+				cached: &test.MockClient{
+					MockList: test.NewMockListFn(nil),
+				},
+				writer: &test.MockClient{
+					MockDelete: test.NewMockDeleteFn(errBoom),
+				},
+				xrdName: "test-xrd",
+				gvk:     testGVK,
+			},
+			want: want{
+				err: cmpopts.AnyError,
+			},
+		},
+		"XRsExistApplyXRDClusterUsageError": {
+			reason: "We should return an error if applying the XRD ClusterUsage fails",
+			args: args{
+				cached: &test.MockClient{
+					MockList: func(_ context.Context, list client.ObjectList, _ ...client.ListOption) error {
+						u := list.(*kunstructured.UnstructuredList)
+						u.Items = []kunstructured.Unstructured{{}}
+						return nil
+					},
+				},
+				writer: &test.MockClient{
+					MockPatch: test.NewMockPatchFn(errBoom),
+				},
+				xrdName: "test-xrd",
+				gvk:     testGVK,
+			},
+			want: want{
+				err: cmpopts.AnyError,
+			},
+		},
+		"XRsExistGetXRDError": {
+			reason: "We should return an error if we can't get the XRD when XRs exist",
+			args: args{
+				cached: &test.MockClient{
+					MockList: func(_ context.Context, list client.ObjectList, _ ...client.ListOption) error {
+						u := list.(*kunstructured.UnstructuredList)
+						u.Items = []kunstructured.Unstructured{{}}
+						return nil
+					},
+					MockGet: test.NewMockGetFn(errBoom),
+				},
+				writer: &test.MockClient{
+					MockPatch: test.NewMockPatchFn(nil),
+				},
+				xrdName: "test-xrd",
+				gvk:     testGVK,
+			},
+			want: want{
+				err: cmpopts.AnyError,
+			},
+		},
+		"XRsExistStandaloneXRDAppliesOnlyXRDClusterUsage": {
+			reason: "When XRs exist and XRD has no controller owner, only the XRD ClusterUsage should be applied",
+			args: args{
+				cached: &test.MockClient{
+					MockList: func(_ context.Context, list client.ObjectList, _ ...client.ListOption) error {
+						u := list.(*kunstructured.UnstructuredList)
+						u.Items = []kunstructured.Unstructured{{}}
+						return nil
+					},
+					MockGet: func(_ context.Context, key client.ObjectKey, obj client.Object) error {
+						if xrd, ok := obj.(*v1.CompositeResourceDefinition); ok {
+							xrd.Name = key.Name
+							// No owner references - standalone XRD.
+							return nil
+						}
+						return kerrors.NewNotFound(schema.GroupResource{}, "")
+					},
+				},
+				writer: &test.MockClient{
+					MockPatch: test.NewMockPatchFn(nil),
+				},
+				xrdName: "test-xrd",
+				gvk:     testGVK,
+			},
+			want: want{
+				r: reconcile.Result{},
+			},
+		},
+		"XRsExistConfigurationOwnedAppliesBothClusterUsages": {
+			reason: "When XRs exist and XRD is owned by a ConfigurationRevision, both ClusterUsages should be applied",
+			args: args{
+				cached: &test.MockClient{
+					MockList: func(_ context.Context, list client.ObjectList, _ ...client.ListOption) error {
+						u := list.(*kunstructured.UnstructuredList)
+						u.Items = []kunstructured.Unstructured{{}}
+						return nil
+					},
+					MockGet: func(_ context.Context, key client.ObjectKey, obj client.Object) error {
+						switch o := obj.(type) {
+						case *v1.CompositeResourceDefinition:
+							o.Name = key.Name
+							o.OwnerReferences = []metav1.OwnerReference{{
+								APIVersion: pkgv1.SchemeGroupVersion.String(),
+								Kind:       pkgv1.ConfigurationRevisionKind,
+								Name:       "test-config-revision",
+								Controller: ptr.To(true),
+							}}
+							return nil
+						case *pkgv1.ConfigurationRevision:
+							o.Name = key.Name
+							o.SetLabels(map[string]string{
+								pkgv1.LabelParentPackage: "test-configuration",
+							})
+							return nil
+						default:
+							return kerrors.NewNotFound(schema.GroupResource{}, "")
+						}
+					},
+				},
+				writer: &test.MockClient{
+					MockPatch: test.NewMockPatchFn(nil),
+				},
+				xrdName: "test-xrd",
+				gvk:     testGVK,
+			},
+			want: want{
+				r: reconcile.Result{},
+			},
+		},
+		"XRsExistConfigurationRevisionNotFound": {
+			reason: "We should return an error if the ConfigurationRevision is not found",
+			args: args{
+				cached: &test.MockClient{
+					MockList: func(_ context.Context, list client.ObjectList, _ ...client.ListOption) error {
+						u := list.(*kunstructured.UnstructuredList)
+						u.Items = []kunstructured.Unstructured{{}}
+						return nil
+					},
+					MockGet: func(_ context.Context, key client.ObjectKey, obj client.Object) error {
+						switch o := obj.(type) {
+						case *v1.CompositeResourceDefinition:
+							o.Name = key.Name
+							o.OwnerReferences = []metav1.OwnerReference{{
+								APIVersion: pkgv1.SchemeGroupVersion.String(),
+								Kind:       pkgv1.ConfigurationRevisionKind,
+								Name:       "test-config-revision",
+								Controller: ptr.To(true),
+							}}
+							return nil
+						case *pkgv1.ConfigurationRevision:
+							return kerrors.NewNotFound(schema.GroupResource{}, key.Name)
+						default:
+							return kerrors.NewNotFound(schema.GroupResource{}, "")
+						}
+					},
+				},
+				writer: &test.MockClient{
+					MockPatch: test.NewMockPatchFn(nil),
+				},
+				xrdName: "test-xrd",
+				gvk:     testGVK,
+			},
+			want: want{
+				err: cmpopts.AnyError,
+			},
+		},
+		"XRsExistApplyConfigClusterUsageError": {
+			reason: "We should return an error if applying the Configuration ClusterUsage fails",
+			args: args{
+				cached: &test.MockClient{
+					MockList: func(_ context.Context, list client.ObjectList, _ ...client.ListOption) error {
+						u := list.(*kunstructured.UnstructuredList)
+						u.Items = []kunstructured.Unstructured{{}}
+						return nil
+					},
+					MockGet: func(_ context.Context, key client.ObjectKey, obj client.Object) error {
+						switch o := obj.(type) {
+						case *v1.CompositeResourceDefinition:
+							o.Name = key.Name
+							o.OwnerReferences = []metav1.OwnerReference{{
+								APIVersion: pkgv1.SchemeGroupVersion.String(),
+								Kind:       pkgv1.ConfigurationRevisionKind,
+								Name:       "test-config-revision",
+								Controller: ptr.To(true),
+							}}
+							return nil
+						case *pkgv1.ConfigurationRevision:
+							o.Name = key.Name
+							o.SetLabels(map[string]string{
+								pkgv1.LabelParentPackage: "test-configuration",
+							})
+							return nil
+						default:
+							return kerrors.NewNotFound(schema.GroupResource{}, "")
+						}
+					},
+				},
+				writer: &test.MockClient{
+					MockPatch: func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) error {
+						// First patch (XRD ClusterUsage) succeeds,
+						// second patch (Config ClusterUsage) fails.
+						if cu, ok := obj.(*protectionv1beta1.ClusterUsage); ok {
+							if strings.HasPrefix(cu.Name, "config-protection-") {
+								return errBoom
+							}
+						}
+						return nil
+					},
+				},
+				xrdName: "test-xrd",
+				gvk:     testGVK,
+			},
+			want: want{
+				err: cmpopts.AnyError,
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			r := &XRDProtectionReconciler{
+				cached:  tc.args.cached,
+				writer:  tc.args.writer,
+				xrdName: tc.args.xrdName,
+				gvk:     tc.args.gvk,
+				log:     logging.NewNopLogger(),
+			}
+
+			got, err := r.Reconcile(context.Background(), reconcile.Request{})
+
+			if diff := cmp.Diff(tc.want.err, err, cmpopts.EquateErrors()); diff != "" {
+				t.Errorf("\n%s\nr.Reconcile(...): -want error, +got error:\n%s", tc.reason, diff)
+			}
+			if diff := cmp.Diff(tc.want.r, got); diff != "" {
+				t.Errorf("\n%s\nr.Reconcile(...): -want, +got:\n%s", tc.reason, diff)
+			}
+		})
+	}
+}
+
+func TestXRDClusterUsageName(t *testing.T) {
+	type args struct {
+		xrdName string
+	}
+	type want struct {
+		prefix        string
+		deterministic bool
+		maxLen        int
+	}
+
+	cases := map[string]struct {
+		reason string
+		args   args
+		want   want
+	}{
+		"ShortName": {
+			reason: "A short XRD name should produce a deterministic name within Kubernetes limits",
+			args: args{
+				xrdName: "test-xrd",
+			},
+			want: want{
+				prefix:        "xrd-protection-",
+				deterministic: true,
+				maxLen:        253,
+			},
+		},
+		"LongName": {
+			reason: "A long XRD name should produce a deterministic name within Kubernetes limits",
+			args: args{
+				xrdName: "very-long-composite-resource-definition-name-that-could-potentially-exceed-kubernetes-limits.some-group.example.com",
+			},
+			want: want{
+				prefix:        "xrd-protection-",
+				deterministic: true,
+				maxLen:        253,
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got := XRDClusterUsageName(tc.args.xrdName)
+
+			if len(got) > tc.want.maxLen {
+				t.Errorf("\n%s\nXRDClusterUsageName(%q) length = %d, want <= %d", tc.reason, tc.args.xrdName, len(got), tc.want.maxLen)
+			}
+			if tc.want.deterministic {
+				if diff := cmp.Diff(got, XRDClusterUsageName(tc.args.xrdName)); diff != "" {
+					t.Errorf("\n%s\nXRDClusterUsageName(%q) is not deterministic: -want, +got:\n%s", tc.reason, tc.args.xrdName, diff)
+				}
+			}
+			if !strings.HasPrefix(got, tc.want.prefix) {
+				t.Errorf("\n%s\nXRDClusterUsageName(%q) = %q, want prefix %q", tc.reason, tc.args.xrdName, got, tc.want.prefix)
+			}
+		})
+	}
+}
+
+func TestConfigClusterUsageName(t *testing.T) {
+	type args struct {
+		xrdName string
+	}
+	type want struct {
+		prefix        string
+		deterministic bool
+		maxLen        int
+	}
+
+	cases := map[string]struct {
+		reason string
+		args   args
+		want   want
+	}{
+		"ShortName": {
+			reason: "A short XRD name should produce a deterministic config protection name within Kubernetes limits",
+			args: args{
+				xrdName: "test-xrd",
+			},
+			want: want{
+				prefix:        "config-protection-",
+				deterministic: true,
+				maxLen:        253,
+			},
+		},
+		"LongName": {
+			reason: "A long XRD name should produce a deterministic config protection name within Kubernetes limits",
+			args: args{
+				xrdName: "very-long-composite-resource-definition-name-that-could-potentially-exceed-kubernetes-limits.some-group.example.com",
+			},
+			want: want{
+				prefix:        "config-protection-",
+				deterministic: true,
+				maxLen:        253,
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got := ConfigClusterUsageName(tc.args.xrdName)
+
+			if len(got) > tc.want.maxLen {
+				t.Errorf("\n%s\nConfigClusterUsageName(%q) length = %d, want <= %d", tc.reason, tc.args.xrdName, len(got), tc.want.maxLen)
+			}
+			if tc.want.deterministic {
+				if diff := cmp.Diff(got, ConfigClusterUsageName(tc.args.xrdName)); diff != "" {
+					t.Errorf("\n%s\nConfigClusterUsageName(%q) is not deterministic: -want, +got:\n%s", tc.reason, tc.args.xrdName, diff)
+				}
+			}
+			if !strings.HasPrefix(got, tc.want.prefix) {
+				t.Errorf("\n%s\nConfigClusterUsageName(%q) = %q, want prefix %q", tc.reason, tc.args.xrdName, got, tc.want.prefix)
+			}
+		})
+	}
+}
+
+func TestXRDProtectionControllerName(t *testing.T) {
+	type args struct {
+		xrdName string
+	}
+	type want struct {
+		name string
+	}
+
+	cases := map[string]struct {
+		reason string
+		args   args
+		want   want
+	}{
+		"StandardName": {
+			reason: "The controller name should be prefixed with xrd-protection/",
+			args: args{
+				xrdName: "test-xrd",
+			},
+			want: want{
+				name: "xrd-protection/test-xrd",
+			},
+		},
+		"FullyQualifiedName": {
+			reason: "The controller name should include the full XRD name",
+			args: args{
+				xrdName: "xdatabases.example.com",
+			},
+			want: want{
+				name: "xrd-protection/xdatabases.example.com",
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got := XRDProtectionControllerName(tc.args.xrdName)
+			if diff := cmp.Diff(tc.want.name, got); diff != "" {
+				t.Errorf("\n%s\nXRDProtectionControllerName(...): -want, +got:\n%s", tc.reason, diff)
+			}
+		})
+	}
+}
+
+func TestResolveConfigurationName(t *testing.T) {
+	errBoom := errors.New("boom")
+
+	cases := map[string]struct {
+		reason string
+		c      client.Client
+		xrd    *v1.CompositeResourceDefinition
+		want   string
+		err    error
+	}{
+		"NoControllerOwner": {
+			reason: "An XRD with no controller owner should return empty string (standalone XRD)",
+			c:      &test.MockClient{},
+			xrd:    &v1.CompositeResourceDefinition{},
+			want:   "",
+		},
+		"NonConfigurationRevisionOwner": {
+			reason: "An XRD owned by a non-ConfigurationRevision should return empty string",
+			c:      &test.MockClient{},
+			xrd: &v1.CompositeResourceDefinition{
+				ObjectMeta: metav1.ObjectMeta{
+					OwnerReferences: []metav1.OwnerReference{{
+						Kind:       "SomeOtherKind",
+						Name:       "test-owner",
+						Controller: ptr.To(true),
+					}},
+				},
+			},
+			want: "",
+		},
+		"GetConfigurationRevisionError": {
+			reason: "An error getting the ConfigurationRevision should be returned",
+			c: &test.MockClient{
+				MockGet: test.NewMockGetFn(errBoom),
+			},
+			xrd: &v1.CompositeResourceDefinition{
+				ObjectMeta: metav1.ObjectMeta{
+					OwnerReferences: []metav1.OwnerReference{{
+						Kind:       pkgv1.ConfigurationRevisionKind,
+						Name:       "test-rev",
+						Controller: ptr.To(true),
+					}},
+				},
+			},
+			err: cmpopts.AnyError,
+		},
+		"NoParentPackageLabel": {
+			reason: "A ConfigurationRevision without the parent package label should return an error",
+			c: &test.MockClient{
+				MockGet: test.NewMockGetFn(nil),
+			},
+			xrd: &v1.CompositeResourceDefinition{
+				ObjectMeta: metav1.ObjectMeta{
+					OwnerReferences: []metav1.OwnerReference{{
+						Kind:       pkgv1.ConfigurationRevisionKind,
+						Name:       "test-rev",
+						Controller: ptr.To(true),
+					}},
+				},
+			},
+			err: cmpopts.AnyError,
+		},
+		"Success": {
+			reason: "We should return the configuration name from the ConfigurationRevision label",
+			c: &test.MockClient{
+				MockGet: func(_ context.Context, _ client.ObjectKey, obj client.Object) error {
+					if rev, ok := obj.(*pkgv1.ConfigurationRevision); ok {
+						rev.SetLabels(map[string]string{
+							pkgv1.LabelParentPackage: "my-configuration",
+						})
+					}
+					return nil
+				},
+			},
+			xrd: &v1.CompositeResourceDefinition{
+				ObjectMeta: metav1.ObjectMeta{
+					OwnerReferences: []metav1.OwnerReference{{
+						Kind:       pkgv1.ConfigurationRevisionKind,
+						Name:       "test-rev",
+						Controller: ptr.To(true),
+					}},
+				},
+			},
+			want: "my-configuration",
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got, err := resolveConfigurationName(context.Background(), tc.c, tc.xrd)
+
+			if diff := cmp.Diff(tc.err, err, cmpopts.EquateErrors()); diff != "" {
+				t.Errorf("\n%s\nresolveConfigurationName(...): -want error, +got error:\n%s", tc.reason, diff)
+			}
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("\n%s\nresolveConfigurationName(...): -want, +got:\n%s", tc.reason, diff)
+			}
+		})
+	}
+}
+
+func TestBuildXRDClusterUsage(t *testing.T) {
+	type args struct {
+		xrdName           string
+		xrTypeDescription string
+	}
+	type want struct {
+		cu *protectionv1beta1.ClusterUsage
+	}
+
+	cases := map[string]struct {
+		reason string
+		args   args
+		want   want
+	}{
+		"StandardUsage": {
+			reason: "A ClusterUsage should be built with the correct metadata, labels, and spec",
+			args: args{
+				xrdName:           "test-xrd",
+				xrTypeDescription: "XDatabase.example.com",
+			},
+			want: want{
+				cu: &protectionv1beta1.ClusterUsage{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: protectionv1beta1.SchemeGroupVersion.String(),
+						Kind:       protectionv1beta1.ClusterUsageKind,
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: XRDClusterUsageName("test-xrd"),
+						Labels: map[string]string{
+							"crossplane.io/xrd-protection":    "true",
+							"apiextensions.crossplane.io/xrd": "test-xrd",
+						},
+					},
+					Spec: protectionv1beta1.ClusterUsageSpec{
+						Of: protectionv1beta1.Resource{
+							APIVersion: v1.SchemeGroupVersion.String(),
+							Kind:       v1.CompositeResourceDefinitionKind,
+							ResourceRef: &protectionv1beta1.ResourceRef{
+								Name: "test-xrd",
+							},
+						},
+						Reason: ptr.To("CompositeResourceDefinition has active composite resources of type XDatabase.example.com"),
+					},
+				},
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got := buildXRDClusterUsage(tc.args.xrdName, tc.args.xrTypeDescription)
+			if diff := cmp.Diff(tc.want.cu, got); diff != "" {
+				t.Errorf("\n%s\nbuildXRDClusterUsage(...): -want, +got:\n%s", tc.reason, diff)
+			}
+		})
+	}
+}
+
+func TestBuildConfigClusterUsage(t *testing.T) {
+	type args struct {
+		xrdName           string
+		configName        string
+		xrTypeDescription string
+	}
+	type want struct {
+		cu *protectionv1beta1.ClusterUsage
+	}
+
+	cases := map[string]struct {
+		reason string
+		args   args
+		want   want
+	}{
+		"StandardUsage": {
+			reason: "A Configuration ClusterUsage should be built with the correct metadata, labels, and spec",
+			args: args{
+				xrdName:           "test-xrd",
+				configName:        "my-configuration",
+				xrTypeDescription: "XDatabase.example.com",
+			},
+			want: want{
+				cu: &protectionv1beta1.ClusterUsage{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: protectionv1beta1.SchemeGroupVersion.String(),
+						Kind:       protectionv1beta1.ClusterUsageKind,
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: ConfigClusterUsageName("test-xrd"),
+						Labels: map[string]string{
+							"crossplane.io/configuration-protection": "true",
+							pkgv1.LabelParentPackage:                 "my-configuration",
+							"apiextensions.crossplane.io/xrd":        "test-xrd",
+						},
+					},
+					Spec: protectionv1beta1.ClusterUsageSpec{
+						Of: protectionv1beta1.Resource{
+							APIVersion: pkgv1.SchemeGroupVersion.String(),
+							Kind:       pkgv1.ConfigurationKind,
+							ResourceRef: &protectionv1beta1.ResourceRef{
+								Name: "my-configuration",
+							},
+						},
+						Reason: ptr.To("Configuration has active composite resources of type XDatabase.example.com"),
+					},
+				},
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got := buildConfigClusterUsage(tc.args.xrdName, tc.args.configName, tc.args.xrTypeDescription)
+			if diff := cmp.Diff(tc.want.cu, got); diff != "" {
+				t.Errorf("\n%s\nbuildConfigClusterUsage(...): -want, +got:\n%s", tc.reason, diff)
+			}
+		})
+	}
+}
+
+func TestXRDResourceMapFunc(t *testing.T) {
+	type args struct {
+		xrdName string
+	}
+	type want struct {
+		reqs []reconcile.Request
+	}
+
+	cases := map[string]struct {
+		reason string
+		args   args
+		want   want
+	}{
+		"EnqueuesFixedRequest": {
+			reason: "XRDResourceMapFunc should return a single reconcile request for the XRD name",
+			args: args{
+				xrdName: "test-xrd",
+			},
+			want: want{
+				reqs: []reconcile.Request{{
+					NamespacedName: types.NamespacedName{Name: "test-xrd"},
+				}},
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			fn := XRDResourceMapFunc(tc.args.xrdName)
+			got := fn(context.Background(), nil)
+			if diff := cmp.Diff(tc.want.reqs, got); diff != "" {
+				t.Errorf("\n%s\nXRDResourceMapFunc(...): -want, +got:\n%s", tc.reason, diff)
+			}
+		})
+	}
+}

--- a/internal/controller/apiextensions/definition/reconciler.go
+++ b/internal/controller/apiextensions/definition/reconciler.go
@@ -36,6 +36,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	kcontroller "sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -43,6 +44,7 @@ import (
 	"github.com/crossplane/crossplane-runtime/v2/pkg/controller"
 	"github.com/crossplane/crossplane-runtime/v2/pkg/errors"
 	"github.com/crossplane/crossplane-runtime/v2/pkg/event"
+	"github.com/crossplane/crossplane-runtime/v2/pkg/feature"
 	"github.com/crossplane/crossplane-runtime/v2/pkg/logging"
 	"github.com/crossplane/crossplane-runtime/v2/pkg/meta"
 	"github.com/crossplane/crossplane-runtime/v2/pkg/resource"
@@ -50,6 +52,7 @@ import (
 	"github.com/crossplane/crossplane-runtime/v2/pkg/xcrd"
 
 	v1 "github.com/crossplane/crossplane/apis/v2/apiextensions/v1"
+	protectionv1beta1 "github.com/crossplane/crossplane/apis/v2/protection/v1beta1"
 	"github.com/crossplane/crossplane/v2/internal/circuit"
 	"github.com/crossplane/crossplane/v2/internal/controller/apiextensions/composite"
 	"github.com/crossplane/crossplane/v2/internal/controller/apiextensions/composite/watch"
@@ -177,10 +180,16 @@ func (fn CRDRenderFn) Render(d *v1.CompositeResourceDefinition) (*extv1.CustomRe
 func Setup(mgr ctrl.Manager, o apiextensionscontroller.Options) error {
 	name := "defined/" + strings.ToLower(v1.CompositeResourceDefinitionGroupKind)
 
+	if o.Features.Enabled(features.EnableAlphaXRDDeletionProtection) &&
+		!o.Features.Enabled(features.EnableBetaUsages) {
+		return errors.New("XRD deletion protection requires usages to be enabled (--enable-usages)")
+	}
+
 	r := NewReconciler(NewClientApplicator(mgr.GetClient()),
 		WithLogger(o.Logger.WithValues("controller", name)),
 		WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name), o.EventFilterFunctions...)),
 		WithControllerEngine(o.ControllerEngine),
+		WithFeatures(o.Features),
 		WithOptions(o))
 
 	return ctrl.NewControllerManagedBy(mgr).
@@ -230,6 +239,13 @@ func WithFinalizer(f resource.Finalizer) ReconcilerOption {
 func WithControllerEngine(c ControllerEngine) ReconcilerOption {
 	return func(r *Reconciler) {
 		r.engine = c
+	}
+}
+
+// WithFeatures specifies the feature flags the Reconciler should use.
+func WithFeatures(f *feature.Flags) ReconcilerOption {
+	return func(r *Reconciler) {
+		r.features = f
 	}
 }
 
@@ -291,7 +307,8 @@ type Reconciler struct {
 
 	composite definition
 
-	engine ControllerEngine
+	engine   ControllerEngine
+	features *feature.Flags
 
 	log        logging.Logger
 	record     event.Recorder
@@ -335,6 +352,8 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 	}
 
 	if meta.WasDeleted(d) {
+		r.cleanupXRDProtection(ctx, log, d.GetName())
+
 		status.MarkConditions(v1.TerminatingComposite())
 
 		if err := r.client.Status().Update(ctx, d); err != nil {
@@ -495,6 +514,17 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 		r.record.Event(d, event.Normal(reasonEstablishXR, waitCRDEstablish))
 
 		return reconcile.Result{Requeue: true}, nil
+	}
+
+	// If XRD deletion protection is enabled, start a protection
+	// controller that watches composite resource instances and manages
+	// ClusterUsage objects.
+	if r.xrdProtectionEnabled() {
+		if err := r.startXRDProtection(ctx, log, d); err != nil {
+			log.Debug("Cannot start XRD deletion protection", "error", err)
+			r.record.Event(d, event.Warning(reasonEstablishXR, err))
+			return reconcile.Result{}, errors.Wrap(err, "cannot start XRD deletion protection")
+		}
 	}
 
 	// Check if XRD has changed since controller was last started
@@ -670,4 +700,73 @@ func ControllerNeedsRestart(d *v1.CompositeResourceDefinition) bool {
 
 	// Restart needed if the XRD has changed since the controller was started
 	return c.ObservedGeneration != d.GetGeneration()
+}
+
+// xrdProtectionEnabled returns true if XRD deletion protection is enabled.
+func (r *Reconciler) xrdProtectionEnabled() bool {
+	return r.features != nil &&
+		r.features.Enabled(features.EnableAlphaXRDDeletionProtection)
+}
+
+// startXRDProtection starts a protection controller for the given XRD that
+// watches composite resource instances and creates/deletes ClusterUsage objects
+// to protect the XRD (and its owning Configuration) from deletion.
+func (r *Reconciler) startXRDProtection(ctx context.Context, log logging.Logger, xrd *v1.CompositeResourceDefinition) error {
+	gvk := xrd.GetCompositeGroupVersionKind()
+	controllerName := XRDProtectionControllerName(xrd.GetName())
+
+	pr := &XRDProtectionReconciler{
+		cached:  r.engine.GetCached(),
+		writer:  r.client.Client,
+		xrdName: xrd.GetName(),
+		gvk:     gvk,
+		log:     log.WithValues("controller", controllerName),
+	}
+
+	ko := kcontroller.Options{Reconciler: pr}
+
+	//nolint:contextcheck // Start intentionally does not take a context; it creates its own so the controller outlives the caller.
+	if err := r.engine.Start(controllerName,
+		engine.WithRuntimeOptions(ko),
+	); err != nil {
+		return errors.Wrap(err, "cannot start XRD protection controller")
+	}
+
+	// Start a watch on composite resource instances. This is idempotent -
+	// it only starts watches that don't already exist.
+	xr := &kunstructured.Unstructured{}
+	xr.SetGroupVersionKind(gvk)
+
+	h := handler.EnqueueRequestsFromMapFunc(XRDResourceMapFunc(xrd.GetName()))
+
+	if err := r.engine.StartWatches(ctx, controllerName,
+		engine.WatchFor(xr, engine.WatchTypeCompositeResource, h),
+	); err != nil {
+		return errors.Wrap(err, "cannot start composite resource watch for protection")
+	}
+
+	return nil
+}
+
+// cleanupXRDProtection stops the protection controller and deletes the
+// ClusterUsage objects for the given XRD. It is a no-op if XRD deletion
+// protection is not enabled.
+func (r *Reconciler) cleanupXRDProtection(ctx context.Context, log logging.Logger, xrdName string) {
+	if !r.xrdProtectionEnabled() {
+		return
+	}
+
+	controllerName := XRDProtectionControllerName(xrdName)
+	if err := r.engine.Stop(ctx, controllerName); err != nil {
+		log.Debug("Cannot stop XRD protection controller", "error", err)
+	}
+
+	// Delete both ClusterUsages (XRD + Configuration).
+	for _, name := range []string{XRDClusterUsageName(xrdName), ConfigClusterUsageName(xrdName)} {
+		cu := &protectionv1beta1.ClusterUsage{}
+		cu.SetName(name)
+		if err := r.client.Delete(ctx, cu); resource.IgnoreNotFound(err) != nil {
+			log.Debug("Cannot delete ClusterUsage", "error", err, "name", name)
+		}
+	}
 }

--- a/internal/controller/apiextensions/definition/reconciler.go
+++ b/internal/controller/apiextensions/definition/reconciler.go
@@ -725,7 +725,6 @@ func (r *Reconciler) startXRDProtection(ctx context.Context, log logging.Logger,
 
 	ko := kcontroller.Options{Reconciler: pr}
 
-	//nolint:contextcheck // Start intentionally does not take a context; it creates its own so the controller outlives the caller.
 	if err := r.engine.Start(controllerName,
 		engine.WithRuntimeOptions(ko),
 	); err != nil {

--- a/internal/features/features.go
+++ b/internal/features/features.go
@@ -53,6 +53,12 @@ const (
 	// automatically protecting Providers from deletion when they still have
 	// active managed resources. Requires EnableBetaUsages to also be enabled.
 	EnableAlphaProviderDeletionProtection feature.Flag = "EnableAlphaProviderDeletionProtection"
+
+	// EnableAlphaXRDDeletionProtection enables alpha support for
+	// automatically protecting CompositeResourceDefinitions (and their
+	// owning Configurations) from deletion when they still have active
+	// composite resources. Requires EnableBetaUsages to also be enabled.
+	EnableAlphaXRDDeletionProtection feature.Flag = "EnableAlphaXRDDeletionProtection"
 )
 
 // Beta Feature Flags.

--- a/test/e2e/manifests/protection/configuration-deletion/configuration.yaml
+++ b/test/e2e/manifests/protection/configuration-deletion/configuration.yaml
@@ -5,3 +5,4 @@ metadata:
 spec:
   package: xpkg.crossplane.io/crossplane-contrib/configuration-quickstart:v0.1.0
   ignoreCrossplaneConstraints: true
+  skipDependencyResolution: true

--- a/test/e2e/manifests/protection/configuration-deletion/configuration.yaml
+++ b/test/e2e/manifests/protection/configuration-deletion/configuration.yaml
@@ -1,0 +1,7 @@
+apiVersion: pkg.crossplane.io/v1
+kind: Configuration
+metadata:
+  name: configuration-quickstart
+spec:
+  package: xpkg.crossplane.io/crossplane-contrib/configuration-quickstart:v0.1.0
+  ignoreCrossplaneConstraints: true

--- a/test/e2e/manifests/protection/configuration-deletion/xr.yaml
+++ b/test/e2e/manifests/protection/configuration-deletion/xr.yaml
@@ -1,0 +1,9 @@
+apiVersion: quickstart.crossplane.io/v1alpha1
+kind: MockDatabase
+metadata:
+  name: database1
+spec:
+  parameters:
+    region: "us-east"
+    size: "small"
+    storage: 10

--- a/test/e2e/manifests/protection/configuration-deletion/xr.yaml
+++ b/test/e2e/manifests/protection/configuration-deletion/xr.yaml
@@ -1,5 +1,5 @@
 apiVersion: quickstart.crossplane.io/v1alpha1
-kind: MockDatabase
+kind: XMockDatabase
 metadata:
   name: database1
 spec:

--- a/test/e2e/manifests/protection/configuration-deletion/xrd.yaml
+++ b/test/e2e/manifests/protection/configuration-deletion/xrd.yaml
@@ -1,0 +1,4 @@
+apiVersion: apiextensions.crossplane.io/v2
+kind: CompositeResourceDefinition
+metadata:
+  name: xmockdatabases.quickstart.crossplane.io

--- a/test/e2e/manifests/protection/xrd-deletion/xr.yaml
+++ b/test/e2e/manifests/protection/xrd-deletion/xr.yaml
@@ -1,0 +1,6 @@
+apiVersion: e2e.crossplane.io/v1alpha1
+kind: XProtectionTest
+metadata:
+  name: protection-test-xr
+spec:
+  coolField: "test"

--- a/test/e2e/manifests/protection/xrd-deletion/xrd.yaml
+++ b/test/e2e/manifests/protection/xrd-deletion/xrd.yaml
@@ -1,0 +1,27 @@
+apiVersion: apiextensions.crossplane.io/v2
+kind: CompositeResourceDefinition
+metadata:
+  name: xprotectiontests.e2e.crossplane.io
+spec:
+  scope: Cluster
+  group: e2e.crossplane.io
+  names:
+    kind: XProtectionTest
+    plural: xprotectiontests
+  versions:
+  - name: v1alpha1
+    served: true
+    referenceable: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            type: object
+            properties:
+              coolField:
+                type: string
+            required:
+            - coolField
+          status:
+            type: object

--- a/test/e2e/protection_xrd_test.go
+++ b/test/e2e/protection_xrd_test.go
@@ -1,0 +1,227 @@
+/*
+Copyright 2025 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"testing"
+	"time"
+
+	k8sapiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/e2e-framework/klient/k8s"
+	"sigs.k8s.io/e2e-framework/klient/k8s/resources"
+	"sigs.k8s.io/e2e-framework/pkg/features"
+	"sigs.k8s.io/e2e-framework/third_party/helm"
+
+	apiextensionsv1 "github.com/crossplane/crossplane/apis/v2/apiextensions/v1"
+	pkgv1 "github.com/crossplane/crossplane/apis/v2/pkg/v1"
+	protectionv1beta1 "github.com/crossplane/crossplane/apis/v2/protection/v1beta1"
+	"github.com/crossplane/crossplane/v2/test/e2e/config"
+	"github.com/crossplane/crossplane/v2/test/e2e/funcs"
+)
+
+// SuiteXRDDeletionProtection is the test suite for XRD deletion
+// protection, which requires the --enable-xrd-deletion-protection flag.
+const SuiteXRDDeletionProtection = "xrd-deletion-protection"
+
+func init() {
+	environment.AddTestSuite(SuiteXRDDeletionProtection,
+		config.WithHelmInstallOpts(
+			helm.WithArgs("--set args={--debug,--enable-xrd-deletion-protection}"),
+		),
+		config.WithLabelsToSelect(features.Labels{
+			config.LabelTestSuite: []string{SuiteXRDDeletionProtection, config.TestSuiteDefault},
+		}),
+	)
+}
+
+func TestXRDDeletionProtection(t *testing.T) {
+	manifests := "test/e2e/manifests/protection/xrd-deletion"
+
+	environment.Test(t,
+		features.NewWithDescription(t.Name(),
+			"Tests that a CompositeResourceDefinition is automatically protected from deletion when it has active composite resources via ClusterUsage.").
+			WithLabel(LabelArea, LabelAreaProtection).
+			WithLabel(LabelStage, LabelStageAlpha).
+			WithLabel(LabelSize, LabelSizeLarge).
+			WithLabel(config.LabelTestSuite, SuiteXRDDeletionProtection).
+
+			// Setup: Apply the XRD and wait for it to be established.
+			WithSetup("CreateXRD", funcs.AllOf(
+				funcs.ApplyResources(FieldManager, manifests, "xrd.yaml"),
+				funcs.ResourcesCreatedWithin(1*time.Minute, manifests, "xrd.yaml"),
+				funcs.ResourcesHaveConditionWithin(1*time.Minute, manifests, "xrd.yaml", apiextensionsv1.WatchingComposite()),
+			)).
+
+			// Create a composite resource so the protection controller creates
+			// a ClusterUsage protecting the XRD.
+			Assess("CreateCompositeResource", funcs.AllOf(
+				funcs.ApplyResources(FieldManager, manifests, "xr.yaml"),
+				funcs.ResourcesCreatedWithin(1*time.Minute, manifests, "xr.yaml"),
+			)).
+
+			// Verify that a ClusterUsage with the xrd-protection label was
+			// created automatically by the protection controller.
+			Assess("ClusterUsageCreatedForXRD",
+				funcs.ListedResourcesValidatedWithin(2*time.Minute,
+					&protectionv1beta1.ClusterUsageList{},
+					1,
+					func(o k8s.Object) bool {
+						cu, ok := o.(*protectionv1beta1.ClusterUsage)
+						if !ok {
+							return false
+						}
+						return cu.Spec.Of.Kind == "CompositeResourceDefinition"
+					},
+					resources.WithLabelSelector("crossplane.io/xrd-protection=true"),
+				),
+			).
+
+			// Attempt to delete the XRD. The usage webhook should block it.
+			Assess("XRDDeletionBlockedByUsage",
+				funcs.DeletionBlockedByUsageWebhook(manifests, "xrd.yaml"),
+			).
+
+			// Delete the composite resource so the protection controller
+			// removes the ClusterUsage.
+			Assess("DeleteCompositeResource", funcs.AllOf(
+				funcs.DeleteResources(manifests, "xr.yaml"),
+				funcs.ResourcesDeletedWithin(1*time.Minute, manifests, "xr.yaml"),
+			)).
+
+			// Verify that the ClusterUsage is removed after the composite
+			// resource is deleted.
+			Assess("ClusterUsageRemovedAfterXRDeletion",
+				funcs.ListedResourcesDeletedWithin(2*time.Minute,
+					&protectionv1beta1.ClusterUsageList{},
+					resources.WithLabelSelector("crossplane.io/xrd-protection=true"),
+				),
+			).
+
+			// Cleanup: Delete the XRD and ensure the CRD is removed.
+			WithTeardown("DeleteXRD", funcs.AllOf(
+				funcs.DeleteResources(manifests, "xrd.yaml"),
+				funcs.ResourcesDeletedWithin(2*time.Minute, manifests, "xrd.yaml"),
+				funcs.ResourceDeletedWithin(2*time.Minute, &k8sapiextensionsv1.CustomResourceDefinition{
+					ObjectMeta: metav1.ObjectMeta{Name: "xprotectiontests.e2e.crossplane.io"},
+				}),
+			)).
+			Feature(),
+	)
+}
+
+func TestConfigurationDeletionProtection(t *testing.T) {
+	manifests := "test/e2e/manifests/protection/configuration-deletion"
+
+	environment.Test(t,
+		features.NewWithDescription(t.Name(),
+			"Tests that a Configuration is automatically protected from deletion when its XRD has active composite resources via ClusterUsage.").
+			WithLabel(LabelArea, LabelAreaProtection).
+			WithLabel(LabelStage, LabelStageAlpha).
+			WithLabel(LabelSize, LabelSizeLarge).
+			WithLabel(config.LabelTestSuite, SuiteXRDDeletionProtection).
+
+			// Setup: Install the Configuration and wait for it to be healthy
+			// and its XRD to be established.
+			WithSetup("InstallConfiguration", funcs.AllOf(
+				funcs.ApplyResources(FieldManager, manifests, "configuration.yaml"),
+				funcs.ResourcesCreatedWithin(1*time.Minute, manifests, "configuration.yaml"),
+				funcs.ResourcesHaveConditionWithin(5*time.Minute, manifests, "configuration.yaml", pkgv1.Healthy(), pkgv1.Active()),
+				funcs.ResourcesHaveConditionWithin(5*time.Minute, manifests, "xrd.yaml",
+					apiextensionsv1.WatchingComposite()),
+			)).
+
+			// Create a composite resource so the protection controller creates
+			// ClusterUsages protecting both the XRD and the Configuration.
+			Assess("CreateCompositeResource", funcs.AllOf(
+				funcs.ApplyResources(FieldManager, manifests, "xr.yaml"),
+				funcs.ResourcesCreatedWithin(1*time.Minute, manifests, "xr.yaml"),
+			)).
+
+			// Verify that a ClusterUsage with the xrd-protection label was
+			// created automatically by the protection controller.
+			Assess("ClusterUsageCreatedForXRD",
+				funcs.ListedResourcesValidatedWithin(2*time.Minute,
+					&protectionv1beta1.ClusterUsageList{},
+					1,
+					func(o k8s.Object) bool {
+						cu, ok := o.(*protectionv1beta1.ClusterUsage)
+						if !ok {
+							return false
+						}
+						return cu.Spec.Of.Kind == "CompositeResourceDefinition"
+					},
+					resources.WithLabelSelector("crossplane.io/xrd-protection=true"),
+				),
+			).
+
+			// Verify that a ClusterUsage with the configuration-protection
+			// label was created automatically by the protection controller.
+			Assess("ClusterUsageCreatedForConfiguration",
+				funcs.ListedResourcesValidatedWithin(2*time.Minute,
+					&protectionv1beta1.ClusterUsageList{},
+					1,
+					func(o k8s.Object) bool {
+						cu, ok := o.(*protectionv1beta1.ClusterUsage)
+						if !ok {
+							return false
+						}
+						return cu.Spec.Of.Kind == "Configuration"
+					},
+					resources.WithLabelSelector("crossplane.io/configuration-protection=true"),
+				),
+			).
+
+			// Attempt to delete the Configuration. The usage webhook should
+			// block it.
+			Assess("ConfigurationDeletionBlockedByUsage",
+				funcs.DeletionBlockedByUsageWebhook(manifests, "configuration.yaml"),
+			).
+
+			// Delete the composite resource so the protection controller
+			// removes the ClusterUsages.
+			Assess("DeleteCompositeResource", funcs.AllOf(
+				funcs.DeleteResources(manifests, "xr.yaml"),
+				funcs.ResourcesDeletedWithin(1*time.Minute, manifests, "xr.yaml"),
+			)).
+
+			// Verify that the ClusterUsages are removed after the composite
+			// resource is deleted.
+			Assess("XRDClusterUsageRemovedAfterXRDeletion",
+				funcs.ListedResourcesDeletedWithin(2*time.Minute,
+					&protectionv1beta1.ClusterUsageList{},
+					resources.WithLabelSelector("crossplane.io/xrd-protection=true,apiextensions.crossplane.io/xrd=xmockdatabases.quickstart.crossplane.io"),
+				),
+			).
+			Assess("ConfigurationClusterUsageRemovedAfterXRDeletion",
+				funcs.ListedResourcesDeletedWithin(2*time.Minute,
+					&protectionv1beta1.ClusterUsageList{},
+					resources.WithLabelSelector("crossplane.io/configuration-protection=true,apiextensions.crossplane.io/xrd=xmockdatabases.quickstart.crossplane.io"),
+				),
+			).
+
+			// Cleanup: Delete the Configuration and ensure the CRD is removed.
+			WithTeardown("DeleteConfiguration", funcs.AllOf(
+				funcs.DeleteResourcesWithPropagationPolicy(manifests, "configuration.yaml", metav1.DeletePropagationForeground),
+				funcs.ResourcesDeletedWithin(3*time.Minute, manifests, "configuration.yaml"),
+				funcs.ResourceDeletedWithin(3*time.Minute, &k8sapiextensionsv1.CustomResourceDefinition{
+					ObjectMeta: metav1.ObjectMeta{Name: "xmockdatabases.quickstart.crossplane.io"},
+				}),
+			)).
+			Feature(),
+	)
+}


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane! Please read the contribution docs
(linked below) if this is your first Crossplane pull request.
-->

### Description of your changes

Follow-up to #7362 (Provider deletion protection). This PR adds the same
protection pattern for `CompositeResourceDefinitions` and `Configurations`:

- When an `XRD` has active composite resources, a `ClusterUsage` blocks the
  `XRD` from deletion
- When the `XRD` is owned by a `Configuration` (via `ConfigurationRevision`),
  a second `ClusterUsage` blocks the `Configuration` from deletion
- Standalone `XRDs` (not owned by a Configuration) only get `XRD` protection

Gated behind `--enable-xrd-deletion-protection` (alpha, requires
`--enable-usages`)

### Open questions

- Shared vs. split protection code: The XRD protection
  (`internal/controller/apiextensions/definition/protection.go`) and
  Provider protection
  (`internal/controller/apiextensions/managed/protection.go`) follow the
  same pattern. Should we extract a generic protection reconciler, or
  keep them separate for clarity?
- Single vs. separate feature flags: This PR uses a separate flag
  (`--enable-xrd-deletion-protection`) from the Provider protection flag
  (`--enable-provider-deletion-protection`). Should we unify them under
  a single flag (e.g. `--enable-deletion-protection`) that covers both?

<!--
Briefly describe what this pull request does, and how it is covered by tests.
Be proactive - direct your reviewers' attention to anything that needs special
consideration.

We love pull requests that fix an open issue. If yours does, use the below line
to indicate which issue it fixes, for example "Fixes #500".
-->

Fixes #

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `./nix.sh flake check` to ensure this PR is ready for review.
- [x] Added or updated unit tests.
- [x] Added or updated e2e tests.
- [x] Linked a PR or a [docs tracking issue] to [document this change].
- [x] Added `backport release-x.y` labels to auto-backport this PR.
- [x] Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md