### PR TITLE
build: tag the apis/ Go submodule on every release

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -24,8 +24,18 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Create Tag
-        uses: negz/create-tag@39bae1e0932567a58c20dea5a1a0d18358503320 # v1
+        uses: negz/create-tag@8dce6c9d9b12d161abe01c02d2b03f19e2e9e9bb # v1
         with:
           version: ${{ github.event.inputs.version }}
+          message: ${{ github.event.inputs.message }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      # Tag the apis/ Go submodule at the same commit. Go's module spec
+      # requires submodules to be tagged with their subdirectory prefix so
+      # consumers can `go get github.com/crossplane/crossplane/apis/v2@vX.Y.Z`.
+      - name: Create apis/ Submodule Tag
+        uses: negz/create-tag@8dce6c9d9b12d161abe01c02d2b03f19e2e9e9bb # v1
+        with:
+          version: apis/${{ github.event.inputs.version }}
           message: ${{ github.event.inputs.message }}
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### Description of your changes

The `apis/` directory is its own Go module (`github.com/crossplane/crossplane/apis/v2`). Go's [module spec](https://go.dev/ref/mod#vcs-version) requires a module in a repository subdirectory to be tagged with that subdirectory as a prefix, so consumers can only `go get github.com/crossplane/crossplane/apis/v2@vX.Y.Z` when an `apis/vX.Y.Z` tag exists at the release commit. The Tag workflow only created the main `vX.Y.Z` tag, so the `apis/` tags had to be backfilled by hand after every release.

This PR adds a second `negz/create-tag` call that creates an `apis/<version>` tag at the same commit as the main tag. It also bumps the pinned `negz/create-tag` to a commit that includes [negz/create-tag#17](https://github.com/negz/create-tag/pull/17), which adds the path-prefix support needed to tag `apis/<version>` strings (the previously pinned `v1` rejected them via `semver.valid`).

### How has this code been tested

Validated end-to-end on a fork running this exact workflow file and the same `negz/create-tag` pin. A single `workflow_dispatch` [run](https://github.com/jbw976/crossplane/actions/runs/26480284885) created both the main tag and the `apis/` tag at the same commit:

- [`v0.0.0-test.5`](https://github.com/jbw976/crossplane/releases/tag/v0.0.0-test.5)
- [`apis/v0.0.0-test.5`](https://github.com/jbw976/crossplane/releases/tag/apis%2Fv0.0.0-test.5)

Fixes #7420

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `./nix.sh flake check` to ensure this PR is ready for review.
- [ ] ~Added or updated unit tests.~ <!-- GitHub Actions workflow change; validated via workflow_dispatch on a fork, see above -->
- [ ] ~Added or updated e2e tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [x] Added `backport release-2.3` label to auto-backport this PR.
- [ ] ~Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md
