### PR TITLE
feat(apis): add IfNotFound resolve policy

### DIFF
--- a/apis/core/v2/policies.go
+++ b/apis/core/v2/policies.go
@@ -108,6 +108,15 @@ const (
 	// be tried to resolve for every reconcile loop.
 	ResolvePolicyAlways ResolvePolicy = "Always"
 
+	// ResolvePolicyIfNotFound is a resolve option.
+	// When the ResolvePolicy is set to ResolvePolicyIfNotFound the reference
+	// will be re-resolved only when the currently stored value cannot be found
+	// on the referenced resource (e.g. the referenced resource was deleted and
+	// recreated, so its extracted value no longer matches the stored value).
+	// This provides the correctness of ResolvePolicyAlways with a clearer
+	// signal of intent: re-resolve when stale, not on every reconcile.
+	ResolvePolicyIfNotFound ResolvePolicy = "IfNotFound"
+
 	// ResolutionPolicyRequired is a resolution option.
 	// When the ResolutionPolicy is set to ResolutionPolicyRequired the execution
 	// could not continue even if the reference cannot be resolved.

--- a/apis/core/v2/resource.go
+++ b/apis/core/v2/resource.go
@@ -104,9 +104,11 @@ type Policy struct {
 	// Resolve specifies when this reference should be resolved. The default
 	// is 'IfNotPresent', which will attempt to resolve the reference only when
 	// the corresponding field is not present. Use 'Always' to resolve the
-	// reference on every reconcile.
+	// reference on every reconcile. Use 'IfNotFound' to re-resolve the
+	// reference only when the currently stored value cannot be found on the
+	// referenced resource.
 	// +optional
-	// +kubebuilder:validation:Enum=Always;IfNotPresent
+	// +kubebuilder:validation:Enum=Always;IfNotPresent;IfNotFound
 	Resolve *ResolvePolicy `json:"resolve,omitempty"`
 
 	// Resolution specifies whether resolution of this reference is required.
@@ -135,6 +137,16 @@ func (p *Policy) IsResolvePolicyAlways() bool {
 	}
 
 	return *p.Resolve == ResolvePolicyAlways
+}
+
+// IsResolvePolicyIfNotFound checks whether the resolution policy of the relevant
+// reference is IfNotFound.
+func (p *Policy) IsResolvePolicyIfNotFound() bool {
+	if p == nil || p.Resolve == nil {
+		return false
+	}
+
+	return *p.Resolve == ResolvePolicyIfNotFound
 }
 
 // A Reference to a named object.

--- a/apis/core/v2/resource_test.go
+++ b/apis/core/v2/resource_test.go
@@ -1,0 +1,54 @@
+/*
+Copyright 2025 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v2
+
+import "testing"
+
+func TestIsResolvePolicyIfNotFound(t *testing.T) {
+	always := ResolvePolicyAlways
+	ifNotFound := ResolvePolicyIfNotFound
+
+	cases := map[string]struct {
+		policy *Policy
+		want   bool
+	}{
+		"NilPolicy": {
+			policy: nil,
+			want:   false,
+		},
+		"NilResolve": {
+			policy: &Policy{},
+			want:   false,
+		},
+		"ResolveAlways": {
+			policy: &Policy{Resolve: &always},
+			want:   false,
+		},
+		"ResolveIfNotFound": {
+			policy: &Policy{Resolve: &ifNotFound},
+			want:   true,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			if got := tc.policy.IsResolvePolicyIfNotFound(); got != tc.want {
+				t.Errorf("IsResolvePolicyIfNotFound() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Description of your changes

Adds a third `ResolvePolicy` option, `IfNotFound`, to the cross-resource reference API.

Today, references support two `resolve` modes:

- `IfNotPresent` (default) — resolve only when the field is empty. A stale value is never re-resolved because the field is not empty, it is just wrong.
- `Always` — re-resolve on every reconcile. Correct, but adds overhead for the common case where the referenced resource has not changed.

`IfNotFound` fills the gap: re-resolve the reference only when the currently stored value can no longer be found on the referenced resource (e.g. the referenced resource was deleted and recreated, so its extracted value no longer matches the stored value).

This is particularly useful for providers that resolve to extracted IDs such as UUIDs (rather than external names). The motivating use case is [crossplane-contrib/provider-keycloak#324](https://github.com/crossplane-contrib/provider-keycloak/issues/324), where multiple authorization resources reference a Keycloak `Client` via its UUID and silently break when the `Client` is recreated.

This PR is the **API-only** part of the change. It adds:

- `ResolvePolicyIfNotFound` constant in `apis/core/v2/policies.go`
- `IfNotFound` entry in the `Policy.Resolve` kubebuilder enum
- `Policy.IsResolvePolicyIfNotFound()` helper, mirroring the existing `IsResolvePolicyAlways()`
- A unit test for the new helper

A follow-up PR to `crossplane/crossplane-runtime` will wire the new policy into `ResolutionRequest.IsNoOp()` and `APIResolver.Resolve` / `ResolveMultiple` so that setting `resolve: IfNotFound` actually changes behaviour. Until that lands, this value is accepted by the enum but behaves like the default `IfNotPresent`.

Fixes #7347

### I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `earthly +reviewable` to ensure this PR is ready for review.
- [x] Added or updated unit tests for this change.
- [ ] Added or updated e2e tests for this change.
- [ ] Linked a PR or a [docs tracking issue] to [document this change].
- [ ] Added `backport release-x.y` labels to auto-backport this PR.

### How has this code been tested

`go test ./...` passes (1257 tests, 65 packages). The new unit test covers the nil-policy, nil-resolve, wrong-value, and `IfNotFound` cases of the new helper.

[contribution process]: https://github.com/crossplane/crossplane/blob/main/CONTRIBUTING.md
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute