### PR TITLE
feat(cli): `upgrade check` command to analyze a control plane for v2 upgrade readiness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,8 @@ gitlab/
 # go build output (from go build ./cmd/crank etc)
 /crank
 /crossplane
+
+# ignore AI tools settings/config
+/.claude
+CLAUDE.md
+AGENTS.md

--- a/cmd/crank/beta/beta.go
+++ b/cmd/crank/beta/beta.go
@@ -23,6 +23,7 @@ import (
 	"github.com/crossplane/crossplane/cmd/crank/beta/convert"
 	"github.com/crossplane/crossplane/cmd/crank/beta/top"
 	"github.com/crossplane/crossplane/cmd/crank/beta/trace"
+	"github.com/crossplane/crossplane/cmd/crank/beta/upgrade"
 	"github.com/crossplane/crossplane/cmd/crank/beta/validate"
 )
 
@@ -33,6 +34,7 @@ type Cmd struct {
 	Convert  convert.Cmd  `cmd:"" help:"Convert a Crossplane resource to a newer version or kind."`
 	Top      top.Cmd      `cmd:"" help:"Display resource (CPU/memory) usage by Crossplane related pods."`
 	Trace    trace.Cmd    `cmd:"" help:"Trace a Crossplane resource to get a detailed output of its relationships, helpful for troubleshooting."`
+	Upgrade  upgrade.Cmd  `cmd:"" help:"Help upgrade a Crossplane control plane to a newer version."`
 	Validate validate.Cmd `cmd:"" help:"Validate Crossplane resources."`
 }
 

--- a/cmd/crank/beta/upgrade/check/cmd.go
+++ b/cmd/crank/beta/upgrade/check/cmd.go
@@ -37,14 +37,6 @@ import (
 	"github.com/crossplane/crossplane/apis"
 )
 
-const (
-	errLoadKubeconfig = "cannot load kubeconfig"
-	errInitScheme     = "cannot register Crossplane types with scheme"
-	errInitClient     = "cannot create Kubernetes client"
-	errPrintReport    = "cannot print report"
-	errBlockersFound  = "blockers found"
-)
-
 // Cmd checks a Crossplane control plane for features that are removed or
 // broken in Crossplane v2.
 type Cmd struct {
@@ -62,7 +54,7 @@ type Cmd struct {
 func (c *Cmd) Help() string {
 	return `
 Checks a Crossplane control plane to see if it is ready to safely upgrade to
-Crossplane v2 by checking for all features that were been removed or had
+Crossplane v2 by checking for all features that were removed or had
 breaking changes in Crossplane v2. Run this against a v1.x control plane to
 surface any usage of APIs that will not work after upgrading to v2.
 
@@ -109,7 +101,7 @@ func (c *Cmd) Run(k *kong.Context, logger logging.Logger) error {
 		&clientcmd.ConfigOverrides{CurrentContext: c.Context},
 	).ClientConfig()
 	if err != nil {
-		return errors.Wrap(err, errLoadKubeconfig)
+		return errors.Wrap(err, "cannot load kubeconfig")
 	}
 	// Give ourselves a bit more QPS/burst than the defaults for our API calls,
 	// we have a lot of checks to get through, and this is a one time tool run, not an
@@ -123,18 +115,18 @@ func (c *Cmd) Run(k *kong.Context, logger logging.Logger) error {
 
 	sch := runtime.NewScheme()
 	if err := scheme.AddToScheme(sch); err != nil {
-		return errors.Wrap(err, errInitScheme)
+		return errors.Wrap(err, "cannot register Crossplane types with scheme")
 	}
 	if err := extv1.AddToScheme(sch); err != nil {
-		return errors.Wrap(err, errInitScheme)
+		return errors.Wrap(err, "cannot register Crossplane types with scheme")
 	}
 	if err := apis.AddToScheme(sch); err != nil {
-		return errors.Wrap(err, errInitScheme)
+		return errors.Wrap(err, "cannot register Crossplane types with scheme")
 	}
 
 	kube, err := client.New(cfg, client.Options{Scheme: sch})
 	if err != nil {
-		return errors.Wrap(err, errInitClient)
+		return errors.Wrap(err, "cannot create Kubernetes client")
 	}
 
 	checks := []Check{
@@ -160,7 +152,7 @@ func (c *Cmd) Run(k *kong.Context, logger logging.Logger) error {
 		return err
 	}
 	if err := p.Print(k.Stdout, report); err != nil {
-		return errors.Wrap(err, errPrintReport)
+		return errors.Wrap(err, "cannot print report")
 	}
 
 	// Returning a non-nil error here makes kong exit non-zero; the report
@@ -169,7 +161,7 @@ func (c *Cmd) Run(k *kong.Context, logger logging.Logger) error {
 	// immediately after this return.
 	if report.HasBlockers() {
 		_, _ = fmt.Fprintln(k.Stderr)
-		return errors.New(errBlockersFound)
+		return errors.New("blockers found")
 	}
 	return nil
 }

--- a/cmd/crank/beta/upgrade/check/cmd.go
+++ b/cmd/crank/beta/upgrade/check/cmd.go
@@ -1,0 +1,175 @@
+/*
+Copyright 2025 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package check implements the `crossplane beta upgrade check` command.
+package check
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/alecthomas/kong"
+	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/clientcmd"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/crossplane/crossplane-runtime/pkg/errors"
+	"github.com/crossplane/crossplane-runtime/pkg/logging"
+
+	"github.com/crossplane/crossplane/apis"
+)
+
+const (
+	errLoadKubeconfig = "cannot load kubeconfig"
+	errInitScheme     = "cannot register Crossplane types with scheme"
+	errInitClient     = "cannot create Kubernetes client"
+	errPrintReport    = "cannot print report"
+	errBlockersFound  = "blockers found"
+)
+
+// Cmd checks a Crossplane control plane for features that are removed or
+// broken in Crossplane v2.
+type Cmd struct {
+	Kubeconfig           string `help:"Path to the kubeconfig file. Defaults to $KUBECONFIG or ~/.kube/config."       name:"kubeconfig"                                                                                                                 type:"existingfile"`
+	Context              string `help:"Kubernetes context to use from the kubeconfig."                                name:"context"                                                                                                                    predictor:"context"                       short:"c"`
+	Namespace            string `help:"Restrict namespaced checks to a single namespace. Defaults to all namespaces." name:"namespace"                                                                                                                  predictor:"namespace"                     short:"n"`
+	CrossplaneNamespace  string `default:"crossplane-system"                                                          help:"Namespace where the Crossplane Deployment runs."                                                                            name:"crossplane-namespace"`
+	CrossplaneSelector   string `default:"app=crossplane"                                                             help:"Label selector for the Crossplane Deployment."                                                                              name:"crossplane-selector"`
+	Output               string `default:"text"                                                                       enum:"text,json"                                                                                                                  help:"Output format. One of: text, json." name:"output" short:"o"`
+	SkipManagedResources bool   `default:"false"                                                                      help:"Skip scanning managed resources for external secret stores usage. Speeds up the check on clusters with many provider CRDs." name:"skip-managed-resources"`
+	Concurrency          int    `default:"10"                                                                         help:"Maximum number of resources to process in parallel."                                                                        name:"concurrency"`
+}
+
+// Help returns help text for the check command.
+func (c *Cmd) Help() string {
+	return `
+Checks a Crossplane control plane to see if it is ready to safely upgrade to
+Crossplane v2 by checking for all features that were been removed or had
+breaking changes in Crossplane v2. Run this against a v1.x control plane to
+surface any usage of APIs that will not work after upgrading to v2.
+
+By default the check sweeps the entire control plane: cluster-scoped
+resources and all namespaces. Use --namespace to restrict namespaced checks
+(e.g. Claims) to a single namespace.
+
+Exits non-zero if any issue-severity findings are produced or any check is
+incomplete (errored out before producing a result). Informational findings
+(flagged with [i]) do not trigger a non-zero exit as they highlight
+functionality that isn't strictly affected by a v2 upgrade, but is worth
+knowing about nonetheless.
+
+To learn more about the breaking changes in Crossplane v2, see the docs:
+https://docs.crossplane.io/latest/whats-new/#backward-compatibility
+
+Examples:
+  # Check a control plane using the current kubeconfig context and all namespaces
+  crossplane beta upgrade check
+
+  # Point at a specific kubeconfig and context
+  crossplane beta upgrade check --kubeconfig ~/.kube/prod.yaml --context prod
+
+  # Restrict Claim checks to a single namespace
+  crossplane beta upgrade check -n team-a
+
+  # Output JSON for CI/automation
+  crossplane beta upgrade check -o json
+`
+}
+
+// Run executes the check command.
+func (c *Cmd) Run(k *kong.Context, logger logging.Logger) error {
+	// Support cancelling the tool (and all in-flight API calls) on Ctrl-C or SIGTERM
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
+	if c.Kubeconfig != "" {
+		loadingRules.ExplicitPath = c.Kubeconfig
+	}
+	cfg, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
+		loadingRules,
+		&clientcmd.ConfigOverrides{CurrentContext: c.Context},
+	).ClientConfig()
+	if err != nil {
+		return errors.Wrap(err, errLoadKubeconfig)
+	}
+	// Give ourselves a bit more QPS/burst than the defaults for our API calls,
+	// we have a lot of checks to get through, and this is a one time tool run, not an
+	// always on controller, so the potential perf impact has a limited duration.
+	if cfg.QPS == 0 {
+		cfg.QPS = 20
+	}
+	if cfg.Burst == 0 {
+		cfg.Burst = 30
+	}
+
+	sch := runtime.NewScheme()
+	if err := scheme.AddToScheme(sch); err != nil {
+		return errors.Wrap(err, errInitScheme)
+	}
+	if err := extv1.AddToScheme(sch); err != nil {
+		return errors.Wrap(err, errInitScheme)
+	}
+	if err := apis.AddToScheme(sch); err != nil {
+		return errors.Wrap(err, errInitScheme)
+	}
+
+	kube, err := client.New(cfg, client.Options{Scheme: sch})
+	if err != nil {
+		return errors.Wrap(err, errInitClient)
+	}
+
+	checks := []Check{
+		&NativePatchAndTransform{Client: kube},
+		&ControllerConfigCheck{Client: kube},
+		&ExternalSecretStores{
+			Client:               kube,
+			CrossplaneNamespace:  c.CrossplaneNamespace,
+			Selector:             c.CrossplaneSelector,
+			ClaimNamespace:       c.Namespace,
+			SkipManagedResources: c.SkipManagedResources,
+			Concurrency:          c.Concurrency,
+		},
+		&CompositeConnectionDetails{Client: kube, Namespace: c.Namespace},
+		&UnqualifiedPackageSources{Client: kube},
+	}
+
+	runner := &Runner{Checks: checks, Logger: logger}
+	report := runner.Run(ctx)
+
+	p, err := NewPrinter(c.Output)
+	if err != nil {
+		return err
+	}
+	if err := p.Print(k.Stdout, report); err != nil {
+		return errors.Wrap(err, errPrintReport)
+	}
+
+	// Returning a non-nil error here makes kong exit non-zero; the report
+	// is already printed. The blank line on stderr separates the report
+	// from kong's "crossplane: error: ..." line, which lands on stderr
+	// immediately after this return.
+	if report.HasBlockers() {
+		_, _ = fmt.Fprintln(k.Stderr)
+		return errors.New(errBlockersFound)
+	}
+	return nil
+}

--- a/cmd/crank/beta/upgrade/check/connection_details.go
+++ b/cmd/crank/beta/upgrade/check/connection_details.go
@@ -38,30 +38,18 @@ type CompositeConnectionDetails struct {
 	Namespace string
 }
 
-// Category returns the check's stable identifier.
-func (c *CompositeConnectionDetails) Category() string { return "composite-connection-details" }
-
-// Title returns the check's human-readable title.
-func (c *CompositeConnectionDetails) Title() string { return "Composite resource connection details" }
-
-// Severity returns the severity of findings produced by this check.
-func (c *CompositeConnectionDetails) Severity() Severity { return SeverityInfo }
-
-// Description explains what this check looks for.
-func (c *CompositeConnectionDetails) Description() string {
-	return "Crossplane v2 keeps legacy XR and Claim connection-detail aggregation working, so no action is required for the upgrade itself. This check is informational: it flags resources that would need explicit composed Secrets if you later migrate them to v2-style namespaced XRs. Managed resources are unaffected and continue to publish via spec.writeConnectionSecretToRef."
-}
-
-// Remediation returns the once-per-section advice for this check.
-func (c *CompositeConnectionDetails) Remediation() string {
-	return "No action required for the upgrade. If you later migrate these XRDs to v2-style namespaced XRs, compose a Kubernetes Secret explicitly to publish connection details. No automated converter exists."
-}
-
-// DocsURLs returns documentation links for this check.
-func (c *CompositeConnectionDetails) DocsURLs() []string {
-	return []string{
-		"https://docs.crossplane.io/latest/guides/upgrade-to-crossplane-v2/#composite-resource-connection-details",
-		"https://docs.crossplane.io/latest/guides/connection-details-composition",
+// Meta returns the check's static metadata.
+func (c *CompositeConnectionDetails) Meta() Meta {
+	return Meta{
+		Category:    "composite-connection-details",
+		Title:       "Composite resource connection details",
+		Severity:    SeverityInfo,
+		Description: "Crossplane v2 keeps legacy XR and Claim connection-detail aggregation working, so no action is required for the upgrade itself. This check is informational: it flags resources that would need explicit composed Secrets if you later migrate them to v2-style namespaced XRs. Managed resources are unaffected and continue to publish via spec.writeConnectionSecretToRef.",
+		Remediation: "No action required for the upgrade. If you later migrate these XRDs to v2-style namespaced XRs, compose a Kubernetes Secret explicitly to publish connection details. No automated converter exists.",
+		DocsURLs: []string{
+			"https://docs.crossplane.io/latest/guides/upgrade-to-crossplane-v2/#composite-resource-connection-details",
+			"https://docs.crossplane.io/latest/guides/connection-details-composition",
+		},
 	}
 }
 
@@ -141,7 +129,7 @@ func (c *CompositeConnectionDetails) Run(ctx context.Context) ([]Finding, error)
 	}
 
 	for _, t := range types {
-		// list all instaces of each XR/Claim type
+		// list all instances of each XR/Claim type
 		instances, err := ListInstances(ctx, c.Client, t, c.Namespace)
 		if err != nil {
 			return findings, errors.Wrapf(err, "cannot list instances of %s", t.GVK.String())

--- a/cmd/crank/beta/upgrade/check/connection_details.go
+++ b/cmd/crank/beta/upgrade/check/connection_details.go
@@ -1,0 +1,215 @@
+/*
+Copyright 2025 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package check
+
+import (
+	"context"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/crossplane/crossplane-runtime/pkg/errors"
+
+	apiextensionsv1 "github.com/crossplane/crossplane/apis/apiextensions/v1"
+)
+
+// CompositeConnectionDetails finds Compositions, XRs, and Claims that rely on
+// built-in composite resource connection details, which are removed in
+// Crossplane v2 for v2 XRs. This support does still exist in v2 for legacy XRs,
+// so this category is considered informational.
+type CompositeConnectionDetails struct {
+	Client client.Client
+	// Namespace, if non-empty, restricts Claim instance lookups to a single
+	// namespace. Empty means list across all namespaces.
+	Namespace string
+}
+
+// Category returns the check's stable identifier.
+func (c *CompositeConnectionDetails) Category() string { return "composite-connection-details" }
+
+// Title returns the check's human-readable title.
+func (c *CompositeConnectionDetails) Title() string { return "Composite resource connection details" }
+
+// Severity returns the severity of findings produced by this check.
+func (c *CompositeConnectionDetails) Severity() Severity { return SeverityInfo }
+
+// Description explains what this check looks for.
+func (c *CompositeConnectionDetails) Description() string {
+	return "Crossplane v2 keeps legacy XR and Claim connection-detail aggregation working, so no action is required for the upgrade itself. This check is informational: it flags resources that would need explicit composed Secrets if you later migrate them to v2-style namespaced XRs. Managed resources are unaffected and continue to publish via spec.writeConnectionSecretToRef."
+}
+
+// Remediation returns the once-per-section advice for this check.
+func (c *CompositeConnectionDetails) Remediation() string {
+	return "No action required for the upgrade. If you later migrate these XRDs to v2-style namespaced XRs, compose a Kubernetes Secret explicitly to publish connection details. No automated converter exists."
+}
+
+// DocsURLs returns documentation links for this check.
+func (c *CompositeConnectionDetails) DocsURLs() []string {
+	return []string{
+		"https://docs.crossplane.io/latest/guides/upgrade-to-crossplane-v2/#composite-resource-connection-details",
+		"https://docs.crossplane.io/latest/guides/connection-details-composition",
+	}
+}
+
+// Run emits a Finding for each XRD, Composition, XR, and Claim that relies on
+// built-in composite resource connection-detail aggregation.
+func (c *CompositeConnectionDetails) Run(ctx context.Context) ([]Finding, error) {
+	// list all compositions
+	comps := &apiextensionsv1.CompositionList{}
+	if err := c.Client.List(ctx, comps); err != nil {
+		return nil, errors.Wrap(err, "cannot list Compositions")
+	}
+
+	group := apiextensionsv1.Group
+
+	findings := make([]Finding, 0, len(comps.Items))
+	for i := range comps.Items {
+		comp := &comps.Items[i]
+		ref := ResourceRef{
+			Group: group,
+			Kind:  apiextensionsv1.CompositionKind,
+			Name:  comp.Name,
+		}
+
+		// check the composition for writeConnectionSecretsToNamespace usage
+		if comp.Spec.WriteConnectionSecretsToNamespace != nil && *comp.Spec.WriteConnectionSecretsToNamespace != "" {
+			findings = append(findings, Finding{
+				Resource:  ref,
+				FieldPath: ".spec.writeConnectionSecretsToNamespace",
+			})
+		}
+
+		// check the composition for native p-and-t connectionDetails usage
+		if nativePublishesConnectionDetails(comp) {
+			findings = append(findings, Finding{
+				Resource:  ref,
+				FieldPath: ".spec.resources[].connectionDetails",
+			})
+		}
+
+		// check the composition for function p-and-t connectionDetails usage
+		usesConnectionDetails, err := pipelinePublishesConnectionDetails(comp)
+		if err != nil {
+			return findings, errors.Wrapf(err, "cannot inspect Composition %s pipeline", comp.Name)
+		}
+		if usesConnectionDetails {
+			findings = append(findings, Finding{
+				Resource:  ref,
+				FieldPath: ".spec.pipeline[].input.resources[].connectionDetails",
+			})
+		}
+	}
+
+	xrds := &apiextensionsv1.CompositeResourceDefinitionList{}
+	if err := c.Client.List(ctx, xrds); err != nil {
+		return findings, errors.Wrap(err, "cannot list CompositeResourceDefinitions")
+	}
+	for i := range xrds.Items {
+		xrd := &xrds.Items[i]
+		// check the XRD for connectionSecretKeys usage
+		if len(xrd.Spec.ConnectionSecretKeys) == 0 {
+			continue
+		}
+		findings = append(findings, Finding{
+			Resource: ResourceRef{
+				Group: group,
+				Kind:  apiextensionsv1.CompositeResourceDefinitionKind,
+				Name:  xrd.Name,
+			},
+			FieldPath: ".spec.connectionSecretKeys",
+		})
+	}
+
+	// find all XR and Claim types
+	types, err := DiscoverXRAndClaimTypes(ctx, c.Client, xrds)
+	if err != nil {
+		return findings, errors.Wrap(err, "cannot discover XR and Claim types")
+	}
+
+	for _, t := range types {
+		// list all instaces of each XR/Claim type
+		instances, err := ListInstances(ctx, c.Client, t, c.Namespace)
+		if err != nil {
+			return findings, errors.Wrapf(err, "cannot list instances of %s", t.GVK.String())
+		}
+		for i := range instances {
+			// check the claim/XR for writeConnectionSecretToRef usage
+			inst := instances[i]
+			ref, found, err := unstructured.NestedMap(inst.Object, "spec", "writeConnectionSecretToRef")
+			if err != nil {
+				return findings, errors.Wrapf(err, "cannot read spec.writeConnectionSecretToRef on %s/%s", inst.GetKind(), inst.GetName())
+			}
+			if !found || ref == nil {
+				continue
+			}
+			findings = append(findings, Finding{
+				Resource:  ResourceRefFromUnstructured(inst),
+				FieldPath: ".spec.writeConnectionSecretToRef",
+			})
+		}
+	}
+
+	return findings, nil
+}
+
+// nativePublishesConnectionDetails reports whether the composition declares
+// connectionDetails on any native patch and transform (mode: Resources)
+// composed resource. If the composition isn't using native p-and-t then this
+// loop will have nothing to iterate over and that's fine.
+func nativePublishesConnectionDetails(comp *apiextensionsv1.Composition) bool {
+	for i := range comp.Spec.Resources {
+		if len(comp.Spec.Resources[i].ConnectionDetails) > 0 {
+			return true
+		}
+	}
+	return false
+}
+
+// pipelinePublishesConnectionDetails reports whether any
+// function-patch-and-transform step in the composition declares
+// connectionDetails on a composed resource. Only inputs in the
+// function-patch-and-transform API group are inspected; other functions carry
+// their own input schemas we can't interpret. If the composition isn't using
+// pipeline mode then this function will have nothing to iterate over and that's
+// fine.
+func pipelinePublishesConnectionDetails(comp *apiextensionsv1.Composition) (bool, error) {
+	for i := range comp.Spec.Pipeline {
+		step := &comp.Spec.Pipeline[i]
+		if step.Input == nil || len(step.Input.Raw) == 0 {
+			continue
+		}
+		u := &unstructured.Unstructured{}
+		if err := u.UnmarshalJSON(step.Input.Raw); err != nil {
+			return false, errors.Wrapf(err, "cannot parse input of pipeline step %q", step.Step)
+		}
+		if u.GroupVersionKind().Group != "pt.fn.crossplane.io" {
+			// not a function-patch-and-transform pipeline step, skip it
+			continue
+		}
+		resources, _, _ := unstructured.NestedSlice(u.Object, "resources")
+		for _, r := range resources {
+			rm, ok := r.(map[string]any)
+			if !ok {
+				continue
+			}
+			if cd, found, _ := unstructured.NestedSlice(rm, "connectionDetails"); found && len(cd) > 0 {
+				return true, nil
+			}
+		}
+	}
+	return false, nil
+}

--- a/cmd/crank/beta/upgrade/check/connection_details_test.go
+++ b/cmd/crank/beta/upgrade/check/connection_details_test.go
@@ -1,0 +1,270 @@
+/*
+Copyright 2025 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package check
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/crossplane/crossplane-runtime/pkg/test"
+
+	apiextensionsv1 "github.com/crossplane/crossplane/apis/apiextensions/v1"
+)
+
+// Pipeline step inputs covering the function-patch-and-transform detection
+// branches in pipelinePublishesConnectionDetails.
+const (
+	ptInputWithConnectionDetails    = `{"apiVersion":"pt.fn.crossplane.io/v1beta1","kind":"Resources","resources":[{"name":"r","connectionDetails":[{"name":"x"}]}]}`
+	ptInputWithoutConnectionDetails = `{"apiVersion":"pt.fn.crossplane.io/v1beta1","kind":"Resources","resources":[{"name":"r"}]}`
+	nonPTInputWithConnectionDetails = `{"apiVersion":"other.fn.crossplane.io/v1beta1","kind":"Input","resources":[{"name":"r","connectionDetails":[{"name":"x"}]}]}`
+)
+
+// connDetailsXRD builds an XRD that declares connectionSecretKeys.
+func connDetailsXRD(name string) apiextensionsv1.CompositeResourceDefinition {
+	x := xrd("example.org", "XThing", "v1", "")
+	x.SetName(name)
+	x.Spec.ConnectionSecretKeys = []string{"endpoint"}
+	return x
+}
+
+// connDetailsFixture is the data and per-stage errors the fake client serves in
+// TestCompositeConnectionDetailsRun. instances is keyed by list kind (e.g.
+// "XThingList"). Zero-value fields serve empty lists and no error, so each case
+// sets only the slice or error branch it exercises; a single non-nil error lets
+// a case exercise one List failure in isolation.
+type connDetailsFixture struct {
+	comps     []apiextensionsv1.Composition
+	xrds      []apiextensionsv1.CompositeResourceDefinition
+	instances map[string][]unstructured.Unstructured
+	compsErr  error
+	xrdsErr   error
+	instErr   error
+}
+
+// connDetailsClient serves the Composition, XRD, and XR/Claim instance List
+// calls the connection-details check makes, from the given fixture.
+func connDetailsClient(f connDetailsFixture) client.Client {
+	return &test.MockClient{
+		MockList: func(_ context.Context, list client.ObjectList, _ ...client.ListOption) error {
+			switch l := list.(type) {
+			case *apiextensionsv1.CompositionList:
+				if f.compsErr != nil {
+					return f.compsErr
+				}
+				l.Items = f.comps
+			case *apiextensionsv1.CompositeResourceDefinitionList:
+				if f.xrdsErr != nil {
+					return f.xrdsErr
+				}
+				l.Items = f.xrds
+			case *unstructured.UnstructuredList:
+				if f.instErr != nil {
+					return f.instErr
+				}
+				l.Items = f.instances[l.GetObjectKind().GroupVersionKind().Kind]
+			}
+			return nil
+		},
+	}
+}
+
+func TestCompositeConnectionDetailsRun(t *testing.T) {
+	type want struct {
+		findings []Finding
+		err      error
+	}
+	cases := map[string]struct {
+		reason string
+		client client.Client
+		want   want
+	}{
+		"Clean": {
+			reason: "A Composition that publishes nothing and no XRDs produce no findings.",
+			client: connDetailsClient(connDetailsFixture{comps: []apiextensionsv1.Composition{{ObjectMeta: metav1.ObjectMeta{Name: "clean"}}}}),
+			want:   want{findings: nil},
+		},
+		"WriteConnectionSecretsToNamespace": {
+			reason: "A Composition with spec.writeConnectionSecretsToNamespace is flagged.",
+			client: connDetailsClient(connDetailsFixture{
+				comps: []apiextensionsv1.Composition{{
+					ObjectMeta: metav1.ObjectMeta{Name: "comp"},
+					Spec: apiextensionsv1.CompositionSpec{
+						WriteConnectionSecretsToNamespace: ptr.To("secrets-ns"),
+					},
+				}},
+			}),
+			want: want{findings: []Finding{{Resource: ResourceRef{Group: apiextensionsv1.Group, Kind: apiextensionsv1.CompositionKind, Name: "comp"}, FieldPath: ".spec.writeConnectionSecretsToNamespace"}}},
+		},
+		"NativeConnectionDetails": {
+			reason: "A native patch-and-transform resource that declares connectionDetails is flagged.",
+			client: connDetailsClient(connDetailsFixture{
+				comps: []apiextensionsv1.Composition{{
+					ObjectMeta: metav1.ObjectMeta{Name: "comp"},
+					Spec: apiextensionsv1.CompositionSpec{
+						Resources: []apiextensionsv1.ComposedTemplate{{ConnectionDetails: make([]apiextensionsv1.ConnectionDetail, 1)}},
+					},
+				}},
+			}),
+			want: want{findings: []Finding{{Resource: ResourceRef{Group: apiextensionsv1.Group, Kind: apiextensionsv1.CompositionKind, Name: "comp"}, FieldPath: ".spec.resources[].connectionDetails"}}},
+		},
+		"PipelineConnectionDetails": {
+			reason: "A function-patch-and-transform pipeline step that declares connectionDetails is flagged.",
+			client: connDetailsClient(connDetailsFixture{
+				comps: []apiextensionsv1.Composition{{
+					ObjectMeta: metav1.ObjectMeta{Name: "comp"},
+					Spec: apiextensionsv1.CompositionSpec{
+						Pipeline: []apiextensionsv1.PipelineStep{{
+							Step:  "pt",
+							Input: &runtime.RawExtension{Raw: []byte(ptInputWithConnectionDetails)},
+						}},
+					},
+				}},
+			}),
+			want: want{findings: []Finding{{Resource: ResourceRef{Group: apiextensionsv1.Group, Kind: apiextensionsv1.CompositionKind, Name: "comp"}, FieldPath: ".spec.pipeline[].input.resources[].connectionDetails"}}},
+		},
+		"PipelineWithoutConnectionDetails": {
+			reason: "A function-patch-and-transform step with no connectionDetails is not flagged.",
+			client: connDetailsClient(connDetailsFixture{
+				comps: []apiextensionsv1.Composition{{
+					ObjectMeta: metav1.ObjectMeta{Name: "comp"},
+					Spec: apiextensionsv1.CompositionSpec{
+						Pipeline: []apiextensionsv1.PipelineStep{{
+							Step:  "pt",
+							Input: &runtime.RawExtension{Raw: []byte(ptInputWithoutConnectionDetails)},
+						}},
+					},
+				}},
+			}),
+			want: want{findings: nil},
+		},
+		"PipelineStepWithoutInput": {
+			reason: "A pipeline step with no input (e.g. function-auto-ready) is skipped.",
+			client: connDetailsClient(connDetailsFixture{
+				comps: []apiextensionsv1.Composition{{
+					ObjectMeta: metav1.ObjectMeta{Name: "comp"},
+					Spec: apiextensionsv1.CompositionSpec{
+						Pipeline: []apiextensionsv1.PipelineStep{{Step: "pt"}},
+					},
+				}},
+			}),
+			want: want{findings: nil},
+		},
+		"PipelineNonPatchAndTransform": {
+			reason: "A pipeline step that isn't function-patch-and-transform is ignored even if it has connectionDetails.",
+			client: connDetailsClient(connDetailsFixture{
+				comps: []apiextensionsv1.Composition{{
+					ObjectMeta: metav1.ObjectMeta{Name: "comp"},
+					Spec: apiextensionsv1.CompositionSpec{
+						Pipeline: []apiextensionsv1.PipelineStep{{
+							Step:  "pt",
+							Input: &runtime.RawExtension{Raw: []byte(nonPTInputWithConnectionDetails)},
+						}},
+					},
+				}},
+			}),
+			want: want{findings: nil},
+		},
+		"PipelineUnparseableInput": {
+			reason: "A pipeline step whose input isn't valid JSON makes the check incomplete.",
+			client: connDetailsClient(connDetailsFixture{
+				comps: []apiextensionsv1.Composition{{
+					ObjectMeta: metav1.ObjectMeta{Name: "comp"},
+					Spec: apiextensionsv1.CompositionSpec{
+						Pipeline: []apiextensionsv1.PipelineStep{{
+							Step:  "pt",
+							Input: &runtime.RawExtension{Raw: []byte("{not json")},
+						}},
+					},
+				}},
+			}),
+			want: want{err: cmpopts.AnyError},
+		},
+		"XRDConnectionSecretKeys": {
+			reason: "An XRD that declares connectionSecretKeys is flagged.",
+			client: connDetailsClient(connDetailsFixture{xrds: []apiextensionsv1.CompositeResourceDefinition{connDetailsXRD("xthings.example.org")}}),
+			want: want{
+				findings: []Finding{
+					{
+						Resource: ResourceRef{
+							Group: apiextensionsv1.Group,
+							Kind:  apiextensionsv1.CompositeResourceDefinitionKind,
+							Name:  "xthings.example.org",
+						},
+						FieldPath: ".spec.connectionSecretKeys",
+					},
+				},
+			},
+		},
+		"XRInstanceWriteConnectionSecretToRef": {
+			reason: "An XR instance with spec.writeConnectionSecretToRef is flagged.",
+			client: connDetailsClient(connDetailsFixture{
+				xrds: []apiextensionsv1.CompositeResourceDefinition{xrd("example.org", "XThing", "v1", "")},
+				instances: map[string][]unstructured.Unstructured{
+					"XThingList": {{Object: map[string]any{
+						"apiVersion": "example.org/v1",
+						"kind":       "XThing",
+						"metadata":   map[string]any{"name": "my-xr"},
+						"spec":       map[string]any{"writeConnectionSecretToRef": map[string]any{"name": "s"}},
+					}}},
+				},
+			}),
+			want: want{findings: []Finding{{Resource: ResourceRef{Group: "example.org", Kind: "XThing", Name: "my-xr"}, FieldPath: ".spec.writeConnectionSecretToRef"}}},
+		},
+		"ListCompositionsError": {
+			reason: "A failure listing Compositions surfaces as an error with no findings.",
+			client: connDetailsClient(connDetailsFixture{compsErr: errBoom}),
+			want:   want{err: cmpopts.AnyError},
+		},
+		"ListXRDsError": {
+			reason: "A failure listing XRDs returns the Composition findings gathered so far plus the error.",
+			client: connDetailsClient(connDetailsFixture{
+				comps: []apiextensionsv1.Composition{{
+					ObjectMeta: metav1.ObjectMeta{Name: "comp"},
+					Spec: apiextensionsv1.CompositionSpec{
+						WriteConnectionSecretsToNamespace: ptr.To("secrets-ns"),
+					},
+				}},
+				xrdsErr: errBoom,
+			}),
+			want: want{
+				findings: []Finding{{Resource: ResourceRef{Group: apiextensionsv1.Group, Kind: apiextensionsv1.CompositionKind, Name: "comp"}, FieldPath: ".spec.writeConnectionSecretsToNamespace"}},
+				err:      cmpopts.AnyError,
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			c := &CompositeConnectionDetails{Client: tc.client}
+			got, err := c.Run(context.Background())
+			if diff := cmp.Diff(tc.want.err, err, cmpopts.EquateErrors()); diff != "" {
+				t.Errorf("\n%s\nRun(): -want error, +got error:\n%s", tc.reason, diff)
+			}
+			if diff := cmp.Diff(tc.want.findings, got, cmpopts.EquateEmpty()); diff != "" {
+				t.Errorf("\n%s\nRun(): -want, +got:\n%s", tc.reason, diff)
+			}
+		})
+	}
+}

--- a/cmd/crank/beta/upgrade/check/controller_config.go
+++ b/cmd/crank/beta/upgrade/check/controller_config.go
@@ -1,0 +1,131 @@
+/*
+Copyright 2025 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package check
+
+import (
+	"context"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/crossplane/crossplane-runtime/pkg/errors"
+
+	pkgv1 "github.com/crossplane/crossplane/apis/pkg/v1"
+	pkgv1alpha1 "github.com/crossplane/crossplane/apis/pkg/v1alpha1"
+)
+
+// ControllerConfigCheck finds usage of the removed ControllerConfig type:
+// ControllerConfig CRs themselves and Providers/Functions that still reference
+// one via spec.controllerConfigRef.
+type ControllerConfigCheck struct {
+	Client client.Client
+}
+
+// Category returns the check's stable identifier.
+func (c *ControllerConfigCheck) Category() string { return "controller-config" }
+
+// Title returns the check's human-readable title.
+func (c *ControllerConfigCheck) Title() string { return "ControllerConfig usage" }
+
+// Severity returns the severity of findings produced by this check.
+func (c *ControllerConfigCheck) Severity() Severity { return SeverityIssue }
+
+// Description returns a short explanation of the check.
+func (c *ControllerConfigCheck) Description() string {
+	return "Crossplane v2 removes the ControllerConfig type. Use DeploymentRuntimeConfig instead."
+}
+
+// Remediation returns the once-per-section advice for this check.
+func (c *ControllerConfigCheck) Remediation() string {
+	return `Migrate to DeploymentRuntimeConfig (pkg.crossplane.io/v1beta1). Run "crossplane beta convert deployment-runtime" to convert existing ControllerConfigs.`
+}
+
+// DocsURLs returns documentation links for this check.
+func (c *ControllerConfigCheck) DocsURLs() []string {
+	return []string{
+		"https://docs.crossplane.io/latest/guides/upgrade-to-crossplane-v2/#controllerconfig-type",
+		"https://docs.crossplane.io/v1.20/cli/command-reference/#beta-convert",
+	}
+}
+
+// Run emits a Finding for each ControllerConfig CR and each Provider or
+// Function whose spec.controllerConfigRef is set.
+func (c *ControllerConfigCheck) Run(ctx context.Context) ([]Finding, error) {
+	// list all ControllerConfigs and report all as findings
+	ccs := &pkgv1alpha1.ControllerConfigList{}
+	if err := c.Client.List(ctx, ccs); err != nil {
+		return nil, errors.Wrap(err, "cannot list ControllerConfigs")
+	}
+
+	// ControllerConfig and Provider/Function share the same Group
+	// (pkg.crossplane.io); only the version differs and version is no longer
+	// part of the ResourceRef identity.
+	group := pkgv1.Group
+
+	findings := make([]Finding, 0, len(ccs.Items))
+	for i := range ccs.Items {
+		cc := &ccs.Items[i]
+		findings = append(findings, Finding{
+			Resource: ResourceRef{
+				Group: group,
+				Kind:  pkgv1alpha1.ControllerConfigKind,
+				Name:  cc.Name,
+			},
+		})
+	}
+
+	// list all providers and find all that are referencing ControllerConfigs
+	providers := &pkgv1.ProviderList{}
+	if err := c.Client.List(ctx, providers); err != nil {
+		return findings, errors.Wrap(err, "cannot list Providers")
+	}
+	for i := range providers.Items {
+		p := &providers.Items[i]
+		if p.Spec.ControllerConfigReference == nil { //nolint:staticcheck // intentional read of deprecated field
+			continue
+		}
+		findings = append(findings, Finding{
+			Resource: ResourceRef{
+				Group: group,
+				Kind:  pkgv1.ProviderKind,
+				Name:  p.Name,
+			},
+			FieldPath: ".spec.controllerConfigRef",
+		})
+	}
+
+	// list all functions and find all that are referencing ControllerConfigs
+	functions := &pkgv1.FunctionList{}
+	if err := c.Client.List(ctx, functions); err != nil {
+		return findings, errors.Wrap(err, "cannot list Functions")
+	}
+	for i := range functions.Items {
+		f := &functions.Items[i]
+		if f.Spec.ControllerConfigReference == nil { //nolint:staticcheck // intentional read of deprecated field
+			continue
+		}
+		findings = append(findings, Finding{
+			Resource: ResourceRef{
+				Group: group,
+				Kind:  pkgv1.FunctionKind,
+				Name:  f.Name,
+			},
+			FieldPath: ".spec.controllerConfigRef",
+		})
+	}
+
+	return findings, nil
+}

--- a/cmd/crank/beta/upgrade/check/controller_config.go
+++ b/cmd/crank/beta/upgrade/check/controller_config.go
@@ -34,30 +34,18 @@ type ControllerConfigCheck struct {
 	Client client.Client
 }
 
-// Category returns the check's stable identifier.
-func (c *ControllerConfigCheck) Category() string { return "controller-config" }
-
-// Title returns the check's human-readable title.
-func (c *ControllerConfigCheck) Title() string { return "ControllerConfig usage" }
-
-// Severity returns the severity of findings produced by this check.
-func (c *ControllerConfigCheck) Severity() Severity { return SeverityIssue }
-
-// Description returns a short explanation of the check.
-func (c *ControllerConfigCheck) Description() string {
-	return "Crossplane v2 removes the ControllerConfig type. Use DeploymentRuntimeConfig instead."
-}
-
-// Remediation returns the once-per-section advice for this check.
-func (c *ControllerConfigCheck) Remediation() string {
-	return `Migrate to DeploymentRuntimeConfig (pkg.crossplane.io/v1beta1). Run "crossplane beta convert deployment-runtime" to convert existing ControllerConfigs.`
-}
-
-// DocsURLs returns documentation links for this check.
-func (c *ControllerConfigCheck) DocsURLs() []string {
-	return []string{
-		"https://docs.crossplane.io/latest/guides/upgrade-to-crossplane-v2/#controllerconfig-type",
-		"https://docs.crossplane.io/v1.20/cli/command-reference/#beta-convert",
+// Meta returns the check's static metadata.
+func (c *ControllerConfigCheck) Meta() Meta {
+	return Meta{
+		Category:    "controller-config",
+		Title:       "ControllerConfig usage",
+		Severity:    SeverityIssue,
+		Description: "Crossplane v2 removes the ControllerConfig type. Use DeploymentRuntimeConfig instead.",
+		Remediation: `Migrate to DeploymentRuntimeConfig (pkg.crossplane.io/v1beta1). Run "crossplane beta convert deployment-runtime" to convert existing ControllerConfigs.`,
+		DocsURLs: []string{
+			"https://docs.crossplane.io/latest/guides/upgrade-to-crossplane-v2/#controllerconfig-type",
+			"https://docs.crossplane.io/v1.20/cli/command-reference/#beta-convert",
+		},
 	}
 }
 

--- a/cmd/crank/beta/upgrade/check/controller_config_test.go
+++ b/cmd/crank/beta/upgrade/check/controller_config_test.go
@@ -1,0 +1,174 @@
+/*
+Copyright 2025 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package check
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/crossplane/crossplane-runtime/pkg/test"
+
+	pkgv1 "github.com/crossplane/crossplane/apis/pkg/v1"
+	pkgv1alpha1 "github.com/crossplane/crossplane/apis/pkg/v1alpha1"
+)
+
+// ccData is the declarative input for one ControllerConfig check Run. Zero-value
+// fields mean the corresponding List returns nothing; a single non-nil error
+// lets a case exercise one List failure in isolation.
+type ccData struct {
+	ccs   []pkgv1alpha1.ControllerConfig
+	provs []pkgv1.Provider
+	fns   []pkgv1.Function
+
+	ccErr   error
+	provErr error
+	fnErr   error
+}
+
+// ccClient builds a MockClient serving the three List calls the ControllerConfig
+// check makes, from the given data.
+func ccClient(d ccData) *test.MockClient {
+	return &test.MockClient{
+		MockList: func(_ context.Context, list client.ObjectList, _ ...client.ListOption) error {
+			switch l := list.(type) {
+			case *pkgv1alpha1.ControllerConfigList:
+				if d.ccErr != nil {
+					return d.ccErr
+				}
+				l.Items = d.ccs
+			case *pkgv1.ProviderList:
+				if d.provErr != nil {
+					return d.provErr
+				}
+				l.Items = d.provs
+			case *pkgv1.FunctionList:
+				if d.fnErr != nil {
+					return d.fnErr
+				}
+				l.Items = d.fns
+			}
+			return nil
+		},
+	}
+}
+
+func TestControllerConfigRun(t *testing.T) {
+	group := pkgv1.Group
+
+	type want struct {
+		findings []Finding
+		err      error
+	}
+	cases := map[string]struct {
+		reason string
+		client client.Client
+		want   want
+	}{
+		"ListControllerConfigsError": {
+			reason: "A failure listing ControllerConfigs surfaces as an error with no findings.",
+			client: ccClient(ccData{ccErr: errBoom}),
+			want:   want{err: cmpopts.AnyError},
+		},
+		"ListProvidersError": {
+			reason: "A failure listing Providers returns the ControllerConfig findings gathered so far plus the error.",
+			client: ccClient(ccData{
+				ccs:     []pkgv1alpha1.ControllerConfig{{ObjectMeta: metav1.ObjectMeta{Name: "cc1"}}},
+				provErr: errBoom,
+			}),
+			want: want{
+				findings: []Finding{{Resource: ResourceRef{Group: group, Kind: pkgv1alpha1.ControllerConfigKind, Name: "cc1"}}},
+				err:      cmpopts.AnyError,
+			},
+		},
+		"ListFunctionsError": {
+			reason: "A failure listing Functions returns earlier findings plus the error.",
+			client: ccClient(ccData{
+				provs: []pkgv1.Provider{{
+					ObjectMeta: metav1.ObjectMeta{Name: "p"},
+					Spec: pkgv1.ProviderSpec{
+						PackageRuntimeSpec: pkgv1.PackageRuntimeSpec{
+							ControllerConfigReference: &pkgv1.ControllerConfigReference{Name: "cc"},
+						},
+					},
+				}},
+				fnErr: errBoom,
+			}),
+			want: want{
+				findings: []Finding{{Resource: ResourceRef{Group: group, Kind: pkgv1.ProviderKind, Name: "p"}, FieldPath: ".spec.controllerConfigRef"}},
+				err:      cmpopts.AnyError,
+			},
+		},
+		"NoUsage": {
+			reason: "No ControllerConfigs and no references means no findings.",
+			client: ccClient(ccData{
+				provs: []pkgv1.Provider{{ObjectMeta: metav1.ObjectMeta{Name: "p"}}},
+				fns:   []pkgv1.Function{{ObjectMeta: metav1.ObjectMeta{Name: "f"}}},
+			}),
+			want: want{findings: nil},
+		},
+		"AllSources": {
+			reason: "Each ControllerConfig CR, and each Provider/Function referencing one, produces a finding.",
+			client: ccClient(ccData{
+				ccs: []pkgv1alpha1.ControllerConfig{{ObjectMeta: metav1.ObjectMeta{Name: "cc1"}}},
+				provs: []pkgv1.Provider{
+					{
+						ObjectMeta: metav1.ObjectMeta{Name: "p-ref"},
+						Spec: pkgv1.ProviderSpec{
+							PackageRuntimeSpec: pkgv1.PackageRuntimeSpec{
+								ControllerConfigReference: &pkgv1.ControllerConfigReference{Name: "cc"},
+							},
+						},
+					},
+					{ObjectMeta: metav1.ObjectMeta{Name: "p-noref"}},
+				},
+				fns: []pkgv1.Function{
+					{
+						ObjectMeta: metav1.ObjectMeta{Name: "f-ref"},
+						Spec: pkgv1.FunctionSpec{
+							PackageRuntimeSpec: pkgv1.PackageRuntimeSpec{
+								ControllerConfigReference: &pkgv1.ControllerConfigReference{Name: "cc"},
+							},
+						},
+					},
+				},
+			}),
+			want: want{findings: []Finding{
+				{Resource: ResourceRef{Group: group, Kind: pkgv1alpha1.ControllerConfigKind, Name: "cc1"}},
+				{Resource: ResourceRef{Group: group, Kind: pkgv1.ProviderKind, Name: "p-ref"}, FieldPath: ".spec.controllerConfigRef"},
+				{Resource: ResourceRef{Group: group, Kind: pkgv1.FunctionKind, Name: "f-ref"}, FieldPath: ".spec.controllerConfigRef"},
+			}},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			c := &ControllerConfigCheck{Client: tc.client}
+			got, err := c.Run(context.Background())
+			if diff := cmp.Diff(tc.want.err, err, cmpopts.EquateErrors()); diff != "" {
+				t.Errorf("\n%s\nRun(): -want error, +got error:\n%s", tc.reason, diff)
+			}
+			if diff := cmp.Diff(tc.want.findings, got, cmpopts.EquateEmpty()); diff != "" {
+				t.Errorf("\n%s\nRun(): -want, +got:\n%s", tc.reason, diff)
+			}
+		})
+	}
+}

--- a/cmd/crank/beta/upgrade/check/native_pnt.go
+++ b/cmd/crank/beta/upgrade/check/native_pnt.go
@@ -1,0 +1,105 @@
+/*
+Copyright 2025 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package check
+
+import (
+	"context"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/crossplane/crossplane-runtime/pkg/errors"
+
+	apiextensionsv1 "github.com/crossplane/crossplane/apis/apiextensions/v1"
+)
+
+// NativePatchAndTransform finds Compositions that rely on native
+// patch-and-transform, which is removed in Crossplane v2.
+type NativePatchAndTransform struct {
+	Client client.Client
+}
+
+// Category returns the check's stable identifier.
+func (c *NativePatchAndTransform) Category() string { return "native-patch-and-transform" }
+
+// Title returns the check's human-readable title.
+func (c *NativePatchAndTransform) Title() string { return "Native patch-and-transform Compositions" }
+
+// Severity returns the severity of findings produced by this check.
+func (c *NativePatchAndTransform) Severity() Severity { return SeverityIssue }
+
+// Description explains what this check looks for.
+func (c *NativePatchAndTransform) Description() string {
+	return "Crossplane v2 removes native patch-and-transform (P&T) Composition. Compositions must use mode: Pipeline with Composition Functions."
+}
+
+// Remediation returns the once-per-section advice for this check.
+func (c *NativePatchAndTransform) Remediation() string {
+	return `Migrate to Composition Functions (spec.mode: Pipeline with spec.pipeline steps). Run "crossplane beta convert pipeline-composition" to convert existing Compositions.`
+}
+
+// DocsURLs returns documentation links for this check.
+func (c *NativePatchAndTransform) DocsURLs() []string {
+	return []string{
+		"https://docs.crossplane.io/latest/guides/upgrade-to-crossplane-v2/#native-patch-and-transform-composition",
+		"https://docs.crossplane.io/v1.20/cli/command-reference/#beta-convert",
+	}
+}
+
+// Run lists Compositions and emits a Finding for each field that indicates
+// native P&T usage. A single Composition may produce multiple findings.
+func (c *NativePatchAndTransform) Run(ctx context.Context) ([]Finding, error) {
+	list := &apiextensionsv1.CompositionList{}
+	if err := c.Client.List(ctx, list); err != nil {
+		return nil, errors.Wrap(err, "cannot list Compositions")
+	}
+
+	group := apiextensionsv1.Group
+
+	var findings []Finding
+	for i := range list.Items {
+		comp := &list.Items[i]
+		ref := ResourceRef{
+			Group: group,
+			Kind:  apiextensionsv1.CompositionKind,
+			Name:  comp.Name,
+		}
+
+		// A nil Mode defaults to Resources; only an explicit Pipeline opts out.
+		if comp.Spec.Mode == nil || *comp.Spec.Mode == apiextensionsv1.CompositionModeResources {
+			findings = append(findings, Finding{
+				Resource:  ref,
+				FieldPath: ".spec.mode",
+			})
+		}
+
+		if len(comp.Spec.Resources) > 0 {
+			findings = append(findings, Finding{
+				Resource:  ref,
+				FieldPath: ".spec.resources",
+			})
+		}
+
+		if len(comp.Spec.PatchSets) > 0 {
+			findings = append(findings, Finding{
+				Resource:  ref,
+				FieldPath: ".spec.patchSets",
+			})
+		}
+	}
+
+	return findings, nil
+}

--- a/cmd/crank/beta/upgrade/check/native_pnt.go
+++ b/cmd/crank/beta/upgrade/check/native_pnt.go
@@ -32,30 +32,18 @@ type NativePatchAndTransform struct {
 	Client client.Client
 }
 
-// Category returns the check's stable identifier.
-func (c *NativePatchAndTransform) Category() string { return "native-patch-and-transform" }
-
-// Title returns the check's human-readable title.
-func (c *NativePatchAndTransform) Title() string { return "Native patch-and-transform Compositions" }
-
-// Severity returns the severity of findings produced by this check.
-func (c *NativePatchAndTransform) Severity() Severity { return SeverityIssue }
-
-// Description explains what this check looks for.
-func (c *NativePatchAndTransform) Description() string {
-	return "Crossplane v2 removes native patch-and-transform (P&T) Composition. Compositions must use mode: Pipeline with Composition Functions."
-}
-
-// Remediation returns the once-per-section advice for this check.
-func (c *NativePatchAndTransform) Remediation() string {
-	return `Migrate to Composition Functions (spec.mode: Pipeline with spec.pipeline steps). Run "crossplane beta convert pipeline-composition" to convert existing Compositions.`
-}
-
-// DocsURLs returns documentation links for this check.
-func (c *NativePatchAndTransform) DocsURLs() []string {
-	return []string{
-		"https://docs.crossplane.io/latest/guides/upgrade-to-crossplane-v2/#native-patch-and-transform-composition",
-		"https://docs.crossplane.io/v1.20/cli/command-reference/#beta-convert",
+// Meta returns the check's static metadata.
+func (c *NativePatchAndTransform) Meta() Meta {
+	return Meta{
+		Category:    "native-patch-and-transform",
+		Title:       "Native patch-and-transform Compositions",
+		Severity:    SeverityIssue,
+		Description: "Crossplane v2 removes native patch-and-transform (P&T) Composition. Compositions must use mode: Pipeline with Composition Functions.",
+		Remediation: `Migrate to Composition Functions (spec.mode: Pipeline with spec.pipeline steps). Run "crossplane beta convert pipeline-composition" to convert existing Compositions.`,
+		DocsURLs: []string{
+			"https://docs.crossplane.io/latest/guides/upgrade-to-crossplane-v2/#native-patch-and-transform-composition",
+			"https://docs.crossplane.io/v1.20/cli/command-reference/#beta-convert",
+		},
 	}
 }
 

--- a/cmd/crank/beta/upgrade/check/native_pnt_test.go
+++ b/cmd/crank/beta/upgrade/check/native_pnt_test.go
@@ -1,0 +1,119 @@
+/*
+Copyright 2025 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package check
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/crossplane/crossplane-runtime/pkg/test"
+
+	apiextensionsv1 "github.com/crossplane/crossplane/apis/apiextensions/v1"
+)
+
+func TestNativePatchAndTransformRun(t *testing.T) {
+	type want struct {
+		findings []Finding
+		err      error
+	}
+	cases := map[string]struct {
+		reason string
+		client client.Client
+		want   want
+	}{
+		"ListError": {
+			reason: "A List failure surfaces as a wrapped error and no findings.",
+			client: &test.MockClient{MockList: test.NewMockListFn(errBoom)},
+			want:   want{err: cmpopts.AnyError},
+		},
+		"PipelineModeClean": {
+			reason: "An explicit Pipeline-mode Composition with no native fields produces no findings.",
+			client: &test.MockClient{MockList: test.NewMockListFn(nil, func(o client.ObjectList) error {
+				o.(*apiextensionsv1.CompositionList).Items = []apiextensionsv1.Composition{{
+					ObjectMeta: metav1.ObjectMeta{Name: "clean"},
+					Spec: apiextensionsv1.CompositionSpec{
+						Mode: ptr.To(apiextensionsv1.CompositionModePipeline),
+					},
+				}}
+				return nil
+			})},
+			want: want{findings: nil},
+		},
+		"NilModeDefaultsToResources": {
+			reason: "A nil Mode defaults to Resources, so it is flagged at .spec.mode.",
+			client: &test.MockClient{MockList: test.NewMockListFn(nil, func(o client.ObjectList) error {
+				o.(*apiextensionsv1.CompositionList).Items = []apiextensionsv1.Composition{{
+					ObjectMeta: metav1.ObjectMeta{Name: "nilmode"},
+				}}
+				return nil
+			})},
+			want: want{findings: []Finding{{Resource: ResourceRef{Group: apiextensionsv1.Group, Kind: apiextensionsv1.CompositionKind, Name: "nilmode"}, FieldPath: ".spec.mode"}}},
+		},
+		"AllNativeFields": {
+			reason: "A Resources-mode Composition with resources and patchSets is flagged on all three fields.",
+			client: &test.MockClient{MockList: test.NewMockListFn(nil, func(o client.ObjectList) error {
+				o.(*apiextensionsv1.CompositionList).Items = []apiextensionsv1.Composition{{
+					ObjectMeta: metav1.ObjectMeta{Name: "native"},
+					Spec: apiextensionsv1.CompositionSpec{
+						Mode:      ptr.To(apiextensionsv1.CompositionModeResources),
+						Resources: make([]apiextensionsv1.ComposedTemplate, 2),
+						PatchSets: make([]apiextensionsv1.PatchSet, 1),
+					},
+				}}
+				return nil
+			})},
+			want: want{findings: []Finding{
+				{Resource: ResourceRef{Group: apiextensionsv1.Group, Kind: apiextensionsv1.CompositionKind, Name: "native"}, FieldPath: ".spec.mode"},
+				{Resource: ResourceRef{Group: apiextensionsv1.Group, Kind: apiextensionsv1.CompositionKind, Name: "native"}, FieldPath: ".spec.resources"},
+				{Resource: ResourceRef{Group: apiextensionsv1.Group, Kind: apiextensionsv1.CompositionKind, Name: "native"}, FieldPath: ".spec.patchSets"},
+			}},
+		},
+		"PipelineModeWithLeftoverResources": {
+			reason: "Resources/patchSets set under Pipeline mode are still flagged; only .spec.mode is clean.",
+			client: &test.MockClient{MockList: test.NewMockListFn(nil, func(o client.ObjectList) error {
+				o.(*apiextensionsv1.CompositionList).Items = []apiextensionsv1.Composition{{
+					ObjectMeta: metav1.ObjectMeta{Name: "leftover"},
+					Spec: apiextensionsv1.CompositionSpec{
+						Mode:      ptr.To(apiextensionsv1.CompositionModePipeline),
+						Resources: make([]apiextensionsv1.ComposedTemplate, 1),
+					},
+				}}
+				return nil
+			})},
+			want: want{findings: []Finding{{Resource: ResourceRef{Group: apiextensionsv1.Group, Kind: apiextensionsv1.CompositionKind, Name: "leftover"}, FieldPath: ".spec.resources"}}},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			c := &NativePatchAndTransform{Client: tc.client}
+			got, err := c.Run(context.Background())
+			if diff := cmp.Diff(tc.want.err, err, cmpopts.EquateErrors()); diff != "" {
+				t.Errorf("\n%s\nRun(): -want error, +got error:\n%s", tc.reason, diff)
+			}
+			if diff := cmp.Diff(tc.want.findings, got, cmpopts.EquateEmpty()); diff != "" {
+				t.Errorf("\n%s\nRun(): -want, +got:\n%s", tc.reason, diff)
+			}
+		})
+	}
+}

--- a/cmd/crank/beta/upgrade/check/package_source.go
+++ b/cmd/crank/beta/upgrade/check/package_source.go
@@ -1,0 +1,137 @@
+/*
+Copyright 2025 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package check
+
+import (
+	"context"
+
+	"github.com/google/go-containerregistry/pkg/name"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/crossplane/crossplane-runtime/pkg/errors"
+
+	pkgv1 "github.com/crossplane/crossplane/apis/pkg/v1"
+)
+
+// UnqualifiedPackageSources finds Providers, Configurations, and Functions
+// whose spec.package is not fully qualified with a registry hostname.
+// Crossplane v2 removes the default registry and the --registry flag, so every
+// package reference must include its registry explicitly.
+type UnqualifiedPackageSources struct {
+	Client client.Client
+}
+
+// Category returns the check's stable identifier.
+func (c *UnqualifiedPackageSources) Category() string { return "unqualified-package-source" }
+
+// Title returns the check's human-readable title.
+func (c *UnqualifiedPackageSources) Title() string { return "Unqualified package sources" }
+
+// Severity returns the severity of findings produced by this check.
+func (c *UnqualifiedPackageSources) Severity() Severity { return SeverityIssue }
+
+// Description explains what this check looks for.
+func (c *UnqualifiedPackageSources) Description() string {
+	return "Crossplane v2 removes the --registry flag and its implicit default registry. Every Provider, Configuration, and Function spec.package (including dependencies) must be a fully qualified reference including its registry hostname."
+}
+
+// Remediation returns the once-per-section advice for this check.
+func (c *UnqualifiedPackageSources) Remediation() string {
+	return "Prefix the package with its fully qualified registry hostname (e.g. xpkg.crossplane.io/crossplane-contrib/provider-nop:v0.4.0) and ensure all package references are valid."
+}
+
+// DocsURLs returns documentation links for this check.
+func (c *UnqualifiedPackageSources) DocsURLs() []string {
+	return []string{"https://docs.crossplane.io/latest/guides/upgrade-to-crossplane-v2/#default-registry-flag"}
+}
+
+// Run lists all package types and emits a Finding for each one whose
+// spec.package is not a fully qualified registry reference.
+func (c *UnqualifiedPackageSources) Run(ctx context.Context) ([]Finding, error) {
+	var findings []Finding
+	group := pkgv1.Group
+
+	// check package sources for all providers
+	providers := &pkgv1.ProviderList{}
+	if err := c.Client.List(ctx, providers); err != nil {
+		return findings, errors.Wrap(err, "cannot list Providers")
+	}
+	for i := range providers.Items {
+		p := &providers.Items[i]
+		if f := checkPackage(p.Spec.Package, ResourceRef{
+			Group: group,
+			Kind:  pkgv1.ProviderKind,
+			Name:  p.Name,
+		}); f != nil {
+			findings = append(findings, *f)
+		}
+	}
+
+	// check package sources for all configurations
+	configurations := &pkgv1.ConfigurationList{}
+	if err := c.Client.List(ctx, configurations); err != nil {
+		return findings, errors.Wrap(err, "cannot list Configurations")
+	}
+	for i := range configurations.Items {
+		cfg := &configurations.Items[i]
+		if f := checkPackage(cfg.Spec.Package, ResourceRef{
+			Group: group,
+			Kind:  pkgv1.ConfigurationKind,
+			Name:  cfg.Name,
+		}); f != nil {
+			findings = append(findings, *f)
+		}
+	}
+
+	// check package sources for all functions
+	functions := &pkgv1.FunctionList{}
+	if err := c.Client.List(ctx, functions); err != nil {
+		return findings, errors.Wrap(err, "cannot list Functions")
+	}
+	for i := range functions.Items {
+		fn := &functions.Items[i]
+		if f := checkPackage(fn.Spec.Package, ResourceRef{
+			Group: group,
+			Kind:  pkgv1.FunctionKind,
+			Name:  fn.Name,
+		}); f != nil {
+			findings = append(findings, *f)
+		}
+	}
+
+	return findings, nil
+}
+
+// checkPackage returns a Finding when pkg is missing a registry hostname or
+// can't be parsed at all.
+func checkPackage(pkg string, ref ResourceRef) *Finding {
+	// Parse with an empty default registry so ParseReference doesn't add a
+	// registry that isn't explicitly declared in the reference we're checking.
+	parsed, err := name.ParseReference(pkg, name.WithDefaultRegistry(""))
+	if err == nil && parsed.Context().RegistryStr() != "" {
+		return nil
+	}
+
+	fieldPath := ".spec.package"
+	if err != nil {
+		// Distinguish "parses but no registry" from "doesn't parse at all" in
+		// the finding so the user can tell what they're looking at.
+		fieldPath = ".spec.package (unparseable)"
+	}
+
+	return &Finding{Resource: ref, FieldPath: fieldPath}
+}

--- a/cmd/crank/beta/upgrade/check/package_source.go
+++ b/cmd/crank/beta/upgrade/check/package_source.go
@@ -35,28 +35,16 @@ type UnqualifiedPackageSources struct {
 	Client client.Client
 }
 
-// Category returns the check's stable identifier.
-func (c *UnqualifiedPackageSources) Category() string { return "unqualified-package-source" }
-
-// Title returns the check's human-readable title.
-func (c *UnqualifiedPackageSources) Title() string { return "Unqualified package sources" }
-
-// Severity returns the severity of findings produced by this check.
-func (c *UnqualifiedPackageSources) Severity() Severity { return SeverityIssue }
-
-// Description explains what this check looks for.
-func (c *UnqualifiedPackageSources) Description() string {
-	return "Crossplane v2 removes the --registry flag and its implicit default registry. Every Provider, Configuration, and Function spec.package (including dependencies) must be a fully qualified reference including its registry hostname."
-}
-
-// Remediation returns the once-per-section advice for this check.
-func (c *UnqualifiedPackageSources) Remediation() string {
-	return "Prefix the package with its fully qualified registry hostname (e.g. xpkg.crossplane.io/crossplane-contrib/provider-nop:v0.4.0) and ensure all package references are valid."
-}
-
-// DocsURLs returns documentation links for this check.
-func (c *UnqualifiedPackageSources) DocsURLs() []string {
-	return []string{"https://docs.crossplane.io/latest/guides/upgrade-to-crossplane-v2/#default-registry-flag"}
+// Meta returns the check's static metadata.
+func (c *UnqualifiedPackageSources) Meta() Meta {
+	return Meta{
+		Category:    "unqualified-package-source",
+		Title:       "Unqualified package sources",
+		Severity:    SeverityIssue,
+		Description: "Crossplane v2 removes the --registry flag and its implicit default registry. Every Provider, Configuration, and Function spec.package (including dependencies) must be a fully qualified reference including its registry hostname.",
+		Remediation: "Prefix the package with its fully qualified registry hostname (e.g. xpkg.crossplane.io/crossplane-contrib/provider-nop:v0.4.0) and ensure all package references are valid.",
+		DocsURLs:    []string{"https://docs.crossplane.io/latest/guides/upgrade-to-crossplane-v2/#default-registry-flag"},
+	}
 }
 
 // Run lists all package types and emits a Finding for each one whose

--- a/cmd/crank/beta/upgrade/check/package_source_test.go
+++ b/cmd/crank/beta/upgrade/check/package_source_test.go
@@ -1,0 +1,208 @@
+/*
+Copyright 2025 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package check
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/crossplane/crossplane-runtime/pkg/test"
+
+	pkgv1 "github.com/crossplane/crossplane/apis/pkg/v1"
+)
+
+// pkgData is the declarative input for one package-sources check Run. Zero-value
+// fields mean the corresponding List returns nothing; a single non-nil error
+// lets a case exercise one List failure in isolation.
+type pkgData struct {
+	provs []pkgv1.Provider
+	cfgs  []pkgv1.Configuration
+	fns   []pkgv1.Function
+
+	provErr error
+	cfgErr  error
+	fnErr   error
+}
+
+// pkgClient builds a MockClient serving the three package-type List calls, from
+// the given data.
+func pkgClient(d pkgData) *test.MockClient {
+	return &test.MockClient{
+		MockList: func(_ context.Context, list client.ObjectList, _ ...client.ListOption) error {
+			switch l := list.(type) {
+			case *pkgv1.ProviderList:
+				if d.provErr != nil {
+					return d.provErr
+				}
+				l.Items = d.provs
+			case *pkgv1.ConfigurationList:
+				if d.cfgErr != nil {
+					return d.cfgErr
+				}
+				l.Items = d.cfgs
+			case *pkgv1.FunctionList:
+				if d.fnErr != nil {
+					return d.fnErr
+				}
+				l.Items = d.fns
+			}
+			return nil
+		},
+	}
+}
+
+func TestUnqualifiedPackageSourcesRun(t *testing.T) {
+	type want struct {
+		findings []Finding
+		err      error
+	}
+	cases := map[string]struct {
+		reason string
+		client client.Client
+		want   want
+	}{
+		"ListProvidersError": {
+			reason: "A failure listing Providers surfaces as an error.",
+			client: pkgClient(pkgData{provErr: errBoom}),
+			want:   want{err: cmpopts.AnyError},
+		},
+		"ListConfigurationsError": {
+			reason: "A failure listing Configurations returns the Provider findings gathered so far plus the error.",
+			client: pkgClient(pkgData{
+				provs: []pkgv1.Provider{{
+					ObjectMeta: metav1.ObjectMeta{Name: "p"},
+					Spec: pkgv1.ProviderSpec{
+						PackageSpec: pkgv1.PackageSpec{Package: "crossplane-contrib/provider-nop:v0.4.0"},
+					},
+				}},
+				cfgErr: errBoom,
+			}),
+			want: want{
+				findings: []Finding{{Resource: ResourceRef{Group: pkgv1.Group, Kind: pkgv1.ProviderKind, Name: "p"}, FieldPath: ".spec.package"}},
+				err:      cmpopts.AnyError,
+			},
+		},
+		"ListFunctionsError": {
+			reason: "A failure listing Functions returns the Provider and Configuration findings gathered so far plus the error.",
+			client: pkgClient(pkgData{
+				provs: []pkgv1.Provider{{
+					ObjectMeta: metav1.ObjectMeta{Name: "p"},
+					Spec: pkgv1.ProviderSpec{
+						PackageSpec: pkgv1.PackageSpec{Package: "crossplane-contrib/provider-nop:v0.4.0"},
+					},
+				}},
+				cfgs: []pkgv1.Configuration{{
+					ObjectMeta: metav1.ObjectMeta{Name: "c"},
+					Spec: pkgv1.ConfigurationSpec{
+						PackageSpec: pkgv1.PackageSpec{Package: "crossplane-contrib/configuration-foo:v0.1.0"},
+					},
+				}},
+				fnErr: errBoom,
+			}),
+			want: want{
+				findings: []Finding{
+					{Resource: ResourceRef{Group: pkgv1.Group, Kind: pkgv1.ProviderKind, Name: "p"}, FieldPath: ".spec.package"},
+					{Resource: ResourceRef{Group: pkgv1.Group, Kind: pkgv1.ConfigurationKind, Name: "c"}, FieldPath: ".spec.package"},
+				},
+				err: cmpopts.AnyError,
+			},
+		},
+		"AllQualified": {
+			reason: "Fully qualified references, produce no findings.",
+			client: pkgClient(pkgData{
+				provs: []pkgv1.Provider{{
+					ObjectMeta: metav1.ObjectMeta{Name: "p"},
+					Spec: pkgv1.ProviderSpec{
+						PackageSpec: pkgv1.PackageSpec{Package: "xpkg.crossplane.io/crossplane-contrib/provider-nop:v0.4.0"},
+					},
+				}},
+				cfgs: []pkgv1.Configuration{{
+					ObjectMeta: metav1.ObjectMeta{Name: "c"},
+					Spec: pkgv1.ConfigurationSpec{
+						PackageSpec: pkgv1.PackageSpec{Package: "docker.io/crossplane/configuration-foo:v0.1.0"},
+					},
+				}},
+				fns: []pkgv1.Function{{
+					ObjectMeta: metav1.ObjectMeta{Name: "f"},
+					Spec: pkgv1.FunctionSpec{
+						PackageSpec: pkgv1.PackageSpec{Package: "xpkg.crossplane.io/crossplane-contrib/function-cool:v0.5.0"},
+					},
+				}},
+			}),
+			want: want{findings: nil},
+		},
+		"UnqualifiedAndUnparseable": {
+			reason: "An unqualified reference is flagged at .spec.package; one that can't be parsed at all is flagged as unparseable. The qualified Function is left alone.",
+			client: pkgClient(pkgData{
+				provs: []pkgv1.Provider{{
+					ObjectMeta: metav1.ObjectMeta{Name: "p"},
+					Spec: pkgv1.ProviderSpec{
+						PackageSpec: pkgv1.PackageSpec{Package: "crossplane-contrib/provider-nop:v0.4.0"}, // no registry host
+					},
+				}},
+				cfgs: []pkgv1.Configuration{{
+					ObjectMeta: metav1.ObjectMeta{Name: "c"},
+					Spec: pkgv1.ConfigurationSpec{
+						PackageSpec: pkgv1.PackageSpec{Package: "NOT A VALID REF!!"}, // unparseable
+					},
+				}},
+				fns: []pkgv1.Function{{
+					ObjectMeta: metav1.ObjectMeta{Name: "f"},
+					Spec: pkgv1.FunctionSpec{
+						PackageSpec: pkgv1.PackageSpec{Package: "xpkg.crossplane.io/crossplane-contrib/function-cool:v0.5.0"},
+					},
+				}},
+			}),
+			want: want{findings: []Finding{
+				{Resource: ResourceRef{Group: pkgv1.Group, Kind: pkgv1.ProviderKind, Name: "p"}, FieldPath: ".spec.package"},
+				{Resource: ResourceRef{Group: pkgv1.Group, Kind: pkgv1.ConfigurationKind, Name: "c"}, FieldPath: ".spec.package (unparseable)"},
+			}},
+		},
+		"BareName": {
+			reason: "A bare image name with no registry host is flagged at .spec.package.",
+			client: pkgClient(pkgData{
+				provs: []pkgv1.Provider{{
+					ObjectMeta: metav1.ObjectMeta{Name: "p"},
+					Spec: pkgv1.ProviderSpec{
+						PackageSpec: pkgv1.PackageSpec{Package: "provider-nop:v0.4.0"},
+					},
+				}},
+			}),
+			want: want{findings: []Finding{
+				{Resource: ResourceRef{Group: pkgv1.Group, Kind: pkgv1.ProviderKind, Name: "p"}, FieldPath: ".spec.package"},
+			}},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			c := &UnqualifiedPackageSources{Client: tc.client}
+			got, err := c.Run(context.Background())
+			if diff := cmp.Diff(tc.want.err, err, cmpopts.EquateErrors()); diff != "" {
+				t.Errorf("\n%s\nRun(): -want error, +got error:\n%s", tc.reason, diff)
+			}
+			if diff := cmp.Diff(tc.want.findings, got, cmpopts.EquateEmpty()); diff != "" {
+				t.Errorf("\n%s\nRun(): -want, +got:\n%s", tc.reason, diff)
+			}
+		})
+	}
+}

--- a/cmd/crank/beta/upgrade/check/printer.go
+++ b/cmd/crank/beta/upgrade/check/printer.go
@@ -1,0 +1,457 @@
+/*
+Copyright 2025 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package check
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"text/tabwriter"
+	"unicode/utf8"
+
+	"github.com/fatih/color"
+	"golang.org/x/term"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/crossplane/crossplane-runtime/pkg/errors"
+)
+
+// minWrapWidth is the floor for body wrapping. Below this we skip wrapping
+// rather than emit tiny fragments.
+const minWrapWidth = 40
+
+// sidebarPrefix stamps every body line in a category section. The leading
+// spaces align body content under the "[✗] " / "[!] " badge in the header.
+const sidebarPrefix = "    │  "
+
+const sidebarClose = "    └──"
+
+// Badge glyphs for the verdict header and category lines. Each state uses the
+// same glyph in both renderers so the visual vocabulary stays consistent.
+const (
+	badgeIssue      = "[✗]"
+	badgeIncomplete = "[!]"
+	badgeInfo       = "[i]"
+	badgeOK         = "[✓]"
+)
+
+// Printer renders a Report.
+type Printer interface {
+	Print(w io.Writer, r Report) error
+}
+
+// NewPrinter returns a Printer for the named output format.
+func NewPrinter(format string) (Printer, error) {
+	switch format {
+	case "text", "":
+		return &TextPrinter{}, nil
+	case "json":
+		return &JSONPrinter{}, nil
+	default:
+		return nil, errors.Errorf("unknown output format %q", format)
+	}
+}
+
+// TextPrinter renders a Report as a kubectl-style, human-readable summary.
+type TextPrinter struct{}
+
+// Print writes the given report to the given writer.
+func (p *TextPrinter) Print(w io.Writer, r Report) error {
+	bodyWidth := detectBodyWidth(w)
+
+	// Print the header of an overall verdict badge plus a fixed
+	// "N issues, M informational, K incomplete checks." breakdown.
+	if len(r.Categories) > 0 {
+		issues, info, incomplete := summarize(r.Categories)
+		printVerdict(w, issues, info, incomplete)
+	}
+
+	for _, c := range r.Categories {
+		printCategory(w, c, bodyWidth)
+	}
+
+	return nil
+}
+
+// summarize tallies issue-severity findings, info-severity findings, and
+// incomplete checks across categories for the verdict header.
+func summarize(categories []CategoryResult) (issues, info, incomplete int) {
+	for _, c := range categories {
+		if c.Err != "" {
+			incomplete++
+		}
+		if c.Severity == SeverityInfo {
+			info += len(c.Findings)
+		} else {
+			issues += len(c.Findings)
+		}
+	}
+	return issues, info, incomplete
+}
+
+// printVerdict writes the one-line overall summary badge and breakdown.
+// Example: [✗] 23 issues, 6 informational, 1 incomplete check.
+func printVerdict(w io.Writer, issues, info, incomplete int) {
+	var badge string
+	switch {
+	case issues > 0:
+		badge = badgeIssue
+	case incomplete > 0:
+		badge = badgeIncomplete
+	case info > 0:
+		badge = badgeInfo
+	default:
+		badge = badgeOK
+	}
+	issuesFrag := color.RedString(pluralize(issues, "issue", "issues"))
+	infoFrag := color.CyanString(pluralize(info, "informational", "informational"))
+	incompleteFrag := color.YellowString(pluralize(incomplete, "incomplete check", "incomplete checks"))
+	_, _ = fmt.Fprintf(w, "%s %s, %s, %s.\n\n", badge, issuesFrag, infoFrag, incompleteFrag)
+}
+
+// printCategory writes one category section: a single confirmation line when
+// healthy, otherwise a header followed by a sidebar body of description,
+// error, fix, docs, and findings.
+func printCategory(w io.Writer, c CategoryResult, bodyWidth int) {
+	// Healthy category: render as a single confirmation line. Description
+	// / Fix / Docs are omitted intentionally - no need to give advice when
+	// there is no problem.
+	if len(c.Findings) == 0 && c.Err == "" {
+		_, _ = fmt.Fprintf(w, "%s %s\n", badgeOK, c.Title)
+		return
+	}
+
+	// An incomplete check beats findings in the badge: the findings list
+	// may be partial when the check errored, so we surface the unknown
+	// rather than imply exhaustiveness.
+	//
+	// Note that for all the printing here, we do a colored badge, no color for
+	// the category title, then color again for the number/type of findings to
+	// call special attention to them.
+	switch {
+	case c.Err != "":
+		_, _ = fmt.Fprintf(w, "%s %s - %s\n", color.YellowString(badgeIncomplete), c.Title, color.YellowString("incomplete check"))
+	case c.Severity == SeverityInfo:
+		_, _ = fmt.Fprintf(w, "%s %s - %s\n", color.CyanString(badgeInfo), c.Title, color.CyanString(pluralize(len(c.Findings), "informational finding", "informational findings")))
+	default:
+		_, _ = fmt.Fprintf(w, "%s %s - %s\n", color.RedString(badgeIssue), c.Title, color.RedString(pluralize(len(c.Findings), "issue", "issues")))
+	}
+
+	pw := newLinePrefixWriter(w, sidebarPrefix)
+	_, _ = fmt.Fprintln(pw)
+
+	// Track whether we wrote any of the description/error/fix/docs block so we
+	// can decide whether the findings table needs its own leading separator.
+	wroteBody := false
+	if c.Description != "" {
+		writeWrapped(pw, "", c.Description, bodyWidth)
+		wroteBody = true
+	}
+	if c.Err != "" {
+		writeWrapped(pw, "Error: ", c.Err, bodyWidth)
+		wroteBody = true
+	}
+	if c.Remediation != "" {
+		writeWrapped(pw, "Fix:   ", c.Remediation, bodyWidth)
+		wroteBody = true
+	}
+	if len(c.DocsURLs) > 0 {
+		// One URL per line. The first carries the "Docs:" label; subsequent
+		// lines indent under it. A single URL longer than the body width
+		// still overflows the sidebar - wrapText won't break mid-word.
+		docsIndent := strings.Repeat(" ", utf8.RuneCountInString("Docs:  "))
+		for i, u := range c.DocsURLs {
+			label := docsIndent
+			if i == 0 {
+				label = "Docs:  "
+			}
+			writeWrapped(pw, label, u, bodyWidth)
+		}
+		wroteBody = true
+	}
+
+	// print all the findings for this category, grouped by Kind so the output
+	// has a familiar kubectl get feel to it
+	if len(c.Findings) > 0 {
+		// Separate the findings table from the body above it - but only when
+		// there was a body. Without this guard, a category that has findings
+		// and nothing else would emit two blank separator lines in a row (the
+		// post-header one plus this one).
+		if wroteBody {
+			_, _ = fmt.Fprintln(pw)
+		}
+		groups := groupByKind(c.Findings)
+		for i, g := range groups {
+			if i > 0 {
+				_, _ = fmt.Fprintln(pw)
+			}
+			printKindGroup(pw, g)
+		}
+	}
+
+	_, _ = fmt.Fprintln(w, sidebarClose)
+}
+
+// linePrefixWriter prepends a constant prefix to each line written through it,
+// e.g. category sections that need a consistent left-edge sidebar.
+//
+// Used as an io.Writer middleware: callers can either write to it directly
+// or wrap it with another writer, in either case every new line written
+// will contain the prefix.
+type linePrefixWriter struct {
+	w           io.Writer
+	prefix      string
+	atLineStart bool
+}
+
+func newLinePrefixWriter(w io.Writer, prefix string) *linePrefixWriter {
+	return &linePrefixWriter{w: w, prefix: prefix, atLineStart: true}
+}
+
+// Write writes the given bytes, prepending the configured prefix to each new
+// line so callers get a consistent left-edge sidebar without having to thread
+// the prefix through every Fprint call.
+func (lw *linePrefixWriter) Write(p []byte) (int, error) {
+	written := 0
+	// Process the given bytes one line at a time so we can stamp the prefix at
+	// the start of each new line.
+	for len(p) > 0 {
+		if lw.atLineStart {
+			// We're at the start of a new line, so emit the prefix now. When
+			// the line has no content (its first byte is the newline), emit the
+			// prefix with its trailing spaces trimmed: the sidebar bar still
+			// continues, but we don't leave trailing whitespace on a blank line.
+			prefix := lw.prefix
+			if p[0] == '\n' {
+				prefix = strings.TrimRight(prefix, " ")
+			}
+			if _, err := io.WriteString(lw.w, prefix); err != nil {
+				return written, err
+			}
+			lw.atLineStart = false
+		}
+
+		nextNewline := bytes.IndexByte(p, '\n')
+		if nextNewline < 0 {
+			// No newlines left in p, flush the rest now
+			n, err := lw.w.Write(p)
+			return written + n, err
+		}
+
+		// Write up to (and including) the next newline
+		n, err := lw.w.Write(p[:nextNewline+1])
+		written += n
+		if err != nil {
+			return written, err
+		}
+
+		// We're at a newline now, set the atLineStart flag again
+		p = p[nextNewline+1:]
+		lw.atLineStart = true
+	}
+	return written, nil
+}
+
+// groupByKind partitions findings into sub-slices that share the same
+// Group+Kind, preserving the order in which kinds were first seen.
+func groupByKind(findings []Finding) [][]Finding {
+	seen := map[string]int{}
+	out := [][]Finding{}
+	for _, f := range findings {
+		key := f.Resource.Group + "|" + f.Resource.Kind
+		if i, ok := seen[key]; ok {
+			// this finding belongs to a kind we've already seen, append it to
+			// the existing list for its kind
+			out[i] = append(out[i], f)
+			continue
+		}
+
+		// we haven't seen this finding's kind yet, start a new list for its kind
+		seen[key] = len(out)
+		out = append(out, []Finding{f})
+	}
+	return out
+}
+
+func printKindGroup(w io.Writer, g []Finding) {
+	// determine if this group is for namespaced resources or not
+	namespaced := false
+	for _, f := range g {
+		if f.Resource.Namespace != "" {
+			namespaced = true
+			break
+		}
+	}
+
+	const padding = 3 // space between columns
+	tw := tabwriter.NewWriter(w, 0, 4, padding, ' ', 0)
+
+	// print the column headers
+	if namespaced {
+		_, _ = fmt.Fprintln(tw, "  NAMESPACE\tNAME\tFIELD")
+	} else {
+		_, _ = fmt.Fprintln(tw, "  NAME\tFIELD")
+	}
+
+	for _, f := range g {
+		// print the name of each resource in a kind.group/name style similar to kubectl
+		gk := schema.GroupKind{Group: f.Resource.Group, Kind: strings.ToLower(f.Resource.Kind)}
+		name := gk.String() + "/" + f.Resource.Name
+
+		field := f.FieldPath
+		if field == "" {
+			// no field path to include, just use "-"
+			field = "-"
+		}
+		if namespaced {
+			ns := f.Resource.Namespace
+			if ns == "" {
+				// no namespace to include, just use "-"
+				ns = "-"
+			}
+			_, _ = fmt.Fprintf(tw, "  %s\t%s\t%s\n", ns, name, field)
+		} else {
+			_, _ = fmt.Fprintf(tw, "  %s\t%s\n", name, field)
+		}
+	}
+	_ = tw.Flush()
+}
+
+func pluralize(n int, singular, plural string) string {
+	if n == 1 {
+		return fmt.Sprintf("%d %s", n, singular)
+	}
+	return fmt.Sprintf("%d %s", n, plural)
+}
+
+// detectBodyWidth returns the column width available for wrapped body lines
+// (terminal width minus sidebar prefix). Returns 0 when the output isn't a
+// terminal, so long lines stay intact for grep and other downstream tools.
+func detectBodyWidth(w io.Writer) int {
+	f, ok := w.(*os.File)
+	if !ok {
+		return 0
+	}
+	cols, _, err := term.GetSize(int(f.Fd()))
+	if err != nil {
+		return 0
+	}
+	cols -= utf8.RuneCountInString(sidebarPrefix)
+	if cols < minWrapWidth {
+		return 0
+	}
+	return cols
+}
+
+// writeWrapped writes label followed by body, word-wrapping body to maxWidth
+// columns and indenting continuation lines under the label. maxWidth <= 0
+// disables wrapping.
+func writeWrapped(w io.Writer, label, body string, maxWidth int) {
+	if maxWidth <= 0 {
+		// wrapping is disabled, just print with no wrapping
+		_, _ = fmt.Fprintf(w, "%s%s\n", label, body)
+		return
+	}
+	labelLen := utf8.RuneCountInString(label)
+	contentWidth := maxWidth - labelLen
+	if contentWidth < minWrapWidth {
+		// the content isn't wide enough to bother wrapping it, print with no wrapping
+		_, _ = fmt.Fprintf(w, "%s%s\n", label, body)
+		return
+	}
+
+	// wrap the entire body to the given width now, which will give us a set of lines
+	lines := wrapText(body, contentWidth)
+	if len(lines) == 0 {
+		// no lines at all, just print the label and we're done
+		_, _ = fmt.Fprintln(w, label)
+		return
+	}
+
+	// print the first line with the label prefixed
+	_, _ = fmt.Fprintln(w, label+lines[0])
+
+	// print the rest of the lines with an indentation the same length as the
+	// label so they all line up nicely
+	indent := strings.Repeat(" ", labelLen)
+	for _, l := range lines[1:] {
+		_, _ = fmt.Fprintln(w, indent+l)
+	}
+}
+
+// wrapText word-wraps s into lines no wider than maxWidth runes. Words longer
+// than maxWidth (typically URLs like docs links) go on their own line and
+// overflow rather than break - a broken URL is worse than one that wraps.
+func wrapText(s string, maxWidth int) []string {
+	// break the string up into words first
+	words := strings.Fields(s)
+	if len(words) == 0 {
+		return nil
+	}
+
+	var lines []string
+	var curLine strings.Builder
+	curLen := 0
+
+	for _, word := range words {
+		wordLen := utf8.RuneCountInString(word)
+
+		switch {
+		case curLen == 0:
+			// nothing on the current line yet, add the entire word - we never
+			// break a word apart
+			curLine.WriteString(word)
+			curLen = wordLen
+
+		case curLen+1+wordLen > maxWidth:
+			// adding the word to the current line would be too long, save the
+			// current line to the output slice, reset the current line builder,
+			// then add the word
+			lines = append(lines, curLine.String())
+			curLine.Reset()
+			curLine.WriteString(word)
+			curLen = wordLen
+
+		default:
+			// there's room for the word, add it to the current line with a
+			// space before it
+			curLine.WriteByte(' ')
+			curLine.WriteString(word)
+			curLen += 1 + wordLen
+		}
+	}
+
+	if curLen > 0 {
+		// add the last straggler line to the output slice
+		lines = append(lines, curLine.String())
+	}
+	return lines
+}
+
+// JSONPrinter emits the report as pretty-printed JSON. This is much more simple
+// than all the text formatting logic in the TextPrinter approach.
+type JSONPrinter struct{}
+
+// Print writes a report to the given writer using JSON encoding.
+func (p *JSONPrinter) Print(w io.Writer, r Report) error {
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	return enc.Encode(r)
+}

--- a/cmd/crank/beta/upgrade/check/printer_test.go
+++ b/cmd/crank/beta/upgrade/check/printer_test.go
@@ -1,0 +1,450 @@
+/*
+Copyright 2025 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package check
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/fatih/color"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+)
+
+func TestNewPrinter(t *testing.T) {
+	type want struct {
+		printer Printer
+		err     error
+	}
+	cases := map[string]struct {
+		reason string
+		format string
+		want   want
+	}{
+		"Text":    {reason: "\"text\" yields a TextPrinter.", format: "text", want: want{printer: &TextPrinter{}}},
+		"Empty":   {reason: "An empty format defaults to text.", format: "", want: want{printer: &TextPrinter{}}},
+		"JSON":    {reason: "\"json\" yields a JSONPrinter.", format: "json", want: want{printer: &JSONPrinter{}}},
+		"Unknown": {reason: "An unknown format is an error.", format: "yaml", want: want{err: cmpopts.AnyError}},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			p, err := NewPrinter(tc.format)
+			if diff := cmp.Diff(tc.want.err, err, cmpopts.EquateErrors()); diff != "" {
+				t.Errorf("\n%s\nNewPrinter(): -want error, +got error:\n%s", tc.reason, diff)
+			}
+			if diff := cmp.Diff(tc.want.printer, p); diff != "" {
+				t.Errorf("\n%s\nNewPrinter(): -want, +got:\n%s", tc.reason, diff)
+			}
+		})
+	}
+}
+
+func TestJSONPrinterRoundTrip(t *testing.T) {
+	report := Report{Categories: []CategoryResult{
+		{
+			Category:    "native-patch-and-transform",
+			Title:       "Native patch-and-transform Compositions",
+			Severity:    SeverityIssue,
+			Description: "desc",
+			Remediation: "fix",
+			DocsURLs:    []string{"https://example.com"},
+			Findings: []Finding{
+				{Resource: ResourceRef{Group: "g", Kind: "K", Namespace: "ns", Name: "n"}, FieldPath: ".spec.mode"},
+			},
+		},
+		{Category: "incomplete", Severity: SeverityIssue, Description: "d", Err: "boom"},
+	}}
+
+	var buf bytes.Buffer
+	if err := (&JSONPrinter{}).Print(&buf, report); err != nil {
+		t.Fatalf("Print() unexpected error: %v", err)
+	}
+
+	got := Report{}
+	if err := json.Unmarshal(buf.Bytes(), &got); err != nil {
+		t.Fatalf("decoding printed JSON: %v", err)
+	}
+	if diff := cmp.Diff(report, got); diff != "" {
+		t.Errorf("\nJSONPrinter round-trips the report unchanged: -want, +got:\n%s", diff)
+	}
+}
+
+func TestWrapText(t *testing.T) {
+	cases := map[string]struct {
+		reason   string
+		s        string
+		maxWidth int
+		want     []string
+	}{
+		"Empty": {
+			reason:   "An empty string yields no lines.",
+			s:        "",
+			maxWidth: 10,
+			want:     nil,
+		},
+		"SingleWord": {
+			reason:   "A word shorter than the width stays on one line.",
+			s:        "hello",
+			maxWidth: 10,
+			want:     []string{"hello"},
+		},
+		"WrapsAtWidth": {
+			reason:   "Words wrap once the line would exceed the width.",
+			s:        "alpha beta gamma",
+			maxWidth: 10,
+			want:     []string{"alpha beta", "gamma"},
+		},
+		"LongWordOverflow": {
+			reason:   "A word longer than the width gets its own line rather than being broken.",
+			s:        "hi supercalifragilistic",
+			maxWidth: 10,
+			want:     []string{"hi", "supercalifragilistic"},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got := wrapText(tc.s, tc.maxWidth)
+			if diff := cmp.Diff(tc.want, got, cmpopts.EquateEmpty()); diff != "" {
+				t.Errorf("\n%s\nwrapText(): -want, +got:\n%s", tc.reason, diff)
+			}
+		})
+	}
+}
+
+func TestWriteWrapped(t *testing.T) {
+	// Each word is 9 runes, so word + 1 space = 10. The wrap widths below are
+	// multiples of 10 (contentWidth 40), so it's a clean 4 words per line with
+	// the break landing at exactly 39 - no off-by-one math when writing wants.
+	const body = "wordnine1 wordnine2 wordnine3 wordnine4 wordnine5"
+
+	cases := map[string]struct {
+		reason   string
+		label    string
+		body     string
+		maxWidth int
+		want     string
+	}{
+		"WrappingDisabled": {
+			reason:   "A non-positive width prints label+body verbatim on one line.",
+			label:    "Fix:   ",
+			body:     body,
+			maxWidth: 0,
+			want:     "Fix:   " + body + "\n",
+		},
+		"NarrowContentNotWrapped": {
+			reason: "When the content column is narrower than the wrap floor, the body is printed unwrapped.",
+			label:  "Fix:   ",
+			body:   body,
+			// After the label (7 chars) there are only 13 columns left for the body, which is below
+			// the 40-column wrap floor (minWrapWidth), so the body is printed whole instead of wrapped.
+			maxWidth: 20,
+			want:     "Fix:   " + body + "\n",
+		},
+		"WrapsWithoutLabel": {
+			reason:   "With no label, the body wraps at the given width and no indent on subsequent lines.",
+			label:    "",
+			body:     body,
+			maxWidth: 40,
+			want:     "wordnine1 wordnine2 wordnine3 wordnine4\nwordnine5\n",
+		},
+		"WrapsWithLabelIndent": {
+			reason:   "Continuation lines indent under the label.",
+			label:    "Fix:   ", // 7 runes; contentWidth 40
+			body:     body,
+			maxWidth: 47, // 7 (label) + 40 content width: wraps at the same 40 cols as the no-label case, isolating the indent
+			want:     "Fix:   wordnine1 wordnine2 wordnine3 wordnine4\n       wordnine5\n",
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			var buf bytes.Buffer
+			writeWrapped(&buf, tc.label, tc.body, tc.maxWidth)
+			if diff := cmp.Diff(tc.want, buf.String()); diff != "" {
+				t.Errorf("\n%s\nwriteWrapped(): -want, +got:\n%s", tc.reason, diff)
+			}
+		})
+	}
+}
+
+func TestGroupByKind(t *testing.T) {
+	// Names encode each finding's Group+Kind: g1A1 and g1A2 share Group+Kind
+	// (g1/A) and differ only by name; g1B differs by Kind; g2A is the same Kind
+	// as the g1/A pair but a different Group, so it must not merge with them.
+	g1A1 := Finding{Resource: ResourceRef{Group: "g1", Kind: "A", Name: "a1"}}
+	g1A2 := Finding{Resource: ResourceRef{Group: "g1", Kind: "A", Name: "a2"}}
+	g1B := Finding{Resource: ResourceRef{Group: "g1", Kind: "B", Name: "b"}}
+	g2A := Finding{Resource: ResourceRef{Group: "g2", Kind: "A", Name: "a"}}
+
+	cases := map[string]struct {
+		reason   string
+		findings []Finding
+		want     [][]Finding
+	}{
+		"Empty": {
+			reason:   "No findings yields no groups.",
+			findings: nil,
+			want:     nil,
+		},
+		"MergesSameGroupKind": {
+			reason:   "Findings sharing a Group+Kind collapse into one group.",
+			findings: []Finding{g1A1, g1A2},
+			want:     [][]Finding{{g1A1, g1A2}},
+		},
+		"SeparatesSameKindDifferentGroup": {
+			reason:   "A matching Kind under a different Group is its own group.",
+			findings: []Finding{g1A1, g2A},
+			want:     [][]Finding{{g1A1}, {g2A}},
+		},
+		"PreservesFirstSeenOrder": {
+			reason:   "Groups appear in the order each Group+Kind was first seen, even when members are interleaved.",
+			findings: []Finding{g1A1, g1B, g1A2, g2A},
+			want:     [][]Finding{{g1A1, g1A2}, {g1B}, {g2A}},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got := groupByKind(tc.findings)
+			if diff := cmp.Diff(tc.want, got, cmpopts.EquateEmpty()); diff != "" {
+				t.Errorf("\n%s\ngroupByKind(): -want, +got:\n%s", tc.reason, diff)
+			}
+		})
+	}
+}
+
+func TestSummarize(t *testing.T) {
+	cases := map[string]struct {
+		reason     string
+		categories []CategoryResult
+		want       []int // [issues, info, incomplete]
+	}{
+		"Empty": {
+			reason:     "No categories tallies to all zeros.",
+			categories: nil,
+			want:       []int{0, 0, 0},
+		},
+		"CountsIssues": {
+			reason:     "Findings in a severity issue category count as issues.",
+			categories: []CategoryResult{{Severity: SeverityIssue, Findings: []Finding{{}, {}}}},
+			want:       []int{2, 0, 0},
+		},
+		"CountsInfo": {
+			reason:     "Findings in an severity info category count as informational, not issues.",
+			categories: []CategoryResult{{Severity: SeverityInfo, Findings: []Finding{{}, {}, {}}}},
+			want:       []int{0, 3, 0},
+		},
+		"CountsIncomplete": {
+			reason:     "A category that errored counts as one incomplete check.",
+			categories: []CategoryResult{{Severity: SeverityIssue, Err: "boom"}},
+			want:       []int{0, 0, 1},
+		},
+		"ErrWithFindingsCountsBoth": {
+			reason:     "A category with both an error and findings is counted as incomplete but still has its findings tallied.",
+			categories: []CategoryResult{{Severity: SeverityIssue, Err: "boom", Findings: []Finding{{}, {}}}},
+			want:       []int{2, 0, 1},
+		},
+		"Mixed": {
+			reason: "Issue, info, and incomplete tallies accumulate independently across categories.",
+			categories: []CategoryResult{
+				{Severity: SeverityIssue, Findings: []Finding{{}, {}}},
+				{Severity: SeverityInfo, Findings: []Finding{{}, {}, {}}},
+				{Severity: SeverityIssue, Err: "boom"},
+			},
+			want: []int{2, 3, 1},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			issues, info, incomplete := summarize(tc.categories)
+			got := []int{issues, info, incomplete}
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("\n%s\nsummarize() tallies [issues, info, incomplete]: -want, +got:\n%s", tc.reason, diff)
+			}
+		})
+	}
+}
+
+func TestPluralize(t *testing.T) {
+	cases := map[string]struct {
+		reason string
+		n      int
+		want   string
+	}{
+		"Zero": {reason: "Zero uses the plural form.", n: 0, want: "0 issues"},
+		"One":  {reason: "One uses the singular form.", n: 1, want: "1 issue"},
+		"Many": {reason: "More than one uses the plural form.", n: 3, want: "3 issues"},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got := pluralize(tc.n, "issue", "issues")
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("\n%s\npluralize(): -want, +got:\n%s", tc.reason, diff)
+			}
+		})
+	}
+}
+
+func TestLinePrefixWriter(t *testing.T) {
+	cases := map[string]struct {
+		reason string
+		writes []string
+		want   string
+	}{
+		"MultiLineSingleWrite": {
+			reason: "Each line written in one call gets the prefix; no trailing prefix after a final newline-less segment.",
+			writes: []string{"a\nb"},
+			want:   "> a\n> b",
+		},
+		"TrailingNewline": {
+			reason: "A trailing newline does not eagerly emit a prefix for a line not yet started.",
+			writes: []string{"a\nb\n"},
+			want:   "> a\n> b\n",
+		},
+		"SplitWrites": {
+			reason: "A line split across multiple Write calls still gets exactly one prefix; the prefix is not re-emitted mid-line.",
+			writes: []string{"a", "b\n"},
+			want:   "> ab\n",
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			var buf bytes.Buffer
+			lw := newLinePrefixWriter(&buf, "> ")
+			for _, w := range tc.writes {
+				if _, err := lw.Write([]byte(w)); err != nil {
+					t.Fatalf("Write() unexpected error: %v", err)
+				}
+			}
+			if diff := cmp.Diff(tc.want, buf.String()); diff != "" {
+				t.Errorf("\n%s\nlinePrefixWriter.Write(): -want, +got:\n%s", tc.reason, diff)
+			}
+		})
+	}
+}
+
+func TestTextPrinter(t *testing.T) {
+	// Pin colors off so the output is plain text. A bytes.Buffer also disables
+	// wrapping (detectBodyWidth returns 0 for a non-*os.File writer), keeping
+	// the layout deterministic.
+	defer func(prev bool) { color.NoColor = prev }(color.NoColor)
+	color.NoColor = true
+
+	type want struct {
+		output string
+		err    error
+	}
+	cases := map[string]struct {
+		reason string
+		report Report
+		want   want
+	}{
+		"Empty": {
+			reason: "An empty report prints nothing - no verdict line, no categories.",
+			report: Report{},
+			want:   want{output: ""},
+		},
+		"MixedReport": {
+			reason: "A healthy category is a single confirmation line; issue/info/incomplete categories render a sidebar body with description, fix, docs, and findings.",
+			report: Report{Categories: []CategoryResult{
+				{
+					Category: "ok",
+					Title:    "Healthy check",
+				},
+				{
+					Category: "issue", Title: "Issue check", Severity: SeverityIssue,
+					Description: "Something is wrong.",
+					Remediation: "Fix it.",
+					DocsURLs:    []string{"https://docs.example.com/page"},
+					Findings: []Finding{
+						{Resource: ResourceRef{Group: "example.org", Kind: "Thing", Name: "n"}, FieldPath: ".spec.x"},
+					},
+				},
+				{
+					Category: "info", Title: "Info check", Severity: SeverityInfo,
+					Findings: []Finding{{Resource: ResourceRef{Group: "example.org", Kind: "Thing", Name: "m"}}},
+				},
+				{
+					Category: "incomplete",
+					Title:    "Incomplete check",
+					Severity: SeverityIssue, Err: "it broke",
+				},
+			}},
+			want: want{output: `[✗] 1 issue, 1 informational, 1 incomplete check.
+
+[✓] Healthy check
+[✗] Issue check - 1 issue
+    │
+    │  Something is wrong.
+    │  Fix:   Fix it.
+    │  Docs:  https://docs.example.com/page
+    │
+    │    NAME                  FIELD
+    │    thing.example.org/n   .spec.x
+    └──
+[i] Info check - 1 informational finding
+    │
+    │    NAME                  FIELD
+    │    thing.example.org/m   -
+    └──
+[!] Incomplete check - incomplete check
+    │
+    │  Error: it broke
+    └──
+`},
+		},
+		"NamespacedFindings": {
+			reason: "Findings with a namespace render a NAMESPACE column; a finding missing a namespace or field path renders \"-\".",
+			report: Report{Categories: []CategoryResult{
+				{
+					Category: "ess", Title: "Namespaced check", Severity: SeverityIssue,
+					Findings: []Finding{
+						{Resource: ResourceRef{Group: "example.org", Kind: "Thing", Namespace: "team-a", Name: "n"}, FieldPath: ".spec.x"},
+						{Resource: ResourceRef{Group: "example.org", Kind: "Thing", Name: "no-ns"}},
+					},
+				},
+			}},
+			want: want{output: `[✗] 2 issues, 0 informational, 0 incomplete checks.
+
+[✗] Namespaced check - 2 issues
+    │
+    │    NAMESPACE   NAME                      FIELD
+    │    team-a      thing.example.org/n       .spec.x
+    │    -           thing.example.org/no-ns   -
+    └──
+`},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			var buf bytes.Buffer
+			err := (&TextPrinter{}).Print(&buf, tc.report)
+			if diff := cmp.Diff(tc.want.err, err, cmpopts.EquateErrors()); diff != "" {
+				t.Errorf("\n%s\nPrint(): -want error, +got error:\n%s", tc.reason, diff)
+			}
+			if diff := cmp.Diff(tc.want.output, buf.String()); diff != "" {
+				t.Errorf("\n%s\nPrint(): -want, +got:\n%s", tc.reason, diff)
+			}
+		})
+	}
+}

--- a/cmd/crank/beta/upgrade/check/resources.go
+++ b/cmd/crank/beta/upgrade/check/resources.go
@@ -1,0 +1,175 @@
+/*
+Copyright 2025 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package check
+
+import (
+	"context"
+	"slices"
+
+	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	apiextensionsv1 "github.com/crossplane/crossplane/apis/apiextensions/v1"
+)
+
+// managedResourceCategory is the CRD category every Crossplane provider
+// applies to its managed resource CRDs.
+const managedResourceCategory = "managed"
+
+// DiscoveredType is an instance type of note that has been discovered on the control plane. The
+// sources for these types are XRs, Claims, and MRs.
+type DiscoveredType struct {
+	GVK        schema.GroupVersionKind
+	Namespaced bool
+}
+
+// DiscoverXRAndClaimTypes returns the GVKs of every XR and Claim type defined by
+// an XRD on the cluster. Prefers each XRD's referenceable version, falling
+// back to the first served one. The caller can optionally supply a list of XRDs
+// if they have already fetched them, if the caller does not provide this list
+// then this function will make the List call to fetch them.
+func DiscoverXRAndClaimTypes(ctx context.Context, c client.Client, xrds *apiextensionsv1.CompositeResourceDefinitionList) ([]DiscoveredType, error) {
+	if xrds == nil {
+		// the caller has not supplied a pre-fetched list of XRDs, fetch them now
+		xrds = &apiextensionsv1.CompositeResourceDefinitionList{}
+		if err := c.List(ctx, xrds); err != nil {
+			return nil, err
+		}
+	}
+
+	types := make([]DiscoveredType, 0, len(xrds.Items)*2)
+	for _, xrd := range xrds.Items {
+		v := pickVersion(xrd)
+		if v == "" {
+			continue
+		}
+		types = append(types, DiscoveredType{
+			GVK:        schema.GroupVersionKind{Group: xrd.Spec.Group, Version: v, Kind: xrd.Spec.Names.Kind},
+			Namespaced: false,
+		})
+		if xrd.Spec.ClaimNames != nil {
+			types = append(types, DiscoveredType{
+				GVK:        schema.GroupVersionKind{Group: xrd.Spec.Group, Version: v, Kind: xrd.Spec.ClaimNames.Kind},
+				Namespaced: true,
+			})
+		}
+	}
+	return types, nil
+}
+
+// pickVersion returns the XRD version to list instances against. Must be a
+// served version - the apiserver silently returns nothing for non-served
+// versions, which would hide resources from the check. Returns "" if no
+// served version exists.
+func pickVersion(xrd apiextensionsv1.CompositeResourceDefinition) string {
+	// prefer the referenceable/served version
+	for _, v := range xrd.Spec.Versions {
+		if v.Referenceable && v.Served {
+			return v.Name
+		}
+	}
+
+	// we didn't find a referenceable version, fall back to the first served version
+	for _, v := range xrd.Spec.Versions {
+		if v.Served {
+			return v.Name
+		}
+	}
+
+	return ""
+}
+
+// ListInstances lists instances of the given discovered type. For namespaced types, a non-empty
+// namespace restricts the list; empty lists across all namespaces. The namespace argument is
+// ignored for cluster-scoped types.
+func ListInstances(ctx context.Context, c client.Client, t DiscoveredType, namespace string) ([]unstructured.Unstructured, error) {
+	listGVK := t.GVK
+	listGVK.Kind += "List"
+
+	u := &unstructured.UnstructuredList{}
+	u.SetGroupVersionKind(listGVK)
+	var opts []client.ListOption
+	if t.Namespaced && namespace != "" {
+		opts = append(opts, client.InNamespace(namespace))
+	}
+	if err := c.List(ctx, u, opts...); err != nil {
+		return nil, err
+	}
+	return u.Items, nil
+}
+
+// DiscoverManagedResources returns the GVKs of every CRD in the "managed"
+// category, preferring each CRD's storage version and falling back to its
+// first served version.
+func DiscoverManagedResources(ctx context.Context, c client.Client) ([]DiscoveredType, error) {
+	crds := &extv1.CustomResourceDefinitionList{}
+	if err := c.List(ctx, crds); err != nil {
+		return nil, err
+	}
+	types := make([]DiscoveredType, 0, len(crds.Items))
+	for i := range crds.Items {
+		crd := &crds.Items[i]
+		if !slices.Contains(crd.Spec.Names.Categories, managedResourceCategory) {
+			// not in the "managed" category, skip it
+			continue
+		}
+		v := pickCRDVersion(crd)
+		if v == "" {
+			continue
+		}
+		types = append(types, DiscoveredType{
+			GVK: schema.GroupVersionKind{
+				Group:   crd.Spec.Group,
+				Version: v,
+				Kind:    crd.Spec.Names.Kind,
+			},
+			Namespaced: crd.Spec.Scope == extv1.NamespaceScoped,
+		})
+	}
+	return types, nil
+}
+
+// pickCRDVersion returns the CRD version to list instances against. Must be
+// a served version (see pickVersion). Returns "" if no served version exists.
+func pickCRDVersion(crd *extv1.CustomResourceDefinition) string {
+	// prefer the storage/served version
+	for _, v := range crd.Spec.Versions {
+		if v.Storage && v.Served {
+			return v.Name
+		}
+	}
+
+	// fall back to first served version
+	for _, v := range crd.Spec.Versions {
+		if v.Served {
+			return v.Name
+		}
+	}
+	return ""
+}
+
+// ResourceRefFromUnstructured builds a ResourceRef from an unstructured object.
+func ResourceRefFromUnstructured(u unstructured.Unstructured) ResourceRef {
+	return ResourceRef{
+		Group:     u.GroupVersionKind().Group,
+		Kind:      u.GetKind(),
+		Namespace: u.GetNamespace(),
+		Name:      u.GetName(),
+	}
+}

--- a/cmd/crank/beta/upgrade/check/resources.go
+++ b/cmd/crank/beta/upgrade/check/resources.go
@@ -55,7 +55,7 @@ func DiscoverXRAndClaimTypes(ctx context.Context, c client.Client, xrds *apiexte
 
 	types := make([]DiscoveredType, 0, len(xrds.Items)*2)
 	for _, xrd := range xrds.Items {
-		v := pickVersion(xrd)
+		v := pickXRDVersion(xrd)
 		if v == "" {
 			continue
 		}
@@ -73,11 +73,11 @@ func DiscoverXRAndClaimTypes(ctx context.Context, c client.Client, xrds *apiexte
 	return types, nil
 }
 
-// pickVersion returns the XRD version to list instances against. Must be a
+// pickXRDVersion returns the XRD version to list instances against. Must be a
 // served version - the apiserver silently returns nothing for non-served
 // versions, which would hide resources from the check. Returns "" if no
 // served version exists.
-func pickVersion(xrd apiextensionsv1.CompositeResourceDefinition) string {
+func pickXRDVersion(xrd apiextensionsv1.CompositeResourceDefinition) string {
 	// prefer the referenceable/served version
 	for _, v := range xrd.Spec.Versions {
 		if v.Referenceable && v.Served {

--- a/cmd/crank/beta/upgrade/check/resources_test.go
+++ b/cmd/crank/beta/upgrade/check/resources_test.go
@@ -1,0 +1,420 @@
+/*
+Copyright 2025 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package check
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/crossplane/crossplane-runtime/pkg/test"
+
+	apiextensionsv1 "github.com/crossplane/crossplane/apis/apiextensions/v1"
+)
+
+func TestPickXRDVersion(t *testing.T) {
+	type want struct {
+		version string
+	}
+	cases := map[string]struct {
+		reason string
+		xrd    apiextensionsv1.CompositeResourceDefinition
+		want   want
+	}{
+		"PrefersReferenceableServed": {
+			reason: "The referenceable and served version wins over other served versions.",
+			xrd: apiextensionsv1.CompositeResourceDefinition{Spec: apiextensionsv1.CompositeResourceDefinitionSpec{
+				Versions: []apiextensionsv1.CompositeResourceDefinitionVersion{
+					{Name: "v1alpha1", Served: true, Referenceable: false},
+					{Name: "v1", Served: true, Referenceable: true},
+				},
+			}},
+			want: want{version: "v1"},
+		},
+		"FallsBackToFirstServed": {
+			reason: "With no referenceable version, the first served version is used.",
+			xrd: apiextensionsv1.CompositeResourceDefinition{Spec: apiextensionsv1.CompositeResourceDefinitionSpec{
+				Versions: []apiextensionsv1.CompositeResourceDefinitionVersion{
+					{Name: "v1alpha1", Served: false},
+					{Name: "v1beta1", Served: true},
+				},
+			}},
+			want: want{version: "v1beta1"},
+		},
+		"NoneServed": {
+			reason: "When nothing is served there is no version to list against.",
+			xrd: apiextensionsv1.CompositeResourceDefinition{Spec: apiextensionsv1.CompositeResourceDefinitionSpec{
+				Versions: []apiextensionsv1.CompositeResourceDefinitionVersion{{Name: "v1", Served: false}},
+			}},
+			want: want{version: ""},
+		},
+		"ReferenceableButNotServedIsSkipped": {
+			reason: "A referenceable-but-unserved version is ignored in favor of a served one.",
+			xrd: apiextensionsv1.CompositeResourceDefinition{Spec: apiextensionsv1.CompositeResourceDefinitionSpec{
+				Versions: []apiextensionsv1.CompositeResourceDefinitionVersion{
+					{Name: "v1", Served: false, Referenceable: true},
+					{Name: "v2", Served: true, Referenceable: false},
+				},
+			}},
+			want: want{version: "v2"},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got := pickXRDVersion(tc.xrd)
+			if diff := cmp.Diff(tc.want.version, got); diff != "" {
+				t.Errorf("\n%s\npickVersion(): -want, +got:\n%s", tc.reason, diff)
+			}
+		})
+	}
+}
+
+func TestPickCRDVersion(t *testing.T) {
+	type want struct {
+		version string
+	}
+	cases := map[string]struct {
+		reason string
+		crd    extv1.CustomResourceDefinition
+		want   want
+	}{
+		"PrefersStorageServed": {
+			reason: "The storage+served version wins.",
+			crd: extv1.CustomResourceDefinition{Spec: extv1.CustomResourceDefinitionSpec{
+				Versions: []extv1.CustomResourceDefinitionVersion{
+					{Name: "v1beta1", Served: true, Storage: false},
+					{Name: "v1", Served: true, Storage: true},
+				},
+			}},
+			want: want{version: "v1"},
+		},
+		"FallsBackToFirstServed": {
+			reason: "With no storage version served, the first served version is used.",
+			crd: extv1.CustomResourceDefinition{Spec: extv1.CustomResourceDefinitionSpec{
+				Versions: []extv1.CustomResourceDefinitionVersion{
+					{Name: "v1alpha1", Served: false, Storage: true},
+					{Name: "v1beta1", Served: true, Storage: false},
+				},
+			}},
+			want: want{version: "v1beta1"},
+		},
+		"NoneServed": {
+			reason: "No served version means no version to list against.",
+			crd: extv1.CustomResourceDefinition{Spec: extv1.CustomResourceDefinitionSpec{
+				Versions: []extv1.CustomResourceDefinitionVersion{{Name: "v1", Served: false, Storage: true}},
+			}},
+			want: want{version: ""},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got := pickCRDVersion(&tc.crd)
+			if diff := cmp.Diff(tc.want.version, got); diff != "" {
+				t.Errorf("\n%s\npickCRDVersion(): -want, +got:\n%s", tc.reason, diff)
+			}
+		})
+	}
+}
+
+func xrd(group, kind, version string, claimKind string) apiextensionsv1.CompositeResourceDefinition {
+	x := apiextensionsv1.CompositeResourceDefinition{}
+	x.Spec.Group = group
+	x.Spec.Names = extv1.CustomResourceDefinitionNames{Kind: kind}
+	x.Spec.Versions = []apiextensionsv1.CompositeResourceDefinitionVersion{
+		{Name: version, Served: true, Referenceable: true},
+	}
+	if claimKind != "" {
+		x.Spec.ClaimNames = &extv1.CustomResourceDefinitionNames{Kind: claimKind}
+	}
+	return x
+}
+
+func TestDiscoverXRAndClaimTypes(t *testing.T) {
+	type want struct {
+		types []DiscoveredType
+		err   error
+	}
+	cases := map[string]struct {
+		reason string
+		client client.Client
+		xrds   *apiextensionsv1.CompositeResourceDefinitionList
+		want   want
+	}{
+		"UseExistingXRDsIfSupplied": {
+			reason: "When the caller passes an XRD list, the function should use that instead of doing a list.",
+			client: &test.MockClient{MockList: test.NewMockListFn(nil, func(_ client.ObjectList) error {
+				return errBoom // we should not hit this list call
+			})},
+			xrds: &apiextensionsv1.CompositeResourceDefinitionList{Items: []apiextensionsv1.CompositeResourceDefinition{
+				xrd("example.org", "XThing", "v1", "Thing"),
+			}},
+			want: want{types: []DiscoveredType{
+				// both the XR and Claim type should be returned
+				{GVK: schema.GroupVersionKind{Group: "example.org", Version: "v1", Kind: "XThing"}, Namespaced: false},
+				{GVK: schema.GroupVersionKind{Group: "example.org", Version: "v1", Kind: "Thing"}, Namespaced: true},
+			}},
+		},
+		"FetchesWhenXRDsNotSupplied": {
+			reason: "When the caller passes no XRD list, the function lists them itself.",
+			client: &test.MockClient{MockList: test.NewMockListFn(nil, func(o client.ObjectList) error {
+				o.(*apiextensionsv1.CompositeResourceDefinitionList).Items = []apiextensionsv1.CompositeResourceDefinition{
+					xrd("example.org", "XThing", "v1", ""),
+				}
+				return nil
+			})},
+			xrds: nil,
+			want: want{types: []DiscoveredType{
+				{GVK: schema.GroupVersionKind{Group: "example.org", Version: "v1", Kind: "XThing"}, Namespaced: false},
+			}},
+		},
+		"ListError": {
+			reason: "With no XRD list supplied, the function lists XRDs itself; a failure of that List is propagated to the caller.",
+			client: &test.MockClient{MockList: test.NewMockListFn(errBoom)},
+			xrds:   nil,
+			want:   want{err: cmpopts.AnyError},
+		},
+		"XRAndClaim": {
+			reason: "An XRD with claim names yields both a cluster-scoped XR type and a namespaced Claim type.",
+			client: &test.MockClient{MockList: test.NewMockListFn(nil, func(o client.ObjectList) error {
+				o.(*apiextensionsv1.CompositeResourceDefinitionList).Items = []apiextensionsv1.CompositeResourceDefinition{
+					xrd("example.org", "XThing", "v1", "Thing"),
+				}
+				return nil
+			})},
+			want: want{types: []DiscoveredType{
+				{GVK: schema.GroupVersionKind{Group: "example.org", Version: "v1", Kind: "XThing"}, Namespaced: false},
+				{GVK: schema.GroupVersionKind{Group: "example.org", Version: "v1", Kind: "Thing"}, Namespaced: true},
+			}},
+		},
+		"SkipsUnservedXRD": {
+			reason: "An XRD with no served version is skipped entirely.",
+			client: &test.MockClient{},
+			xrds: &apiextensionsv1.CompositeResourceDefinitionList{Items: []apiextensionsv1.CompositeResourceDefinition{
+				{Spec: apiextensionsv1.CompositeResourceDefinitionSpec{
+					Group:    "example.org",
+					Names:    extv1.CustomResourceDefinitionNames{Kind: "XDead"},
+					Versions: []apiextensionsv1.CompositeResourceDefinitionVersion{{Name: "v1", Served: false}},
+				}},
+			}},
+			want: want{types: []DiscoveredType{}},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got, err := DiscoverXRAndClaimTypes(context.Background(), tc.client, tc.xrds)
+			if diff := cmp.Diff(tc.want.err, err, cmpopts.EquateErrors()); diff != "" {
+				t.Errorf("\n%s\nDiscoverXRAndClaimTypes(): -want error, +got error:\n%s", tc.reason, diff)
+			}
+			if diff := cmp.Diff(tc.want.types, got, cmpopts.EquateEmpty()); diff != "" {
+				t.Errorf("\n%s\nDiscoverXRAndClaimTypes(): -want, +got:\n%s", tc.reason, diff)
+			}
+		})
+	}
+}
+
+func managedCRD(group, kind, version string, namespaced bool) extv1.CustomResourceDefinition {
+	scope := extv1.ClusterScoped
+	if namespaced {
+		scope = extv1.NamespaceScoped
+	}
+	return extv1.CustomResourceDefinition{Spec: extv1.CustomResourceDefinitionSpec{
+		Group:    group,
+		Scope:    scope,
+		Names:    extv1.CustomResourceDefinitionNames{Kind: kind, Categories: []string{managedResourceCategory}},
+		Versions: []extv1.CustomResourceDefinitionVersion{{Name: version, Served: true, Storage: true}},
+	}}
+}
+
+func TestDiscoverManagedResources(t *testing.T) {
+	type want struct {
+		types []DiscoveredType
+		err   error
+	}
+	cases := map[string]struct {
+		reason string
+		client client.Client
+		want   want
+	}{
+		"ListError": {
+			reason: "A failure listing CRDs surfaces as an error.",
+			client: &test.MockClient{MockList: test.NewMockListFn(errBoom)},
+			want:   want{err: cmpopts.AnyError},
+		},
+		"OnlyManagedCategory": {
+			reason: "Only CRDs in the \"managed\" category are returned, with scope reflected.",
+			client: &test.MockClient{MockList: test.NewMockListFn(nil, func(o client.ObjectList) error {
+				o.(*extv1.CustomResourceDefinitionList).Items = []extv1.CustomResourceDefinition{
+					managedCRD("aws.example.org", "Bucket", "v1beta1", false),
+					managedCRD("ns.example.org", "Queue", "v1", true),
+					{Spec: extv1.CustomResourceDefinitionSpec{ // not a "managed" CRD, should be ignored
+						Group:    "example.org",
+						Names:    extv1.CustomResourceDefinitionNames{Kind: "Other"},
+						Versions: []extv1.CustomResourceDefinitionVersion{{Name: "v1", Served: true, Storage: true}},
+					}},
+				}
+				return nil
+			})},
+			want: want{types: []DiscoveredType{
+				{GVK: schema.GroupVersionKind{Group: "aws.example.org", Version: "v1beta1", Kind: "Bucket"}, Namespaced: false},
+				{GVK: schema.GroupVersionKind{Group: "ns.example.org", Version: "v1", Kind: "Queue"}, Namespaced: true},
+			}},
+		},
+		"SkipsUnservedManagedCRD": {
+			reason: "A managed CRD with no served version is skipped entirely.",
+			client: &test.MockClient{MockList: test.NewMockListFn(nil, func(o client.ObjectList) error {
+				o.(*extv1.CustomResourceDefinitionList).Items = []extv1.CustomResourceDefinition{
+					{Spec: extv1.CustomResourceDefinitionSpec{
+						Group:    "aws.example.org",
+						Names:    extv1.CustomResourceDefinitionNames{Kind: "Dead", Categories: []string{managedResourceCategory}},
+						Versions: []extv1.CustomResourceDefinitionVersion{{Name: "v1", Served: false, Storage: true}},
+					}},
+				}
+				return nil
+			})},
+			want: want{types: []DiscoveredType{}},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got, err := DiscoverManagedResources(context.Background(), tc.client)
+			if diff := cmp.Diff(tc.want.err, err, cmpopts.EquateErrors()); diff != "" {
+				t.Errorf("\n%s\nDiscoverManagedResources(): -want error, +got error:\n%s", tc.reason, diff)
+			}
+			if diff := cmp.Diff(tc.want.types, got, cmpopts.EquateEmpty()); diff != "" {
+				t.Errorf("\n%s\nDiscoverManagedResources(): -want, +got:\n%s", tc.reason, diff)
+			}
+		})
+	}
+}
+
+func TestListInstances(t *testing.T) {
+	type want struct {
+		listGVK    schema.GroupVersionKind
+		namespaced string // the namespace passed via client.InNamespace, "" if none
+		err        error
+	}
+	cases := map[string]struct {
+		reason    string
+		dt        DiscoveredType
+		namespace string
+		want      want
+	}{
+		"ClusterScopedIgnoresNamespace": {
+			reason:    "Cluster-scoped types list with no namespace option even when one is given.",
+			dt:        DiscoveredType{GVK: schema.GroupVersionKind{Group: "g", Version: "v1", Kind: "XThing"}, Namespaced: false},
+			namespace: "team-a",
+			want: want{
+				listGVK:    schema.GroupVersionKind{Group: "g", Version: "v1", Kind: "XThingList"},
+				namespaced: "",
+			},
+		},
+		"NamespacedWithNamespace": {
+			reason:    "A namespaced type with a namespace restricts the List via InNamespace.",
+			dt:        DiscoveredType{GVK: schema.GroupVersionKind{Group: "g", Version: "v1", Kind: "Thing"}, Namespaced: true},
+			namespace: "team-a",
+			want: want{
+				listGVK:    schema.GroupVersionKind{Group: "g", Version: "v1", Kind: "ThingList"},
+				namespaced: "team-a",
+			},
+		},
+		"NamespacedAllNamespaces": {
+			reason:    "A namespaced type with an empty namespace lists across all namespaces.",
+			dt:        DiscoveredType{GVK: schema.GroupVersionKind{Group: "g", Version: "v1", Kind: "Thing"}, Namespaced: true},
+			namespace: "",
+			want: want{
+				listGVK:    schema.GroupVersionKind{Group: "g", Version: "v1", Kind: "ThingList"},
+				namespaced: "",
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			var gotGVK schema.GroupVersionKind
+			var gotNS string
+			c := &test.MockClient{
+				MockList: func(_ context.Context, list client.ObjectList, opts ...client.ListOption) error {
+					gotGVK = list.GetObjectKind().GroupVersionKind()
+					for _, o := range opts {
+						if ns, ok := o.(client.InNamespace); ok {
+							gotNS = string(ns)
+						}
+					}
+					return nil
+				},
+			}
+			_, err := ListInstances(context.Background(), c, tc.dt, tc.namespace)
+			if diff := cmp.Diff(tc.want.err, err, cmpopts.EquateErrors()); diff != "" {
+				t.Errorf("\n%s\nListInstances(): -want error, +got error:\n%s", tc.reason, diff)
+			}
+			if diff := cmp.Diff(tc.want.listGVK, gotGVK); diff != "" {
+				t.Errorf("\n%s\nListInstances() list GVK: -want, +got:\n%s", tc.reason, diff)
+			}
+			if diff := cmp.Diff(tc.want.namespaced, gotNS); diff != "" {
+				t.Errorf("\n%s\nListInstances() namespace: -want, +got:\n%s", tc.reason, diff)
+			}
+		})
+	}
+}
+
+func TestResourceRefFromUnstructured(t *testing.T) {
+	cases := map[string]struct {
+		reason    string
+		gvk       schema.GroupVersionKind
+		namespace string
+		name      string
+		want      ResourceRef
+	}{
+		"Namespaced": {
+			reason:    "Group/kind/namespace/name are kept; the version is dropped (ResourceRef carries no version).",
+			gvk:       schema.GroupVersionKind{Group: "example.org", Version: "v1", Kind: "Thing"},
+			namespace: "team-a",
+			name:      "my-thing",
+			want:      ResourceRef{Group: "example.org", Kind: "Thing", Namespace: "team-a", Name: "my-thing"},
+		},
+		"ClusterScoped": {
+			reason: "A resource with no namespace set yields an empty Namespace.",
+			gvk:    schema.GroupVersionKind{Group: "example.org", Version: "v1", Kind: "XThing"},
+			name:   "my-xthing",
+			want:   ResourceRef{Group: "example.org", Kind: "XThing", Name: "my-xthing"},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			u := unstructured.Unstructured{}
+			u.SetGroupVersionKind(tc.gvk)
+			u.SetNamespace(tc.namespace)
+			u.SetName(tc.name)
+
+			got := ResourceRefFromUnstructured(u)
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("\n%s\nResourceRefFromUnstructured(): -want, +got:\n%s", tc.reason, diff)
+			}
+		})
+	}
+}

--- a/cmd/crank/beta/upgrade/check/runner.go
+++ b/cmd/crank/beta/upgrade/check/runner.go
@@ -1,0 +1,170 @@
+/*
+Copyright 2025 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package check
+
+import (
+	"context"
+	"sort"
+	"sync"
+
+	"github.com/crossplane/crossplane-runtime/pkg/logging"
+)
+
+// Severity classifies findings by whether they block an upgrade.
+type Severity string
+
+const (
+	// SeverityIssue marks findings that must be addressed before upgrading,
+	// e.g. if you upgrade a control plane that has these findings, you'll be in
+	// a broken state after the upgrade. Issue-severity findings cause the
+	// command to exit non-zero.
+	SeverityIssue Severity = "issue"
+	// SeverityInfo marks findings that are informational only. The underlying
+	// behavior keeps working after the upgrade; the finding surfaces work the
+	// user may want to do for forward-looking migration. Info findings do not
+	// cause a non-zero exit.
+	SeverityInfo Severity = "info"
+)
+
+// ResourceRef identifies the offending resource.
+type ResourceRef struct {
+	Group     string `json:"group,omitempty"`
+	Kind      string `json:"kind,omitempty"`
+	Namespace string `json:"namespace,omitempty"`
+	Name      string `json:"name,omitempty"`
+}
+
+// Finding describes one thing the user should address before upgrading, including both the
+// offending resource and the offending field path within the resource (if applicable).
+type Finding struct {
+	Resource  ResourceRef `json:"resource,omitempty"`
+	FieldPath string      `json:"fieldPath,omitempty"`
+}
+
+// CategoryResult groups findings produced by a single Check. The
+// help/remediation content lives here because they apply for all findings in
+// the category.
+type CategoryResult struct {
+	Category    string    `json:"category"`
+	Title       string    `json:"title"`
+	Severity    Severity  `json:"severity,omitempty"`
+	Description string    `json:"description"`
+	Remediation string    `json:"remediation,omitempty"`
+	DocsURLs    []string  `json:"docsURLs,omitempty"` //nolint:tagliatelle // URLs is a Go initialism; goCamel's suggested "docsUrLs" is a worse JSON key.
+	Findings    []Finding `json:"findings,omitempty"`
+	Err         string    `json:"error,omitempty"`
+}
+
+// Report is the full combined output of a run including all the categories/checks/findings.
+type Report struct {
+	Categories []CategoryResult `json:"categories"`
+}
+
+// HasBlockers reports whether the run produced anything that the user really should address before
+// upgrading to v2 and should therefore trigger a non-zero exit: any issue-severity finding, or an
+// incomplete check (one that errored out before producing a result). An incomplete check counts
+// because the user is left without an answer for that category. Info-severity findings are not
+// blockers.
+func (r Report) HasBlockers() bool {
+	for _, c := range r.Categories {
+		if c.Err != "" {
+			return true
+		}
+		if c.Severity != SeverityInfo && len(c.Findings) > 0 {
+			return true
+		}
+	}
+	return false
+}
+
+// Check is a single upgrade compatibility check.
+type Check interface { //nolint:interfacebloat // A check's metadata accessors and Run form one cohesive contract the Runner consumes together to build a CategoryResult.
+	// Category is a stable, machine-friendly identifier for the check.
+	Category() string
+	// Title is a short human-readable title shown in output.
+	Title() string
+	// Severity is the severity of findings produced by this check.
+	Severity() Severity
+	// Description explains what the check looks for.
+	Description() string
+	// Remediation is one-line, action-oriented advice for the whole category.
+	// Must not contain URLs - see DocsURLs.
+	Remediation() string
+	// DocsURLs returns documentation links for the category. Empty when none apply.
+	DocsURLs() []string
+	// Run executes the check and returns any findings.
+	Run(ctx context.Context) ([]Finding, error)
+}
+
+// Runner executes checks and aggregates results.
+type Runner struct {
+	Checks []Check
+	Logger logging.Logger
+}
+
+// Run executes all checks concurrently. A check that errors out is captured
+// on its CategoryResult.Err and surfaces as an incomplete check; the Runner
+// itself does not fail.
+func (r *Runner) Run(ctx context.Context) Report {
+	results := make([]CategoryResult, len(r.Checks))
+	var wg sync.WaitGroup
+
+	// launch every check on a separate go-routine
+	for i, c := range r.Checks {
+		wg.Add(1)
+		go func(i int, c Check) {
+			defer wg.Done()
+			r.Logger.Debug("running check", "category", c.Category())
+			res := CategoryResult{
+				Category:    c.Category(),
+				Title:       c.Title(),
+				Severity:    c.Severity(),
+				Description: c.Description(),
+				Remediation: c.Remediation(),
+				DocsURLs:    c.DocsURLs(),
+			}
+
+			// run the check and save any error we encounter, which means the check is incomplete
+			findings, err := c.Run(ctx)
+			if err != nil {
+				res.Err = err.Error()
+				r.Logger.Debug("check incomplete", "category", c.Category(), "error", err)
+			}
+
+			// sort the findings on kind -> namespace -> name
+			sort.SliceStable(findings, func(a, b int) bool {
+				if findings[a].Resource.Kind != findings[b].Resource.Kind {
+					return findings[a].Resource.Kind < findings[b].Resource.Kind
+				}
+				if findings[a].Resource.Namespace != findings[b].Resource.Namespace {
+					return findings[a].Resource.Namespace < findings[b].Resource.Namespace
+				}
+				if findings[a].Resource.Name != findings[b].Resource.Name {
+					return findings[a].Resource.Name < findings[b].Resource.Name
+				}
+				return findings[a].FieldPath < findings[b].FieldPath
+			})
+
+			res.Findings = findings
+			results[i] = res
+		}(i, c)
+	}
+
+	// wait until all the checks have finished
+	wg.Wait()
+	return Report{Categories: results}
+}

--- a/cmd/crank/beta/upgrade/check/runner.go
+++ b/cmd/crank/beta/upgrade/check/runner.go
@@ -145,7 +145,7 @@ func (r *Runner) Run(ctx context.Context) Report {
 				r.Logger.Debug("check incomplete", "category", c.Category(), "error", err)
 			}
 
-			// sort the findings on kind -> namespace -> name
+			// sort the findings on kind -> namespace -> name -> field path
 			sort.SliceStable(findings, func(a, b int) bool {
 				if findings[a].Resource.Kind != findings[b].Resource.Kind {
 					return findings[a].Resource.Kind < findings[b].Resource.Kind

--- a/cmd/crank/beta/upgrade/check/runner.go
+++ b/cmd/crank/beta/upgrade/check/runner.go
@@ -18,6 +18,8 @@ package check
 
 import (
 	"context"
+	"fmt"
+	"runtime/debug"
 	"sort"
 	"sync"
 
@@ -91,21 +93,28 @@ func (r Report) HasBlockers() bool {
 	return false
 }
 
-// Check is a single upgrade compatibility check.
-type Check interface { //nolint:interfacebloat // A check's metadata accessors and Run form one cohesive contract the Runner consumes together to build a CategoryResult.
+// Meta is the static metadata describing a Check: identity, severity, and
+// the help/remediation content shown for all of its findings.
+type Meta struct {
 	// Category is a stable, machine-friendly identifier for the check.
-	Category() string
+	Category string
 	// Title is a short human-readable title shown in output.
-	Title() string
-	// Severity is the severity of findings produced by this check.
-	Severity() Severity
+	Title string
+	// Severity is the severity of findings produced by the check.
+	Severity Severity
 	// Description explains what the check looks for.
-	Description() string
+	Description string
 	// Remediation is one-line, action-oriented advice for the whole category.
 	// Must not contain URLs - see DocsURLs.
-	Remediation() string
-	// DocsURLs returns documentation links for the category. Empty when none apply.
-	DocsURLs() []string
+	Remediation string
+	// DocsURLs are documentation links for the category. Empty when none apply.
+	DocsURLs []string
+}
+
+// Check is a single upgrade compatibility check.
+type Check interface {
+	// Meta returns the check's static metadata.
+	Meta() Meta
 	// Run executes the check and returns any findings.
 	Run(ctx context.Context) ([]Finding, error)
 }
@@ -128,21 +137,34 @@ func (r *Runner) Run(ctx context.Context) Report {
 		wg.Add(1)
 		go func(i int, c Check) {
 			defer wg.Done()
-			r.Logger.Debug("running check", "category", c.Category())
+			m := c.Meta()
+			r.Logger.Debug("running check", "category", m.Category)
 			res := CategoryResult{
-				Category:    c.Category(),
-				Title:       c.Title(),
-				Severity:    c.Severity(),
-				Description: c.Description(),
-				Remediation: c.Remediation(),
-				DocsURLs:    c.DocsURLs(),
+				Category:    m.Category,
+				Title:       m.Title,
+				Severity:    m.Severity,
+				Description: m.Description,
+				Remediation: m.Remediation,
+				DocsURLs:    m.DocsURLs,
 			}
+
+			// Recover any panics in this goroutine into an incomplete-check error so one bad check
+			// can't crash the CLI and discard every other check's results. This mirrors how we
+			// treat a check that returns an error below.
+			defer func() {
+				if rec := recover(); rec != nil {
+					// Keep the user-facing error concise, but add the full stack in the debug log
+					res.Err = fmt.Sprintf("check panicked: %v", rec)
+					r.Logger.Debug("check panicked", "category", m.Category, "panic", rec, "stack", string(debug.Stack()))
+					results[i] = res
+				}
+			}()
 
 			// run the check and save any error we encounter, which means the check is incomplete
 			findings, err := c.Run(ctx)
 			if err != nil {
 				res.Err = err.Error()
-				r.Logger.Debug("check incomplete", "category", c.Category(), "error", err)
+				r.Logger.Debug("check incomplete", "category", m.Category, "error", err)
 			}
 
 			// sort the findings on kind -> namespace -> name -> field path

--- a/cmd/crank/beta/upgrade/check/runner_test.go
+++ b/cmd/crank/beta/upgrade/check/runner_test.go
@@ -1,0 +1,280 @@
+/*
+Copyright 2025 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package check
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	"github.com/crossplane/crossplane-runtime/pkg/errors"
+	"github.com/crossplane/crossplane-runtime/pkg/logging"
+)
+
+// errBoom is the generic error injected into mocks across the package's tests.
+var errBoom = errors.New("boom")
+
+// MockCheck is a configurable Check used to drive Runner tests without touching
+// a real cluster.
+var _ Check = &MockCheck{}
+
+type MockCheck struct {
+	category    string
+	title       string
+	severity    Severity
+	description string
+	remediation string
+	docsURLs    []string
+	findings    []Finding
+	err         error
+}
+
+func (m *MockCheck) Category() string                       { return m.category }
+func (m *MockCheck) Title() string                          { return m.title }
+func (m *MockCheck) Severity() Severity                     { return m.severity }
+func (m *MockCheck) Description() string                    { return m.description }
+func (m *MockCheck) Remediation() string                    { return m.remediation }
+func (m *MockCheck) DocsURLs() []string                     { return m.docsURLs }
+func (m *MockCheck) Run(context.Context) ([]Finding, error) { return m.findings, m.err }
+
+// TestCheckMetadata locks the stable, machine-friendly Category identifiers and
+// severities that downstream tooling and the non-zero-exit logic depend on, and
+// guards against a check shipping with empty human-facing metadata.
+func TestCheckMetadata(t *testing.T) {
+	// metadata captures the stable identity of a check plus whether its
+	// human-facing fields are populated. We compare presence (not the exact
+	// long strings) so the test locks the contract without restating the source.
+	type metadata struct {
+		category       string
+		severity       Severity
+		hasTitle       bool
+		hasDescription bool
+		hasRemediation bool
+		hasDocs        bool
+	}
+	// Clients for each check are not set, we expect metadata accessors to not touch the cluster.
+	cases := map[string]struct {
+		reason string
+		check  Check
+		want   metadata
+	}{
+		"NativePatchAndTransform": {
+			reason: "Native P&T is an upgrade blocker.",
+			check:  &NativePatchAndTransform{},
+			want:   metadata{category: "native-patch-and-transform", severity: SeverityIssue, hasTitle: true, hasDescription: true, hasRemediation: true, hasDocs: true},
+		},
+		"ControllerConfig": {
+			reason: "ControllerConfig usage is an upgrade blocker.",
+			check:  &ControllerConfigCheck{},
+			want:   metadata{category: "controller-config", severity: SeverityIssue, hasTitle: true, hasDescription: true, hasRemediation: true, hasDocs: true},
+		},
+		"ExternalSecretStores": {
+			reason: "External secret stores usage is an upgrade blocker.",
+			check:  &ExternalSecretStores{},
+			want:   metadata{category: "external-secret-stores", severity: SeverityIssue, hasTitle: true, hasDescription: true, hasRemediation: true, hasDocs: true},
+		},
+		"CompositeConnectionDetails": {
+			reason: "Composite connection details keep working post-upgrade, so this is informational.",
+			check:  &CompositeConnectionDetails{},
+			want:   metadata{category: "composite-connection-details", severity: SeverityInfo, hasTitle: true, hasDescription: true, hasRemediation: true, hasDocs: true},
+		},
+		"UnqualifiedPackageSources": {
+			reason: "Unqualified package sources are an upgrade blocker.",
+			check:  &UnqualifiedPackageSources{},
+			want:   metadata{category: "unqualified-package-source", severity: SeverityIssue, hasTitle: true, hasDescription: true, hasRemediation: true, hasDocs: true},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got := metadata{
+				category:       tc.check.Category(),
+				severity:       tc.check.Severity(),
+				hasTitle:       tc.check.Title() != "",
+				hasDescription: tc.check.Description() != "",
+				hasRemediation: tc.check.Remediation() != "",
+				hasDocs:        len(tc.check.DocsURLs()) > 0,
+			}
+			if diff := cmp.Diff(tc.want, got, cmp.AllowUnexported(metadata{})); diff != "" {
+				t.Errorf("\n%s\ncheck metadata: -want, +got:\n%s", tc.reason, diff)
+			}
+		})
+	}
+}
+
+func TestReportHasBlockers(t *testing.T) {
+	type want struct {
+		blockers bool
+	}
+	cases := map[string]struct {
+		reason string
+		report Report
+		want   want
+	}{
+		"Empty": {
+			reason: "A report with no categories has no blockers.",
+			report: Report{},
+			want:   want{blockers: false},
+		},
+		"InfoFindingsOnly": {
+			reason: "Info-severity findings are not blockers.",
+			report: Report{Categories: []CategoryResult{{
+				Severity: SeverityInfo,
+				Findings: []Finding{{Resource: ResourceRef{Kind: "X"}}},
+			}}},
+			want: want{blockers: false},
+		},
+		"IssueFindings": {
+			reason: "Issue-severity findings are blockers.",
+			report: Report{Categories: []CategoryResult{{
+				Severity: SeverityIssue,
+				Findings: []Finding{{Resource: ResourceRef{Kind: "X"}}},
+			}}},
+			want: want{blockers: true},
+		},
+		"IncompleteCheck": {
+			reason: "A check that errored out is a blocker even with no findings.",
+			report: Report{Categories: []CategoryResult{{
+				Severity: SeverityIssue,
+				Err:      "boom",
+			}}},
+			want: want{blockers: true},
+		},
+		"InfoWithError": {
+			reason: "An info check that errored out is still a blocker: the user has no answer for that category.",
+			report: Report{Categories: []CategoryResult{{
+				Severity: SeverityInfo,
+				Err:      "boom",
+			}}},
+			want: want{blockers: true},
+		},
+		"IssueCategoryNoFindings": {
+			reason: "An issue-severity category that produced no findings and no error is clean.",
+			report: Report{Categories: []CategoryResult{{
+				Severity: SeverityIssue,
+			}}},
+			want: want{blockers: false},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got := tc.report.HasBlockers()
+			if diff := cmp.Diff(tc.want.blockers, got); diff != "" {
+				t.Errorf("\n%s\nHasBlockers(): -want, +got:\n%s", tc.reason, diff)
+			}
+		})
+	}
+}
+
+func TestRunnerRun(t *testing.T) {
+	type want struct {
+		report Report
+	}
+	cases := map[string]struct {
+		reason string
+		checks []Check
+		want   want
+	}{
+		"NoChecks": {
+			reason: "A runner with no checks produces an empty report.",
+			checks: nil,
+			want:   want{report: Report{Categories: []CategoryResult{}}},
+		},
+		"MetadataAndFindings": {
+			reason: "The runner copies each check's metadata onto its CategoryResult and carries its findings.",
+			checks: []Check{
+				&MockCheck{
+					category:    "cat-a",
+					title:       "Title A",
+					severity:    SeverityIssue,
+					description: "desc",
+					remediation: "fix",
+					docsURLs:    []string{"https://example.com"},
+					findings:    []Finding{{Resource: ResourceRef{Kind: "Kind", Name: "n"}}},
+				},
+			},
+			want: want{report: Report{Categories: []CategoryResult{{
+				Category:    "cat-a",
+				Title:       "Title A",
+				Severity:    SeverityIssue,
+				Description: "desc",
+				Remediation: "fix",
+				DocsURLs:    []string{"https://example.com"},
+				Findings:    []Finding{{Resource: ResourceRef{Kind: "Kind", Name: "n"}}},
+			}}}},
+		},
+		"ErrorBecomesIncomplete": {
+			reason: "A check that returns an error has its error recorded on Err, marking the category incomplete.",
+			checks: []Check{
+				&MockCheck{category: "cat-err", severity: SeverityIssue, err: errBoom},
+			},
+			want: want{report: Report{Categories: []CategoryResult{{
+				Category: "cat-err",
+				Severity: SeverityIssue,
+				Err:      "boom",
+			}}}},
+		},
+		"PreservesCheckOrder": {
+			reason: "Results are indexed by check position, so concurrent execution preserves input order.",
+			checks: []Check{
+				&MockCheck{category: "first"},
+				&MockCheck{category: "second"},
+			},
+			want: want{report: Report{Categories: []CategoryResult{
+				{Category: "first"},
+				{Category: "second"},
+			}}},
+		},
+		"SortsFindings": {
+			reason: "Findings are sorted by kind, then namespace, then name, then field path.",
+			checks: []Check{
+				&MockCheck{
+					category: "sort",
+					findings: []Finding{
+						{Resource: ResourceRef{Kind: "B", Name: "a"}},
+						{Resource: ResourceRef{Kind: "A", Namespace: "ns2", Name: "a"}},
+						{Resource: ResourceRef{Kind: "A", Namespace: "ns1", Name: "z"}},
+						{Resource: ResourceRef{Kind: "A", Namespace: "ns1", Name: "a"}, FieldPath: ".y"},
+						{Resource: ResourceRef{Kind: "A", Namespace: "ns1", Name: "a"}, FieldPath: ".x"},
+					},
+				},
+			},
+			want: want{report: Report{Categories: []CategoryResult{{
+				Category: "sort",
+				Findings: []Finding{
+					{Resource: ResourceRef{Kind: "A", Namespace: "ns1", Name: "a"}, FieldPath: ".x"},
+					{Resource: ResourceRef{Kind: "A", Namespace: "ns1", Name: "a"}, FieldPath: ".y"},
+					{Resource: ResourceRef{Kind: "A", Namespace: "ns1", Name: "z"}},
+					{Resource: ResourceRef{Kind: "A", Namespace: "ns2", Name: "a"}},
+					{Resource: ResourceRef{Kind: "B", Name: "a"}},
+				},
+			}}}},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			r := &Runner{Checks: tc.checks, Logger: logging.NewNopLogger()}
+			got := r.Run(context.Background())
+			if diff := cmp.Diff(tc.want.report, got); diff != "" {
+				t.Errorf("\n%s\nRunner.Run(): -want, +got:\n%s", tc.reason, diff)
+			}
+		})
+	}
+}

--- a/cmd/crank/beta/upgrade/check/runner_test.go
+++ b/cmd/crank/beta/upgrade/check/runner_test.go
@@ -34,23 +34,19 @@ var errBoom = errors.New("boom")
 var _ Check = &MockCheck{}
 
 type MockCheck struct {
-	category    string
-	title       string
-	severity    Severity
-	description string
-	remediation string
-	docsURLs    []string
-	findings    []Finding
-	err         error
+	meta     Meta
+	findings []Finding
+	err      error
+	panicVal any
 }
 
-func (m *MockCheck) Category() string                       { return m.category }
-func (m *MockCheck) Title() string                          { return m.title }
-func (m *MockCheck) Severity() Severity                     { return m.severity }
-func (m *MockCheck) Description() string                    { return m.description }
-func (m *MockCheck) Remediation() string                    { return m.remediation }
-func (m *MockCheck) DocsURLs() []string                     { return m.docsURLs }
-func (m *MockCheck) Run(context.Context) ([]Finding, error) { return m.findings, m.err }
+func (m *MockCheck) Meta() Meta { return m.meta }
+func (m *MockCheck) Run(context.Context) ([]Finding, error) {
+	if m.panicVal != nil {
+		panic(m.panicVal)
+	}
+	return m.findings, m.err
+}
 
 // TestCheckMetadata locks the stable, machine-friendly Category identifiers and
 // severities that downstream tooling and the non-zero-exit logic depend on, and
@@ -102,13 +98,14 @@ func TestCheckMetadata(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
+			m := tc.check.Meta()
 			got := metadata{
-				category:       tc.check.Category(),
-				severity:       tc.check.Severity(),
-				hasTitle:       tc.check.Title() != "",
-				hasDescription: tc.check.Description() != "",
-				hasRemediation: tc.check.Remediation() != "",
-				hasDocs:        len(tc.check.DocsURLs()) > 0,
+				category:       m.Category,
+				severity:       m.Severity,
+				hasTitle:       m.Title != "",
+				hasDescription: m.Description != "",
+				hasRemediation: m.Remediation != "",
+				hasDocs:        len(m.DocsURLs) > 0,
 			}
 			if diff := cmp.Diff(tc.want, got, cmp.AllowUnexported(metadata{})); diff != "" {
 				t.Errorf("\n%s\ncheck metadata: -want, +got:\n%s", tc.reason, diff)
@@ -200,13 +197,15 @@ func TestRunnerRun(t *testing.T) {
 			reason: "The runner copies each check's metadata onto its CategoryResult and carries its findings.",
 			checks: []Check{
 				&MockCheck{
-					category:    "cat-a",
-					title:       "Title A",
-					severity:    SeverityIssue,
-					description: "desc",
-					remediation: "fix",
-					docsURLs:    []string{"https://example.com"},
-					findings:    []Finding{{Resource: ResourceRef{Kind: "Kind", Name: "n"}}},
+					meta: Meta{
+						Category:    "cat-a",
+						Title:       "Title A",
+						Severity:    SeverityIssue,
+						Description: "desc",
+						Remediation: "fix",
+						DocsURLs:    []string{"https://example.com"},
+					},
+					findings: []Finding{{Resource: ResourceRef{Kind: "Kind", Name: "n"}}},
 				},
 			},
 			want: want{report: Report{Categories: []CategoryResult{{
@@ -222,7 +221,7 @@ func TestRunnerRun(t *testing.T) {
 		"ErrorBecomesIncomplete": {
 			reason: "A check that returns an error has its error recorded on Err, marking the category incomplete.",
 			checks: []Check{
-				&MockCheck{category: "cat-err", severity: SeverityIssue, err: errBoom},
+				&MockCheck{meta: Meta{Category: "cat-err", Severity: SeverityIssue}, err: errBoom},
 			},
 			want: want{report: Report{Categories: []CategoryResult{{
 				Category: "cat-err",
@@ -230,11 +229,36 @@ func TestRunnerRun(t *testing.T) {
 				Err:      "boom",
 			}}}},
 		},
+		"PanicBecomesIncomplete": {
+			reason: "A check that panics is recovered into an Err, marking the category incomplete instead of crashing the run.",
+			checks: []Check{
+				&MockCheck{meta: Meta{Category: "cat-panic", Severity: SeverityIssue}, panicVal: "panic boom"},
+			},
+			want: want{report: Report{Categories: []CategoryResult{{
+				Category: "cat-panic",
+				Severity: SeverityIssue,
+				Err:      "check panicked: panic boom",
+			}}}},
+		},
+		"PanicDoesNotDropSiblingResults": {
+			reason: "A panic in one check must not discard a healthy sibling check's findings.",
+			checks: []Check{
+				&MockCheck{meta: Meta{Category: "cat-panic", Severity: SeverityIssue}, panicVal: "panic boom"},
+				&MockCheck{
+					meta:     Meta{Category: "cat-ok", Severity: SeverityIssue},
+					findings: []Finding{{Resource: ResourceRef{Kind: "Kind", Name: "n"}}},
+				},
+			},
+			want: want{report: Report{Categories: []CategoryResult{
+				{Category: "cat-panic", Severity: SeverityIssue, Err: "check panicked: panic boom"},
+				{Category: "cat-ok", Severity: SeverityIssue, Findings: []Finding{{Resource: ResourceRef{Kind: "Kind", Name: "n"}}}},
+			}}},
+		},
 		"PreservesCheckOrder": {
 			reason: "Results are indexed by check position, so concurrent execution preserves input order.",
 			checks: []Check{
-				&MockCheck{category: "first"},
-				&MockCheck{category: "second"},
+				&MockCheck{meta: Meta{Category: "first"}},
+				&MockCheck{meta: Meta{Category: "second"}},
 			},
 			want: want{report: Report{Categories: []CategoryResult{
 				{Category: "first"},
@@ -245,7 +269,7 @@ func TestRunnerRun(t *testing.T) {
 			reason: "Findings are sorted by kind, then namespace, then name, then field path.",
 			checks: []Check{
 				&MockCheck{
-					category: "sort",
+					meta: Meta{Category: "sort"},
 					findings: []Finding{
 						{Resource: ResourceRef{Kind: "B", Name: "a"}},
 						{Resource: ResourceRef{Kind: "A", Namespace: "ns2", Name: "a"}},

--- a/cmd/crank/beta/upgrade/check/secret_stores.go
+++ b/cmd/crank/beta/upgrade/check/secret_stores.go
@@ -22,7 +22,6 @@ import (
 	"strings"
 	"sync"
 
-	"golang.org/x/sync/errgroup"
 	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
@@ -78,31 +77,19 @@ const (
 	defaultStoreConfigName = "default"
 )
 
-// Category returns the check category identifier.
-func (c *ExternalSecretStores) Category() string { return "external-secret-stores" }
-
-// Title returns the human-readable title.
-func (c *ExternalSecretStores) Title() string { return "External secret stores" }
-
-// Severity returns the severity of findings produced by this check.
-func (c *ExternalSecretStores) Severity() Severity { return SeverityIssue }
-
-// Description explains what this check looks for.
-func (c *ExternalSecretStores) Description() string {
-	return "Crossplane v2 removes support for external secret stores. Publish connection details as Kubernetes Secrets composed by your Compositions, or adopt External Secrets Operator if you need an external store."
-}
-
-// Remediation returns the once-per-section advice for this check.
-func (c *ExternalSecretStores) Remediation() string {
-	return "Disable --enable-external-secret-stores on the Crossplane Deployment, replace StoreConfig-based publishing with composed Kubernetes Secrets (or adopt External Secrets Operator), then delete StoreConfig resources. No automated converter exists."
-}
-
-// DocsURLs returns documentation links for this check.
-func (c *ExternalSecretStores) DocsURLs() []string {
-	return []string{
-		"https://docs.crossplane.io/latest/guides/upgrade-to-crossplane-v2/#external-secret-stores",
-		"https://docs.crossplane.io/latest/guides/connection-details-composition",
-		"https://github.com/external-secrets/external-secrets",
+// Meta returns the check's static metadata.
+func (c *ExternalSecretStores) Meta() Meta {
+	return Meta{
+		Category:    "external-secret-stores",
+		Title:       "External secret stores",
+		Severity:    SeverityIssue,
+		Description: "Crossplane v2 removes support for external secret stores. Publish connection details as Kubernetes Secrets composed by your Compositions, or adopt External Secrets Operator if you need an external store.",
+		Remediation: "Disable --enable-external-secret-stores on the Crossplane Deployment, replace StoreConfig-based publishing with composed Kubernetes Secrets (or adopt External Secrets Operator), then delete StoreConfig resources. No automated converter exists.",
+		DocsURLs: []string{
+			"https://docs.crossplane.io/latest/guides/upgrade-to-crossplane-v2/#external-secret-stores",
+			"https://docs.crossplane.io/latest/guides/connection-details-composition",
+			"https://github.com/external-secrets/external-secrets",
+		},
 	}
 }
 
@@ -226,57 +213,62 @@ func (c *ExternalSecretStores) checkManagedResources(ctx context.Context) ([]Fin
 		return nil, errors.Wrap(err, "cannot discover managed resource types")
 	}
 
-	var g errgroup.Group
-	if c.Concurrency > 0 {
-		g.SetLimit(c.Concurrency)
-	}
+	// create a semaphore (buffered channel) that will limit the number of goroutines executing at
+	// the same time to our concurrency limit (lowest possible concurrency is 1)
+	sem := make(chan struct{}, max(c.Concurrency, 1))
+	var wg sync.WaitGroup
 
-	var (
-		mu       sync.Mutex // lock for all writes to our findings and listErrs
+	// Each type writes into its own slot, so the goroutines never share mutable
+	// state and need no lock. We flatten the slots once they've all finished.
+	type typeResult struct {
 		findings []Finding
-		listErrs []error
-	)
+		errs     []error
+	}
+	typeResults := make([]typeResult, len(types))
 
-	// start a goroutine to list all MR instances for each MR type - the errgroup.Group will limit
-	// the concurrency for us, blocking new goroutines from starting when we are at the limit.
+	// list all MR instances for each MR type concurrently
 	for i := range types {
 		t := types[i]
-		g.Go(func() error {
+		// block starting a new goroutine until the semaphore lets us in
+		sem <- struct{}{}
+		wg.Go(func() {
+			// make sure to release our semaphore when we're done
+			defer func() { <-sem }()
+
 			instances, err := ListInstances(ctx, c.Client, t, "")
 			if err != nil {
-				mu.Lock()
-				listErrs = append(listErrs, errors.Wrapf(err, "cannot list %s", t.GVK))
-				mu.Unlock()
-				return nil
+				typeResults[i].errs = append(typeResults[i].errs, errors.Wrapf(err, "cannot list %s", t.GVK))
+				return
 			}
-			var instanceFindings []Finding
+			// check each instance for a user-set spec.publishConnectionDetailsTo
 			for j := range instances {
 				inst := &instances[j]
 				v, found, err := unstructured.NestedMap(inst.Object, "spec", "publishConnectionDetailsTo")
 				if err != nil {
-					mu.Lock()
-					listErrs = append(listErrs, errors.Wrapf(err, "cannot read .spec.publishConnectionDetailsTo on %s/%s", inst.GetKind(), inst.GetName()))
-					mu.Unlock()
+					typeResults[i].errs = append(typeResults[i].errs, errors.Wrapf(err, "cannot read .spec.publishConnectionDetailsTo on %s/%s", inst.GetKind(), inst.GetName()))
 					continue
 				}
 				if !found || len(v) == 0 {
 					continue
 				}
-				instanceFindings = append(instanceFindings, Finding{
+				typeResults[i].findings = append(typeResults[i].findings, Finding{
 					Resource:  ResourceRefFromUnstructured(*inst),
 					FieldPath: ".spec.publishConnectionDetailsTo",
 				})
 			}
-			if len(instanceFindings) > 0 {
-				mu.Lock()
-				findings = append(findings, instanceFindings...)
-				mu.Unlock()
-			}
-			// Always nil; errors go to listErrs so errgroup never cancels.
-			return nil
 		})
 	}
-	_ = g.Wait()
+	wg.Wait()
+
+	// flatten the per-type slots now that we've finished our concurrent listing and checking and
+	// have findings/errors for all types. We can do this single-threaded, no need for
+	// concurrency/locks.
+	var findings []Finding
+	var listErrs []error
+	for i := range typeResults {
+		findings = append(findings, typeResults[i].findings...)
+		listErrs = append(listErrs, typeResults[i].errs...)
+	}
 
 	if len(listErrs) > 0 {
 		return findings, errors.Join(listErrs...)

--- a/cmd/crank/beta/upgrade/check/secret_stores.go
+++ b/cmd/crank/beta/upgrade/check/secret_stores.go
@@ -347,11 +347,8 @@ func containerHasEnabledFlag(args []string, flag string) bool {
 		case a == flag:
 			// we found the flag in the container args, check to see if the next arg is disabling it
 			// so we don't find a false positive
-			if i+1 < len(args) {
-				next := args[i+1]
-				if !strings.HasPrefix(next, "-") && strings.EqualFold(next, "false") {
-					return false
-				}
+			if i+1 < len(args) && strings.EqualFold(args[i+1], "false") {
+				return false
 			}
 			return true
 		case strings.HasPrefix(a, flagEqualsPrefix):

--- a/cmd/crank/beta/upgrade/check/secret_stores.go
+++ b/cmd/crank/beta/upgrade/check/secret_stores.go
@@ -1,0 +1,376 @@
+/*
+Copyright 2025 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package check
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+
+	"golang.org/x/sync/errgroup"
+	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/labels"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
+	"github.com/crossplane/crossplane-runtime/pkg/errors"
+
+	apiextensionsv1 "github.com/crossplane/crossplane/apis/apiextensions/v1"
+	secretsv1alpha1 "github.com/crossplane/crossplane/apis/secrets/v1alpha1"
+)
+
+// ExternalSecretStores surfaces use of the external secret stores feature, removed in Crossplane
+// v2. We do some specific checks here because of all the auto defaulting that sets default values
+// for a lot of the ESS related fields. Therefore, we check more specific conditions than just the
+// presence of certain fields having a value so that we can find and flag true user intent of
+// actually using the external secret stores feature. The check flags:
+//
+//   - Crossplane Deployments running with --enable-external-secret-stores.
+//   - StoreConfig CRs other than the unmodified "default" that v1's init
+//     controller creates on every cluster.
+//   - Compositions whose spec.publishConnectionDetailsWithStoreConfigRef.name
+//     differs from "default". The apiserver injects that name as a kubebuilder
+//     default on every Composition, so only other values reflect user intent.
+//   - Managed resources and Claims with a non-empty spec.publishConnectionDetailsTo.
+//   - XRs with a non-empty spec.publishConnectionDetailsTo whose name field
+//     is not the XR's own metadata.uid. The composite reconciler auto-injects
+//     this field on every XR using the UID as the entry name when the feature
+//     is on, so name == UID is the controller's fingerprint and is filtered
+//     out; anything else is a user-explicit override.
+type ExternalSecretStores struct {
+	Client              client.Client
+	CrossplaneNamespace string
+	Selector            string
+	// ClaimNamespace restricts Claim instance lookups; empty lists across
+	// all namespaces. XRs and managed resources are cluster-scoped in v1.
+	ClaimNamespace string
+
+	// SkipManagedResources disables the MR scan, which is the expensive part
+	// of this check on clusters with many provider CRDs.
+	SkipManagedResources bool
+
+	// Concurrency bounds parallel List calls during the MR scan
+	Concurrency int
+}
+
+const (
+	flagEnableExternalSecretStores = "--enable-external-secret-stores"
+
+	// defaultStoreConfigName is the kubebuilder default the apiserver injects
+	// on Composition.spec.publishConnectionDetailsWithStoreConfigRef.name; only
+	// values other than this signal user intent.
+	defaultStoreConfigName = "default"
+)
+
+// Category returns the check category identifier.
+func (c *ExternalSecretStores) Category() string { return "external-secret-stores" }
+
+// Title returns the human-readable title.
+func (c *ExternalSecretStores) Title() string { return "External secret stores" }
+
+// Severity returns the severity of findings produced by this check.
+func (c *ExternalSecretStores) Severity() Severity { return SeverityIssue }
+
+// Description explains what this check looks for.
+func (c *ExternalSecretStores) Description() string {
+	return "Crossplane v2 removes support for external secret stores. Publish connection details as Kubernetes Secrets composed by your Compositions, or adopt External Secrets Operator if you need an external store."
+}
+
+// Remediation returns the once-per-section advice for this check.
+func (c *ExternalSecretStores) Remediation() string {
+	return "Disable --enable-external-secret-stores on the Crossplane Deployment, replace StoreConfig-based publishing with composed Kubernetes Secrets (or adopt External Secrets Operator), then delete StoreConfig resources. No automated converter exists."
+}
+
+// DocsURLs returns documentation links for this check.
+func (c *ExternalSecretStores) DocsURLs() []string {
+	return []string{
+		"https://docs.crossplane.io/latest/guides/upgrade-to-crossplane-v2/#external-secret-stores",
+		"https://docs.crossplane.io/latest/guides/connection-details-composition",
+		"https://github.com/external-secrets/external-secrets",
+	}
+}
+
+// Run emits a Finding for each of the signals described on ExternalSecretStores.
+func (c *ExternalSecretStores) Run(ctx context.Context) ([]Finding, error) {
+	// check if the user has explicitly set the --enable-external-secret-stores alpha feature flag
+	findings, err := c.checkDeploymentFlag(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	// list all StoreConfigs to find any user created non default instances
+	storeConfigs := &secretsv1alpha1.StoreConfigList{}
+	if err := c.Client.List(ctx, storeConfigs); err != nil {
+		return findings, errors.Wrap(err, "cannot list StoreConfigs")
+	}
+	for i := range storeConfigs.Items {
+		sc := &storeConfigs.Items[i]
+		if isAutoCreatedDefaultStoreConfig(sc) {
+			continue
+		}
+		findings = append(findings, Finding{
+			Resource: ResourceRef{
+				Group: secretsv1alpha1.Group,
+				Kind:  secretsv1alpha1.StoreConfigKind,
+				Name:  sc.Name,
+			},
+		})
+	}
+
+	// list all compositions and check if they are using PublishConnectionDetailsWithStoreConfigRef
+	comps := &apiextensionsv1.CompositionList{}
+	if err := c.Client.List(ctx, comps); err != nil {
+		return findings, errors.Wrap(err, "cannot list Compositions")
+	}
+	for i := range comps.Items {
+		comp := &comps.Items[i]
+		ref := comp.Spec.PublishConnectionDetailsWithStoreConfigRef
+		if ref == nil || ref.Name == defaultStoreConfigName {
+			continue
+		}
+		findings = append(findings, Finding{
+			Resource: ResourceRef{
+				Group: apiextensionsv1.Group,
+				Kind:  apiextensionsv1.CompositionKind,
+				Name:  comp.Name,
+			},
+			FieldPath: ".spec.publishConnectionDetailsWithStoreConfigRef",
+		})
+	}
+
+	xrClaimFindings, err := c.checkXRsAndClaims(ctx)
+	findings = append(findings, xrClaimFindings...)
+	if err != nil {
+		return findings, err
+	}
+
+	if !c.SkipManagedResources {
+		mrFindings, err := c.checkManagedResources(ctx)
+		findings = append(findings, mrFindings...)
+		if err != nil {
+			return findings, err
+		}
+	}
+
+	return findings, nil
+}
+
+// checkXRsAndClaims flags XR and Claim instances with a user-set
+// spec.publishConnectionDetailsTo. See the package godoc for the XR UID
+// filter rationale.
+func (c *ExternalSecretStores) checkXRsAndClaims(ctx context.Context) ([]Finding, error) {
+	types, err := DiscoverXRAndClaimTypes(ctx, c.Client, nil)
+	if err != nil {
+		return nil, errors.Wrap(err, "cannot discover XR and Claim types")
+	}
+
+	// iterate over all discovered XR and claim types to find and check all instances of those types
+	var findings []Finding
+	for _, t := range types {
+		ns := ""
+		if t.Namespaced {
+			ns = c.ClaimNamespace
+		}
+		instances, err := ListInstances(ctx, c.Client, t, ns)
+		if err != nil {
+			return findings, errors.Wrapf(err, "cannot list instances of %s", t.GVK)
+		}
+		for i := range instances {
+			inst := &instances[i]
+			v, found, err := unstructured.NestedMap(inst.Object, "spec", "publishConnectionDetailsTo")
+			if err != nil {
+				return findings, errors.Wrapf(err, "cannot read .spec.publishConnectionDetailsTo on %s/%s", inst.GetKind(), inst.GetName())
+			}
+			if !found || len(v) == 0 {
+				continue
+			}
+			// Skip the composite reconciler's auto-injected entries on XRs.
+			if !t.Namespaced {
+				name, _, _ := unstructured.NestedString(v, "name")
+				if name == string(inst.GetUID()) {
+					continue
+				}
+			}
+			findings = append(findings, Finding{
+				Resource:  ResourceRefFromUnstructured(*inst),
+				FieldPath: ".spec.publishConnectionDetailsTo",
+			})
+		}
+	}
+	return findings, nil
+}
+
+// checkManagedResources flags MRs with a user-set spec.publishConnectionDetailsTo.
+// One List per MR type runs concurrently. List failures are aggregated rather
+// than returned, so one flaky CRD doesn't drop findings from healthy types.
+func (c *ExternalSecretStores) checkManagedResources(ctx context.Context) ([]Finding, error) {
+	// first discover all manage resource types, there could be a lot of these
+	types, err := DiscoverManagedResources(ctx, c.Client)
+	if err != nil {
+		return nil, errors.Wrap(err, "cannot discover managed resource types")
+	}
+
+	var g errgroup.Group
+	if c.Concurrency > 0 {
+		g.SetLimit(c.Concurrency)
+	}
+
+	var (
+		mu       sync.Mutex // lock for all writes to our findings and listErrs
+		findings []Finding
+		listErrs []error
+	)
+
+	// start a goroutine to list all MR instances for each MR type - the errgroup.Group will limit
+	// the concurrency for us, blocking new goroutines from starting when we are at the limit.
+	for i := range types {
+		t := types[i]
+		g.Go(func() error {
+			instances, err := ListInstances(ctx, c.Client, t, "")
+			if err != nil {
+				mu.Lock()
+				listErrs = append(listErrs, errors.Wrapf(err, "cannot list %s", t.GVK))
+				mu.Unlock()
+				return nil
+			}
+			var instanceFindings []Finding
+			for j := range instances {
+				inst := &instances[j]
+				v, found, err := unstructured.NestedMap(inst.Object, "spec", "publishConnectionDetailsTo")
+				if err != nil {
+					mu.Lock()
+					listErrs = append(listErrs, errors.Wrapf(err, "cannot read .spec.publishConnectionDetailsTo on %s/%s", inst.GetKind(), inst.GetName()))
+					mu.Unlock()
+					continue
+				}
+				if !found || len(v) == 0 {
+					continue
+				}
+				instanceFindings = append(instanceFindings, Finding{
+					Resource:  ResourceRefFromUnstructured(*inst),
+					FieldPath: ".spec.publishConnectionDetailsTo",
+				})
+			}
+			if len(instanceFindings) > 0 {
+				mu.Lock()
+				findings = append(findings, instanceFindings...)
+				mu.Unlock()
+			}
+			// Always nil; errors go to listErrs so errgroup never cancels.
+			return nil
+		})
+	}
+	_ = g.Wait()
+
+	if len(listErrs) > 0 {
+		return findings, errors.Join(listErrs...)
+	}
+	return findings, nil
+}
+
+// checkDeploymentFlag flags Crossplane Deployments started with
+// --enable-external-secret-stores.
+func (c *ExternalSecretStores) checkDeploymentFlag(ctx context.Context) ([]Finding, error) {
+	sel, err := labels.Parse(c.Selector)
+	if err != nil {
+		return nil, errors.Wrap(err, "cannot parse Crossplane label selector")
+	}
+
+	// list all Deployments matching the given Crossplane namespace and label selector
+	deploys := &appsv1.DeploymentList{}
+	if err := c.Client.List(ctx, deploys,
+		client.InNamespace(c.CrossplaneNamespace),
+		client.MatchingLabelsSelector{Selector: sel},
+	); err != nil {
+		return nil, errors.Wrap(err, "cannot list Crossplane Deployments")
+	}
+
+	var findings []Finding
+	for i := range deploys.Items {
+		d := &deploys.Items[i]
+		ref := ResourceRef{
+			Group:     appsv1.SchemeGroupVersion.Group,
+			Kind:      "Deployment",
+			Namespace: d.Namespace,
+			Name:      d.Name,
+		}
+		containers := d.Spec.Template.Spec.Containers
+		// check each container for this deployment to see if it is using the ESS flag
+		for ci := range containers {
+			ctr := &containers[ci]
+			if containerHasEnabledFlag(ctr.Args, flagEnableExternalSecretStores) {
+				findings = append(findings, Finding{
+					Resource:  ref,
+					FieldPath: fmt.Sprintf(".spec.template.spec.containers[%d].args", ci),
+				})
+			}
+		}
+	}
+	return findings, nil
+}
+
+// isAutoCreatedDefaultStoreConfig reports whether the given StoreConfig is the "default"
+// StoreConfig that v1's init controller creates on every cluster. The auto-created shape has only
+// DefaultScope set; any user-customized provider config disqualifies it.
+func isAutoCreatedDefaultStoreConfig(sc *secretsv1alpha1.StoreConfig) bool {
+	if sc.Name != defaultStoreConfigName {
+		return false
+	}
+	cfg := sc.Spec.SecretStoreConfig
+	if cfg.Type != nil && *cfg.Type != xpv1.SecretStoreKubernetes {
+		return false
+	}
+	if cfg.Kubernetes != nil {
+		return false
+	}
+	if cfg.Plugin != nil {
+		return false
+	}
+	return true
+}
+
+// containerHasEnabledFlag reports whether args enables flag. The flag is
+// enabled when it appears standalone, as `flag=<anything-but-false>`, or
+// followed by a non-flag value other than "false".
+func containerHasEnabledFlag(args []string, flag string) bool {
+	flagEqualsPrefix := flag + "="
+	for i, a := range args {
+		switch {
+		case a == flag:
+			// we found the flag in the container args, check to see if the next arg is disabling it
+			// so we don't find a false positive
+			if i+1 < len(args) {
+				next := args[i+1]
+				if !strings.HasPrefix(next, "-") && strings.EqualFold(next, "false") {
+					return false
+				}
+			}
+			return true
+		case strings.HasPrefix(a, flagEqualsPrefix):
+			// the flag is being explicitly set with "=" in the container args, check if its being
+			// enabled or disabled
+			value := strings.TrimPrefix(a, flagEqualsPrefix)
+			if strings.EqualFold(value, "false") {
+				return false
+			}
+			return true
+		}
+	}
+	return false
+}

--- a/cmd/crank/beta/upgrade/check/secret_stores_test.go
+++ b/cmd/crank/beta/upgrade/check/secret_stores_test.go
@@ -1,0 +1,500 @@
+/*
+Copyright 2025 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package check
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
+	"github.com/crossplane/crossplane-runtime/pkg/test"
+
+	apiextensionsv1 "github.com/crossplane/crossplane/apis/apiextensions/v1"
+	secretsv1alpha1 "github.com/crossplane/crossplane/apis/secrets/v1alpha1"
+)
+
+func TestContainerHasEnabledFlag(t *testing.T) {
+	const flag = flagEnableExternalSecretStores
+
+	cases := map[string]struct {
+		reason string
+		args   []string
+		want   bool
+	}{
+		"Absent":             {reason: "The flag isn't present.", args: []string{"--other"}, want: false},
+		"Empty":              {reason: "No args at all.", args: nil, want: false},
+		"Standalone":         {reason: "A bare flag with no value enables it.", args: []string{flag}, want: true},
+		"FollowedByFalse":    {reason: "A bare flag whose next arg is \"false\" is disabled.", args: []string{flag, "false"}, want: false},
+		"FollowedByFalseCap": {reason: "Disabling value is matched case-insensitively.", args: []string{flag, "False"}, want: false},
+		"FollowedByFlag":     {reason: "A following flag is not a value, so the flag stays enabled.", args: []string{flag, "--metrics"}, want: true},
+		"FollowedByValue":    {reason: "A following non-false value leaves the flag enabled.", args: []string{flag, "something"}, want: true},
+		"EqualsTrue":         {reason: "flag=true enables it.", args: []string{flag + "=true"}, want: true},
+		"EqualsFalse":        {reason: "flag=false disables it.", args: []string{flag + "=false"}, want: false},
+		"EqualsFalseCap":     {reason: "flag=False is matched case-insensitively.", args: []string{flag + "=False"}, want: false},
+		"EqualsOtherValue":   {reason: "flag=<non-false> enables it.", args: []string{flag + "=1"}, want: true},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got := containerHasEnabledFlag(tc.args, flag)
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("\n%s\ncontainerHasEnabledFlag(): -want, +got:\n%s", tc.reason, diff)
+			}
+		})
+	}
+}
+
+func TestIsAutoCreatedDefaultStoreConfig(t *testing.T) {
+	cases := map[string]struct {
+		reason string
+		sc     secretsv1alpha1.StoreConfig
+		want   bool
+	}{
+		"CleanDefault": {
+			reason: "The bare \"default\" StoreConfig the init controller creates should be detected as such.",
+			sc:     secretsv1alpha1.StoreConfig{ObjectMeta: metav1.ObjectMeta{Name: defaultStoreConfigName}},
+			want:   true,
+		},
+		"ExplicitKubernetesType": {
+			reason: "An explicit Kubernetes type still matches the auto-created shape.",
+			sc: secretsv1alpha1.StoreConfig{
+				ObjectMeta: metav1.ObjectMeta{Name: defaultStoreConfigName},
+				Spec: secretsv1alpha1.StoreConfigSpec{
+					SecretStoreConfig: xpv1.SecretStoreConfig{Type: ptr.To(xpv1.SecretStoreKubernetes)},
+				},
+			},
+			want: true,
+		},
+		"WrongName": {
+			reason: "Any name other than \"default\" is user-created.",
+			sc:     secretsv1alpha1.StoreConfig{ObjectMeta: metav1.ObjectMeta{Name: "custom"}},
+			want:   false,
+		},
+		"NonKubernetesType": {
+			reason: "A non-Kubernetes store type signals user intent.",
+			sc: secretsv1alpha1.StoreConfig{
+				ObjectMeta: metav1.ObjectMeta{Name: defaultStoreConfigName},
+				Spec: secretsv1alpha1.StoreConfigSpec{
+					SecretStoreConfig: xpv1.SecretStoreConfig{Type: ptr.To(xpv1.SecretStoreType("Vault"))},
+				},
+			},
+			want: false,
+		},
+		"KubernetesConfigSet": {
+			reason: "A populated Kubernetes config disqualifies the auto-created shape.",
+			sc: secretsv1alpha1.StoreConfig{
+				ObjectMeta: metav1.ObjectMeta{Name: defaultStoreConfigName},
+				Spec: secretsv1alpha1.StoreConfigSpec{
+					SecretStoreConfig: xpv1.SecretStoreConfig{Type: ptr.To(xpv1.SecretStoreKubernetes), Kubernetes: &xpv1.KubernetesSecretStoreConfig{}},
+				},
+			},
+			want: false,
+		},
+		"PluginSet": {
+			reason: "A populated Plugin config disqualifies the auto-created shape.",
+			sc: secretsv1alpha1.StoreConfig{
+				ObjectMeta: metav1.ObjectMeta{Name: defaultStoreConfigName},
+				Spec: secretsv1alpha1.StoreConfigSpec{
+					SecretStoreConfig: xpv1.SecretStoreConfig{Plugin: &xpv1.PluginStoreConfig{}},
+				},
+			},
+			want: false,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			sc := tc.sc
+			got := isAutoCreatedDefaultStoreConfig(&sc)
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("\n%s\nisAutoCreatedDefaultStoreConfig(): -want, +got:\n%s", tc.reason, diff)
+			}
+		})
+	}
+}
+
+// essData is the declarative input for one Run scenario. Zero-value fields mean
+// "the corresponding List returns nothing". instances is keyed by list kind
+// (e.g. "XThingList", "BucketList"); instErr is keyed the same way so a case can
+// fail a single instance List without disturbing the others.
+type essData struct {
+	deploys      []appsv1.Deployment
+	storeConfigs []secretsv1alpha1.StoreConfig
+	comps        []apiextensionsv1.Composition
+	xrds         []apiextensionsv1.CompositeResourceDefinition
+	crds         []extv1.CustomResourceDefinition
+	instances    map[string][]unstructured.Unstructured
+
+	deployErr      error
+	storeConfigErr error
+	compErr        error
+	xrdErr         error
+	crdErr         error
+	instErr        map[string]error
+}
+
+func essClient(d essData) client.Client {
+	return &test.MockClient{
+		MockList: func(_ context.Context, list client.ObjectList, _ ...client.ListOption) error {
+			switch l := list.(type) {
+			case *appsv1.DeploymentList:
+				if d.deployErr != nil {
+					return d.deployErr
+				}
+				l.Items = d.deploys
+			case *secretsv1alpha1.StoreConfigList:
+				if d.storeConfigErr != nil {
+					return d.storeConfigErr
+				}
+				l.Items = d.storeConfigs
+			case *apiextensionsv1.CompositionList:
+				if d.compErr != nil {
+					return d.compErr
+				}
+				l.Items = d.comps
+			case *apiextensionsv1.CompositeResourceDefinitionList:
+				if d.xrdErr != nil {
+					return d.xrdErr
+				}
+				l.Items = d.xrds
+			case *extv1.CustomResourceDefinitionList:
+				if d.crdErr != nil {
+					return d.crdErr
+				}
+				l.Items = d.crds
+			case *unstructured.UnstructuredList:
+				kind := l.GetObjectKind().GroupVersionKind().Kind
+				if err := d.instErr[kind]; err != nil {
+					return err
+				}
+				l.Items = d.instances[kind]
+			}
+			return nil
+		},
+	}
+}
+
+func TestExternalSecretStoresRun(t *testing.T) {
+	type want struct {
+		findings []Finding
+		err      error
+	}
+	cases := map[string]struct {
+		reason   string
+		selector string // when empty, this test will set it to the CLI flag default "app=crossplane"
+		skipMR   bool
+		data     essData
+		want     want
+	}{
+		"Clean": {
+			reason: "An empty control plane (including an empty managed-resource scan) produces no findings.",
+			data:   essData{},
+			want:   want{findings: nil},
+		},
+		"BadSelector": {
+			reason:   "An unparseable Crossplane label selector is a hard error.",
+			selector: "!!!bad",
+			skipMR:   true,
+			data:     essData{},
+			want:     want{err: cmpopts.AnyError},
+		},
+		"ListDeploymentsError": {
+			reason: "A failure listing Crossplane Deployments is a hard error.",
+			skipMR: true,
+			data:   essData{deployErr: errBoom},
+			want:   want{err: cmpopts.AnyError},
+		},
+		"DeploymentFlagEnabled": {
+			reason: "A Crossplane Deployment running with --enable-external-secret-stores is flagged.",
+			skipMR: true,
+			data: essData{deploys: []appsv1.Deployment{{
+				ObjectMeta: metav1.ObjectMeta{Name: "crossplane", Namespace: "crossplane-system"},
+				Spec: appsv1.DeploymentSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{{Name: "crossplane", Args: []string{"--enable-external-secret-stores"}}},
+						},
+					},
+				},
+			}}},
+			want: want{findings: []Finding{{
+				Resource:  ResourceRef{Group: appsv1.SchemeGroupVersion.Group, Kind: "Deployment", Namespace: "crossplane-system", Name: "crossplane"},
+				FieldPath: ".spec.template.spec.containers[0].args",
+			}}},
+		},
+		"DeploymentFlagDisabled": {
+			reason: "A Deployment that explicitly disables the flag is not flagged.",
+			skipMR: true,
+			data: essData{deploys: []appsv1.Deployment{{
+				ObjectMeta: metav1.ObjectMeta{Name: "crossplane", Namespace: "crossplane-system"},
+				Spec: appsv1.DeploymentSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{{Name: "crossplane", Args: []string{"--enable-external-secret-stores=false"}}},
+						},
+					},
+				},
+			}}},
+			want: want{findings: nil},
+		},
+		"NonDefaultStoreConfig": {
+			reason: "A user-created StoreConfig is flagged.",
+			skipMR: true,
+			data:   essData{storeConfigs: []secretsv1alpha1.StoreConfig{{ObjectMeta: metav1.ObjectMeta{Name: "custom"}}}},
+			want:   want{findings: []Finding{{Resource: ResourceRef{Group: secretsv1alpha1.Group, Kind: secretsv1alpha1.StoreConfigKind, Name: "custom"}}}},
+		},
+		"DefaultStoreConfigIgnored": {
+			reason: "The auto-created \"default\" StoreConfig is not flagged.",
+			skipMR: true,
+			data:   essData{storeConfigs: []secretsv1alpha1.StoreConfig{{ObjectMeta: metav1.ObjectMeta{Name: defaultStoreConfigName}}}},
+			want:   want{findings: nil},
+		},
+		"ListStoreConfigsError": {
+			reason: "A failure listing StoreConfigs is surfaced as an error.",
+			skipMR: true,
+			data:   essData{storeConfigErr: errBoom},
+			want:   want{err: cmpopts.AnyError},
+		},
+		"CompositionStoreConfigRef": {
+			reason: "A Composition whose publishConnectionDetailsWithStoreConfigRef.name differs from \"default\" is flagged.",
+			skipMR: true,
+			data: essData{comps: []apiextensionsv1.Composition{{
+				ObjectMeta: metav1.ObjectMeta{Name: "comp"},
+				Spec: apiextensionsv1.CompositionSpec{
+					PublishConnectionDetailsWithStoreConfigRef: &apiextensionsv1.StoreConfigReference{Name: "custom"},
+				},
+			}}},
+			want: want{findings: []Finding{{Resource: ResourceRef{Group: apiextensionsv1.Group, Kind: apiextensionsv1.CompositionKind, Name: "comp"}, FieldPath: ".spec.publishConnectionDetailsWithStoreConfigRef"}}},
+		},
+		"CompositionDefaultStoreConfigRefIgnored": {
+			reason: "The apiserver-injected \"default\" store-config ref is not flagged.",
+			skipMR: true,
+			data: essData{comps: []apiextensionsv1.Composition{{
+				ObjectMeta: metav1.ObjectMeta{Name: "comp"},
+				Spec: apiextensionsv1.CompositionSpec{
+					PublishConnectionDetailsWithStoreConfigRef: &apiextensionsv1.StoreConfigReference{Name: defaultStoreConfigName},
+				},
+			}}},
+			want: want{findings: nil},
+		},
+		"XRUserOverrideFlaggedUIDFiltered": {
+			reason: "An XR with a user-set publishConnectionDetailsTo is flagged; the controller's auto-injected entry (name == metadata.uid) is filtered out.",
+			skipMR: true,
+			data: essData{
+				xrds: []apiextensionsv1.CompositeResourceDefinition{xrd("example.org", "XThing", "v1", "")},
+				instances: map[string][]unstructured.Unstructured{
+					"XThingList": {
+						// publishConnectionDetailsTo.name == metadata.uid, so skipped
+						{Object: map[string]any{
+							"apiVersion": "example.org/v1",
+							"kind":       "XThing",
+							"metadata":   map[string]any{"name": "xr-auto", "uid": "uid-1"},
+							"spec":       map[string]any{"publishConnectionDetailsTo": map[string]any{"name": "uid-1"}},
+						}},
+						// user override, flagged
+						{Object: map[string]any{
+							"apiVersion": "example.org/v1",
+							"kind":       "XThing",
+							"metadata":   map[string]any{"name": "xr-user", "uid": "uid-2"},
+							"spec":       map[string]any{"publishConnectionDetailsTo": map[string]any{"name": "custom"}},
+						}},
+					},
+				},
+			},
+			want: want{findings: []Finding{{Resource: ResourceRef{Group: "example.org", Kind: "XThing", Name: "xr-user"}, FieldPath: ".spec.publishConnectionDetailsTo"}}},
+		},
+		"ClaimFlagged": {
+			reason: "A namespaced Claim with publishConnectionDetailsTo is flagged with no UID filtering.",
+			skipMR: true,
+			data: essData{
+				xrds: []apiextensionsv1.CompositeResourceDefinition{xrd("example.org", "XThing", "v1", "Thing")},
+				instances: map[string][]unstructured.Unstructured{
+					"ThingList": {{Object: map[string]any{
+						"apiVersion": "example.org/v1",
+						"kind":       "Thing",
+						"metadata":   map[string]any{"name": "claim-1", "namespace": "team-a"},
+						"spec":       map[string]any{"publishConnectionDetailsTo": map[string]any{"name": "anything"}},
+					}}},
+				},
+			},
+			want: want{findings: []Finding{{Resource: ResourceRef{Group: "example.org", Kind: "Thing", Namespace: "team-a", Name: "claim-1"}, FieldPath: ".spec.publishConnectionDetailsTo"}}},
+		},
+		"XRInstanceListError": {
+			reason: "A failure listing XR instances during the XR/Claim scan is a hard error.",
+			skipMR: true,
+			data: essData{
+				xrds:    []apiextensionsv1.CompositeResourceDefinition{xrd("example.org", "XThing", "v1", "")},
+				instErr: map[string]error{"XThingList": errBoom},
+			},
+			want: want{err: cmpopts.AnyError},
+		},
+		"DiscoverXRTypesError": {
+			reason: "A failure listing XRDs while discovering XR/Claim types is a hard error.",
+			skipMR: true,
+			data:   essData{xrdErr: errBoom},
+			want:   want{err: cmpopts.AnyError},
+		},
+		"DiscoverManagedResourcesError": {
+			reason: "A failure listing CRDs while discovering managed-resource types is a hard error.",
+			data:   essData{crdErr: errBoom},
+			want:   want{err: cmpopts.AnyError},
+		},
+		"ManagedResourceFlagged": {
+			reason: "A managed resource with a user-set publishConnectionDetailsTo is flagged when the MR scan runs.",
+			data: essData{
+				crds: []extv1.CustomResourceDefinition{managedCRD("aws.example.org", "Bucket", "v1", false)},
+				instances: map[string][]unstructured.Unstructured{
+					"BucketList": {{Object: map[string]any{
+						"apiVersion": "aws.example.org/v1",
+						"kind":       "Bucket",
+						"metadata":   map[string]any{"name": "my-bucket"},
+						"spec":       map[string]any{"publishConnectionDetailsTo": map[string]any{"name": "secret"}},
+					}}},
+				},
+			},
+			want: want{findings: []Finding{{Resource: ResourceRef{Group: "aws.example.org", Kind: "Bucket", Name: "my-bucket"}, FieldPath: ".spec.publishConnectionDetailsTo"}}},
+		},
+		"SkipManagedResources": {
+			reason: "With --skip-managed-resources the MR scan is skipped, so a flaggable managed resource produces no finding.",
+			skipMR: true,
+			data: essData{
+				crds: []extv1.CustomResourceDefinition{managedCRD("aws.example.org", "Bucket", "v1", false)},
+				instances: map[string][]unstructured.Unstructured{
+					"BucketList": {{Object: map[string]any{
+						"apiVersion": "aws.example.org/v1",
+						"kind":       "Bucket",
+						"metadata":   map[string]any{"name": "my-bucket"},
+						"spec":       map[string]any{"publishConnectionDetailsTo": map[string]any{"name": "secret"}},
+					}}},
+				},
+			},
+			want: want{findings: nil},
+		},
+		"ManagedResourceListErrorAggregated": {
+			reason: "When one managed-resource type's List fails, its error is surfaced while findings from healthy types still come back - one flaky CRD doesn't drop the rest.",
+			data: essData{
+				crds: []extv1.CustomResourceDefinition{
+					managedCRD("aws.example.org", "Bucket", "v1", false),
+					managedCRD("other.example.org", "Queue", "v1", false),
+				},
+				instErr: map[string]error{"BucketList": errBoom}, // only return an error when listing Buckets
+				instances: map[string][]unstructured.Unstructured{
+					"QueueList": {{Object: map[string]any{
+						"apiVersion": "other.example.org/v1",
+						"kind":       "Queue",
+						"metadata":   map[string]any{"name": "my-queue"},
+						"spec":       map[string]any{"publishConnectionDetailsTo": map[string]any{"name": "secret"}},
+					}}},
+				},
+			},
+			want: want{
+				findings: []Finding{{Resource: ResourceRef{Group: "other.example.org", Kind: "Queue", Name: "my-queue"}, FieldPath: ".spec.publishConnectionDetailsTo"}},
+				err:      cmpopts.AnyError,
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			selector := tc.selector
+			if selector == "" {
+				selector = "app=crossplane"
+			}
+			c := &ExternalSecretStores{
+				Client:               essClient(tc.data),
+				CrossplaneNamespace:  "crossplane-system",
+				Selector:             selector,
+				SkipManagedResources: tc.skipMR,
+				Concurrency:          10,
+			}
+			got, err := c.Run(context.Background())
+			if diff := cmp.Diff(tc.want.err, err, cmpopts.EquateErrors()); diff != "" {
+				t.Errorf("\n%s\nRun(): -want error, +got error:\n%s", tc.reason, diff)
+			}
+			if diff := cmp.Diff(tc.want.findings, got, cmpopts.EquateEmpty()); diff != "" {
+				t.Errorf("\n%s\nRun(): -want, +got:\n%s", tc.reason, diff)
+			}
+		})
+	}
+}
+
+func TestCheckXRsAndClaimsNamespaceScope(t *testing.T) {
+	// checkXRsAndClaims lists cluster-scoped XRs across the whole cluster but
+	// scopes namespaced Claim lookups to ClaimNamespace (empty means all
+	// namespaces). We capture the namespace ListInstances applies per list kind
+	// to prove that selection. The single XRD below yields both an XThing (XR)
+	// and a Thing (Claim) type, so one call exercises both branches.
+	cases := map[string]struct {
+		reason         string
+		claimNamespace string
+		want           map[string]string // map of "list kind": "namespace used for list call"
+	}{
+		"ScopedToClaimNamespace": {
+			reason:         "A set ClaimNamespace scopes the Claim list but not the cluster-scoped XR list.",
+			claimNamespace: "team-a",
+			want:           map[string]string{"XThingList": "", "ThingList": "team-a"},
+		},
+		"AllNamespacesWhenEmpty": {
+			reason:         "An empty ClaimNamespace lists Claims across all namespaces, so neither list is namespace-scoped.",
+			claimNamespace: "",
+			want:           map[string]string{"XThingList": "", "ThingList": ""},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			gotNS := map[string]string{}
+			c := &ExternalSecretStores{
+				ClaimNamespace: tc.claimNamespace,
+				Client: &test.MockClient{
+					MockList: func(_ context.Context, list client.ObjectList, opts ...client.ListOption) error {
+						switch l := list.(type) {
+						case *apiextensionsv1.CompositeResourceDefinitionList:
+							l.Items = []apiextensionsv1.CompositeResourceDefinition{xrd("example.org", "XThing", "v1", "Thing")}
+						case *unstructured.UnstructuredList:
+							ns := ""
+							for _, o := range opts {
+								if in, ok := o.(client.InNamespace); ok {
+									ns = string(in)
+								}
+							}
+							gotNS[l.GetObjectKind().GroupVersionKind().Kind] = ns
+						}
+						return nil
+					},
+				},
+			}
+
+			if _, err := c.checkXRsAndClaims(context.Background()); err != nil {
+				t.Fatalf("checkXRsAndClaims() unexpected error: %v", err)
+			}
+			if diff := cmp.Diff(tc.want, gotNS); diff != "" {
+				t.Errorf("\n%s\ncheckXRsAndClaims() namespace per list kind: -want, +got:\n%s", tc.reason, diff)
+			}
+		})
+	}
+}

--- a/cmd/crank/beta/upgrade/check/secret_stores_test.go
+++ b/cmd/crank/beta/upgrade/check/secret_stores_test.go
@@ -137,6 +137,17 @@ func TestIsAutoCreatedDefaultStoreConfig(t *testing.T) {
 	}
 }
 
+// mrInstance builds an unstructured managed resource with a user-set
+// spec.publishConnectionDetailsTo, the shape checkManagedResources flags.
+func mrInstance(apiVersion, kind, name string) unstructured.Unstructured {
+	return unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": apiVersion,
+		"kind":       kind,
+		"metadata":   map[string]any{"name": name},
+		"spec":       map[string]any{"publishConnectionDetailsTo": map[string]any{"name": "secret"}},
+	}}
+}
+
 // essData is the declarative input for one Run scenario. Zero-value fields mean
 // "the corresponding List returns nothing". instances is keyed by list kind
 // (e.g. "XThingList", "BucketList"); instErr is keyed the same way so a case can
@@ -204,14 +215,15 @@ func TestExternalSecretStoresRun(t *testing.T) {
 		err      error
 	}
 	cases := map[string]struct {
-		reason   string
-		selector string // when empty, this test will set it to the CLI flag default "app=crossplane"
-		skipMR   bool
-		data     essData
-		want     want
+		reason      string
+		selector    string // when empty, this test will set it to the CLI flag default "app=crossplane"
+		skipMR      bool
+		concurrency int // when zero, this test will set it to 10
+		data        essData
+		want        want
 	}{
 		"Clean": {
-			reason: "An empty control plane (including an empty managed-resource scan) produces no findings.",
+			reason: "An empty control plane (including an empty managed resource scan) produces no findings.",
 			data:   essData{},
 			want:   want{findings: nil},
 		},
@@ -359,7 +371,7 @@ func TestExternalSecretStoresRun(t *testing.T) {
 			want:   want{err: cmpopts.AnyError},
 		},
 		"DiscoverManagedResourcesError": {
-			reason: "A failure listing CRDs while discovering managed-resource types is a hard error.",
+			reason: "A failure listing CRDs while discovering managed resource types is a hard error.",
 			data:   essData{crdErr: errBoom},
 			want:   want{err: cmpopts.AnyError},
 		},
@@ -395,7 +407,7 @@ func TestExternalSecretStoresRun(t *testing.T) {
 			want: want{findings: nil},
 		},
 		"ManagedResourceListErrorAggregated": {
-			reason: "When one managed-resource type's List fails, its error is surfaced while findings from healthy types still come back - one flaky CRD doesn't drop the rest.",
+			reason: "When one managed resource type's List fails, its error is surfaced while findings from healthy types still come back - one flaky CRD doesn't drop the rest.",
 			data: essData{
 				crds: []extv1.CustomResourceDefinition{
 					managedCRD("aws.example.org", "Bucket", "v1", false),
@@ -416,6 +428,33 @@ func TestExternalSecretStoresRun(t *testing.T) {
 				err:      cmpopts.AnyError,
 			},
 		},
+		"ManagedResourcesExceedConcurrencyLimit": {
+			reason:      "With more managed resource types than the concurrency limit, the bounded scan must process every type without deadlocking or dropping findings. Findings come back in type-discovery order because each type writes its own result slot.",
+			concurrency: 2, // small concurency limit of 2, less than the number of MR types we need to check
+			data: essData{
+				crds: []extv1.CustomResourceDefinition{
+					managedCRD("a.example.org", "Aa", "v1", false),
+					managedCRD("b.example.org", "Bb", "v1", false),
+					managedCRD("c.example.org", "Cc", "v1", false),
+					managedCRD("d.example.org", "Dd", "v1", false),
+					managedCRD("e.example.org", "Ee", "v1", false),
+				},
+				instances: map[string][]unstructured.Unstructured{
+					"AaList": {mrInstance("a.example.org/v1", "Aa", "aa")},
+					"BbList": {mrInstance("b.example.org/v1", "Bb", "bb")},
+					"CcList": {mrInstance("c.example.org/v1", "Cc", "cc")},
+					"DdList": {mrInstance("d.example.org/v1", "Dd", "dd")},
+					"EeList": {mrInstance("e.example.org/v1", "Ee", "ee")},
+				},
+			},
+			want: want{findings: []Finding{
+				{Resource: ResourceRef{Group: "a.example.org", Kind: "Aa", Name: "aa"}, FieldPath: ".spec.publishConnectionDetailsTo"},
+				{Resource: ResourceRef{Group: "b.example.org", Kind: "Bb", Name: "bb"}, FieldPath: ".spec.publishConnectionDetailsTo"},
+				{Resource: ResourceRef{Group: "c.example.org", Kind: "Cc", Name: "cc"}, FieldPath: ".spec.publishConnectionDetailsTo"},
+				{Resource: ResourceRef{Group: "d.example.org", Kind: "Dd", Name: "dd"}, FieldPath: ".spec.publishConnectionDetailsTo"},
+				{Resource: ResourceRef{Group: "e.example.org", Kind: "Ee", Name: "ee"}, FieldPath: ".spec.publishConnectionDetailsTo"},
+			}},
+		},
 	}
 
 	for name, tc := range cases {
@@ -424,12 +463,16 @@ func TestExternalSecretStoresRun(t *testing.T) {
 			if selector == "" {
 				selector = "app=crossplane"
 			}
+			concurrency := tc.concurrency
+			if concurrency == 0 {
+				concurrency = 10
+			}
 			c := &ExternalSecretStores{
 				Client:               essClient(tc.data),
 				CrossplaneNamespace:  "crossplane-system",
 				Selector:             selector,
 				SkipManagedResources: tc.skipMR,
-				Concurrency:          10,
+				Concurrency:          concurrency,
 			}
 			got, err := c.Run(context.Background())
 			if diff := cmp.Diff(tc.want.err, err, cmpopts.EquateErrors()); diff != "" {

--- a/cmd/crank/beta/upgrade/upgrade.go
+++ b/cmd/crank/beta/upgrade/upgrade.go
@@ -1,0 +1,32 @@
+/*
+Copyright 2025 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package upgrade contains commands that help users upgrade Crossplane.
+package upgrade
+
+import (
+	"github.com/crossplane/crossplane/cmd/crank/beta/upgrade/check"
+)
+
+// Cmd groups Crossplane upgrade related commands.
+type Cmd struct {
+	Check check.Cmd `cmd:"" help:"Check a control plane for features that are removed or broken in Crossplane v2."`
+}
+
+// Help returns help for the upgrade command.
+func (c *Cmd) Help() string {
+	return "Commands associated with upgrading a Crossplane control plane to a newer version."
+}

--- a/go.mod
+++ b/go.mod
@@ -198,7 +198,7 @@ require (
 	github.com/emicklei/go-restful/v3 v3.12.1 // indirect
 	github.com/evanphx/json-patch v5.9.11+incompatible // indirect
 	github.com/evanphx/json-patch/v5 v5.9.0 // indirect
-	github.com/fatih/color v1.18.0 // indirect
+	github.com/fatih/color v1.18.0
 	github.com/fsnotify/fsnotify v1.9.0 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect


### PR DESCRIPTION
### Description of your changes

Crossplane v2 removes or changes the behavior of a handful of v1 features as described in https://docs.crossplane.io/latest/whats-new/#backward-compatibility. An operator running a v1.x control plane today has no way to know whether their compositions, packages, or resources are actively using something that would break if they were to upgrade to v2.

This PR adds `crossplane beta upgrade check`: a new read-only command for the v1.20 Crossplane CLI that connects to a live v1.x control plane and scans it for usage of features that are removed or have breaking changes in v2. Run it against a cluster before upgrading and it tells you what will break.

It checks for:

- **Native patch-and-transform Compositions** (removed in v2).
- **ControllerConfig** CRs, and Providers/Functions still referencing one via `spec.controllerConfigRef` (the type is removed).
- **External secret stores** usage (the alpha feature is removed).
- **Composite resource connection details** (removed for v2 XRs, retained for legacy XRs, so flagged informationally rather than as a blocker).
- **Unqualified package sources**, which break because v2 drops the default registry.

Each check sits behind a small `Check` interface; a `Runner` collects their `Finding`s into a report that prints as nicely formatted pretty colored text (default) or JSON (`-o json`). All findings carry a severity. Issue-severity findings, and any check that errors out before completing, cause a non-zero exit. Informational findings do not.

A recurring challenge in some of the checks is separating real user intent from controller and api server injected defaults. The external secret stores check, for example, ignores the `default` StoreConfig that v1 creates on every cluster, and the `publishConnectionDetailsTo` entry the composite reconciler auto-injects keyed by an XR's own UID. It flags only values that reflect an explicit opt-in and usage of the removed feature by the user.

The managed resource scan is the expensive part of the secret stores check on clusters with many provider CRDs. `--skip-managed-resources` opts out of it, and `--concurrency` (default 10) sets a limit on the number of parallel API calls. To further help with perf, the client runs at a slightly raised QPS/burst since this is a short-lived tool as opposed to a long-running controller.

By default the check sweeps the whole control plane (cluster-scoped resources and all namespaces) but has a `--namespace` option that restricts namespaced checks to just that namespace.

Fixes #7348

### How has this been tested?

In addition to the suite of unit tests, I have been iterating/testing on a live v1.20 control plane seeded with usage of all the breaking changes functionality.

Testers/reviewers can also easily set up a control plane like this with the following demo repo:

* https://github.com/jbw976/xp-v2-upgrade-checks

Simply run the `./setup.sh` from that repo and it will create a v1.20 cluster and apply all sorts of broken functionality that this tool will catch.

Then I run these commands to test:
```
go install ./cmd/crank
crank beta upgrade check
```

If you're curious what the output looks like, see the collapsed section below:
<details>
<summary>Full upgrade check output example</summary>

```
❯ crank beta upgrade check
[✗] 23 issues, 6 informational, 0 incomplete checks.

[✗] Native patch-and-transform Compositions - 9 issues
    │
    │  Crossplane v2 removes native patch-and-transform (P&T) Composition. Compositions must use mode: Pipeline with Composition Functions.
    │  Fix:   Migrate to Composition Functions (spec.mode: Pipeline with spec.pipeline steps). Run "crossplane beta convert pipeline-composition" to convert existing Compositions.
    │  Docs:  https://docs.crossplane.io/latest/guides/upgrade-to-crossplane-v2/#native-patch-and-transform-composition
    │         https://docs.crossplane.io/v1.20/cli/command-reference/#beta-convert
    │
    │    NAME                                                                 FIELD
    │    composition.apiextensions.crossplane.io/conn-secrets-composition     .spec.mode
    │    composition.apiextensions.crossplane.io/conn-secrets-composition     .spec.resources
    │    composition.apiextensions.crossplane.io/extsecretstore-composition   .spec.mode
    │    composition.apiextensions.crossplane.io/extsecretstore-composition   .spec.resources
    │    composition.apiextensions.crossplane.io/native-connection-details    .spec.mode
    │    composition.apiextensions.crossplane.io/native-connection-details    .spec.resources
    │    composition.apiextensions.crossplane.io/nativepnt-composition        .spec.mode
    │    composition.apiextensions.crossplane.io/nativepnt-composition        .spec.patchSets
    │    composition.apiextensions.crossplane.io/nativepnt-composition        .spec.resources
    └──
[✗] ControllerConfig usage - 3 issues
    │
    │  Crossplane v2 removes the ControllerConfig type. Use DeploymentRuntimeConfig instead.
    │  Fix:   Migrate to DeploymentRuntimeConfig (pkg.crossplane.io/v1beta1). Run "crossplane beta convert deployment-runtime" to convert existing ControllerConfigs.
    │  Docs:  https://docs.crossplane.io/latest/guides/upgrade-to-crossplane-v2/#controllerconfig-type
    │         https://docs.crossplane.io/v1.20/cli/command-reference/#beta-convert
    │
    │    NAME                                                       FIELD
    │    controllerconfig.pkg.crossplane.io/test-controllerconfig   -
    │
    │    NAME                                                        FIELD
    │    function.pkg.crossplane.io/function-with-controllerconfig   .spec.controllerConfigRef
    │
    │    NAME                                                        FIELD
    │    provider.pkg.crossplane.io/provider-with-controllerconfig   .spec.controllerConfigRef
    └──
[✗] External secret stores - 9 issues
    │
    │  Crossplane v2 removes support for external secret stores. Publish connection details as Kubernetes Secrets composed by your Compositions, or adopt External Secrets Operator if
    │  you need an external store.
    │  Fix:   Disable --enable-external-secret-stores on the Crossplane Deployment, replace StoreConfig-based publishing with composed Kubernetes Secrets (or adopt External Secrets
    │         Operator), then delete StoreConfig resources. No automated converter exists.
    │  Docs:  https://docs.crossplane.io/latest/guides/upgrade-to-crossplane-v2/#external-secret-stores
    │         https://docs.crossplane.io/latest/guides/connection-details-composition
    │         https://github.com/external-secrets/external-secrets
    │
    │    NAME                                                                 FIELD
    │    composition.apiextensions.crossplane.io/extsecretstore-composition   .spec.publishConnectionDetailsWithStoreConfigRef
    │
    │    NAMESPACE           NAME                         FIELD
    │    crossplane-system   deployment.apps/crossplane   .spec.template.spec.containers[0].args
    │
    │    NAMESPACE   NAME                                                            FIELD
    │    default     extsecretstore.upgradetest.crossplane.io/extsecretstore-claim   .spec.publishConnectionDetailsTo
    │
    │    NAME                                                             FIELD
    │    nopresource.nop.crossplane.io/extsecretstore-claim-hgpq8-cw28n   .spec.publishConnectionDetailsTo
    │    nopresource.nop.crossplane.io/extsecretstore-claim-hgpq8-nth8f   .spec.publishConnectionDetailsTo
    │    nopresource.nop.crossplane.io/extsecretstore-xr-289hf            .spec.publishConnectionDetailsTo
    │    nopresource.nop.crossplane.io/extsecretstore-xr-bfzlj            .spec.publishConnectionDetailsTo
    │
    │    NAME                                                 FIELD
    │    storeconfig.secrets.crossplane.io/test-storeconfig   -
    │
    │    NAME                                                          FIELD
    │    xextsecretstore.upgradetest.crossplane.io/extsecretstore-xr   .spec.publishConnectionDetailsTo
    └──
[i] Composite resource connection details - 6 informational findings
    │
    │  Crossplane v2 keeps legacy XR and Claim connection-detail aggregation working, so no action is required for the upgrade itself. This check is informational: it flags resources
    │  that would need explicit composed Secrets if you later migrate them to v2-style namespaced XRs. Managed resources are unaffected and continue to publish via
    │  spec.writeConnectionSecretToRef.
    │  Fix:   No action required for the upgrade. If you later migrate these XRDs to v2-style namespaced XRs, compose a Kubernetes Secret explicitly to publish connection details. No
    │         automated converter exists.
    │  Docs:  https://docs.crossplane.io/latest/guides/upgrade-to-crossplane-v2/#composite-resource-connection-details
    │         https://docs.crossplane.io/latest/guides/connection-details-composition
    │
    │    NAME                                                                                             FIELD
    │    compositeresourcedefinition.apiextensions.crossplane.io/xconndetails.upgradetest.crossplane.io   .spec.connectionSecretKeys
    │
    │    NAME                                                                  FIELD
    │    composition.apiextensions.crossplane.io/conn-secrets-composition      .spec.writeConnectionSecretsToNamespace
    │    composition.apiextensions.crossplane.io/native-connection-details     .spec.resources[].connectionDetails
    │    composition.apiextensions.crossplane.io/pipeline-connection-details   .spec.pipeline[].input.resources[].connectionDetails
    │
    │    NAMESPACE   NAME                                                      FIELD
    │    default     conndetails.upgradetest.crossplane.io/conndetails-claim   .spec.writeConnectionSecretToRef
    │
    │    NAME                                                    FIELD
    │    xconndetails.upgradetest.crossplane.io/conndetails-xr   .spec.writeConnectionSecretToRef
    └──
[✗] Unqualified package sources - 2 issues
    │
    │  Crossplane v2 removes the --registry flag and its implicit default registry. Every Provider, Configuration, and Function spec.package (including dependencies) must be a fully
    │  qualified reference including its registry hostname.
    │  Fix:   Prefix the package with its fully qualified registry hostname (e.g. xpkg.crossplane.io/crossplane-contrib/provider-nop:v0.4.0) and ensure all package references are
    │         valid.
    │  Docs:  https://docs.crossplane.io/latest/guides/upgrade-to-crossplane-v2/#default-registry-flag
    │
    │    NAME                                              FIELD
    │    function.pkg.crossplane.io/unqualified-function   .spec.package
    │
    │    NAME                                              FIELD
    │    provider.pkg.crossplane.io/unqualified-provider   .spec.package
    └──

crossplane: error: blockers found
```

</details>

### Releasing

Note this PR is on the v1.20 branch directly - this command will not ship in v2.x branches because it is only useful before upgrading to v2. In the v2 branches, all of the types that this tool uses have been removed anyways 😅 

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `./nix.sh flake check` to ensure this PR is ready for review.
- [x] Added or updated unit tests.
- [ ] ~Added or updated e2e tests.~
- [x] Linked a PR or a [docs tracking issue] to [document this change].
  - https://github.com/crossplane/docs/issues/1102
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~
- [ ] ~Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `crank beta upgrade check` command to scan clusters for upgrade compatibility issues before migrating to newer Crossplane versions. Supports multiple checks including deprecated features and legacy patterns with text and JSON output formats.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/crossplane/crossplane/pull/7451?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->