### PR TITLE
fix(render): return requirements even on fatal errors

### DIFF
--- a/cmd/crossplane/render/render.go
+++ b/cmd/crossplane/render/render.go
@@ -131,30 +131,40 @@ func (c *Command) Run(log logging.Logger) error {
 		return errors.New("render request must set exactly one of: composite, operation, cron_operation, watch_operation")
 	}
 
-	// On a pipeline FATAL we must surface the partial output to stdout
-	// before propagating the error so callers iterating on requirements can
-	// recover the recorded RequiredResources/RequiredSchemas. Other errors
-	// keep the previous behavior (stdout empty, generic non-zero exit).
+	// On a pipeline FATAL we surface the partial output to stdout before
+	// propagating the error so callers iterating on requirements can recover
+	// the recorded RequiredResources/RequiredSchemas. We only take that
+	// path when there's actually a partial output to emit (rsp.Output set):
+	// if BuildOutput failed alongside the pipeline FATAL, there's no usable
+	// stdout to emit so we fall through to the regular error path. Callers
+	// can still recover *PipelineFatalError from the returned error via
+	// errors.As regardless of which path we take.
 	var pfe *xcomposite.PipelineFatalError
-	if renderErr != nil && !errors.As(renderErr, &pfe) {
+	hasPartialOutput := rsp.GetOutput() != nil && errors.As(renderErr, &pfe)
+	if renderErr != nil && !hasPartialOutput {
 		return renderErr
 	}
 
 	out, err := proto.Marshal(rsp)
 	if err != nil {
-		// Surface marshal failure even when there was a pipeline FATAL: the
-		// caller cannot consume an unmarshalled stdout, and a marshal error
-		// is itself unexpected.
+		// Marshal failure means we cannot deliver any stdout; surface both
+		// the marshal error and the pipeline FATAL (if any) via errors.Join
+		// so callers can still recover *PipelineFatalError via errors.As.
+		// The combined error does not implement kong.ExitCoder, so the
+		// process exits with the generic non-zero code instead of 3 — which
+		// is correct because the partial-output contract isn't being met.
+		merr := errors.Wrap(err, "cannot marshal render response")
 		if renderErr != nil {
-			return errors.Wrap(err, "cannot marshal render response (also: "+renderErr.Error()+")")
+			return errors.Join(merr, renderErr)
 		}
-		return errors.Wrap(err, "cannot marshal render response")
+		return merr
 	}
 	if _, err := c.stdout.Write(out); err != nil {
+		werr := errors.Wrap(err, "cannot write render response")
 		if renderErr != nil {
-			return errors.Wrap(err, "cannot write render response (also: "+renderErr.Error()+")")
+			return errors.Join(werr, renderErr)
 		}
-		return errors.Wrap(err, "cannot write render response")
+		return werr
 	}
 
 	if pfe != nil {

--- a/cmd/crossplane/render/render.go
+++ b/cmd/crossplane/render/render.go
@@ -150,21 +150,16 @@ func (c *Command) Run(log logging.Logger) error {
 		// Marshal failure means we cannot deliver any stdout; surface both
 		// the marshal error and the pipeline FATAL (if any) via errors.Join
 		// so callers can still recover *PipelineFatalError via errors.As.
-		// The combined error does not implement kong.ExitCoder, so the
-		// process exits with the generic non-zero code instead of 3 — which
-		// is correct because the partial-output contract isn't being met.
-		merr := errors.Wrap(err, "cannot marshal render response")
-		if renderErr != nil {
-			return errors.Join(merr, renderErr)
-		}
-		return merr
+		// When renderErr is nil, errors.Join wraps the marshal error in a
+		// MultiError whose Error() string and errors.As/Is behavior match
+		// the wrapped error exactly. The combined error does not implement
+		// kong.ExitCoder, so the process exits with the generic non-zero
+		// code instead of 3 — correct because the partial-output contract
+		// isn't being met.
+		return errors.Join(errors.Wrap(err, "cannot marshal render response"), renderErr)
 	}
 	if _, err := c.stdout.Write(out); err != nil {
-		werr := errors.Wrap(err, "cannot write render response")
-		if renderErr != nil {
-			return errors.Join(werr, renderErr)
-		}
-		return werr
+		return errors.Join(errors.Wrap(err, "cannot write render response"), renderErr)
 	}
 
 	if pfe != nil {

--- a/cmd/crossplane/render/render.go
+++ b/cmd/crossplane/render/render.go
@@ -31,16 +31,44 @@ import (
 	"github.com/crossplane/crossplane-runtime/v2/pkg/errors"
 	"github.com/crossplane/crossplane-runtime/v2/pkg/logging"
 
+	xcomposite "github.com/crossplane/crossplane/v2/internal/controller/apiextensions/composite"
 	"github.com/crossplane/crossplane/v2/internal/render/composite"
 	"github.com/crossplane/crossplane/v2/internal/render/operation"
 	renderv1alpha1 "github.com/crossplane/crossplane/v2/proto/render/v1alpha1"
 )
+
+// ExitCodePipelineFatal is the process exit code reported when a function
+// pipeline step returns a SEVERITY_FATAL result. It is distinct from the
+// generic non-zero exit Kong reports for other errors so that wrappers can
+// branch on FATAL without parsing stderr. See issue #7446.
+const ExitCodePipelineFatal = 3
 
 // Command renders a resource using the real reconciler engine backed by a fake
 // in-memory client. It reads a protobuf RenderRequest from stdin and writes a
 // protobuf RenderResponse to stdout.
 type Command struct {
 	Timeout time.Duration `default:"2m" help:"Timeout for the render operation."`
+
+	// stdin and stdout default to os.Stdin/os.Stdout. They are unexported
+	// so they don't expand the production API surface; in-package tests can
+	// set them to substitute buffers without process-level redirection.
+	// AfterApply (called by Kong after parsing) populates these if unset,
+	// so Run can use them directly.
+	stdin  io.Reader
+	stdout io.Writer
+}
+
+// AfterApply is invoked by Kong after CLI parsing, before Run. It applies
+// stdin/stdout defaults so callers (Kong in production, tests injecting
+// buffers) only need to override what they want substituted.
+func (c *Command) AfterApply() error {
+	if c.stdin == nil {
+		c.stdin = os.Stdin
+	}
+	if c.stdout == nil {
+		c.stdout = os.Stdout
+	}
+	return nil
 }
 
 // Run executes the render command.
@@ -48,7 +76,7 @@ func (c *Command) Run(log logging.Logger) error {
 	ctx, cancel := context.WithTimeout(context.Background(), c.Timeout)
 	defer cancel()
 
-	data, err := io.ReadAll(os.Stdin)
+	data, err := io.ReadAll(c.stdin)
 	if err != nil {
 		return errors.Wrap(err, "cannot read render request from stdin")
 	}
@@ -60,20 +88,30 @@ func (c *Command) Run(log logging.Logger) error {
 
 	rsp := &renderv1alpha1.RenderResponse{Meta: &renderv1alpha1.ResponseMeta{}}
 
+	// renderErr captures the render-side failure if any. We resolve it after
+	// the switch so the success path can still return a marshalled response,
+	// and the pipeline-fatal path can return both the partial response on
+	// stdout AND a typed error with a distinct exit code.
+	var renderErr error
+
 	switch in := req.GetInput().(type) {
 	case *renderv1alpha1.RenderRequest_Composite:
 		out, err := composite.Render(ctx, log, in.Composite)
-		if err != nil {
-			return errors.Wrap(err, "cannot render composite resource")
+		if out != nil {
+			rsp.Output = &renderv1alpha1.RenderResponse_Composite{Composite: out}
 		}
-		rsp.Output = &renderv1alpha1.RenderResponse_Composite{Composite: out}
+		if err != nil {
+			renderErr = errors.Wrap(err, "cannot render composite resource")
+		}
 
 	case *renderv1alpha1.RenderRequest_Operation:
 		out, err := operation.Render(ctx, log, in.Operation)
-		if err != nil {
-			return errors.Wrap(err, "cannot render operation")
+		if out != nil {
+			rsp.Output = &renderv1alpha1.RenderResponse_Operation{Operation: out}
 		}
-		rsp.Output = &renderv1alpha1.RenderResponse_Operation{Operation: out}
+		if err != nil {
+			renderErr = errors.Wrap(err, "cannot render operation")
+		}
 
 	case *renderv1alpha1.RenderRequest_CronOperation:
 		out, err := operation.NewFromCronOperation(in.CronOperation)
@@ -93,11 +131,51 @@ func (c *Command) Run(log logging.Logger) error {
 		return errors.New("render request must set exactly one of: composite, operation, cron_operation, watch_operation")
 	}
 
-	out, err := proto.Marshal(rsp)
-	if err != nil {
-		return errors.Wrap(err, "cannot marshal render response")
+	// On a pipeline FATAL we must surface the partial output to stdout
+	// before propagating the error so callers iterating on requirements can
+	// recover the recorded RequiredResources/RequiredSchemas. Other errors
+	// keep the previous behavior (stdout empty, generic non-zero exit).
+	var pfe *xcomposite.PipelineFatalError
+	if renderErr != nil && !errors.As(renderErr, &pfe) {
+		return renderErr
 	}
 
-	_, err = os.Stdout.Write(out)
-	return errors.Wrap(err, "cannot write render response")
+	out, err := proto.Marshal(rsp)
+	if err != nil {
+		// Surface marshal failure even when there was a pipeline FATAL: the
+		// caller cannot consume an unmarshalled stdout, and a marshal error
+		// is itself unexpected.
+		if renderErr != nil {
+			return errors.Wrap(err, "cannot marshal render response (also: "+renderErr.Error()+")")
+		}
+		return errors.Wrap(err, "cannot marshal render response")
+	}
+	if _, err := c.stdout.Write(out); err != nil {
+		if renderErr != nil {
+			return errors.Wrap(err, "cannot write render response (also: "+renderErr.Error()+")")
+		}
+		return errors.Wrap(err, "cannot write render response")
+	}
+
+	if pfe != nil {
+		// Wrap with an exit-code marker so Kong (via the kong.ExitCoder
+		// interface) sets the process exit code to ExitCodePipelineFatal.
+		// The wrapped chain still contains *xcomposite.PipelineFatalError,
+		// so
+		// callers using errors.As can recover it.
+		return &exitCodeError{err: renderErr, code: ExitCodePipelineFatal}
+	}
+	return nil
 }
+
+// exitCodeError wraps an error to communicate a specific process exit code
+// to Kong via the kong.ExitCoder interface. Unwrap preserves the chain so
+// callers using errors.As/Is still see whatever was wrapped.
+type exitCodeError struct {
+	err  error
+	code int
+}
+
+func (e *exitCodeError) Error() string { return e.err.Error() }
+func (e *exitCodeError) Unwrap() error { return e.err }
+func (e *exitCodeError) ExitCode() int { return e.code }

--- a/cmd/crossplane/render/render_test.go
+++ b/cmd/crossplane/render/render_test.go
@@ -18,14 +18,9 @@ package render
 
 import (
 	"bytes"
-	"context"
-	"net"
-	"sync"
 	"testing"
-	"time"
 
 	"github.com/alecthomas/kong"
-	"google.golang.org/grpc"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/structpb"
 
@@ -33,55 +28,10 @@ import (
 	"github.com/crossplane/crossplane-runtime/v2/pkg/logging"
 
 	xcomposite "github.com/crossplane/crossplane/v2/internal/controller/apiextensions/composite"
+	"github.com/crossplane/crossplane/v2/internal/render/rendertest"
 	fnv1 "github.com/crossplane/crossplane/v2/proto/fn/v1"
 	renderv1alpha1 "github.com/crossplane/crossplane/v2/proto/render/v1alpha1"
 )
-
-// fatalFunctionServer announces a required resource on its first call and
-// returns SEVERITY_FATAL on its second, mirroring the
-// function-extra-resources / function-environment-configs scenarios that
-// motivated issue #7446.
-type fatalFunctionServer struct {
-	fnv1.UnimplementedFunctionRunnerServiceServer
-	requirementName string
-	selector        *fnv1.ResourceSelector
-	fatalMessage    string
-
-	mu    sync.Mutex
-	calls int
-}
-
-func (s *fatalFunctionServer) RunFunction(_ context.Context, _ *fnv1.RunFunctionRequest) (*fnv1.RunFunctionResponse, error) {
-	s.mu.Lock()
-	s.calls++
-	call := s.calls
-	s.mu.Unlock()
-
-	rsp := &fnv1.RunFunctionResponse{
-		Requirements: &fnv1.Requirements{
-			Resources: map[string]*fnv1.ResourceSelector{
-				s.requirementName: s.selector,
-			},
-		},
-	}
-	if call > 1 {
-		rsp.Results = []*fnv1.Result{{Severity: fnv1.Severity_SEVERITY_FATAL, Message: s.fatalMessage}}
-	}
-	return rsp, nil
-}
-
-func startTestFunctionServer(t *testing.T, ss fnv1.FunctionRunnerServiceServer) string {
-	t.Helper()
-	lis, err := net.Listen("tcp", "127.0.0.1:0")
-	if err != nil {
-		t.Fatalf("cannot listen for test gRPC server: %v", err)
-	}
-	s := grpc.NewServer()
-	fnv1.RegisterFunctionRunnerServiceServer(s, ss)
-	go func() { _ = s.Serve(lis) }()
-	t.Cleanup(s.Stop)
-	return lis.Addr().String()
-}
 
 func mustStruct(t *testing.T, m map[string]any) *structpb.Struct {
 	t.Helper()
@@ -103,7 +53,9 @@ func mustMarshalRequest(t *testing.T, req *renderv1alpha1.RenderRequest) *bytes.
 	return bytes.NewBuffer(data)
 }
 
-func TestRunWritesPartialResponseOnPipelineFatal(t *testing.T) {
+func TestRun(t *testing.T) {
+	// Constants for the FATAL case shared between request construction and
+	// expected-result assertions.
 	const stepName = "fetch-extras"
 	const fatalMsg = "Required extra resource \"namedClusterRole\" not found"
 	const requirementName = "namedClusterRole"
@@ -116,143 +68,197 @@ func TestRunWritesPartialResponseOnPipelineFatal(t *testing.T) {
 		},
 	}
 
-	addr := startTestFunctionServer(t, &fatalFunctionServer{
-		requirementName: requirementName,
-		selector:        wantSelector,
-		fatalMessage:    fatalMsg,
-	})
+	type want struct {
+		// pipelineFatal asserts whether *xcomposite.PipelineFatalError is
+		// expected in the returned error's chain (errors.As).
+		pipelineFatal bool
+		// fatalStep / fatalMessage are checked only when pipelineFatal is
+		// true.
+		fatalStep, fatalMessage string
+		// exitCode is the expected kong.ExitCoder code; zero means the
+		// returned error must NOT implement kong.ExitCoder.
+		exitCode int
+		// compositeOutput indicates we expect stdout to contain a parseable
+		// RenderResponse with Composite set; otherwise stdout must be empty.
+		compositeOutput bool
+		// requiredResources is the expected
+		// CompositeOutput.RequiredResources count when compositeOutput is
+		// true.
+		requiredResources int
+	}
 
-	req := &renderv1alpha1.RenderRequest{
-		Input: &renderv1alpha1.RenderRequest_Composite{
-			Composite: &renderv1alpha1.CompositeInput{
-				CompositeResource: mustStruct(t, map[string]any{
-					"apiVersion": "example.org/v1alpha1",
-					"kind":       "XExample",
-					"metadata":   map[string]any{"name": "my-example"},
-				}),
-				Composition: mustStruct(t, map[string]any{
-					"metadata": map[string]any{"name": "example-composition"},
-					"spec": map[string]any{
-						"compositeTypeRef": map[string]any{
-							"apiVersion": "example.org/v1alpha1",
-							"kind":       "XExample",
-						},
-						"mode": "Pipeline",
-						"pipeline": []any{
-							map[string]any{
-								"step":        stepName,
-								"functionRef": map[string]any{"name": "function-extra-resources"},
+	cases := map[string]struct {
+		reason string
+		// req returns the RenderRequest. It's a closure so each test case
+		// can stand up its own gRPC fixture and bake the address into the
+		// request.
+		req  func(t *testing.T) *renderv1alpha1.RenderRequest
+		want want
+	}{
+		"PipelineFatalReturnsPartialOutputWithExitCode3": {
+			reason: "When a pipeline step returns SEVERITY_FATAL, Run must marshal the partial RenderResponse (with recorded RequiredResources) to stdout and return an error with kong.ExitCoder code 3 and *PipelineFatalError reachable via errors.As.",
+			req: func(t *testing.T) *renderv1alpha1.RenderRequest {
+				t.Helper()
+				addr := rendertest.StartFunctionServer(t, &rendertest.FatalFunctionServer{
+					RequirementName: requirementName,
+					Selector:        wantSelector,
+					FatalMessage:    fatalMsg,
+				})
+				return &renderv1alpha1.RenderRequest{
+					Input: &renderv1alpha1.RenderRequest_Composite{
+						Composite: &renderv1alpha1.CompositeInput{
+							CompositeResource: mustStruct(t, map[string]any{
+								"apiVersion": "example.org/v1alpha1",
+								"kind":       "XExample",
+								"metadata":   map[string]any{"name": "my-example"},
+							}),
+							Composition: mustStruct(t, map[string]any{
+								"metadata": map[string]any{"name": "example-composition"},
+								"spec": map[string]any{
+									"compositeTypeRef": map[string]any{
+										"apiVersion": "example.org/v1alpha1",
+										"kind":       "XExample",
+									},
+									"mode": "Pipeline",
+									"pipeline": []any{
+										map[string]any{
+											"step":        stepName,
+											"functionRef": map[string]any{"name": "function-extra-resources"},
+										},
+									},
+								},
+							}),
+							Functions: []*renderv1alpha1.FunctionInput{
+								{Name: "function-extra-resources", Address: addr},
 							},
 						},
 					},
-				}),
-				Functions: []*renderv1alpha1.FunctionInput{
-					{Name: "function-extra-resources", Address: addr},
-				},
+				}
+			},
+			want: want{
+				pipelineFatal:     true,
+				fatalStep:         stepName,
+				fatalMessage:      fatalMsg,
+				exitCode:          ExitCodePipelineFatal,
+				compositeOutput:   true,
+				requiredResources: 1,
 			},
 		},
-	}
-
-	stdin := mustMarshalRequest(t, req)
-	stdout := &bytes.Buffer{}
-
-	cmd := &Command{
-		Timeout: 30 * time.Second,
-		stdin:   stdin,
-		stdout:  stdout,
-	}
-	err := cmd.Run(logging.NewNopLogger())
-
-	// AC5.1: the returned error must signal a non-zero exit code of 3 to Kong
-	// so wrappers can branch on the FATAL pipeline result without parsing
-	// stderr.
-	if err == nil {
-		t.Fatalf("Run(...) expected error, got nil")
-	}
-	var ec kong.ExitCoder
-	if !errors.As(err, &ec) {
-		t.Fatalf("returned error does not implement kong.ExitCoder: %T: %v", err, err)
-	}
-	if got, want := ec.ExitCode(), 3; got != want {
-		t.Errorf("ExitCode() = %d, want %d", got, want)
-	}
-
-	// AC5.1: the returned error chain must still surface the typed
-	// PipelineFatalError so callers using the library directly can match it.
-	// Assert the typed-error properties (Step, Message) — not the error
-	// string — per the contribution guide's "Test Error Properties, not
-	// Error Strings" guidance.
-	var pfe *xcomposite.PipelineFatalError
-	if !errors.As(err, &pfe) {
-		t.Fatalf("error chain missing *PipelineFatalError: %v", err)
-	}
-	if pfe.Step != stepName {
-		t.Errorf("PipelineFatalError.Step = %q, want %q", pfe.Step, stepName)
-	}
-	if pfe.Message != fatalMsg {
-		t.Errorf("PipelineFatalError.Message = %q, want %q", pfe.Message, fatalMsg)
-	}
-
-	// AC5.1: stdout must contain a parseable RenderResponse with the
-	// recorded RequiredResources populated.
-	rsp := &renderv1alpha1.RenderResponse{}
-	if err := proto.Unmarshal(stdout.Bytes(), rsp); err != nil {
-		t.Fatalf("cannot unmarshal stdout RenderResponse: %v (bytes=%d)", err, stdout.Len())
-	}
-	composite := rsp.GetComposite()
-	if composite == nil {
-		t.Fatalf("RenderResponse.Composite is nil; expected partial output")
-	}
-	if got := len(composite.GetRequiredResources()); got != 1 {
-		t.Fatalf("len(RequiredResources) = %d, want 1; rsp=%v", got, rsp)
-	}
-}
-
-func TestRunWrapsNonFatalRenderErrorAsBefore(t *testing.T) {
-	// AC5.2: A non-fatal render error must still be returned wrapped with
-	// "cannot render composite resource" and stdout must be empty (no
-	// partial response) so existing wrappers don't see ambiguous output.
-	req := &renderv1alpha1.RenderRequest{
-		Input: &renderv1alpha1.RenderRequest_Composite{
-			Composite: &renderv1alpha1.CompositeInput{
-				// Missing CompositeResource fields cause Render to fail before
-				// Reconcile.
-				CompositeResource: mustStruct(t, map[string]any{}),
-				Composition: mustStruct(t, map[string]any{
-					"metadata": map[string]any{"name": "broken"},
-					"spec": map[string]any{
-						"compositeTypeRef": map[string]any{
-							"apiVersion": "example.org/v1alpha1",
-							"kind":       "XBroken",
+		"NonFatalRenderErrorWrapsAsBefore": {
+			reason: "A non-fatal render error must be returned wrapped with the existing 'cannot render composite resource' context; stdout must be empty and the error must NOT implement kong.ExitCoder.",
+			req: func(t *testing.T) *renderv1alpha1.RenderRequest {
+				t.Helper()
+				return &renderv1alpha1.RenderRequest{
+					Input: &renderv1alpha1.RenderRequest_Composite{
+						Composite: &renderv1alpha1.CompositeInput{
+							// Missing CompositeResource fields cause Render
+							// to fail before Reconcile.
+							CompositeResource: mustStruct(t, map[string]any{}),
+							Composition: mustStruct(t, map[string]any{
+								"metadata": map[string]any{"name": "broken"},
+								"spec": map[string]any{
+									"compositeTypeRef": map[string]any{
+										"apiVersion": "example.org/v1alpha1",
+										"kind":       "XBroken",
+									},
+									"pipeline": []any{},
+								},
+							}),
 						},
-						"pipeline": []any{},
 					},
-				}),
+				}
+			},
+			want: want{
+				pipelineFatal: false,
+				exitCode:      0,
 			},
 		},
 	}
 
-	stdin := mustMarshalRequest(t, req)
-	stdout := &bytes.Buffer{}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			stdin := mustMarshalRequest(t, tc.req(t))
+			stdout := &bytes.Buffer{}
 
-	cmd := &Command{
-		Timeout: 30 * time.Second,
-		stdin:   stdin,
-		stdout:  stdout,
-	}
-	err := cmd.Run(logging.NewNopLogger())
-	if err == nil {
-		t.Fatalf("Run(...) expected error, got nil")
-	}
-	var pfe *xcomposite.PipelineFatalError
-	if errors.As(err, &pfe) {
-		t.Errorf("non-fatal error unexpectedly classified as PipelineFatalError: %v", err)
-	}
-	var ec kong.ExitCoder
-	if errors.As(err, &ec) {
-		t.Errorf("non-fatal error unexpectedly implements kong.ExitCoder with code %d", ec.ExitCode())
-	}
-	if stdout.Len() != 0 {
-		t.Errorf("stdout should be empty on non-fatal failure; got %d bytes", stdout.Len())
+			// Minimal Kong tree mirroring how the render subcommand is
+			// mounted in main.go's cli struct. We pre-set the unexported
+			// stdin/stdout fields; Kong's reflection ignores untagged
+			// unexported fields and doesn't clobber them, so the values
+			// survive parsing.
+			var cli struct {
+				Render Command `cmd:""`
+			}
+			cli.Render.stdin = stdin
+			cli.Render.stdout = stdout
+
+			// Bind the logging.Logger interface the same way main.go does
+			// (kong.BindTo with the interface pointer); without this Kong
+			// can't satisfy Run's logging.Logger parameter.
+			parser, err := kong.New(&cli,
+				kong.BindTo(logging.NewNopLogger(), (*logging.Logger)(nil)),
+			)
+			if err != nil {
+				t.Fatalf("%s\nkong.New: %v", tc.reason, err)
+			}
+			ktx, err := parser.Parse([]string{"render", "--timeout=30s"})
+			if err != nil {
+				t.Fatalf("%s\nkong.Parse: %v", tc.reason, err)
+			}
+			err = ktx.Run()
+
+			if err == nil {
+				t.Fatalf("%s\nRun(...) expected error, got nil", tc.reason)
+			}
+
+			// PipelineFatalError property check (errors.As + Step/Message),
+			// per the contribution guide's "Test Error Properties, not
+			// Error Strings" guidance.
+			var pfe *xcomposite.PipelineFatalError
+			gotFatal := errors.As(err, &pfe)
+			if gotFatal != tc.want.pipelineFatal {
+				t.Errorf("%s\nerrors.As(*PipelineFatalError) = %v, want %v; err=%v", tc.reason, gotFatal, tc.want.pipelineFatal, err)
+			}
+			if tc.want.pipelineFatal && gotFatal {
+				if pfe.Step != tc.want.fatalStep {
+					t.Errorf("%s\nPipelineFatalError.Step = %q, want %q", tc.reason, pfe.Step, tc.want.fatalStep)
+				}
+				if pfe.Message != tc.want.fatalMessage {
+					t.Errorf("%s\nPipelineFatalError.Message = %q, want %q", tc.reason, pfe.Message, tc.want.fatalMessage)
+				}
+			}
+
+			// Kong exit-code property check.
+			var ec kong.ExitCoder
+			gotEC := errors.As(err, &ec)
+			wantEC := tc.want.exitCode != 0
+			if gotEC != wantEC {
+				t.Errorf("%s\nerrors.As(kong.ExitCoder) = %v, want %v; err=%v", tc.reason, gotEC, wantEC, err)
+			}
+			if wantEC && gotEC {
+				if got := ec.ExitCode(); got != tc.want.exitCode {
+					t.Errorf("%s\nExitCode() = %d, want %d", tc.reason, got, tc.want.exitCode)
+				}
+			}
+
+			// stdout shape.
+			if !tc.want.compositeOutput {
+				if stdout.Len() != 0 {
+					t.Errorf("%s\nstdout should be empty; got %d bytes", tc.reason, stdout.Len())
+				}
+				return
+			}
+
+			rsp := &renderv1alpha1.RenderResponse{}
+			if err := proto.Unmarshal(stdout.Bytes(), rsp); err != nil {
+				t.Fatalf("%s\ncannot unmarshal stdout RenderResponse: %v (bytes=%d)", tc.reason, err, stdout.Len())
+			}
+			composite := rsp.GetComposite()
+			if composite == nil {
+				t.Fatalf("%s\nRenderResponse.Composite is nil; expected partial output", tc.reason)
+			}
+			if got := len(composite.GetRequiredResources()); got != tc.want.requiredResources {
+				t.Errorf("%s\nlen(RequiredResources) = %d, want %d; rsp=%v", tc.reason, got, tc.want.requiredResources, rsp)
+			}
+		})
 	}
 }

--- a/cmd/crossplane/render/render_test.go
+++ b/cmd/crossplane/render/render_test.go
@@ -179,9 +179,18 @@ func TestRunWritesPartialResponseOnPipelineFatal(t *testing.T) {
 
 	// AC5.1: the returned error chain must still surface the typed
 	// PipelineFatalError so callers using the library directly can match it.
+	// Assert the typed-error properties (Step, Message) — not the error
+	// string — per the contribution guide's "Test Error Properties, not
+	// Error Strings" guidance.
 	var pfe *xcomposite.PipelineFatalError
 	if !errors.As(err, &pfe) {
-		t.Errorf("error chain missing *PipelineFatalError: %v", err)
+		t.Fatalf("error chain missing *PipelineFatalError: %v", err)
+	}
+	if pfe.Step != stepName {
+		t.Errorf("PipelineFatalError.Step = %q, want %q", pfe.Step, stepName)
+	}
+	if pfe.Message != fatalMsg {
+		t.Errorf("PipelineFatalError.Message = %q, want %q", pfe.Message, fatalMsg)
 	}
 
 	// AC5.1: stdout must contain a parseable RenderResponse with the

--- a/cmd/crossplane/render/render_test.go
+++ b/cmd/crossplane/render/render_test.go
@@ -1,0 +1,249 @@
+/*
+Copyright 2026 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package render
+
+import (
+	"bytes"
+	"context"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/alecthomas/kong"
+	"google.golang.org/grpc"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/structpb"
+
+	"github.com/crossplane/crossplane-runtime/v2/pkg/errors"
+	"github.com/crossplane/crossplane-runtime/v2/pkg/logging"
+
+	xcomposite "github.com/crossplane/crossplane/v2/internal/controller/apiextensions/composite"
+	fnv1 "github.com/crossplane/crossplane/v2/proto/fn/v1"
+	renderv1alpha1 "github.com/crossplane/crossplane/v2/proto/render/v1alpha1"
+)
+
+// fatalFunctionServer announces a required resource on its first call and
+// returns SEVERITY_FATAL on its second, mirroring the
+// function-extra-resources / function-environment-configs scenarios that
+// motivated issue #7446.
+type fatalFunctionServer struct {
+	fnv1.UnimplementedFunctionRunnerServiceServer
+	requirementName string
+	selector        *fnv1.ResourceSelector
+	fatalMessage    string
+
+	mu    sync.Mutex
+	calls int
+}
+
+func (s *fatalFunctionServer) RunFunction(_ context.Context, _ *fnv1.RunFunctionRequest) (*fnv1.RunFunctionResponse, error) {
+	s.mu.Lock()
+	s.calls++
+	call := s.calls
+	s.mu.Unlock()
+
+	rsp := &fnv1.RunFunctionResponse{
+		Requirements: &fnv1.Requirements{
+			Resources: map[string]*fnv1.ResourceSelector{
+				s.requirementName: s.selector,
+			},
+		},
+	}
+	if call > 1 {
+		rsp.Results = []*fnv1.Result{{Severity: fnv1.Severity_SEVERITY_FATAL, Message: s.fatalMessage}}
+	}
+	return rsp, nil
+}
+
+func startTestFunctionServer(t *testing.T, ss fnv1.FunctionRunnerServiceServer) string {
+	t.Helper()
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("cannot listen for test gRPC server: %v", err)
+	}
+	s := grpc.NewServer()
+	fnv1.RegisterFunctionRunnerServiceServer(s, ss)
+	go func() { _ = s.Serve(lis) }()
+	t.Cleanup(s.Stop)
+	return lis.Addr().String()
+}
+
+func mustStruct(t *testing.T, m map[string]any) *structpb.Struct {
+	t.Helper()
+	s, err := structpb.NewStruct(m)
+	if err != nil {
+		t.Fatalf("structpb.NewStruct: %v", err)
+	}
+	return s
+}
+
+// mustMarshalRequest serializes a RenderRequest to a buffer that the CLI can
+// read from stdin.
+func mustMarshalRequest(t *testing.T, req *renderv1alpha1.RenderRequest) *bytes.Buffer {
+	t.Helper()
+	data, err := proto.Marshal(req)
+	if err != nil {
+		t.Fatalf("proto.Marshal request: %v", err)
+	}
+	return bytes.NewBuffer(data)
+}
+
+func TestRunWritesPartialResponseOnPipelineFatal(t *testing.T) {
+	const stepName = "fetch-extras"
+	const fatalMsg = "Required extra resource \"namedClusterRole\" not found"
+	const requirementName = "namedClusterRole"
+
+	wantSelector := &fnv1.ResourceSelector{
+		ApiVersion: "rbac.authorization.k8s.io/v1",
+		Kind:       "ClusterRole",
+		Match: &fnv1.ResourceSelector_MatchName{
+			MatchName: "some-cluster-role",
+		},
+	}
+
+	addr := startTestFunctionServer(t, &fatalFunctionServer{
+		requirementName: requirementName,
+		selector:        wantSelector,
+		fatalMessage:    fatalMsg,
+	})
+
+	req := &renderv1alpha1.RenderRequest{
+		Input: &renderv1alpha1.RenderRequest_Composite{
+			Composite: &renderv1alpha1.CompositeInput{
+				CompositeResource: mustStruct(t, map[string]any{
+					"apiVersion": "example.org/v1alpha1",
+					"kind":       "XExample",
+					"metadata":   map[string]any{"name": "my-example"},
+				}),
+				Composition: mustStruct(t, map[string]any{
+					"metadata": map[string]any{"name": "example-composition"},
+					"spec": map[string]any{
+						"compositeTypeRef": map[string]any{
+							"apiVersion": "example.org/v1alpha1",
+							"kind":       "XExample",
+						},
+						"mode": "Pipeline",
+						"pipeline": []any{
+							map[string]any{
+								"step":        stepName,
+								"functionRef": map[string]any{"name": "function-extra-resources"},
+							},
+						},
+					},
+				}),
+				Functions: []*renderv1alpha1.FunctionInput{
+					{Name: "function-extra-resources", Address: addr},
+				},
+			},
+		},
+	}
+
+	stdin := mustMarshalRequest(t, req)
+	stdout := &bytes.Buffer{}
+
+	cmd := &Command{
+		Timeout: 30 * time.Second,
+		stdin:   stdin,
+		stdout:  stdout,
+	}
+	err := cmd.Run(logging.NewNopLogger())
+
+	// AC5.1: the returned error must signal a non-zero exit code of 3 to Kong
+	// so wrappers can branch on the FATAL pipeline result without parsing
+	// stderr.
+	if err == nil {
+		t.Fatalf("Run(...) expected error, got nil")
+	}
+	var ec kong.ExitCoder
+	if !errors.As(err, &ec) {
+		t.Fatalf("returned error does not implement kong.ExitCoder: %T: %v", err, err)
+	}
+	if got, want := ec.ExitCode(), 3; got != want {
+		t.Errorf("ExitCode() = %d, want %d", got, want)
+	}
+
+	// AC5.1: the returned error chain must still surface the typed
+	// PipelineFatalError so callers using the library directly can match it.
+	var pfe *xcomposite.PipelineFatalError
+	if !errors.As(err, &pfe) {
+		t.Errorf("error chain missing *PipelineFatalError: %v", err)
+	}
+
+	// AC5.1: stdout must contain a parseable RenderResponse with the
+	// recorded RequiredResources populated.
+	rsp := &renderv1alpha1.RenderResponse{}
+	if err := proto.Unmarshal(stdout.Bytes(), rsp); err != nil {
+		t.Fatalf("cannot unmarshal stdout RenderResponse: %v (bytes=%d)", err, stdout.Len())
+	}
+	composite := rsp.GetComposite()
+	if composite == nil {
+		t.Fatalf("RenderResponse.Composite is nil; expected partial output")
+	}
+	if got := len(composite.GetRequiredResources()); got != 1 {
+		t.Fatalf("len(RequiredResources) = %d, want 1; rsp=%v", got, rsp)
+	}
+}
+
+func TestRunWrapsNonFatalRenderErrorAsBefore(t *testing.T) {
+	// AC5.2: A non-fatal render error must still be returned wrapped with
+	// "cannot render composite resource" and stdout must be empty (no
+	// partial response) so existing wrappers don't see ambiguous output.
+	req := &renderv1alpha1.RenderRequest{
+		Input: &renderv1alpha1.RenderRequest_Composite{
+			Composite: &renderv1alpha1.CompositeInput{
+				// Missing CompositeResource fields cause Render to fail before
+				// Reconcile.
+				CompositeResource: mustStruct(t, map[string]any{}),
+				Composition: mustStruct(t, map[string]any{
+					"metadata": map[string]any{"name": "broken"},
+					"spec": map[string]any{
+						"compositeTypeRef": map[string]any{
+							"apiVersion": "example.org/v1alpha1",
+							"kind":       "XBroken",
+						},
+						"pipeline": []any{},
+					},
+				}),
+			},
+		},
+	}
+
+	stdin := mustMarshalRequest(t, req)
+	stdout := &bytes.Buffer{}
+
+	cmd := &Command{
+		Timeout: 30 * time.Second,
+		stdin:   stdin,
+		stdout:  stdout,
+	}
+	err := cmd.Run(logging.NewNopLogger())
+	if err == nil {
+		t.Fatalf("Run(...) expected error, got nil")
+	}
+	var pfe *xcomposite.PipelineFatalError
+	if errors.As(err, &pfe) {
+		t.Errorf("non-fatal error unexpectedly classified as PipelineFatalError: %v", err)
+	}
+	var ec kong.ExitCoder
+	if errors.As(err, &ec) {
+		t.Errorf("non-fatal error unexpectedly implements kong.ExitCoder with code %d", ec.ExitCode())
+	}
+	if stdout.Len() != 0 {
+		t.Errorf("stdout should be empty on non-fatal failure; got %d bytes", stdout.Len())
+	}
+}

--- a/internal/controller/apiextensions/composite/composition_functions.go
+++ b/internal/controller/apiextensions/composite/composition_functions.go
@@ -79,7 +79,6 @@ const (
 	errFmtRenderMetadata              = "cannot render metadata for composed resource %q"
 	errFmtGenerateName                = "cannot generate a name for composed resource %q"
 	errFmtCDAsStruct                  = "cannot encode composed resource %q to protocol buffer Struct well-known type"
-	errFmtFatalResult                 = "pipeline step %q returned a fatal result: %s"
 	errFmtInvalidName                 = "cannot apply composed resource %q because it has an invalid name %q. Must be a valid RFC 1123 subdomain name."
 	errFmtGetResourceMapping          = "cannot check if composed resource %q is namespaced (a %s named %s)"
 	errFmtNamespacedXRClusterResource = "cannot apply cluster scoped composed resource %q (a %s named %s) for a namespaced composite resource."
@@ -87,6 +86,28 @@ const (
 	errFmtFetchBootstrapSchemas       = "cannot fetch bootstrap required schema for requirement %q"
 	errFmtNamespaceOverridden         = "cannot create composed resource %q in namespace %q, using XR namespace %q instead"
 )
+
+// PipelineFatalErrorFmt is the format string used by PipelineFatalError.Error
+// and is exported so callers (typically tests) can recognize the error string
+// without depending on the typed value.
+const PipelineFatalErrorFmt = "pipeline step %q returned a fatal result: %s"
+
+// PipelineFatalError indicates that a function pipeline step returned a
+// result with SEVERITY_FATAL. Callers can use errors.As to distinguish it
+// from other reconcile errors and recover any side effects (events,
+// conditions, recorded resource selectors) that the pipeline produced before
+// failing. The same type is returned by the operation reconciler; render
+// packages alias it for caller convenience.
+type PipelineFatalError struct {
+	Step    string
+	Message string
+}
+
+// Error formats the error so that reconciler events and condition messages
+// remain identical to the previous untyped error.
+func (e *PipelineFatalError) Error() string {
+	return fmt.Sprintf(PipelineFatalErrorFmt, e.Step, e.Message)
+}
 
 // Server-side-apply field owners. We need two of these because it's possible
 // an invocation of this controller will operate on the same resource in two
@@ -437,7 +458,7 @@ func (c *FunctionComposer) Compose(ctx context.Context, xr *composite.Unstructur
 
 			switch rs.GetSeverity() {
 			case fnv1.Severity_SEVERITY_FATAL:
-				return CompositionResult{Events: events, Conditions: conditions}, errors.Errorf(errFmtFatalResult, fn.Step, rs.GetMessage())
+				return CompositionResult{Events: events, Conditions: conditions}, &PipelineFatalError{Step: fn.Step, Message: rs.GetMessage()}
 			case fnv1.Severity_SEVERITY_WARNING:
 				e.Event = event.Warning(reason, errors.New(rs.GetMessage()))
 				e.Detail = fmt.Sprintf("Pipeline step %q", fn.Step)

--- a/internal/controller/apiextensions/composite/composition_functions_test.go
+++ b/internal/controller/apiextensions/composite/composition_functions_test.go
@@ -319,7 +319,7 @@ func TestFunctionCompose(t *testing.T) {
 				},
 			},
 			want: want{
-				err: errors.Errorf(errFmtFatalResult, "run-cool-function", "oh no"),
+				err: &PipelineFatalError{Step: "run-cool-function", Message: "oh no"},
 				res: CompositionResult{
 					Events: []TargetedEvent{
 						// The event with minimum values.
@@ -2219,5 +2219,45 @@ func TestUpdateResourceRefs(t *testing.T) {
 				t.Errorf("\n%s\nUpdateResourceRefs(...): -want, +got:\n%s", tc.reason, diff)
 			}
 		})
+	}
+}
+
+func TestPipelineFatalErrorError(t *testing.T) {
+	// PipelineFatalError.Error() must produce the same string as the
+	// PipelineFatalErrorFmt format, byte-identical, so reconciler events
+	// and condition messages remain unchanged.
+	cases := map[string]struct {
+		err  *PipelineFatalError
+		want string
+	}{
+		"PopulatedFields": {
+			err:  &PipelineFatalError{Step: "fetch-extras", Message: "Required extra resource \"namedClusterRole\" not found"},
+			want: fmt.Sprintf(PipelineFatalErrorFmt, "fetch-extras", "Required extra resource \"namedClusterRole\" not found"),
+		},
+		"EmptyFields": {
+			err:  &PipelineFatalError{},
+			want: fmt.Sprintf(PipelineFatalErrorFmt, "", ""),
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			if diff := cmp.Diff(tc.want, tc.err.Error()); diff != "" {
+				t.Errorf("PipelineFatalError.Error(): -want, +got:\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestPipelineFatalErrorAs(t *testing.T) {
+	// errors.As traverses errors.Wrap chains.
+	pfe := &PipelineFatalError{Step: "s", Message: "m"}
+	wrapped := errors.Wrap(pfe, "cannot compose resources")
+
+	var got *PipelineFatalError
+	if !errors.As(wrapped, &got) {
+		t.Fatalf("errors.As did not find *PipelineFatalError in wrapped chain")
+	}
+	if diff := cmp.Diff(pfe, got); diff != "" {
+		t.Errorf("errors.As recovered PipelineFatalError: -want, +got:\n%s", diff)
 	}
 }

--- a/internal/controller/ops/operation/reconciler.go
+++ b/internal/controller/ops/operation/reconciler.go
@@ -43,6 +43,7 @@ import (
 	xpv2 "github.com/crossplane/crossplane/apis/v2/core/v2"
 	"github.com/crossplane/crossplane/apis/v2/ops/v1alpha1"
 	pkgmetav1 "github.com/crossplane/crossplane/apis/v2/pkg/meta/v1"
+	xcomposite "github.com/crossplane/crossplane/v2/internal/controller/apiextensions/composite"
 	"github.com/crossplane/crossplane/v2/internal/controller/apiextensions/composite/step"
 	"github.com/crossplane/crossplane/v2/internal/xfn"
 	fnv1 "github.com/crossplane/crossplane/v2/proto/fn/v1"
@@ -306,7 +307,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 				op.Status.Failures++
 
 				log.Debug("Pipeline step returned a fatal result", "error", rs.GetMessage(), "failures", op.Status.Failures)
-				err = errors.New(rs.GetMessage())
+				err = &xcomposite.PipelineFatalError{Step: fn.Step, Message: rs.GetMessage()}
 				r.record.Event(op, event.Warning(reasonFunctionInvocation, err))
 				status.MarkConditions(xpv2.ReconcileError(err))
 				_ = r.client.Status().Update(ctx, op)

--- a/internal/render/composite/render.go
+++ b/internal/render/composite/render.go
@@ -229,20 +229,25 @@ func Render(ctx context.Context, log logging.Logger, in *renderv1alpha1.Composit
 			u.GetNamespace() == xr.GetNamespace() &&
 			u.GetName() == xr.GetName()
 	}, rec, rrf, rsf)
-	if berr != nil {
-		if rerr != nil {
-			return nil, errors.Join(rerr, berr)
-		}
+	switch {
+	case berr != nil && rerr != nil:
+		// Both reconcile and BuildOutput failed; surface both via
+		// errors.Join so callers can recover *PipelineFatalError from the
+		// chain via errors.As when present.
+		return nil, errors.Join(rerr, berr)
+	case berr != nil:
 		return nil, berr
-	}
-
-	if rerr != nil {
-		// On a function-pipeline FATAL we still return the partial output so
-		// callers can recover RequiredResources/RequiredSchemas. Other
-		// reconcile errors keep the previous behavior.
+	case rerr != nil:
+		// On a function-pipeline FATAL we still return the partial output
+		// so callers can recover RequiredResources/RequiredSchemas. We
+		// return the full wrapped error chain (rather than the extracted
+		// *PipelineFatalError) so callers preserve the reconciler's
+		// "cannot compose resources" diagnostic context; *PipelineFatalError
+		// remains reachable via errors.As. Other reconcile errors keep the
+		// previous "reconcile failed" wrapping.
 		var pfe *composite.PipelineFatalError
 		if errors.As(rerr, &pfe) {
-			return out, pfe
+			return out, rerr
 		}
 		return nil, errors.Wrap(rerr, "reconcile failed")
 	}

--- a/internal/render/composite/render.go
+++ b/internal/render/composite/render.go
@@ -230,13 +230,13 @@ func Render(ctx context.Context, log logging.Logger, in *renderv1alpha1.Composit
 			u.GetName() == xr.GetName()
 	}, rec, rrf, rsf)
 	switch {
-	case berr != nil && rerr != nil:
-		// Both reconcile and BuildOutput failed; surface both via
-		// errors.Join so callers can recover *PipelineFatalError from the
-		// chain via errors.As when present.
-		return nil, errors.Join(rerr, berr)
 	case berr != nil:
-		return nil, berr
+		// Surface BuildOutput's failure. If reconcile also failed, join
+		// both so callers can recover *PipelineFatalError via errors.As.
+		// When rerr is nil, errors.Join wraps berr in a MultiError whose
+		// Error() string and errors.As/Is behavior match berr exactly —
+		// callers using those traversals see no difference.
+		return nil, errors.Join(rerr, berr)
 	case rerr != nil:
 		// On a function-pipeline FATAL we still return the partial output
 		// so callers can recover RequiredResources/RequiredSchemas. We

--- a/internal/render/composite/render.go
+++ b/internal/render/composite/render.go
@@ -217,15 +217,37 @@ func Render(ctx context.Context, log logging.Logger, in *renderv1alpha1.Composit
 		Name:      xr.GetName(),
 	}}
 
-	if _, err := r.Reconcile(ctx, req); err != nil {
-		return nil, errors.Wrap(err, "reconcile failed")
-	}
+	_, rerr := r.Reconcile(ctx, req)
 
-	return BuildOutput(c, func(u kunstructured.Unstructured) bool {
+	// Always build the output, even on reconcile error: the recording
+	// fetchers (rrf, rsf) and the EventRecorder (rec) may have captured
+	// useful state — in particular the resource selectors a function
+	// requested before returning a fatal result — that callers iterating on
+	// requirements need to make progress. See issue #7446.
+	out, berr := BuildOutput(c, func(u kunstructured.Unstructured) bool {
 		return u.GroupVersionKind() == gvk &&
 			u.GetNamespace() == xr.GetNamespace() &&
 			u.GetName() == xr.GetName()
 	}, rec, rrf, rsf)
+	if berr != nil {
+		if rerr != nil {
+			return nil, errors.Join(rerr, berr)
+		}
+		return nil, berr
+	}
+
+	if rerr != nil {
+		// On a function-pipeline FATAL we still return the partial output so
+		// callers can recover RequiredResources/RequiredSchemas. Other
+		// reconcile errors keep the previous behavior.
+		var pfe *composite.PipelineFatalError
+		if errors.As(rerr, &pfe) {
+			return out, pfe
+		}
+		return nil, errors.Wrap(rerr, "reconcile failed")
+	}
+
+	return out, nil
 }
 
 // selectSchema picks the composite.Schema for an input XR. With no XRD

--- a/internal/render/composite/render_test.go
+++ b/internal/render/composite/render_test.go
@@ -18,18 +18,25 @@ package composite
 
 import (
 	"context"
+	"net"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+	"google.golang.org/grpc"
+	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/testing/protocmp"
 	"google.golang.org/protobuf/types/known/structpb"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
+	"github.com/crossplane/crossplane-runtime/v2/pkg/errors"
 	"github.com/crossplane/crossplane-runtime/v2/pkg/logging"
 	ucomposite "github.com/crossplane/crossplane-runtime/v2/pkg/resource/unstructured/composite"
 
+	xcomposite "github.com/crossplane/crossplane/v2/internal/controller/apiextensions/composite"
+	fnv1 "github.com/crossplane/crossplane/v2/proto/fn/v1"
 	renderv1alpha1 "github.com/crossplane/crossplane/v2/proto/render/v1alpha1"
 )
 
@@ -547,4 +554,197 @@ func mustStruct(m map[string]any) *structpb.Struct {
 		panic(err)
 	}
 	return s
+}
+
+// fatalFunctionServer simulates a real function-extra-resources style pipeline
+// step. On its first call it announces its required resources via
+// Requirements.Resources (no FATAL), letting the FetchingFunctionRunner record
+// the selectors via the recording fetcher. On its second call (when the
+// fetched resources came back empty because the caller did not pre-populate
+// them) it returns SEVERITY_FATAL.
+type fatalFunctionServer struct {
+	fnv1.UnimplementedFunctionRunnerServiceServer
+	requirementName string
+	selector        *fnv1.ResourceSelector
+	fatalMessage    string
+
+	mu    sync.Mutex
+	calls int
+}
+
+func (s *fatalFunctionServer) RunFunction(_ context.Context, _ *fnv1.RunFunctionRequest) (*fnv1.RunFunctionResponse, error) {
+	s.mu.Lock()
+	s.calls++
+	call := s.calls
+	s.mu.Unlock()
+
+	if call == 1 {
+		// First iteration: announce the required resource. The
+		// FetchingFunctionRunner will then fetch it, which is when the
+		// RecordingRequiredResourcesFetcher records the selector.
+		return &fnv1.RunFunctionResponse{
+			Requirements: &fnv1.Requirements{
+				Resources: map[string]*fnv1.ResourceSelector{
+					s.requirementName: s.selector,
+				},
+			},
+		}, nil
+	}
+
+	// Second iteration: the requirement still isn't satisfied; return FATAL.
+	return &fnv1.RunFunctionResponse{
+		Requirements: &fnv1.Requirements{
+			Resources: map[string]*fnv1.ResourceSelector{
+				s.requirementName: s.selector,
+			},
+		},
+		Results: []*fnv1.Result{
+			{Severity: fnv1.Severity_SEVERITY_FATAL, Message: s.fatalMessage},
+		},
+	}, nil
+}
+
+// startTestFunctionServer starts an in-process gRPC server registered with the
+// supplied FunctionRunnerServiceServer and returns its address. The server is
+// stopped automatically when the test ends.
+func startTestFunctionServer(t *testing.T, ss fnv1.FunctionRunnerServiceServer) string {
+	t.Helper()
+
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("cannot listen for test gRPC server: %v", err)
+	}
+
+	s := grpc.NewServer()
+	fnv1.RegisterFunctionRunnerServiceServer(s, ss)
+	go func() { _ = s.Serve(lis) }()
+
+	t.Cleanup(func() {
+		s.Stop()
+	})
+
+	return lis.Addr().String()
+}
+
+func TestRenderPipelineFatalReturnsRequirements(t *testing.T) {
+	// Function step name and the FATAL message we expect to see propagated.
+	const stepName = "fetch-extras"
+	const fatalMsg = "Required extra resource \"namedClusterRole\" not found"
+	const requirementName = "namedClusterRole"
+
+	// Selector the function records as a requirement before fataling. After
+	// the FATAL, this selector must still surface in CompositeOutput.
+	wantSelector := &fnv1.ResourceSelector{
+		ApiVersion: "rbac.authorization.k8s.io/v1",
+		Kind:       "ClusterRole",
+		Match: &fnv1.ResourceSelector_MatchName{
+			MatchName: "some-cluster-role",
+		},
+	}
+
+	server := &fatalFunctionServer{
+		requirementName: requirementName,
+		selector:        wantSelector,
+		fatalMessage:    fatalMsg,
+	}
+
+	addr := startTestFunctionServer(t, server)
+
+	in := &renderv1alpha1.CompositeInput{
+		CompositeResource: mustStruct(map[string]any{
+			"apiVersion": "example.org/v1alpha1",
+			"kind":       "XExample",
+			"metadata":   map[string]any{"name": "my-example"},
+		}),
+		Composition: mustStruct(map[string]any{
+			"metadata": map[string]any{"name": "example-composition"},
+			"spec": map[string]any{
+				"compositeTypeRef": map[string]any{
+					"apiVersion": "example.org/v1alpha1",
+					"kind":       "XExample",
+				},
+				"mode": "Pipeline",
+				"pipeline": []any{
+					map[string]any{
+						"step":        stepName,
+						"functionRef": map[string]any{"name": "function-extra-resources"},
+					},
+				},
+			},
+		}),
+		Functions: []*renderv1alpha1.FunctionInput{
+			{Name: "function-extra-resources", Address: addr},
+		},
+	}
+
+	out, err := Render(context.Background(), logging.NewNopLogger(), in)
+
+	// the error must be a typed PipelineFatalError with the right step
+	// and message, even when wrapped by the reconciler chain.
+	var pfe *xcomposite.PipelineFatalError
+	if !errors.As(err, &pfe) {
+		t.Fatalf("Render(...) error: want *PipelineFatalError in chain, got %T: %v", err, err)
+	}
+	if pfe.Step != stepName {
+		t.Errorf("PipelineFatalError.Step = %q, want %q", pfe.Step, stepName)
+	}
+	if pfe.Message != fatalMsg {
+		t.Errorf("PipelineFatalError.Message = %q, want %q", pfe.Message, fatalMsg)
+	}
+
+	// the partial output must be returned and must contain the
+	// recorded resource selector, so callers can iterate on requirements.
+	if out == nil {
+		t.Fatalf("Render(...) returned nil output on PipelineFatalError; want non-nil with RequiredResources populated")
+	}
+	if got := len(out.GetRequiredResources()); got != 1 {
+		t.Fatalf("len(out.RequiredResources) = %d, want 1; out=%v", got, out)
+	}
+
+	// Decode the recorded selector and compare to the one the function
+	// returned. Render encodes selectors via protojson; reverse it.
+	gotSelector := &fnv1.ResourceSelector{}
+	bs, err := out.GetRequiredResources()[0].MarshalJSON()
+	if err != nil {
+		t.Fatalf("cannot marshal recorded selector to JSON: %v", err)
+	}
+	if err := protojson.Unmarshal(bs, gotSelector); err != nil {
+		t.Fatalf("cannot decode recorded ResourceSelector: %v", err)
+	}
+	if diff := cmp.Diff(wantSelector, gotSelector, protocmp.Transform()); diff != "" {
+		t.Errorf("recorded ResourceSelector: -want, +got:\n%s", diff)
+	}
+}
+
+func TestRenderNonFatalReconcileErrorWraps(t *testing.T) {
+	// A render request whose CompositeResource cannot be decoded
+	// fails before Reconcile even runs. The error must NOT be a
+	// PipelineFatalError, and the existing wrapping must be preserved.
+	in := &renderv1alpha1.CompositeInput{
+		// Missing CompositeResource — Render's protobuf decode of the XR
+		// returns an error before reaching the reconciler.
+		CompositeResource: mustStruct(map[string]any{}),
+		Composition: mustStruct(map[string]any{
+			"metadata": map[string]any{"name": "broken"},
+			"spec": map[string]any{
+				"compositeTypeRef": map[string]any{
+					"apiVersion": "example.org/v1alpha1",
+					"kind":       "XBroken",
+				},
+				"pipeline": []any{},
+			},
+		}),
+	}
+
+	out, err := Render(context.Background(), logging.NewNopLogger(), in)
+	if err == nil {
+		t.Fatalf("Render(...) expected error, got nil; out=%v", out)
+	}
+	var pfe *xcomposite.PipelineFatalError
+	if errors.As(err, &pfe) {
+		t.Errorf("Render(...) error unexpectedly classified as PipelineFatalError: %v", err)
+	}
+	if out != nil {
+		t.Errorf("Render(...) returned out=%v on non-fatal error; want nil", out)
+	}
 }

--- a/internal/render/composite/render_test.go
+++ b/internal/render/composite/render_test.go
@@ -17,15 +17,11 @@ limitations under the License.
 package composite
 
 import (
-	"context"
-	"net"
 	"strings"
-	"sync"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	"google.golang.org/grpc"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/testing/protocmp"
 	"google.golang.org/protobuf/types/known/structpb"
@@ -36,6 +32,7 @@ import (
 	ucomposite "github.com/crossplane/crossplane-runtime/v2/pkg/resource/unstructured/composite"
 
 	xcomposite "github.com/crossplane/crossplane/v2/internal/controller/apiextensions/composite"
+	"github.com/crossplane/crossplane/v2/internal/render/rendertest"
 	fnv1 "github.com/crossplane/crossplane/v2/proto/fn/v1"
 	renderv1alpha1 "github.com/crossplane/crossplane/v2/proto/render/v1alpha1"
 )
@@ -387,7 +384,7 @@ func TestRender(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			out, err := Render(context.Background(), logging.NewNopLogger(), tc.input)
+			out, err := Render(t.Context(), logging.NewNopLogger(), tc.input)
 
 			if diff := cmp.Diff(tc.want.err, err, cmpopts.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\nRender(...): -want error, +got error:\n%s", tc.reason, diff)
@@ -546,94 +543,13 @@ func TestSelectSchema(t *testing.T) {
 	}
 }
 
-func strPtr(s string) *string { return &s }
-
-func mustStruct(m map[string]any) *structpb.Struct {
-	s, err := structpb.NewStruct(m)
-	if err != nil {
-		panic(err)
-	}
-	return s
-}
-
-// fatalFunctionServer simulates a real function-extra-resources style pipeline
-// step. On its first call it announces its required resources via
-// Requirements.Resources (no FATAL), letting the FetchingFunctionRunner record
-// the selectors via the recording fetcher. On its second call (when the
-// fetched resources came back empty because the caller did not pre-populate
-// them) it returns SEVERITY_FATAL.
-type fatalFunctionServer struct {
-	fnv1.UnimplementedFunctionRunnerServiceServer
-	requirementName string
-	selector        *fnv1.ResourceSelector
-	fatalMessage    string
-
-	mu    sync.Mutex
-	calls int
-}
-
-func (s *fatalFunctionServer) RunFunction(_ context.Context, _ *fnv1.RunFunctionRequest) (*fnv1.RunFunctionResponse, error) {
-	s.mu.Lock()
-	s.calls++
-	call := s.calls
-	s.mu.Unlock()
-
-	if call == 1 {
-		// First iteration: announce the required resource. The
-		// FetchingFunctionRunner will then fetch it, which is when the
-		// RecordingRequiredResourcesFetcher records the selector.
-		return &fnv1.RunFunctionResponse{
-			Requirements: &fnv1.Requirements{
-				Resources: map[string]*fnv1.ResourceSelector{
-					s.requirementName: s.selector,
-				},
-			},
-		}, nil
-	}
-
-	// Second iteration: the requirement still isn't satisfied; return FATAL.
-	return &fnv1.RunFunctionResponse{
-		Requirements: &fnv1.Requirements{
-			Resources: map[string]*fnv1.ResourceSelector{
-				s.requirementName: s.selector,
-			},
-		},
-		Results: []*fnv1.Result{
-			{Severity: fnv1.Severity_SEVERITY_FATAL, Message: s.fatalMessage},
-		},
-	}, nil
-}
-
-// startTestFunctionServer starts an in-process gRPC server registered with the
-// supplied FunctionRunnerServiceServer and returns its address. The server is
-// stopped automatically when the test ends.
-func startTestFunctionServer(t *testing.T, ss fnv1.FunctionRunnerServiceServer) string {
-	t.Helper()
-
-	lis, err := net.Listen("tcp", "127.0.0.1:0")
-	if err != nil {
-		t.Fatalf("cannot listen for test gRPC server: %v", err)
-	}
-
-	s := grpc.NewServer()
-	fnv1.RegisterFunctionRunnerServiceServer(s, ss)
-	go func() { _ = s.Serve(lis) }()
-
-	t.Cleanup(func() {
-		s.Stop()
-	})
-
-	return lis.Addr().String()
-}
-
-func TestRenderPipelineFatalReturnsRequirements(t *testing.T) {
-	// Function step name and the FATAL message we expect to see propagated.
+func TestRenderErrors(t *testing.T) {
+	// Constants for the FATAL case shared between request construction and
+	// expected-result assertions.
 	const stepName = "fetch-extras"
 	const fatalMsg = "Required extra resource \"namedClusterRole\" not found"
 	const requirementName = "namedClusterRole"
 
-	// Selector the function records as a requirement before fataling. After
-	// the FATAL, this selector must still surface in CompositeOutput.
 	wantSelector := &fnv1.ResourceSelector{
 		ApiVersion: "rbac.authorization.k8s.io/v1",
 		Kind:       "ClusterRole",
@@ -642,109 +558,163 @@ func TestRenderPipelineFatalReturnsRequirements(t *testing.T) {
 		},
 	}
 
-	server := &fatalFunctionServer{
-		requirementName: requirementName,
-		selector:        wantSelector,
-		fatalMessage:    fatalMsg,
+	type want struct {
+		// pipelineFatal asserts whether *PipelineFatalError is
+		// expected in the returned error chain (errors.As).
+		pipelineFatal bool
+		// fatalStep / fatalMessage are checked only when pipelineFatal is
+		// true.
+		fatalStep, fatalMessage string
+		// hasOutput indicates that Render must return non-nil output (the
+		// partial-output contract on FATAL); when false, output must be nil.
+		hasOutput bool
+		// requiredResources is the expected count of recorded resource
+		// selectors in the partial output. Checked only when hasOutput.
+		requiredResources int
+		// wantSelector is the expected first recorded selector. Checked
+		// only when hasOutput && requiredResources > 0.
+		wantSelector *fnv1.ResourceSelector
 	}
 
-	addr := startTestFunctionServer(t, server)
-
-	in := &renderv1alpha1.CompositeInput{
-		CompositeResource: mustStruct(map[string]any{
-			"apiVersion": "example.org/v1alpha1",
-			"kind":       "XExample",
-			"metadata":   map[string]any{"name": "my-example"},
-		}),
-		Composition: mustStruct(map[string]any{
-			"metadata": map[string]any{"name": "example-composition"},
-			"spec": map[string]any{
-				"compositeTypeRef": map[string]any{
-					"apiVersion": "example.org/v1alpha1",
-					"kind":       "XExample",
-				},
-				"mode": "Pipeline",
-				"pipeline": []any{
-					map[string]any{
-						"step":        stepName,
-						"functionRef": map[string]any{"name": "function-extra-resources"},
+	cases := map[string]struct {
+		reason string
+		// input returns the CompositeInput. It's a closure so the FATAL
+		// case can stand up its own gRPC fixture and bake the address in.
+		input func(t *testing.T) *renderv1alpha1.CompositeInput
+		want  want
+	}{
+		"PipelineFatalReturnsRequirements": {
+			reason: "When a pipeline step returns SEVERITY_FATAL, Render must return the partial CompositeOutput (with recorded RequiredResources) and an error chain containing *PipelineFatalError reachable via errors.As.",
+			input: func(t *testing.T) *renderv1alpha1.CompositeInput {
+				t.Helper()
+				addr := rendertest.StartFunctionServer(t, &rendertest.FatalFunctionServer{
+					RequirementName: requirementName,
+					Selector:        wantSelector,
+					FatalMessage:    fatalMsg,
+				})
+				return &renderv1alpha1.CompositeInput{
+					CompositeResource: mustStruct(map[string]any{
+						"apiVersion": "example.org/v1alpha1",
+						"kind":       "XExample",
+						"metadata":   map[string]any{"name": "my-example"},
+					}),
+					Composition: mustStruct(map[string]any{
+						"metadata": map[string]any{"name": "example-composition"},
+						"spec": map[string]any{
+							"compositeTypeRef": map[string]any{
+								"apiVersion": "example.org/v1alpha1",
+								"kind":       "XExample",
+							},
+							"mode": "Pipeline",
+							"pipeline": []any{
+								map[string]any{
+									"step":        stepName,
+									"functionRef": map[string]any{"name": "function-extra-resources"},
+								},
+							},
+						},
+					}),
+					Functions: []*renderv1alpha1.FunctionInput{
+						{Name: "function-extra-resources", Address: addr},
 					},
-				},
+				}
 			},
-		}),
-		Functions: []*renderv1alpha1.FunctionInput{
-			{Name: "function-extra-resources", Address: addr},
+			want: want{
+				pipelineFatal:     true,
+				fatalStep:         stepName,
+				fatalMessage:      fatalMsg,
+				hasOutput:         true,
+				requiredResources: 1,
+				wantSelector:      wantSelector,
+			},
+		},
+		"NonFatalReconcileErrorWrapsAsBefore": {
+			reason: "A render request whose CompositeResource cannot be decoded fails before Reconcile runs. The error must NOT be a *PipelineFatalError, and no partial output must be returned.",
+			input: func(t *testing.T) *renderv1alpha1.CompositeInput {
+				t.Helper()
+				return &renderv1alpha1.CompositeInput{
+					// Empty CompositeResource fails before Reconcile.
+					CompositeResource: mustStruct(map[string]any{}),
+					Composition: mustStruct(map[string]any{
+						"metadata": map[string]any{"name": "broken"},
+						"spec": map[string]any{
+							"compositeTypeRef": map[string]any{
+								"apiVersion": "example.org/v1alpha1",
+								"kind":       "XBroken",
+							},
+							"pipeline": []any{},
+						},
+					}),
+				}
+			},
+			want: want{
+				pipelineFatal: false,
+				hasOutput:     false,
+			},
 		},
 	}
 
-	out, err := Render(context.Background(), logging.NewNopLogger(), in)
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			out, err := Render(t.Context(), logging.NewNopLogger(), tc.input(t))
 
-	// the error must be a typed PipelineFatalError with the right step
-	// and message, even when wrapped by the reconciler chain.
-	var pfe *xcomposite.PipelineFatalError
-	if !errors.As(err, &pfe) {
-		t.Fatalf("Render(...) error: want *PipelineFatalError in chain, got %T: %v", err, err)
-	}
-	if pfe.Step != stepName {
-		t.Errorf("PipelineFatalError.Step = %q, want %q", pfe.Step, stepName)
-	}
-	if pfe.Message != fatalMsg {
-		t.Errorf("PipelineFatalError.Message = %q, want %q", pfe.Message, fatalMsg)
-	}
+			if err == nil {
+				t.Fatalf("%s\nRender(...) expected error, got nil", tc.reason)
+			}
 
-	// the partial output must be returned and must contain the
-	// recorded resource selector, so callers can iterate on requirements.
-	if out == nil {
-		t.Fatalf("Render(...) returned nil output on PipelineFatalError; want non-nil with RequiredResources populated")
-	}
-	if got := len(out.GetRequiredResources()); got != 1 {
-		t.Fatalf("len(out.RequiredResources) = %d, want 1; out=%v", got, out)
-	}
+			// PipelineFatalError property check (errors.As + Step/Message),
+			// per the contribution guide's "Test Error Properties, not
+			// Error Strings" guidance.
+			var pfe *xcomposite.PipelineFatalError
+			gotFatal := errors.As(err, &pfe)
+			if gotFatal != tc.want.pipelineFatal {
+				t.Errorf("%s\nerrors.As(*PipelineFatalError) = %v, want %v; err=%v", tc.reason, gotFatal, tc.want.pipelineFatal, err)
+			}
+			if tc.want.pipelineFatal && gotFatal {
+				if pfe.Step != tc.want.fatalStep {
+					t.Errorf("%s\nPipelineFatalError.Step = %q, want %q", tc.reason, pfe.Step, tc.want.fatalStep)
+				}
+				if pfe.Message != tc.want.fatalMessage {
+					t.Errorf("%s\nPipelineFatalError.Message = %q, want %q", tc.reason, pfe.Message, tc.want.fatalMessage)
+				}
+			}
 
-	// Decode the recorded selector and compare to the one the function
-	// returned. Render encodes selectors via protojson; reverse it.
-	gotSelector := &fnv1.ResourceSelector{}
-	bs, err := out.GetRequiredResources()[0].MarshalJSON()
-	if err != nil {
-		t.Fatalf("cannot marshal recorded selector to JSON: %v", err)
-	}
-	if err := protojson.Unmarshal(bs, gotSelector); err != nil {
-		t.Fatalf("cannot decode recorded ResourceSelector: %v", err)
-	}
-	if diff := cmp.Diff(wantSelector, gotSelector, protocmp.Transform()); diff != "" {
-		t.Errorf("recorded ResourceSelector: -want, +got:\n%s", diff)
+			// Output presence + recorded selectors.
+			if !tc.want.hasOutput {
+				if out != nil {
+					t.Errorf("%s\nRender(...) returned out=%v on non-fatal error; want nil", tc.reason, out)
+				}
+				return
+			}
+			if out == nil {
+				t.Fatalf("%s\nRender(...) returned nil output; want non-nil with RequiredResources populated", tc.reason)
+			}
+			if got := len(out.GetRequiredResources()); got != tc.want.requiredResources {
+				t.Fatalf("%s\nlen(out.RequiredResources) = %d, want %d; out=%v", tc.reason, got, tc.want.requiredResources, out)
+			}
+			if tc.want.requiredResources > 0 && tc.want.wantSelector != nil {
+				gotSelector := &fnv1.ResourceSelector{}
+				bs, err := out.GetRequiredResources()[0].MarshalJSON()
+				if err != nil {
+					t.Fatalf("%s\ncannot marshal recorded selector to JSON: %v", tc.reason, err)
+				}
+				if err := protojson.Unmarshal(bs, gotSelector); err != nil {
+					t.Fatalf("%s\ncannot decode recorded ResourceSelector: %v", tc.reason, err)
+				}
+				if diff := cmp.Diff(tc.want.wantSelector, gotSelector, protocmp.Transform()); diff != "" {
+					t.Errorf("%s\nrecorded ResourceSelector: -want, +got:\n%s", tc.reason, diff)
+				}
+			}
+		})
 	}
 }
 
-func TestRenderNonFatalReconcileErrorWraps(t *testing.T) {
-	// A render request whose CompositeResource cannot be decoded
-	// fails before Reconcile even runs. The error must NOT be a
-	// PipelineFatalError, and the existing wrapping must be preserved.
-	in := &renderv1alpha1.CompositeInput{
-		// Missing CompositeResource — Render's protobuf decode of the XR
-		// returns an error before reaching the reconciler.
-		CompositeResource: mustStruct(map[string]any{}),
-		Composition: mustStruct(map[string]any{
-			"metadata": map[string]any{"name": "broken"},
-			"spec": map[string]any{
-				"compositeTypeRef": map[string]any{
-					"apiVersion": "example.org/v1alpha1",
-					"kind":       "XBroken",
-				},
-				"pipeline": []any{},
-			},
-		}),
-	}
+func strPtr(s string) *string { return &s }
 
-	out, err := Render(context.Background(), logging.NewNopLogger(), in)
-	if err == nil {
-		t.Fatalf("Render(...) expected error, got nil; out=%v", out)
+func mustStruct(m map[string]any) *structpb.Struct {
+	s, err := structpb.NewStruct(m)
+	if err != nil {
+		panic(err)
 	}
-	var pfe *xcomposite.PipelineFatalError
-	if errors.As(err, &pfe) {
-		t.Errorf("Render(...) error unexpectedly classified as PipelineFatalError: %v", err)
-	}
-	if out != nil {
-		t.Errorf("Render(...) returned out=%v on non-fatal error; want nil", out)
-	}
+	return s
 }

--- a/internal/render/operation/render.go
+++ b/internal/render/operation/render.go
@@ -132,17 +132,21 @@ func Render(ctx context.Context, log logging.Logger, in *renderv1alpha1.Operatio
 			u.GetNamespace() == op.GetNamespace() &&
 			u.GetName() == op.GetName()
 	}, rec, rrf, rsf)
-	if berr != nil {
-		if rerr != nil {
-			return nil, errors.Join(rerr, berr)
-		}
+	switch {
+	case berr != nil && rerr != nil:
+		// Both reconcile and buildOutput failed; surface both via
+		// errors.Join so callers can recover *PipelineFatalError from the
+		// chain via errors.As when present.
+		return nil, errors.Join(rerr, berr)
+	case berr != nil:
 		return nil, berr
-	}
-
-	if rerr != nil {
+	case rerr != nil:
+		// Symmetrical with composite.Render: return the full wrapped error
+		// chain so callers preserve any reconciler-added diagnostic context;
+		// *PipelineFatalError remains reachable via errors.As.
 		var pfe *xcomposite.PipelineFatalError
 		if errors.As(rerr, &pfe) {
-			return out, pfe
+			return out, rerr
 		}
 		return nil, errors.Wrap(rerr, "reconcile failed")
 	}

--- a/internal/render/operation/render.go
+++ b/internal/render/operation/render.go
@@ -133,13 +133,13 @@ func Render(ctx context.Context, log logging.Logger, in *renderv1alpha1.Operatio
 			u.GetName() == op.GetName()
 	}, rec, rrf, rsf)
 	switch {
-	case berr != nil && rerr != nil:
-		// Both reconcile and buildOutput failed; surface both via
-		// errors.Join so callers can recover *PipelineFatalError from the
-		// chain via errors.As when present.
-		return nil, errors.Join(rerr, berr)
 	case berr != nil:
-		return nil, berr
+		// Surface buildOutput's failure. If reconcile also failed, join
+		// both so callers can recover *PipelineFatalError via errors.As.
+		// When rerr is nil, errors.Join wraps berr in a MultiError whose
+		// Error() string and errors.As/Is behavior match berr exactly —
+		// callers using those traversals see no difference.
+		return nil, errors.Join(rerr, berr)
 	case rerr != nil:
 		// Symmetrical with composite.Render: return the full wrapped error
 		// chain so callers preserve any reconciler-added diagnostic context;

--- a/internal/render/operation/render.go
+++ b/internal/render/operation/render.go
@@ -37,6 +37,7 @@ import (
 
 	apis "github.com/crossplane/crossplane/apis/v2"
 	opsv1alpha1 "github.com/crossplane/crossplane/apis/v2/ops/v1alpha1"
+	xcomposite "github.com/crossplane/crossplane/v2/internal/controller/apiextensions/composite"
 	cronrec "github.com/crossplane/crossplane/v2/internal/controller/ops/cronoperation"
 	oprec "github.com/crossplane/crossplane/v2/internal/controller/ops/operation"
 	watchrec "github.com/crossplane/crossplane/v2/internal/controller/ops/watched"
@@ -118,16 +119,35 @@ func Render(ctx context.Context, log logging.Logger, in *renderv1alpha1.Operatio
 		Name:      op.GetName(),
 	}}
 
-	if _, err := r.Reconcile(ctx, req); err != nil {
-		return nil, errors.Wrap(err, "reconcile failed")
-	}
+	_, rerr := r.Reconcile(ctx, req)
 
+	// Always build the output, even on reconcile error: the recording
+	// fetchers and the EventRecorder may have captured useful state — in
+	// particular the resource selectors a function requested before
+	// returning a fatal result — that callers iterating on requirements
+	// need to make progress. See issue #7446.
 	opGVK := opsv1alpha1.OperationGroupVersionKind
-	return buildOutput(c, func(u kunstructured.Unstructured) bool {
+	out, berr := buildOutput(c, func(u kunstructured.Unstructured) bool {
 		return u.GroupVersionKind() == opGVK &&
 			u.GetNamespace() == op.GetNamespace() &&
 			u.GetName() == op.GetName()
 	}, rec, rrf, rsf)
+	if berr != nil {
+		if rerr != nil {
+			return nil, errors.Join(rerr, berr)
+		}
+		return nil, berr
+	}
+
+	if rerr != nil {
+		var pfe *xcomposite.PipelineFatalError
+		if errors.As(rerr, &pfe) {
+			return out, pfe
+		}
+		return nil, errors.Wrap(rerr, "reconcile failed")
+	}
+
+	return out, nil
 }
 
 // NewFromCronOperation produces the Operation a CronOperation would create.

--- a/internal/render/operation/render_test.go
+++ b/internal/render/operation/render_test.go
@@ -18,15 +18,22 @@ package operation
 
 import (
 	"context"
+	"net"
+	"sync"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+	"google.golang.org/grpc"
+	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/testing/protocmp"
 	"google.golang.org/protobuf/types/known/structpb"
 
+	"github.com/crossplane/crossplane-runtime/v2/pkg/errors"
 	"github.com/crossplane/crossplane-runtime/v2/pkg/logging"
 
+	xcomposite "github.com/crossplane/crossplane/v2/internal/controller/apiextensions/composite"
+	fnv1 "github.com/crossplane/crossplane/v2/proto/fn/v1"
 	renderv1alpha1 "github.com/crossplane/crossplane/v2/proto/render/v1alpha1"
 )
 
@@ -120,4 +127,144 @@ func mustStruct(m map[string]any) *structpb.Struct {
 		panic(err)
 	}
 	return s
+}
+
+// fatalFunctionServer simulates a real function-extra-resources style pipeline
+// step. On its first call it announces its required resources via
+// Requirements.Resources (no FATAL), letting the FetchingFunctionRunner record
+// the selectors via the recording fetcher. On its second call (when the
+// fetched resources came back empty because the caller did not pre-populate
+// them) it returns SEVERITY_FATAL.
+type fatalFunctionServer struct {
+	fnv1.UnimplementedFunctionRunnerServiceServer
+	requirementName string
+	selector        *fnv1.ResourceSelector
+	fatalMessage    string
+
+	mu    sync.Mutex
+	calls int
+}
+
+func (s *fatalFunctionServer) RunFunction(_ context.Context, _ *fnv1.RunFunctionRequest) (*fnv1.RunFunctionResponse, error) {
+	s.mu.Lock()
+	s.calls++
+	call := s.calls
+	s.mu.Unlock()
+
+	if call == 1 {
+		return &fnv1.RunFunctionResponse{
+			Requirements: &fnv1.Requirements{
+				Resources: map[string]*fnv1.ResourceSelector{
+					s.requirementName: s.selector,
+				},
+			},
+		}, nil
+	}
+
+	return &fnv1.RunFunctionResponse{
+		Requirements: &fnv1.Requirements{
+			Resources: map[string]*fnv1.ResourceSelector{
+				s.requirementName: s.selector,
+			},
+		},
+		Results: []*fnv1.Result{
+			{Severity: fnv1.Severity_SEVERITY_FATAL, Message: s.fatalMessage},
+		},
+	}, nil
+}
+
+func startTestFunctionServer(t *testing.T, ss fnv1.FunctionRunnerServiceServer) string {
+	t.Helper()
+
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("cannot listen for test gRPC server: %v", err)
+	}
+
+	s := grpc.NewServer()
+	fnv1.RegisterFunctionRunnerServiceServer(s, ss)
+	go func() { _ = s.Serve(lis) }()
+
+	t.Cleanup(func() {
+		s.Stop()
+	})
+
+	return lis.Addr().String()
+}
+
+func TestRenderPipelineFatalReturnsRequirements(t *testing.T) {
+	const stepName = "fetch-extras"
+	const fatalMsg = "Required extra resource \"namedClusterRole\" not found"
+	const requirementName = "namedClusterRole"
+
+	wantSelector := &fnv1.ResourceSelector{
+		ApiVersion: "rbac.authorization.k8s.io/v1",
+		Kind:       "ClusterRole",
+		Match: &fnv1.ResourceSelector_MatchName{
+			MatchName: "some-cluster-role",
+		},
+	}
+
+	server := &fatalFunctionServer{
+		requirementName: requirementName,
+		selector:        wantSelector,
+		fatalMessage:    fatalMsg,
+	}
+
+	addr := startTestFunctionServer(t, server)
+
+	in := &renderv1alpha1.OperationInput{
+		Operation: mustStruct(map[string]any{
+			"apiVersion": "ops.crossplane.io/v1alpha1",
+			"kind":       "Operation",
+			"metadata": map[string]any{
+				"name":      "my-operation",
+				"namespace": "default",
+			},
+			"spec": map[string]any{
+				"mode": "Pipeline",
+				"pipeline": []any{
+					map[string]any{
+						"step":        stepName,
+						"functionRef": map[string]any{"name": "function-extra-resources"},
+					},
+				},
+			},
+		}),
+		Functions: []*renderv1alpha1.FunctionInput{
+			{Name: "function-extra-resources", Address: addr},
+		},
+	}
+
+	out, err := Render(context.Background(), logging.NewNopLogger(), in)
+
+	var pfe *xcomposite.PipelineFatalError
+	if !errors.As(err, &pfe) {
+		t.Fatalf("Render(...) error: want *PipelineFatalError in chain, got %T: %v", err, err)
+	}
+	if pfe.Step != stepName {
+		t.Errorf("PipelineFatalError.Step = %q, want %q", pfe.Step, stepName)
+	}
+	if pfe.Message != fatalMsg {
+		t.Errorf("PipelineFatalError.Message = %q, want %q", pfe.Message, fatalMsg)
+	}
+
+	if out == nil {
+		t.Fatalf("Render(...) returned nil output on PipelineFatalError; want non-nil with RequiredResources populated")
+	}
+	if got := len(out.GetRequiredResources()); got != 1 {
+		t.Fatalf("len(out.RequiredResources) = %d, want 1; out=%v", got, out)
+	}
+
+	gotSelector := &fnv1.ResourceSelector{}
+	bs, err := out.GetRequiredResources()[0].MarshalJSON()
+	if err != nil {
+		t.Fatalf("cannot marshal recorded selector to JSON: %v", err)
+	}
+	if err := protojson.Unmarshal(bs, gotSelector); err != nil {
+		t.Fatalf("cannot decode recorded ResourceSelector: %v", err)
+	}
+	if diff := cmp.Diff(wantSelector, gotSelector, protocmp.Transform()); diff != "" {
+		t.Errorf("recorded ResourceSelector: -want, +got:\n%s", diff)
+	}
 }

--- a/internal/render/operation/render_test.go
+++ b/internal/render/operation/render_test.go
@@ -268,3 +268,45 @@ func TestRenderPipelineFatalReturnsRequirements(t *testing.T) {
 		t.Errorf("recorded ResourceSelector: -want, +got:\n%s", diff)
 	}
 }
+
+func TestRenderNonFatalReconcileErrorWraps(t *testing.T) {
+	// A pipeline step whose function name is not registered in
+	// FunctionInput causes the reconciler to fail with an "unknown function"
+	// error — a non-fatal failure mode. The returned error must NOT be a
+	// *PipelineFatalError, and no partial output must be returned. This
+	// guards the non-fatal path against regressions that would accidentally
+	// surface partial output for any reconcile failure.
+	in := &renderv1alpha1.OperationInput{
+		Operation: mustStruct(map[string]any{
+			"apiVersion": "ops.crossplane.io/v1alpha1",
+			"kind":       "Operation",
+			"metadata": map[string]any{
+				"name":      "my-operation",
+				"namespace": "default",
+			},
+			"spec": map[string]any{
+				"mode": "Pipeline",
+				"pipeline": []any{
+					map[string]any{
+						"step":        "missing",
+						"functionRef": map[string]any{"name": "function-does-not-exist"},
+					},
+				},
+			},
+		}),
+		// Functions list intentionally empty so the runner has no
+		// connection for "function-does-not-exist".
+	}
+
+	out, err := Render(context.Background(), logging.NewNopLogger(), in)
+	if err == nil {
+		t.Fatalf("Render(...) expected error, got nil; out=%v", out)
+	}
+	var pfe *PipelineFatalError
+	if errors.As(err, &pfe) {
+		t.Errorf("Render(...) error unexpectedly classified as *PipelineFatalError: %v", err)
+	}
+	if out != nil {
+		t.Errorf("Render(...) returned out=%v on non-fatal error; want nil", out)
+	}
+}

--- a/internal/render/operation/render_test.go
+++ b/internal/render/operation/render_test.go
@@ -17,14 +17,10 @@ limitations under the License.
 package operation
 
 import (
-	"context"
-	"net"
-	"sync"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	"google.golang.org/grpc"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/testing/protocmp"
 	"google.golang.org/protobuf/types/known/structpb"
@@ -33,6 +29,7 @@ import (
 	"github.com/crossplane/crossplane-runtime/v2/pkg/logging"
 
 	xcomposite "github.com/crossplane/crossplane/v2/internal/controller/apiextensions/composite"
+	"github.com/crossplane/crossplane/v2/internal/render/rendertest"
 	fnv1 "github.com/crossplane/crossplane/v2/proto/fn/v1"
 	renderv1alpha1 "github.com/crossplane/crossplane/v2/proto/render/v1alpha1"
 )
@@ -109,7 +106,7 @@ func TestRender(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			out, err := Render(context.Background(), logging.NewNopLogger(), tc.input)
+			out, err := Render(t.Context(), logging.NewNopLogger(), tc.input)
 
 			if diff := cmp.Diff(tc.want.err, err, cmpopts.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\nRender(...): -want error, +got error:\n%s", tc.reason, diff)
@@ -121,78 +118,7 @@ func TestRender(t *testing.T) {
 	}
 }
 
-func mustStruct(m map[string]any) *structpb.Struct {
-	s, err := structpb.NewStruct(m)
-	if err != nil {
-		panic(err)
-	}
-	return s
-}
-
-// fatalFunctionServer simulates a real function-extra-resources style pipeline
-// step. On its first call it announces its required resources via
-// Requirements.Resources (no FATAL), letting the FetchingFunctionRunner record
-// the selectors via the recording fetcher. On its second call (when the
-// fetched resources came back empty because the caller did not pre-populate
-// them) it returns SEVERITY_FATAL.
-type fatalFunctionServer struct {
-	fnv1.UnimplementedFunctionRunnerServiceServer
-	requirementName string
-	selector        *fnv1.ResourceSelector
-	fatalMessage    string
-
-	mu    sync.Mutex
-	calls int
-}
-
-func (s *fatalFunctionServer) RunFunction(_ context.Context, _ *fnv1.RunFunctionRequest) (*fnv1.RunFunctionResponse, error) {
-	s.mu.Lock()
-	s.calls++
-	call := s.calls
-	s.mu.Unlock()
-
-	if call == 1 {
-		return &fnv1.RunFunctionResponse{
-			Requirements: &fnv1.Requirements{
-				Resources: map[string]*fnv1.ResourceSelector{
-					s.requirementName: s.selector,
-				},
-			},
-		}, nil
-	}
-
-	return &fnv1.RunFunctionResponse{
-		Requirements: &fnv1.Requirements{
-			Resources: map[string]*fnv1.ResourceSelector{
-				s.requirementName: s.selector,
-			},
-		},
-		Results: []*fnv1.Result{
-			{Severity: fnv1.Severity_SEVERITY_FATAL, Message: s.fatalMessage},
-		},
-	}, nil
-}
-
-func startTestFunctionServer(t *testing.T, ss fnv1.FunctionRunnerServiceServer) string {
-	t.Helper()
-
-	lis, err := net.Listen("tcp", "127.0.0.1:0")
-	if err != nil {
-		t.Fatalf("cannot listen for test gRPC server: %v", err)
-	}
-
-	s := grpc.NewServer()
-	fnv1.RegisterFunctionRunnerServiceServer(s, ss)
-	go func() { _ = s.Serve(lis) }()
-
-	t.Cleanup(func() {
-		s.Stop()
-	})
-
-	return lis.Addr().String()
-}
-
-func TestRenderPipelineFatalReturnsRequirements(t *testing.T) {
+func TestRenderErrors(t *testing.T) {
 	const stepName = "fetch-extras"
 	const fatalMsg = "Required extra resource \"namedClusterRole\" not found"
 	const requirementName = "namedClusterRole"
@@ -205,108 +131,147 @@ func TestRenderPipelineFatalReturnsRequirements(t *testing.T) {
 		},
 	}
 
-	server := &fatalFunctionServer{
-		requirementName: requirementName,
-		selector:        wantSelector,
-		fatalMessage:    fatalMsg,
+	type want struct {
+		pipelineFatal           bool
+		fatalStep, fatalMessage string
+		hasOutput               bool
+		requiredResources       int
+		wantSelector            *fnv1.ResourceSelector
 	}
 
-	addr := startTestFunctionServer(t, server)
-
-	in := &renderv1alpha1.OperationInput{
-		Operation: mustStruct(map[string]any{
-			"apiVersion": "ops.crossplane.io/v1alpha1",
-			"kind":       "Operation",
-			"metadata": map[string]any{
-				"name":      "my-operation",
-				"namespace": "default",
-			},
-			"spec": map[string]any{
-				"mode": "Pipeline",
-				"pipeline": []any{
-					map[string]any{
-						"step":        stepName,
-						"functionRef": map[string]any{"name": "function-extra-resources"},
+	cases := map[string]struct {
+		reason string
+		input  func(t *testing.T) *renderv1alpha1.OperationInput
+		want   want
+	}{
+		"PipelineFatalReturnsRequirements": {
+			reason: "When a pipeline step returns SEVERITY_FATAL, Render must return the partial OperationOutput (with recorded RequiredResources) and an error chain containing *PipelineFatalError reachable via errors.As.",
+			input: func(t *testing.T) *renderv1alpha1.OperationInput {
+				t.Helper()
+				addr := rendertest.StartFunctionServer(t, &rendertest.FatalFunctionServer{
+					RequirementName: requirementName,
+					Selector:        wantSelector,
+					FatalMessage:    fatalMsg,
+				})
+				return &renderv1alpha1.OperationInput{
+					Operation: mustStruct(map[string]any{
+						"apiVersion": "ops.crossplane.io/v1alpha1",
+						"kind":       "Operation",
+						"metadata": map[string]any{
+							"name":      "my-operation",
+							"namespace": "default",
+						},
+						"spec": map[string]any{
+							"mode": "Pipeline",
+							"pipeline": []any{
+								map[string]any{
+									"step":        stepName,
+									"functionRef": map[string]any{"name": "function-extra-resources"},
+								},
+							},
+						},
+					}),
+					Functions: []*renderv1alpha1.FunctionInput{
+						{Name: "function-extra-resources", Address: addr},
 					},
-				},
+				}
 			},
-		}),
-		Functions: []*renderv1alpha1.FunctionInput{
-			{Name: "function-extra-resources", Address: addr},
+			want: want{
+				pipelineFatal:     true,
+				fatalStep:         stepName,
+				fatalMessage:      fatalMsg,
+				hasOutput:         true,
+				requiredResources: 1,
+				wantSelector:      wantSelector,
+			},
+		},
+		"NonFatalReconcileErrorWraps": {
+			reason: "A pipeline step whose function name is not registered in FunctionInput causes the reconciler to fail with an 'unknown function' error — a non-fatal failure mode. The error must NOT be a *PipelineFatalError, and no partial output must be returned.",
+			input: func(t *testing.T) *renderv1alpha1.OperationInput {
+				t.Helper()
+				return &renderv1alpha1.OperationInput{
+					Operation: mustStruct(map[string]any{
+						"apiVersion": "ops.crossplane.io/v1alpha1",
+						"kind":       "Operation",
+						"metadata": map[string]any{
+							"name":      "my-operation",
+							"namespace": "default",
+						},
+						"spec": map[string]any{
+							"mode": "Pipeline",
+							"pipeline": []any{
+								map[string]any{
+									"step":        "missing",
+									"functionRef": map[string]any{"name": "function-does-not-exist"},
+								},
+							},
+						},
+					}),
+					// Functions list intentionally empty.
+				}
+			},
+			want: want{
+				pipelineFatal: false,
+				hasOutput:     false,
+			},
 		},
 	}
 
-	out, err := Render(context.Background(), logging.NewNopLogger(), in)
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			out, err := Render(t.Context(), logging.NewNopLogger(), tc.input(t))
 
-	var pfe *xcomposite.PipelineFatalError
-	if !errors.As(err, &pfe) {
-		t.Fatalf("Render(...) error: want *PipelineFatalError in chain, got %T: %v", err, err)
-	}
-	if pfe.Step != stepName {
-		t.Errorf("PipelineFatalError.Step = %q, want %q", pfe.Step, stepName)
-	}
-	if pfe.Message != fatalMsg {
-		t.Errorf("PipelineFatalError.Message = %q, want %q", pfe.Message, fatalMsg)
-	}
+			if err == nil {
+				t.Fatalf("%s\nRender(...) expected error, got nil", tc.reason)
+			}
 
-	if out == nil {
-		t.Fatalf("Render(...) returned nil output on PipelineFatalError; want non-nil with RequiredResources populated")
-	}
-	if got := len(out.GetRequiredResources()); got != 1 {
-		t.Fatalf("len(out.RequiredResources) = %d, want 1; out=%v", got, out)
-	}
+			var pfe *xcomposite.PipelineFatalError
+			gotFatal := errors.As(err, &pfe)
+			if gotFatal != tc.want.pipelineFatal {
+				t.Errorf("%s\nerrors.As(*PipelineFatalError) = %v, want %v; err=%v", tc.reason, gotFatal, tc.want.pipelineFatal, err)
+			}
+			if tc.want.pipelineFatal && gotFatal {
+				if pfe.Step != tc.want.fatalStep {
+					t.Errorf("%s\nPipelineFatalError.Step = %q, want %q", tc.reason, pfe.Step, tc.want.fatalStep)
+				}
+				if pfe.Message != tc.want.fatalMessage {
+					t.Errorf("%s\nPipelineFatalError.Message = %q, want %q", tc.reason, pfe.Message, tc.want.fatalMessage)
+				}
+			}
 
-	gotSelector := &fnv1.ResourceSelector{}
-	bs, err := out.GetRequiredResources()[0].MarshalJSON()
-	if err != nil {
-		t.Fatalf("cannot marshal recorded selector to JSON: %v", err)
-	}
-	if err := protojson.Unmarshal(bs, gotSelector); err != nil {
-		t.Fatalf("cannot decode recorded ResourceSelector: %v", err)
-	}
-	if diff := cmp.Diff(wantSelector, gotSelector, protocmp.Transform()); diff != "" {
-		t.Errorf("recorded ResourceSelector: -want, +got:\n%s", diff)
+			if !tc.want.hasOutput {
+				if out != nil {
+					t.Errorf("%s\nRender(...) returned out=%v on non-fatal error; want nil", tc.reason, out)
+				}
+				return
+			}
+			if out == nil {
+				t.Fatalf("%s\nRender(...) returned nil output; want non-nil with RequiredResources populated", tc.reason)
+			}
+			if got := len(out.GetRequiredResources()); got != tc.want.requiredResources {
+				t.Fatalf("%s\nlen(out.RequiredResources) = %d, want %d; out=%v", tc.reason, got, tc.want.requiredResources, out)
+			}
+			if tc.want.requiredResources > 0 && tc.want.wantSelector != nil {
+				gotSelector := &fnv1.ResourceSelector{}
+				bs, err := out.GetRequiredResources()[0].MarshalJSON()
+				if err != nil {
+					t.Fatalf("%s\ncannot marshal recorded selector to JSON: %v", tc.reason, err)
+				}
+				if err := protojson.Unmarshal(bs, gotSelector); err != nil {
+					t.Fatalf("%s\ncannot decode recorded ResourceSelector: %v", tc.reason, err)
+				}
+				if diff := cmp.Diff(tc.want.wantSelector, gotSelector, protocmp.Transform()); diff != "" {
+					t.Errorf("%s\nrecorded ResourceSelector: -want, +got:\n%s", tc.reason, diff)
+				}
+			}
+		})
 	}
 }
 
-func TestRenderNonFatalReconcileErrorWraps(t *testing.T) {
-	// A pipeline step whose function name is not registered in
-	// FunctionInput causes the reconciler to fail with an "unknown function"
-	// error — a non-fatal failure mode. The returned error must NOT be a
-	// *PipelineFatalError, and no partial output must be returned. This
-	// guards the non-fatal path against regressions that would accidentally
-	// surface partial output for any reconcile failure.
-	in := &renderv1alpha1.OperationInput{
-		Operation: mustStruct(map[string]any{
-			"apiVersion": "ops.crossplane.io/v1alpha1",
-			"kind":       "Operation",
-			"metadata": map[string]any{
-				"name":      "my-operation",
-				"namespace": "default",
-			},
-			"spec": map[string]any{
-				"mode": "Pipeline",
-				"pipeline": []any{
-					map[string]any{
-						"step":        "missing",
-						"functionRef": map[string]any{"name": "function-does-not-exist"},
-					},
-				},
-			},
-		}),
-		// Functions list intentionally empty so the runner has no
-		// connection for "function-does-not-exist".
+func mustStruct(m map[string]any) *structpb.Struct {
+	s, err := structpb.NewStruct(m)
+	if err != nil {
+		panic(err)
 	}
-
-	out, err := Render(context.Background(), logging.NewNopLogger(), in)
-	if err == nil {
-		t.Fatalf("Render(...) expected error, got nil; out=%v", out)
-	}
-	var pfe *PipelineFatalError
-	if errors.As(err, &pfe) {
-		t.Errorf("Render(...) error unexpectedly classified as *PipelineFatalError: %v", err)
-	}
-	if out != nil {
-		t.Errorf("Render(...) returned out=%v on non-fatal error; want nil", out)
-	}
+	return s
 }

--- a/internal/render/rendertest/fixtures.go
+++ b/internal/render/rendertest/fixtures.go
@@ -1,0 +1,94 @@
+/*
+Copyright 2026 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package rendertest contains shared test fixtures for the render packages
+// (internal/render, cmd/crossplane/render). They are exported so that tests
+// across packages can share them — they are not intended for production use.
+package rendertest
+
+import (
+	"context"
+	"net"
+	"sync"
+	"testing"
+
+	"google.golang.org/grpc"
+
+	fnv1 "github.com/crossplane/crossplane/v2/proto/fn/v1"
+)
+
+// FatalFunctionServer is an in-process gRPC FunctionRunnerService server that
+// announces a required resource on its first call and returns
+// SEVERITY_FATAL on its second. It mirrors the function-extra-resources /
+// function-environment-configs scenarios that motivated issue #7446: a
+// function declares a requirement on the first call, then FATALs on the
+// second call when the requirement still isn't satisfied.
+type FatalFunctionServer struct {
+	fnv1.UnimplementedFunctionRunnerServiceServer
+
+	// RequirementName is the key of the required-resource selector returned
+	// in the response's Requirements.Resources map.
+	RequirementName string
+	// Selector is the resource selector returned for RequirementName.
+	Selector *fnv1.ResourceSelector
+	// FatalMessage is the message attached to the SEVERITY_FATAL result on
+	// the second call.
+	FatalMessage string
+
+	mu    sync.Mutex
+	calls int
+}
+
+// RunFunction implements fnv1.FunctionRunnerServiceServer.
+func (s *FatalFunctionServer) RunFunction(_ context.Context, _ *fnv1.RunFunctionRequest) (*fnv1.RunFunctionResponse, error) {
+	s.mu.Lock()
+	s.calls++
+	call := s.calls
+	s.mu.Unlock()
+
+	if call == 1 {
+		return &fnv1.RunFunctionResponse{
+			Requirements: &fnv1.Requirements{
+				Resources: map[string]*fnv1.ResourceSelector{
+					s.RequirementName: s.Selector,
+				},
+			},
+		}, nil
+	}
+	return &fnv1.RunFunctionResponse{
+		Results: []*fnv1.Result{{Severity: fnv1.Severity_SEVERITY_FATAL, Message: s.FatalMessage}},
+	}, nil
+}
+
+// StartFunctionServer starts an in-process gRPC server registered with the
+// supplied FunctionRunnerServiceServer and returns its TCP address. The
+// server is stopped automatically when the test ends.
+func StartFunctionServer(t *testing.T, ss fnv1.FunctionRunnerServiceServer) string {
+	t.Helper()
+
+	var lc net.ListenConfig
+	lis, err := lc.Listen(t.Context(), "tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("cannot listen for test gRPC server: %v", err)
+	}
+
+	s := grpc.NewServer()
+	fnv1.RegisterFunctionRunnerServiceServer(s, ss)
+	go func() { _ = s.Serve(lis) }()
+
+	t.Cleanup(s.Stop)
+	return lis.Addr().String()
+}


### PR DESCRIPTION


### Description of your changes



Fixes #7446

I have: 

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `./nix.sh flake check` to ensure this PR is ready for review.
- [x] Added or updated unit tests.
- ~~[ ] Added or updated e2e tests.~~ The fix is in the `crossplane internal render` subprocess protocol, which is not exercised by the cluster-based harness in `test/e2e/` (kind cluster, helm chart, real reconciliation). The closest test we can reasonably achieve for a CLI subcommand is in [`cmd/crossplane/render/render_test.go`](cmd/crossplane/render/render_test.go): `TestRun` constructs the same Kong CLI tree main.go uses, parses real CLI args (`render --timeout=30s`), and dispatches through Kong's reflection-based `Run()` invocation against an in-process gRPC `FunctionRunnerService` fixture and the real composite reconciler — exercising the full user-facing CLI pathway end-to-end inside the `go test` process. The existing `TestOperationRetryLogic` e2e additionally covers the related operation reconciler FATAL path through a real cluster.
~~- [ ] Linked a PR or a [docs tracking issue] to [document this change].~~
- [x] Added `backport release-x.y` labels to auto-backport this PR.
~~- [ ] Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md
