### PR TITLE
fix(offered): add claim composite-GVK index only once

### DIFF
--- a/internal/controller/apiextensions/offered/reconciler.go
+++ b/internal/controller/apiextensions/offered/reconciler.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"sync"
 	"time"
 
 	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -270,6 +271,38 @@ type Reconciler struct {
 	conditions conditions.Manager
 
 	options apiextensionscontroller.Options
+
+	// claimIndexMu guards claimIndexAdded, which tracks whether the
+	// XRD-by-composite-GVK index used by claim controllers has been added to
+	// the engine's cache. The index only needs to be added once.
+	claimIndexMu    sync.Mutex
+	claimIndexAdded bool
+}
+
+// addCompositeResourceClaimIndex adds the XRD-by-composite-GVK index that claim
+// controllers rely on to the engine's cache. The index only needs to be added
+// once: it is a no-op once added successfully, so calling it on every reconcile
+// no longer logs a spurious "indexer conflict" error. It retries until the
+// index is added successfully to remain resilient to transient failures.
+func (r *Reconciler) addCompositeResourceClaimIndex(ctx context.Context, log logging.Logger) {
+	r.claimIndexMu.Lock()
+	defer r.claimIndexMu.Unlock()
+
+	if r.claimIndexAdded {
+		return
+	}
+
+	indexer := r.engine.GetFieldIndexer()
+	if indexer == nil {
+		return
+	}
+
+	if err := indexer.IndexField(ctx, &v1.CompositeResourceDefinition{}, claim.XRDByCompositeGVKIndex(), claim.IndexXRDByCompositeGVK()); err != nil {
+		log.Debug(errAddIndex, "error", err)
+		return
+	}
+
+	r.claimIndexAdded = true
 }
 
 // Reconcile a CompositeResourceDefinition by defining a new kind of composite
@@ -495,12 +528,9 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 			"desired-version", desired.APIVersion)
 	}
 
-	// Add an index to the controller engine's client.
-	if indexer := r.engine.GetFieldIndexer(); indexer != nil {
-		if err := indexer.IndexField(ctx, &v1.CompositeResourceDefinition{}, claim.XRDByCompositeGVKIndex(), claim.IndexXRDByCompositeGVK()); err != nil {
-			log.Debug(errAddIndex, "error", err)
-		}
-	}
+	// Add the index claim controllers rely on to the engine's cache. This only
+	// needs to happen once, so calling it on every reconcile is fine.
+	r.addCompositeResourceClaimIndex(ctx, log)
 
 	controllerName := claim.ControllerName(d.GetName())
 	gvkClaim := d.GetClaimGroupVersionKind()

--- a/internal/controller/apiextensions/offered/reconciler_test.go
+++ b/internal/controller/apiextensions/offered/reconciler_test.go
@@ -38,7 +38,6 @@ import (
 	"github.com/crossplane/crossplane-runtime/v2/pkg/test"
 
 	v1 "github.com/crossplane/crossplane/apis/v2/apiextensions/v1"
-	"github.com/crossplane/crossplane/v2/internal/controller/apiextensions/claim"
 	"github.com/crossplane/crossplane/v2/internal/engine"
 )
 
@@ -82,19 +81,20 @@ func (m *MockEngine) GetFieldIndexer() client.FieldIndexer {
 
 // fakeFieldIndexer models controller-runtime's cache: registering the same
 // field index twice returns an "indexer conflict" error, like the underlying
-// client-go thread-safe store. forceErr makes IndexField fail without
-// registering, to simulate a transient failure.
+// client-go thread-safe store. failFirst makes the leading calls fail with a
+// transient error (without registering), to simulate transient failures.
 type fakeFieldIndexer struct {
 	registered map[string]bool
 	calls      int
 	conflicts  int
-	forceErr   error
+	failFirst  int
 }
 
 func (f *fakeFieldIndexer) IndexField(_ context.Context, _ client.Object, field string, _ client.IndexerFunc) error {
 	f.calls++
-	if f.forceErr != nil {
-		return f.forceErr
+	if f.failFirst > 0 {
+		f.failFirst--
+		return errors.New("transient indexer error")
 	}
 	if f.registered == nil {
 		f.registered = map[string]bool{}
@@ -119,72 +119,68 @@ func (l recordingLogger) Debug(msg string, _ ...any) {
 func (l recordingLogger) WithValues(_ ...any) logging.Logger { return l }
 
 func TestAddCompositeResourceClaimIndex(t *testing.T) {
-	t.Run("AddedOnceAndDoesNotLogConflict", func(t *testing.T) {
-		// Across many reconciles the index is added exactly once, so the cache
-		// never reports a conflict and the spurious debug message that #7399
-		// reports is never logged.
-		idx := &fakeFieldIndexer{}
-		r := &Reconciler{
-			engine: &MockEngine{
-				MockGetFieldIndexer: func() client.FieldIndexer { return idx },
-			},
-		}
-		var debug []string
-		log := recordingLogger{debug: &debug}
+	type args struct {
+		failFirst  int
+		reconciles int
+	}
 
-		for range 5 {
-			r.addCompositeResourceClaimIndex(context.Background(), log)
-		}
+	type want struct {
+		calls          int
+		conflicts      int
+		loggedAddIndex bool
+	}
 
-		if diff := cmp.Diff(1, idx.calls); diff != "" {
-			t.Errorf("IndexField call count: -want, +got:\n%s", diff)
-		}
-		if idx.conflicts != 0 {
-			t.Errorf("want 0 indexer conflicts, got %d", idx.conflicts)
-		}
-		for _, m := range debug {
-			if m == errAddIndex {
-				t.Errorf("unexpected %q debug log emitted after fix", errAddIndex)
+	cases := map[string]struct {
+		reason string
+		args   args
+		want   want
+	}{
+		"AddedOnceAcrossManyReconciles": {
+			reason: "The index is added once, so repeated reconciles never re-register it, never hit an indexer conflict, and never log the spurious message from #7399.",
+			args:   args{failFirst: 0, reconciles: 5},
+			want:   want{calls: 1, conflicts: 0, loggedAddIndex: false},
+		},
+		"RetriesUntilSuccess": {
+			reason: "A transient failure is retried on the next reconcile rather than being marked as added, so IndexField is called until it succeeds.",
+			args:   args{failFirst: 2, reconciles: 5},
+			want:   want{calls: 3, conflicts: 0, loggedAddIndex: true},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			idx := &fakeFieldIndexer{failFirst: tc.args.failFirst}
+			r := &Reconciler{
+				engine: &MockEngine{
+					MockGetFieldIndexer: func() client.FieldIndexer { return idx },
+				},
 			}
-		}
-	})
 
-	t.Run("UnpatchedEveryReconcileWouldConflict", func(t *testing.T) {
-		// Documents the bug the fix prevents: registering the index on every
-		// reconcile (the previous behavior) makes the cache report a conflict
-		// on every reconcile after the first.
-		idx := &fakeFieldIndexer{}
-		for range 5 {
-			_ = idx.IndexField(context.Background(), &v1.CompositeResourceDefinition{}, claim.XRDByCompositeGVKIndex(), claim.IndexXRDByCompositeGVK())
-		}
-		if diff := cmp.Diff(4, idx.conflicts); diff != "" {
-			t.Errorf("want 4 indexer conflicts from unpatched behavior, -want, +got:\n%s", diff)
-		}
-	})
+			var debug []string
+			log := recordingLogger{debug: &debug}
 
-	t.Run("RetriesUntilSuccess", func(t *testing.T) {
-		// A transient failure is retried on the next call rather than being
-		// marked as added.
-		idx := &fakeFieldIndexer{forceErr: errors.New("boom")}
-		r := &Reconciler{
-			engine: &MockEngine{
-				MockGetFieldIndexer: func() client.FieldIndexer { return idx },
-			},
-		}
+			for range tc.args.reconciles {
+				r.addCompositeResourceClaimIndex(context.Background(), log)
+			}
 
-		// Two failed attempts both call IndexField.
-		r.addCompositeResourceClaimIndex(context.Background(), logging.NewNopLogger())
-		r.addCompositeResourceClaimIndex(context.Background(), logging.NewNopLogger())
+			loggedAddIndex := false
+			for _, m := range debug {
+				if m == errAddIndex {
+					loggedAddIndex = true
+				}
+			}
 
-		// Once it succeeds, subsequent calls are no-ops.
-		idx.forceErr = nil
-		r.addCompositeResourceClaimIndex(context.Background(), logging.NewNopLogger())
-		r.addCompositeResourceClaimIndex(context.Background(), logging.NewNopLogger())
-
-		if diff := cmp.Diff(3, idx.calls); diff != "" {
-			t.Errorf("IndexField call count: -want, +got:\n%s", diff)
-		}
-	})
+			if diff := cmp.Diff(tc.want.calls, idx.calls); diff != "" {
+				t.Errorf("\n%s\naddCompositeResourceClaimIndex(): IndexField calls: -want, +got:\n%s", tc.reason, diff)
+			}
+			if diff := cmp.Diff(tc.want.conflicts, idx.conflicts); diff != "" {
+				t.Errorf("\n%s\naddCompositeResourceClaimIndex(): indexer conflicts: -want, +got:\n%s", tc.reason, diff)
+			}
+			if diff := cmp.Diff(tc.want.loggedAddIndex, loggedAddIndex); diff != "" {
+				t.Errorf("\n%s\naddCompositeResourceClaimIndex(): logged %q: -want, +got:\n%s", tc.reason, errAddIndex, diff)
+			}
+		})
+	}
 }
 
 func TestReconcile(t *testing.T) {

--- a/internal/controller/apiextensions/offered/reconciler_test.go
+++ b/internal/controller/apiextensions/offered/reconciler_test.go
@@ -38,6 +38,7 @@ import (
 	"github.com/crossplane/crossplane-runtime/v2/pkg/test"
 
 	v1 "github.com/crossplane/crossplane/apis/v2/apiextensions/v1"
+	"github.com/crossplane/crossplane/v2/internal/controller/apiextensions/claim"
 	"github.com/crossplane/crossplane/v2/internal/engine"
 )
 
@@ -77,6 +78,113 @@ func (m *MockEngine) GetCached() client.Client {
 
 func (m *MockEngine) GetFieldIndexer() client.FieldIndexer {
 	return m.MockGetFieldIndexer()
+}
+
+// fakeFieldIndexer models controller-runtime's cache: registering the same
+// field index twice returns an "indexer conflict" error, like the underlying
+// client-go thread-safe store. forceErr makes IndexField fail without
+// registering, to simulate a transient failure.
+type fakeFieldIndexer struct {
+	registered map[string]bool
+	calls      int
+	conflicts  int
+	forceErr   error
+}
+
+func (f *fakeFieldIndexer) IndexField(_ context.Context, _ client.Object, field string, _ client.IndexerFunc) error {
+	f.calls++
+	if f.forceErr != nil {
+		return f.forceErr
+	}
+	if f.registered == nil {
+		f.registered = map[string]bool{}
+	}
+	if f.registered[field] {
+		f.conflicts++
+		return errors.Errorf("indexer conflict: map[field:%s:{}]", field)
+	}
+	f.registered[field] = true
+	return nil
+}
+
+// recordingLogger records the debug messages it is asked to log.
+type recordingLogger struct {
+	debug *[]string
+}
+
+func (l recordingLogger) Info(_ string, _ ...any) {}
+func (l recordingLogger) Debug(msg string, _ ...any) {
+	*l.debug = append(*l.debug, msg)
+}
+func (l recordingLogger) WithValues(_ ...any) logging.Logger { return l }
+
+func TestAddCompositeResourceClaimIndex(t *testing.T) {
+	t.Run("AddedOnceAndDoesNotLogConflict", func(t *testing.T) {
+		// Across many reconciles the index is added exactly once, so the cache
+		// never reports a conflict and the spurious debug message that #7399
+		// reports is never logged.
+		idx := &fakeFieldIndexer{}
+		r := &Reconciler{
+			engine: &MockEngine{
+				MockGetFieldIndexer: func() client.FieldIndexer { return idx },
+			},
+		}
+		var debug []string
+		log := recordingLogger{debug: &debug}
+
+		for range 5 {
+			r.addCompositeResourceClaimIndex(context.Background(), log)
+		}
+
+		if diff := cmp.Diff(1, idx.calls); diff != "" {
+			t.Errorf("IndexField call count: -want, +got:\n%s", diff)
+		}
+		if idx.conflicts != 0 {
+			t.Errorf("want 0 indexer conflicts, got %d", idx.conflicts)
+		}
+		for _, m := range debug {
+			if m == errAddIndex {
+				t.Errorf("unexpected %q debug log emitted after fix", errAddIndex)
+			}
+		}
+	})
+
+	t.Run("UnpatchedEveryReconcileWouldConflict", func(t *testing.T) {
+		// Documents the bug the fix prevents: registering the index on every
+		// reconcile (the previous behavior) makes the cache report a conflict
+		// on every reconcile after the first.
+		idx := &fakeFieldIndexer{}
+		for range 5 {
+			_ = idx.IndexField(context.Background(), &v1.CompositeResourceDefinition{}, claim.XRDByCompositeGVKIndex(), claim.IndexXRDByCompositeGVK())
+		}
+		if diff := cmp.Diff(4, idx.conflicts); diff != "" {
+			t.Errorf("want 4 indexer conflicts from unpatched behavior, -want, +got:\n%s", diff)
+		}
+	})
+
+	t.Run("RetriesUntilSuccess", func(t *testing.T) {
+		// A transient failure is retried on the next call rather than being
+		// marked as added.
+		idx := &fakeFieldIndexer{forceErr: errors.New("boom")}
+		r := &Reconciler{
+			engine: &MockEngine{
+				MockGetFieldIndexer: func() client.FieldIndexer { return idx },
+			},
+		}
+
+		// Two failed attempts both call IndexField.
+		r.addCompositeResourceClaimIndex(context.Background(), logging.NewNopLogger())
+		r.addCompositeResourceClaimIndex(context.Background(), logging.NewNopLogger())
+
+		// Once it succeeds, subsequent calls are no-ops.
+		idx.forceErr = nil
+		r.addCompositeResourceClaimIndex(context.Background(), logging.NewNopLogger())
+		r.addCompositeResourceClaimIndex(context.Background(), logging.NewNopLogger())
+
+		if diff := cmp.Diff(3, idx.calls); diff != "" {
+			t.Errorf("IndexField call count: -want, +got:\n%s", diff)
+		}
+	})
 }
 
 func TestReconcile(t *testing.T) {


### PR DESCRIPTION
The offered XRD controller adds the `xrdByCompositeGVK` field index to the engine cache inside `Reconcile`. Since a field index can only be registered once, every reconcile after the first logs `cannot add composite resource claim index ... indexer conflict: map[field:xrdByCompositeGVK:{}]` at debug. It is functionally a no-op (the index is already there) but produces log noise on every XRD reconcile.

This tracks whether the index has been added and stops re-adding it once it succeeds, retrying only until it succeeds so a transient failure is still recovered. Behavior is otherwise unchanged.

Added a unit test asserting the index is added only once across repeated calls, and is retried until success.

Fixes #7399

### I have:
- [x] Read and followed Crossplane's [contribution process].
- [x] Added or updated unit tests.
- [x] Run `earthly +reviewable` or at least `go build`, `go test`, and `golangci-lint run` on the changed package.