### PR TITLE
apiextensions: opt-in per-tenant identity for composition ExtraResources

### DIFF
--- a/.chloggen/extra-resources-impersonation.yaml
+++ b/.chloggen/extra-resources-impersonation.yaml
@@ -1,0 +1,15 @@
+change_type: enhancement
+component: apiextensions/composite
+note: >
+  Add alpha feature flag --enable-extra-resources-impersonation. When enabled,
+  Crossplane fetches composition ExtraResources for namespaced composite resources
+  under an identity derived from the XR, using Kubernetes client impersonation.
+  The ServiceAccount to impersonate is taken from the
+  crossplane.io/extra-resources-as annotation on the XR, or from the
+  --extra-resources-impersonation-default-sa flag. Cluster-scoped XRs are never
+  impersonated. Default-off; existing behaviour is unchanged when the flag is
+  absent.
+issues: [7461]
+subtext: >
+  This enables tenant RBAC to govern which ExtraResources a composition function
+  may read, without granting Crossplane's own ServiceAccount broader access.

--- a/cmd/crossplane/core/core.go
+++ b/cmd/crossplane/core/core.go
@@ -130,6 +130,7 @@ type startCommand struct {
 	TLSClientSecretName string `env:"TLS_CLIENT_SECRET_NAME" help:"The name of the TLS Secret that will be store Crossplane's client certificate."`
 	TLSClientCertsDir   string `env:"TLS_CLIENT_CERTS_DIR"   help:"The path of the folder which will store TLS client certificate of Crossplane."`
 
+	EnableExtraResourcesImpersonation bool `group:"Alpha Features:" help:"Enable per-tenant identity for composition ExtraResources fetches. When enabled, Crossplane impersonates a ServiceAccount in the XR's namespace when reading ExtraResources. Only applies to namespaced XRs. See --extra-resources-impersonation-default-sa."`
 	EnableDependencyVersionUpgrades   bool `group:"Alpha Features:" help:"Enable support for upgrading dependency versions when the parent package is updated."`
 	EnableDependencyVersionDowngrades bool `group:"Alpha Features:" help:"Enable support for upgrading and downgrading dependency versions when a dependent package is updated."`
 	EnableSignatureVerification       bool `group:"Alpha Features:" help:"Enable support for package signature verification via ImageConfig API."`
@@ -141,6 +142,8 @@ type startCommand struct {
 	XfnCacheDir             string        `default:"/cache/xfn"                         env:"XFN_CACHE_DIR"             group:"Alpha Features:" help:"Directory used for caching function responses. Requires --enable-function-response-cache."`
 	XfnCacheMaxTTL          time.Duration `default:"24h"                                env:"XFN_CACHE_MAX_TTL"         group:"Alpha Features:" help:"Maximum TTL for cached function responses. Set to 0 to disable. Requires --enable-function-response-cache."`
 	PipelineInspectorSocket string        `default:"/var/run/pipeline-inspector/socket" env:"PIPELINE_INSPECTOR_SOCKET" group:"Alpha Features:" help:"Unix socket path for pipeline inspector sidecar. Requires --enable-pipeline-inspector."`
+
+	ExtraResourcesImpersonationDefaultSA string `default:"" env:"EXTRA_RESOURCES_IMPERSONATION_DEFAULT_SA" group:"Alpha Features:" help:"Default ServiceAccount name to impersonate when fetching ExtraResources for a namespaced XR that has no crossplane.io/extra-resources-as annotation. If empty, ExtraResources for unannotated XRs are fetched as Crossplane (no impersonation). Requires --enable-extra-resources-impersonation."`
 
 	EnableDeploymentRuntimeConfigs          bool `default:"true" group:"Beta Features:" help:"Enable support for Deployment Runtime Configs."`
 	EnableUsages                            bool `default:"true" group:"Beta Features:" help:"Enable support for deletion ordering and resource protection with Usages."`
@@ -297,6 +300,11 @@ func (c *startCommand) Run(s *runtime.Scheme, log logging.Logger) error { //noli
 	go pfr.GarbageCollectConnections(ctx, 10*time.Minute)
 
 	var runner xfn.FunctionRunner = pfr
+
+	if c.EnableExtraResourcesImpersonation {
+		o.Features.Enable(features.EnableAlphaExtraResourcesImpersonation)
+		log.Info("Alpha feature enabled", "flag", features.EnableAlphaExtraResourcesImpersonation)
+	}
 
 	if c.EnablePipelineInspector {
 		o.Features.Enable(features.EnableAlphaPipelineInspector)
@@ -473,11 +481,33 @@ func (c *startCommand) Run(s *runtime.Scheme, log logging.Logger) error { //noli
 		return errors.Wrap(err, "cannot setup discovery cache invalidation")
 	}
 
+	// With per-tenant impersonation on, wrap the fetcher so namespaced XRs read
+	// ExtraResources under an impersonated identity.
+	var resourcesFetcher xfn.RequiredResourcesFetcher = xfn.NewExistingRequiredResourcesFetcher(cached)
+	if o.Features.Enabled(features.EnableAlphaExtraResourcesImpersonation) {
+		baseFetcher := xfn.NewExistingRequiredResourcesFetcher(cached)
+		resolver := xfn.AnnotationImpersonationResolver{
+			DefaultSA: c.ExtraResourcesImpersonationDefaultSA,
+		}
+		// No HTTPClient: client.New must build it from the impersonating
+		// rest.Config, else cfg.Impersonate is ignored. Scheme/Mapper avoid discovery.
+		clientOpts := client.Options{
+			Scheme: mgr.GetScheme(),
+			Mapper: mgr.GetRESTMapper(),
+		}
+		resourcesFetcher = xfn.NewImpersonatingRequiredResourcesFetcher(
+			baseFetcher,
+			resolver,
+			cfg,
+			xfn.NewUncachedClientFactory(clientOpts),
+		)
+	}
+
 	// Middleware layering: We want Cache → FetchingFunctionRunner → gRPC.
 	// First, wrap the runner with FetchingFunctionRunner to handle
 	// requirements.
 	runner = xfn.NewFetchingFunctionRunner(runner,
-		xfn.NewExistingRequiredResourcesFetcher(cached),
+		resourcesFetcher,
 		xfn.NewOpenAPIRequiredSchemasFetcher(oac))
 
 	// Then, if caching is enabled, wrap with the cache layer.
@@ -534,6 +564,7 @@ func (c *startCommand) Run(s *runtime.Scheme, log logging.Logger) error { //noli
 		CircuitBreakerRefillRate: c.CircuitBreakerRefillRate,
 		CircuitBreakerCooldown:   c.CircuitBreakerCooldown,
 		MinPollInterval:          c.MinPollInterval,
+		ResourcesFetcher:         resourcesFetcher,
 	}
 
 	if err := apiextensions.Setup(mgr, ao); err != nil {

--- a/internal/controller/apiextensions/composite/composition_functions.go
+++ b/internal/controller/apiextensions/composite/composition_functions.go
@@ -267,6 +267,9 @@ func NewFunctionComposer(cached, uncached client.Client, r FunctionRunner, o ...
 // Compose resources using the Functions pipeline.
 func (c *FunctionComposer) Compose(ctx context.Context, xr *composite.Unstructured, req CompositionRequest) (CompositionResult, error) { //nolint:gocognit // We probably don't want any further abstraction for the sake of reduced complexity.
 	ctx = step.ForCompositions(ctx)
+	// Make the XR available to the ExtraResources fetch path so that an
+	// ImpersonatingRequiredResourcesFetcher can derive the per-tenant identity.
+	ctx = xfn.WithXRInContext(ctx, xr)
 	// Observe our existing composed resources. We need to do this before we
 	// render any P&T templates, so that we can make sure we use the same
 	// composed resource names (as in, metadata.name) every time. We know what

--- a/internal/controller/apiextensions/controller/options.go
+++ b/internal/controller/apiextensions/controller/options.go
@@ -56,4 +56,10 @@ type Options struct {
 	// MinPollInterval is the shortest per-resource poll interval allowed
 	// via the crossplane.io/poll-interval annotation.
 	MinPollInterval time.Duration
+
+	// ResourcesFetcher is used to fetch required resources for composition
+	// functions. When nil the default cached-client fetcher is used. Set to
+	// an ImpersonatingRequiredResourcesFetcher when
+	// EnableAlphaExtraResourcesImpersonation is on.
+	ResourcesFetcher xfn.RequiredResourcesFetcher
 }

--- a/internal/controller/apiextensions/definition/reconciler.go
+++ b/internal/controller/apiextensions/definition/reconciler.go
@@ -514,11 +514,20 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 	}
 
 	fetcher := composite.NewSecretConnectionDetailsFetcher(r.engine.GetCached())
-	fc := composite.NewFunctionComposer(r.engine.GetCached(), r.engine.GetUncached(), r.options.FunctionRunner,
+
+	fcOpts := []composite.FunctionComposerOption{
 		composite.WithComposedResourceObserver(composite.NewExistingComposedResourceObserver(r.engine.GetCached(), r.engine.GetUncached(), fetcher)),
 		composite.WithCompositeConnectionDetailsFetcher(fetcher),
 		composite.WithRequiredSchemasFetcher(xfn.NewOpenAPIRequiredSchemasFetcher(r.options.OpenAPIClient)),
-	)
+	}
+
+	// Use the configured resources fetcher (e.g. the impersonating one) for
+	// bootstrap requirement fetches when set.
+	if r.options.ResourcesFetcher != nil {
+		fcOpts = append(fcOpts, composite.WithRequiredResourcesFetcher(r.options.ResourcesFetcher))
+	}
+
+	fc := composite.NewFunctionComposer(r.engine.GetCached(), r.engine.GetUncached(), r.options.FunctionRunner, fcOpts...)
 
 	controllerName := composite.ControllerName(d.GetName())
 	gvk := d.GetCompositeGroupVersionKind()

--- a/internal/features/features.go
+++ b/internal/features/features.go
@@ -21,6 +21,12 @@ import "github.com/crossplane/crossplane-runtime/v2/pkg/feature"
 
 // Alpha Feature flags.
 const (
+	// EnableAlphaExtraResourcesImpersonation fetches a namespaced XR's
+	// composition ExtraResources under a ServiceAccount in the XR's namespace,
+	// so RBAC governs per-tenant read access.
+	// See https://github.com/crossplane/crossplane/issues/7461.
+	EnableAlphaExtraResourcesImpersonation feature.Flag = "EnableAlphaExtraResourcesImpersonation"
+
 	// EnableAlphaDependencyVersionUpgrades enables alpha support for
 	// upgrading the version of a package's dependencies when needed.
 	EnableAlphaDependencyVersionUpgrades feature.Flag = "EnableAlphaDependencyVersionUpgrades"

--- a/internal/xfn/required_resources.go
+++ b/internal/xfn/required_resources.go
@@ -17,6 +17,7 @@ package xfn
 
 import (
 	"context"
+	"fmt"
 	"maps"
 	"sort"
 
@@ -24,13 +25,19 @@ import (
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	kunstructured "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/crossplane/crossplane-runtime/v2/pkg/errors"
+	"github.com/crossplane/crossplane-runtime/v2/pkg/resource/unstructured/composite"
 
 	"github.com/crossplane/crossplane/v2/internal/controller/apiextensions/composite/step"
 	fnv1 "github.com/crossplane/crossplane/v2/proto/fn/v1"
 )
+
+// AnnotationKeyExtraResourcesAs names the ServiceAccount (in the XR's
+// namespace) to impersonate when fetching the XR's ExtraResources.
+const AnnotationKeyExtraResourcesAs = "crossplane.io/extra-resources-as"
 
 // MaxRequirementsIterations is the maximum number of times a Function should be
 // called, limiting the number of times it can request for required resources,
@@ -225,4 +232,121 @@ func (e *ExistingRequiredResourcesFetcher) Fetch(ctx context.Context, rs *fnv1.R
 	}
 
 	return &fnv1.Resources{Items: resources}, nil
+}
+
+// ImpersonationConfig is the impersonation identity for an ExtraResources fetch.
+type ImpersonationConfig = rest.ImpersonationConfig
+
+// An ImpersonationResolver decides, per XR, whether ExtraResources should be
+// fetched under an impersonated identity. (nil, false) means no impersonation.
+type ImpersonationResolver interface {
+	Resolve(xr *composite.Unstructured) (*ImpersonationConfig, bool)
+}
+
+// An ImpersonationResolverFn is a func that implements ImpersonationResolver.
+type ImpersonationResolverFn func(xr *composite.Unstructured) (*ImpersonationConfig, bool)
+
+// Resolve calls fn.
+func (fn ImpersonationResolverFn) Resolve(xr *composite.Unstructured) (*ImpersonationConfig, bool) {
+	return fn(xr)
+}
+
+// AnnotationImpersonationResolver impersonates the ServiceAccount named by the
+// crossplane.io/extra-resources-as annotation (or DefaultSA) in a namespaced
+// XR's namespace. Cluster-scoped XRs are never impersonated.
+type AnnotationImpersonationResolver struct {
+	DefaultSA string
+}
+
+// Resolve implements ImpersonationResolver.
+func (r AnnotationImpersonationResolver) Resolve(xr *composite.Unstructured) (*ImpersonationConfig, bool) {
+	ns := xr.GetNamespace()
+	if ns == "" {
+		return nil, false
+	}
+	sa := xr.GetAnnotations()[AnnotationKeyExtraResourcesAs]
+	if sa == "" {
+		sa = r.DefaultSA
+	}
+	if sa == "" {
+		return nil, false
+	}
+	return &ImpersonationConfig{
+		UserName: fmt.Sprintf("system:serviceaccount:%s:%s", ns, sa),
+	}, true
+}
+
+// clientFactory builds an uncached client.Reader from a *rest.Config.
+type clientFactory func(cfg *rest.Config) (client.Reader, error)
+
+// ImpersonatingRequiredResourcesFetcher fetches ExtraResources under a per-XR
+// impersonated identity when the resolver returns one, and otherwise delegates
+// to base unchanged.
+type ImpersonatingRequiredResourcesFetcher struct {
+	base     *ExistingRequiredResourcesFetcher
+	resolver ImpersonationResolver
+	restCfg  *rest.Config
+	factory  clientFactory
+}
+
+// NewImpersonatingRequiredResourcesFetcher returns an ImpersonatingRequiredResourcesFetcher.
+func NewImpersonatingRequiredResourcesFetcher(
+	base *ExistingRequiredResourcesFetcher,
+	resolver ImpersonationResolver,
+	restCfg *rest.Config,
+	factory clientFactory,
+) *ImpersonatingRequiredResourcesFetcher {
+	return &ImpersonatingRequiredResourcesFetcher{
+		base:     base,
+		resolver: resolver,
+		restCfg:  restCfg,
+		factory:  factory,
+	}
+}
+
+// Fetch impersonates the XR's resolved identity when applicable, otherwise
+// delegates to the base fetcher.
+func (f *ImpersonatingRequiredResourcesFetcher) Fetch(ctx context.Context, rs *fnv1.ResourceSelector) (*fnv1.Resources, error) {
+	xr, ok := xrFromContext(ctx)
+	if !ok {
+		return f.base.Fetch(ctx, rs)
+	}
+	cfg, impersonate := f.resolver.Resolve(xr)
+	if !impersonate {
+		return f.base.Fetch(ctx, rs)
+	}
+	impCfg := rest.CopyConfig(f.restCfg)
+	impCfg.Impersonate = *cfg
+	c, err := f.factory(impCfg)
+	if err != nil {
+		return nil, errors.Wrap(err, "cannot build impersonating client for ExtraResources fetch")
+	}
+	return (&ExistingRequiredResourcesFetcher{client: c}).Fetch(ctx, rs)
+}
+
+type xrContextKey struct{}
+
+// WithXRInContext returns ctx carrying xr for ImpersonatingRequiredResourcesFetcher.
+func WithXRInContext(ctx context.Context, xr *composite.Unstructured) context.Context {
+	return context.WithValue(ctx, xrContextKey{}, xr)
+}
+
+func xrFromContext(ctx context.Context) (*composite.Unstructured, bool) {
+	xr, ok := ctx.Value(xrContextKey{}).(*composite.Unstructured)
+	return xr, ok && xr != nil
+}
+
+// NewUncachedClientFactory returns a clientFactory that builds an uncached
+// client from the (impersonating) rest.Config. It clears opts.HTTPClient so
+// client.New builds the client from cfg; a pre-built HTTPClient would ignore
+// cfg.Impersonate.
+func NewUncachedClientFactory(opts client.Options) clientFactory {
+	return func(cfg *rest.Config) (client.Reader, error) {
+		opts.HTTPClient = nil
+		c, err := client.New(cfg, opts)
+		if err != nil {
+			return nil, err
+		}
+		return c, nil
+	}
 }

--- a/internal/xfn/required_resources.go
+++ b/internal/xfn/required_resources.go
@@ -319,7 +319,7 @@ func (f *ImpersonatingRequiredResourcesFetcher) Fetch(ctx context.Context, rs *f
 	impCfg.Impersonate = *cfg
 	c, err := f.factory(impCfg)
 	if err != nil {
-		return nil, errors.Wrap(err, "cannot build impersonating client for ExtraResources fetch")
+		return nil, errors.Wrapf(err, "cannot build impersonating client for ExtraResources fetch (xr %q, impersonating %q)", xr.GetName(), cfg.UserName)
 	}
 	return (&ExistingRequiredResourcesFetcher{client: c}).Fetch(ctx, rs)
 }

--- a/internal/xfn/required_resources_test.go
+++ b/internal/xfn/required_resources_test.go
@@ -27,10 +27,12 @@ import (
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	kunstructured "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/rest"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/crossplane/crossplane-runtime/v2/pkg/errors"
+	"github.com/crossplane/crossplane-runtime/v2/pkg/resource/unstructured/composite"
 	"github.com/crossplane/crossplane-runtime/v2/pkg/test"
 
 	fnv1 "github.com/crossplane/crossplane/v2/proto/fn/v1"
@@ -888,4 +890,254 @@ func TestFetchingFunctionRunner(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestAnnotationImpersonationResolver(t *testing.T) {
+	type args struct {
+		xr        *composite.Unstructured
+		defaultSA string
+	}
+
+	type want struct {
+		cfg         *ImpersonationConfig
+		impersonate bool
+	}
+
+	cases := map[string]struct {
+		reason string
+		args   args
+		want   want
+	}{
+		"ClusterScopedNeverImpersonates": {
+			reason: "Cluster-scoped XRs (empty namespace) must never produce an impersonation config",
+			args: args{
+				xr:        newUnstructuredXR("", "my-xr", nil),
+				defaultSA: "crossplane-extra-resources",
+			},
+			want: want{cfg: nil, impersonate: false},
+		},
+		"NamespacedWithAnnotation": {
+			reason: "A namespaced XR with the crossplane.io/extra-resources-as annotation should impersonate the annotated SA",
+			args: args{
+				xr: newUnstructuredXR("tenant-ns", "my-xr", map[string]string{
+					AnnotationKeyExtraResourcesAs: "tenant-reader",
+				}),
+				defaultSA: "",
+			},
+			want: want{
+				cfg:         &ImpersonationConfig{UserName: "system:serviceaccount:tenant-ns:tenant-reader"},
+				impersonate: true,
+			},
+		},
+		"NamespacedWithDefaultSA": {
+			reason: "A namespaced XR without the annotation but with a non-empty defaultSA should impersonate the default SA",
+			args: args{
+				xr:        newUnstructuredXR("tenant-ns", "my-xr", nil),
+				defaultSA: "crossplane-extra-resources",
+			},
+			want: want{
+				cfg:         &ImpersonationConfig{UserName: "system:serviceaccount:tenant-ns:crossplane-extra-resources"},
+				impersonate: true,
+			},
+		},
+		"AnnotationOverridesDefault": {
+			reason: "The annotation takes precedence over the default SA when both are present",
+			args: args{
+				xr: newUnstructuredXR("tenant-ns", "my-xr", map[string]string{
+					AnnotationKeyExtraResourcesAs: "annotation-sa",
+				}),
+				defaultSA: "default-sa",
+			},
+			want: want{
+				cfg:         &ImpersonationConfig{UserName: "system:serviceaccount:tenant-ns:annotation-sa"},
+				impersonate: true,
+			},
+		},
+		"NamespacedNoAnnotationNoDefault": {
+			reason: "A namespaced XR without an annotation and no default SA falls back to the normal client (no impersonation)",
+			args: args{
+				xr:        newUnstructuredXR("tenant-ns", "my-xr", nil),
+				defaultSA: "",
+			},
+			want: want{cfg: nil, impersonate: false},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			r := AnnotationImpersonationResolver{DefaultSA: tc.args.defaultSA}
+			cfg, impersonate := r.Resolve(tc.args.xr)
+
+			if diff := cmp.Diff(tc.want.impersonate, impersonate); diff != "" {
+				t.Errorf("\n%s\nResolve(): impersonate -want, +got:\n%s", tc.reason, diff)
+			}
+
+			if diff := cmp.Diff(tc.want.cfg, cfg); diff != "" {
+				t.Errorf("\n%s\nResolve(): cfg -want, +got:\n%s", tc.reason, diff)
+			}
+		})
+	}
+}
+
+func TestImpersonatingRequiredResourcesFetcherFetch(t *testing.T) {
+	errBoom := errors.New("boom")
+
+	coolObj := &kunstructured.Unstructured{}
+	coolObj.SetName("cool-resource")
+	coolObj.SetAPIVersion("test.crossplane.io/v1")
+	coolObj.SetKind("Foo")
+
+	selector := &fnv1.ResourceSelector{
+		ApiVersion: "test.crossplane.io/v1",
+		Kind:       "Foo",
+		Match: &fnv1.ResourceSelector_MatchName{
+			MatchName: "cool-resource",
+		},
+	}
+
+	type params struct {
+		xr       *composite.Unstructured
+		resolver ImpersonationResolver
+		factory  clientFactory
+		baseMock client.Reader
+	}
+
+	type want struct {
+		res *fnv1.Resources
+		err error
+	}
+
+	cases := map[string]struct {
+		reason string
+		params params
+		want   want
+	}{
+		"NoXRInContextFallsBackToBase": {
+			reason: "Without an XR in context the base fetcher is used",
+			params: params{
+				xr: nil, // will not be injected into context
+				resolver: ImpersonationResolverFn(func(_ *composite.Unstructured) (*ImpersonationConfig, bool) {
+					return nil, false
+				}),
+				baseMock: &test.MockClient{
+					MockGet: test.NewMockGetFn(nil, func(obj client.Object) error {
+						obj.SetName("cool-resource")
+						return nil
+					}),
+				},
+			},
+			want: want{
+				res: &fnv1.Resources{
+					Items: []*fnv1.Resource{
+						{Resource: MustStruct(map[string]any{
+							"apiVersion": "test.crossplane.io/v1",
+							"kind":       "Foo",
+							"metadata":   map[string]any{"name": "cool-resource"},
+						})},
+					},
+				},
+			},
+		},
+		"ResolverReturnsFalseFallsBackToBase": {
+			reason: "When the resolver returns (nil, false) the base fetcher is used",
+			params: params{
+				xr:       newUnstructuredXR("", "cluster-xr", nil), // cluster-scoped
+				resolver: AnnotationImpersonationResolver{},
+				baseMock: &test.MockClient{
+					MockGet: test.NewMockGetFn(nil, func(obj client.Object) error {
+						obj.SetName("cool-resource")
+						return nil
+					}),
+				},
+			},
+			want: want{
+				res: &fnv1.Resources{
+					Items: []*fnv1.Resource{
+						{Resource: MustStruct(map[string]any{
+							"apiVersion": "test.crossplane.io/v1",
+							"kind":       "Foo",
+							"metadata":   map[string]any{"name": "cool-resource"},
+						})},
+					},
+				},
+			},
+		},
+		"ImpersonationApplied": {
+			reason: "When the resolver says to impersonate, a new client is built and the fetch uses it",
+			params: params{
+				xr: newUnstructuredXR("tenant-ns", "my-xr", map[string]string{
+					AnnotationKeyExtraResourcesAs: "tenant-reader",
+				}),
+				resolver: AnnotationImpersonationResolver{},
+				factory: func(cfg *rest.Config) (client.Reader, error) {
+					if cfg.Impersonate.UserName != "system:serviceaccount:tenant-ns:tenant-reader" {
+						return nil, errors.Errorf("unexpected impersonation user %q", cfg.Impersonate.UserName)
+					}
+					return &test.MockClient{
+						MockGet: test.NewMockGetFn(nil, func(obj client.Object) error {
+							obj.SetName("cool-resource")
+							return nil
+						}),
+					}, nil
+				},
+			},
+			want: want{
+				res: &fnv1.Resources{
+					Items: []*fnv1.Resource{
+						{Resource: MustStruct(map[string]any{
+							"apiVersion": "test.crossplane.io/v1",
+							"kind":       "Foo",
+							"metadata":   map[string]any{"name": "cool-resource"},
+						})},
+					},
+				},
+			},
+		},
+		"ClientFactoryError": {
+			reason: "An error from the client factory is propagated",
+			params: params{
+				xr: newUnstructuredXR("tenant-ns", "my-xr", map[string]string{
+					AnnotationKeyExtraResourcesAs: "tenant-reader",
+				}),
+				resolver: AnnotationImpersonationResolver{},
+				factory: func(_ *rest.Config) (client.Reader, error) {
+					return nil, errBoom
+				},
+			},
+			want: want{err: cmpopts.AnyError},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			base := NewExistingRequiredResourcesFetcher(tc.params.baseMock)
+			f := NewImpersonatingRequiredResourcesFetcher(base, tc.params.resolver, &rest.Config{}, tc.params.factory)
+
+			ctx := context.Background()
+			if tc.params.xr != nil {
+				ctx = WithXRInContext(ctx, tc.params.xr)
+			}
+
+			res, err := f.Fetch(ctx, selector)
+			if diff := cmp.Diff(tc.want.err, err, cmpopts.EquateErrors()); diff != "" {
+				t.Errorf("\n%s\nFetch(...): -want, +got:\n%s", tc.reason, diff)
+			}
+
+			if diff := cmp.Diff(tc.want.res, res, protocmp.Transform()); diff != "" {
+				t.Errorf("\n%s\nFetch(...): -want, +got:\n%s", tc.reason, diff)
+			}
+		})
+	}
+}
+
+// newUnstructuredXR returns a composite.Unstructured with the given namespace,
+// name, and annotations.
+func newUnstructuredXR(namespace, name string, annotations map[string]string) *composite.Unstructured {
+	xr := composite.New()
+	xr.SetNamespace(namespace)
+	xr.SetName(name)
+	if len(annotations) > 0 {
+		xr.SetAnnotations(annotations)
+	}
+	return xr
 }


### PR DESCRIPTION
## Description of your changes

Adds an **opt-in, default-off** alpha feature so that, when fetching a composition's
`ExtraResources` for a **namespaced** Composite Resource, those reads run under a
ServiceAccount in the XR's own namespace instead of the broad Crossplane SA. This lets
RBAC govern per-tenant read access to ExtraResources in multi-tenant control planes.

Today, ExtraResources reads execute as the Crossplane SA with a function-supplied
selector namespace (empty selector = all namespaces). With v2 namespaced XRs, composed
resource **writes** are confined to the XR's namespace, but **reads** are not — and
admission cannot gate GET/LIST. In a shared control plane that is a cross-tenant
read-exfiltration path.

Behind the new alpha feature flag `EnableAlphaExtraResourcesImpersonation` (default off),
and gated per-XR by the `crossplane.io/extra-resources-as` annotation, the apiextensions
composite controller builds an impersonating client
(`system:serviceaccount:<xr-namespace>:<sa>`) for the ExtraResources fetch. Cluster-scoped
XRs are unaffected (no impersonation is applied). When the flag is off, the existing
fetcher is used unchanged.

Fixes #7461.

## I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Added unit tests covering the new behavior (`internal/xfn/required_resources_test.go`).
- [x] Added a changelog entry (`.chloggen/extra-resources-impersonation.yaml`).

## How has this code been tested

- New unit tests cover the annotation resolver (namespaced XR → impersonate the named SA
  in the XR's namespace; cluster-scoped XR → no impersonation) and the impersonating
  fetcher (delegates to the base fetcher when no impersonation applies, builds an
  impersonating client otherwise).
- Build and `go test ./internal/xfn/...` pass.
- The default-off path is unchanged: the resources fetcher remains the existing uncached
  fetcher unless the feature flag is explicitly enabled.

[contribution process]: https://github.com/crossplane/crossplane/blob/main/contributing/README.md
