### PR TITLE
test(e2e): add realtime performance test for namespaced XR composition

### DIFF
--- a/test/e2e/apiextensions_compositions_test.go
+++ b/test/e2e/apiextensions_compositions_test.go
@@ -589,3 +589,100 @@ func TestComposedResourceObservation(t *testing.T) {
 			Feature(),
 	)
 }
+
+func TestRealtimeNamespacedXR(t *testing.T) {
+	manifests := "test/e2e/manifests/apiextensions/composition/realtime-namespaced-xr"
+	environment.Test(t,
+		features.NewWithDescription(t.Name(), "Tests realtime composition performance for namespaced XRs — composed resource changes must be detected within seconds, not minutes (regression guard for #6780).").
+			WithLabel(LabelArea, LabelAreaAPIExtensions).
+			WithLabel(LabelSize, LabelSizeSmall).
+			WithLabel(config.LabelTestSuite, config.TestSuiteDefault).
+			WithSetup("CreatePrerequisites", funcs.AllOf(
+				funcs.ApplyResources(FieldManager, manifests, "setup/*.yaml"),
+				funcs.ResourcesCreatedWithin(30*time.Second, manifests, "setup/*.yaml"),
+				funcs.ResourcesHaveConditionWithin(1*time.Minute, manifests, "setup/definition.yaml", apiextensionsv1.WatchingComposite()),
+				funcs.ResourcesHaveConditionWithin(2*time.Minute, manifests, "setup/functions.yaml", pkgv1.Healthy(), pkgv1.Active()),
+			)).
+			WithSetup("CreateConfigMap", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+				t.Helper()
+
+				cm := &unstructured.Unstructured{}
+				cm.SetAPIVersion("v1")
+				cm.SetKind("ConfigMap")
+				cm.SetNamespace("default")
+				cm.SetName("realtime-test-configmap")
+				cm.SetLabels(map[string]string{"app": "crossplane-e2e"})
+				fieldpath.Pave(cm.Object).SetString("data.message", "initial")
+
+				//nolint:staticcheck // TODO(adamwg) Stop using client.Apply after the v2.2 release.
+				if err := cfg.Client().Resources().GetControllerRuntimeClient().Patch(ctx, cm, client.Apply, client.FieldOwner(FieldManager), client.ForceOwnership); err != nil {
+					t.Fatalf("failed to create ConfigMap: %v", err)
+					return ctx
+				}
+
+				t.Log("Created ConfigMap with initial data")
+				return ctx
+			}).
+			Assess("CreateXR", funcs.AllOf(
+				funcs.ApplyResources(FieldManager, manifests, "xr.yaml"),
+				funcs.ResourcesCreatedWithin(30*time.Second, manifests, "xr.yaml"),
+			)).
+			Assess("XRIsReady",
+				funcs.ResourcesHaveConditionWithin(1*time.Minute, manifests, "xr.yaml", xpv2.Available(), xpv2.ReconcileSuccess()),
+			).
+			Assess("ResourceWasReceived",
+				funcs.ResourcesHaveFieldValueWithin(1*time.Minute, manifests, "xr.yaml", "status.resourceReceived", true),
+			).
+			Assess("InitialObservationReflected",
+				funcs.ResourcesHaveFieldValueWithin(10*time.Second, manifests, "xr.yaml", "status.observedData.message", "initial"),
+			).
+			Assess("ModifyConfigMapDirectly", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+				t.Helper()
+
+				t.Log("Modifying ConfigMap directly to trigger realtime detection...")
+
+				cm := &unstructured.Unstructured{}
+				cm.SetAPIVersion("v1")
+				cm.SetKind("ConfigMap")
+				cm.SetNamespace("default")
+				cm.SetName("realtime-test-configmap")
+				fieldpath.Pave(cm.Object).SetString("data.message", "realtime-update")
+
+				//nolint:staticcheck // TODO(adamwg) Stop using client.Apply after the v2.2 release.
+				if err := cfg.Client().Resources().GetControllerRuntimeClient().Patch(ctx, cm, client.Apply, client.FieldOwner(FieldManager), client.ForceOwnership); err != nil {
+					t.Fatalf("failed to modify ConfigMap: %v", err)
+					return ctx
+				}
+
+				t.Log("ConfigMap modified — expecting realtime XR update")
+				return ctx
+			}).
+			Assess("XRStatusReflectsChangeInRealtime",
+				funcs.ResourcesHaveFieldValueWithin(3*time.Second, manifests, "xr.yaml", "status.observedData.message", "realtime-update"),
+			).
+			WithTeardown("DeleteXR", funcs.AllOf(
+				funcs.DeleteResourcesWithPropagationPolicy(manifests, "xr.yaml", metav1.DeletePropagationForeground),
+				funcs.ResourcesDeletedWithin(1*time.Minute, manifests, "xr.yaml"),
+			)).
+			WithTeardown("DeleteConfigMap", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+				t.Helper()
+
+				cm := &unstructured.Unstructured{}
+				cm.SetAPIVersion("v1")
+				cm.SetKind("ConfigMap")
+				cm.SetNamespace("default")
+				cm.SetName("realtime-test-configmap")
+
+				if err := cfg.Client().Resources().Delete(ctx, cm); err != nil {
+					t.Logf("failed to delete ConfigMap: %v", err)
+				}
+
+				return ctx
+			}).
+			WithTeardown("DeletePrerequisites", funcs.AllOf(
+				funcs.DeleteResourcesWithPropagationPolicy(manifests, "setup/*.yaml", metav1.DeletePropagationForeground),
+				funcs.ResourcesDeletedWithin(3*time.Minute, manifests, "setup/*.yaml"),
+			)).
+			Feature(),
+	)
+}

--- a/test/e2e/apiextensions_compositions_test.go
+++ b/test/e2e/apiextensions_compositions_test.go
@@ -519,7 +519,7 @@ func TestComposedResourceObservation(t *testing.T) {
 
 				//nolint:staticcheck // TODO(adamwg) Stop using client.Apply after the v2.2 release.
 				if err := cfg.Client().Resources().GetControllerRuntimeClient().Patch(ctx, cm, client.Apply, client.FieldOwner(FieldManager), client.ForceOwnership); err != nil {
-					t.Errorf("failed to create ConfigMap: %v", err)
+					t.Fatalf("failed to create ConfigMap: %v", err)
 					return ctx
 				}
 
@@ -553,7 +553,7 @@ func TestComposedResourceObservation(t *testing.T) {
 
 				//nolint:staticcheck // TODO(adamwg) Stop using client.Apply after the v2.2 release.
 				if err := cfg.Client().Resources().GetControllerRuntimeClient().Patch(ctx, cm, client.Apply, client.FieldOwner(FieldManager), client.ForceOwnership); err != nil {
-					t.Errorf("failed to modify ConfigMap: %v", err)
+					t.Fatalf("failed to modify ConfigMap: %v", err)
 					return ctx
 				}
 

--- a/test/e2e/apiextensions_compositions_test.go
+++ b/test/e2e/apiextensions_compositions_test.go
@@ -492,3 +492,100 @@ func TestRequiredResources(t *testing.T) {
 			Feature(),
 	)
 }
+
+func TestComposedResourceObservation(t *testing.T) {
+	manifests := "test/e2e/manifests/apiextensions/composition/composed-resource-observation"
+	environment.Test(t,
+		features.NewWithDescription(t.Name(), "Tests that composed resource changes are detected and reflected in XR status within a tight timeout.").
+			WithLabel(LabelArea, LabelAreaAPIExtensions).
+			WithLabel(LabelSize, LabelSizeSmall).
+			WithLabel(config.LabelTestSuite, config.TestSuiteDefault).
+			WithSetup("CreatePrerequisites", funcs.AllOf(
+				funcs.ApplyResources(FieldManager, manifests, "setup/*.yaml"),
+				funcs.ResourcesCreatedWithin(30*time.Second, manifests, "setup/*.yaml"),
+				funcs.ResourcesHaveConditionWithin(1*time.Minute, manifests, "setup/definition.yaml", apiextensionsv1.WatchingComposite()),
+				funcs.ResourcesHaveConditionWithin(2*time.Minute, manifests, "setup/functions.yaml", pkgv1.Healthy(), pkgv1.Active()),
+			)).
+			WithSetup("CreateConfigMap", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+				t.Helper()
+
+				cm := &unstructured.Unstructured{}
+				cm.SetAPIVersion("v1")
+				cm.SetKind("ConfigMap")
+				cm.SetNamespace("default")
+				cm.SetName("observe-test-configmap")
+				cm.SetLabels(map[string]string{"app": "crossplane-e2e"})
+				fieldpath.Pave(cm.Object).SetString("data.message", "initial")
+
+				//nolint:staticcheck // TODO(adamwg) Stop using client.Apply after the v2.2 release.
+				if err := cfg.Client().Resources().GetControllerRuntimeClient().Patch(ctx, cm, client.Apply, client.FieldOwner(FieldManager), client.ForceOwnership); err != nil {
+					t.Errorf("failed to create ConfigMap: %v", err)
+					return ctx
+				}
+
+				t.Log("Created ConfigMap with initial data")
+				return ctx
+			}).
+			Assess("CreateXR", funcs.AllOf(
+				funcs.ApplyResources(FieldManager, manifests, "xr.yaml"),
+				funcs.ResourcesCreatedWithin(30*time.Second, manifests, "xr.yaml"),
+			)).
+			Assess("XRIsReady",
+				funcs.ResourcesHaveConditionWithin(1*time.Minute, manifests, "xr.yaml", xpv2.Available(), xpv2.ReconcileSuccess()),
+			).
+			Assess("ResourceWasReceived",
+				funcs.ResourcesHaveFieldValueWithin(1*time.Minute, manifests, "xr.yaml", "status.resourceReceived", true),
+			).
+			Assess("InitialObservationReflected",
+				funcs.ResourcesHaveFieldValueWithin(1*time.Minute, manifests, "xr.yaml", "status.observedData.message", "initial"),
+			).
+			Assess("ModifyConfigMapDirectly", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+				t.Helper()
+
+				t.Log("Modifying ConfigMap directly to trigger observation...")
+
+				cm := &unstructured.Unstructured{}
+				cm.SetAPIVersion("v1")
+				cm.SetKind("ConfigMap")
+				cm.SetNamespace("default")
+				cm.SetName("observe-test-configmap")
+				fieldpath.Pave(cm.Object).SetString("data.message", "modified-by-test")
+
+				//nolint:staticcheck // TODO(adamwg) Stop using client.Apply after the v2.2 release.
+				if err := cfg.Client().Resources().GetControllerRuntimeClient().Patch(ctx, cm, client.Apply, client.FieldOwner(FieldManager), client.ForceOwnership); err != nil {
+					t.Errorf("failed to modify ConfigMap: %v", err)
+					return ctx
+				}
+
+				t.Log("ConfigMap modified with new message")
+				return ctx
+			}).
+			Assess("XRStatusReflectsChange",
+				funcs.ResourcesHaveFieldValueWithin(30*time.Second, manifests, "xr.yaml", "status.observedData.message", "modified-by-test"),
+			).
+			WithTeardown("DeleteXR", funcs.AllOf(
+				funcs.DeleteResourcesWithPropagationPolicy(manifests, "xr.yaml", metav1.DeletePropagationForeground),
+				funcs.ResourcesDeletedWithin(1*time.Minute, manifests, "xr.yaml"),
+			)).
+			WithTeardown("DeleteConfigMap", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+				t.Helper()
+
+				cm := &unstructured.Unstructured{}
+				cm.SetAPIVersion("v1")
+				cm.SetKind("ConfigMap")
+				cm.SetNamespace("default")
+				cm.SetName("observe-test-configmap")
+
+				if err := cfg.Client().Resources().Delete(ctx, cm); err != nil {
+					t.Logf("failed to delete ConfigMap: %v", err)
+				}
+
+				return ctx
+			}).
+			WithTeardown("DeletePrerequisites", funcs.AllOf(
+				funcs.DeleteResourcesWithPropagationPolicy(manifests, "setup/*.yaml", metav1.DeletePropagationForeground),
+				funcs.ResourcesDeletedWithin(3*time.Minute, manifests, "setup/*.yaml"),
+			)).
+			Feature(),
+	)
+}

--- a/test/e2e/manifests/apiextensions/composition/composed-resource-observation/setup/composition.yaml
+++ b/test/e2e/manifests/apiextensions/composition/composed-resource-observation/setup/composition.yaml
@@ -14,7 +14,7 @@ spec:
     input:
       apiVersion: python.fn.crossplane.io/v1beta1
       kind: Script
-      script: |\
+      script: |
         from crossplane.function import response, request
         from crossplane.function.proto.v1 import run_function_pb2 as fnv1
 

--- a/test/e2e/manifests/apiextensions/composition/composed-resource-observation/setup/composition.yaml
+++ b/test/e2e/manifests/apiextensions/composition/composed-resource-observation/setup/composition.yaml
@@ -1,0 +1,60 @@
+apiVersion: apiextensions.crossplane.io/v1
+kind: Composition
+metadata:
+  name: observe-composition-namespaced
+spec:
+  compositeTypeRef:
+    apiVersion: example.org/v1alpha1
+    kind: Test
+  mode: Pipeline
+  pipeline:
+  - step: observe-configmap
+    functionRef:
+      name: function-python-resources
+    input:
+      apiVersion: python.fn.crossplane.io/v1beta1
+      kind: Script
+      script: |\
+        from crossplane.function import response, request
+        from crossplane.function.proto.v1 import run_function_pb2 as fnv1
+
+        def compose(req: fnv1.RunFunctionRequest, rsp: fnv1.RunFunctionResponse):
+            # Request observation of the ConfigMap that we manage.
+            response.require_resources(
+                rsp,
+                name="observe-configmap",
+                api_version="v1",
+                kind="ConfigMap",
+                match_name="observe-test-configmap",
+                namespace="default",
+            )
+
+            # Check if we received the resource in this iteration.
+            resource_received = "observe-configmap" in req.required_resources
+
+            # Read the ConfigMap data if available.
+            observed_message = "not-found"
+            if resource_received:
+                cm = request.get_required_resource(req, "observe-configmap")
+                if cm:
+                    data = cm.get("data", {})
+                    observed_message = data.get("message", "no-message")
+
+            # Set XR status to reflect the observed ConfigMap data.
+            rsp.desired.composite.resource.update({
+                "status": {
+                    "observedData": {
+                        "message": observed_message,
+                    },
+                    "resourceReceived": resource_received,
+                }
+            })
+
+            # Add a result for observability.
+            result = fnv1.Result()
+            result.severity = fnv1.SEVERITY_NORMAL
+            if resource_received:
+                result.message = f"Observed ConfigMap with message: {observed_message}"
+            else:
+                result.message = "Waiting for ConfigMap"
+            rsp.results.append(result)

--- a/test/e2e/manifests/apiextensions/composition/composed-resource-observation/setup/definition.yaml
+++ b/test/e2e/manifests/apiextensions/composition/composed-resource-observation/setup/definition.yaml
@@ -28,3 +28,5 @@ spec:
               type: object
               additionalProperties:
                 type: string
+            resourceReceived:
+              type: boolean

--- a/test/e2e/manifests/apiextensions/composition/composed-resource-observation/setup/definition.yaml
+++ b/test/e2e/manifests/apiextensions/composition/composed-resource-observation/setup/definition.yaml
@@ -1,0 +1,30 @@
+apiVersion: apiextensions.crossplane.io/v2
+kind: CompositeResourceDefinition
+metadata:
+  name: tests.example.org
+spec:
+  scope: Namespaced
+  group: example.org
+  names:
+    kind: Test
+    plural: tests
+  versions:
+  - name: v1alpha1
+    served: true
+    referenceable: true
+    schema:
+     openAPIV3Schema:
+       type: object
+       properties:
+        spec:
+          type: object
+          properties:
+            coolField:
+              type: string
+        status:
+          type: object
+          properties:
+            observedData:
+              type: object
+              additionalProperties:
+                type: string

--- a/test/e2e/manifests/apiextensions/composition/composed-resource-observation/setup/functions.yaml
+++ b/test/e2e/manifests/apiextensions/composition/composed-resource-observation/setup/functions.yaml
@@ -1,0 +1,6 @@
+apiVersion: pkg.crossplane.io/v1
+kind: Function
+metadata:
+  name: function-python-resources
+spec:
+  package: xpkg.crossplane.io/crossplane-contrib/function-python:v0.4.0

--- a/test/e2e/manifests/apiextensions/composition/composed-resource-observation/xr.yaml
+++ b/test/e2e/manifests/apiextensions/composition/composed-resource-observation/xr.yaml
@@ -1,0 +1,10 @@
+apiVersion: example.org/v1alpha1
+kind: Test
+metadata:
+  namespace: default
+  name: observe-test-xr
+spec:
+  coolField: "test"
+  crossplane:
+    compositionRef:
+      name: observe-composition-namespaced

--- a/test/e2e/manifests/apiextensions/composition/realtime-namespaced-xr/setup/composition.yaml
+++ b/test/e2e/manifests/apiextensions/composition/realtime-namespaced-xr/setup/composition.yaml
@@ -1,0 +1,55 @@
+apiVersion: apiextensions.crossplane.io/v1
+kind: Composition
+metadata:
+  name: realtime-composition-namespaced
+spec:
+  compositeTypeRef:
+    apiVersion: nop.example.org/v1alpha1
+    kind: XRealtimeTest
+  mode: Pipeline
+  pipeline:
+  - step: observe-configmap
+    functionRef:
+      name: function-python-realtime-namespaced
+    input:
+      apiVersion: python.fn.crossplane.io/v1beta1
+      kind: Script
+      script: |
+        from crossplane.function import response, request
+        from crossplane.function.proto.v1 import run_function_pb2 as fnv1
+
+        def compose(req: fnv1.RunFunctionRequest, rsp: fnv1.RunFunctionResponse):
+            response.require_resources(
+                rsp,
+                name="observe-configmap",
+                api_version="v1",
+                kind="ConfigMap",
+                match_name="realtime-test-configmap",
+                namespace="default",
+            )
+
+            resource_received = "observe-configmap" in req.required_resources
+
+            observed_message = "not-found"
+            if resource_received:
+                cm = request.get_required_resource(req, "observe-configmap")
+                if cm:
+                    data = cm.get("data", {})
+                    observed_message = data.get("message", "no-message")
+
+            rsp.desired.composite.resource.update({
+                "status": {
+                    "observedData": {
+                        "message": observed_message,
+                    },
+                    "resourceReceived": resource_received,
+                }
+            })
+
+            result = fnv1.Result()
+            result.severity = fnv1.SEVERITY_NORMAL
+            if resource_received:
+                result.message = f"Observed ConfigMap with message: {observed_message}"
+            else:
+                result.message = "Waiting for ConfigMap"
+            rsp.results.append(result)

--- a/test/e2e/manifests/apiextensions/composition/realtime-namespaced-xr/setup/definition.yaml
+++ b/test/e2e/manifests/apiextensions/composition/realtime-namespaced-xr/setup/definition.yaml
@@ -1,0 +1,32 @@
+apiVersion: apiextensions.crossplane.io/v2
+kind: CompositeResourceDefinition
+metadata:
+  name: realtimetests.nop.example.org
+spec:
+  scope: Namespaced
+  group: nop.example.org
+  names:
+    kind: XRealtimeTest
+    plural: realtimetests
+  versions:
+  - name: v1alpha1
+    served: true
+    referenceable: true
+    schema:
+     openAPIV3Schema:
+       type: object
+       properties:
+        spec:
+          type: object
+          properties:
+            coolField:
+              type: string
+        status:
+          type: object
+          properties:
+            observedData:
+              type: object
+              additionalProperties:
+                type: string
+            resourceReceived:
+              type: boolean

--- a/test/e2e/manifests/apiextensions/composition/realtime-namespaced-xr/setup/functions.yaml
+++ b/test/e2e/manifests/apiextensions/composition/realtime-namespaced-xr/setup/functions.yaml
@@ -1,0 +1,6 @@
+apiVersion: pkg.crossplane.io/v1
+kind: Function
+metadata:
+  name: function-python-realtime-namespaced
+spec:
+  package: xpkg.crossplane.io/crossplane-contrib/function-python:v0.4.0

--- a/test/e2e/manifests/apiextensions/composition/realtime-namespaced-xr/xr.yaml
+++ b/test/e2e/manifests/apiextensions/composition/realtime-namespaced-xr/xr.yaml
@@ -1,0 +1,10 @@
+apiVersion: nop.example.org/v1alpha1
+kind: XRealtimeTest
+metadata:
+  namespace: default
+  name: realtime-xr-namespaced
+spec:
+  coolField: "realtime test"
+  crossplane:
+    compositionRef:
+      name: realtime-composition-namespaced


### PR DESCRIPTION
Closes #6788

## Summary

Add `TestRealtimeNamespacedXR` that validates realtime composition performance specifically for namespaced XRs. The existing test suite validates functional correctness for both cluster-scoped and namespaced XRs, but does not check that realtime composition responds within seconds (as opposed to falling back to ~60-second polling).

This was the regression that was caught in #6780 where namespaced XRs fell back to polling because of an indexing bug.

## Changes

- **`test/e2e/apiextensions/composition/realtime-namespaced-xr/`**: New test manifests including:
  - `setup/definition.yaml` — Namespaced CRD (`XRealtimeTest`)
  - `setup/composition.yaml` — Composition using Python function to observe ConfigMap changes
  - `setup/functions.yaml` — function-python package
  - `xr.yaml` — Namespaced XR instance

- **`test/e2e/apiextensions_compositions_test.go`**: Added `TestRealtimeNamespacedXR`:
  1. Creates a namespaced XR that composes a ConfigMap via observation
  2. Waits for initial composition to complete
  3. Directly modifies the ConfigMap
  4. Verifies the XR status reflects the change within **3 seconds** (polling fallback would take ~60s)

## How to Test

```bash
make test-e2e TEST_FILTER=TestRealtimeNamespacedXR
```

This test runs against a kind cluster with Crossplane installed and validates that the namespaced XR detects composed resource changes in realtime.