### PR TITLE
skip incomplete version tags in findDependencyVersionToUpdate

### DIFF
--- a/internal/controller/pkg/resolver/reconciler.go
+++ b/internal/controller/pkg/resolver/reconciler.go
@@ -541,6 +541,14 @@ func (r *Reconciler) findDependencyVersionToUpdate(ctx context.Context, ref name
 			continue
 		}
 
+		// We also skip any tags that are incomplete semantic versions (e.g.,
+		// "v1" will parse as "v1.0.0"). This prevents a "v1" tag, which may not
+		// point to v1.0.0 of a package, from being selected over the concrete
+		// "v1.0.0" tag during an upgrade.
+		if v.String() != strings.TrimPrefix(v.Original(), "v") {
+			continue
+		}
+
 		availableVersions = append(availableVersions, v)
 	}
 

--- a/internal/controller/pkg/resolver/reconciler_test.go
+++ b/internal/controller/pkg/resolver/reconciler_test.go
@@ -1231,6 +1231,29 @@ func TestReconcilerFindDependencyVersionToUpgrade(t *testing.T) {
 				version: "v2.0.0",
 			},
 		},
+		"SkipIncompleteVersion": {
+			reason: "We should skip incomplete version tags and select the concrete version when upgrading.",
+			args: args{
+				mgr:    &fake.Manager{Client: test.NewMockClient()},
+				insVer: "v1.0.0",
+				dep: &dag.DependencyNode{
+					Dependency: v1beta1.Dependency{
+						Package: "xpkg.crossplane.io/cool-repo/cool-image",
+						ParentConstraints: []string{
+							">v1.0.0",
+						},
+					},
+				},
+				rec: []ReconcilerOption{
+					WithClient(&fakexpkg.MockClient{
+						MockListVersions: fakexpkg.NewMockListVersionsFn([]string{"v1.0.0", "v2", "v2.0.0"}, nil),
+					}),
+				},
+			},
+			want: want{
+				version: "v2.0.0",
+			},
+		},
 		"ErrorNoValidVersion": {
 			reason: "We should return an error if no valid version exists for dependency.",
 			args: args{


### PR DESCRIPTION
1. findDependencyVersionToUpdate ranges over the tags returned by ListVersions but, unlike findDependencyVersionToInstall, never filters incomplete semantic versions.
2. A floating tag like "v2" parses as "2.0.0" and sorts equal to the concrete "v2.0.0", so it can be selected and pinned as the upgrade target even though the registry may later repoint it to a different 2.x build.
3. Added the same incomplete-version skip the install path already uses, plus a regression case (tags v1.0.0, v2, v2.0.0 now resolve to v2.0.0 instead of v2).

Validated by running the resolver package tests. The new case selects "v2" before the change and "v2.0.0" after it.