### PR TITLE
pkg: include package generation in revision ID

### DIFF
--- a/internal/controller/pkg/manager/reconciler.go
+++ b/internal/controller/pkg/manager/reconciler.go
@@ -21,9 +21,9 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
-	"fmt"
 	"math"
 	"reflect"
+	"strconv"
 	"strings"
 	"time"
 
@@ -102,7 +102,7 @@ func WithNewPackageFn(f func() v1.Package) ReconcilerOption {
 
 // packageRevisionID returns the revision identifier used to derive a PackageRevision name.
 func packageRevisionID(digest string, generation int64) string {
-	h := sha256.Sum256([]byte(fmt.Sprintf("%s|%d", digest, generation)))
+	h := sha256.Sum256([]byte(digest + "|" + strconv.FormatInt(generation, 10)))
 	return hex.EncodeToString(h[:])
 }
 
@@ -330,6 +330,12 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 		r.record.Event(p, event.Warning(reasonList, err))
 
 		return reconcile.Result{}, err
+	}
+
+	// Don't create or update package revisions while the package is being deleted.
+	// Kubernetes garbage collection owns deletion of controlled package revisions.
+	if meta.WasDeleted(p) {
+		return reconcile.Result{}, nil
 	}
 
 	// Fetch the package to get its digest and any applied ImageConfigs.

--- a/internal/controller/pkg/manager/reconciler.go
+++ b/internal/controller/pkg/manager/reconciler.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"fmt"
 	"math"
 	"reflect"
 	"strings"
@@ -99,47 +100,9 @@ func WithNewPackageFn(f func() v1.Package) ReconcilerOption {
 	}
 }
 
-// Ignore the implicit default runtime config when computing revision IDs.
-// Package dependencies commonly inherit the default runtime configuration.
-// Including it in the revision identity would change revision names for
-// packages that do not explicitly select a runtime configuration. We only
-// want runtime configuration changes to affect revision identity when a
-// non-default runtime config is selected.
-func isDefaultRuntimeConfigRef(ref *v1.RuntimeConfigReference) bool {
-	if ref == nil {
-		return true
-	}
-
-	return ref.Name == "default" &&
-		(ref.APIVersion == nil || *ref.APIVersion == v1beta1.SchemeGroupVersion.String()) &&
-		(ref.Kind == nil || *ref.Kind == v1beta1.DeploymentRuntimeConfigKind)
-}
-
-// packageRevisionID returns the revision identifier used to derive a
-// PackageRevision name. Non-default runtime configuration references are included
-// so that changing runtimeConfigRef results in a new PackageRevision.
-func packageRevisionID(digest string, ref *v1.RuntimeConfigReference) string {
-	if ref == nil || isDefaultRuntimeConfigRef(ref) {
-		return digest
-	}
-
-	apiVersion := ""
-	if ref.APIVersion != nil {
-		apiVersion = *ref.APIVersion
-	}
-
-	kind := ""
-	if ref.Kind != nil {
-		kind = *ref.Kind
-	}
-
-	h := sha256.Sum256([]byte(strings.Join([]string{
-		digest,
-		apiVersion,
-		kind,
-		ref.Name,
-	}, "|")))
-
+// packageRevisionID returns the revision identifier used to derive a PackageRevision name.
+func packageRevisionID(digest string, generation int64) string {
+	h := sha256.Sum256([]byte(fmt.Sprintf("%s|%d", digest, generation)))
 	return hex.EncodeToString(h[:])
 }
 
@@ -400,11 +363,10 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 
 	p.SetResolvedSource(pkg.ResolvedRef())
 
+	// Calculate the revision ID from the package digest and package generation.
 	revisionID := pkg.DigestHex()
 	if r.features.Enabled(features.EnableBetaDeploymentRuntimeConfigs) {
-		if pwr, ok := p.(v1.PackageWithRuntime); ok {
-			revisionID = packageRevisionID(revisionID, pwr.GetRuntimeConfigRef())
-		}
+		revisionID = packageRevisionID(revisionID, p.GetGeneration())
 	}
 	revisionName := xpkg.FriendlyID(p.GetName(), revisionID)
 

--- a/internal/controller/pkg/manager/reconciler.go
+++ b/internal/controller/pkg/manager/reconciler.go
@@ -36,6 +36,7 @@ import (
 	"github.com/crossplane/crossplane-runtime/v2/pkg/conditions"
 	"github.com/crossplane/crossplane-runtime/v2/pkg/errors"
 	"github.com/crossplane/crossplane-runtime/v2/pkg/event"
+	"github.com/crossplane/crossplane-runtime/v2/pkg/feature"
 	"github.com/crossplane/crossplane-runtime/v2/pkg/logging"
 	"github.com/crossplane/crossplane-runtime/v2/pkg/meta"
 	"github.com/crossplane/crossplane-runtime/v2/pkg/resource"
@@ -45,6 +46,7 @@ import (
 	v1 "github.com/crossplane/crossplane/apis/v2/pkg/v1"
 	"github.com/crossplane/crossplane/apis/v2/pkg/v1beta1"
 	"github.com/crossplane/crossplane/v2/internal/controller/pkg/controller"
+	"github.com/crossplane/crossplane/v2/internal/features"
 )
 
 const (
@@ -193,6 +195,13 @@ func WithManagingRevisionRuntimeSpec() ReconcilerOption {
 	}
 }
 
+// WithFeatureFlags specifies the feature flags to inject into the Reconciler.
+func WithFeatureFlags(f *feature.Flags) ReconcilerOption {
+	return func(r *Reconciler) {
+		r.features = f
+	}
+}
+
 // Reconciler reconciles packages.
 type Reconciler struct {
 	kube       resource.ClientApplicator
@@ -200,6 +209,7 @@ type Reconciler struct {
 	log        logging.Logger
 	record     event.Recorder
 	conditions conditions.Manager
+	features   *feature.Flags
 
 	setPackageRuntimeManagedFields func(p v1.Package, pr v1.PackageRevision)
 
@@ -223,6 +233,7 @@ func SetupProvider(mgr ctrl.Manager, o controller.Options) error {
 		WithClient(o.Client),
 		WithLogger(log),
 		WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name), o.EventFilterFunctions...)),
+		WithFeatureFlags(o.Features),
 	}
 
 	if o.PackageRuntime.For(v1.ProviderKind) == controller.PackageRuntimeDeployment {
@@ -279,6 +290,7 @@ func SetupFunction(mgr ctrl.Manager, o controller.Options) error {
 		WithClient(o.Client),
 		WithLogger(log),
 		WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name), o.EventFilterFunctions...)),
+		WithFeatureFlags(o.Features),
 	}
 
 	if o.PackageRuntime.For(v1.FunctionKind) == controller.PackageRuntimeDeployment {
@@ -389,8 +401,10 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 	p.SetResolvedSource(pkg.ResolvedRef())
 
 	revisionID := pkg.DigestHex()
-	if pwr, ok := p.(v1.PackageWithRuntime); ok {
-		revisionID = packageRevisionID(revisionID, pwr.GetRuntimeConfigRef())
+	if r.features != nil && r.features.Enabled(features.EnableBetaDeploymentRuntimeConfigs) {
+		if pwr, ok := p.(v1.PackageWithRuntime); ok {
+			revisionID = packageRevisionID(revisionID, pwr.GetRuntimeConfigRef())
+		}
 	}
 	revisionName := xpkg.FriendlyID(p.GetName(), revisionID)
 

--- a/internal/controller/pkg/manager/reconciler.go
+++ b/internal/controller/pkg/manager/reconciler.go
@@ -97,11 +97,27 @@ func WithNewPackageFn(f func() v1.Package) ReconcilerOption {
 	}
 }
 
-// packageRevisionID returns the revision identifier used to derive a
-// PackageRevision name. The runtime configuration reference is included in the
-// identifier so that changing runtimeConfigRef results in a new PackageRevision.
-func packageRevisionID(digest string, ref *v1.RuntimeConfigReference) string {
+// Ignore the implicit default runtime config when computing revision IDs.
+// Package dependencies commonly inherit the default runtime configuration.
+// Including it in the revision identity would change revision names for
+// packages that do not explicitly select a runtime configuration. We only
+// want runtime configuration changes to affect revision identity when a
+// non-default runtime config is selected.
+func isDefaultRuntimeConfigRef(ref *v1.RuntimeConfigReference) bool {
 	if ref == nil {
+		return true
+	}
+
+	return ref.Name == "default" &&
+		(ref.APIVersion == nil || *ref.APIVersion == v1beta1.SchemeGroupVersion.String()) &&
+		(ref.Kind == nil || *ref.Kind == v1beta1.DeploymentRuntimeConfigKind)
+}
+
+// packageRevisionID returns the revision identifier used to derive a
+// PackageRevision name. Non-default runtime configuration references are included
+// so that changing runtimeConfigRef results in a new PackageRevision.
+func packageRevisionID(digest string, ref *v1.RuntimeConfigReference) string {
+	if ref == nil || isDefaultRuntimeConfigRef(ref) {
 		return digest
 	}
 

--- a/internal/controller/pkg/manager/reconciler.go
+++ b/internal/controller/pkg/manager/reconciler.go
@@ -37,7 +37,6 @@ import (
 	"github.com/crossplane/crossplane-runtime/v2/pkg/conditions"
 	"github.com/crossplane/crossplane-runtime/v2/pkg/errors"
 	"github.com/crossplane/crossplane-runtime/v2/pkg/event"
-	"github.com/crossplane/crossplane-runtime/v2/pkg/feature"
 	"github.com/crossplane/crossplane-runtime/v2/pkg/logging"
 	"github.com/crossplane/crossplane-runtime/v2/pkg/meta"
 	"github.com/crossplane/crossplane-runtime/v2/pkg/resource"
@@ -47,7 +46,6 @@ import (
 	v1 "github.com/crossplane/crossplane/apis/v2/pkg/v1"
 	"github.com/crossplane/crossplane/apis/v2/pkg/v1beta1"
 	"github.com/crossplane/crossplane/v2/internal/controller/pkg/controller"
-	"github.com/crossplane/crossplane/v2/internal/features"
 )
 
 const (
@@ -158,13 +156,6 @@ func WithManagingRevisionRuntimeSpec() ReconcilerOption {
 	}
 }
 
-// WithFeatureFlags specifies the feature flags to inject into the Reconciler.
-func WithFeatureFlags(f *feature.Flags) ReconcilerOption {
-	return func(r *Reconciler) {
-		r.features = f
-	}
-}
-
 // Reconciler reconciles packages.
 type Reconciler struct {
 	kube       resource.ClientApplicator
@@ -172,7 +163,6 @@ type Reconciler struct {
 	log        logging.Logger
 	record     event.Recorder
 	conditions conditions.Manager
-	features   *feature.Flags
 
 	setPackageRuntimeManagedFields func(p v1.Package, pr v1.PackageRevision)
 
@@ -196,7 +186,6 @@ func SetupProvider(mgr ctrl.Manager, o controller.Options) error {
 		WithClient(o.Client),
 		WithLogger(log),
 		WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name), o.EventFilterFunctions...)),
-		WithFeatureFlags(o.Features),
 	}
 
 	if o.PackageRuntime.For(v1.ProviderKind) == controller.PackageRuntimeDeployment {
@@ -253,7 +242,6 @@ func SetupFunction(mgr ctrl.Manager, o controller.Options) error {
 		WithClient(o.Client),
 		WithLogger(log),
 		WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name), o.EventFilterFunctions...)),
-		WithFeatureFlags(o.Features),
 	}
 
 	if o.PackageRuntime.For(v1.FunctionKind) == controller.PackageRuntimeDeployment {
@@ -370,10 +358,8 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 	p.SetResolvedSource(pkg.ResolvedRef())
 
 	// Calculate the revision ID from the package digest and package generation.
-	revisionID := pkg.DigestHex()
-	if r.features.Enabled(features.EnableBetaDeploymentRuntimeConfigs) {
-		revisionID = packageRevisionID(revisionID, p.GetGeneration())
-	}
+	revisionID := packageRevisionID(pkg.DigestHex(), p.GetGeneration())
+
 	revisionName := xpkg.FriendlyID(p.GetName(), revisionID)
 
 	// Set the current revision and identifier.

--- a/internal/controller/pkg/manager/reconciler.go
+++ b/internal/controller/pkg/manager/reconciler.go
@@ -19,6 +19,8 @@ package manager
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"math"
 	"reflect"
 	"strings"
@@ -93,6 +95,34 @@ func WithNewPackageFn(f func() v1.Package) ReconcilerOption {
 	return func(r *Reconciler) {
 		r.newPackage = f
 	}
+}
+
+// packageRevisionID returns the revision identifier used to derive a
+// PackageRevision name. The runtime configuration reference is included in the
+// identifier so that changing runtimeConfigRef results in a new PackageRevision.
+func packageRevisionID(digest string, ref *v1.RuntimeConfigReference) string {
+	if ref == nil {
+		return digest
+	}
+
+	apiVersion := ""
+	if ref.APIVersion != nil {
+		apiVersion = *ref.APIVersion
+	}
+
+	kind := ""
+	if ref.Kind != nil {
+		kind = *ref.Kind
+	}
+
+	h := sha256.Sum256([]byte(strings.Join([]string{
+		digest,
+		apiVersion,
+		kind,
+		ref.Name,
+	}, "|")))
+
+	return hex.EncodeToString(h[:])
 }
 
 // WithNewPackageRevisionFn determines the type of package being reconciled.
@@ -342,7 +372,11 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 
 	p.SetResolvedSource(pkg.ResolvedRef())
 
-	revisionName := xpkg.FriendlyID(p.GetName(), pkg.DigestHex())
+	revisionID := pkg.DigestHex()
+	if pwr, ok := p.(v1.PackageWithRuntime); ok {
+		revisionID = packageRevisionID(revisionID, pwr.GetRuntimeConfigRef())
+	}
+	revisionName := xpkg.FriendlyID(p.GetName(), revisionID)
 
 	// Set the current revision and identifier.
 	p.SetCurrentRevision(revisionName)

--- a/internal/controller/pkg/manager/reconciler.go
+++ b/internal/controller/pkg/manager/reconciler.go
@@ -401,7 +401,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 	p.SetResolvedSource(pkg.ResolvedRef())
 
 	revisionID := pkg.DigestHex()
-	if r.features != nil && r.features.Enabled(features.EnableBetaDeploymentRuntimeConfigs) {
+	if r.features.Enabled(features.EnableBetaDeploymentRuntimeConfigs) {
 		if pwr, ok := p.(v1.PackageWithRuntime); ok {
 			revisionID = packageRevisionID(revisionID, pwr.GetRuntimeConfigRef())
 		}

--- a/internal/controller/pkg/manager/reconciler_test.go
+++ b/internal/controller/pkg/manager/reconciler_test.go
@@ -47,28 +47,31 @@ import (
 
 func TestPackageRevisionID(t *testing.T) {
 	digest := "123456789012"
-	apiVersion := "pkg.crossplane.io/v1beta1"
-	kind := "DeploymentRuntimeConfig"
 
-	defaultID := packageRevisionID(digest, &v1.RuntimeConfigReference{
-		APIVersion: &apiVersion,
-		Kind:       &kind,
-		Name:       "default",
-	})
-
-	azureID := packageRevisionID(digest, &v1.RuntimeConfigReference{
-		APIVersion: &apiVersion,
-		Kind:       &kind,
-		Name:       "azure-test",
-	})
-
-	if defaultID == azureID {
-		t.Fatalf("expected different runtime config references to produce different revision IDs")
+	tests := []struct {
+		name       string
+		generation int64
+	}{
+		{name: "generation 1 package creation", generation: 1},
+		{name: "generation 2 spec update", generation: 2},
 	}
 
-	plainID := packageRevisionID(digest, nil)
-	if plainID != digest {
-		t.Fatalf("expected nil runtime config reference to preserve package digest")
+	ids := map[int64]string{}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := packageRevisionID(digest, tc.generation)
+
+			if got == digest {
+				t.Fatalf("expected revision ID to differ from package digest")
+			}
+
+			ids[tc.generation] = got
+		})
+	}
+
+	if ids[1] == ids[2] {
+		t.Fatalf("expected different generations to produce different revision IDs")
 	}
 }
 

--- a/internal/controller/pkg/manager/reconciler_test.go
+++ b/internal/controller/pkg/manager/reconciler_test.go
@@ -81,6 +81,8 @@ func TestReconcile(t *testing.T) {
 	pullAlways := corev1.PullAlways
 	trueVal := true
 	revHistory := int64(1)
+	digest := "1234567890123456789012345678901234567890123456789012345678901234"
+	revisionName := xpkg.FriendlyID("test", packageRevisionID(digest, 0))
 
 	type args struct {
 		req reconcile.Request
@@ -211,7 +213,7 @@ func TestReconcile(t *testing.T) {
 								want := &v1.Configuration{}
 								want.SetName("test")
 								want.SetGroupVersionKind(v1.ConfigurationGroupVersionKind)
-								want.SetCurrentRevision("test-123456789012")
+								want.SetCurrentRevision(revisionName)
 								want.SetActivationPolicy(&v1.AutomaticActivation)
 								want.SetConditions(v1.Unhealthy().WithMessage("Package revision health is \"Unknown\""))
 								want.SetConditions(v1.Active())
@@ -271,7 +273,7 @@ func TestReconcile(t *testing.T) {
 								want := &v1.Configuration{}
 								want.SetName("test")
 								want.SetGroupVersionKind(v1.ConfigurationGroupVersionKind)
-								want.SetCurrentRevision("test-123456789012")
+								want.SetCurrentRevision(revisionName)
 								want.SetActivationPolicy(&v1.AutomaticActivation)
 								want.SetConditions(v1.Unhealthy().WithMessage("Package revision health is \"Unknown\""))
 								want.SetConditions(v1.Active())
@@ -327,7 +329,7 @@ func TestReconcile(t *testing.T) {
 								want := &v1.Configuration{}
 								want.SetName("test")
 								want.SetGroupVersionKind(v1.ConfigurationGroupVersionKind)
-								want.SetCurrentRevision("test-123456789012")
+								want.SetCurrentRevision(revisionName)
 								want.SetActivationPolicy(&v1.AutomaticActivation)
 								want.SetPackagePullPolicy(&pullAlways)
 								want.SetConditions(v1.Unhealthy().WithMessage("Package revision health is \"Unknown\""))
@@ -384,7 +386,7 @@ func TestReconcile(t *testing.T) {
 								want.SetName("test")
 								want.SetGroupVersionKind(v1.ConfigurationGroupVersionKind)
 								want.SetActivationPolicy(&v1.ManualActivation)
-								want.SetCurrentRevision("test-123456789012")
+								want.SetCurrentRevision(revisionName)
 								want.SetConditions(v1.Unhealthy().WithMessage("Package revision health is \"Unknown\""))
 								want.SetConditions(v1.Inactive().WithMessage("Package is inactive"))
 								want.SetResolvedSource("xpkg.crossplane.io/test:v1.0.0")
@@ -436,10 +438,12 @@ func TestReconcile(t *testing.T) {
 								l := o.(*v1.ConfigurationRevisionList)
 								cr := v1.ConfigurationRevision{
 									ObjectMeta: metav1.ObjectMeta{
-										Name: "test-123456789012",
+										Name: revisionName,
 									},
 								}
 								cr.SetConditions(v1.RevisionHealthy())
+								cr.SetDesiredState(v1.PackageRevisionActive)
+								cr.SetRevision(1)
 								c := v1.ConfigurationRevisionList{
 									Items: []v1.ConfigurationRevision{cr},
 								}
@@ -450,7 +454,7 @@ func TestReconcile(t *testing.T) {
 								want := &v1.Configuration{}
 								want.SetName("test")
 								want.SetGroupVersionKind(v1.ConfigurationGroupVersionKind)
-								want.SetCurrentRevision("test-123456789012")
+								want.SetCurrentRevision(revisionName)
 								want.SetConditions(v1.Healthy())
 								want.SetConditions(v1.Active())
 								want.SetResolvedSource("xpkg.crossplane.io/test:v1.0.0")
@@ -502,7 +506,7 @@ func TestReconcile(t *testing.T) {
 								l := o.(*v1.ConfigurationRevisionList)
 								cr := v1.ConfigurationRevision{
 									ObjectMeta: metav1.ObjectMeta{
-										Name: "test-123456789012",
+										Name: revisionName,
 									},
 								}
 								cr.SetGroupVersionKind(v1.ConfigurationRevisionGroupVersionKind)
@@ -519,7 +523,7 @@ func TestReconcile(t *testing.T) {
 								want := &v1.Configuration{}
 								want.SetName("test")
 								want.SetGroupVersionKind(v1.ConfigurationGroupVersionKind)
-								want.SetCurrentRevision("test-123456789012")
+								want.SetCurrentRevision(revisionName)
 								want.SetConditions(v1.Healthy())
 								want.SetConditions(v1.Active())
 								want.SetResolvedSource("xpkg.crossplane.io/test:v1.0.0")
@@ -532,7 +536,7 @@ func TestReconcile(t *testing.T) {
 						Applicator: resource.ApplyFn(func(_ context.Context, o client.Object, _ ...resource.ApplyOption) error {
 							want := &v1.ConfigurationRevision{}
 							want.SetLabels(map[string]string{"pkg.crossplane.io/package": "test"})
-							want.SetName("test-123456789012")
+							want.SetName(revisionName)
 							want.SetOwnerReferences([]metav1.OwnerReference{{
 								APIVersion:         v1.SchemeGroupVersion.String(),
 								Kind:               v1.ConfigurationKind,
@@ -588,10 +592,11 @@ func TestReconcile(t *testing.T) {
 								l := o.(*v1.ConfigurationRevisionList)
 								cr := v1.ConfigurationRevision{
 									ObjectMeta: metav1.ObjectMeta{
-										Name: "test-123456789012",
+										Name: revisionName,
 									},
 								}
 								cr.SetGroupVersionKind(v1.ConfigurationRevisionGroupVersionKind)
+								cr.SetRevision(1)
 								cr.SetConditions(v1.RevisionHealthy())
 								cr.SetDesiredState(v1.PackageRevisionInactive)
 								c := v1.ConfigurationRevisionList{
@@ -604,7 +609,7 @@ func TestReconcile(t *testing.T) {
 								want := &v1.Configuration{}
 								want.SetName("test")
 								want.SetGroupVersionKind(v1.ConfigurationGroupVersionKind)
-								want.SetCurrentRevision("test-123456789012")
+								want.SetCurrentRevision(revisionName)
 								want.SetConditions(v1.Healthy())
 								if diff := cmp.Diff(want, o, test.EquateConditions()); diff != "" {
 									t.Errorf("-want, +got:\n%s", diff)
@@ -654,10 +659,11 @@ func TestReconcile(t *testing.T) {
 								l := o.(*v1.ConfigurationRevisionList)
 								cr := v1.ConfigurationRevision{
 									ObjectMeta: metav1.ObjectMeta{
-										Name: "test-123456789012",
+										Name: revisionName,
 									},
 								}
 								cr.SetGroupVersionKind(v1.ConfigurationRevisionGroupVersionKind)
+								cr.SetRevision(1)
 								cr.SetConditions(v1.RevisionUnhealthy().WithMessage("some message"))
 								cr.SetDesiredState(v1.PackageRevisionActive)
 								c := v1.ConfigurationRevisionList{
@@ -670,7 +676,7 @@ func TestReconcile(t *testing.T) {
 								want := &v1.Configuration{}
 								want.SetName("test")
 								want.SetGroupVersionKind(v1.ConfigurationGroupVersionKind)
-								want.SetCurrentRevision("test-123456789012")
+								want.SetCurrentRevision(revisionName)
 								want.SetConditions(v1.Unhealthy().WithMessage("Package revision health is \"False\" with message: some message"))
 								want.SetConditions(v1.Active())
 								want.SetResolvedSource("xpkg.crossplane.io/test:v1.0.0")
@@ -722,7 +728,7 @@ func TestReconcile(t *testing.T) {
 								l := o.(*v1.ConfigurationRevisionList)
 								cr := v1.ConfigurationRevision{
 									ObjectMeta: metav1.ObjectMeta{
-										Name: "test-123456789012",
+										Name: revisionName,
 									},
 								}
 								cr.SetRevision(3)
@@ -757,7 +763,7 @@ func TestReconcile(t *testing.T) {
 								want := &v1.Configuration{}
 								want.SetName("test")
 								want.SetGroupVersionKind(v1.ConfigurationGroupVersionKind)
-								want.SetCurrentRevision("test-123456789012")
+								want.SetCurrentRevision(revisionName)
 								want.SetConditions(v1.Healthy())
 								want.SetConditions(v1.Active())
 								want.SetResolvedSource("xpkg.crossplane.io/test:v1.0.0")
@@ -771,7 +777,7 @@ func TestReconcile(t *testing.T) {
 						Applicator: resource.ApplyFn(func(_ context.Context, o client.Object, _ ...resource.ApplyOption) error {
 							want := &v1.ConfigurationRevision{}
 							want.SetLabels(map[string]string{"pkg.crossplane.io/package": "test"})
-							want.SetName("test-123456789012")
+							want.SetName(revisionName)
 							want.SetOwnerReferences([]metav1.OwnerReference{{
 								APIVersion:         v1.SchemeGroupVersion.String(),
 								Kind:               v1.ConfigurationKind,
@@ -828,7 +834,7 @@ func TestReconcile(t *testing.T) {
 								l := o.(*v1.ConfigurationRevisionList)
 								cr := v1.ConfigurationRevision{
 									ObjectMeta: metav1.ObjectMeta{
-										Name: "test-123456789012",
+										Name: revisionName,
 									},
 								}
 								cr.SetRevision(3)
@@ -865,7 +871,7 @@ func TestReconcile(t *testing.T) {
 								want := &v1.Configuration{}
 								want.SetName("test")
 								want.SetGroupVersionKind(v1.ConfigurationGroupVersionKind)
-								want.SetCurrentRevision("test-123456789012")
+								want.SetCurrentRevision(revisionName)
 								want.SetRevisionHistoryLimit(&revHistory)
 								if diff := cmp.Diff(want, o, test.EquateConditions()); diff != "" {
 									t.Errorf("-want, +got:\n%s", diff)

--- a/internal/controller/pkg/manager/reconciler_test.go
+++ b/internal/controller/pkg/manager/reconciler_test.go
@@ -45,6 +45,33 @@ import (
 	v1 "github.com/crossplane/crossplane/apis/v2/pkg/v1"
 )
 
+func TestPackageRevisionID(t *testing.T) {
+	digest := "123456789012"
+	apiVersion := "pkg.crossplane.io/v1beta1"
+	kind := "DeploymentRuntimeConfig"
+
+	defaultID := packageRevisionID(digest, &v1.RuntimeConfigReference{
+		APIVersion: &apiVersion,
+		Kind:       &kind,
+		Name:       "default",
+	})
+
+	azureID := packageRevisionID(digest, &v1.RuntimeConfigReference{
+		APIVersion: &apiVersion,
+		Kind:       &kind,
+		Name:       "azure-test",
+	})
+
+	if defaultID == azureID {
+		t.Fatalf("expected different runtime config references to produce different revision IDs")
+	}
+
+	plainID := packageRevisionID(digest, nil)
+	if plainID != digest {
+		t.Fatalf("expected nil runtime config reference to preserve package digest")
+	}
+}
+
 func TestReconcile(t *testing.T) {
 	errBoom := errors.New("boom")
 	testLog := logging.NewLogrLogger(zap.New(zap.UseDevMode(true), zap.WriteTo(io.Discard)).WithName("testlog"))

--- a/test/e2e/manifests/pkg/image-config/runtime-config/function-new-runtime.yaml
+++ b/test/e2e/manifests/pkg/image-config/runtime-config/function-new-runtime.yaml
@@ -1,0 +1,11 @@
+apiVersion: pkg.crossplane.io/v1beta1
+kind: Function
+metadata:
+  name: function-image-config-runtime
+spec:
+  # This function is directly installed (not as a dependency) and should have
+  # the ImageConfig runtime config applied to it.
+  package: xpkg.crossplane.io/crossplane-contrib/function-dummy:v0.4.1
+  # The runtimeConfigRef should be overridden by the ImageConfig.
+  runtimeConfigRef:
+    name: image-config-rc

--- a/test/e2e/pkg_test.go
+++ b/test/e2e/pkg_test.go
@@ -268,6 +268,104 @@ func TestDeploymentRuntimeConfig(t *testing.T) {
 	)
 }
 
+// Helper used in 4 tests : TestPackageRevisionLifeCycle, TestImageConfigVerificationKeyless.
+// TestImageConfigAttestationVerificationPrivateKeylessCosignV2, TestImageConfigAttestationVerificationPrivateKeylessCosignV3.
+func CurrentPackageRevisionHasConditionWithin(
+	d time.Duration,
+	pkg pkgv1.Package,
+	revision pkgv1.PackageRevision,
+	conditions ...xpv2.Condition,
+) features.Func {
+	return func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+		t.Helper()
+
+		if err := c.Client().Resources().Get(ctx, pkg.GetName(), "", pkg); err != nil {
+			t.Errorf("cannot get package %q: %v", pkg.GetName(), err)
+			return ctx
+		}
+
+		if pkg.GetCurrentRevision() == "" {
+			t.Errorf("package %q has an empty status.currentRevision", pkg.GetName())
+			return ctx
+		}
+
+		revision.SetName(pkg.GetCurrentRevision())
+
+		return funcs.ResourceHasConditionWithin(
+			d,
+			revision,
+			conditions...,
+		)(ctx, t, c)
+	}
+}
+
+// Tests that a new package revision is upon spec update (via .metadada.generation).
+func TestPackageRevisionLifeCycle(t *testing.T) {
+	manifests := "test/e2e/manifests/pkg/image-config/runtime-config"
+	var firstRevision string
+	environment.Test(t,
+		features.NewWithDescription(t.Name(), "Tests that a package (Function, Provider) get a new revision on spec change.").
+			WithLabel(LabelArea, LabelAreaPkg).
+			WithLabel(LabelSize, LabelSizeSmall).
+			WithLabel(config.LabelTestSuite, config.TestSuiteDefault).
+			WithSetup("CreatePackage", funcs.AllOf(
+				funcs.ApplyResources(FieldManager, manifests, "deployment-runtime-config.yaml"),
+				funcs.ApplyResources(FieldManager, manifests, "function.yaml"),
+				funcs.ResourcesCreatedWithin(30*time.Second, manifests, "deployment-runtime-config.yaml"),
+				funcs.ResourcesCreatedWithin(30*time.Second, manifests, "function.yaml"),
+			)).
+			Assess("PackageRevisionOneCreated", funcs.AllOf(
+				funcs.ResourceHasFieldValueWithin(2*time.Minute, &pkgv1.Function{ObjectMeta: metav1.ObjectMeta{Name: "function-image-config-runtime"}}, "metadata.generation", int64(1)),
+				funcs.ResourceHasFieldValueWithin(2*time.Minute, &pkgv1.Function{ObjectMeta: metav1.ObjectMeta{Name: "function-image-config-runtime"}}, "status.currentRevision", funcs.Any),
+				CurrentPackageRevisionHasConditionWithin(2*time.Minute, &pkgv1.Function{ObjectMeta: metav1.ObjectMeta{Name: "function-image-config-runtime"}}, &pkgv1.FunctionRevision{}, pkgv1.RevisionHealthy()),
+				funcs.ResourceHasConditionWithin(2*time.Minute, &pkgv1.Function{ObjectMeta: metav1.ObjectMeta{Name: "function-image-config-runtime"}}, pkgv1.Active(), pkgv1.Healthy()),
+				func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+					t.Helper()
+
+					f := &pkgv1.Function{}
+					if err := c.Client().Resources().Get(ctx, "function-image-config-runtime", "", f); err != nil {
+						t.Errorf("cannot get Function: %v", err)
+						return ctx
+					}
+
+					firstRevision = f.Status.CurrentRevision
+					return ctx
+				},
+			)).
+			Assess("UpdatePackageRuntime", funcs.AllOf(
+				funcs.ApplyResources(FieldManager, manifests, "function-new-runtime.yaml"),
+				funcs.ResourcesCreatedWithin(30*time.Second, manifests, "function-new-runtime.yaml"),
+			)).
+			Assess("PackageRevisionTwoCreated", funcs.AllOf(
+				funcs.ResourceHasFieldValueWithin(2*time.Minute, &pkgv1.Function{ObjectMeta: metav1.ObjectMeta{Name: "function-image-config-runtime"}}, "metadata.generation", int64(2)),
+				func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+					t.Helper()
+
+					f := &pkgv1.Function{}
+					if err := c.Client().Resources().Get(ctx, "function-image-config-runtime", "", f); err != nil {
+						t.Errorf("cannot get Function: %v", err)
+						return ctx
+					}
+
+					if f.Status.CurrentRevision == firstRevision {
+						t.Errorf("expected current revision to change, still %q", firstRevision)
+					}
+
+					return ctx
+				},
+			)).
+			WithTeardown("DeleteFunction", funcs.AllOf(
+				funcs.DeleteResourcesWithPropagationPolicy(manifests, "function-new-runtime.yaml", metav1.DeletePropagationForeground),
+				funcs.ResourcesDeletedWithin(3*time.Minute, manifests, "function-new-runtime.yaml"),
+			)).
+			WithTeardown("DeletePrerequisites", funcs.AllOf(
+				funcs.DeleteResourcesWithPropagationPolicy(manifests, "deployment-runtime-config.yaml", metav1.DeletePropagationForeground),
+				funcs.ResourcesDeletedWithin(1*time.Minute, manifests, "deployment-runtime-config.yaml"),
+			)).
+			Feature(),
+	)
+}
+
 func TestImageConfigRuntimeConfig(t *testing.T) {
 	manifests := "test/e2e/manifests/pkg/image-config/runtime-config"
 	environment.Test(t,
@@ -931,7 +1029,8 @@ func TestImageConfigVerificationKeyless(t *testing.T) {
 			)).
 			Assess("SignatureVerificationSucceeded", funcs.AllOf(
 				funcs.ApplyResources(FieldManager, manifests, "provider-signed.yaml"),
-				funcs.ResourceHasConditionWithin(2*time.Minute, &pkgv1.ProviderRevision{ObjectMeta: metav1.ObjectMeta{Name: "e2e-provider-signed-keyless-37f3300ebfa7"}}, pkgv1.RevisionHealthy()),
+				funcs.ResourceHasFieldValueWithin(2*time.Minute, &pkgv1.Provider{ObjectMeta: metav1.ObjectMeta{Name: "e2e-provider-signed-keyless"}}, "status.currentRevision", funcs.Any),
+				CurrentPackageRevisionHasConditionWithin(2*time.Minute, &pkgv1.Provider{ObjectMeta: metav1.ObjectMeta{Name: "e2e-provider-signed-keyless"}}, &pkgv1.ProviderRevision{}, pkgv1.RevisionHealthy()),
 				funcs.ResourceHasConditionWithin(2*time.Minute, &pkgv1.Provider{ObjectMeta: metav1.ObjectMeta{Name: "e2e-provider-signed-keyless"}}, pkgv1.Active(), pkgv1.Healthy()),
 			)).
 			WithTeardown("DeletePackageAndImageConfig", funcs.AllOf(
@@ -973,7 +1072,8 @@ func TestImageConfigAttestationVerificationPrivateKeylessCosignV2(t *testing.T) 
 			)).
 			Assess("SignatureVerificationSucceeded", funcs.AllOf(
 				funcs.ApplyResources(FieldManager, manifests, "provider-signed-cosign-v2.yaml"),
-				funcs.ResourceHasConditionWithin(2*time.Minute, &pkgv1.ProviderRevision{ObjectMeta: metav1.ObjectMeta{Name: "e2e-private-provider-signed-keyless-v2-37f3300ebfa7"}}, pkgv1.RevisionHealthy()),
+				funcs.ResourceHasFieldValueWithin(2*time.Minute, &pkgv1.Provider{ObjectMeta: metav1.ObjectMeta{Name: "e2e-private-provider-signed-keyless-v2"}}, "status.currentRevision", funcs.Any),
+				CurrentPackageRevisionHasConditionWithin(2*time.Minute, &pkgv1.Provider{ObjectMeta: metav1.ObjectMeta{Name: "e2e-private-provider-signed-keyless-v2"}}, &pkgv1.ProviderRevision{}, pkgv1.RevisionHealthy()),
 				funcs.ResourceHasConditionWithin(2*time.Minute, &pkgv1.Provider{ObjectMeta: metav1.ObjectMeta{Name: "e2e-private-provider-signed-keyless-v2"}}, pkgv1.Active(), pkgv1.Healthy()),
 			)).
 			WithTeardown("DeletePackageAndImageConfig", funcs.AllOf(
@@ -1006,7 +1106,8 @@ func TestImageConfigAttestationVerificationPrivateKeylessCosignV3(t *testing.T) 
 			)).
 			Assess("SignatureVerificationSucceeded", funcs.AllOf(
 				funcs.ApplyResources(FieldManager, manifests, "provider-signed-cosign-v3.yaml"),
-				funcs.ResourceHasConditionWithin(2*time.Minute, &pkgv1.ProviderRevision{ObjectMeta: metav1.ObjectMeta{Name: "e2e-private-provider-signed-keyless-v3-37f3300ebfa7"}}, pkgv1.RevisionHealthy()),
+				funcs.ResourceHasFieldValueWithin(2*time.Minute, &pkgv1.Provider{ObjectMeta: metav1.ObjectMeta{Name: "e2e-private-provider-signed-keyless-v3"}}, "status.currentRevision", funcs.Any),
+				CurrentPackageRevisionHasConditionWithin(2*time.Minute, &pkgv1.Provider{ObjectMeta: metav1.ObjectMeta{Name: "e2e-private-provider-signed-keyless-v3"}}, &pkgv1.ProviderRevision{}, pkgv1.RevisionHealthy()),
 				funcs.ResourceHasConditionWithin(2*time.Minute, &pkgv1.Provider{ObjectMeta: metav1.ObjectMeta{Name: "e2e-private-provider-signed-keyless-v3"}}, pkgv1.Active(), pkgv1.Healthy()),
 			)).
 			WithTeardown("DeletePackageAndImageConfig", funcs.AllOf(

--- a/test/e2e/pkg_test.go
+++ b/test/e2e/pkg_test.go
@@ -992,7 +992,8 @@ func TestImageConfigVerificationWithKey(t *testing.T) {
 			)).
 			Assess("SignatureVerificationSucceeded", funcs.AllOf(
 				funcs.ApplyResources(FieldManager, manifests, "configuration-signed.yaml"),
-				funcs.ResourceHasConditionWithin(2*time.Minute, &pkgv1.ConfigurationRevision{ObjectMeta: metav1.ObjectMeta{Name: "e2e-configuration-signed-with-key-1765fb139d01"}}, pkgv1.RevisionHealthy()),
+				funcs.ResourceHasFieldValueWithin(2*time.Minute, &pkgv1.Configuration{ObjectMeta: metav1.ObjectMeta{Name: "e2e-configuration-signed-with-key"}}, "status.currentRevision", funcs.Any),
+				CurrentPackageRevisionHasConditionWithin(2*time.Minute, &pkgv1.Configuration{ObjectMeta: metav1.ObjectMeta{Name: "e2e-configuration-signed-with-key"}}, &pkgv1.ConfigurationRevision{}, pkgv1.RevisionHealthy()),
 				funcs.ResourceHasConditionWithin(2*time.Minute, &pkgv1.Configuration{ObjectMeta: metav1.ObjectMeta{Name: "e2e-configuration-signed-with-key"}}, pkgv1.Active(), pkgv1.Healthy()),
 			)).
 			WithTeardown("DeletePackageAndImageConfig", funcs.AllOf(

--- a/test/e2e/pkg_test.go
+++ b/test/e2e/pkg_test.go
@@ -1051,6 +1051,36 @@ func TestImageConfigRewrite(t *testing.T) {
 	)
 }
 
+func CurrentProviderRevisionHasFieldValueWithin(
+	d time.Duration,
+	providerName string,
+	path string,
+	want any,
+) features.Func {
+	return func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+		t.Helper()
+
+		p := &pkgv1.Provider{}
+		if err := c.Client().Resources().Get(ctx, providerName, "", p); err != nil {
+			t.Errorf("cannot get Provider %q: %v", providerName, err)
+			return ctx
+		}
+
+		pr := &pkgv1.ProviderRevision{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: p.Status.CurrentRevision,
+			},
+		}
+
+		return funcs.ResourceHasFieldValueWithin(
+			d,
+			pr,
+			path,
+			want,
+		)(ctx, t, c)
+	}
+}
+
 func TestCommonAnnotationsAndLabels(t *testing.T) {
 	manifests := "test/e2e/manifests/pkg/provider"
 
@@ -1064,8 +1094,20 @@ func TestCommonAnnotationsAndLabels(t *testing.T) {
 				funcs.ResourcesCreatedWithin(1*time.Minute, manifests, "provider-common-annotations-and-labels.yaml"),
 				funcs.ResourcesHaveConditionWithin(2*time.Minute, manifests, "provider-common-annotations-and-labels.yaml", pkgv1.Healthy(), pkgv1.Active()),
 			)).
-			Assess("AnnotationsPropagated", funcs.ResourcesHaveFieldValueWithin(1*time.Minute, manifests, "provider-revision-common-annotations-and-labels.yaml", "spec.commonAnnotations.foo", "bar")).
-			Assess("LabelsPropagated", funcs.ResourcesHaveFieldValueWithin(1*time.Minute, manifests, "provider-revision-common-annotations-and-labels.yaml", "spec.commonLabels.baz", "qux")).
+			Assess("AnnotationsPropagated",
+				CurrentProviderRevisionHasFieldValueWithin(
+					1*time.Minute,
+					"provider-nop",
+					"spec.commonAnnotations.foo",
+					"bar",
+				)).
+			Assess("LabelsPropagated",
+				CurrentProviderRevisionHasFieldValueWithin(
+					1*time.Minute,
+					"provider-nop",
+					"spec.commonLabels.baz",
+					"qux",
+				)).
 			WithTeardown("DeleteProvider", funcs.AllOf(
 				funcs.DeleteResourcesWithPropagationPolicy(manifests, "provider-common-annotations-and-labels.yaml", metav1.DeletePropagationForeground),
 				funcs.ResourcesDeletedWithin(1*time.Minute, manifests, "provider-common-annotations-and-labels.yaml"),

--- a/test/e2e/pkg_test.go
+++ b/test/e2e/pkg_test.go
@@ -624,6 +624,7 @@ func TestUpgradeDependencyVersionSharedTransitiveNoop(t *testing.T) {
 // test/e2e/manifests/pkg/dependency-upgrade/digest/package folder.
 func TestUpgradeDependencyDigest(t *testing.T) {
 	manifests := "test/e2e/manifests/pkg/dependency-upgrade/digest"
+	var providerRevisionName string
 
 	environment.Test(t,
 		features.NewWithDescription(t.Name(), "Tests that a Configuration with a dependency on provider with digest upgrades when dependency changes to another digest.").
@@ -647,18 +648,40 @@ func TestUpgradeDependencyDigest(t *testing.T) {
 				funcs.ResourcesHaveConditionWithin(2*time.Minute, manifests, "configuration-updated.yaml", pkgv1.Healthy(), pkgv1.Active())).
 			Assess("LockConditionDependencyResolutionSucceeded",
 				funcs.ResourcesHaveConditionWithin(2*time.Minute, manifests, "lock.yaml", v1beta1.ResolutionSucceeded())). // TODO(ezgidemirel): use ResourceHasConditionWithin instead
-			// Dependencies are not automatically deleted.
 			WithTeardown("DeleteConfiguration", funcs.AllOf(
 				funcs.DeleteResourcesWithPropagationPolicy(manifests, "configuration-updated.yaml", metav1.DeletePropagationForeground),
 				funcs.ResourcesDeletedWithin(1*time.Minute, manifests, "configuration-updated.yaml"),
 			)).
-			WithTeardown("DeleteRequiredProvider", funcs.AllOf(
-				funcs.DeleteResourcesWithPropagationPolicy(manifests, "provider.yaml", metav1.DeletePropagationForeground),
-				funcs.ResourcesDeletedWithin(1*time.Minute, manifests, "provider.yaml"),
-			)).
-			WithTeardown("DeleteProviderRevision", funcs.AllOf(
-				funcs.ResourcesDeletedWithin(1*time.Minute, manifests, "provider-revision.yaml"),
-			)).Feature(),
+			WithTeardown("DeleteRequiredProvider",
+				func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+					t.Helper()
+
+					p := &pkgv1.Provider{}
+					if err := c.Client().Resources().Get(ctx, "crossplane-contrib-provider-nop", "", p); err == nil {
+						providerRevisionName = p.Status.CurrentRevision
+						t.Logf("Recorded ProviderRevision %q", providerRevisionName)
+					}
+
+					return funcs.AllOf(
+						funcs.DeleteResourcesWithPropagationPolicy(manifests, "provider.yaml", metav1.DeletePropagationForeground),
+						funcs.ResourcesDeletedWithin(1*time.Minute, manifests, "provider.yaml"),
+					)(ctx, t, c)
+				}).
+			WithTeardown("DeleteProviderRevision",
+				func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+					t.Helper()
+
+					if providerRevisionName == "" {
+						t.Log("ProviderRevision name was not recorded; skipping ProviderRevision deletion wait")
+						return ctx
+					}
+
+					return funcs.ResourceDeletedWithin(1*time.Minute, &pkgv1.ProviderRevision{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: providerRevisionName,
+						},
+					})(ctx, t, c)
+				}).Feature(),
 	)
 }
 
@@ -1070,6 +1093,11 @@ func CurrentProviderRevisionHasFieldValueWithin(
 			ObjectMeta: metav1.ObjectMeta{
 				Name: p.Status.CurrentRevision,
 			},
+		}
+
+		if pr.GetName() == "" {
+			t.Errorf("provider %q does not report status.currentRevision yet; wait for provider to become fully reconciled", providerName)
+			return ctx
 		}
 
 		return funcs.ResourceHasFieldValueWithin(

--- a/test/e2e/pkg_test.go
+++ b/test/e2e/pkg_test.go
@@ -1096,7 +1096,7 @@ func CurrentProviderRevisionHasFieldValueWithin(
 		}
 
 		if pr.GetName() == "" {
-			t.Errorf("provider %q does not report status.currentRevision yet; wait for provider to become fully reconciled", providerName)
+			t.Errorf("provider %q has an empty status.currentRevision; this is unexpected after the provider became healthy and active", providerName)
 			return ctx
 		}
 


### PR DESCRIPTION
# Summary

Include runtimeConfigRef in the package revision identifier used to derive PackageRevision names.

Today, package revision names are derived only from the package digest:

revisionName := xpkg.FriendlyID(p.GetName(), pkg.DigestHex())

As a result, changing runtimeConfigRef reuses the existing PackageRevision rather than creating a new one.

This change includes the runtime configuration reference in the revision identifier while keeping the runtime configuration content itself out of scope. Only the reference value (apiVersion, kind, name) participates in revision identity.

# Motivation

Fixes #5068

This addresses the long-standing issue where changing runtimeConfigRef does not create a new PackageRevision, which can lead to stale runtime-related settings being reused.

In particular, it helps avoid situations where a previous controllerConfigRef remains associated with an existing revision after switching to runtimeConfigRef.

# Testing

Added a unit test covering:

different runtimeConfigRef values produce different revision identifiers
a nil runtimeConfigRef preserves the existing behavior and returns the package digest unchanged

All tests in internal/controller/pkg/manager pass.

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `./nix.sh flake check` to ensure this PR is ready for review.
- [x] Added or updated unit tests.
- [x] Added or updated e2e tests.
- [x] Linked a PR or a [docs tracking issue] to [document this change].
- [ ] ~~Added `backport release-x.y` labels to auto-backport this PR.~~
- [ ] Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.


[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md
