### PR TITLE
redact secret stringData before emitting to pipeline inspector

### DIFF
--- a/internal/xfn/inspected/socket.go
+++ b/internal/xfn/inspected/socket.go
@@ -199,8 +199,9 @@ func redactConnectionDetails(connectionDetails map[string][]byte) {
 	}
 }
 
-// stripSecretData redacts the data field values from a resource if it is a Kubernetes Secret.
-// The keys are preserved but values are replaced with redactedValue.
+// stripSecretData redacts the data and stringData field values from a resource
+// if it is a Kubernetes Secret. The keys are preserved but values are replaced
+// with redactedValue.
 func stripSecretData(resource *structpb.Struct) {
 	if resource == nil {
 		return
@@ -214,9 +215,13 @@ func stripSecretData(resource *structpb.Struct) {
 	apiVersion := fields["apiVersion"].GetStringValue()
 	kind := fields["kind"].GetStringValue()
 	if apiVersion == "v1" && kind == "Secret" {
-		if data := fields["data"].GetStructValue(); data != nil {
-			for k := range data.GetFields() {
-				data.Fields[k] = structpb.NewStringValue(redactedValue)
+		// Desired Secrets authored by functions may carry plaintext values in
+		// stringData rather than base64 in data, so redact both.
+		for _, key := range []string{"data", "stringData"} {
+			if d := fields[key].GetStructValue(); d != nil {
+				for k := range d.GetFields() {
+					d.Fields[k] = structpb.NewStringValue(redactedValue)
+				}
 			}
 		}
 	}

--- a/internal/xfn/inspected/socket_test.go
+++ b/internal/xfn/inspected/socket_test.go
@@ -682,6 +682,47 @@ func TestSanitizeState(t *testing.T) {
 				},
 			},
 		},
+		"RedactsSecretStringData": {
+			reason: "Should redact stringData field values from Secret resources, preserving keys.",
+			state: &fnv1.State{
+				Resources: map[string]*fnv1.Resource{
+					"my-secret": {
+						Resource: &structpb.Struct{
+							Fields: map[string]*structpb.Value{
+								"apiVersion": structpb.NewStringValue("v1"),
+								"kind":       structpb.NewStringValue("Secret"),
+								"stringData": structpb.NewStructValue(&structpb.Struct{
+									Fields: map[string]*structpb.Value{
+										"password": structpb.NewStringValue("secret"),
+										"username": structpb.NewStringValue("admin"),
+									},
+								}),
+								"type": structpb.NewStringValue("Opaque"),
+							},
+						},
+					},
+				},
+			},
+			want: &fnv1.State{
+				Resources: map[string]*fnv1.Resource{
+					"my-secret": {
+						Resource: &structpb.Struct{
+							Fields: map[string]*structpb.Value{
+								"apiVersion": structpb.NewStringValue("v1"),
+								"kind":       structpb.NewStringValue("Secret"),
+								"stringData": structpb.NewStructValue(&structpb.Struct{
+									Fields: map[string]*structpb.Value{
+										"password": structpb.NewStringValue(redactedValue),
+										"username": structpb.NewStringValue(redactedValue),
+									},
+								}),
+								"type": structpb.NewStringValue("Opaque"),
+							},
+						},
+					},
+				},
+			},
+		},
 		"PreservesNonSecretData": {
 			reason: "Should preserve data-like fields on non-Secret resources.",
 			state: &fnv1.State{


### PR DESCRIPTION
1. `stripSecretData` redacts a Secret's `data` field before the request/response is emitted to the pipeline inspector sidecar, but leaves `stringData` untouched.
2. desired Secrets authored by composition functions often carry plaintext values in `stringData` rather than base64 in `data`, so those values reached the inspector unredacted.

Redacted both `data` and `stringData` in the helper so the single sanitizer covers every caller (`sanitizeState` and `sanitizeRequiredResources`). Added a `RedactsSecretStringData` case to `TestSanitizeState` that fails before the change and passes after.