### PR TITLE
test(e2e) : allow E2E tests to assert condition observedGeneration

### DIFF
--- a/test/e2e/apiextensions_xrds_test.go
+++ b/test/e2e/apiextensions_xrds_test.go
@@ -87,12 +87,6 @@ func TestXRDValidation(t *testing.T) {
 func TestXRDReferenceableVersionChange(t *testing.T) {
 	manifests := "test/e2e/manifests/apiextensions/xrd/referenceable-version-change"
 
-	// TODO(negz): https://github.com/crossplane/crossplane/issues/6805
-	// This test would be more robust if it could verify that the WatchingComposite
-	// condition's observedGeneration changes from 1 to 2 when the XRD is updated.
-	// Currently we can only see this in the test logs due to the observedGeneration
-	// workaround in ResourcesHaveConditionWithin.
-
 	environment.Test(t,
 		features.NewWithDescription(
 			"XRDReferenceableVersionChange",
@@ -105,7 +99,7 @@ func TestXRDReferenceableVersionChange(t *testing.T) {
 			WithSetup("CreateXRDWithV1Referenceable", funcs.AllOf(
 				funcs.ApplyResources(FieldManager, manifests, "setup/*.yaml"),
 				funcs.ResourcesCreatedWithin(30*time.Second, manifests, "setup/*.yaml"),
-				funcs.ResourcesHaveConditionWithin(1*time.Minute, manifests, "setup/xrd-v1-referenceable.yaml", apiextensionsv1.WatchingComposite()),
+				funcs.ResourcesHaveConditionWithin(1*time.Minute, manifests, "setup/xrd-v1-referenceable.yaml", apiextensionsv1.WatchingComposite().WithObservedGeneration(1)),
 			)).
 			Assess("CreateXRBeforeChange", funcs.AllOf(
 				funcs.ApplyResources(FieldManager, manifests, "xr-before-change.yaml"),
@@ -117,7 +111,7 @@ func TestXRDReferenceableVersionChange(t *testing.T) {
 				funcs.ApplyResources(FieldManager, manifests, "xrd-v2-referenceable.yaml"),
 				funcs.ResourcesCreatedWithin(30*time.Second, manifests, "xrd-v2-referenceable.yaml"),
 				// Wait for controller to restart with new generation
-				funcs.ResourcesHaveConditionWithin(1*time.Minute, manifests, "xrd-v2-referenceable.yaml", apiextensionsv1.WatchingComposite()),
+				funcs.ResourcesHaveConditionWithin(1*time.Minute, manifests, "xrd-v2-referenceable.yaml", apiextensionsv1.WatchingComposite().WithObservedGeneration(2)),
 			)).
 			Assess("CreateXRAfterChange", funcs.AllOf(
 				funcs.ApplyResources(FieldManager, manifests, "xr-after-change.yaml"),

--- a/test/e2e/funcs/feature.go
+++ b/test/e2e/funcs/feature.go
@@ -387,7 +387,6 @@ func ResourceHasConditionWithin(d time.Duration, o k8s.Object, cds ...xpv2.Condi
 
 		t.Logf("Waiting %s for %s to become %s...", d, identifier(o), desired)
 
-		ogReport := make(map[string]bool)
 		old := make([]xpv2.Condition, len(cds))
 		match := func(o k8s.Object) bool {
 			u := asUnstructured(o)
@@ -395,25 +394,7 @@ func ResourceHasConditionWithin(d time.Duration, o k8s.Object, cds ...xpv2.Condi
 			_ = fieldpath.Pave(u.Object).GetValueInto("status", &s)
 
 			for i, want := range cds {
-				// Update the wanted observed generation to the latest object generation.
-				want.ObservedGeneration = u.GetGeneration()
-
 				got := s.GetCondition(want.Type)
-
-				// Until https://github.com/crossplane/crossplane/issues/6420 is resolved, crossplane will be in a
-				// transition period. A condition with an observedGeneration of zero means it is not yet being
-				// propagated when setting the conditions. To help that transition, we will move the generation forward
-				// ONLY if it is zero. But we will also log this fact to find it in the logs.
-				if got.ObservedGeneration == 0 {
-					got.ObservedGeneration = u.GetGeneration()
-
-					key := fmt.Sprintf("%s[%s]", u.GetKind(), got.Type)
-					if !ogReport[key] {
-						ogReport[key] = true
-
-						t.Logf("https://github.com/crossplane/crossplane/issues/6420: Warning, an unset observedGeneration was artificially updated for %s.status.conditions[%s]", u.GetKind(), got.Type)
-					}
-				}
 
 				if !got.Equal(old[i]) {
 					old[i] = got


### PR DESCRIPTION


This Pr fixes #6805 

### Descritiption

- Remove the `observedGeneration` workaround from E2E condition helpers.

- `ResourcesHaveConditionWithin` no longer overwrite expected or actual observedGeneration values. This allows E2E tests to assert specific `observedGeneration` values while preserving existing behavior for conditions that leave `observedGeneration` unset.

- Updated the `TestXRDReferenceableVersionChange` to verify the WatchingComposite condition observes generation 1 initially and generation 2 after the XRD update.