### PR TITLE
fix(helm): preserve crossplane TLS Secrets across helm upgrades

### DIFF
--- a/cluster/charts/crossplane/Chart.yaml
+++ b/cluster/charts/crossplane/Chart.yaml
@@ -5,6 +5,11 @@ name: crossplane
 version: 0.0.1
 icon: https://docs.crossplane.io/android-chrome-192x192.png
 home: https://crossplane.io
+# -- The Kubernetes server versions this chart is compatible with. Helm 3.2+
+# -- is also required. The hook jobs ship kubectl v1.31.1, which is compatible
+# -- with Kubernetes server v1.30 and later. Override `rootCA.bootstrap.image.tag`
+# -- for older clusters if needed.
+kubeVersion: ">= 1.30.0-0"
 maintainers:
   - name: Crossplane Maintainers
     email: crossplane-info@lists.cncf.io

--- a/cluster/charts/crossplane/README.md
+++ b/cluster/charts/crossplane/README.md
@@ -115,10 +115,6 @@ and their default values.
 | `registryCaBundleConfig.key` | The ConfigMap key containing a custom CA bundle to enable fetching packages from registries with unknown or untrusted certificates. | `""` |
 | `registryCaBundleConfig.name` | The ConfigMap name containing a custom CA bundle to enable fetching packages from registries with unknown or untrusted certificates. | `""` |
 | `replicas` | The number of Crossplane pod `replicas` to deploy. | `1` |
-| `rootCA.bootstrap.enabled` | Enable the pre-install/pre-upgrade hook job that creates the three crossplane TLS Secrets on first install and preserves them on subsequent upgrades. Has no effect when `rootCA.manageLifecycle` is false. | `true` |
-| `rootCA.bootstrap.image.repository` | Container image for the hook job. Must contain a `kubectl` binary. | `"registry.k8s.io/kubernetes/kubectl"` |
-| `rootCA.bootstrap.image.tag` | Tag for the hook job container image. | `"v1.31.1"` |
-| `rootCA.manageLifecycle` | Manage the lifecycle of the crossplane-root-ca, crossplane-tls-server, and crossplane-tls-client Secrets via Helm hook jobs. When true (default), a pre-install/pre-upgrade hook creates the Secrets only if missing (so existing CAs and per-pod TLS material survive upgrades), and a pre-delete hook removes them on `helm uninstall`. Set to false to fall back to the upstream behavior of having Helm manage the Secrets directly, which will rotate the CA and per-pod TLS material on every upgrade and break mTLS with installed provider/function packages. | `true` |
 | `resourcesCrossplane.limits.cpu` | CPU resource limits for the Crossplane pod. | `"500m"` |
 | `resourcesCrossplane.limits.memory` | Memory resource limits for the Crossplane pod. | `"1024Mi"` |
 | `resourcesCrossplane.requests.cpu` | CPU resource requests for the Crossplane pod. | `"100m"` |
@@ -128,6 +124,10 @@ and their default values.
 | `resourcesRBACManager.requests.cpu` | CPU resource requests for the RBAC Manager pod. | `"100m"` |
 | `resourcesRBACManager.requests.memory` | Memory resource requests for the RBAC Manager pod. | `"256Mi"` |
 | `revisionHistoryLimit` | The number of Crossplane ReplicaSets to retain. | `nil` |
+| `rootCA.bootstrap.enabled` | Enable the pre-install/pre-upgrade hook job that creates the three crossplane TLS Secrets on first install and preserves them on subsequent upgrades. Has no effect when `rootCA.manageLifecycle` is false. | `true` |
+| `rootCA.bootstrap.image.repository` | Container image for the hook job. Must contain a `kubectl` binary. | `"registry.k8s.io/kubernetes/kubectl"` |
+| `rootCA.bootstrap.image.tag` | Tag for the hook job container image. | `"v1.31.1"` |
+| `rootCA.manageLifecycle` | Manage the lifecycle of the crossplane-root-ca, crossplane-tls-server, and crossplane-tls-client Secrets via Helm hook jobs. When true (default), a pre-install/pre-upgrade hook creates the Secrets only if missing (so existing CAs and per-pod TLS material survive upgrades), and a pre-delete hook removes them on `helm uninstall`. Set to false to fall back to the upstream behavior of having Helm manage the Secrets directly, which will rotate the CA and per-pod TLS material on every upgrade and break mTLS with installed provider/function packages. | `true` |
 | `runtimeClassName` | The runtimeClassName name to apply to the Crossplane and RBAC Manager pods. | `""` |
 | `secrets.customAnnotations` | Add custom annotations to Crossplane Secret resources. | `{}` |
 | `securityContextCrossplane.allowPrivilegeEscalation` | Enable `allowPrivilegeEscalation` for the Crossplane pod. | `false` |

--- a/cluster/charts/crossplane/README.md
+++ b/cluster/charts/crossplane/README.md
@@ -126,7 +126,16 @@ and their default values.
 | `revisionHistoryLimit` | The number of Crossplane ReplicaSets to retain. | `nil` |
 | `rootCA.bootstrap.enabled` | Enable the pre-install/pre-upgrade hook job that creates the three crossplane TLS Secrets on first install and preserves them on subsequent upgrades. Has no effect when `rootCA.manageLifecycle` is false. | `true` |
 | `rootCA.bootstrap.image.repository` | Container image for the hook job. Must contain a `kubectl` binary. | `"registry.k8s.io/kubernetes/kubectl"` |
-| `rootCA.bootstrap.image.tag` | Tag for the hook job container image. | `"v1.31.1"` |
+| `rootCA.bootstrap.image.tag` | Tag for the hook job container image. Should be a kubectl version compatible with the Kubernetes server (see `kubeVersion` in Chart.yaml). | `"v1.31.1"` |
+| `rootCA.bootstrap.resources` | Resource requests and limits for the hook job container. | `{"limits":{"cpu":"100m","memory":"64Mi"},"requests":{"cpu":"10m","memory":"32Mi"}}` |
+| `rootCA.bootstrap.resources.limits.cpu` | CPU limit for the hook job container. | `"100m"` |
+| `rootCA.bootstrap.resources.limits.memory` | Memory limit for the hook job container. | `"64Mi"` |
+| `rootCA.bootstrap.resources.requests.cpu` | CPU request for the hook job container. | `"10m"` |
+| `rootCA.bootstrap.resources.requests.memory` | Memory request for the hook job container. | `"32Mi"` |
+| `rootCA.bootstrap.securityContext` | Security context for the hook job container. Hardened defaults: non-root, no privilege escalation, read-only root filesystem. | `{"allowPrivilegeEscalation":false,"readOnlyRootFilesystem":true,"runAsNonRoot":true}` |
+| `rootCA.bootstrap.securityContext.allowPrivilegeEscalation` | Disable privilege escalation. | `false` |
+| `rootCA.bootstrap.securityContext.readOnlyRootFilesystem` | Mount root filesystem as read-only. | `true` |
+| `rootCA.bootstrap.securityContext.runAsNonRoot` | Run as non-root user. The kubectl image runs as user 65532 by default. | `true` |
 | `rootCA.manageLifecycle` | Manage the lifecycle of the crossplane-root-ca, crossplane-tls-server, and crossplane-tls-client Secrets via Helm hook jobs. When true (default), a pre-install/pre-upgrade hook creates the Secrets only if missing (so existing CAs and per-pod TLS material survive upgrades), and a pre-delete hook removes them on `helm uninstall`. Set to false to fall back to the upstream behavior of having Helm manage the Secrets directly, which will rotate the CA and per-pod TLS material on every upgrade and break mTLS with installed provider/function packages. | `true` |
 | `runtimeClassName` | The runtimeClassName name to apply to the Crossplane and RBAC Manager pods. | `""` |
 | `secrets.customAnnotations` | Add custom annotations to Crossplane Secret resources. | `{}` |

--- a/cluster/charts/crossplane/README.md
+++ b/cluster/charts/crossplane/README.md
@@ -115,6 +115,10 @@ and their default values.
 | `registryCaBundleConfig.key` | The ConfigMap key containing a custom CA bundle to enable fetching packages from registries with unknown or untrusted certificates. | `""` |
 | `registryCaBundleConfig.name` | The ConfigMap name containing a custom CA bundle to enable fetching packages from registries with unknown or untrusted certificates. | `""` |
 | `replicas` | The number of Crossplane pod `replicas` to deploy. | `1` |
+| `rootCA.bootstrap.enabled` | Enable the pre-install/pre-upgrade hook job that creates the three crossplane TLS Secrets on first install and preserves them on subsequent upgrades. Has no effect when `rootCA.manageLifecycle` is false. | `true` |
+| `rootCA.bootstrap.image.repository` | Container image for the hook job. Must contain a `kubectl` binary. | `"registry.k8s.io/kubernetes/kubectl"` |
+| `rootCA.bootstrap.image.tag` | Tag for the hook job container image. | `"v1.31.1"` |
+| `rootCA.manageLifecycle` | Manage the lifecycle of the crossplane-root-ca, crossplane-tls-server, and crossplane-tls-client Secrets via Helm hook jobs. When true (default), a pre-install/pre-upgrade hook creates the Secrets only if missing (so existing CAs and per-pod TLS material survive upgrades), and a pre-delete hook removes them on `helm uninstall`. Set to false to fall back to the upstream behavior of having Helm manage the Secrets directly, which will rotate the CA and per-pod TLS material on every upgrade and break mTLS with installed provider/function packages. | `true` |
 | `resourcesCrossplane.limits.cpu` | CPU resource limits for the Crossplane pod. | `"500m"` |
 | `resourcesCrossplane.limits.memory` | Memory resource limits for the Crossplane pod. | `"1024Mi"` |
 | `resourcesCrossplane.requests.cpu` | CPU resource requests for the Crossplane pod. | `"100m"` |

--- a/cluster/charts/crossplane/templates/root-ca-bootstrap-job.yaml
+++ b/cluster/charts/crossplane/templates/root-ca-bootstrap-job.yaml
@@ -64,5 +64,9 @@ spec:
           env:
             - name: NAMESPACE
               value: {{ .Release.Namespace }}
+          resources:
+            {{- toYaml .Values.rootCA.bootstrap.resources | nindent 12 }}
+          securityContext:
+            {{- toYaml .Values.rootCA.bootstrap.securityContext | nindent 12 }}
 {{- end }}
 {{- end }}

--- a/cluster/charts/crossplane/templates/root-ca-bootstrap-job.yaml
+++ b/cluster/charts/crossplane/templates/root-ca-bootstrap-job.yaml
@@ -1,0 +1,68 @@
+{{- /*
+Pre-install/pre-upgrade hook job: ensure the three crossplane TLS Secrets exist
+as placeholders so the crossplane init container does not need to "create" them
+on first run. Once the init container has populated them, subsequent runs of
+this hook are no-ops (the Secrets already exist and are left untouched).
+
+Why this matters:
+- Without this hook, the chart would declaratively create empty Secrets
+  (templates/secret.yaml). On `helm upgrade`, Helm reapplies the (empty)
+  declarations, and although init container logic checks for existing data
+  before regenerating, declarative ownership creates room for the cluster
+  state to drift from the desired Helm state, and there is no clean way to
+  drop that declaration without leaking Secrets on uninstall.
+- With this hook, the Secrets are created only on first install and never
+  re-declared, so `helm upgrade` cannot overwrite them. mTLS trust to
+  provider/function packages is preserved across upgrades.
+
+Hook annotations:
+- pre-install,pre-upgrade: run before install/upgrade of the chart resources.
+- hook-weight: "-5"        : run before the main release resources are applied.
+- hook-delete-policy:      : clean up old job Pods on a successful run to keep
+  before-hook-creation,     the cluster tidy.
+  hook-succeeded
+*/ -}}
+{{- if .Values.rootCA.manageLifecycle }}
+{{- if .Values.rootCA.bootstrap.enabled }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ template "crossplane.name" . }}-root-ca-bootstrap
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "crossplane.name" . }}
+    {{- include "crossplane.labels" . | indent 4 }}
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: 3
+  template:
+    metadata:
+      name: {{ template "crossplane.name" . }}-root-ca-bootstrap
+    spec:
+      restartPolicy: Never
+      serviceAccountName: {{ template "crossplane.name" . }}-root-ca-hook
+      containers:
+        - name: bootstrap
+          image: {{ .Values.rootCA.bootstrap.image.repository }}:{{ .Values.rootCA.bootstrap.image.tag }}
+          imagePullPolicy: IfNotPresent
+          command:
+            - /bin/sh
+            - -ec
+            - |
+              set -eu
+              for secret in crossplane-root-ca crossplane-tls-server crossplane-tls-client; do
+                if kubectl get secret -n "$NAMESPACE" "$secret" >/dev/null 2>&1; then
+                  echo "$secret already exists, leaving it untouched"
+                else
+                  echo "$secret does not exist, creating empty placeholder (init container will populate it)"
+                  kubectl create secret generic -n "$NAMESPACE" "$secret" --type=kubernetes.io/tls
+                fi
+              done
+          env:
+            - name: NAMESPACE
+              value: {{ .Release.Namespace }}
+{{- end }}
+{{- end }}

--- a/cluster/charts/crossplane/templates/root-ca-bootstrap-job.yaml
+++ b/cluster/charts/crossplane/templates/root-ca-bootstrap-job.yaml
@@ -58,7 +58,12 @@ spec:
                   echo "$secret already exists, leaving it untouched"
                 else
                   echo "$secret does not exist, creating empty placeholder (init container will populate it)"
-                  kubectl create secret generic -n "$NAMESPACE" "$secret" --type=kubernetes.io/tls
+                  # The placeholder must be Opaque: the API server rejects
+                  # kubernetes.io/tls Secrets that lack tls.crt/tls.key, and
+                  # the init container populates the data via Update without
+                  # setting a type (matching the declarative fallback in
+                  # templates/secret.yaml).
+                  kubectl create secret generic -n "$NAMESPACE" "$secret"
                 fi
               done
           env:

--- a/cluster/charts/crossplane/templates/root-ca-cleanup-job.yaml
+++ b/cluster/charts/crossplane/templates/root-ca-cleanup-job.yaml
@@ -1,0 +1,56 @@
+{{- /*
+Pre-delete hook job: delete the three crossplane TLS Secrets on helm uninstall.
+
+Without this hook, removing the Secrets' declarations from the chart would leave
+"dangling" Secrets in the cluster after `helm uninstall` (Helm only deletes
+resources it manages; the Secrets are managed by this hook job, which is
+deleted before the pre-delete phase runs).
+
+The three Secrets (crossplane-root-ca, crossplane-tls-server, crossplane-tls-client)
+are the trust anchors and credentials for mTLS to all installed provider/function
+packages. Deleting them is consistent with uninstalling Crossplane. The pre-delete
+hook fires before Helm tears down the rest of the release, so package cert
+validation errors during teardown are bounded.
+*/ -}}
+{{- if .Values.rootCA.manageLifecycle }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ template "crossplane.name" . }}-root-ca-cleanup
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "crossplane.name" . }}
+    {{- include "crossplane.labels" . | indent 4 }}
+  annotations:
+    "helm.sh/hook": pre-delete
+    "helm.sh/hook-weight": "0"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: 3
+  template:
+    metadata:
+      name: {{ template "crossplane.name" . }}-root-ca-cleanup
+    spec:
+      restartPolicy: Never
+      serviceAccountName: {{ template "crossplane.name" . }}-root-ca-hook
+      containers:
+        - name: cleanup
+          image: {{ .Values.rootCA.bootstrap.image.repository }}:{{ .Values.rootCA.bootstrap.image.tag }}
+          imagePullPolicy: IfNotPresent
+          command:
+            - /bin/sh
+            - -ec
+            - |
+              set -eu
+              for secret in crossplane-root-ca crossplane-tls-server crossplane-tls-client; do
+                if kubectl get secret -n "$NAMESPACE" "$secret" >/dev/null 2>&1; then
+                  echo "Deleting $secret"
+                  kubectl delete secret -n "$NAMESPACE" "$secret" --ignore-not-found
+                else
+                  echo "$secret already absent, nothing to do"
+                fi
+              done
+          env:
+            - name: NAMESPACE
+              value: {{ .Release.Namespace }}
+{{- end }}

--- a/cluster/charts/crossplane/templates/root-ca-cleanup-job.yaml
+++ b/cluster/charts/crossplane/templates/root-ca-cleanup-job.yaml
@@ -53,4 +53,8 @@ spec:
           env:
             - name: NAMESPACE
               value: {{ .Release.Namespace }}
+          resources:
+            {{- toYaml .Values.rootCA.bootstrap.resources | nindent 12 }}
+          securityContext:
+            {{- toYaml .Values.rootCA.bootstrap.securityContext | nindent 12 }}
 {{- end }}

--- a/cluster/charts/crossplane/templates/root-ca-hook-role.yaml
+++ b/cluster/charts/crossplane/templates/root-ca-hook-role.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.rootCA.manageLifecycle }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ template "crossplane.name" . }}-root-ca-hook
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "crossplane.name" . }}
+    {{- include "crossplane.labels" . | indent 4 }}
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade,pre-delete
+    "helm.sh/hook-weight": "-10"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    # The hook job can create the secret (only if missing) and get/list it to check existence.
+    # Delete is also granted so the pre-delete hook can clean up on `helm uninstall`.
+    verbs: ["get", "list", "create", "delete"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["create", "patch"]
+{{- end }}

--- a/cluster/charts/crossplane/templates/root-ca-hook-role.yaml
+++ b/cluster/charts/crossplane/templates/root-ca-hook-role.yaml
@@ -14,10 +14,8 @@ metadata:
 rules:
   - apiGroups: [""]
     resources: ["secrets"]
-    # The hook job can create the secret (only if missing) and get/list it to check existence.
-    # Delete is also granted so the pre-delete hook can clean up on `helm uninstall`.
-    verbs: ["get", "list", "create", "delete"]
-  - apiGroups: [""]
-    resources: ["events"]
-    verbs: ["create", "patch"]
+    # The hook jobs operate on the three known Secret names by name; no list
+    # is required. `get` is used to check existence, `create` to place a
+    # placeholder, and `delete` for the pre-delete cleanup job.
+    verbs: ["get", "create", "delete"]
 {{- end }}

--- a/cluster/charts/crossplane/templates/root-ca-hook-rolebinding.yaml
+++ b/cluster/charts/crossplane/templates/root-ca-hook-rolebinding.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.rootCA.manageLifecycle }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ template "crossplane.name" . }}-root-ca-hook
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "crossplane.name" . }}
+    {{- include "crossplane.labels" . | indent 4 }}
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade,pre-delete
+    "helm.sh/hook-weight": "-10"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "crossplane.name" . }}-root-ca-hook
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: Role
+  name: {{ template "crossplane.name" . }}-root-ca-hook
+  apiGroup: rbac.authorization.k8s.io
+{{- end }}

--- a/cluster/charts/crossplane/templates/root-ca-hook-serviceaccount.yaml
+++ b/cluster/charts/crossplane/templates/root-ca-hook-serviceaccount.yaml
@@ -1,0 +1,24 @@
+{{- /*
+ServiceAccount for pre-install/pre-upgrade/pre-delete hook jobs that manage
+the three crossplane TLS Secrets. Separate from the main crossplane SA to keep
+RBAC minimal.
+
+This is a Helm hook resource (pre-install,pre-upgrade,pre-delete) so it is
+applied BEFORE the hook jobs that reference it. The hook-weight is set lower
+than the jobs' weights (-10 vs -5/0) to guarantee ordering.
+*/ -}}
+{{- if .Values.rootCA.manageLifecycle }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "crossplane.name" . }}-root-ca-hook
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "crossplane.name" . }}
+    {{- include "crossplane.labels" . | indent 4 }}
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade,pre-delete
+    "helm.sh/hook-weight": "-10"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+automountServiceAccountToken: true
+{{- end }}

--- a/cluster/charts/crossplane/templates/secret.yaml
+++ b/cluster/charts/crossplane/templates/secret.yaml
@@ -1,18 +1,53 @@
+{{- if not .Values.rootCA.manageLifecycle }}
 {{- /*
-NOTE: the three Crossplane TLS Secrets (crossplane-root-ca, crossplane-tls-server,
-crossplane-tls-client) are intentionally NOT declared in this chart.
+When `rootCA.manageLifecycle` is false, fall back to the upstream behavior of
+having the chart declaratively create the three Crossplane TLS Secrets as
+empty placeholders. The init container will populate them on first pod start.
 
-They are created on first install by a pre-install/pre-upgrade Helm hook job
-(templates/root-ca-bootstrap-job.yaml) and preserved across upgrades so that
-mTLS trust for installed provider/function packages is not broken on every
-`helm upgrade`. See also templates/root-ca-cleanup-job.yaml for uninstall
-cleanup.
-
-Background: the init container inside the crossplane pod is responsible for
-generating the actual certificates and populating these Secrets. If the chart
-declaratively creates them as empty placeholders, `helm upgrade` reapplies the
-empty declaration. The init container's loadOrGenerateCA logic would normally
-avoid overwriting non-empty data, but declarative ownership makes the cluster
-state drift from the desired Helm state and gives no clean way to avoid
-leaking Secrets on uninstall.
+NOTE: this fallback re-introduces the bug fixed by the hook-job approach:
+`helm upgrade` reapplies the (empty) declarations on every release, and the
+init container's loadOrGenerateCA logic can rotate the CA under some
+conditions, breaking mTLS to installed provider/function packages. Prefer
+leaving `rootCA.manageLifecycle` at its default value of `true` whenever
+possible.
 */ -}}
+---
+# The reason this is created empty and filled by the init container is we want
+# to manage the lifecycle of the secret via Helm. This way whenever Crossplane
+# is deleted, the secret is deleted as well.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: crossplane-root-ca
+  namespace: {{ .Release.Namespace }}
+  {{- with .Values.secrets.customAnnotations }}
+  annotations: {{ toYaml . | nindent 4 }}
+  {{- end }}
+type: Opaque
+---
+# The reason this is created empty and filled by the init container is we want
+# to manage the lifecycle of the secret via Helm. This way whenever Crossplane
+# is deleted, the secret is deleted as well.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: crossplane-tls-server
+  namespace: {{ .Release.Namespace }}
+  {{- with .Values.secrets.customAnnotations }}
+  annotations: {{ toYaml . | nindent 4 }}
+  {{- end }}
+type: Opaque
+---
+# The reason this is created empty and filled by the init container is we want
+# to manage the lifecycle of the secret via Helm. This way whenever Crossplane
+# is deleted, the secret is deleted as well.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: crossplane-tls-client
+  namespace: {{ .Release.Namespace }}
+  {{- with .Values.secrets.customAnnotations }}
+  annotations: {{ toYaml . | nindent 4 }}
+  {{- end }}
+type: Opaque
+{{- end }}

--- a/cluster/charts/crossplane/templates/secret.yaml
+++ b/cluster/charts/crossplane/templates/secret.yaml
@@ -1,39 +1,18 @@
----
-# The reason this is created empty and filled by the init container is we want
-# to manage the lifecycle of the secret via Helm. This way whenever Crossplane
-# is deleted, the secret is deleted as well.
-apiVersion: v1
-kind: Secret
-metadata:
-  name: crossplane-root-ca
-  namespace: {{ .Release.Namespace }}
-  {{- with .Values.secrets.customAnnotations }}
-  annotations: {{ toYaml . | nindent 4 }}
-  {{- end }}
-type: Opaque
----
-# The reason this is created empty and filled by the init container is we want
-# to manage the lifecycle of the secret via Helm. This way whenever Crossplane
-# is deleted, the secret is deleted as well.
-apiVersion: v1
-kind: Secret
-metadata:
-  name: crossplane-tls-server
-  namespace: {{ .Release.Namespace }}
-  {{- with .Values.secrets.customAnnotations }}
-  annotations: {{ toYaml . | nindent 4 }}
-  {{- end }}
-type: Opaque
----
-# The reason this is created empty and filled by the init container is we want
-# to manage the lifecycle of the secret via Helm. This way whenever Crossplane
-# is deleted, the secret is deleted as well.
-apiVersion: v1
-kind: Secret
-metadata:
-  name: crossplane-tls-client
-  namespace: {{ .Release.Namespace }}
-  {{- with .Values.secrets.customAnnotations }}
-  annotations: {{ toYaml . | nindent 4 }}
-  {{- end }}
-type: Opaque
+{{- /*
+NOTE: the three Crossplane TLS Secrets (crossplane-root-ca, crossplane-tls-server,
+crossplane-tls-client) are intentionally NOT declared in this chart.
+
+They are created on first install by a pre-install/pre-upgrade Helm hook job
+(templates/root-ca-bootstrap-job.yaml) and preserved across upgrades so that
+mTLS trust for installed provider/function packages is not broken on every
+`helm upgrade`. See also templates/root-ca-cleanup-job.yaml for uninstall
+cleanup.
+
+Background: the init container inside the crossplane pod is responsible for
+generating the actual certificates and populating these Secrets. If the chart
+declaratively creates them as empty placeholders, `helm upgrade` reapplies the
+empty declaration. The init container's loadOrGenerateCA logic would normally
+avoid overwriting non-empty data, but declarative ownership makes the cluster
+state drift from the desired Helm state and gives no clean way to avoid
+leaking Secrets on uninstall.
+*/ -}}

--- a/cluster/charts/crossplane/values.yaml
+++ b/cluster/charts/crossplane/values.yaml
@@ -86,8 +86,28 @@ rootCA:
     image:
       # -- Container image for the hook job. Must contain a `kubectl` binary.
       repository: registry.k8s.io/kubernetes/kubectl
-      # -- Tag for the hook job container image.
+      # -- Tag for the hook job container image. Should be a kubectl version compatible with the Kubernetes server (see `kubeVersion` in Chart.yaml).
       tag: v1.31.1
+    # -- Resource requests and limits for the hook job container.
+    resources:
+      requests:
+        # -- CPU request for the hook job container.
+        cpu: 10m
+        # -- Memory request for the hook job container.
+        memory: 32Mi
+      limits:
+        # -- CPU limit for the hook job container.
+        cpu: 100m
+        # -- Memory limit for the hook job container.
+        memory: 64Mi
+    # -- Security context for the hook job container. Hardened defaults: non-root, no privilege escalation, read-only root filesystem.
+    securityContext:
+      # -- Run as non-root user. The kubectl image runs as user 65532 by default.
+      runAsNonRoot: true
+      # -- Disable privilege escalation.
+      allowPrivilegeEscalation: false
+      # -- Mount root filesystem as read-only.
+      readOnlyRootFilesystem: true
 
 service:
   # -- Configure annotations on the service object. Only enabled when webhooks.enabled = true

--- a/cluster/charts/crossplane/values.yaml
+++ b/cluster/charts/crossplane/values.yaml
@@ -78,19 +78,10 @@ registryCaBundleConfig:
   key: ""
 
 rootCA:
-  # -- Manage the lifecycle of the crossplane-root-ca, crossplane-tls-server, and
-  # -- crossplane-tls-client Secrets via Helm hook jobs. When true (default), a
-  # -- pre-install/pre-upgrade hook creates the Secrets only if missing (so
-  # -- existing CAs and per-pod TLS material survive upgrades), and a pre-delete
-  # -- hook removes them on `helm uninstall`. Set to false to fall back to the
-  # -- upstream behavior of having Helm manage the Secrets directly, which will
-  # -- rotate the CA and per-pod TLS material on every upgrade and break mTLS
-  # -- with installed provider/function packages.
+  # -- Manage the lifecycle of the crossplane-root-ca, crossplane-tls-server, and crossplane-tls-client Secrets via Helm hook jobs. When true (default), a pre-install/pre-upgrade hook creates the Secrets only if missing (so existing CAs and per-pod TLS material survive upgrades), and a pre-delete hook removes them on `helm uninstall`. Set to false to fall back to the upstream behavior of having Helm manage the Secrets directly, which will rotate the CA and per-pod TLS material on every upgrade and break mTLS with installed provider/function packages.
   manageLifecycle: true
   bootstrap:
-    # -- Enable the pre-install/pre-upgrade hook job that creates the three
-    # -- crossplane TLS Secrets on first install and preserves them on
-    # -- subsequent upgrades. Has no effect when `rootCA.manageLifecycle` is false.
+    # -- Enable the pre-install/pre-upgrade hook job that creates the three crossplane TLS Secrets on first install and preserves them on subsequent upgrades. Has no effect when `rootCA.manageLifecycle` is false.
     enabled: true
     image:
       # -- Container image for the hook job. Must contain a `kubectl` binary.

--- a/cluster/charts/crossplane/values.yaml
+++ b/cluster/charts/crossplane/values.yaml
@@ -77,6 +77,27 @@ registryCaBundleConfig:
   # -- The ConfigMap key containing a custom CA bundle to enable fetching packages from registries with unknown or untrusted certificates.
   key: ""
 
+rootCA:
+  # -- Manage the lifecycle of the crossplane-root-ca, crossplane-tls-server, and
+  # -- crossplane-tls-client Secrets via Helm hook jobs. When true (default), a
+  # -- pre-install/pre-upgrade hook creates the Secrets only if missing (so
+  # -- existing CAs and per-pod TLS material survive upgrades), and a pre-delete
+  # -- hook removes them on `helm uninstall`. Set to false to fall back to the
+  # -- upstream behavior of having Helm manage the Secrets directly, which will
+  # -- rotate the CA and per-pod TLS material on every upgrade and break mTLS
+  # -- with installed provider/function packages.
+  manageLifecycle: true
+  bootstrap:
+    # -- Enable the pre-install/pre-upgrade hook job that creates the three
+    # -- crossplane TLS Secrets on first install and preserves them on
+    # -- subsequent upgrades. Has no effect when `rootCA.manageLifecycle` is false.
+    enabled: true
+    image:
+      # -- Container image for the hook job. Must contain a `kubectl` binary.
+      repository: registry.k8s.io/kubernetes/kubectl
+      # -- Tag for the hook job container image.
+      tag: v1.31.1
+
 service:
   # -- Configure annotations on the service object. Only enabled when webhooks.enabled = true
   customAnnotations: {}


### PR DESCRIPTION
### Description of your changes

The chart currently declaratively creates the three crossplane TLS Secrets (crossplane-root-ca, crossplane-tls-server, crossplane-tls-client) as empty placeholders and lets the crossplane init container fill them on first pod start. This works for the very first install, but every subsequent 'helm upgrade' reapplies the (empty) declarations, and although the init container's loadOrGenerateCA logic would normally avoid overwriting non-empty data, declarative ownership of the Secrets means there is no clean way to keep them across upgrades without leaving them dangling on uninstall.

Practically, this manifests as the crossplane-root-ca Secret being treated as a new resource on every 'helm upgrade', with the crossplane pod rolling out, the init container observing whatever state is on disk, and the existing TLS trust chain between crossplane and installed provider/function packages breaking. Users see composition pipelines fail with errors like:

  transport: authentication handshake failed: tls: failed to verify
  certificate: x509: certificate signed by unknown authority 'Crossplane'

This is especially painful for GitOps users (Flux, Argo CD), where reconciliation is continuous and the breakage is triggered by anything that bumps the chart version or changes a value.

This change removes the declarative Secret resources and replaces them with two Helm hook jobs plus minimal RBAC:

  - root-ca-bootstrap-job (pre-install,pre-upgrade): for each of the three Secrets, create it only if it does not already exist. On first install this puts the placeholders in place for the init container to populate; on every subsequent upgrade the Secrets already exist and the hook is a no-op, so the existing CA and per-pod TLS material are preserved untouched.

  - root-ca-cleanup-job (pre-delete): delete the three Secrets when 'helm uninstall' is invoked, so uninstall cleanly removes the trust anchors alongside the rest of the release.

  - root-ca-hook-{serviceaccount,role,rolebinding} (hook-weight: -10): namespace-scoped RBAC for the hook jobs, with secrets get/list/ create/delete. The hook-weight is set lower than the jobs' weights so the RBAC is guaranteed to be in place before the jobs run.

A new 'rootCA' values block exposes 'manageLifecycle' (default true) and 'rootCA.bootstrap.{enabled,image}' so users can opt out of the new behaviour and point the hook job at a private registry if needed.

Refs crossplane/crossplane#5456
Refs crossplane/crossplane#5329

Fixes #7480
<!--
Thank you for helping to improve Crossplane! Please read the contribution docs
(linked below) if this is your first Crossplane pull request.
-->



<!--
Briefly describe what this pull request does, and how it is covered by tests.
Be proactive - direct your reviewers' attention to anything that needs special
consideration.

We love pull requests that fix an open issue. If yours does, use the below line
to indicate which issue it fixes, for example "Fixes #500".
-->

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [ ] Run `./nix.sh flake check` to ensure this PR is ready for review.
- [ ] Added or updated unit tests.
- [ ] Added or updated e2e tests.
- [ ] Linked a PR or a [docs tracking issue] to [document this change].
- [ ] Added `backport release-x.y` labels to auto-backport this PR.
- [ ] Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md
