### PR TITLE
ci(renovate): disable the per-hour PR creation throttle

### DIFF
--- a/.github/renovate-base.json5
+++ b/.github/renovate-base.json5
@@ -10,6 +10,10 @@
   rebaseWhen: 'conflicted',
   // The maximum number of PRs to be created in parallel
   prConcurrentLimit: 5,
+  // Disable the default 2 per hour PR creation limit. prConcurrentLimit already caps how many PRs
+  // can be open at once and our renovate job runs on a daily schedule, so having any hourly
+  // throttling can actually slow us down.
+  prHourlyLimit: 0,
   // The branches renovate should target
   // PLEASE UPDATE THIS WHEN RELEASING.
   baseBranches: [


### PR DESCRIPTION
### Description of your changes

This PR sets Renovate's `prHourlyLimit` to `0`, disabling the default cap of 2 PRs created per hour.

Renovate docs entry for this field: https://docs.renovatebot.com/configuration-options/#prhourlylimit 

`prConcurrentLimit` (5) already bounds how many Renovate PRs stay open at once, and our Renovate job runs on a once-daily schedule, so we are already protected that way. This hourly limit seemingly just slows us down, possibly limiting us to only 2 PRs per day (the one hour where our job runs once per day).

Note that Security PRs already bypass both limits, so this only affects regular updates.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] ~~Run `./nix.sh flake check` to ensure this PR is ready for review.~~ Renovate config-only change; the Renovate config validation workflow covers it.
- [ ] ~~Added or updated unit tests.~~ Config-only change.
- [ ] ~~Added or updated e2e tests.~~ Config-only change.
- [ ] ~~Linked a PR or a [docs tracking issue] to [document this change].~~ Internal CI tooling, not user-facing.
- [ ] ~~Added `backport release-x.y` labels to auto-backport this PR.~~ Renovate reads this config from `main` for all base branches; no per-branch backport needed.
- [ ] ~~Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~~ No API change.

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md
