### PR TITLE
use unambiguous separator for usage index key

### DIFF
--- a/internal/protection/usage/finder.go
+++ b/internal/protection/usage/finder.go
@@ -53,7 +53,12 @@ func indexVal(apiVersion, kind, name, namespace string) string {
 	// ignore the error is that the IndexerFunc using this value to index the
 	// objects does not return an error, so we cannot bubble up the error here.
 	gr, _ := schema.ParseGroupVersion(apiVersion)
-	return fmt.Sprintf("%s.%s.%s.%s", gr.Group, kind, name, namespace)
+	// Join with '/' rather than '.'. API groups and resource names may both
+	// contain '.', so a '.'-joined key is ambiguous and distinct resources can
+	// collapse to the same value (e.g. group "example.org"/name "bar" and group
+	// "example"/name "Foo.bar"). '/' cannot appear in a group, kind, name, or
+	// namespace, so it keeps each resource's key unique.
+	return fmt.Sprintf("%s/%s/%s/%s", gr.Group, kind, name, namespace)
 }
 
 // A Finder finds all usages of a resource. It supports all known types of usage

--- a/internal/protection/usage/finder_test.go
+++ b/internal/protection/usage/finder_test.go
@@ -196,19 +196,37 @@ func TestIndexVal(t *testing.T) {
 		namespace  string
 	}
 
-	// Two resources that are clearly distinct, but whose group and name place
-	// the '.' boundary differently. With a '.'-joined key they collapse to the
-	// same value, which makes the usage finder associate one resource with the
-	// other's Usages.
-	a := args{apiVersion: "example.org/v1", kind: "Foo", name: "bar", namespace: "x"}
-	b := args{apiVersion: "example/v1", kind: "org", name: "Foo.bar", namespace: "x"}
-
-	got := map[string]bool{}
-	for _, in := range []args{a, b} {
-		got[indexVal(in.apiVersion, in.kind, in.name, in.namespace)] = true
+	type want struct {
+		key string
 	}
 
-	if len(got) != 2 {
-		t.Errorf("indexVal(...): distinct resources produced colliding keys: %v", got)
+	// The two cases below are distinct resources whose group and name place the
+	// '.' boundary differently. With a '.'-joined key they collapse to the same
+	// value, which makes the usage finder associate one resource with the
+	// other's Usages. The '/' separator keeps them distinct.
+	cases := map[string]struct {
+		reason string
+		args   args
+		want   want
+	}{
+		"GroupContainsDot": {
+			reason: "A '.' in the API group should not bleed into the following key segments.",
+			args:   args{apiVersion: "example.org/v1", kind: "Foo", name: "bar", namespace: "x"},
+			want:   want{key: "example.org/Foo/bar/x"},
+		},
+		"NameContainsDot": {
+			reason: "A '.' in the name should not collide with a group that contains a '.'.",
+			args:   args{apiVersion: "example/v1", kind: "org", name: "Foo.bar", namespace: "x"},
+			want:   want{key: "example/org/Foo.bar/x"},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got := indexVal(tc.args.apiVersion, tc.args.kind, tc.args.name, tc.args.namespace)
+			if diff := cmp.Diff(tc.want.key, got); diff != "" {
+				t.Errorf("%s\nindexVal(...): -want key, +got key:\n%s", tc.reason, diff)
+			}
+		})
 	}
 }

--- a/internal/protection/usage/finder_test.go
+++ b/internal/protection/usage/finder_test.go
@@ -187,3 +187,28 @@ func TestFindUsageOf(t *testing.T) {
 		})
 	}
 }
+
+func TestIndexVal(t *testing.T) {
+	type args struct {
+		apiVersion string
+		kind       string
+		name       string
+		namespace  string
+	}
+
+	// Two resources that are clearly distinct, but whose group and name place
+	// the '.' boundary differently. With a '.'-joined key they collapse to the
+	// same value, which makes the usage finder associate one resource with the
+	// other's Usages.
+	a := args{apiVersion: "example.org/v1", kind: "Foo", name: "bar", namespace: "x"}
+	b := args{apiVersion: "example/v1", kind: "org", name: "Foo.bar", namespace: "x"}
+
+	got := map[string]bool{}
+	for _, in := range []args{a, b} {
+		got[indexVal(in.apiVersion, in.kind, in.name, in.namespace)] = true
+	}
+
+	if len(got) != 2 {
+		t.Errorf("indexVal(...): distinct resources produced colliding keys: %v", got)
+	}
+}


### PR DESCRIPTION
### Description of your changes

1. indexVal builds the deletion-protection field index key by joining group, kind, name, and namespace with '.', but API groups and resource names can both contain '.', so the key is ambiguous and two distinct resources can collapse to the same value (e.g. group "example.org"/name "bar" and group "example"/name "Foo.bar").
2. FindUsageOf and the Usage/ClusterUsage/legacy indexers all use that key to match a resource to the Usages protecting it, so a collision makes the webhook associate a resource with another resource's Usages and block a deletion that should be allowed.

Switched the separator to '/', which can't appear in a group, kind, name, or namespace. Added a regression test covering the colliding pair (it fails on the old separator and passes on the new one).

I have:

- [x] Read and followed Crossplane's [contribution process].
- [ ] ~Run `./nix.sh flake check` to ensure this PR is ready for review.~
- [x] Added or updated unit tests.
- [ ] ~Added or updated e2e tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~
- [ ] ~Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md