### PR TITLE
fix(pkg/manager): wire poll interval into package manager reconcilers

### DIFF
--- a/cmd/crossplane/core/core.go
+++ b/cmd/crossplane/core/core.go
@@ -114,6 +114,7 @@ type startCommand struct {
 	MinPollInterval                  time.Duration `default:"1s"                 help:"Minimum per-resource poll interval allowed via the crossplane.io/poll-interval annotation."`
 	MaxConcurrentReconciles          int           `aliases:"max-reconcile-rate" default:"100"                                                                                            help:"The maximum number of concurrent reconcile operations (worker pool size)."`
 	MaxConcurrentPackageEstablishers int           `default:"10"                 help:"The maximum number of goroutines to use for establishing Providers, Configurations and Functions."`
+	PackagePollInterval              time.Duration `default:"1m"                 help:"How often packages with PullPolicy Always are re-checked for updated content in the registry. Distinct from --poll-interval (drift detection) to avoid coupling drift checks to expensive registry re-pulls."`
 
 	CircuitBreakerBurst      float64       `default:"100.0" help:"XR circuit breaker token bucket capacity."`
 	CircuitBreakerRefillRate float64       `default:"1.0"   help:"XR circuit breaker token refill rate (tokens/second)."`
@@ -637,6 +638,7 @@ func (c *startCommand) Run(s *runtime.Scheme, log logging.Logger) error { //noli
 		ServiceAccount:                   c.ServiceAccount,
 		PackageRuntime:                   pr,
 		MaxConcurrentPackageEstablishers: c.MaxConcurrentPackageEstablishers,
+		PackagePollInterval:              c.PackagePollInterval,
 	}
 
 	if err := pkg.Setup(mgr, po); err != nil {

--- a/internal/controller/pkg/controller/options.go
+++ b/internal/controller/pkg/controller/options.go
@@ -18,6 +18,8 @@ limitations under the License.
 package controller
 
 import (
+	"time"
+
 	"github.com/crossplane/crossplane-runtime/v2/pkg/controller"
 	"github.com/crossplane/crossplane-runtime/v2/pkg/xpkg"
 )
@@ -41,4 +43,11 @@ type Options struct {
 	// MaxConcurrentPackageEstablishers is the maximum number of goroutines to use
 	// for establishing Providers, Configurations and Functions.
 	MaxConcurrentPackageEstablishers int
+
+	// PackagePollInterval is how often the package manager reconciler requeues
+	// packages with PullPolicy Always to check for updated content. This is
+	// separate from PollInterval (drift detection) because registry re-pulls are
+	// a full fetch+parse+verify cycle and should not be coupled to the general
+	// poll knob. Defaults to 1m.
+	PackagePollInterval time.Duration
 }

--- a/internal/controller/pkg/manager/reconciler.go
+++ b/internal/controller/pkg/manager/reconciler.go
@@ -48,21 +48,12 @@ import (
 const (
 	reconcileTimeout = 1 * time.Minute
 
-	// pullWait is the time after which the package manager will check for
-	// updated content for the given package reference. This behavior is only
-	// enabled when the packagePullPolicy is Always.
-	pullWait = 1 * time.Minute
+	// defaultPullWait is the fallback requeue interval for packages with
+	// PullPolicy Always when no poll interval is configured.
+	defaultPullWait = 1 * time.Minute
 
 	reconcilePausedMsg = "Reconciliation (including deletion) is paused via the pause annotation"
 )
-
-func pullBasedRequeue(p *corev1.PullPolicy) reconcile.Result {
-	if p != nil && *p == corev1.PullAlways {
-		return reconcile.Result{RequeueAfter: pullWait}
-	}
-
-	return reconcile.Result{Requeue: false}
-}
 
 const (
 	errGetPackage           = "cannot get package"
@@ -130,6 +121,14 @@ func WithRecorder(er event.Recorder) ReconcilerOption {
 	}
 }
 
+// WithPollInterval specifies how long the Reconciler should wait before
+// requeueing a package with PullPolicy Always to check for updated content.
+func WithPollInterval(interval time.Duration) ReconcilerOption {
+	return func(r *Reconciler) {
+		r.pollInterval = interval
+	}
+}
+
 // WithManagingRevisionRuntimeSpec will allow this reconciler to propagate the
 // runtime spec fields to revisions.
 func WithManagingRevisionRuntimeSpec() ReconcilerOption {
@@ -149,11 +148,12 @@ func WithManagingRevisionRuntimeSpec() ReconcilerOption {
 
 // Reconciler reconciles packages.
 type Reconciler struct {
-	kube       resource.ClientApplicator
-	pkg        xpkg.Client
-	log        logging.Logger
-	record     event.Recorder
-	conditions conditions.Manager
+	kube         resource.ClientApplicator
+	pkg          xpkg.Client
+	log          logging.Logger
+	record       event.Recorder
+	conditions   conditions.Manager
+	pollInterval time.Duration
 
 	setPackageRuntimeManagedFields func(p v1.Package, pr v1.PackageRevision)
 
@@ -177,6 +177,7 @@ func SetupProvider(mgr ctrl.Manager, o controller.Options) error {
 		WithClient(o.Client),
 		WithLogger(log),
 		WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name), o.EventFilterFunctions...)),
+		WithPollInterval(o.PollInterval),
 	}
 
 	if o.PackageRuntime.For(v1.ProviderKind) == controller.PackageRuntimeDeployment {
@@ -207,6 +208,7 @@ func SetupConfiguration(mgr ctrl.Manager, o controller.Options) error {
 		WithClient(o.Client),
 		WithLogger(log),
 		WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name), o.EventFilterFunctions...)),
+		WithPollInterval(o.PollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).
@@ -233,6 +235,7 @@ func SetupFunction(mgr ctrl.Manager, o controller.Options) error {
 		WithClient(o.Client),
 		WithLogger(log),
 		WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name), o.EventFilterFunctions...)),
+		WithPollInterval(o.PollInterval),
 	}
 
 	if o.PackageRuntime.For(v1.FunctionKind) == controller.PackageRuntimeDeployment {
@@ -255,9 +258,10 @@ func NewReconciler(mgr ctrl.Manager, opts ...ReconcilerOption) *Reconciler {
 			Client:     mgr.GetClient(),
 			Applicator: resource.NewAPIPatchingApplicator(mgr.GetClient()),
 		},
-		log:        logging.NewNopLogger(),
-		record:     event.NewNopRecorder(),
-		conditions: conditions.ObservedGenerationPropagationManager{},
+		log:          logging.NewNopLogger(),
+		record:       event.NewNopRecorder(),
+		conditions:   conditions.ObservedGenerationPropagationManager{},
+		pollInterval: defaultPullWait,
 	}
 
 	for _, f := range opts {
@@ -265,6 +269,21 @@ func NewReconciler(mgr ctrl.Manager, opts ...ReconcilerOption) *Reconciler {
 	}
 
 	return r
+}
+
+// pullBasedRequeue returns a reconcile result that requeues after the
+// configured poll interval for packages with PullPolicy Always, so that
+// Crossplane checks for updated package content on the configured schedule.
+func (r *Reconciler) pullBasedRequeue(p *corev1.PullPolicy) reconcile.Result {
+	if p != nil && *p == corev1.PullAlways {
+		interval := r.pollInterval
+		if interval <= 0 {
+			interval = defaultPullWait
+		}
+		return reconcile.Result{RequeueAfter: interval}
+	}
+
+	return reconcile.Result{Requeue: false}
 }
 
 // Reconcile package.
@@ -499,5 +518,5 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 	// package, the health of the package is not set until the revision reports
 	// its health. If updating from an existing revision, the package health
 	// will match the health of the old revision until the next reconcile.
-	return pullBasedRequeue(p.GetPackagePullPolicy()), errors.Wrap(r.kube.Status().Update(ctx, p), errUpdateStatus)
+	return r.pullBasedRequeue(p.GetPackagePullPolicy()), errors.Wrap(r.kube.Status().Update(ctx, p), errUpdateStatus)
 }

--- a/internal/controller/pkg/manager/reconciler.go
+++ b/internal/controller/pkg/manager/reconciler.go
@@ -48,9 +48,11 @@ import (
 const (
 	reconcileTimeout = 1 * time.Minute
 
-	// defaultPullWait is the fallback requeue interval for packages with
-	// PullPolicy Always when no poll interval is configured.
-	defaultPullWait = 1 * time.Minute
+	// defaultPackagePollInterval is the fallback requeue interval for packages
+	// with PullPolicy Always when no package-specific poll interval is
+	// configured. Kept at 1m to preserve the deliberate floor from
+	// https://github.com/crossplane/crossplane/pull/3581.
+	defaultPackagePollInterval = 1 * time.Minute
 
 	reconcilePausedMsg = "Reconciliation (including deletion) is paused via the pause annotation"
 )
@@ -177,7 +179,7 @@ func SetupProvider(mgr ctrl.Manager, o controller.Options) error {
 		WithClient(o.Client),
 		WithLogger(log),
 		WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name), o.EventFilterFunctions...)),
-		WithPollInterval(o.PollInterval),
+		WithPollInterval(o.PackagePollInterval),
 	}
 
 	if o.PackageRuntime.For(v1.ProviderKind) == controller.PackageRuntimeDeployment {
@@ -208,7 +210,7 @@ func SetupConfiguration(mgr ctrl.Manager, o controller.Options) error {
 		WithClient(o.Client),
 		WithLogger(log),
 		WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name), o.EventFilterFunctions...)),
-		WithPollInterval(o.PollInterval),
+		WithPollInterval(o.PackagePollInterval),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).
@@ -235,7 +237,7 @@ func SetupFunction(mgr ctrl.Manager, o controller.Options) error {
 		WithClient(o.Client),
 		WithLogger(log),
 		WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name), o.EventFilterFunctions...)),
-		WithPollInterval(o.PollInterval),
+		WithPollInterval(o.PackagePollInterval),
 	}
 
 	if o.PackageRuntime.For(v1.FunctionKind) == controller.PackageRuntimeDeployment {
@@ -261,7 +263,7 @@ func NewReconciler(mgr ctrl.Manager, opts ...ReconcilerOption) *Reconciler {
 		log:          logging.NewNopLogger(),
 		record:       event.NewNopRecorder(),
 		conditions:   conditions.ObservedGenerationPropagationManager{},
-		pollInterval: defaultPullWait,
+		pollInterval: defaultPackagePollInterval,
 	}
 
 	for _, f := range opts {
@@ -278,7 +280,7 @@ func (r *Reconciler) pullBasedRequeue(p *corev1.PullPolicy) reconcile.Result {
 	if p != nil && *p == corev1.PullAlways {
 		interval := r.pollInterval
 		if interval <= 0 {
-			interval = defaultPullWait
+			interval = defaultPackagePollInterval
 		}
 		return reconcile.Result{RequeueAfter: interval}
 	}

--- a/internal/controller/pkg/manager/reconciler_test.go
+++ b/internal/controller/pkg/manager/reconciler_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"io"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	corev1 "k8s.io/api/core/v1"
@@ -275,13 +276,14 @@ func TestReconcile(t *testing.T) {
 			},
 		},
 		"SuccessfulNoExistingRevisionsAutoActivatePullAlways": {
-			reason: "We should be active and requeue after wait on successful creation of the first revision with auto activation and package pull policy Always.",
+			reason: "We should be active and requeue after the configured poll interval on successful creation of the first revision with auto activation and package pull policy Always.",
 			args: args{
 				req: reconcile.Request{NamespacedName: types.NamespacedName{Name: "test"}},
 				rec: &Reconciler{
 					newPackage:             func() v1.Package { return &v1.Configuration{} },
 					newPackageRevision:     func() v1.PackageRevision { return &v1.ConfigurationRevision{} },
 					newPackageRevisionList: func() v1.PackageRevisionList { return &v1.ConfigurationRevisionList{} },
+					pollInterval:           7 * time.Minute,
 					kube: resource.ClientApplicator{
 						Client: &test.MockClient{
 							MockGet: test.NewMockGetFn(nil, func(o client.Object) error {
@@ -328,7 +330,7 @@ func TestReconcile(t *testing.T) {
 				},
 			},
 			want: want{
-				r: reconcile.Result{RequeueAfter: pullWait},
+				r: reconcile.Result{RequeueAfter: 7 * time.Minute},
 			},
 		},
 		"SuccessfulNoExistingRevisionsManualActivate": {
@@ -981,6 +983,68 @@ func TestReconcile(t *testing.T) {
 
 			if diff := cmp.Diff(tc.want.r, got, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\nr.Reconcile(...): -want, +got:\n%s", tc.reason, diff)
+			}
+		})
+	}
+}
+
+func TestPullBasedRequeue(t *testing.T) {
+	pullAlways := corev1.PullAlways
+	pullIfNotPresent := corev1.PullIfNotPresent
+
+	type args struct {
+		r *Reconciler
+		p *corev1.PullPolicy
+	}
+
+	type want struct {
+		result reconcile.Result
+	}
+
+	cases := map[string]struct {
+		reason string
+		args   args
+		want   want
+	}{
+		"NilPolicyNoRequeue": {
+			reason: "A nil pull policy should not requeue.",
+			args: args{
+				r: &Reconciler{pollInterval: 5 * time.Minute},
+				p: nil,
+			},
+			want: want{result: reconcile.Result{Requeue: false}},
+		},
+		"PullIfNotPresentNoRequeue": {
+			reason: "PullIfNotPresent should not requeue.",
+			args: args{
+				r: &Reconciler{pollInterval: 5 * time.Minute},
+				p: &pullIfNotPresent,
+			},
+			want: want{result: reconcile.Result{Requeue: false}},
+		},
+		"PullAlwaysUsesConfiguredInterval": {
+			reason: "PullAlways should requeue after the configured poll interval.",
+			args: args{
+				r: &Reconciler{pollInterval: 5 * time.Minute},
+				p: &pullAlways,
+			},
+			want: want{result: reconcile.Result{RequeueAfter: 5 * time.Minute}},
+		},
+		"PullAlwaysZeroIntervalFallsBackToDefault": {
+			reason: "PullAlways with a zero poll interval should fall back to defaultPullWait.",
+			args: args{
+				r: &Reconciler{pollInterval: 0},
+				p: &pullAlways,
+			},
+			want: want{result: reconcile.Result{RequeueAfter: defaultPullWait}},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got := tc.args.r.pullBasedRequeue(tc.args.p)
+			if diff := cmp.Diff(tc.want.result, got); diff != "" {
+				t.Errorf("\n%s\nr.pullBasedRequeue(...): -want, +got:\n%s", tc.reason, diff)
 			}
 		})
 	}

--- a/internal/controller/pkg/manager/reconciler_test.go
+++ b/internal/controller/pkg/manager/reconciler_test.go
@@ -1031,12 +1031,12 @@ func TestPullBasedRequeue(t *testing.T) {
 			want: want{result: reconcile.Result{RequeueAfter: 5 * time.Minute}},
 		},
 		"PullAlwaysZeroIntervalFallsBackToDefault": {
-			reason: "PullAlways with a zero poll interval should fall back to defaultPullWait.",
+			reason: "PullAlways with a zero poll interval should fall back to defaultPackagePollInterval.",
 			args: args{
 				r: &Reconciler{pollInterval: 0},
 				p: &pullAlways,
 			},
-			want: want{result: reconcile.Result{RequeueAfter: defaultPullWait}},
+			want: want{result: reconcile.Result{RequeueAfter: defaultPackagePollInterval}},
 		},
 	}
 


### PR DESCRIPTION
### Description of your changes

Fixes #7245

The package manager controllers (Provider, Configuration, Function) used a
hardcoded 1-minute constant for requeueing packages with `PullPolicy Always`,
ignoring the `--poll-interval` flag passed to Crossplane.

This change wires `o.PollInterval` through to each package manager reconciler
via a new `WithPollInterval` option, so the requeue interval respects the
configured value. A zero-value fallback to `defaultPullWait` guards against
accidental disabling.

I have:
- [x] Read and followed [Crossplane's contribution process](https://git.io/fj2I9).
- [x] Run `./nix.sh flake check` to ensure this PR is ready for review.
- [x] Added or updated unit tests for my change.
- [ ] Added or updated e2e tests for my change (n/a — no new observable behaviour, existing e2e covers poll-interval wiring at a higher level).
- [ ] Linked a PR or a docs tracking issue to document this change (n/a — existing `--poll-interval` flag docs remain accurate).
- [ ] Added `backport release-x.y` labels to auto-backport this PR.
- [ ] Followed the [API promotion workflow](https://git.io/fjT2T) if this PR introduces, removes, or promotes an API.