### PR TITLE
Backport xpkg signature verification fix to release-2.2

### DIFF
--- a/internal/xpkg/client.go
+++ b/internal/xpkg/client.go
@@ -318,15 +318,21 @@ func (c *CachedClient) Get(ctx context.Context, ref string, opts ...GetOption) (
 	if err != nil {
 		return nil, errors.Wrap(err, "cannot get image verification config")
 	}
+	// Pin all subsequent registry interactions to the digest resolved by
+	// Head. Pulling by the original tag would let a registry that serves
+	// different content between Head and Fetch slip an unsigned image past
+	// the verifier (the verifier above attests `digest`, not whatever bytes
+	// the tag happens to resolve to a few milliseconds later).
+	digestRef := parsedResolvedRef.Context().Digest(digest)
+
 	if vc != nil {
-		ref := parsedResolvedRef.Context().Digest(digest)
-		if err := c.validator.Validate(ctx, ref, vc, secrets...); err != nil {
+		if err := c.validator.Validate(ctx, digestRef, vc, secrets...); err != nil {
 			return nil, errors.Wrap(err, "signature verification failed")
 		}
 		applied = append(applied, ImageConfig{Name: name, Reason: ImageConfigReasonVerify})
 	}
 
-	img, err := c.fetcher.Fetch(ctx, parsedResolvedRef, secrets...)
+	img, err := c.fetcher.Fetch(ctx, digestRef, secrets...)
 	if err != nil {
 		return nil, errors.Wrapf(err, "cannot fetch package %s", resolvedRef)
 	}


### PR DESCRIPTION
### Description of your changes

Manual backport of the fix for [GHSA-wfqx-gjrf-g28r](https://github.com/crossplane/crossplane/security/advisories/GHSA-wfqx-gjrf-g28r).

This code moved to crossplane-runtime during v2.3 development, but the fix applies cleanly to the pre-move copy in the release-2.2 branch.

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `./nix.sh flake check` to ensure this PR is ready for review.
~- [ ] Added or updated unit tests.~
~- [ ] Added or updated e2e tests.~
~- [ ] Linked a PR or a [docs tracking issue] to [document this change].~
~- [ ] Added `backport release-x.y` labels to auto-backport this PR.~
~- [ ] Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md
