### PR TITLE
test(e2e): fix flaky TestLegacyComposition teardown

### DIFF
--- a/test/e2e/apiextensions_compositions_legacy_test.go
+++ b/test/e2e/apiextensions_compositions_legacy_test.go
@@ -25,6 +25,8 @@ import (
 	"sigs.k8s.io/e2e-framework/pkg/features"
 	"sigs.k8s.io/e2e-framework/third_party/helm"
 
+	"github.com/crossplane/crossplane-runtime/v2/pkg/resource/unstructured/composed"
+
 	apiextensionsv1 "github.com/crossplane/crossplane/apis/v2/apiextensions/v1"
 	xpv2 "github.com/crossplane/crossplane/apis/v2/core/v2"
 	pkgv1 "github.com/crossplane/crossplane/apis/v2/pkg/v1"
@@ -64,6 +66,20 @@ func TestLegacyComposition(t *testing.T) {
 			WithTeardown("DeleteClaim", funcs.AllOf(
 				funcs.DeleteResourcesWithPropagationPolicy(manifests, "claim.yaml", metav1.DeletePropagationForeground),
 				funcs.ResourcesDeletedWithin(2*time.Minute, manifests, "claim.yaml"),
+
+				// The claim's composition composes a provider-nop
+				// managed resource. Deleting the claim deletes the XR,
+				// and thus its composed resources, with foreground
+				// deletion - but the managed resources can briefly
+				// outlive the claim. Wait for them to be gone while
+				// provider-nop is still running to remove their
+				// finalizers. Otherwise DeletePrerequisites tears down
+				// the provider first, leaving the managed resource (and
+				// its CRD) stuck terminating and blocking teardown.
+				funcs.ListedResourcesDeletedWithin(2*time.Minute, composed.NewList(composed.FromReferenceToList(v1.ObjectReference{
+					APIVersion: "nop.crossplane.io/v1alpha1",
+					Kind:       "NopResource",
+				}))),
 			)).
 			WithTeardown("DeletePrerequisites", funcs.AllOf(
 				funcs.DeleteResourcesWithPropagationPolicy(manifests, "setup/*.yaml", metav1.DeletePropagationForeground),


### PR DESCRIPTION
### Description of your changes

`TestLegacyComposition` flakes in its `DeletePrerequisites` teardown, timing out after 3 minutes with `resources not deleted: client rate limiter Wait returned an error ... context deadline`.

Root cause is a teardown ordering race. The claim composes a provider-nop managed resource (`NopResource.nop.crossplane.io`). `DeleteClaim` only waits for the claim object to disappear (~0.5s), but the composed managed resource briefly outlives it. `DeletePrerequisites` then deletes provider-nop while that managed resource is still terminating — with the provider gone, nothing removes the resource's finalizer, so its CRD gets stuck `Terminating: InstanceDeletionInProgress`, blocking foreground deletion of the owning ProviderRevision/Provider and stalling teardown until it times out. (The "client rate limiter" error is just the symptom of the deadline expiring mid-poll.)

This waits for the composed managed resources to be gone in `DeleteClaim`, while provider-nop is still running to remove their finalizers, before tearing down the prerequisites — the same approach already used in `install_test.go`.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `./nix.sh flake check` to ensure this PR is ready for review.
- [ ] ~Added or updated unit tests.~ (e2e-only change)
- [x] Added or updated e2e tests.
- [ ] ~Linked a PR or a docs tracking issue.~ (no docs impact)
- [ ] ~Added backport labels.~ (maintainer's call)
- [ ] ~Followed the API promotion workflow.~ (no API change)

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing