### PR TITLE
render: Set namespace on injected resource refs only for cluster-scoped XRs

### DIFF
--- a/internal/render/composite/render.go
+++ b/internal/render/composite/render.go
@@ -338,14 +338,17 @@ func InjectResourceRefs(xr *ucomposite.Unstructured, observed []kunstructured.Un
 		return
 	}
 
-	refs := make([]corev1.ObjectReference, 0, len(observed))
-	for _, o := range observed {
-		refs = append(refs, corev1.ObjectReference{
+	refs := make([]corev1.ObjectReference, len(observed))
+	for i, o := range observed {
+		refs[i] = corev1.ObjectReference{
 			APIVersion: o.GetAPIVersion(),
 			Kind:       o.GetKind(),
 			Name:       o.GetName(),
-			Namespace:  o.GetNamespace(),
-		})
+		}
+		// Only cluster-scoped XRs have namespaced resource refs.
+		if xr.GetNamespace() == "" {
+			refs[i].Namespace = o.GetNamespace()
+		}
 	}
 
 	xr.SetResourceReferences(refs)


### PR DESCRIPTION
### Description of your changes

Namespaced XRs can compose resources only in their own namespace, and as such their `resourceRefs` are local references without a namespace field. The composite reconciler is sensitive to this difference and sets the namespace in resource refs only for cluster-scoped XRs.

In render, we inject references to any provided observed resources before calling the function pipeline. Previously, we unconditionally set the namespace for each ref. Aside from being inaccurate to the real behavior, this causes problems for composition functions with strict schemas (e.g., the generated KCL bindings in control plane projects), since we have set a field that isn't part of the schema.

Use the same logic as the real reconciler when injecting resource references, setting the namespace only if the XR's namespace is empty (i.e., it's a cluster-scoped resource).

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `./nix.sh flake check` to ensure this PR is ready for review.
~- [ ] Added or updated unit tests.~
~- [ ] Added or updated e2e tests.~
~- [ ] Linked a PR or a [docs tracking issue] to [document this change].~
- [x] Added `backport release-x.y` labels to auto-backport this PR.
~- [ ] Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md
