### PR TITLE
docs: fix duplicated word in crossplane-v2 proposal

### DIFF
--- a/design/proposal-crossplane-v2.md
+++ b/design/proposal-crossplane-v2.md
@@ -750,7 +750,7 @@ need to be able to differentiate between the two by adding `apiVersion` and
 `kind` fields to the existing `spec.providerConfigRef` MR fields.
 
 When you create an MR without specifying a providerConfigRef, Crossplane
-defaults the the `providerConfigRef` to a ProviderConfig named `default`.
+defaults the `providerConfigRef` to a ProviderConfig named `default`.
 
 I propose that in v2 MRs default to a ClusterProviderConfig named `default`.
 This is due to the bootstrapping issue. It's easier to create a default


### PR DESCRIPTION
### Description of your changes

The v2 design proposal read "defaults the the `providerConfigRef`" — removed the duplicated "the". Proposal/docs-only wording fix, no functional change.

Fixes # (n/a — trivial docs typo)

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `earthly +reviewable` to ensure this PR is ready for review. (n/a — single-word docs typo, no code)
- [x] Added or updated unit tests. (n/a — docs-only)
- [x] Added or updated e2e tests. (n/a — docs-only)
- [x] Linked a PR or a [docs tracking issue] to [document this change]. (n/a — typo fix, no behavior change)
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary. (n/a — not needed)
