### PR TITLE
[release-1.20] bump Go to 1.25.11 [security]

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -3,7 +3,7 @@ VERSION --try --raw-output 0.8
 
 PROJECT crossplane/crossplane
 
-ARG --global GO_VERSION=1.25.10
+ARG --global GO_VERSION=1.25.11
 
 # reviewable checks that a branch is ready for review. Run it before opening a
 # pull request. It will catch a lot of the things our CI workflow will catch.

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/crossplane/crossplane
 
-go 1.25.10
+go 1.25.11
 
 require (
 	dario.cat/mergo v1.0.1


### PR DESCRIPTION
## Description

Bumps the Go toolchain to **1.25.11**, the latest Go 1.25 security patch.
Changes `GO_VERSION` in the `Earthfile` and the `go` directive in `go.mod`
(1.25.10 → 1.25.11). Pure version bump — no code changes.

Go 1.25.11 standard-library security fixes:

| CVE | Package | Issue |
|---|---|---|
| CVE-2026-27145 | crypto/x509 | Quadratic-time hostname verification with large DNS SAN lists (DoS) |
| CVE-2026-42504 | mime | Malicious MIME header with many invalid encoded-words → excessive CPU |
| CVE-2026-42507 | net/textproto | Unescaped user-controlled input in error messages |

## Note: cosign bump deferred

This PR originally also bumped `github.com/sigstore/cosign/v2` 2.2.4 → 2.6.2
(CVE-2026-22703, Medium). **That commit was dropped.** On this branch the
cosign bump transitively force-upgrades `k8s.io/*` 0.31 → 0.34 and
`sigs.k8s.io/structured-merge-diff` v4 → v6, which breaks composition patch
behavior (`TestPatchApply`) and `check-diff`. Remediating CVE-2026-22703
properly requires a coordinated Kubernetes API upgrade that is out of scope
for a security backport, so **CVE-2026-22703 remains unaddressed on
release-1.20** for now and will be tracked separately.

## Not addressed

`github.com/docker/docker` (CVE-2026-34040) — there is no consumable `v29` Go
module (moby split the client into `github.com/moby/moby/client` at v29), so
remediation requires a code migration rather than a dependency bump.

## Testing

- `go build ./...` — passes
- `go vet ./...` — passes
- Only `go.mod` (`go` directive) and the `Earthfile` toolchain arg changed.

I have: <!-- You MUST either [x] check or [ ] ~~strike through~~ every item. -->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `./nix.sh flake check` to ensure this PR is ready for review.
- [ ] ~~Added or updated unit tests.~~
- [ ] ~~Added or updated e2e tests.~~
- [ ] ~~Linked a PR or a [docs tracking issue] to [document this change].~~
- [ ] ~~Added `backport release-x.y` labels to auto-backport this PR.~~
- [ ] ~~Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~~

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md
