### PR TITLE
[release-2.2] bump Go to 1.25.11 [security]

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -58,11 +58,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1778869304,
-        "narHash": "sha256-30sZNZoA1cqF5JNO9fVX+wgiQYjB7HJqqJ4ztCDeBZE=",
+        "lastModified": 1781607440,
+        "narHash": "sha256-rxO+uc/KFbSJp+pgyXRuAX6QlG9hJdnt0BXpEQRXY+U=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d233902339c02a9c334e7e593de68855ad26c4cb",
+        "rev": "3e41b24abd260e8f71dbe2f5737d24122f972158",
         "type": "github"
       },
       "original": {

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/crossplane/crossplane/v2
 
-go 1.25.10
+go 1.25.11
 
 require (
 	dario.cat/mergo v1.0.2


### PR DESCRIPTION
## Description

Bumps the Go toolchain used by the reproducible nix build to **1.25.11**, the
latest Go 1.25 security patch.

- `go.mod`: `go` directive 1.25.10 → 1.25.11.
- `flake.lock`: bumps the `nixpkgs-unstable` input. The build Go is sourced
  from `nixpkgs-unstable` (via the `go-unstable` overlay in `flake.nix`,
  `pkgs.unstable.go_1_25`), used by the release binary/image builds and dev
  tooling. The new pin provides `go_1_25 = 1.25.11` (confirmed via
  `nix develop --command go version` → `go1.25.11`).

Go 1.25.11 standard-library security fixes:

| CVE | Package | Issue |
|---|---|---|
| CVE-2026-27145 | crypto/x509 | Quadratic-time hostname verification with large DNS SAN lists (DoS) |
| CVE-2026-42504 | mime | Malicious MIME header with many invalid encoded-words → excessive CPU |
| CVE-2026-42507 | net/textproto | Unescaped user-controlled input in error messages |

## Not addressed

`github.com/docker/docker` (CVE-2026-34040) is **not** addressed here: there
is no consumable `v29` Go module to bump to (moby split the client into
`github.com/moby/moby/client` at v29), so remediation requires a code
migration rather than a dependency bump.

## Testing

- `nix run .#tidy` — clean (no `gomod2nix.toml` changes resulted)
- `go build ./...` — passes
- Full reproducible `nix build` is exercised by CI.

I have: <!-- You MUST either [x] check or [ ] ~~strike through~~ every item. -->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `./nix.sh flake check` to ensure this PR is ready for review.
- [ ] ~~Added or updated unit tests.~~
- [ ] ~~Added or updated e2e tests.~~
- [ ] ~~Linked a PR or a [docs tracking issue] to [document this change].~~
- [ ] ~~Added `backport release-x.y` labels to auto-backport this PR.~~
- [ ] ~~Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~~

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md
