### PR TITLE
Fix CronOperation stuck in 'already exists' loop due to clock skew

### DIFF
--- a/internal/controller/ops/cronoperation/reconciler.go
+++ b/internal/controller/ops/cronoperation/reconciler.go
@@ -111,9 +111,11 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 		return reconcile.Result{}, err
 	}
 
-	// Derive our last scheduled time from the last time we created an
-	// Operation.
-	if t := lifecycle.LatestCreateTime(ol.Items...); !t.IsZero() {
+	// Derive our last scheduled time from the scheduled time encoded in the
+	// most recent Operation's name. This avoids using creationTimestamp,
+	// which can be slightly earlier than the scheduled time due to clock skew
+	// between the controller and the API server.
+	if t := lifecycle.LatestScheduledTime(co.GetName(), ol.Items...); !t.IsZero() {
 		co.Status.LastScheduleTime = &metav1.Time{Time: t}
 	}
 

--- a/internal/ops/lifecycle/operations.go
+++ b/internal/ops/lifecycle/operations.go
@@ -19,6 +19,8 @@ package lifecycle
 
 import (
 	"slices"
+	"strconv"
+	"strings"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -35,6 +37,34 @@ func LatestCreateTime(ops ...v1alpha1.Operation) time.Time {
 	for _, op := range ops {
 		if t := op.GetCreationTimestamp(); t.After(latest) {
 			latest = t.Time
+		}
+	}
+
+	return latest
+}
+
+// LatestScheduledTime returns the latest scheduled time from a set of
+// Operations by parsing the Unix timestamp suffix from Operation names. Names
+// are expected to be in the format "<cronoperation-name>-<unix-seconds>", as
+// produced by NewOperation. Operations whose names don't match this format are
+// skipped. This avoids using the Kubernetes creationTimestamp, which can differ
+// from the intended schedule time due to clock skew between the controller and
+// the API server.
+func LatestScheduledTime(cronName string, ops ...v1alpha1.Operation) time.Time {
+	prefix := cronName + "-"
+	var latest time.Time
+
+	for _, op := range ops {
+		name := op.GetName()
+		if !strings.HasPrefix(name, prefix) {
+			continue
+		}
+		unix, err := strconv.ParseInt(strings.TrimPrefix(name, prefix), 10, 64)
+		if err != nil {
+			continue
+		}
+		if t := time.Unix(unix, 0); t.After(latest) {
+			latest = t
 		}
 	}
 

--- a/internal/ops/lifecycle/operations_test.go
+++ b/internal/ops/lifecycle/operations_test.go
@@ -107,6 +107,95 @@ func TestLatestCreateTime(t *testing.T) {
 	}
 }
 
+func TestLatestScheduledTime(t *testing.T) {
+	type args struct {
+		cronName string
+		ops      []v1alpha1.Operation
+	}
+	type want struct {
+		latest time.Time
+	}
+
+	cases := map[string]struct {
+		reason string
+		args   args
+		want   want
+	}{
+		"EmptySlice": {
+			reason: "Should return zero time for empty slice",
+			args: args{
+				cronName: "my-cron",
+				ops:      []v1alpha1.Operation{},
+			},
+			want: want{latest: time.Time{}},
+		},
+		"SingleOperation": {
+			reason: "Should parse the Unix timestamp from a single Operation name",
+			args: args{
+				cronName: "my-cron",
+				ops: []v1alpha1.Operation{
+					{ObjectMeta: metav1.ObjectMeta{Name: "my-cron-1781709000"}},
+				},
+			},
+			want: want{latest: time.Unix(1781709000, 0)},
+		},
+		"MultipleOperations": {
+			reason: "Should return the latest scheduled time from multiple Operations",
+			args: args{
+				cronName: "my-cron",
+				ops: []v1alpha1.Operation{
+					{ObjectMeta: metav1.ObjectMeta{Name: "my-cron-1781708700"}},
+					{ObjectMeta: metav1.ObjectMeta{Name: "my-cron-1781709000"}},
+					{ObjectMeta: metav1.ObjectMeta{Name: "my-cron-1781708400"}},
+				},
+			},
+			want: want{latest: time.Unix(1781709000, 0)},
+		},
+		"SkipsMalformedNames": {
+			reason: "Should skip Operations whose names don't have a valid Unix suffix",
+			args: args{
+				cronName: "my-cron",
+				ops: []v1alpha1.Operation{
+					{ObjectMeta: metav1.ObjectMeta{Name: "my-cron-notanumber"}},
+					{ObjectMeta: metav1.ObjectMeta{Name: "my-cron-1781709000"}},
+				},
+			},
+			want: want{latest: time.Unix(1781709000, 0)},
+		},
+		"SkipsWrongPrefix": {
+			reason: "Should skip Operations that don't belong to this CronOperation",
+			args: args{
+				cronName: "my-cron",
+				ops: []v1alpha1.Operation{
+					{ObjectMeta: metav1.ObjectMeta{Name: "other-cron-9999999999"}},
+					{ObjectMeta: metav1.ObjectMeta{Name: "my-cron-1781709000"}},
+				},
+			},
+			want: want{latest: time.Unix(1781709000, 0)},
+		},
+		"AllMalformed": {
+			reason: "Should return zero time when no names are parseable",
+			args: args{
+				cronName: "my-cron",
+				ops: []v1alpha1.Operation{
+					{ObjectMeta: metav1.ObjectMeta{Name: "my-cron-abc"}},
+					{ObjectMeta: metav1.ObjectMeta{Name: "unrelated"}},
+				},
+			},
+			want: want{latest: time.Time{}},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got := LatestScheduledTime(tc.args.cronName, tc.args.ops...)
+			if diff := cmp.Diff(tc.want.latest, got); diff != "" {
+				t.Errorf("\n%s\nLatestScheduledTime(...): -want, +got:\n%s", tc.reason, diff)
+			}
+		})
+	}
+}
+
 func TestLatestSucceededTransitionTime(t *testing.T) {
 	now := time.Now()
 	earlier := now.Add(-time.Hour)


### PR DESCRIPTION
## Description

Fixes #7524

The CronOperation controller derives `LastScheduleTime` from the Kubernetes `creationTimestamp` of the most recent Operation via `lifecycle.LatestCreateTime()`. When there is clock skew (≥1 second) between the controller pod and the API server — which is common in multi-node clusters — `creationTimestamp` can land just before the cron schedule boundary.

This causes `Next(schedule, lastScheduleTime)` to recompute the same scheduled time as an already-existing Operation. The Create call fails with AlreadyExists, the controller requeues, re-derives the same stale `LastScheduleTime`, and loops forever.

### Root Cause

Two time sources disagree:
1. **Operation name** uses the scheduled time: `fmt.Sprintf("%s-%d", co.GetName(), scheduled.Unix())`
2. **`LastScheduleTime`** is derived from `creationTimestamp` (API server clock)

When the API server stamps `creationTimestamp: 15:09:59` but the Operation was scheduled for `15:10:00`, subsequent reconciles compute `Next("*/5 * * * *", 15:09:59)` → `15:10:00` → name collision → infinite loop.

### Fix

Replace `LatestCreateTime` (reads `creationTimestamp`) with `LatestScheduledTime` (parses the Unix timestamp from the Operation name suffix). Since `NewOperation` deterministically encodes the scheduled time in the name, this ensures `LastScheduleTime` always reflects the intended schedule time regardless of API server clock differences.

`LatestCreateTime` is preserved for backward compatibility but is no longer used by the CronOperation reconciler.

### Testing

- Added unit tests for `LatestScheduledTime` covering: single/multiple Operations, malformed names, wrong prefix, and empty input.
- All existing CronOperation reconciler tests pass unchanged.

### Workaround (for affected users before this fix is released)

Delete the conflicting Operation manually:
```bash
kubectl delete operation <cronoperation-name>-<unix-timestamp>
```
