### PR TITLE
fix(rbac): grant provider RBAC for owned CRDs/MRDs not in objectRefs

### DIFF
--- a/cluster/charts/crossplane/templates/rbac-manager-clusterrole.yaml
+++ b/cluster/charts/crossplane/templates/rbac-manager-clusterrole.yaml
@@ -48,6 +48,9 @@ rules:
   - apiextensions.crossplane.io
   resources:
   - compositeresourcedefinitions
+  # The RBAC manager derives a provider's permissions from the CRDs and MRDs its
+  # ProviderRevision owns, so it needs to read (and watch) ManagedResourceDefinitions.
+  - managedresourcedefinitions
   verbs:
   - get
   - list

--- a/internal/controller/rbac/provider/roles/reconciler.go
+++ b/internal/controller/rbac/provider/roles/reconciler.go
@@ -27,10 +27,13 @@ import (
 	"github.com/google/go-containerregistry/pkg/name"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
+	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -89,6 +92,12 @@ func Setup(mgr ctrl.Manager, o controller.Options) error {
 			Named(name).
 			For(&v1.ProviderRevision{}).
 			Owns(&rbacv1.ClusterRole{}).
+			// Watch the CRDs and MRDs a revision owns so we reconcile its RBAC
+			// as soon as they're established, even if they're not yet reflected
+			// in the revision's status.objectRefs. We cache metadata only so we
+			// don't hold the full schema of every CRD in the cluster in memory.
+			Owns(&extv1.CustomResourceDefinition{}, builder.OnlyMetadata).
+			Owns(&v1alpha1.ManagedResourceDefinition{}, builder.OnlyMetadata).
 			WithOptions(o.ForControllerRuntime()).
 			Complete(errors.WithSilentRequeueOnConflict(r))
 	}
@@ -106,6 +115,12 @@ func Setup(mgr ctrl.Manager, o controller.Options) error {
 		Named(name).
 		For(&v1.ProviderRevision{}).
 		Owns(&rbacv1.ClusterRole{}).
+		// Watch the CRDs and MRDs a revision owns so we reconcile its RBAC as
+		// soon as they're established, even if they're not yet reflected in the
+		// revision's status.objectRefs. We cache metadata only so we don't hold
+		// the full schema of every CRD in the cluster in memory.
+		Owns(&extv1.CustomResourceDefinition{}, builder.OnlyMetadata).
+		Owns(&v1alpha1.ManagedResourceDefinition{}, builder.OnlyMetadata).
 		Watches(&v1.ProviderRevision{}, sfh).
 		WithOptions(o.ForControllerRuntime()).
 		Complete(errors.WithSilentRequeueOnConflict(r))
@@ -227,53 +242,15 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 		return reconcile.Result{Requeue: false}, nil
 	}
 
-	resources := DefinedResources(pr.Status.ObjectRefs)
-
-	// If this revision is part of a provider family we consider it to 'own' all
-	// of the family's CRDs (despite it not actually being an owner reference).
-	// This allows the revision to use core types installed by another provider,
-	// e.g. ProviderConfigs. It also allows the provider to cross-resource
-	// reference resources from other providers within its family.
-	//
-	// TODO(negz): Once generic cross-resource references are implemented we can
-	// reduce this to only allowing access to core types, like ProviderConfig.
-	// https://github.com/crossplane/crossplane/issues/1770
-	if family := pr.GetLabels()[v1.LabelProviderFamily]; family != "" {
-		// TODO(negz): Get active revisions in family.
-		prs := &v1.ProviderRevisionList{}
-		if err := r.client.List(ctx, prs, client.MatchingLabels{v1.LabelProviderFamily: family}); err != nil {
-			if kerrors.IsConflict(err) {
-				return reconcile.Result{Requeue: true}, nil
-			}
-
-			err = errors.Wrap(err, errListPRs)
-			r.record.Event(pr, event.Warning(reasonApplyRoles, err))
-
-			return reconcile.Result{}, err
+	resources, err := r.definedResources(ctx, pr)
+	if err != nil {
+		if kerrors.IsConflict(err) {
+			return reconcile.Result{Requeue: true}, nil
 		}
 
-		// TODO(negz): Should we filter down to only active revisions? I don't
-		// think there's any benefit. If the revision is inactive and never
-		// created any CRDs there will be no CRDs to grant permissions for. If
-		// it's inactive but did create (or would share) CRDs then this provider
-		// might try use them, and we should let it.
-		for _, member := range prs.Items {
-			// We already added our own resources.
-			if member.GetUID() == pr.GetUID() {
-				continue
-			}
+		r.record.Event(pr, event.Warning(reasonApplyRoles, err))
 
-			// We only allow packages in the same OCI registry and org to be
-			// part of the same family. This prevents a malicious provider from
-			// declaring itself part of a family and thus being granted RBAC
-			// access to its types.
-			// TODO(negz): Consider using package signing here in future.
-			if r.org.Differs(pr.Spec.Package, member.Spec.Package) {
-				continue
-			}
-
-			resources = append(resources, DefinedResources(member.Status.ObjectRefs)...)
-		}
+		return reconcile.Result{}, err
 	}
 
 	applied := make([]string, 0)
@@ -321,6 +298,69 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 	return reconcile.Result{Requeue: false}, nil
 }
 
+// definedResources returns the resources the supplied ProviderRevision should be
+// granted RBAC access to: those recorded in its status, those of other providers
+// in its family, and those of the CRDs and MRDs it actually controls.
+func (r *Reconciler) definedResources(ctx context.Context, pr *v1.ProviderRevision) ([]Resource, error) {
+	resources := DefinedResources(pr.Status.ObjectRefs)
+
+	// If this revision is part of a provider family we consider it to 'own' all
+	// of the family's CRDs (despite it not actually being an owner reference).
+	// This allows the revision to use core types installed by another provider,
+	// e.g. ProviderConfigs. It also allows the provider to cross-resource
+	// reference resources from other providers within its family.
+	//
+	// TODO(negz): Once generic cross-resource references are implemented we can
+	// reduce this to only allowing access to core types, like ProviderConfig.
+	// https://github.com/crossplane/crossplane/issues/1770
+	if family := pr.GetLabels()[v1.LabelProviderFamily]; family != "" {
+		// TODO(negz): Get active revisions in family.
+		prs := &v1.ProviderRevisionList{}
+		if err := r.client.List(ctx, prs, client.MatchingLabels{v1.LabelProviderFamily: family}); err != nil {
+			return nil, errors.Wrap(err, errListPRs)
+		}
+
+		// TODO(negz): Should we filter down to only active revisions? I don't
+		// think there's any benefit. If the revision is inactive and never
+		// created any CRDs there will be no CRDs to grant permissions for. If
+		// it's inactive but did create (or would share) CRDs then this provider
+		// might try use them, and we should let it.
+		for _, member := range prs.Items {
+			// We already added our own resources.
+			if member.GetUID() == pr.GetUID() {
+				continue
+			}
+
+			// We only allow packages in the same OCI registry and org to be
+			// part of the same family. This prevents a malicious provider from
+			// declaring itself part of a family and thus being granted RBAC
+			// access to its types.
+			// TODO(negz): Consider using package signing here in future.
+			if r.org.Differs(pr.Spec.Package, member.Spec.Package) {
+				continue
+			}
+
+			resources = append(resources, DefinedResources(member.Status.ObjectRefs)...)
+		}
+	}
+
+	// A revision's status.objectRefs is its own record of the resources it
+	// defined, but it can be incomplete or stale - e.g. after a backup/restore
+	// that drops the status subresource, or when a managed resource is
+	// established after the revision last reconciled. Relying on it alone can
+	// leave the provider's system ClusterRole missing permissions for resources
+	// it runs controllers for, which prevents the provider from starting. So we
+	// also grant access to the CRDs and MRDs the revision actually controls,
+	// derived from the live API server rather than status. We watch both kinds
+	// (see Setup) so roles are reconciled as soon as they're established.
+	owned, err := r.ownedResources(ctx, pr)
+	if err != nil {
+		return nil, err
+	}
+
+	return append(resources, owned...), nil
+}
+
 // DefinedResources returns the resources defined by the supplied references.
 func DefinedResources(refs []xpv2.TypedReference) []Resource {
 	out := make([]Resource, 0, len(refs))
@@ -341,16 +381,62 @@ func DefinedResources(refs []xpv2.TypedReference) []Resource {
 			continue
 		}
 
-		p, g, valid := strings.Cut(ref.Name, ".")
-		if !valid {
+		res, ok := resourceFromName(ref.Name)
+		if !ok {
 			// This shouldn't be possible - CRDs must be named <plural>.<group>.
 			continue
 		}
 
-		out = append(out, Resource{Group: g, Plural: p})
+		out = append(out, res)
 	}
 
 	return out
+}
+
+// ownedResources returns the resources defined by the CRDs and MRDs that the
+// supplied ProviderRevision controls. Unlike status.objectRefs, this reflects
+// the actual state of the API server, so it lets us grant RBAC access even when
+// the revision's status is incomplete or stale. We only need each object's name
+// and owner references, so we list metadata only rather than caching the full
+// schema of every CRD in the cluster.
+func (r *Reconciler) ownedResources(ctx context.Context, pr *v1.ProviderRevision) ([]Resource, error) {
+	crds := &metav1.PartialObjectMetadataList{}
+	crds.SetGroupVersionKind(extv1.SchemeGroupVersion.WithKind("CustomResourceDefinitionList"))
+	if err := r.client.List(ctx, crds); err != nil {
+		return nil, errors.Wrapf(err, "cannot list CustomResourceDefinitions for ProviderRevision %q", pr.GetName())
+	}
+
+	mrds := &metav1.PartialObjectMetadataList{}
+	mrds.SetGroupVersionKind(v1alpha1.SchemeGroupVersion.WithKind("ManagedResourceDefinitionList"))
+	if err := r.client.List(ctx, mrds); err != nil {
+		return nil, errors.Wrapf(err, "cannot list ManagedResourceDefinitions for ProviderRevision %q", pr.GetName())
+	}
+
+	out := []Resource{}
+	for _, items := range [][]metav1.PartialObjectMetadata{crds.Items, mrds.Items} {
+		for i := range items {
+			if !metav1.IsControlledBy(&items[i], pr) {
+				continue
+			}
+			if res, ok := resourceFromName(items[i].GetName()); ok {
+				out = append(out, res)
+			}
+		}
+	}
+
+	return out, nil
+}
+
+// resourceFromName derives a Resource from a CRD or MRD name, which by
+// convention is <plural>.<group>. It returns false if the name doesn't follow
+// that convention.
+func resourceFromName(name string) (Resource, bool) {
+	p, g, ok := strings.Cut(name, ".")
+	if !ok {
+		return Resource{}, false
+	}
+
+	return Resource{Group: g, Plural: p}, true
 }
 
 // ClusterRolesDiffer returns true if the supplied objects are different

--- a/internal/controller/rbac/provider/roles/reconciler_test.go
+++ b/internal/controller/rbac/provider/roles/reconciler_test.go
@@ -19,6 +19,8 @@ package roles
 import (
 	"context"
 	"io"
+	"slices"
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -29,6 +31,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -142,6 +145,26 @@ func TestReconcile(t *testing.T) {
 				err: errors.Wrap(errBoom, errListPRs),
 			},
 		},
+		"ListOwnedResourcesError": {
+			reason: "We should return an error encountered listing the CRDs owned by the ProviderRevision.",
+			args: args{
+				mgr: &fake.Manager{},
+				opts: []ReconcilerOption{
+					WithClientApplicator(resource.ClientApplicator{
+						Client: &test.MockClient{
+							MockGet: test.NewMockGetFn(nil, func(o client.Object) error {
+								o.(*v1.ProviderRevision).SetName("provider-revision")
+								return nil
+							}),
+							MockList: test.NewMockListFn(errBoom),
+						},
+					}),
+				},
+			},
+			want: want{
+				err: errors.Wrapf(errBoom, "cannot list CustomResourceDefinitions for ProviderRevision %q", "provider-revision"),
+			},
+		},
 		"ApplyClusterRoleError": {
 			reason: "We should return an error encountered applying a ClusterRole.",
 			args: args{
@@ -204,7 +227,12 @@ func TestReconcile(t *testing.T) {
 								return nil
 							}),
 							MockList: test.NewMockListFn(nil, func(o client.ObjectList) error {
-								l := o.(*v1.ProviderRevisionList)
+								// ownedResources also lists CRDs and MRDs; only
+								// populate the ProviderRevision family list here.
+								l, ok := o.(*v1.ProviderRevisionList)
+								if !ok {
+									return nil
+								}
 								l.Items = []v1.ProviderRevision{
 									{
 										ObjectMeta: metav1.ObjectMeta{UID: familyUID},
@@ -272,6 +300,166 @@ func TestReconcile(t *testing.T) {
 
 			if diff := cmp.Diff(tc.want.r, got, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\nr.Reconcile(...): -want, +got:\n%s", tc.reason, diff)
+			}
+		})
+	}
+}
+
+// clusterRoleGrants reports whether the ClusterRole grants any verb on the
+// supplied API group and resource.
+func clusterRoleGrants(cr rbacv1.ClusterRole, group, plural string) bool {
+	for _, rule := range cr.Rules {
+		if slices.Contains(rule.APIGroups, group) && slices.Contains(rule.Resources, plural) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// TestReconcileGrantsOwnedResources covers the case where a ProviderRevision's
+// status.objectRefs is incomplete - e.g. lost after a backup/restore, or not yet
+// updated after a managed resource was established. The provider's system
+// ClusterRole must still grant access to the CRDs and MRDs the revision controls
+// (derived from the live API server), otherwise the provider crashes for lack of
+// RBAC on resources it runs controllers for.
+func TestReconcileGrantsOwnedResources(t *testing.T) {
+	testLog := logging.NewLogrLogger(zap.New(zap.UseDevMode(true), zap.WriteTo(io.Discard)).WithName("testlog"))
+	prUID := types.UID("provider-revision-uid")
+
+	// ownedBy points a resource's controller reference at our ProviderRevision.
+	ownedBy := []metav1.OwnerReference{{
+		APIVersion: "pkg.crossplane.io/v1",
+		Kind:       "ProviderRevision",
+		Name:       "provider-revision",
+		UID:        prUID,
+		Controller: ptr.To(true),
+	}}
+
+	// getProviderRevision returns a Get that populates our ProviderRevision with
+	// the supplied references in its status.objectRefs.
+	getProviderRevision := func(refs ...xpv2.TypedReference) test.MockGetFn {
+		return test.NewMockGetFn(nil, func(o client.Object) error {
+			pr := o.(*v1.ProviderRevision)
+			pr.SetName("provider-revision")
+			pr.SetUID(prUID)
+			pr.Status.ObjectRefs = refs
+			return nil
+		})
+	}
+
+	// listOwned returns a List that returns the supplied CRD and MRD metadata.
+	// ownedResources lists CRDs and MRDs as metadata only, so both calls arrive
+	// as PartialObjectMetadataLists distinguished by their kind.
+	listOwned := func(crds, mrds []metav1.PartialObjectMetadata) test.MockListFn {
+		return test.NewMockListFn(nil, func(o client.ObjectList) error {
+			l, ok := o.(*metav1.PartialObjectMetadataList)
+			if !ok {
+				return nil
+			}
+			switch l.GetObjectKind().GroupVersionKind().Kind {
+			case "CustomResourceDefinitionList":
+				l.Items = crds
+			case "ManagedResourceDefinitionList":
+				l.Items = mrds
+			}
+			return nil
+		})
+	}
+
+	type args struct {
+		client client.Client
+	}
+
+	type want struct {
+		// grants maps a "group/plural" resource to whether the provider's system
+		// ClusterRole should grant access to it.
+		grants map[string]bool
+	}
+
+	cases := map[string]struct {
+		reason string
+		args   args
+		want   want
+	}{
+		"OwnedResourcesAbsentFromObjectRefs": {
+			reason: "Resources the revision owns must be granted even when status.objectRefs is empty, and resources it doesn't own must not be.",
+			args: args{
+				client: &test.MockClient{
+					MockGet: getProviderRevision(),
+					MockList: listOwned(
+						[]metav1.PartialObjectMetadata{
+							{ObjectMeta: metav1.ObjectMeta{Name: "policies.rbac.example.org", OwnerReferences: ownedBy}},
+							// Not controlled by our revision - must be ignored.
+							{ObjectMeta: metav1.ObjectMeta{Name: "widgets.unowned.example.org"}},
+						},
+						[]metav1.PartialObjectMetadata{
+							{ObjectMeta: metav1.ObjectMeta{Name: "tests.synthetic.example.org", OwnerReferences: ownedBy}},
+						},
+					),
+				},
+			},
+			want: want{
+				grants: map[string]bool{
+					"rbac.example.org/policies":   true,
+					"synthetic.example.org/tests": true,
+					"unowned.example.org/widgets": false,
+				},
+			},
+		},
+		"UnionOfObjectRefsAndOwnedResources": {
+			reason: "Resources from status.objectRefs and owned resources must both be granted.",
+			args: args{
+				client: &test.MockClient{
+					MockGet: getProviderRevision(xpv2.TypedReference{
+						APIVersion: extv1.SchemeGroupVersion.String(),
+						Kind:       "CustomResourceDefinition",
+						Name:       "monitors.alerting.example.org",
+					}),
+					MockList: listOwned(
+						[]metav1.PartialObjectMetadata{
+							{ObjectMeta: metav1.ObjectMeta{Name: "policies.rbac.example.org", OwnerReferences: ownedBy}},
+						},
+						nil,
+					),
+				},
+			},
+			want: want{
+				grants: map[string]bool{
+					"alerting.example.org/monitors": true,
+					"rbac.example.org/policies":     true,
+				},
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			applied := map[string]rbacv1.ClusterRole{}
+			ca := resource.ClientApplicator{
+				Client: tc.args.client,
+				Applicator: resource.ApplyFn(func(_ context.Context, o client.Object, _ ...resource.ApplyOption) error {
+					cr := o.(*rbacv1.ClusterRole)
+					applied[cr.GetName()] = *cr.DeepCopy()
+					return nil
+				}),
+			}
+
+			r := NewReconciler(&fake.Manager{}, WithClientApplicator(ca), WithLogger(testLog))
+			if _, err := r.Reconcile(context.Background(), reconcile.Request{}); err != nil {
+				t.Fatalf("%s\nr.Reconcile(...): unexpected error: %v", tc.reason, err)
+			}
+
+			system := applied[SystemClusterRoleName("provider-revision")]
+
+			got := make(map[string]bool, len(tc.want.grants))
+			for gr := range tc.want.grants {
+				group, plural, _ := strings.Cut(gr, "/")
+				got[gr] = clusterRoleGrants(system, group, plural)
+			}
+
+			if diff := cmp.Diff(tc.want.grants, got); diff != "" {
+				t.Errorf("%s\nr.Reconcile(...): -want grants, +got grants:\n%s", tc.reason, diff)
 			}
 		})
 	}

--- a/internal/controller/rbac/provider/roles/roles.go
+++ b/internal/controller/rbac/provider/roles/roles.go
@@ -100,6 +100,12 @@ func RenderClusterRoles(pr *v1.ProviderRevision, rs []Resource) []rbacv1.Cluster
 		return nil
 	}
 
+	// Callers may supply the same resource more than once - e.g. a resource that
+	// appears both in a revision's status.objectRefs and in the set of CRDs/MRDs
+	// it owns, or a type shared by multiple providers in a family. Deduplicate so
+	// we emit each resource in our RBAC rules only once.
+	rs = dedupeResources(rs)
+
 	// Our list of resources has no guaranteed order, so we sort them in order
 	// to ensure we don't reorder our RBAC rules on each update.
 	sort.Slice(rs, func(i, j int) bool {
@@ -202,4 +208,21 @@ func withVerbs(r []rbacv1.PolicyRule, verbs []string) []rbacv1.PolicyRule {
 	}
 
 	return verbal
+}
+
+// dedupeResources returns the supplied resources with duplicates removed,
+// preserving the order in which each distinct resource first appeared.
+func dedupeResources(rs []Resource) []Resource {
+	seen := make(map[Resource]struct{}, len(rs))
+	out := make([]Resource, 0, len(rs))
+	for _, r := range rs {
+		if _, ok := seen[r]; ok {
+			continue
+		}
+
+		seen[r] = struct{}{}
+		out = append(out, r)
+	}
+
+	return out
 }

--- a/test/e2e/manifests/pkg/provider-rbac/provider.yaml
+++ b/test/e2e/manifests/pkg/provider-rbac/provider.yaml
@@ -1,0 +1,7 @@
+apiVersion: pkg.crossplane.io/v1
+kind: Provider
+metadata:
+  name: provider-nop-rbac
+spec:
+  package: xpkg.upbound.io/crossplane-contrib/provider-nop:v0.3.0
+  ignoreCrossplaneConstraints: true

--- a/test/e2e/pkg_rbac_test.go
+++ b/test/e2e/pkg_rbac_test.go
@@ -1,0 +1,205 @@
+/*
+Copyright 2026 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"context"
+	"slices"
+	"testing"
+	"time"
+
+	rbacv1 "k8s.io/api/rbac/v1"
+	k8sapiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/e2e-framework/klient/k8s"
+	"sigs.k8s.io/e2e-framework/pkg/envconf"
+	"sigs.k8s.io/e2e-framework/pkg/features"
+
+	pkgv1 "github.com/crossplane/crossplane/apis/v2/pkg/v1"
+	"github.com/crossplane/crossplane/v2/test/e2e/config"
+	"github.com/crossplane/crossplane/v2/test/e2e/funcs"
+)
+
+// TestProviderSystemRoleGrantsOwnedResources verifies that a provider's system
+// ClusterRole grants access to a resource the ProviderRevision owns even when it
+// isn't recorded in the revision's status.objectRefs. We simulate that drift by
+// creating a CRD with a controller owner reference to the active ProviderRevision
+// without it ever being part of the package (so it never enters objectRefs). The
+// RBAC manager must still grant access to it, because it derives the system role
+// from the CRDs/MRDs the revision actually owns, not only from objectRefs.
+func TestProviderSystemRoleGrantsOwnedResources(t *testing.T) {
+	manifests := "test/e2e/manifests/pkg/provider-rbac"
+
+	const (
+		providerName = "provider-nop-rbac"
+		ownedGroup   = "rbac-e2e.crossplane.io"
+		ownedPlural  = "ownedresources"
+		ownedCRDName = ownedPlural + "." + ownedGroup
+	)
+
+	environment.Test(t,
+		features.NewWithDescription(t.Name(), "Tests that a provider's system ClusterRole grants access to a CRD the ProviderRevision owns even when it isn't recorded in status.objectRefs.").
+			WithLabel(LabelArea, LabelAreaPkg).
+			WithLabel(LabelSize, LabelSizeSmall).
+			WithLabel(config.LabelTestSuite, config.TestSuiteDefault).
+			WithSetup("InstallProvider", funcs.AllOf(
+				funcs.ApplyResources(FieldManager, manifests, "provider.yaml"),
+				funcs.ResourcesCreatedWithin(1*time.Minute, manifests, "provider.yaml"),
+				funcs.ResourcesHaveConditionWithin(3*time.Minute, manifests, "provider.yaml", pkgv1.Healthy(), pkgv1.Active()),
+			)).
+			WithSetup("CreateCRDOwnedByProviderRevision",
+				createCRDOwnedByActiveProviderRevision(providerName, ownedCRDName, ownedGroup, ownedPlural)).
+			// Only the provider's system ClusterRole grants the (unique) owned
+			// resource, so we don't need a label selector to find it.
+			Assess("SystemClusterRoleGrantsOwnedResource",
+				funcs.ListedResourcesValidatedWithin(2*time.Minute, &rbacv1.ClusterRoleList{}, 1,
+					clusterRoleGrantsResource(ownedGroup, ownedPlural),
+				)).
+			WithTeardown("DeleteOwnedCRD", deleteCustomResourceDefinition(ownedCRDName)).
+			WithTeardown("DeleteProvider", funcs.AllOf(
+				funcs.DeleteResourcesWithPropagationPolicy(manifests, "provider.yaml", metav1.DeletePropagationForeground),
+				funcs.ResourcesDeletedWithin(2*time.Minute, manifests, "provider.yaml"),
+			)).
+			Feature(),
+	)
+}
+
+// clusterRoleGrantsResource returns a validator reporting whether a ClusterRole
+// grants the verbs an informer needs - list and watch - on the supplied API
+// group and resource. Those are the permissions whose absence causes the
+// cache-sync crash this fix addresses, so we assert them rather than mere
+// presence of the group/resource.
+func clusterRoleGrantsResource(group, plural string) func(o k8s.Object) bool {
+	return func(o k8s.Object) bool {
+		cr, ok := o.(*rbacv1.ClusterRole)
+		if !ok {
+			return false
+		}
+		for _, r := range cr.Rules {
+			if !slices.Contains(r.APIGroups, group) || !slices.Contains(r.Resources, plural) {
+				continue
+			}
+			if slices.Contains(r.Verbs, rbacv1.VerbAll) {
+				return true
+			}
+			if slices.Contains(r.Verbs, "list") && slices.Contains(r.Verbs, "watch") {
+				return true
+			}
+		}
+		return false
+	}
+}
+
+// createCRDOwnedByActiveProviderRevision creates a CRD whose controller owner
+// reference points at the named provider's active ProviderRevision, simulating a
+// resource the revision owns but that isn't recorded in its status.objectRefs.
+func createCRDOwnedByActiveProviderRevision(providerName, crdName, group, plural string) features.Func {
+	return func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+		t.Helper()
+
+		prs := &pkgv1.ProviderRevisionList{}
+		if err := c.Client().Resources().List(ctx, prs); err != nil {
+			t.Fatalf("cannot list ProviderRevisions: %v", err)
+			return ctx
+		}
+
+		var pr *pkgv1.ProviderRevision
+		for i := range prs.Items {
+			rev := &prs.Items[i]
+			if rev.GetDesiredState() != pkgv1.PackageRevisionActive {
+				continue
+			}
+			for _, or := range rev.GetOwnerReferences() {
+				if or.Name == providerName {
+					pr = rev
+					break
+				}
+			}
+			if pr != nil {
+				break
+			}
+		}
+		if pr == nil {
+			t.Fatalf("no active ProviderRevision found for provider %q", providerName)
+			return ctx
+		}
+
+		crd := &k8sapiextensionsv1.CustomResourceDefinition{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: crdName,
+				// Controller owner reference to the ProviderRevision - this is
+				// what makes the revision 'own' the CRD without it being part of
+				// the package.
+				OwnerReferences: []metav1.OwnerReference{{
+					APIVersion:         pkgv1.SchemeGroupVersion.String(),
+					Kind:               pkgv1.ProviderRevisionKind,
+					Name:               pr.GetName(),
+					UID:                pr.GetUID(),
+					Controller:         ptr.To(true),
+					BlockOwnerDeletion: ptr.To(true),
+				}},
+			},
+			Spec: k8sapiextensionsv1.CustomResourceDefinitionSpec{
+				Group: group,
+				Names: k8sapiextensionsv1.CustomResourceDefinitionNames{
+					Plural:   plural,
+					Singular: "ownedresource",
+					Kind:     "OwnedResource",
+					ListKind: "OwnedResourceList",
+				},
+				Scope: k8sapiextensionsv1.ClusterScoped,
+				Versions: []k8sapiextensionsv1.CustomResourceDefinitionVersion{{
+					Name:    "v1alpha1",
+					Served:  true,
+					Storage: true,
+					Schema: &k8sapiextensionsv1.CustomResourceValidation{
+						OpenAPIV3Schema: &k8sapiextensionsv1.JSONSchemaProps{
+							Type:                   "object",
+							XPreserveUnknownFields: ptr.To(true),
+						},
+					},
+				}},
+			},
+		}
+
+		if err := c.Client().Resources().Create(ctx, crd); err != nil {
+			t.Fatalf("cannot create CRD %q: %v", crdName, err)
+			return ctx
+		}
+
+		t.Logf("Created CRD %q owned by ProviderRevision %q", crdName, pr.GetName())
+		return ctx
+	}
+}
+
+// deleteCustomResourceDefinition deletes the named CRD, tolerating its absence.
+func deleteCustomResourceDefinition(crdName string) features.Func {
+	return func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+		t.Helper()
+
+		crd := &k8sapiextensionsv1.CustomResourceDefinition{ObjectMeta: metav1.ObjectMeta{Name: crdName}}
+		if err := c.Client().Resources().Delete(ctx, crd); err != nil {
+			if !kerrors.IsNotFound(err) {
+				t.Fatalf("cannot delete CRD %q: %v", crdName, err)
+			}
+			t.Logf("CRD %q already absent", crdName)
+		}
+		return ctx
+	}
+}


### PR DESCRIPTION
### Description of your changes

The RBAC manager derives a provider's system `ClusterRole` (`crossplane:provider:<revision>:system`) solely from `ProviderRevision.status.objectRefs`. When that status is incomplete relative to the CRDs/MRDs the revision actually owns — e.g. after a backup/restore that drops the status subresource, when MRDs are activated after the revision last reconciled, or during an upgrade/adoption transition — the system role is missing rules for some managed resources. The provider still starts a controller for every active owned resource, so it tries to list/watch a resource it has no RBAC for, the informer cache never syncs, and the provider crash-loops:

```
Cannot start controller manager: failed to wait for managed/.../v1alpha1, kind=policy caches to sync ... timed out waiting for cache to be synced
```

Both the producer (`pkg/revision`) and consumer (`rbac/provider/roles`) controllers are edge-triggered and never reconcile RBAC against the API server's actual state, so once `objectRefs` is incomplete the role stays wedged (the rbac-manager logs a perpetual `Skipped no-op RBAC ClusterRole apply`, and even the hourly cache resync re-reads the same stale status).

This change makes the rbac-roles controller derive the system role from ground truth in addition to status:

- `definedResources` now unions `DefinedResources(status.objectRefs)` (preserving the existing provider-family cross-grant) with `ownedResources` — the CRDs and MRDs whose controller `ownerReference` is the `ProviderRevision`.
- `ownedResources` lists CRDs and MRDs **metadata-only** (`PartialObjectMetadataList`) so the rbac-manager doesn't cache the full schema of every CRD in the cluster.
- `Setup` adds `Owns(CustomResourceDefinition)` / `Owns(ManagedResourceDefinition)` watches (`builder.OnlyMetadata`) so the role is reconciled as soon as a managed resource is established, rather than waiting for the next status write or cache resync.
- `RenderClusterRoles` deduplicates resources, since `objectRefs` and the owned set overlap.
- The rbac-manager `ClusterRole` now also grants `get/list/watch` on `managedresourcedefinitions` (it already had it for `customresourcedefinitions`), which the controller needs to read/watch owned MRDs.

This makes provider RBAC self-healing against any cause of `objectRefs` drift. It does not change the producer side (`pkg/revision`); the consumer now tolerates an incomplete status rather than depending on it.

### How it's tested

**Unit tests** (`reconciler_test.go`, table-driven): `TestReconcileGrantsOwnedResources` asserts that CRDs/MRDs the revision owns are granted even when `status.objectRefs` is empty, that resources it doesn't own are excluded, and that `objectRefs`-derived and owned resources are unioned. These fail without the change. Plus a `ListOwnedResourcesError` case for the list-error path.

**E2E test** (`test/e2e/pkg_rbac_test.go`): installs a provider, then creates a CRD with a controller `ownerReference` to its active `ProviderRevision` **without** it being part of the package — so it never enters `status.objectRefs` — and asserts the provider's system `ClusterRole` still grants access to it. This exercises the owned-resource derivation and the new watches against a real cluster. It's what surfaced the need for the rbac-manager `managedresourcedefinitions` grant above (without it, the reconcile errored on the MRD list and no system role was written).

Validated with `./nix.sh flake check` and `./nix.sh run .#e2e`. Also verified on a production cluster: the affected provider recovered and stays healthy across subsequent `objectRefs` drift.

**Note on footprint:** the rbac-manager now watches CRDs/MRDs cluster-wide, but metadata-only. Happy to scope this further (e.g. a label-selected cache) if preferred.

Fixes #7536

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `./nix.sh flake check` to ensure this PR is ready for review.
- [x] Added or updated unit tests.
- [x] Added or updated e2e tests.
- [ ] ~Linked a PR or a docs tracking issue to document this change.~ No user-facing behaviour/API change.
- [ ] Added `backport release-x.y` labels to auto-backport this PR. <!-- happy to add for the active release branch(es) per maintainer guidance -->
- [ ] ~Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~ No API change.

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md