### PR TITLE
Update crossplane-runtime to v1.20.10

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/Masterminds/semver v1.5.0
 	github.com/alecthomas/kong v1.4.0
 	github.com/containerd/errdefs v1.0.0
-	github.com/crossplane/crossplane-runtime v1.20.9
+	github.com/crossplane/crossplane-runtime v1.20.10
 	github.com/docker/docker v28.5.2+incompatible
 	github.com/docker/go-connections v0.5.0
 	github.com/emicklei/dot v1.6.2

--- a/go.sum
+++ b/go.sum
@@ -213,8 +213,8 @@ github.com/cpuguy83/go-md2man/v2 v2.0.1/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46t
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/creack/pty v1.1.18 h1:n56/Zwd5o6whRC5PMGretI4IdRLlmBXYNjScPaBgsbY=
 github.com/creack/pty v1.1.18/go.mod h1:MOBLtS5ELjhRRrroQr9kyvTxUAFNvYEK993ew/Vr4O4=
-github.com/crossplane/crossplane-runtime v1.20.9 h1:iz4ZfkwRnZa0eUqKfq0+U29O0XriDZs12upih0rqsGI=
-github.com/crossplane/crossplane-runtime v1.20.9/go.mod h1:EbFC7+3EDUlEmOkDOA0QNwwpen3sfzAUJVquCK9juyY=
+github.com/crossplane/crossplane-runtime v1.20.10 h1:NyfZXaG3hNlD/ZyBRN3kXCSYmZ18gERh3jsZJKCGNjw=
+github.com/crossplane/crossplane-runtime v1.20.10/go.mod h1:EbFC7+3EDUlEmOkDOA0QNwwpen3sfzAUJVquCK9juyY=
 github.com/cyberphone/json-canonicalization v0.0.0-20231011164504-785e29786b46 h1:2Dx4IHfC1yHWI12AxQDJM1QbRCDfk6M+blLzlZCXdrc=
 github.com/cyberphone/json-canonicalization v0.0.0-20231011164504-785e29786b46/go.mod h1:uzvlm1mxhHkdfqitSA92i7Se+S9ksOn3a3qmv/kyOCw=
 github.com/cyphar/filepath-securejoin v0.6.1 h1:5CeZ1jPXEiYt3+Z6zqprSAgSWiggmpVyciv8syjIpVE=


### PR DESCRIPTION
Bump crossplane-runtime dependency to v1.20.10 for the patch release.

**Changes in runtime v1.20.10:**
- chore(deps): update curlimages/curl docker tag to v8.20.0

Release: https://github.com/crossplane/crossplane-runtime/releases/tag/v1.20.10

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `./nix.sh flake check` to ensure this PR is ready for review.
- [ ] ~Added or updated unit tests.~
- [ ] ~Added or updated e2e tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~ No user-facing behaviour/API change.
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~
- [ ] ~Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~ No API change.

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md