### PR TITLE
Update crossplane-runtime to v2.1.7

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/Masterminds/semver v1.5.0
 	github.com/alecthomas/kong v1.4.0
 	github.com/containerd/errdefs v1.0.0
-	github.com/crossplane/crossplane-runtime/v2 v2.1.6
+	github.com/crossplane/crossplane-runtime/v2 v2.1.7
 	github.com/docker/docker v28.5.2+incompatible
 	github.com/docker/go-connections v0.5.0
 	github.com/emicklei/dot v1.8.0

--- a/go.sum
+++ b/go.sum
@@ -164,8 +164,8 @@ github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSV
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/creack/pty v1.1.18 h1:n56/Zwd5o6whRC5PMGretI4IdRLlmBXYNjScPaBgsbY=
 github.com/creack/pty v1.1.18/go.mod h1:MOBLtS5ELjhRRrroQr9kyvTxUAFNvYEK993ew/Vr4O4=
-github.com/crossplane/crossplane-runtime/v2 v2.1.6 h1:eFYUDNS4BrjSlafGBCtXU3r+utTyfpXoa8JUKulsqYM=
-github.com/crossplane/crossplane-runtime/v2 v2.1.6/go.mod h1:sKrvoljhLVTCI7bVuCEwsAyr627fs4gdPTMwRQyuQjc=
+github.com/crossplane/crossplane-runtime/v2 v2.1.7 h1:lROOt5T8wmQqsne75R1eWnyqfHHISJVQfRbQA4/33VY=
+github.com/crossplane/crossplane-runtime/v2 v2.1.7/go.mod h1:gWBQYs35SDFJwqE537voFxs8Z86IPa4WtfSU+/YMNmw=
 github.com/cyberphone/json-canonicalization v0.0.0-20241213102144-19d51d7fe467 h1:uX1JmpONuD549D73r6cgnxyUu18Zb7yHAy5AYU0Pm4Q=
 github.com/cyberphone/json-canonicalization v0.0.0-20241213102144-19d51d7fe467/go.mod h1:uzvlm1mxhHkdfqitSA92i7Se+S9ksOn3a3qmv/kyOCw=
 github.com/cyphar/filepath-securejoin v0.6.1 h1:5CeZ1jPXEiYt3+Z6zqprSAgSWiggmpVyciv8syjIpVE=


### PR DESCRIPTION
Bump crossplane-runtime dependency to v2.1.7 for the patch release.

**Changes in runtime v2.1.7:**
- chore(deps): update module golang.org/x/sys to v0.44.0 [security]
- chore(deps): update module golang.org/x/net to v0.55.0 [security]
- chore(deps): update curlimages/curl docker tag to v8.20.0

Release: https://github.com/crossplane/crossplane-runtime/releases/tag/v2.1.7

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `./nix.sh flake check` to ensure this PR is ready for review.
- [ ] ~Added or updated unit tests.~
- [ ] ~Added or updated e2e tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~ No user-facing behaviour/API change.
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~
- [ ] ~Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~ No API change.

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md