### PR TITLE
Update crossplane-runtime to v2.2.3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/alecthomas/kong v1.14.0
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/containerd/errdefs v1.0.0
-	github.com/crossplane/crossplane-runtime/v2 v2.2.2
+	github.com/crossplane/crossplane-runtime/v2 v2.2.3
 	github.com/docker/docker v28.5.2+incompatible
 	github.com/docker/go-connections v0.6.0
 	github.com/emicklei/dot v1.10.0

--- a/go.sum
+++ b/go.sum
@@ -180,8 +180,8 @@ github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSV
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/creack/pty v1.1.18 h1:n56/Zwd5o6whRC5PMGretI4IdRLlmBXYNjScPaBgsbY=
 github.com/creack/pty v1.1.18/go.mod h1:MOBLtS5ELjhRRrroQr9kyvTxUAFNvYEK993ew/Vr4O4=
-github.com/crossplane/crossplane-runtime/v2 v2.2.2 h1:/as5jRTqT90Kd37pj8BRTlZCfu57Ys7I7E97cW942bU=
-github.com/crossplane/crossplane-runtime/v2 v2.2.2/go.mod h1:er5/a4b8fT8+wTipkLxjB+lqkX+s5vP92FGzoMbvbjE=
+github.com/crossplane/crossplane-runtime/v2 v2.2.3 h1:/ACD1n1ukspHUDj5NXi8yMpyYsrLDCy7I5x5VTiwlcM=
+github.com/crossplane/crossplane-runtime/v2 v2.2.3/go.mod h1:4hjtObq7yln3BweiFCuSB4j0/a/pHUn6vSuY+Bb8Qf0=
 github.com/cyberphone/json-canonicalization v0.0.0-20241213102144-19d51d7fe467 h1:uX1JmpONuD549D73r6cgnxyUu18Zb7yHAy5AYU0Pm4Q=
 github.com/cyberphone/json-canonicalization v0.0.0-20241213102144-19d51d7fe467/go.mod h1:uzvlm1mxhHkdfqitSA92i7Se+S9ksOn3a3qmv/kyOCw=
 github.com/cyphar/filepath-securejoin v0.6.1 h1:5CeZ1jPXEiYt3+Z6zqprSAgSWiggmpVyciv8syjIpVE=


### PR DESCRIPTION
Bump crossplane-runtime dependency to v2.2.3 for the patch release.

**Changes in runtime v2.2.3:**
- chore(deps): update module golang.org/x/sys to v0.44.0 [security]
- chore(deps): update module golang.org/x/net to v0.55.0 [security]

Release: https://github.com/crossplane/crossplane-runtime/releases/tag/v2.2.3

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `./nix.sh flake check` to ensure this PR is ready for review.
- [ ] ~Added or updated unit tests.~
- [ ] ~Added or updated e2e tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~ No user-facing behaviour/API change.
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~
- [ ] ~Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~ No API change.

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md