### PR TITLE
Watch resources required by composition functions

### DIFF
--- a/cmd/crossplane/core/core.go
+++ b/cmd/crossplane/core/core.go
@@ -137,6 +137,7 @@ type startCommand struct {
 	EnableOperations                  bool `group:"Alpha Features:" help:"Enable support for Operations."`
 	EnablePipelineInspector           bool `group:"Alpha Features:" help:"Enable support for emitting function pipeline execution data to a sidecar."`
 	EnableProviderDeletionProtection  bool `group:"Alpha Features:" help:"Enable automatic protection of Providers from deletion when they have active managed resources. Requires --enable-usages."`
+	EnableRequiredResourceWatches     bool `group:"Alpha Features:" help:"Enable watching the resources a composition function requires, reconciling a composite resource (XR) when a required resource changes. Requires --enable-realtime-compositions."`
 
 	XfnCacheDir             string        `default:"/cache/xfn"                         env:"XFN_CACHE_DIR"             group:"Alpha Features:" help:"Directory used for caching function responses. Requires --enable-function-response-cache."`
 	XfnCacheMaxTTL          time.Duration `default:"24h"                                env:"XFN_CACHE_MAX_TTL"         group:"Alpha Features:" help:"Maximum TTL for cached function responses. Set to 0 to disable. Requires --enable-function-response-cache."`
@@ -358,6 +359,20 @@ func (c *startCommand) Run(s *runtime.Scheme, log logging.Logger) error { //noli
 		log.Info("Alpha feature enabled", "flag", features.EnableAlphaProviderDeletionProtection)
 	}
 
+	if c.EnableRequiredResourceWatches {
+		o.Features.Enable(features.EnableAlphaRequiredResourceWatches)
+		log.Info("Alpha feature enabled", "flag", features.EnableAlphaRequiredResourceWatches)
+
+		// Required resource watches rely on the watch machinery that realtime
+		// compositions sets up. Without it the feature is a no-op, so warn
+		// rather than silently doing nothing.
+		if !c.EnableRealtimeCompositions {
+			log.Info("Required resource watches are enabled but will have no effect, because they require realtime compositions",
+				"required-flag", features.EnableAlphaRequiredResourceWatches,
+				"missing-flag", features.EnableBetaRealtimeCompositions)
+		}
+	}
+
 	cacheOptionsAPIExt := cache.Options{
 		HTTPClient: mgr.GetHTTPClient(),
 		Scheme:     mgr.GetScheme(),
@@ -473,29 +488,80 @@ func (c *startCommand) Run(s *runtime.Scheme, log logging.Logger) error { //noli
 		return errors.Wrap(err, "cannot setup discovery cache invalidation")
 	}
 
-	// Middleware layering: We want Cache → FetchingFunctionRunner → gRPC.
-	// First, wrap the runner with FetchingFunctionRunner to handle
-	// requirements.
-	runner = xfn.NewFetchingFunctionRunner(runner,
-		xfn.NewExistingRequiredResourcesFetcher(cached),
-		xfn.NewOpenAPIRequiredSchemasFetcher(oac))
+	// When required resource watches are enabled, the function runner remembers
+	// the requirements functions return (to pre-satisfy them next reconcile) and
+	// starts watches on the resources they require. The registry lets per-XR-kind
+	// watchers, registered by the definition controller, start those watches on
+	// the right controller. Both are nil unless the feature is enabled.
+	var requirementsCache *xfn.RequirementsCache
+	var requiredResourceWatchers *xfn.RequiredResourceWatcherRegistry
+	if c.EnableRequiredResourceWatches {
+		requirementsCache = xfn.NewRequirementsCache()
+		requiredResourceWatchers = xfn.NewRequiredResourceWatcherRegistry()
+	}
 
-	// Then, if caching is enabled, wrap with the cache layer.
-	// This ensures the cache stores final responses after all requirements are fulfilled.
-	if c.EnableFunctionResponseCache {
-		cfrm := xfncached.NewPrometheusMetrics()
-		metrics.Registry.MustRegister(cfrm)
+	// Without required resource watches we layer Cache → FetchingFunctionRunner
+	// → gRPC. The cache wraps the whole requirement-resolution loop, so a single
+	// cache hit skips the loop entirely - including its Kubernetes reads.
+	if !c.EnableRequiredResourceWatches {
+		// Wrap the base runner to fetch required resources and schemas.
+		runner = xfn.NewFetchingFunctionRunner(runner,
+			xfn.NewExistingRequiredResourcesFetcher(cached),
+			xfn.NewOpenAPIRequiredSchemasFetcher(oac))
 
-		cfr := xfncached.NewFileBackedRunner(runner, c.XfnCacheDir,
-			xfncached.WithLogger(log),
-			xfncached.WithMaxTTL(c.XfnCacheMaxTTL),
-			xfncached.WithMetrics(cfrm),
+		if c.EnableFunctionResponseCache {
+			cfrm := xfncached.NewPrometheusMetrics()
+			metrics.Registry.MustRegister(cfrm)
+
+			cfr := xfncached.NewFileBackedRunner(runner, c.XfnCacheDir,
+				xfncached.WithLogger(log),
+				xfncached.WithMaxTTL(c.XfnCacheMaxTTL),
+				xfncached.WithMetrics(cfrm),
+			)
+			// Periodically delete expired cache entries.
+			go cfr.GarbageCollectFiles(ctx, 1*time.Minute)
+
+			runner = cfr
+		}
+	}
+
+	// With required resource watches we layer FetchingFunctionRunner → Cache →
+	// gRPC. The cache sits below the runner, so it caches each call the runner
+	// makes while resolving requirements, keyed by a request that includes the
+	// resources fetched so far. This is what lets a change to a required
+	// resource invalidate the cache: the changed resource changes the request,
+	// so the request's tag (the cache key) changes, so the cache misses and the
+	// function re-runs. The runner recomputes the tag each iteration to make
+	// this work. This arrangement is less effective at caching multi-iteration
+	// functions, which is why we only use it when required resource watches need
+	// the invalidation it provides.
+	if c.EnableRequiredResourceWatches {
+		// Wrap the base runner with a cache.
+		if c.EnableFunctionResponseCache {
+			cfrm := xfncached.NewPrometheusMetrics()
+			metrics.Registry.MustRegister(cfrm)
+
+			cfr := xfncached.NewFileBackedRunner(runner, c.XfnCacheDir,
+				xfncached.WithLogger(log),
+				xfncached.WithMaxTTL(c.XfnCacheMaxTTL),
+				xfncached.WithMetrics(cfrm),
+			)
+			// Periodically delete expired cache entries.
+			go cfr.GarbageCollectFiles(ctx, 1*time.Minute)
+
+			runner = cfr
+		}
+
+		// Then wrap the cache with a fetching function runner. The
+		// cache is below the runner, so the runner must retag each
+		// iteration for the cache to key on the resolved request.
+		runner = xfn.NewFetchingFunctionRunner(runner,
+			xfn.NewExistingRequiredResourcesFetcher(cached),
+			xfn.NewOpenAPIRequiredSchemasFetcher(oac),
+			xfn.WithRequirementsRecorder(requirementsCache),
+			xfn.WithRequiredResourceWatcher(requiredResourceWatchers),
+			xfn.WithPerIterationTagging(),
 		)
-
-		// Periodically delete expired cache entries.
-		go cfr.GarbageCollectFiles(ctx, 1*time.Minute)
-
-		runner = cfr
 	}
 
 	// Then, last, if pipeline inspection is enabled, wrap with the inspector layer.
@@ -528,6 +594,8 @@ func (c *startCommand) Run(s *runtime.Scheme, log logging.Logger) error { //noli
 		Options:                  o,
 		ControllerEngine:         ce,
 		FunctionRunner:           runner,
+		RequiredResourceWatchers: requiredResourceWatchers,
+		RequirementsCache:        requirementsCache,
 		OpenAPIClient:            oac,
 		CircuitBreakerMetrics:    cbm,
 		CircuitBreakerBurst:      c.CircuitBreakerBurst,

--- a/internal/controller/apiextensions/composite/watch/watch.go
+++ b/internal/controller/apiextensions/composite/watch/watch.go
@@ -14,7 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package watch implements a garbage collector for composed resource watches.
+// Package watch implements a garbage collector for the composed and required
+// resource watches a composite resource (XR) controller starts.
 package watch
 
 import (
@@ -40,17 +41,34 @@ type ControllerEngine interface {
 	GetUncached() client.Client
 }
 
+// A RequiredResourceProvider knows which kinds of resource an XR's function
+// pipeline requires. The garbage collector uses it to learn which required
+// resource watches are still in use. It's typically backed by the function
+// runner's requirements cache.
+type RequiredResourceProvider interface {
+	// RequiredGVKs returns the kinds of resource required by the XR with the
+	// supplied UID.
+	RequiredGVKs(xrUID string) []schema.GroupVersionKind
+
+	// RetainForKind forgets what it knows about XRs of the supplied kind whose
+	// UID isn't in the supplied set of live UIDs, so it doesn't leak memory for
+	// deleted XRs.
+	RetainForKind(gvk schema.GroupVersionKind, live map[string]bool)
+}
+
 // A GarbageCollector garbage collects watches for a single composite resource
 // (XR) controller. A watch is eligible for garbage collection when none of the
-// XRs the controller owns resource references its GVK. The garbage collector
-// periodically lists all the controller's XRs to determine what GVKs they still
-// reference.
+// XRs the controller owns still needs it - either because no XR composes the
+// watched kind (composed resource watches) or because no XR's function pipeline
+// requires it (required resource watches). The garbage collector periodically
+// lists all the controller's XRs to determine what they still need.
 type GarbageCollector struct {
 	controllerName string
 	gvk            schema.GroupVersionKind
 	schema         composite.Schema
 
-	engine ControllerEngine
+	engine   ControllerEngine
+	required RequiredResourceProvider
 
 	log logging.Logger
 }
@@ -73,12 +91,30 @@ func WithCompositeSchema(s composite.Schema) GarbageCollectorOption {
 	}
 }
 
+// WithRequiredResourceProvider configures the GarbageCollector to also garbage
+// collect required resource watches, using the supplied provider to learn which
+// required resources the controller's XRs still need.
+func WithRequiredResourceProvider(p RequiredResourceProvider) GarbageCollectorOption {
+	return func(gc *GarbageCollector) {
+		gc.required = p
+	}
+}
+
+// A nopRequiredResourceProvider reports that no required resources are needed.
+// It's the default, so that unless a provider is configured the garbage
+// collector only collects composed resource watches.
+type nopRequiredResourceProvider struct{}
+
+func (nopRequiredResourceProvider) RequiredGVKs(_ string) []schema.GroupVersionKind            { return nil }
+func (nopRequiredResourceProvider) RetainForKind(_ schema.GroupVersionKind, _ map[string]bool) {}
+
 // NewGarbageCollector creates a new watch garbage collector for a controller.
 func NewGarbageCollector(name string, of schema.GroupVersionKind, ce ControllerEngine, o ...GarbageCollectorOption) *GarbageCollector {
 	gc := &GarbageCollector{
 		controllerName: name,
 		gvk:            of,
 		engine:         ce,
+		required:       nopRequiredResourceProvider{},
 		log:            logging.NewNopLogger(),
 	}
 	for _, fn := range o {
@@ -108,9 +144,9 @@ func (gc *GarbageCollector) GarbageCollectWatches(ctx context.Context, interval 
 	}
 }
 
-// GarbageCollectWatchesNow stops any watches for resource types that are no
-// longer composed by any composite resource (XR). It's safe to call from
-// multiple goroutines.
+// GarbageCollectWatchesNow stops any composed resource watches for kinds no XR
+// composes, and any required resource watches for kinds no XR's function
+// pipeline requires. It's safe to call from multiple goroutines.
 func (gc *GarbageCollector) GarbageCollectWatchesNow(ctx context.Context) error {
 	// Get the set of running watches.
 	running, err := gc.engine.GetWatches(gc.controllerName)
@@ -118,59 +154,37 @@ func (gc *GarbageCollector) GarbageCollectWatchesNow(ctx context.Context) error 
 		return errors.Wrap(err, "cannot get running watches")
 	}
 
-	composed := make([]engine.WatchID, 0, len(running))
+	// We only garbage collect composed and required resource watches. The other
+	// watch types should only be stopped when the XR controller stops.
+	collectable := make([]engine.WatchID, 0, len(running))
 	for _, wid := range running {
-		// Only stop watches for composed resources. The other watch
-		// types should only be stopped when the XR controller stops.
-		if wid.Type == engine.WatchTypeComposedResource {
-			composed = append(composed, wid)
+		if wid.Type == engine.WatchTypeComposedResource || wid.Type == engine.WatchTypeRequiredResource {
+			collectable = append(collectable, wid)
 		}
 	}
 
-	// No composed resource watches exist. Nothing to do.
-	if len(composed) == 0 {
+	// No collectable watches exist. Nothing to do.
+	if len(collectable) == 0 {
 		return nil
 	}
 
-	// List all XRs of the type we're interested in. This list is from
-	// cache, so it could be stale.
-	l := &kunstructured.UnstructuredList{}
-	l.SetAPIVersion(gc.gvk.GroupVersion().String())
-	l.SetKind(gc.gvk.Kind + "List")
-
-	if err := gc.engine.GetCached().List(ctx, l); err != nil {
-		return errors.Wrap(err, "cannot list composite resources")
+	// Determine which watches look unused, based on a (possibly stale) cached
+	// list of XRs.
+	used, _, err := gc.usedGVKs(ctx, gc.engine.GetCached())
+	if err != nil {
+		return err
 	}
+	stop := unusedWatches(collectable, used)
 
-	// Build the set of GVKs they still reference.
-	used := make(map[schema.GroupVersionKind]bool)
-	for _, u := range l.Items {
-		xr := &composite.Unstructured{Unstructured: u, Schema: gc.schema}
-		for _, ref := range xr.GetResourceReferences() {
-			used[schema.FromAPIVersionAndKind(ref.APIVersion, ref.Kind)] = true
-		}
-	}
-
-	stop := make([]engine.WatchID, 0)
-
-	for _, wid := range composed {
-		// Only stop watches for types no XR composes.
-		if used[wid.GVK] {
-			continue
-		}
-
-		stop = append(stop, wid)
-	}
-
-	// We listed from cache, so the set of 'used' GVKs still composed by at
-	// least one XR could be stale. For example a watch for kind: X exists,
-	// our stale cache told us an XR was still composing kind: X, but really
-	// it wasn't. That's okay. We'll stop the watch on the next GC cycle.
+	// We listed from cache, so the set of 'used' GVKs could be stale. For
+	// example a watch for kind: X exists, our stale cache told us an XR was
+	// still using kind: X, but really it wasn't. That's okay. We'll stop the
+	// watch on the next GC cycle.
 	//
 	// What we really want to avoid is stopping a watch that we shouldn't.
 	// For example a watch for kind: X exists, our stale cache told us no XR
-	// was still composing kind: X, but really one was. e.g Because it
-	// started the watch very recently.
+	// was still using kind: X, but really one was. e.g Because it started the
+	// watch very recently.
 	//
 	// So if it looks like there's no watches to stop we return early. If it
 	// looks like there _are_ watches to stop, we double check using an
@@ -179,39 +193,21 @@ func (gc *GarbageCollector) GarbageCollectWatchesNow(ctx context.Context) error 
 		return nil
 	}
 
-	// List all XRs again, this time using an uncached client.
-	l = &kunstructured.UnstructuredList{}
-	l.SetAPIVersion(gc.gvk.GroupVersion().String())
-	l.SetKind(gc.gvk.Kind + "List")
-
-	if err := gc.engine.GetUncached().List(ctx, l); err != nil {
-		return errors.Wrap(err, "cannot list composite resources")
+	// Recompute the used set using an uncached list of XRs.
+	used, live, err := gc.usedGVKs(ctx, gc.engine.GetUncached())
+	if err != nil {
+		return err
 	}
+	stop = unusedWatches(collectable, used)
 
-	// Build the set of GVKs they still reference.
-	used = make(map[schema.GroupVersionKind]bool)
-
-	for _, u := range l.Items {
-		xr := &composite.Unstructured{Unstructured: u}
-		for _, ref := range xr.GetResourceReferences() {
-			used[schema.FromAPIVersionAndKind(ref.APIVersion, ref.Kind)] = true
-		}
-	}
-
-	stop = make([]engine.WatchID, 0)
-	for _, wid := range composed {
-		// Only stop watches for composed resources. The other watch
-		// types should only be stopped when the XR controller stops.
-		if wid.Type != engine.WatchTypeComposedResource {
-			continue
-		}
-		// Only stop watches for types no XR composes.
-		if used[wid.GVK] {
-			continue
-		}
-
-		stop = append(stop, wid)
-	}
+	// Forget what we remember about XRs of our kind that no longer exist, so we
+	// don't leak memory for deleted XRs. We evict using the authoritative
+	// uncached list, so we never forget a live XR's requirements (which would
+	// wrongly stop its required resource watches). This means we only evict on
+	// cycles where there's at least one watch to stop, but that's fine: a
+	// deleted XR's watch is exactly such a watch, so we evict whenever it
+	// matters.
+	gc.required.RetainForKind(gc.gvk, live)
 
 	// No need to call StopWatches if there's nothing to stop.
 	if len(stop) == 0 {
@@ -233,5 +229,53 @@ func (gc *GarbageCollector) GarbageCollectWatchesNow(ctx context.Context) error 
 	gc.log.Debug("Garbage collecting watches", "count", len(stop))
 	_, err = gc.engine.StopWatches(ctx, gc.controllerName, stop...)
 
-	return errors.Wrap(err, "cannot stop watches for composed resource types that are no longer referenced by any composite resource")
+	return errors.Wrap(err, "cannot stop watches for resource types no longer needed by any composite resource")
+}
+
+// usedGVKs lists the controller's XRs using the supplied client, and returns the
+// kinds of resource they still need, keyed by the type of watch that delivers
+// changes to those kinds. A composed resource kind is needed while an XR
+// composes it; a required resource kind is needed while an XR's function
+// pipeline requires it. It also returns the set of live XR UIDs.
+func (gc *GarbageCollector) usedGVKs(ctx context.Context, c client.Reader) (map[engine.WatchType]map[schema.GroupVersionKind]bool, map[string]bool, error) {
+	l := &kunstructured.UnstructuredList{}
+	l.SetAPIVersion(gc.gvk.GroupVersion().String())
+	l.SetKind(gc.gvk.Kind + "List")
+
+	if err := c.List(ctx, l); err != nil {
+		return nil, nil, errors.Wrap(err, "cannot list composite resources")
+	}
+
+	composed := make(map[schema.GroupVersionKind]bool)
+	required := make(map[schema.GroupVersionKind]bool)
+	live := make(map[string]bool, len(l.Items))
+
+	for _, u := range l.Items {
+		xr := &composite.Unstructured{Unstructured: u, Schema: gc.schema}
+		live[string(xr.GetUID())] = true
+		for _, ref := range xr.GetResourceReferences() {
+			composed[schema.FromAPIVersionAndKind(ref.APIVersion, ref.Kind)] = true
+		}
+		for _, gvk := range gc.required.RequiredGVKs(string(xr.GetUID())) {
+			required[gvk] = true
+		}
+	}
+
+	return map[engine.WatchType]map[schema.GroupVersionKind]bool{
+		engine.WatchTypeComposedResource: composed,
+		engine.WatchTypeRequiredResource: required,
+	}, live, nil
+}
+
+// unusedWatches returns the watches whose GVK isn't in the used set for their
+// watch type.
+func unusedWatches(watches []engine.WatchID, used map[engine.WatchType]map[schema.GroupVersionKind]bool) []engine.WatchID {
+	stop := make([]engine.WatchID, 0)
+	for _, wid := range watches {
+		if used[wid.Type][wid.GVK] {
+			continue
+		}
+		stop = append(stop, wid)
+	}
+	return stop
 }

--- a/internal/controller/apiextensions/composite/watch/watch_test.go
+++ b/internal/controller/apiextensions/composite/watch/watch_test.go
@@ -37,6 +37,24 @@ import (
 
 var _ ControllerEngine = &MockEngine{}
 
+var _ RequiredResourceProvider = &MockRequiredResourceProvider{}
+
+// MockRequiredResourceProvider is a mock RequiredResourceProvider.
+type MockRequiredResourceProvider struct {
+	MockRequiredGVKs  func(xrUID string) []schema.GroupVersionKind
+	MockRetainForKind func(gvk schema.GroupVersionKind, live map[string]bool)
+}
+
+func (m *MockRequiredResourceProvider) RequiredGVKs(xrUID string) []schema.GroupVersionKind {
+	return m.MockRequiredGVKs(xrUID)
+}
+
+func (m *MockRequiredResourceProvider) RetainForKind(gvk schema.GroupVersionKind, live map[string]bool) {
+	if m.MockRetainForKind != nil {
+		m.MockRetainForKind(gvk, live)
+	}
+}
+
 type MockEngine struct {
 	MockGetWatches  func(name string) ([]engine.WatchID, error)
 	MockStopWatches func(ctx context.Context, name string, ws ...engine.WatchID) (int, error)
@@ -291,6 +309,119 @@ func TestGarbageCollectWatchesNow(t *testing.T) {
 				},
 				o: []GarbageCollectorOption{
 					WithLogger(logging.NewNopLogger()),
+				},
+			},
+			want: want{
+				err: nil,
+			},
+		},
+		"LegacyComposedResourceWatchesUseLegacySchema": {
+			reason: "For a legacy XR controller we should read composed resource refs using the legacy schema, so we keep watches the XR still composes.",
+			params: params{
+				of: schema.GroupVersionKind{Group: "example.org", Version: "v1", Kind: "LegacyXR"},
+				ce: &MockEngine{
+					MockGetCached: func() client.Client {
+						return &test.MockClient{
+							MockList: test.NewMockListFn(nil, func(obj client.ObjectList) error {
+								// A legacy XR composing StillComposed. Legacy XRs
+								// store refs at spec.resourceRefs, which only the
+								// legacy schema reads.
+								xr := composite.New(composite.WithSchema(composite.SchemaLegacy))
+								xr.SetResourceReferences([]corev1.ObjectReference{{
+									APIVersion: "example.org/v1",
+									Kind:       "StillComposed",
+								}})
+								obj.(*unstructured.UnstructuredList).Items = []unstructured.Unstructured{xr.Unstructured}
+								return nil
+							}),
+						}
+					},
+					MockGetWatches: func(_ string) ([]engine.WatchID, error) {
+						return []engine.WatchID{{
+							Type: engine.WatchTypeComposedResource,
+							GVK:  schema.GroupVersionKind{Group: "example.org", Version: "v1", Kind: "StillComposed"},
+						}}, nil
+					},
+					// StopWatches isn't mocked: the test fails if it's called,
+					// because StillComposed is still composed and must be kept.
+				},
+				o: []GarbageCollectorOption{
+					WithLogger(logging.NewNopLogger()),
+					WithCompositeSchema(composite.SchemaLegacy),
+				},
+			},
+			want: want{
+				err: nil,
+			},
+		},
+		"UnneededRequiredResourceWatchesStopped": {
+			reason: "We should stop a required resource watch for a kind no XR's function pipeline requires, and keep one that's still required.",
+			params: params{
+				ce: &MockEngine{
+					MockGetCached: func() client.Client {
+						return &test.MockClient{
+							MockList: test.NewMockListFn(nil, func(obj client.ObjectList) error {
+								xr := composite.New()
+								xr.SetUID("xr-uid")
+								obj.(*unstructured.UnstructuredList).Items = []unstructured.Unstructured{xr.Unstructured}
+								return nil
+							}),
+						}
+					},
+					MockGetUncached: func() client.Client {
+						return &test.MockClient{
+							MockList: test.NewMockListFn(nil, func(obj client.ObjectList) error {
+								xr := composite.New()
+								xr.SetUID("xr-uid")
+								obj.(*unstructured.UnstructuredList).Items = []unstructured.Unstructured{xr.Unstructured}
+								return nil
+							}),
+						}
+					},
+					MockGetWatches: func(_ string) ([]engine.WatchID, error) {
+						return []engine.WatchID{
+							// Still required - keep it.
+							{
+								Type: engine.WatchTypeRequiredResource,
+								GVK:  schema.GroupVersionKind{Group: "example.org", Version: "v1", Kind: "StillRequired"},
+							},
+							// No longer required - GC it.
+							{
+								Type: engine.WatchTypeRequiredResource,
+								GVK:  schema.GroupVersionKind{Group: "example.org", Version: "v1", Kind: "GarbageCollectMe"},
+							},
+						}, nil
+					},
+					MockStopWatches: func(_ context.Context, _ string, ws ...engine.WatchID) (int, error) {
+						want := []engine.WatchID{
+							{
+								Type: engine.WatchTypeRequiredResource,
+								GVK:  schema.GroupVersionKind{Group: "example.org", Version: "v1", Kind: "GarbageCollectMe"},
+							},
+						}
+						if diff := cmp.Diff(want, ws); diff != "" {
+							t.Errorf("\nMockStopWatches(...) -want, +got:\n%s", diff)
+						}
+						return 0, nil
+					},
+				},
+				o: []GarbageCollectorOption{
+					WithLogger(logging.NewNopLogger()),
+					WithRequiredResourceProvider(&MockRequiredResourceProvider{
+						MockRequiredGVKs: func(xrUID string) []schema.GroupVersionKind {
+							if xrUID != "xr-uid" {
+								return nil
+							}
+							return []schema.GroupVersionKind{{Group: "example.org", Version: "v1", Kind: "StillRequired"}}
+						},
+						MockRetainForKind: func(_ schema.GroupVersionKind, live map[string]bool) {
+							// We evict using the authoritative uncached live set,
+							// which contains our one live XR.
+							if diff := cmp.Diff(map[string]bool{"xr-uid": true}, live); diff != "" {
+								t.Errorf("\nRetainForKind() live: -want, +got:\n%s", diff)
+							}
+						},
+					}),
 				},
 			},
 			want: want{

--- a/internal/controller/apiextensions/controller/options.go
+++ b/internal/controller/apiextensions/controller/options.go
@@ -37,6 +37,16 @@ type Options struct {
 	// FunctionRunner used to run Composition Functions.
 	FunctionRunner xfn.FunctionRunner
 
+	// RequiredResourceWatchers registers per-composite-resource-kind watchers
+	// for the resources composition functions require. It's nil unless required
+	// resource watches are enabled.
+	RequiredResourceWatchers *xfn.RequiredResourceWatcherRegistry
+
+	// RequirementsCache remembers the resources composition functions require,
+	// so the watch garbage collector can tell which required resource watches
+	// are still in use. It's nil unless required resource watches are enabled.
+	RequirementsCache *xfn.RequirementsCache
+
 	// OpenAPIClient used to fetch OpenAPI schemas for bootstrap requirements
 	// specified in Compositions.
 	OpenAPIClient xfn.OpenAPIV3Client

--- a/internal/controller/apiextensions/definition/handlers.go
+++ b/internal/controller/apiextensions/definition/handlers.go
@@ -109,6 +109,45 @@ func SelfMapFunc() handler.MapFunc {
 	}
 }
 
+// RequiredResourcesMapFunc returns a MapFunc that maps a changed required
+// resource to the composite resources (XRs) of the supplied kind, so they
+// reconcile when a resource their function pipeline requires changes.
+//
+// Unlike composed resources, required resources aren't referenced by the XR, so
+// we can't index XRs by the required resources they use. A function can also
+// require a resource by label selector, matching resources no XR records. We
+// therefore enqueue every XR of this controller's kind when a required resource
+// of a watched kind changes. This is deliberately coarse: an XR whose
+// requirements didn't actually change still reconciles. The function response
+// cache (when enabled) serves its pipeline from cache, so the redundant
+// reconcile doesn't re-run the function pipeline - though it does still cost a
+// reconcile, and this map function still lists every XR of our kind per event.
+func RequiredResourcesMapFunc(of schema.GroupVersionKind, c client.Reader, log logging.Logger) handler.MapFunc {
+	return func(ctx context.Context, obj client.Object) []reconcile.Request {
+		// We can't tell which XRs require the changed resource, so we enqueue
+		// every XR of our kind. We use the changed object only for logging.
+		xrs := kunstructured.UnstructuredList{}
+		xrs.SetGroupVersionKind(of.GroupVersion().WithKind(of.Kind + "List"))
+		if err := c.List(ctx, &xrs); err != nil {
+			log.Debug("cannot list composite resources related to a required resource change",
+				"error", err,
+				"composite-gvk", of.String(),
+				"required-gvk", obj.GetObjectKind().GroupVersionKind().String(),
+				"required-name", obj.GetName(),
+				"required-namespace", obj.GetNamespace(),
+			)
+			return nil
+		}
+
+		requests := make([]reconcile.Request, len(xrs.Items))
+		for i, xr := range xrs.Items {
+			requests[i] = reconcile.Request{NamespacedName: client.ObjectKeyFromObject(&xr)}
+		}
+
+		return requests
+	}
+}
+
 // CompositeResourcesMapFunc returns a MapFunc that maps composed resources to affected XRs.
 func CompositeResourcesMapFunc(of schema.GroupVersionKind, c client.Reader, log logging.Logger) handler.MapFunc {
 	return func(ctx context.Context, obj client.Object) []reconcile.Request {

--- a/internal/controller/apiextensions/definition/handlers_test.go
+++ b/internal/controller/apiextensions/definition/handlers_test.go
@@ -13,6 +13,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
+	"github.com/crossplane/crossplane-runtime/v2/pkg/errors"
 	"github.com/crossplane/crossplane-runtime/v2/pkg/logging"
 	"github.com/crossplane/crossplane-runtime/v2/pkg/resource/unstructured/composite"
 	"github.com/crossplane/crossplane-runtime/v2/pkg/test"
@@ -333,6 +334,100 @@ func TestCompositeResourcesMapFunc(t *testing.T) {
 
 			if diff := cmp.Diff(tc.want.requests, requests); diff != "" {
 				t.Errorf("\n%s\nCompositeResourcesMapFunc(...): -want, +got:\n%s", tc.reason, diff)
+			}
+		})
+	}
+}
+
+func TestRequiredResourcesMapFunc(t *testing.T) {
+	type args struct {
+		of     schema.GroupVersionKind
+		reader client.Reader
+		obj    client.Object
+	}
+
+	type want struct {
+		requests []reconcile.Request
+	}
+
+	dog := schema.GroupVersionKind{Group: "example.com", Version: "v1", Kind: "Dog"}
+	configMap := schema.GroupVersionKind{Group: "", Version: "v1", Kind: "ConfigMap"}
+
+	tests := map[string]struct {
+		reason string
+		args   args
+		want   want
+	}{
+		"ListError": {
+			reason: "If we can't list XRs we should enqueue nothing.",
+			args: args{
+				of: dog,
+				reader: &test.MockClient{
+					MockList: func(_ context.Context, _ client.ObjectList, _ ...client.ListOption) error {
+						return errors.New("boom")
+					},
+				},
+				obj: &kunstructured.Unstructured{},
+			},
+			want: want{
+				requests: nil,
+			},
+		},
+		"NoXRs": {
+			reason: "If there are no XRs of our kind we should enqueue nothing.",
+			args: args{
+				of: dog,
+				reader: &test.MockClient{
+					MockList: func(_ context.Context, _ client.ObjectList, _ ...client.ListOption) error {
+						return nil
+					},
+				},
+				obj: &kunstructured.Unstructured{},
+			},
+			want: want{
+				requests: []reconcile.Request{},
+			},
+		},
+		"AllXRsOfKind": {
+			reason: "We should enqueue every XR of our kind when a required resource changes, since we can't tell which XRs require the changed resource.",
+			args: args{
+				of: dog,
+				reader: &test.MockClient{
+					MockList: func(_ context.Context, list client.ObjectList, _ ...client.ListOption) error {
+						var xr1, xr2 kunstructured.Unstructured
+						xr1.SetName("xr1")
+						xr2.SetName("xr2")
+						list.(*kunstructured.UnstructuredList).Items = []kunstructured.Unstructured{xr1, xr2}
+						return nil
+					},
+				},
+				obj: &kunstructured.Unstructured{
+					Object: map[string]any{
+						"apiVersion": configMap.GroupVersion().String(),
+						"kind":       configMap.Kind,
+						"metadata": map[string]any{
+							"name":      "my-config",
+							"namespace": "default",
+						},
+					},
+				},
+			},
+			want: want{
+				requests: []reconcile.Request{
+					{NamespacedName: types.NamespacedName{Name: "xr1"}},
+					{NamespacedName: types.NamespacedName{Name: "xr2"}},
+				},
+			},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			mapFunc := RequiredResourcesMapFunc(tc.args.of, tc.args.reader, logging.NewNopLogger())
+			requests := mapFunc(context.TODO(), tc.args.obj)
+
+			if diff := cmp.Diff(tc.want.requests, requests); diff != "" {
+				t.Errorf("\n%s\nRequiredResourcesMapFunc(...): -want, +got:\n%s", tc.reason, diff)
 			}
 		})
 	}

--- a/internal/controller/apiextensions/definition/reconciler.go
+++ b/internal/controller/apiextensions/definition/reconciler.go
@@ -440,6 +440,9 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 			return reconcile.Result{}, err
 		}
 
+		// The controller is gone, so forget its required resource watcher.
+		r.deregisterRequiredResourceWatcher(d.GetCompositeGroupVersionKind())
+
 		log.Debug("Stopped composite resource controller")
 
 		if err := r.client.Delete(ctx, crd); resource.IgnoreNotFound(err) != nil {
@@ -507,6 +510,10 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 
 			return reconcile.Result{}, err
 		}
+
+		// Forget the stopped controller's required resource watcher. We'll
+		// re-register it below when we restart the controller.
+		r.deregisterRequiredResourceWatcher(d.GetCompositeGroupVersionKind())
 
 		log.Debug("XRD generation changed; stopped composite resource controller",
 			"observed-generation", d.GetCondition(v1.TypeEstablished).ObservedGeneration,
@@ -603,7 +610,15 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 		// If realtime composition is enabled we'll start watches dynamically,
 		// so we want to garbage collect watches for composed resource kinds
 		// that aren't used anymore.
-		gc := watch.NewGarbageCollector(controllerName, gvk, r.engine, watch.WithCompositeSchema(schema), watch.WithLogger(log))
+		gco := []watch.GarbageCollectorOption{watch.WithCompositeSchema(schema), watch.WithLogger(log)}
+
+		// If we're also watching required resources, the garbage collector
+		// needs to know which required resource watches are still in use.
+		if r.options.Features.Enabled(features.EnableAlphaRequiredResourceWatches) && r.options.RequirementsCache != nil {
+			gco = append(gco, watch.WithRequiredResourceProvider(r.options.RequirementsCache))
+		}
+
+		gc := watch.NewGarbageCollector(controllerName, gvk, r.engine, gco...)
 		co = append(co, engine.WithWatchGarbageCollector(gc))
 	}
 
@@ -646,10 +661,35 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 		return reconcile.Result{}, err
 	}
 
+	// Register a required resource watcher for this XR's kind, so the shared
+	// function runner can start watches on this controller when a function's
+	// requirements stabilize. We register after starting the controller, so the
+	// runner never dispatches to a controller that isn't running yet. Required
+	// resource watches build on realtime compositions' watch machinery, so we
+	// only register when both features are enabled.
+	if r.options.Features.Enabled(features.EnableBetaRealtimeCompositions) &&
+		r.options.Features.Enabled(features.EnableAlphaRequiredResourceWatches) &&
+		r.options.RequiredResourceWatchers != nil {
+		rmf := RequiredResourcesMapFunc(gvk, r.engine.GetCached(), r.log)
+		rh := handler.EnqueueRequestsFromMapFunc(circuit.NewMapFunc(rmf, cb))
+		r.options.RequiredResourceWatchers.Register(gvk, NewRequiredResourceWatchStarter(controllerName, r.engine, rh, r.log))
+	}
+
 	d.Status.Controllers.CompositeResourceTypeRef = v1.TypeReferenceTo(d.GetCompositeGroupVersionKind())
 	status.MarkConditions(v1.WatchingComposite())
 
 	return reconcile.Result{Requeue: false}, errors.Wrap(r.client.Status().Update(ctx, d), errUpdateStatus)
+}
+
+// deregisterRequiredResourceWatcher forgets the required resource watcher for
+// the supplied XR kind, if we're registering them. It's called when an XR
+// controller stops, so the shared function runner doesn't dispatch to a watcher
+// for a controller that's no longer running.
+func (r *Reconciler) deregisterRequiredResourceWatcher(gvk schema.GroupVersionKind) {
+	if r.options.RequiredResourceWatchers == nil {
+		return
+	}
+	r.options.RequiredResourceWatchers.Deregister(gvk)
 }
 
 // ControllerNeedsRestart returns true if the composite resource controller

--- a/internal/controller/apiextensions/definition/required_resources.go
+++ b/internal/controller/apiextensions/definition/required_resources.go
@@ -1,0 +1,72 @@
+/*
+Copyright 2026 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package definition
+
+import (
+	"context"
+
+	kunstructured "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+
+	"github.com/crossplane/crossplane-runtime/v2/pkg/errors"
+	"github.com/crossplane/crossplane-runtime/v2/pkg/logging"
+
+	"github.com/crossplane/crossplane/v2/internal/controller/apiextensions/composite"
+	"github.com/crossplane/crossplane/v2/internal/engine"
+)
+
+// A RequiredResourceWatchStarter starts watches for the resources a composite
+// resource's (XR's) function pipeline requires, on a single XR controller. It
+// satisfies xfn.RequiredResourceWatcher. The definition reconciler registers one
+// per XR controller, so the shared function runner can start required resource
+// watches on the right controller when a function's requirements stabilize.
+type RequiredResourceWatchStarter struct {
+	controllerName string
+	engine         composite.WatchStarter
+	handler        handler.EventHandler
+	log            logging.Logger
+}
+
+// NewRequiredResourceWatchStarter creates a RequiredResourceWatchStarter that
+// starts watches on the named controller, enqueuing reconciles via the supplied
+// handler.
+func NewRequiredResourceWatchStarter(name string, e composite.WatchStarter, h handler.EventHandler, log logging.Logger) *RequiredResourceWatchStarter {
+	return &RequiredResourceWatchStarter{controllerName: name, engine: e, handler: h, log: log}
+}
+
+// WatchRequiredResources ensures the controller is watching each of the supplied
+// required resource kinds. StartWatches is idempotent, so it's safe to call on
+// every reconcile that resolves requirements; it only starts watches that aren't
+// already running.
+func (s *RequiredResourceWatchStarter) WatchRequiredResources(ctx context.Context, _ schema.GroupVersionKind, required []schema.GroupVersionKind) error {
+	if len(required) == 0 {
+		return nil
+	}
+
+	ws := make([]engine.Watch, len(required))
+	for i, gvk := range required {
+		// controller-runtime only supports watching *unstructured.Unstructured,
+		// not our wrapper types.
+		u := &kunstructured.Unstructured{}
+		u.SetGroupVersionKind(gvk)
+		ws[i] = engine.WatchFor(u, engine.WatchTypeRequiredResource, s.handler)
+	}
+
+	s.log.Debug("Starting required resource watches", "controller", s.controllerName, "count", len(ws))
+	return errors.Wrap(s.engine.StartWatches(ctx, s.controllerName, ws...), "cannot start required resource watches")
+}

--- a/internal/controller/apiextensions/definition/required_resources_test.go
+++ b/internal/controller/apiextensions/definition/required_resources_test.go
@@ -1,0 +1,114 @@
+/*
+Copyright 2026 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package definition
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	kunstructured "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/crossplane/crossplane-runtime/v2/pkg/errors"
+	"github.com/crossplane/crossplane-runtime/v2/pkg/logging"
+
+	"github.com/crossplane/crossplane/v2/internal/engine"
+)
+
+// watchStarterFn adapts a function to the WatchStarter interface.
+type watchStarterFn func(ctx context.Context, name string, ws ...engine.Watch) error
+
+func (fn watchStarterFn) StartWatches(ctx context.Context, name string, ws ...engine.Watch) error {
+	return fn(ctx, name, ws...)
+}
+
+func watchForGVK(gvk schema.GroupVersionKind) engine.Watch {
+	u := &kunstructured.Unstructured{}
+	u.SetGroupVersionKind(gvk)
+	return engine.WatchFor(u, engine.WatchTypeRequiredResource, nil)
+}
+
+func TestRequiredResourceWatchStarterWatchRequiredResources(t *testing.T) {
+	type args struct {
+		xr       schema.GroupVersionKind
+		required []schema.GroupVersionKind
+	}
+	type want struct {
+		watches []engine.Watch
+		err     error
+	}
+
+	thing := schema.GroupVersionKind{Group: "example.org", Version: "v1", Kind: "Thing"}
+	other := schema.GroupVersionKind{Group: "example.org", Version: "v1", Kind: "Other"}
+
+	cases := map[string]struct {
+		reason string
+		err    error // returned by the StartWatches stub
+		args   args
+		want   want
+	}{
+		"NoRequiredResources": {
+			reason: "We should not start any watches when there are no required resources.",
+			args:   args{xr: thing, required: nil},
+			want:   want{watches: nil},
+		},
+		"StartsWatchPerRequiredKind": {
+			reason: "We should start a required resource watch for each required kind.",
+			args: args{
+				xr:       thing,
+				required: []schema.GroupVersionKind{thing, other},
+			},
+			want: want{
+				watches: []engine.Watch{watchForGVK(thing), watchForGVK(other)},
+			},
+		},
+		"StartWatchesError": {
+			reason: "We should wrap and return an error from StartWatches.",
+			err:    errors.New("boom"),
+			args: args{
+				xr:       thing,
+				required: []schema.GroupVersionKind{thing},
+			},
+			want: want{
+				watches: []engine.Watch{watchForGVK(thing)},
+				err:     cmpopts.AnyError,
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			var got []engine.Watch
+			startFn := watchStarterFn(func(_ context.Context, _ string, ws ...engine.Watch) error {
+				got = ws
+				return tc.err
+			})
+
+			s := NewRequiredResourceWatchStarter("ctrl", startFn, nil, logging.NewNopLogger())
+			err := s.WatchRequiredResources(context.Background(), tc.args.xr, tc.args.required)
+
+			if diff := cmp.Diff(tc.want.err, err, cmpopts.EquateErrors()); diff != "" {
+				t.Errorf("\n%s\nWatchRequiredResources(...): -want error, +got error:\n%s", tc.reason, diff)
+			}
+			if diff := cmp.Diff(tc.want.watches, got, cmp.AllowUnexported(engine.Watch{}), cmpopts.EquateEmpty()); diff != "" {
+				t.Errorf("\n%s\nStarted watches: -want, +got:\n%s", tc.reason, diff)
+			}
+		})
+	}
+}

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -425,6 +425,7 @@ const (
 	WatchTypeComposedResource    WatchType = "ComposedResource"
 	WatchTypeCompositionRevision WatchType = "CompositionRevision"
 	WatchTypeManagedResource     WatchType = "ManagedResource"
+	WatchTypeRequiredResource    WatchType = "RequiredResource"
 )
 
 // Watch an object.

--- a/internal/features/features.go
+++ b/internal/features/features.go
@@ -53,6 +53,12 @@ const (
 	// automatically protecting Providers from deletion when they still have
 	// active managed resources. Requires EnableBetaUsages to also be enabled.
 	EnableAlphaProviderDeletionProtection feature.Flag = "EnableAlphaProviderDeletionProtection"
+
+	// EnableAlphaRequiredResourceWatches enables alpha support for watching the
+	// resources a composition function requires, and reconciling a composite
+	// resource (XR) when a resource its function pipeline requires changes.
+	// Requires EnableBetaRealtimeCompositions to also be enabled.
+	EnableAlphaRequiredResourceWatches feature.Flag = "EnableAlphaRequiredResourceWatches"
 )
 
 // Beta Feature Flags.

--- a/internal/xfn/required_resource_watcher.go
+++ b/internal/xfn/required_resource_watcher.go
@@ -1,0 +1,144 @@
+/*
+Copyright 2026 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+this file except in compliance with the License. You may obtain a copy of the
+License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed
+under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+*/
+
+package xfn
+
+import (
+	"context"
+	"sync"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	fnv1 "github.com/crossplane/crossplane/v2/proto/fn/v1"
+)
+
+// A RequiredResourceWatcher starts watches for the resources a composite
+// resource's (XR's) function pipeline requires. The composite resource (XR)
+// controller calls a function pipeline both when the XR or its composed
+// resources change and - if this watcher is wired up - when a resource the
+// pipeline requires changes.
+//
+// The FetchingFunctionRunner calls a RequiredResourceWatcher once a function's
+// requirements have stabilized, passing the XR the function ran for and the
+// kinds of resource it required. The watcher is responsible for translating
+// those into watches on the right XR controller. It dispatches on the XR's
+// GroupVersionKind, because the runner is shared by every XR controller but each
+// controller watches resources independently.
+type RequiredResourceWatcher interface {
+	// WatchRequiredResources ensures the controller for the supplied composite
+	// resource (XR) is watching the supplied required resource kinds. Implementations
+	// must be safe to call from multiple goroutines, and idempotent - the runner
+	// calls it on every reconcile that resolves requirements.
+	WatchRequiredResources(ctx context.Context, xr schema.GroupVersionKind, required []schema.GroupVersionKind) error
+}
+
+// A RequiredResourceWatcherFn is a function that satisfies RequiredResourceWatcher.
+type RequiredResourceWatcherFn func(ctx context.Context, xr schema.GroupVersionKind, required []schema.GroupVersionKind) error
+
+// WatchRequiredResources calls fn.
+func (fn RequiredResourceWatcherFn) WatchRequiredResources(ctx context.Context, xr schema.GroupVersionKind, required []schema.GroupVersionKind) error {
+	return fn(ctx, xr, required)
+}
+
+// A NopRequiredResourceWatcher does nothing. It's the default - required
+// resource watches are only started when the watcher is explicitly registered
+// for an XR's kind, behind a feature flag.
+type NopRequiredResourceWatcher struct{}
+
+// WatchRequiredResources does nothing.
+func (NopRequiredResourceWatcher) WatchRequiredResources(_ context.Context, _ schema.GroupVersionKind, _ []schema.GroupVersionKind) error {
+	return nil
+}
+
+// A RequiredResourceWatcherRegistry dispatches to a per-XR-kind
+// RequiredResourceWatcher. The FetchingFunctionRunner is shared by every XR
+// controller, so it holds a single registry. Each XR controller registers a
+// watcher for its own kind when it starts, and deregisters it when it stops.
+//
+// An XR kind with no registered watcher is silently ignored. This is the common
+// case: required resource watches are an opt-in alpha feature, so most XR kinds
+// never register a watcher.
+//
+// A RequiredResourceWatcherRegistry is safe for concurrent use, and satisfies
+// RequiredResourceWatcher itself.
+type RequiredResourceWatcherRegistry struct {
+	mx       sync.RWMutex
+	watchers map[schema.GroupVersionKind]RequiredResourceWatcher
+}
+
+// A RequiredResourceWatcherRegistry is itself a RequiredResourceWatcher.
+var _ RequiredResourceWatcher = &RequiredResourceWatcherRegistry{}
+
+// NewRequiredResourceWatcherRegistry creates a RequiredResourceWatcherRegistry.
+func NewRequiredResourceWatcherRegistry() *RequiredResourceWatcherRegistry {
+	return &RequiredResourceWatcherRegistry{watchers: make(map[schema.GroupVersionKind]RequiredResourceWatcher)}
+}
+
+// Register the supplied watcher for the supplied XR kind. It replaces any
+// watcher already registered for the kind.
+func (r *RequiredResourceWatcherRegistry) Register(xr schema.GroupVersionKind, w RequiredResourceWatcher) {
+	r.mx.Lock()
+	defer r.mx.Unlock()
+	r.watchers[xr] = w
+}
+
+// Deregister the watcher for the supplied XR kind, if any. It's called when an
+// XR controller stops, so we don't dispatch to a watcher for a controller that's
+// no longer running.
+func (r *RequiredResourceWatcherRegistry) Deregister(xr schema.GroupVersionKind) {
+	r.mx.Lock()
+	defer r.mx.Unlock()
+	delete(r.watchers, xr)
+}
+
+// WatchRequiredResources dispatches to the watcher registered for the supplied
+// XR kind. It's a no-op if no watcher is registered for the kind.
+func (r *RequiredResourceWatcherRegistry) WatchRequiredResources(ctx context.Context, xr schema.GroupVersionKind, required []schema.GroupVersionKind) error {
+	r.mx.RLock()
+	w, ok := r.watchers[xr]
+	r.mx.RUnlock()
+
+	if !ok {
+		return nil
+	}
+	return w.WatchRequiredResources(ctx, xr, required)
+}
+
+// requiredGVKs returns the distinct GroupVersionKinds of the resources the
+// supplied requirements select. It ignores schema requirements, which don't
+// correspond to watchable resources.
+func requiredGVKs(r *fnv1.Requirements) []schema.GroupVersionKind {
+	seen := make(map[schema.GroupVersionKind]bool)
+	gvks := make([]schema.GroupVersionKind, 0)
+
+	add := func(s *fnv1.ResourceSelector) {
+		gvk := schema.FromAPIVersionAndKind(s.GetApiVersion(), s.GetKind())
+		if gvk.Empty() || seen[gvk] {
+			return
+		}
+		seen[gvk] = true
+		gvks = append(gvks, gvk)
+	}
+
+	//nolint:staticcheck // We must account for the deprecated extra_resources field.
+	for _, s := range r.GetExtraResources() {
+		add(s)
+	}
+	for _, s := range r.GetResources() {
+		add(s)
+	}
+
+	return gvks
+}

--- a/internal/xfn/required_resource_watcher_test.go
+++ b/internal/xfn/required_resource_watcher_test.go
@@ -1,0 +1,167 @@
+/*
+Copyright 2026 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+this file except in compliance with the License. You may obtain a copy of the
+License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed
+under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+*/
+
+package xfn
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/crossplane/crossplane-runtime/v2/pkg/errors"
+
+	fnv1 "github.com/crossplane/crossplane/v2/proto/fn/v1"
+)
+
+func TestRequiredGVKs(t *testing.T) {
+	type args struct {
+		r *fnv1.Requirements
+	}
+	type want struct {
+		gvks []schema.GroupVersionKind
+	}
+
+	cases := map[string]struct {
+		reason string
+		args   args
+		want   want
+	}{
+		"Nil": {
+			reason: "Nil requirements select no GVKs.",
+			args:   args{r: nil},
+			want:   want{gvks: []schema.GroupVersionKind{}},
+		},
+		"Resources": {
+			reason: "We return the GVK of each required resource selector.",
+			args: args{r: &fnv1.Requirements{
+				Resources: map[string]*fnv1.ResourceSelector{
+					"a": {ApiVersion: "example.org/v1", Kind: "Thing"},
+				},
+			}},
+			want: want{gvks: []schema.GroupVersionKind{
+				{Group: "example.org", Version: "v1", Kind: "Thing"},
+			}},
+		},
+		"Deduplicates": {
+			reason: "Two selectors for the same GVK collapse to one watch.",
+			args: args{r: &fnv1.Requirements{
+				Resources: map[string]*fnv1.ResourceSelector{
+					"by-name":  {ApiVersion: "example.org/v1", Kind: "Thing", Match: &fnv1.ResourceSelector_MatchName{MatchName: "x"}},
+					"by-label": {ApiVersion: "example.org/v1", Kind: "Thing"},
+				},
+			}},
+			want: want{gvks: []schema.GroupVersionKind{
+				{Group: "example.org", Version: "v1", Kind: "Thing"},
+			}},
+		},
+		"IgnoresSchemas": {
+			reason: "Schema requirements don't correspond to watchable resources.",
+			args: args{r: &fnv1.Requirements{
+				Schemas: map[string]*fnv1.SchemaSelector{
+					"s": {ApiVersion: "example.org/v1", Kind: "Thing"},
+				},
+			}},
+			want: want{gvks: []schema.GroupVersionKind{}},
+		},
+		"IgnoresEmptySelector": {
+			reason: "A selector with no apiVersion or kind yields no GVK.",
+			args: args{r: &fnv1.Requirements{
+				Resources: map[string]*fnv1.ResourceSelector{
+					"empty": {},
+				},
+			}},
+			want: want{gvks: []schema.GroupVersionKind{}},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got := requiredGVKs(tc.args.r)
+			if diff := cmp.Diff(tc.want.gvks, got, cmpopts.SortSlices(func(a, b schema.GroupVersionKind) bool {
+				return a.String() < b.String()
+			}), cmpopts.EquateEmpty()); diff != "" {
+				t.Errorf("\n%s\nrequiredGVKs(...): -want, +got:\n%s", tc.reason, diff)
+			}
+		})
+	}
+}
+
+func TestRequiredResourceWatcherRegistry(t *testing.T) {
+	errBoom := errors.New("boom")
+
+	xrGVK := schema.GroupVersionKind{Group: "example.org", Version: "v1", Kind: "XR"}
+	required := []schema.GroupVersionKind{{Group: "example.org", Version: "v1", Kind: "Thing"}}
+
+	t.Run("DispatchesToRegisteredWatcher", func(t *testing.T) {
+		var gotXR schema.GroupVersionKind
+		var gotRequired []schema.GroupVersionKind
+
+		reg := NewRequiredResourceWatcherRegistry()
+		reg.Register(xrGVK, RequiredResourceWatcherFn(func(_ context.Context, xr schema.GroupVersionKind, req []schema.GroupVersionKind) error {
+			gotXR = xr
+			gotRequired = req
+			return nil
+		}))
+
+		if err := reg.WatchRequiredResources(context.Background(), xrGVK, required); err != nil {
+			t.Fatalf("WatchRequiredResources() error: %v", err)
+		}
+		if diff := cmp.Diff(xrGVK, gotXR); diff != "" {
+			t.Errorf("dispatched XR GVK: -want, +got:\n%s", diff)
+		}
+		if diff := cmp.Diff(required, gotRequired); diff != "" {
+			t.Errorf("dispatched required GVKs: -want, +got:\n%s", diff)
+		}
+	})
+
+	t.Run("IgnoresUnregisteredKind", func(t *testing.T) {
+		// An XR kind with no registered watcher is silently ignored - the common
+		// case, since required resource watches are opt-in.
+		reg := NewRequiredResourceWatcherRegistry()
+		if err := reg.WatchRequiredResources(context.Background(), xrGVK, required); err != nil {
+			t.Errorf("WatchRequiredResources() for unregistered kind: want nil, got %v", err)
+		}
+	})
+
+	t.Run("PropagatesWatcherError", func(t *testing.T) {
+		reg := NewRequiredResourceWatcherRegistry()
+		reg.Register(xrGVK, RequiredResourceWatcherFn(func(_ context.Context, _ schema.GroupVersionKind, _ []schema.GroupVersionKind) error {
+			return errBoom
+		}))
+		err := reg.WatchRequiredResources(context.Background(), xrGVK, required)
+		if diff := cmp.Diff(errBoom, err, cmpopts.EquateErrors()); diff != "" {
+			t.Errorf("WatchRequiredResources(): -want error, +got error:\n%s", diff)
+		}
+	})
+
+	t.Run("DeregisterStopsDispatch", func(t *testing.T) {
+		called := false
+		reg := NewRequiredResourceWatcherRegistry()
+		reg.Register(xrGVK, RequiredResourceWatcherFn(func(_ context.Context, _ schema.GroupVersionKind, _ []schema.GroupVersionKind) error {
+			called = true
+			return nil
+		}))
+		reg.Deregister(xrGVK)
+		if err := reg.WatchRequiredResources(context.Background(), xrGVK, required); err != nil {
+			t.Fatalf("WatchRequiredResources() error: %v", err)
+		}
+		if called {
+			t.Error("watcher was called after Deregister")
+		}
+	})
+}

--- a/internal/xfn/required_resources.go
+++ b/internal/xfn/required_resources.go
@@ -23,6 +23,7 @@ import (
 	"google.golang.org/protobuf/proto"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	kunstructured "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -50,18 +51,95 @@ func (fn RequiredResourcesFetcherFn) Fetch(ctx context.Context, rs *fnv1.Resourc
 	return fn(ctx, rs)
 }
 
+// A RequirementsRecorder remembers the requirements a function last returned for
+// a composite resource (XR), so they can be pre-satisfied next reconcile. The
+// FetchingFunctionRunner defaults to one that remembers nothing.
+type RequirementsRecorder interface {
+	// Get returns the requirements the named function last returned for the XR
+	// with the supplied UID, if any.
+	Get(xrUID, function string) (*fnv1.Requirements, bool)
+
+	// Set records the requirements the named function returned for the XR with
+	// the supplied UID and kind.
+	Set(xrUID string, gvk schema.GroupVersionKind, function string, r *fnv1.Requirements)
+}
+
 // A FetchingFunctionRunner wraps an underlyin FunctionRunner, adding support
 // for fetching any required resources requested by the function it runs.
 type FetchingFunctionRunner struct {
 	wrapped   FunctionRunner
 	resources RequiredResourcesFetcher
 	schemas   RequiredSchemasFetcher
+
+	// recorder remembers the requirements each function returns and lets the
+	// runner pre-satisfy them on the first call of the next reconcile, to avoid
+	// always calling a function twice (once to discover its requirements, once
+	// to confirm they're satisfied). It defaults to remembering nothing, so the
+	// runner always discovers requirements afresh.
+	recorder RequirementsRecorder
+
+	// watcher starts watches for the kinds of resource a function requires, once
+	// those requirements stabilize. This lets an XR controller reconcile an XR
+	// when a resource its pipeline requires changes, not only when the XR or its
+	// composed resources change. It defaults to a no-op.
+	watcher RequiredResourceWatcher
+
+	// tagPerIteration makes the runner recompute the request's tag on each
+	// iteration. It's needed when a response cache sits below the runner, so the
+	// cache keys on the resolved request. It's off by default - when the cache
+	// sits above the runner, retagging would be wasted work.
+	tagPerIteration bool
+}
+
+// A FetchingFunctionRunnerOption configures a FetchingFunctionRunner.
+type FetchingFunctionRunnerOption func(*FetchingFunctionRunner)
+
+// WithRequirementsRecorder configures a FetchingFunctionRunner to remember the
+// requirements functions return, and pre-satisfy them on the first call of the
+// next reconcile.
+func WithRequirementsRecorder(rec RequirementsRecorder) FetchingFunctionRunnerOption {
+	return func(r *FetchingFunctionRunner) {
+		r.recorder = rec
+	}
+}
+
+// WithRequiredResourceWatcher configures a FetchingFunctionRunner to start
+// watches for the kinds of resource a function requires, once those requirements
+// stabilize.
+func WithRequiredResourceWatcher(w RequiredResourceWatcher) FetchingFunctionRunnerOption {
+	return func(r *FetchingFunctionRunner) {
+		r.watcher = w
+	}
+}
+
+// WithPerIterationTagging makes a FetchingFunctionRunner recompute the request's
+// tag on each iteration of its requirement-resolution loop. Use it when a
+// response cache sits below the runner, so the cache keys on each iteration's
+// resolved request - and so a change to a required resource invalidates the
+// cache.
+func WithPerIterationTagging() FetchingFunctionRunnerOption {
+	return func(r *FetchingFunctionRunner) {
+		r.tagPerIteration = true
+	}
 }
 
 // NewFetchingFunctionRunner returns a FunctionRunner that supports fetching
 // required resources.
-func NewFetchingFunctionRunner(r FunctionRunner, rf RequiredResourcesFetcher, sf RequiredSchemasFetcher) *FetchingFunctionRunner {
-	return &FetchingFunctionRunner{wrapped: r, resources: rf, schemas: sf}
+func NewFetchingFunctionRunner(r FunctionRunner, rf RequiredResourcesFetcher, sf RequiredSchemasFetcher, o ...FetchingFunctionRunnerOption) *FetchingFunctionRunner {
+	f := &FetchingFunctionRunner{
+		wrapped:   r,
+		resources: rf,
+		schemas:   sf,
+
+		// Optional dependencies default to no-ops. By default we don't remember
+		// requirements across reconciles, and we don't watch required resources.
+		recorder: nopRequirementsRecorder{},
+		watcher:  NopRequiredResourceWatcher{},
+	}
+	for _, fn := range o {
+		fn(f)
+	}
+	return f
 }
 
 // RunFunction runs a function, repeatedly fetching any required resources it asks
@@ -74,9 +152,46 @@ func (c *FetchingFunctionRunner) RunFunction(ctx context.Context, name string, r
 	bootstrapResources := maps.Clone(req.GetRequiredResources())
 	bootstrapSchemas := maps.Clone(req.GetRequiredSchemas())
 
+	// If we remember the requirements this function returned last reconcile,
+	// pre-satisfy them on the first call. We also seed requirements with what we
+	// remembered, so that if the function returns the same requirements on its
+	// first call we recognize they've stabilized and return without a second
+	// call. If our memory is wrong - the function returns different requirements
+	// - we fall through to the iterative loop below, which self-corrects.
+	//
+	// A function must always return its requirements, so it's safe to satisfy
+	// requirements it didn't ask for this reconcile: it'll simply return its
+	// real (different) requirements, and we'll re-fetch them.
+	xr := &kunstructured.Unstructured{}
+	if err := FromStruct(xr, req.GetObserved().GetComposite().GetResource()); err != nil {
+		return nil, errors.Wrap(err, "cannot load observed composite resource")
+	}
+	xrUID := string(xr.GetUID())
+
+	if xrUID != "" {
+		if r, ok := c.recorder.Get(xrUID, name); ok {
+			if err := c.satisfy(ctx, req, r, bootstrapResources, bootstrapSchemas); err != nil {
+				return nil, err
+			}
+			requirements = r
+		}
+	}
+
 	for i := int32(0); i <= MaxRequirementsIterations; i++ {
 		// Update the iteration counter in the context for downstream components.
 		iterCtx := step.ContextWithStepIteration(ctx, i)
+
+		// Recompute the request's tag, so it reflects the resources we fetched
+		// for this iteration. The tag is the response cache's key. When the cache
+		// sits below us, without this an iteration that fetched different
+		// required resources would still carry the previous iteration's tag, and
+		// the cache would serve the wrong response. It also means a change to a
+		// required resource produces a different tag, so the cache misses and
+		// the function re-runs - this is how required resource changes invalidate
+		// the cache.
+		if c.tagPerIteration {
+			retag(req)
+		}
 
 		rsp, err := c.wrapped.RunFunction(iterCtx, name, req)
 		if err != nil {
@@ -86,62 +201,36 @@ func (c *FetchingFunctionRunner) RunFunction(ctx context.Context, name string, r
 
 		for _, rs := range rsp.GetResults() {
 			if rs.GetSeverity() == fnv1.Severity_SEVERITY_FATAL {
-				// We won't iterate if the function returned a fatal result.
+				// We won't iterate if the function returned a fatal result. We
+				// don't remember requirements from a fatal response - we can't
+				// trust them, and the function didn't get to act on them.
 				return rsp, nil
 			}
 		}
 
 		newRequirements := rsp.GetRequirements()
 		if proto.Equal(newRequirements, requirements) {
-			// The requirements stabilized, the function is done.
+			// The requirements stabilized, the function is done. If we know the
+			// XR's identity, remember its requirements so we can pre-satisfy
+			// them next reconcile, and start watches for the kinds of resource
+			// they require so we reconcile the XR when one of those resources
+			// changes. We need the XR's UID to key what we remember, and its
+			// kind to start watches on the right controller; without an
+			// identifiable XR we can do neither.
+			if xrUID != "" {
+				c.recorder.Set(xrUID, xr.GroupVersionKind(), name, newRequirements)
+				if err := c.watcher.WatchRequiredResources(ctx, xr.GroupVersionKind(), requiredGVKs(newRequirements)); err != nil {
+					return nil, errors.Wrap(err, "cannot watch required resources")
+				}
+			}
 			return rsp, nil
 		}
 
 		// Store the requirements for the next iteration.
 		requirements = newRequirements
 
-		// Clean up resources from the previous iteration to store the new ones.
-		req.ExtraResources = make(map[string]*fnv1.Resources) //nolint:staticcheck // Supporting deprecated field for backward compatibility
-		req.RequiredResources = maps.Clone(bootstrapResources)
-		if req.RequiredResources == nil {
-			req.RequiredResources = make(map[string]*fnv1.Resources)
-		}
-
-		// Clean up schemas from the previous iteration to store the new ones.
-		req.RequiredSchemas = maps.Clone(bootstrapSchemas)
-		if req.RequiredSchemas == nil {
-			req.RequiredSchemas = make(map[string]*fnv1.Schema)
-		}
-
-		// Fetch the requested resources and add them to the desired state.
-		// Support both old (extra_resources) and new (resources) field names.
-		for name, selector := range newRequirements.GetExtraResources() { //nolint:staticcheck // Supporting deprecated field for backward compatibility
-			resources, err := c.resources.Fetch(ctx, selector)
-			if err != nil {
-				return nil, errors.Wrapf(err, "fetching resources for %s", name)
-			}
-
-			// Resources would be nil in case of not found resources.
-			req.ExtraResources[name] = resources //nolint:staticcheck // Supporting deprecated field for backward compatibility
-		}
-
-		for name, selector := range newRequirements.GetResources() {
-			resources, err := c.resources.Fetch(ctx, selector)
-			if err != nil {
-				return nil, errors.Wrapf(err, "fetching resources for %s", name)
-			}
-
-			// Resources would be nil in case of not found resources.
-			req.RequiredResources[name] = resources
-		}
-
-		for name, selector := range newRequirements.GetSchemas() {
-			schema, err := c.schemas.Fetch(ctx, selector)
-			if err != nil {
-				return nil, errors.Wrapf(err, "fetching schema for %s", name)
-			}
-
-			req.RequiredSchemas[name] = schema
+		if err := c.satisfy(ctx, req, newRequirements, bootstrapResources, bootstrapSchemas); err != nil {
+			return nil, err
 		}
 
 		// Pass down the updated context across iterations.
@@ -149,6 +238,73 @@ func (c *FetchingFunctionRunner) RunFunction(ctx context.Context, name string, r
 	}
 	// The requirements didn't stabilize after the maximum number of iterations.
 	return nil, errors.Errorf("requirements didn't stabilize after the maximum number of iterations (%d)", MaxRequirementsIterations)
+}
+
+// retag sets req.Meta.Tag to a tag derived from the request's content. It
+// computes the tag over the request with its Meta excluded, so the tag doesn't
+// depend on itself (or on the capabilities Crossplane advertises). This matches
+// how the composer computes the initial tag - it calls Tag before setting
+// req.Meta - so retagging an unchanged request reproduces the composer's tag.
+func retag(req *fnv1.RunFunctionRequest) {
+	meta := req.GetMeta()
+	req.Meta = nil
+	tag := Tag(req)
+	if meta == nil {
+		meta = &fnv1.RequestMeta{}
+	}
+	meta.Tag = tag
+	req.Meta = meta
+}
+
+// satisfy fetches the resources and schemas required by r and populates them on
+// req, alongside the supplied bootstrap resources and schemas. It replaces any
+// required resources and schemas already on req, so that requirements from a
+// previous iteration don't leak into the next.
+func (c *FetchingFunctionRunner) satisfy(ctx context.Context, req *fnv1.RunFunctionRequest, r *fnv1.Requirements, bootstrapResources map[string]*fnv1.Resources, bootstrapSchemas map[string]*fnv1.Schema) error {
+	// Start from the bootstrap requirements, replacing anything we fetched for a
+	// previous iteration.
+	req.ExtraResources = make(map[string]*fnv1.Resources) //nolint:staticcheck // Supporting deprecated field for backward compatibility
+	req.RequiredResources = maps.Clone(bootstrapResources)
+	if req.RequiredResources == nil {
+		req.RequiredResources = make(map[string]*fnv1.Resources)
+	}
+	req.RequiredSchemas = maps.Clone(bootstrapSchemas)
+	if req.RequiredSchemas == nil {
+		req.RequiredSchemas = make(map[string]*fnv1.Schema)
+	}
+
+	// Fetch the requested resources. Support both the old (extra_resources) and
+	// new (resources) field names.
+	for name, selector := range r.GetExtraResources() { //nolint:staticcheck // Supporting deprecated field for backward compatibility
+		resources, err := c.resources.Fetch(ctx, selector)
+		if err != nil {
+			return errors.Wrapf(err, "fetching resources for %s", name)
+		}
+
+		// Resources would be nil in case of not found resources.
+		req.ExtraResources[name] = resources //nolint:staticcheck // Supporting deprecated field for backward compatibility
+	}
+
+	for name, selector := range r.GetResources() {
+		resources, err := c.resources.Fetch(ctx, selector)
+		if err != nil {
+			return errors.Wrapf(err, "fetching resources for %s", name)
+		}
+
+		// Resources would be nil in case of not found resources.
+		req.RequiredResources[name] = resources
+	}
+
+	for name, selector := range r.GetSchemas() {
+		schema, err := c.schemas.Fetch(ctx, selector)
+		if err != nil {
+			return errors.Wrapf(err, "fetching schema for %s", name)
+		}
+
+		req.RequiredSchemas[name] = schema
+	}
+
+	return nil
 }
 
 // ExistingRequiredResourcesFetcher fetches required resources requested by

--- a/internal/xfn/required_resources_test.go
+++ b/internal/xfn/required_resources_test.go
@@ -412,9 +412,10 @@ func TestFetchingFunctionRunner(t *testing.T) {
 	called := false
 
 	type params struct {
-		wrapped   FunctionRunner
-		resources RequiredResourcesFetcher
-		schemas   RequiredSchemasFetcher
+		wrapped    FunctionRunner
+		resources  RequiredResourcesFetcher
+		schemas    RequiredSchemasFetcher
+		remembered *RequirementsCache
 	}
 
 	type args struct {
@@ -876,7 +877,11 @@ func TestFetchingFunctionRunner(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			r := NewFetchingFunctionRunner(tc.params.wrapped, tc.params.resources, tc.params.schemas)
+			o := []FetchingFunctionRunnerOption{}
+			if tc.params.remembered != nil {
+				o = append(o, WithRequirementsRecorder(tc.params.remembered))
+			}
+			r := NewFetchingFunctionRunner(tc.params.wrapped, tc.params.resources, tc.params.schemas, o...)
 
 			rsp, err := r.RunFunction(tc.args.ctx, tc.args.name, tc.args.req)
 			if diff := cmp.Diff(tc.want.err, err, cmpopts.EquateErrors()); diff != "" {

--- a/internal/xfn/requirements_cache.go
+++ b/internal/xfn/requirements_cache.go
@@ -1,0 +1,185 @@
+/*
+Copyright 2026 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+this file except in compliance with the License. You may obtain a copy of the
+License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed
+under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+*/
+
+package xfn
+
+import (
+	"sync"
+
+	"google.golang.org/protobuf/proto"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	fnv1 "github.com/crossplane/crossplane/v2/proto/fn/v1"
+)
+
+// A RequirementsCache remembers the requirements a function last returned for a
+// composite resource (XR). The FetchingFunctionRunner uses it to pre-satisfy a
+// function's requirements on the first call of a reconcile, rather than always
+// discovering them on a first call and confirming them on a second.
+//
+// A composition function must return its requirements on every call - it can't
+// assume Crossplane remembers them. Functions therefore typically gate on their
+// requirements: if Crossplane satisfied them, proceed; if not, return early
+// asking for them to be satisfied. A function's requirements are usually stable
+// across reconciles (e.g. derived from the XR), so remembering them lets us
+// satisfy the gate on the first call. If our memory is wrong - the function
+// returns different requirements than we remembered - the runner falls back to
+// its iterative fetch loop and self-corrects.
+//
+// A RequirementsCache is safe for concurrent use.
+type RequirementsCache struct {
+	mx sync.RWMutex
+
+	// Keyed by XR UID. We key by XR UID rather than name/namespace so that
+	// recreating an XR with the same name doesn't inherit a stale predecessor's
+	// requirements.
+	entries map[string]*xrRequirements
+}
+
+// xrRequirements is what a RequirementsCache remembers for one XR: the
+// requirements each of its functions returned, plus the XR's kind so the cache
+// can evict entries for deleted XRs of a given kind.
+type xrRequirements struct {
+	gvk        schema.GroupVersionKind
+	byFunction map[string]*fnv1.Requirements
+}
+
+// A RequirementsCache is a RequirementsRecorder.
+var _ RequirementsRecorder = &RequirementsCache{}
+
+// NewRequirementsCache creates a RequirementsCache.
+func NewRequirementsCache() *RequirementsCache {
+	return &RequirementsCache{entries: make(map[string]*xrRequirements)}
+}
+
+// A nopRequirementsRecorder remembers nothing. It's the FetchingFunctionRunner's
+// default, so that by default the runner discovers a function's requirements
+// afresh each reconcile rather than pre-satisfying remembered ones.
+type nopRequirementsRecorder struct{}
+
+func (nopRequirementsRecorder) Get(_, _ string) (*fnv1.Requirements, bool) { return nil, false }
+func (nopRequirementsRecorder) Set(_ string, _ schema.GroupVersionKind, _ string, _ *fnv1.Requirements) {
+}
+
+// Get returns the requirements the named function last returned for the XR with
+// the supplied UID, if any. It returns a clone, so callers can't mutate the
+// cached copy, and so a caller holding the result doesn't race with a concurrent
+// Set.
+func (c *RequirementsCache) Get(xrUID, function string) (*fnv1.Requirements, bool) {
+	c.mx.RLock()
+	defer c.mx.RUnlock()
+
+	e, ok := c.entries[xrUID]
+	if !ok {
+		return nil, false
+	}
+	r, ok := e.byFunction[function]
+	if !ok {
+		return nil, false
+	}
+
+	clone, ok := proto.Clone(r).(*fnv1.Requirements)
+	if !ok {
+		return nil, false
+	}
+	return clone, true
+}
+
+// RequiredGVKs returns the distinct GroupVersionKinds of the resources required
+// by any of the XR's functions. The watch garbage collector uses it to learn
+// which required resource watches are still in use.
+func (c *RequirementsCache) RequiredGVKs(xrUID string) []schema.GroupVersionKind {
+	c.mx.RLock()
+	defer c.mx.RUnlock()
+
+	e, ok := c.entries[xrUID]
+	if !ok {
+		return nil
+	}
+
+	seen := make(map[schema.GroupVersionKind]bool)
+	gvks := make([]schema.GroupVersionKind, 0)
+	for _, r := range e.byFunction {
+		for _, gvk := range requiredGVKs(r) {
+			if seen[gvk] {
+				continue
+			}
+			seen[gvk] = true
+			gvks = append(gvks, gvk)
+		}
+	}
+	return gvks
+}
+
+// Set records the requirements the named function returned for the XR with the
+// supplied UID and kind. It clones the requirements so the caller can't mutate
+// the cached copy. Set deletes the function's entry when passed empty
+// requirements, so an XR whose function stops requiring resources doesn't retain
+// a stale entry.
+func (c *RequirementsCache) Set(xrUID string, gvk schema.GroupVersionKind, function string, r *fnv1.Requirements) {
+	c.mx.Lock()
+	defer c.mx.Unlock()
+
+	if isEmptyRequirements(r) {
+		if e, ok := c.entries[xrUID]; ok {
+			delete(e.byFunction, function)
+			if len(e.byFunction) == 0 {
+				delete(c.entries, xrUID)
+			}
+		}
+		return
+	}
+
+	e, ok := c.entries[xrUID]
+	if !ok {
+		e = &xrRequirements{gvk: gvk, byFunction: make(map[string]*fnv1.Requirements)}
+		c.entries[xrUID] = e
+	}
+
+	// proto.Clone of a *fnv1.Requirements always returns a *fnv1.Requirements,
+	// but we check the assertion to satisfy the linter and guard against a
+	// future change to the message type.
+	clone, ok := proto.Clone(r).(*fnv1.Requirements)
+	if !ok {
+		return
+	}
+	e.byFunction[function] = clone
+}
+
+// RetainForKind forgets the requirements of every XR of the supplied kind whose
+// UID isn't in the supplied set of live UIDs. The watch garbage collector calls
+// it with the UIDs of the XRs that still exist, so the cache doesn't leak
+// entries for deleted XRs.
+func (c *RequirementsCache) RetainForKind(gvk schema.GroupVersionKind, live map[string]bool) {
+	c.mx.Lock()
+	defer c.mx.Unlock()
+
+	for uid, e := range c.entries {
+		if e.gvk == gvk && !live[uid] {
+			delete(c.entries, uid)
+		}
+	}
+}
+
+// isEmptyRequirements returns true if r requires nothing. We treat nil and a
+// requirements message with no selectors identically - both mean "this function
+// needs nothing", which we don't bother remembering.
+func isEmptyRequirements(r *fnv1.Requirements) bool {
+	if r == nil {
+		return true
+	}
+	//nolint:staticcheck // We must account for the deprecated extra_resources field.
+	return len(r.GetResources()) == 0 && len(r.GetExtraResources()) == 0 && len(r.GetSchemas()) == 0
+}

--- a/internal/xfn/requirements_cache_test.go
+++ b/internal/xfn/requirements_cache_test.go
@@ -1,0 +1,432 @@
+/*
+Copyright 2026 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+this file except in compliance with the License. You may obtain a copy of the
+License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed
+under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+*/
+
+package xfn
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"google.golang.org/protobuf/testing/protocmp"
+	"google.golang.org/protobuf/types/known/structpb"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/crossplane/crossplane-runtime/v2/pkg/errors"
+
+	fnv1 "github.com/crossplane/crossplane/v2/proto/fn/v1"
+)
+
+var errGate = errors.New("required resource not satisfied")
+
+func sel(name string) *fnv1.ResourceSelector {
+	return &fnv1.ResourceSelector{
+		ApiVersion: "example.org/v1",
+		Kind:       "Thing",
+		Match:      &fnv1.ResourceSelector_MatchName{MatchName: name},
+	}
+}
+
+func reqs(names ...string) *fnv1.Requirements {
+	r := &fnv1.Requirements{Resources: map[string]*fnv1.ResourceSelector{}}
+	for _, n := range names {
+		r.Resources[n] = sel(n)
+	}
+	return r
+}
+
+func TestRequirementsCache(t *testing.T) {
+	xrKind := schema.GroupVersionKind{Group: "example.org", Version: "v1", Kind: "XR"}
+
+	c := NewRequirementsCache()
+
+	// An empty cache returns nothing.
+	if _, ok := c.Get("xr-uid", "fn"); ok {
+		t.Fatal("Get() on empty cache returned ok=true")
+	}
+
+	// Setting then getting round-trips a clone.
+	want := reqs("a", "b")
+	c.Set("xr-uid", xrKind, "fn", want)
+	got, ok := c.Get("xr-uid", "fn")
+	if !ok {
+		t.Fatal("Get() after Set() returned ok=false")
+	}
+	if diff := cmp.Diff(want, got, protocmp.Transform()); diff != "" {
+		t.Errorf("Get() after Set(): -want, +got:\n%s", diff)
+	}
+
+	// The cache stores a clone - mutating what we stored doesn't change it.
+	want.Resources["c"] = sel("c")
+	got, _ = c.Get("xr-uid", "fn")
+	if _, leaked := got.GetResources()["c"]; leaked {
+		t.Error("Get() returned a value mutated through the caller's reference; cache didn't clone")
+	}
+
+	// Entries are scoped per (XR UID, function).
+	if _, ok := c.Get("xr-uid", "other-fn"); ok {
+		t.Error("Get() for a different function returned ok=true")
+	}
+	if _, ok := c.Get("other-uid", "fn"); ok {
+		t.Error("Get() for a different XR returned ok=true")
+	}
+
+	// Setting empty requirements deletes the entry rather than storing it.
+	c.Set("xr-uid", xrKind, "fn", &fnv1.Requirements{})
+	if _, ok := c.Get("xr-uid", "fn"); ok {
+		t.Error("Get() after Set() with empty requirements returned ok=true; entry not deleted")
+	}
+
+	// RetainForKind forgets XRs of a kind whose UID isn't live.
+	c.Set("xr-uid", xrKind, "fn1", reqs("a"))
+	c.Set("xr-uid", xrKind, "fn2", reqs("b"))
+	c.RetainForKind(xrKind, map[string]bool{}) // No live UIDs.
+	if _, ok := c.Get("xr-uid", "fn1"); ok {
+		t.Error("Get() after RetainForKind() returned ok=true")
+	}
+	if _, ok := c.Get("xr-uid", "fn2"); ok {
+		t.Error("Get() after RetainForKind() returned ok=true")
+	}
+}
+
+func TestRequirementsCacheRetainForKind(t *testing.T) {
+	xrKind := schema.GroupVersionKind{Group: "example.org", Version: "v1", Kind: "XR"}
+	otherKind := schema.GroupVersionKind{Group: "example.org", Version: "v1", Kind: "Other"}
+
+	c := NewRequirementsCache()
+	c.Set("live", xrKind, "fn", reqs("a"))
+	c.Set("dead", xrKind, "fn", reqs("b"))
+	c.Set("other", otherKind, "fn", reqs("c"))
+
+	// Retain only "live" among XRs of xrKind. "dead" is evicted; "other" is a
+	// different kind and untouched even though it's not in the live set.
+	c.RetainForKind(xrKind, map[string]bool{"live": true})
+
+	if _, ok := c.Get("live", "fn"); !ok {
+		t.Error("RetainForKind() evicted a live XR's requirements")
+	}
+	if _, ok := c.Get("dead", "fn"); ok {
+		t.Error("RetainForKind() didn't evict a dead XR's requirements")
+	}
+	if _, ok := c.Get("other", "fn"); !ok {
+		t.Error("RetainForKind() evicted an XR of a different kind")
+	}
+}
+
+// xrReq builds a RunFunctionRequest whose observed composite resource has the
+// supplied UID, so the FetchingFunctionRunner can key the RequirementsCache. The
+// XR is an example.org/v1 XR.
+func xrReq(uid string) *fnv1.RunFunctionRequest {
+	return &fnv1.RunFunctionRequest{
+		Observed: &fnv1.State{
+			Composite: &fnv1.Resource{
+				Resource: &structpb.Struct{Fields: map[string]*structpb.Value{
+					"apiVersion": structpb.NewStringValue("example.org/v1"),
+					"kind":       structpb.NewStringValue("XR"),
+					"metadata": structpb.NewStructValue(&structpb.Struct{Fields: map[string]*structpb.Value{
+						"uid": structpb.NewStringValue(uid),
+					}}),
+				}},
+			},
+		},
+	}
+}
+
+func TestFetchingFunctionRunnerPreSatisfy(t *testing.T) {
+	// A function with a single, stable, dynamic requirement. It returns the same
+	// requirement every call. Without pre-satisfaction this costs two calls: one
+	// to discover the requirement, one to confirm it's satisfied.
+	stable := reqs("needed")
+
+	t.Run("CollapsesDoubleCallWhenRemembered", func(t *testing.T) {
+		calls := 0
+		wrapped := FunctionRunnerFn(func(_ context.Context, _ string, req *fnv1.RunFunctionRequest) (*fnv1.RunFunctionResponse, error) {
+			calls++
+			// The function gates on its requirement: it only does real work once
+			// the resource is present. We assert it's present on the very first
+			// call, proving we pre-satisfied it.
+			if _, ok := req.GetRequiredResources()["needed"]; !ok {
+				return nil, errGate
+			}
+			return &fnv1.RunFunctionResponse{Requirements: stable}, nil
+		})
+
+		fetched := RequiredResourcesFetcherFn(func(_ context.Context, _ *fnv1.ResourceSelector) (*fnv1.Resources, error) {
+			return &fnv1.Resources{}, nil
+		})
+
+		cache := NewRequirementsCache()
+		// Pre-seed the cache as though a previous reconcile already learned the
+		// requirement.
+		cache.Set("xr-uid", schema.GroupVersionKind{Group: "example.org", Version: "v1", Kind: "XR"}, "fn", stable)
+
+		r := NewFetchingFunctionRunner(wrapped, fetched, NopRequiredSchemasFetcher{}, WithRequirementsRecorder(cache))
+
+		_, err := r.RunFunction(context.Background(), "fn", xrReq("xr-uid"))
+		if err != nil {
+			t.Fatalf("RunFunction() error: %v", err)
+		}
+		if calls != 1 {
+			t.Errorf("expected 1 function call when requirements were remembered, got %d", calls)
+		}
+	})
+
+	t.Run("LearnsAndRemembersOnFirstReconcile", func(t *testing.T) {
+		calls := 0
+		wrapped := FunctionRunnerFn(func(_ context.Context, _ string, _ *fnv1.RunFunctionRequest) (*fnv1.RunFunctionResponse, error) {
+			calls++
+			return &fnv1.RunFunctionResponse{Requirements: stable}, nil
+		})
+		fetched := RequiredResourcesFetcherFn(func(_ context.Context, _ *fnv1.ResourceSelector) (*fnv1.Resources, error) {
+			return &fnv1.Resources{}, nil
+		})
+
+		cache := NewRequirementsCache()
+		r := NewFetchingFunctionRunner(wrapped, fetched, NopRequiredSchemasFetcher{}, WithRequirementsRecorder(cache))
+
+		// First reconcile: cache is cold, so it costs the usual two calls.
+		if _, err := r.RunFunction(context.Background(), "fn", xrReq("xr-uid")); err != nil {
+			t.Fatalf("RunFunction() error: %v", err)
+		}
+		if calls != 2 {
+			t.Errorf("expected 2 function calls on a cold cache, got %d", calls)
+		}
+
+		// It should have remembered the requirement.
+		got, ok := cache.Get("xr-uid", "fn")
+		if !ok {
+			t.Fatal("requirement not remembered after first reconcile")
+		}
+		if diff := cmp.Diff(stable, got, protocmp.Transform()); diff != "" {
+			t.Errorf("remembered requirement: -want, +got:\n%s", diff)
+		}
+
+		// Second reconcile (fresh request, same XR): now it costs one call.
+		calls = 0
+		if _, err := r.RunFunction(context.Background(), "fn", xrReq("xr-uid")); err != nil {
+			t.Fatalf("RunFunction() error: %v", err)
+		}
+		if calls != 1 {
+			t.Errorf("expected 1 function call on a warm cache, got %d", calls)
+		}
+	})
+
+	t.Run("SelfCorrectsWhenRequirementsChange", func(t *testing.T) {
+		// We remembered an old requirement, but the function now wants a
+		// different one. The runner must fall back to its iterative loop.
+		old := reqs("old")
+		current := reqs("new")
+
+		calls := 0
+		wrapped := FunctionRunnerFn(func(_ context.Context, _ string, req *fnv1.RunFunctionRequest) (*fnv1.RunFunctionResponse, error) {
+			calls++
+			// Gate on the current requirement being satisfied.
+			if _, ok := req.GetRequiredResources()["new"]; ok {
+				return &fnv1.RunFunctionResponse{Requirements: current}, nil
+			}
+			return &fnv1.RunFunctionResponse{Requirements: current}, nil
+		})
+		fetched := RequiredResourcesFetcherFn(func(_ context.Context, _ *fnv1.ResourceSelector) (*fnv1.Resources, error) {
+			return &fnv1.Resources{}, nil
+		})
+
+		cache := NewRequirementsCache()
+		cache.Set("xr-uid", schema.GroupVersionKind{Group: "example.org", Version: "v1", Kind: "XR"}, "fn", old)
+
+		r := NewFetchingFunctionRunner(wrapped, fetched, NopRequiredSchemasFetcher{}, WithRequirementsRecorder(cache))
+		if _, err := r.RunFunction(context.Background(), "fn", xrReq("xr-uid")); err != nil {
+			t.Fatalf("RunFunction() error: %v", err)
+		}
+
+		// Two calls: the first returns the new (unexpected) requirement, the
+		// second confirms it after we fetch it.
+		if calls != 2 {
+			t.Errorf("expected 2 calls when remembered requirements were stale, got %d", calls)
+		}
+
+		// The cache should now hold the corrected requirement.
+		got, _ := cache.Get("xr-uid", "fn")
+		if diff := cmp.Diff(current, got, protocmp.Transform()); diff != "" {
+			t.Errorf("corrected requirement: -want, +got:\n%s", diff)
+		}
+	})
+}
+
+func TestFetchingFunctionRunnerWatch(t *testing.T) {
+	t.Run("WatchesRequiredResourcesAtStabilization", func(t *testing.T) {
+		// A function with a stable requirement on a single kind.
+		stable := reqs("needed")
+
+		wrapped := FunctionRunnerFn(func(_ context.Context, _ string, _ *fnv1.RunFunctionRequest) (*fnv1.RunFunctionResponse, error) {
+			return &fnv1.RunFunctionResponse{Requirements: stable}, nil
+		})
+		fetched := RequiredResourcesFetcherFn(func(_ context.Context, _ *fnv1.ResourceSelector) (*fnv1.Resources, error) {
+			return &fnv1.Resources{}, nil
+		})
+
+		var gotXR schema.GroupVersionKind
+		var gotRequired []schema.GroupVersionKind
+		watcher := RequiredResourceWatcherFn(func(_ context.Context, xr schema.GroupVersionKind, required []schema.GroupVersionKind) error {
+			gotXR = xr
+			gotRequired = required
+			return nil
+		})
+
+		r := NewFetchingFunctionRunner(wrapped, fetched, NopRequiredSchemasFetcher{}, WithRequiredResourceWatcher(watcher))
+		if _, err := r.RunFunction(context.Background(), "fn", xrReq("xr-uid")); err != nil {
+			t.Fatalf("RunFunction() error: %v", err)
+		}
+
+		wantXR := schema.GroupVersionKind{Group: "example.org", Version: "v1", Kind: "XR"}
+		if diff := cmp.Diff(wantXR, gotXR); diff != "" {
+			t.Errorf("watched XR GVK: -want, +got:\n%s", diff)
+		}
+		wantRequired := []schema.GroupVersionKind{{Group: "example.org", Version: "v1", Kind: "Thing"}}
+		if diff := cmp.Diff(wantRequired, gotRequired); diff != "" {
+			t.Errorf("watched required GVKs: -want, +got:\n%s", diff)
+		}
+	})
+
+	t.Run("PropagatesWatcherError", func(t *testing.T) {
+		wrapped := FunctionRunnerFn(func(_ context.Context, _ string, _ *fnv1.RunFunctionRequest) (*fnv1.RunFunctionResponse, error) {
+			return &fnv1.RunFunctionResponse{Requirements: reqs("needed")}, nil
+		})
+		fetched := RequiredResourcesFetcherFn(func(_ context.Context, _ *fnv1.ResourceSelector) (*fnv1.Resources, error) {
+			return &fnv1.Resources{}, nil
+		})
+		watcher := RequiredResourceWatcherFn(func(_ context.Context, _ schema.GroupVersionKind, _ []schema.GroupVersionKind) error {
+			return errGate
+		})
+
+		r := NewFetchingFunctionRunner(wrapped, fetched, NopRequiredSchemasFetcher{}, WithRequiredResourceWatcher(watcher))
+		_, err := r.RunFunction(context.Background(), "fn", xrReq("xr-uid"))
+		if !errors.Is(err, errGate) {
+			t.Errorf("RunFunction(): want wrapped errGate, got %v", err)
+		}
+	})
+
+	t.Run("DoesNotRememberOrWatchWithoutXRUID", func(t *testing.T) {
+		// An XR with no UID can't be keyed in the cache or identified for
+		// watching. We must not remember its requirements (which would collide
+		// with other unidentifiable XRs under the empty key) or start watches.
+		wrapped := FunctionRunnerFn(func(_ context.Context, _ string, _ *fnv1.RunFunctionRequest) (*fnv1.RunFunctionResponse, error) {
+			return &fnv1.RunFunctionResponse{Requirements: reqs("needed")}, nil
+		})
+		fetched := RequiredResourcesFetcherFn(func(_ context.Context, _ *fnv1.ResourceSelector) (*fnv1.Resources, error) {
+			return &fnv1.Resources{}, nil
+		})
+
+		watched := false
+		watcher := RequiredResourceWatcherFn(func(_ context.Context, _ schema.GroupVersionKind, _ []schema.GroupVersionKind) error {
+			watched = true
+			return nil
+		})
+
+		cache := NewRequirementsCache()
+		r := NewFetchingFunctionRunner(wrapped, fetched, NopRequiredSchemasFetcher{},
+			WithRequirementsRecorder(cache),
+			WithRequiredResourceWatcher(watcher))
+
+		// A request with no observed composite at all - no UID, no GVK.
+		if _, err := r.RunFunction(context.Background(), "fn", &fnv1.RunFunctionRequest{}); err != nil {
+			t.Fatalf("RunFunction() error: %v", err)
+		}
+
+		if watched {
+			t.Error("started watches for an XR with no UID")
+		}
+		if _, ok := cache.Get("", "fn"); ok {
+			t.Error("remembered requirements under the empty XR UID key")
+		}
+	})
+}
+
+func TestFetchingFunctionRunnerRetag(t *testing.T) {
+	// The runner sits above the response cache, which keys on the request's tag.
+	// Each iteration's request must carry a tag derived from that iteration's
+	// content - including the required resources fetched so far - so the cache
+	// keys on the resolved request, and a change to a required resource produces
+	// a different tag (a cache miss).
+	t.Run("TagReflectsFetchedResources", func(t *testing.T) {
+		// Record the tag the wrapped runner sees on each call.
+		var tags []string
+		wrapped := FunctionRunnerFn(func(_ context.Context, _ string, req *fnv1.RunFunctionRequest) (*fnv1.RunFunctionResponse, error) {
+			tags = append(tags, req.GetMeta().GetTag())
+			return &fnv1.RunFunctionResponse{Requirements: reqs("needed")}, nil
+		})
+
+		// The fetched resource's content varies, so the iteration-1 request
+		// (which carries it) differs from iteration 0.
+		resourceContent := "first"
+		fetched := RequiredResourcesFetcherFn(func(_ context.Context, _ *fnv1.ResourceSelector) (*fnv1.Resources, error) {
+			return &fnv1.Resources{Items: []*fnv1.Resource{{Resource: MustStruct(map[string]any{"data": resourceContent})}}}, nil
+		})
+
+		r := NewFetchingFunctionRunner(wrapped, fetched, NopRequiredSchemasFetcher{}, WithPerIterationTagging())
+		if _, err := r.RunFunction(context.Background(), "fn", xrReq("xr-uid")); err != nil {
+			t.Fatalf("RunFunction() error: %v", err)
+		}
+
+		// Two calls: iteration 0 (no required resources) and iteration 1 (with
+		// them). Their tags must differ, and neither may be empty.
+		if len(tags) != 2 {
+			t.Fatalf("expected 2 calls, got %d", len(tags))
+		}
+		if tags[0] == "" || tags[1] == "" {
+			t.Errorf("expected non-empty tags, got %q and %q", tags[0], tags[1])
+		}
+		if tags[0] == tags[1] {
+			t.Error("iteration 0 and iteration 1 had the same tag; the tag doesn't reflect fetched required resources")
+		}
+
+		// Re-running with different required resource content must produce a
+		// different iteration-1 tag - this is what invalidates the cache.
+		firstIter1 := tags[1]
+		tags = nil
+		resourceContent = "second"
+		if _, err := r.RunFunction(context.Background(), "fn", xrReq("xr-uid")); err != nil {
+			t.Fatalf("RunFunction() error: %v", err)
+		}
+		if tags[1] == firstIter1 {
+			t.Error("a changed required resource produced the same tag; the cache wouldn't be invalidated")
+		}
+	})
+
+	t.Run("DoesNotTagWithoutOption", func(t *testing.T) {
+		// Without per-iteration tagging the runner leaves the request's tag
+		// alone, preserving behavior for when the cache sits above the runner.
+		var tags []string
+		wrapped := FunctionRunnerFn(func(_ context.Context, _ string, req *fnv1.RunFunctionRequest) (*fnv1.RunFunctionResponse, error) {
+			tags = append(tags, req.GetMeta().GetTag())
+			return &fnv1.RunFunctionResponse{}, nil
+		})
+		fetched := RequiredResourcesFetcherFn(func(_ context.Context, _ *fnv1.ResourceSelector) (*fnv1.Resources, error) {
+			return &fnv1.Resources{}, nil
+		})
+
+		r := NewFetchingFunctionRunner(wrapped, fetched, NopRequiredSchemasFetcher{})
+		// The incoming request carries a pre-set tag; the runner must not change it.
+		req := xrReq("xr-uid")
+		req.Meta = &fnv1.RequestMeta{Tag: "preset"}
+		if _, err := r.RunFunction(context.Background(), "fn", req); err != nil {
+			t.Fatalf("RunFunction() error: %v", err)
+		}
+		for _, tag := range tags {
+			if tag != "preset" {
+				t.Errorf("runner changed the request tag without WithPerIterationTagging: got %q", tag)
+			}
+		}
+	})
+}


### PR DESCRIPTION
### Description of your changes

The composite resource (XR) controller calls its function pipeline when the XR or one of its composed resources changes, but not when a resource a function _requires_ (via `requirements.resources`) changes. A pipeline that selects, say, all `ConfigMap`s with a label only observes them as they were at the last reconcile until something else triggers one.

This adds alpha support for watching the kinds of resource a function requires, and reconciling the XR when one changes - the required-resource equivalent of realtime compositions for composed resources. It's behind `--enable-required-resource-watches`, and builds on the realtime compositions watch machinery, so it requires `--enable-realtime-compositions` and is a no-op (with a warning) without it.

`FetchingFunctionRunner` resolves a pipeline's requirements, so it's where we learn which kinds a pipeline requires. Rather than surface those selectors up to the reconciler, a `RequiredResourceWatcher` is pushed down into the runner; when requirements stabilize it starts watches for the required kinds. The runner is shared by every XR controller, so it dispatches to a per-XR-kind watcher via a registry the definition controller populates when it starts an XR controller and clears when it stops one. Required resources aren't referenced by the XR, so there's no index to map a changed resource back to the XRs that need it - a change enqueues every XR of that controller's kind, and the response cache keeps the redundant reconciles cheap.

The runner also now remembers the requirements a function last returned per `(XR, function)` and pre-satisfies them next reconcile, so a function with stable requirements is called once instead of twice (discover, then confirm). The watch garbage collector reads this memory to reclaim watches for kinds no XR requires.

The response cache keys on a hash of the request and sits above requirement resolution, so it can't tell a required resource changed. When both this feature and the cache are enabled the layering is reordered to `FetchingFunctionRunner → Cache → gRPC` and the runner retags the request each iteration, so a changed required resource invalidates the cache. That reorder caches multi-iteration functions less effectively, so it's gated on the feature - the existing layering is unchanged when it's off.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `./nix.sh flake check` to ensure this PR is ready for review.
- [x] Added or updated unit tests.
- [ ] ~Added or updated e2e tests.~
- [ ] Linked a PR or a [docs tracking issue] to [document this change].
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~
- [ ] ~Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md
