### PR TITLE
render: Don't overwrite the input XR's UID if it has one and validate observed resources

### DIFF
--- a/internal/render/composite/render.go
+++ b/internal/render/composite/render.go
@@ -27,6 +27,7 @@ import (
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/structpb"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kunstructured "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -106,6 +107,10 @@ func Render(ctx context.Context, log logging.Logger, in *renderv1alpha1.Composit
 			return nil, errors.Wrap(err, "cannot convert observed resource from protobuf")
 		}
 		observed = append(observed, *u)
+	}
+
+	if err := CheckObservedResources(xr, observed); err != nil {
+		return nil, errors.Wrap(err, "invalid observed resources")
 	}
 
 	// Inject spec.resourceRefs for observed resources so the real
@@ -330,6 +335,32 @@ func selectSchema(gvk schema.GroupVersionKind, def *structpb.Struct) (ucomposite
 	}
 
 	return cschema, nil
+}
+
+// CheckObservedResources validates that all observed resources will be
+// correctly read by the controller. This requires that they:
+//
+//  1. Either have no controller ref or have a controller ref that matches the
+//     XR.
+//  2. Are in the same namespace as the XR if the XR is namespaced.
+func CheckObservedResources(xr *ucomposite.Unstructured, observed []kunstructured.Unstructured) error {
+	var errs []error
+
+	xrUID := xr.GetUID()
+	for _, o := range observed {
+		if c := metav1.GetControllerOf(&o); c != nil && c.UID != xrUID {
+			errs = append(errs,
+				errors.Errorf("observed resource %s has a controller ref but is not controlled by the XR", o.GetName()),
+			)
+		}
+		if xr.GetNamespace() != "" && o.GetNamespace() != xr.GetNamespace() {
+			errs = append(errs,
+				errors.Errorf("observed resource %s is not in the same namespace as the XR", o.GetName()),
+			)
+		}
+	}
+
+	return errors.Join(errs...)
 }
 
 // InjectResourceRefs sets spec.resourceRefs on the XR for each observed

--- a/internal/render/composite/render.go
+++ b/internal/render/composite/render.go
@@ -87,11 +87,13 @@ func Render(ctx context.Context, log logging.Logger, in *renderv1alpha1.Composit
 		return nil, errors.Wrap(err, "cannot convert composite resource from protobuf")
 	}
 
-	// Set a deterministic fake UID. The NameGenerator uses the owner UID for
-	// deterministic name generation of composed resources. The namespace is
-	// included so that two namespaced XRs with the same GVK and name in
-	// different namespaces produce different composed resource names.
-	xr.SetUID(types.UID(uuid.NewSHA1(uuid.Nil, []byte(gvk.String()+"\x00"+xr.GetNamespace()+"\x00"+xr.GetName())).String()))
+	// Set a deterministic fake UID for the input XR if it doesn't have
+	// one. Generating a deterministic UID keeps output stable across runs, but
+	// we don't want to overwrite an existing UID because the user might have
+	// observed resources with ownerRefs that match it.
+	if xr.GetUID() == "" {
+		xr.SetUID(types.UID(uuid.NewSHA1(uuid.Nil, []byte(gvk.String()+"\x00"+xr.GetNamespace()+"\x00"+xr.GetName())).String()))
+	}
 
 	// Set a resourceVersion to avoid "object has no resource version" errors.
 	xr.SetResourceVersion("999")

--- a/internal/render/composite/render_test.go
+++ b/internal/render/composite/render_test.go
@@ -25,7 +25,11 @@ import (
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/testing/protocmp"
 	"google.golang.org/protobuf/types/known/structpb"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kunstructured "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
 
 	"github.com/crossplane/crossplane-runtime/v2/pkg/errors"
 	"github.com/crossplane/crossplane-runtime/v2/pkg/logging"
@@ -465,13 +469,13 @@ func TestSelectSchema(t *testing.T) {
 		"V1XRDExplicitLegacyClusterScope": {
 			reason:     "A v1 XRD with explicit Spec.Scope=LegacyCluster yields SchemaLegacy.",
 			gvk:        xrGVK,
-			def:        v1XRD("xlegacyresources.example.org", "example.org", "XLegacyResource", strPtr("LegacyCluster")),
+			def:        v1XRD("xlegacyresources.example.org", "example.org", "XLegacyResource", ptr.To("LegacyCluster")),
 			wantSchema: ucomposite.SchemaLegacy,
 		},
 		"V1XRDExplicitClusterScope": {
 			reason:     "A v1 XRD with explicit Spec.Scope=Cluster (theoretical edge case) yields SchemaModern. Mirrors the production reconciler's rule.",
 			gvk:        xrGVK,
-			def:        v1XRD("xlegacyresources.example.org", "example.org", "XLegacyResource", strPtr("Cluster")),
+			def:        v1XRD("xlegacyresources.example.org", "example.org", "XLegacyResource", ptr.To("Cluster")),
 			wantSchema: ucomposite.SchemaModern,
 		},
 		"V2XRD": {
@@ -483,7 +487,7 @@ func TestSelectSchema(t *testing.T) {
 		"V2FormPreservingLegacyClusterScope": {
 			reason:     "A v2-form XRD with Spec.Scope=LegacyCluster (e.g. a v1-posted XRD round-tripped through the storage version) yields SchemaLegacy. The v2 Go type's Spec.Scope is a string alias with no runtime enum validation, so 'LegacyCluster' survives the round-trip and must be honored to avoid forcing consumers to specifically fetch v1-form.",
 			gvk:        xrGVK,
-			def:        v2XRD("xlegacyresources.example.org", "example.org", "XLegacyResource", strPtr("LegacyCluster")),
+			def:        v2XRD("xlegacyresources.example.org", "example.org", "XLegacyResource", ptr.To("LegacyCluster")),
 			wantSchema: ucomposite.SchemaLegacy,
 		},
 		"XRDDoesNotMatchXR": {
@@ -709,7 +713,147 @@ func TestRenderErrors(t *testing.T) {
 	}
 }
 
-func strPtr(s string) *string { return &s }
+func TestCheckObservedResources(t *testing.T) {
+	const xrUID = types.UID("xr-uid")
+
+	observed := func(name, namespace string, owners ...metav1.OwnerReference) kunstructured.Unstructured {
+		u := kunstructured.Unstructured{}
+		u.SetGroupVersionKind(schema.GroupVersionKind{Group: "example.org", Version: "v1alpha1", Kind: "XComposed"})
+		u.SetName(name)
+		u.SetNamespace(namespace)
+		u.SetOwnerReferences(owners)
+
+		return u
+	}
+	controllerRef := func(uid types.UID) metav1.OwnerReference {
+		return metav1.OwnerReference{
+			APIVersion: "example.org/v1alpha1",
+			Kind:       "XLegacyResource",
+			Name:       "my-xr",
+			UID:        uid,
+			Controller: ptr.To(true),
+		}
+	}
+	nonControllerRef := func(uid types.UID) metav1.OwnerReference {
+		return metav1.OwnerReference{
+			APIVersion: "example.org/v1alpha1",
+			Kind:       "XLegacyResource",
+			Name:       "my-xr",
+			UID:        uid,
+		}
+	}
+
+	cases := map[string]struct {
+		reason      string
+		xrNamespace string
+		observed    []kunstructured.Unstructured
+		// wantErrContains lists substrings that must all appear in the error
+		// message. An empty/nil slice means no error is expected.
+		wantErrContains []string
+	}{
+		"NoObservedResources": {
+			reason:   "An XR with no observed resources should pass validation.",
+			observed: nil,
+		},
+		"NoControllerRefClusterScoped": {
+			reason: "An observed resource with no owner refs should pass validation.",
+			observed: []kunstructured.Unstructured{
+				observed("obs-1", ""),
+			},
+		},
+		"MatchingControllerRef": {
+			reason: "An observed resource controlled by the XR (matching UID) should pass validation.",
+			observed: []kunstructured.Unstructured{
+				observed("obs-1", "", controllerRef(xrUID)),
+			},
+		},
+		"NonControllerOwnerRefIgnored": {
+			reason: "An observed resource with a non-controller owner ref (Controller != true) should pass validation even if its UID differs, because only controller refs are checked.",
+			observed: []kunstructured.Unstructured{
+				observed("obs-1", "", nonControllerRef("other-uid")),
+			},
+		},
+		"MismatchedControllerRef": {
+			reason: "An observed resource with a controller ref whose UID does not match the XR should fail validation.",
+			observed: []kunstructured.Unstructured{
+				observed("obs-bad", "", controllerRef("other-uid")),
+			},
+			wantErrContains: []string{"has a controller ref but is not controlled by the XR", "obs-bad"},
+		},
+		"NamespacedXRSameNamespace": {
+			reason:      "A namespaced XR with an observed resource in the same namespace should pass validation.",
+			xrNamespace: "ns-a",
+			observed: []kunstructured.Unstructured{
+				observed("obs-1", "ns-a"),
+			},
+		},
+		"NamespacedXRDifferentNamespace": {
+			reason:      "A namespaced XR with an observed resource in a different namespace should fail validation.",
+			xrNamespace: "ns-a",
+			observed: []kunstructured.Unstructured{
+				observed("obs-bad", "ns-b"),
+			},
+			wantErrContains: []string{"is not in the same namespace as the XR", "obs-bad"},
+		},
+		"ClusterScopedXRIgnoresNamespace": {
+			reason: "A cluster-scoped XR (empty namespace) should not enforce the namespace check, so an observed resource with any namespace passes validation.",
+			observed: []kunstructured.Unstructured{
+				observed("obs-1", "ns-b"),
+			},
+		},
+		"MultipleViolationsJoined": {
+			reason:      "A single observed resource that both has a mismatched controller ref and is in a different namespace should produce a joined error naming both violations.",
+			xrNamespace: "ns-a",
+			observed: []kunstructured.Unstructured{
+				observed("obs-bad", "ns-b", controllerRef("other-uid")),
+			},
+			wantErrContains: []string{
+				"has a controller ref but is not controlled by the XR",
+				"is not in the same namespace as the XR",
+				"obs-bad",
+			},
+		},
+		"MultipleResourcesOneBad": {
+			reason: "When multiple observed resources are supplied, only the offending one should be reported.",
+			observed: []kunstructured.Unstructured{
+				observed("obs-good", "", controllerRef(xrUID)),
+				observed("obs-bad", "", controllerRef("other-uid")),
+			},
+			wantErrContains: []string{"has a controller ref but is not controlled by the XR", "obs-bad"},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			xr := ucomposite.New()
+			xr.SetUID(xrUID)
+			if tc.xrNamespace != "" {
+				xr.SetNamespace(tc.xrNamespace)
+			}
+
+			err := CheckObservedResources(xr, tc.observed)
+
+			// Error assertions use substring matching rather than cmp.Diff(...,
+			// cmpopts.EquateErrors()): the substrings assert that the
+			// user-facing message names the offending resource and the specific
+			// violation, which EquateErrors cannot check.
+			if len(tc.wantErrContains) == 0 {
+				if err != nil {
+					t.Fatalf("\n%s\nCheckObservedResources(...): unexpected error: %v", tc.reason, err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("\n%s\nCheckObservedResources(...): expected error, got nil", tc.reason)
+			}
+			for _, sub := range tc.wantErrContains {
+				if !strings.Contains(err.Error(), sub) {
+					t.Errorf("\n%s\nCheckObservedResources(...): error %q does not contain %q", tc.reason, err.Error(), sub)
+				}
+			}
+		})
+	}
+}
 
 func mustStruct(m map[string]any) *structpb.Struct {
 	s, err := structpb.NewStruct(m)


### PR DESCRIPTION
### Description of your changes

`crossplane internal render` sets a deterministic fake UID on the input XR to ensure output is stable. However, if a user runs render with an XR and observed resources fetched from a real cluster, we overwrite the real UID in the XR with the fake one, which causes a mismatch with the observed resources' controller references and prevents observed resources from being read by the function pipeline. Let the input XR keep its existing UID if it already has one. This still ensures stable output, but also ensures any references to the real UID are correct.

While we're here, validate observed resources to avoid two gotchas that are easy to hit:

1. If an observed resource has a controller reference, the UID in the reference must match the input XR's UID.
2. If the input XR is namespaced, all observed resources must be in the same namespace as the XR (since namespaced XRs can only compose resources in their own namespace).

Return a clear error rather than a success with surprising results (due to observed resources not being passed into the function pipeline) if observed resources fail either of the above checks.

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `./nix.sh flake check` to ensure this PR is ready for review.
- [x] Added or updated unit tests.
~- [ ] Added or updated e2e tests.~
~- [ ] Linked a PR or a [docs tracking issue] to [document this change].~
- [x] Added `backport release-x.y` labels to auto-backport this PR.
~- [ ] Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md
