### PR TITLE
test(e2e): use DefaultPollInterval in remaining wait.For calls

### DIFF
--- a/test/e2e/funcs/feature.go
+++ b/test/e2e/funcs/feature.go
@@ -854,7 +854,7 @@ func ClaimUnderTestMustNotChangeWithin(d time.Duration) features.Func {
 
 		t.Logf("Ensuring claim %s does not change within %s", identifier(cm), d.String())
 
-		if err := wait.For(conditions.New(c.Client().Resources()).ResourcesMatch(list, m), wait.WithTimeout(d)); err != nil {
+		if err := wait.For(conditions.New(c.Client().Resources()).ResourcesMatch(list, m), wait.WithTimeout(d), wait.WithInterval(DefaultPollInterval)); err != nil {
 			if deadlineExceed(err) {
 				t.Logf("Claim %s did not change within %s", identifier(cm), d.String())
 				return ctx
@@ -909,7 +909,7 @@ func CompositeUnderTestMustNotChangeWithin(d time.Duration) features.Func {
 
 		t.Logf("Ensuring composite resource %s does not change within %s", identifier(cp), d.String())
 
-		if err := wait.For(conditions.New(c.Client().Resources()).ResourcesMatch(list, m), wait.WithTimeout(d)); err != nil {
+		if err := wait.For(conditions.New(c.Client().Resources()).ResourcesMatch(list, m), wait.WithTimeout(d), wait.WithInterval(DefaultPollInterval)); err != nil {
 			if deadlineExceed(err) {
 				t.Logf("Composite resource %s did not change within %s", identifier(cp), d.String())
 				return ctx
@@ -963,7 +963,7 @@ func CompositeResourceMustMatchWithin(d time.Duration, dir, claimFile string, ma
 			return match(&composite.Unstructured{Unstructured: *u})
 		}
 
-		if err := wait.For(conditions.New(c.Client().Resources()).ResourcesMatch(list, m), wait.WithTimeout(d)); err != nil && count.Load() > 0 {
+		if err := wait.For(conditions.New(c.Client().Resources()).ResourcesMatch(list, m), wait.WithTimeout(d), wait.WithInterval(DefaultPollInterval)); err != nil && count.Load() > 0 {
 			t.Errorf("composite %s did not match the condition before timeout (%s): %s\n\n", identifier(&uxr), d.String(), err)
 			return ctx
 		}


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane! Please read the contribution docs
(linked below) if this is your first Crossplane pull request.
-->

### Description of your changes

Three e2e helpers in `test/e2e/funcs/feature.go` called `wait.For` without `wait.WithInterval(DefaultPollInterval)`:

- `ClaimUnderTestMustNotChangeWithin`
- `CompositeUnderTestMustNotChangeWithin`
- `CompositeResourceMustMatchWithin`

Every other `wait.For` in this file already uses the shared 500ms interval. This aligns the remaining helpers with the rest of the file so composition/claim tests don't rely on the e2e-framework default polling interval.

Refs #5671

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `./nix.sh flake check` to ensure this PR is ready for review.
- [ ] ~Added or updated unit tests.~
- [x] Added or updated e2e tests.
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~
- [ ] ~Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md
