### PR TITLE
test(e2e): guard namespaced XR realtime composition performance

### DIFF
--- a/test/e2e/apiextensions_compositions_test.go
+++ b/test/e2e/apiextensions_compositions_test.go
@@ -506,26 +506,14 @@ func TestRealtimeNamespacedXR(t *testing.T) {
 				funcs.ResourcesHaveConditionWithin(1*time.Minute, manifests, "setup/definition.yaml", apiextensionsv1.WatchingComposite()),
 				funcs.ResourcesHaveConditionWithin(2*time.Minute, manifests, "setup/functions.yaml", pkgv1.Healthy(), pkgv1.Active()),
 			)).
-			WithSetup("CreateConfigMap", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
-				t.Helper()
-
-				cm := &unstructured.Unstructured{}
-				cm.SetAPIVersion("v1")
-				cm.SetKind("ConfigMap")
-				cm.SetNamespace("default")
-				cm.SetName("realtime-test-configmap")
-				cm.SetLabels(map[string]string{"app": "crossplane-e2e"})
-				fieldpath.Pave(cm.Object).SetString("data.message", "initial")
-
-				//nolint:staticcheck // TODO(adamwg) Stop using client.Apply after the v2.2 release.
-				if err := cfg.Client().Resources().GetControllerRuntimeClient().Patch(ctx, cm, client.Apply, client.FieldOwner(FieldManager), client.ForceOwnership); err != nil {
-					t.Fatalf("failed to create ConfigMap: %v", err)
+			WithSetup("CreateConfigMap", funcs.AllOf(
+				funcs.ApplyConfigMapMessage(FieldManager, "default", "realtime-test-configmap", "initial", map[string]string{"app": "crossplane-e2e"}),
+				func(ctx context.Context, t *testing.T, _ *envconf.Config) context.Context {
+					t.Helper()
+					t.Log("Created ConfigMap with initial data")
 					return ctx
-				}
-
-				t.Log("Created ConfigMap with initial data")
-				return ctx
-			}).
+				},
+			)).
 			Assess("CreateXR", funcs.AllOf(
 				funcs.ApplyResources(FieldManager, manifests, "xr.yaml"),
 				funcs.ResourcesCreatedWithin(30*time.Second, manifests, "xr.yaml"),
@@ -539,27 +527,19 @@ func TestRealtimeNamespacedXR(t *testing.T) {
 			Assess("InitialObservationReflected",
 				funcs.ResourcesHaveFieldValueWithin(10*time.Second, manifests, "xr.yaml", "status.observedData.message", "initial"),
 			).
-			Assess("ModifyConfigMapDirectly", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
-				t.Helper()
-
-				t.Log("Modifying ConfigMap directly to trigger realtime detection...")
-
-				cm := &unstructured.Unstructured{}
-				cm.SetAPIVersion("v1")
-				cm.SetKind("ConfigMap")
-				cm.SetNamespace("default")
-				cm.SetName("realtime-test-configmap")
-				fieldpath.Pave(cm.Object).SetString("data.message", "realtime-update")
-
-				//nolint:staticcheck // TODO(adamwg) Stop using client.Apply after the v2.2 release.
-				if err := cfg.Client().Resources().GetControllerRuntimeClient().Patch(ctx, cm, client.Apply, client.FieldOwner(FieldManager), client.ForceOwnership); err != nil {
-					t.Fatalf("failed to modify ConfigMap: %v", err)
+			Assess("ModifyConfigMapDirectly", funcs.AllOf(
+				func(ctx context.Context, t *testing.T, _ *envconf.Config) context.Context {
+					t.Helper()
+					t.Log("Modifying ConfigMap directly to trigger realtime detection...")
 					return ctx
-				}
-
-				t.Log("ConfigMap modified — expecting realtime XR update")
-				return ctx
-			}).
+				},
+				funcs.ApplyConfigMapMessage(FieldManager, "default", "realtime-test-configmap", "realtime-update", nil),
+				func(ctx context.Context, t *testing.T, _ *envconf.Config) context.Context {
+					t.Helper()
+					t.Log("ConfigMap modified — expecting realtime XR update")
+					return ctx
+				},
+			)).
 			Assess("XRStatusReflectsChangeInRealtime",
 				funcs.ResourcesHaveFieldValueWithin(3*time.Second, manifests, "xr.yaml", "status.observedData.message", "realtime-update"),
 			).

--- a/test/e2e/apiextensions_compositions_test.go
+++ b/test/e2e/apiextensions_compositions_test.go
@@ -492,3 +492,100 @@ func TestRequiredResources(t *testing.T) {
 			Feature(),
 	)
 }
+
+func TestRealtimeNamespacedXR(t *testing.T) {
+	manifests := "test/e2e/manifests/apiextensions/composition/realtime-namespaced-xr"
+	environment.Test(t,
+		features.NewWithDescription(t.Name(), "Tests realtime composition performance for namespaced XRs — composed resource changes must be detected within seconds, not minutes (regression guard for #6780).").
+			WithLabel(LabelArea, LabelAreaAPIExtensions).
+			WithLabel(LabelSize, LabelSizeSmall).
+			WithLabel(config.LabelTestSuite, config.TestSuiteDefault).
+			WithSetup("CreatePrerequisites", funcs.AllOf(
+				funcs.ApplyResources(FieldManager, manifests, "setup/*.yaml"),
+				funcs.ResourcesCreatedWithin(30*time.Second, manifests, "setup/*.yaml"),
+				funcs.ResourcesHaveConditionWithin(1*time.Minute, manifests, "setup/definition.yaml", apiextensionsv1.WatchingComposite()),
+				funcs.ResourcesHaveConditionWithin(2*time.Minute, manifests, "setup/functions.yaml", pkgv1.Healthy(), pkgv1.Active()),
+			)).
+			WithSetup("CreateConfigMap", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+				t.Helper()
+
+				cm := &unstructured.Unstructured{}
+				cm.SetAPIVersion("v1")
+				cm.SetKind("ConfigMap")
+				cm.SetNamespace("default")
+				cm.SetName("realtime-test-configmap")
+				cm.SetLabels(map[string]string{"app": "crossplane-e2e"})
+				fieldpath.Pave(cm.Object).SetString("data.message", "initial")
+
+				//nolint:staticcheck // TODO(adamwg) Stop using client.Apply after the v2.2 release.
+				if err := cfg.Client().Resources().GetControllerRuntimeClient().Patch(ctx, cm, client.Apply, client.FieldOwner(FieldManager), client.ForceOwnership); err != nil {
+					t.Fatalf("failed to create ConfigMap: %v", err)
+					return ctx
+				}
+
+				t.Log("Created ConfigMap with initial data")
+				return ctx
+			}).
+			Assess("CreateXR", funcs.AllOf(
+				funcs.ApplyResources(FieldManager, manifests, "xr.yaml"),
+				funcs.ResourcesCreatedWithin(30*time.Second, manifests, "xr.yaml"),
+			)).
+			Assess("XRIsReady",
+				funcs.ResourcesHaveConditionWithin(1*time.Minute, manifests, "xr.yaml", xpv2.Available(), xpv2.ReconcileSuccess()),
+			).
+			Assess("ResourceWasReceived",
+				funcs.ResourcesHaveFieldValueWithin(1*time.Minute, manifests, "xr.yaml", "status.resourceReceived", true),
+			).
+			Assess("InitialObservationReflected",
+				funcs.ResourcesHaveFieldValueWithin(10*time.Second, manifests, "xr.yaml", "status.observedData.message", "initial"),
+			).
+			Assess("ModifyConfigMapDirectly", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+				t.Helper()
+
+				t.Log("Modifying ConfigMap directly to trigger realtime detection...")
+
+				cm := &unstructured.Unstructured{}
+				cm.SetAPIVersion("v1")
+				cm.SetKind("ConfigMap")
+				cm.SetNamespace("default")
+				cm.SetName("realtime-test-configmap")
+				fieldpath.Pave(cm.Object).SetString("data.message", "realtime-update")
+
+				//nolint:staticcheck // TODO(adamwg) Stop using client.Apply after the v2.2 release.
+				if err := cfg.Client().Resources().GetControllerRuntimeClient().Patch(ctx, cm, client.Apply, client.FieldOwner(FieldManager), client.ForceOwnership); err != nil {
+					t.Fatalf("failed to modify ConfigMap: %v", err)
+					return ctx
+				}
+
+				t.Log("ConfigMap modified — expecting realtime XR update")
+				return ctx
+			}).
+			Assess("XRStatusReflectsChangeInRealtime",
+				funcs.ResourcesHaveFieldValueWithin(3*time.Second, manifests, "xr.yaml", "status.observedData.message", "realtime-update"),
+			).
+			WithTeardown("DeleteXR", funcs.AllOf(
+				funcs.DeleteResourcesWithPropagationPolicy(manifests, "xr.yaml", metav1.DeletePropagationForeground),
+				funcs.ResourcesDeletedWithin(1*time.Minute, manifests, "xr.yaml"),
+			)).
+			WithTeardown("DeleteConfigMap", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+				t.Helper()
+
+				cm := &unstructured.Unstructured{}
+				cm.SetAPIVersion("v1")
+				cm.SetKind("ConfigMap")
+				cm.SetNamespace("default")
+				cm.SetName("realtime-test-configmap")
+
+				if err := cfg.Client().Resources().Delete(ctx, cm); err != nil {
+					t.Logf("failed to delete ConfigMap: %v", err)
+				}
+
+				return ctx
+			}).
+			WithTeardown("DeletePrerequisites", funcs.AllOf(
+				funcs.DeleteResourcesWithPropagationPolicy(manifests, "setup/*.yaml", metav1.DeletePropagationForeground),
+				funcs.ResourcesDeletedWithin(3*time.Minute, manifests, "setup/*.yaml"),
+			)).
+			Feature(),
+	)
+}

--- a/test/e2e/funcs/feature.go
+++ b/test/e2e/funcs/feature.go
@@ -704,6 +704,32 @@ func ApplyResources(manager, dir, pattern string, options ...decoder.DecodeOptio
 	}
 }
 
+// ApplyConfigMapMessage server-side applies a ConfigMap with data.message set to
+// the supplied value. Optional labels are applied when non-nil.
+func ApplyConfigMapMessage(manager, namespace, name, message string, labels map[string]string) features.Func {
+	return func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+		t.Helper()
+
+		cm := &unstructured.Unstructured{}
+		cm.SetAPIVersion("v1")
+		cm.SetKind("ConfigMap")
+		cm.SetNamespace(namespace)
+		cm.SetName(name)
+		if len(labels) > 0 {
+			cm.SetLabels(labels)
+		}
+		fieldpath.Pave(cm.Object).SetString("data.message", message)
+
+		//nolint:staticcheck // TODO(adamwg) Stop using client.Apply after the v2.2 release.
+		if err := c.Client().Resources().GetControllerRuntimeClient().Patch(ctx, cm, client.Apply, client.FieldOwner(manager), client.ForceOwnership); err != nil {
+			t.Fatalf("failed to apply ConfigMap %s/%s: %v", namespace, name, err)
+			return ctx
+		}
+
+		return ctx
+	}
+}
+
 type claimCtxKey struct{}
 
 // ApplyClaim applies the claim stored in the given folder and file

--- a/test/e2e/manifests/apiextensions/composition/realtime-namespaced-xr/setup/composition.yaml
+++ b/test/e2e/manifests/apiextensions/composition/realtime-namespaced-xr/setup/composition.yaml
@@ -1,0 +1,55 @@
+apiVersion: apiextensions.crossplane.io/v1
+kind: Composition
+metadata:
+  name: realtime-composition-namespaced
+spec:
+  compositeTypeRef:
+    apiVersion: nop.example.org/v1alpha1
+    kind: XRealtimeTest
+  mode: Pipeline
+  pipeline:
+  - step: observe-configmap
+    functionRef:
+      name: function-python-realtime-namespaced
+    input:
+      apiVersion: python.fn.crossplane.io/v1beta1
+      kind: Script
+      script: |
+        from crossplane.function import response, request
+        from crossplane.function.proto.v1 import run_function_pb2 as fnv1
+
+        def compose(req: fnv1.RunFunctionRequest, rsp: fnv1.RunFunctionResponse):
+            response.require_resources(
+                rsp,
+                name="observe-configmap",
+                api_version="v1",
+                kind="ConfigMap",
+                match_name="realtime-test-configmap",
+                namespace="default",
+            )
+
+            resource_received = "observe-configmap" in req.required_resources
+
+            observed_message = "not-found"
+            if resource_received:
+                cm = request.get_required_resource(req, "observe-configmap")
+                if cm:
+                    data = cm.get("data", {})
+                    observed_message = data.get("message", "no-message")
+
+            rsp.desired.composite.resource.update({
+                "status": {
+                    "observedData": {
+                        "message": observed_message,
+                    },
+                    "resourceReceived": resource_received,
+                }
+            })
+
+            result = fnv1.Result()
+            result.severity = fnv1.SEVERITY_NORMAL
+            if resource_received:
+                result.message = f"Observed ConfigMap with message: {observed_message}"
+            else:
+                result.message = "Waiting for ConfigMap"
+            rsp.results.append(result)

--- a/test/e2e/manifests/apiextensions/composition/realtime-namespaced-xr/setup/definition.yaml
+++ b/test/e2e/manifests/apiextensions/composition/realtime-namespaced-xr/setup/definition.yaml
@@ -1,0 +1,32 @@
+apiVersion: apiextensions.crossplane.io/v2
+kind: CompositeResourceDefinition
+metadata:
+  name: realtimetests.nop.example.org
+spec:
+  scope: Namespaced
+  group: nop.example.org
+  names:
+    kind: XRealtimeTest
+    plural: realtimetests
+  versions:
+  - name: v1alpha1
+    served: true
+    referenceable: true
+    schema:
+     openAPIV3Schema:
+       type: object
+       properties:
+        spec:
+          type: object
+          properties:
+            coolField:
+              type: string
+        status:
+          type: object
+          properties:
+            observedData:
+              type: object
+              additionalProperties:
+                type: string
+            resourceReceived:
+              type: boolean

--- a/test/e2e/manifests/apiextensions/composition/realtime-namespaced-xr/setup/functions.yaml
+++ b/test/e2e/manifests/apiextensions/composition/realtime-namespaced-xr/setup/functions.yaml
@@ -1,0 +1,6 @@
+apiVersion: pkg.crossplane.io/v1
+kind: Function
+metadata:
+  name: function-python-realtime-namespaced
+spec:
+  package: xpkg.crossplane.io/crossplane-contrib/function-python:v0.4.0

--- a/test/e2e/manifests/apiextensions/composition/realtime-namespaced-xr/xr.yaml
+++ b/test/e2e/manifests/apiextensions/composition/realtime-namespaced-xr/xr.yaml
@@ -1,0 +1,10 @@
+apiVersion: nop.example.org/v1alpha1
+kind: XRealtimeTest
+metadata:
+  namespace: default
+  name: realtime-xr-namespaced
+spec:
+  coolField: "realtime test"
+  crossplane:
+    compositionRef:
+      name: realtime-composition-namespaced


### PR DESCRIPTION
## Summary

Adds `TestRealtimeNamespacedXR` and supporting manifests to ensure namespaced XRs detect composed resource changes in realtime (within seconds), not via the ~60s polling fallback.

This is a regression guard for #6780, where namespaced XRs silently fell back to polling because of an indexing bug.

Closes #6788

## Approach

- Namespaced XRD + pipeline composition using `function-python` to observe a ConfigMap via `require_resources`
- Test creates the ConfigMap, reconciles the XR, mutates the ConfigMap, then asserts `status.observedData.message` updates within **3 seconds**

## Test plan

- [ ] `make test-e2e TEST_FILTER=TestRealtimeNamespacedXR` (requires kind cluster + Crossplane install per project docs)
- [ ] Full e2e CI when maintainers trigger it