### PR TITLE
Do not delete package runtime deployments owned by another revision

### DIFF
--- a/internal/controller/pkg/runtime/runtime.go
+++ b/internal/controller/pkg/runtime/runtime.go
@@ -22,8 +22,12 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/crossplane/crossplane-runtime/v2/pkg/errors"
 	"github.com/crossplane/crossplane-runtime/v2/pkg/meta"
+	"github.com/crossplane/crossplane-runtime/v2/pkg/resource"
 
 	v1 "github.com/crossplane/crossplane/apis/v2/pkg/v1"
 	"github.com/crossplane/crossplane/apis/v2/pkg/v1beta1"
@@ -111,6 +115,32 @@ type Hooks interface {
 
 	// Deactivate performs operations meant to happen before deactivating a revision.
 	Deactivate(ctx context.Context, pr v1.PackageRevisionWithRuntime, b ManifestBuilder) error
+}
+
+const (
+	errCopyRuntimeObject    = "cannot copy package runtime object for deletion"
+	errGetRuntimeDeployment = "cannot get package runtime deployment for deletion"
+)
+
+func deleteRuntimeObjectControlledBy(ctx context.Context, c client.Client, owner metav1.Object, obj client.Object) error {
+	current, ok := obj.DeepCopyObject().(client.Object)
+	if !ok {
+		return errors.Errorf("%s: %T", errCopyRuntimeObject, obj)
+	}
+
+	if err := c.Get(ctx, client.ObjectKeyFromObject(obj), current); err != nil {
+		if resource.IgnoreNotFound(err) == nil {
+			return nil
+		}
+
+		return errors.Wrap(err, errGetRuntimeDeployment)
+	}
+
+	if !metav1.IsControlledBy(current, owner) {
+		return nil
+	}
+
+	return c.Delete(ctx, current, client.Preconditions{UID: ptr.To(current.GetUID())})
 }
 
 // DeploymentRuntimeBuilder builds the Deployment runtime manifests for

--- a/internal/controller/pkg/runtime/runtime_function.go
+++ b/internal/controller/pkg/runtime/runtime_function.go
@@ -161,13 +161,13 @@ func (h *FunctionHooks) Post(ctx context.Context, pr v1.PackageRevisionWithRunti
 }
 
 // Deactivate performs operations meant to happen before deactivating a revision.
-func (h *FunctionHooks) Deactivate(ctx context.Context, _ v1.PackageRevisionWithRuntime, build ManifestBuilder) error {
+func (h *FunctionHooks) Deactivate(ctx context.Context, pr v1.PackageRevisionWithRuntime, build ManifestBuilder) error {
 	sa := build.ServiceAccount()
 	// Delete the deployment if it exists.
 	// Different from the Post runtimeHook, we don't need to pass the
 	// "functionDeploymentOverrides()" here, because we're only interested
 	// in the name and namespace of the deployment to delete it.
-	if err := h.client.Delete(ctx, build.Deployment(sa.Name)); resource.IgnoreNotFound(err) != nil {
+	if err := deleteRuntimeObjectControlledBy(ctx, h.client.Client, pr, build.Deployment(sa.Name)); err != nil {
 		return errors.Wrap(err, errDeleteFunctionDeployment)
 	}
 

--- a/internal/controller/pkg/runtime/runtime_function_test.go
+++ b/internal/controller/pkg/runtime/runtime_function_test.go
@@ -615,9 +615,10 @@ func TestFunctionDeactivateHook(t *testing.T) {
 		args   args
 		want   want
 	}{
-		"ErrDeleteDeployment": {
-			reason: "Should return error if we fail to delete deployment.",
+		"ErrGetDeployment": {
+			reason: "Should return error if we fail to get deployment before deleting it.",
 			args: args{
+				rev: &v1.FunctionRevision{},
 				manifests: &MockManifestBuilder{
 					ServiceAccountFn: func(_ ...ServiceAccountOverride) *corev1.ServiceAccount {
 						return &corev1.ServiceAccount{}
@@ -627,6 +628,34 @@ func TestFunctionDeactivateHook(t *testing.T) {
 					},
 				},
 				client: &test.MockClient{
+					MockGet: test.NewMockGetFn(errBoom),
+					MockDelete: func(_ context.Context, _ client.Object, _ ...client.DeleteOption) error {
+						return errors.New("deployment should not be deleted")
+					},
+				},
+			},
+			want: want{
+				err: errors.Wrap(errors.Wrap(errBoom, errGetRuntimeDeployment), errDeleteFunctionDeployment),
+				rev: &v1.FunctionRevision{},
+			},
+		},
+		"ErrDeleteDeployment": {
+			reason: "Should return error if we fail to delete deployment.",
+			args: args{
+				rev: &v1.FunctionRevision{},
+				manifests: &MockManifestBuilder{
+					ServiceAccountFn: func(_ ...ServiceAccountOverride) *corev1.ServiceAccount {
+						return &corev1.ServiceAccount{}
+					},
+					DeploymentFn: func(_ string, _ ...DeploymentOverride) *appsv1.Deployment {
+						return &appsv1.Deployment{}
+					},
+				},
+				client: &test.MockClient{
+					MockGet: test.NewMockGetFn(nil, func(obj client.Object) error {
+						obj.SetOwnerReferences([]metav1.OwnerReference{{Controller: ptr.To(true)}})
+						return nil
+					}),
 					MockDelete: func(_ context.Context, obj client.Object, _ ...client.DeleteOption) error {
 						if _, ok := obj.(*appsv1.Deployment); ok {
 							return errBoom
@@ -637,11 +666,13 @@ func TestFunctionDeactivateHook(t *testing.T) {
 			},
 			want: want{
 				err: errors.Wrap(errBoom, errDeleteFunctionDeployment),
+				rev: &v1.FunctionRevision{},
 			},
 		},
 		"Successful": {
 			reason: "Should not return error if successfully deleted service account and deployment.",
 			args: args{
+				rev: &v1.FunctionRevision{},
 				manifests: &MockManifestBuilder{
 					ServiceAccountFn: func(_ ...ServiceAccountOverride) *corev1.ServiceAccount {
 						return &corev1.ServiceAccount{
@@ -670,17 +701,52 @@ func TestFunctionDeactivateHook(t *testing.T) {
 					},
 				},
 				client: &test.MockClient{
+					MockGet: test.NewMockGetFn(nil, func(obj client.Object) error {
+						obj.SetOwnerReferences([]metav1.OwnerReference{{Controller: ptr.To(true)}})
+						return nil
+					}),
+					MockDelete: func(_ context.Context, _ client.Object, _ ...client.DeleteOption) error {
+						return nil
+					},
+				},
+			},
+			want: want{
+				rev: &v1.FunctionRevision{},
+			},
+		},
+		"DeploymentControlledByDifferentRevision": {
+			reason: "Should not delete deployment controlled by a different package revision.",
+			args: args{
+				rev: &v1.FunctionRevision{
+					ObjectMeta: metav1.ObjectMeta{
+						UID: "inactive-uid",
+					},
+				},
+				manifests: &MockManifestBuilder{
+					ServiceAccountFn: func(_ ...ServiceAccountOverride) *corev1.ServiceAccount {
+						return &corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: "some-sa"}}
+					},
+					DeploymentFn: func(_ string, _ ...DeploymentOverride) *appsv1.Deployment {
+						return &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "some-deployment"}}
+					},
+				},
+				client: &test.MockClient{
+					MockGet: test.NewMockGetFn(nil, func(obj client.Object) error {
+						obj.SetOwnerReferences([]metav1.OwnerReference{{UID: "active-uid", Controller: ptr.To(true)}})
+						return nil
+					}),
 					MockDelete: func(_ context.Context, obj client.Object, _ ...client.DeleteOption) error {
-						switch obj.(type) {
-						case *corev1.ServiceAccount:
-							return errors.New("service account should not be deleted during deactivation")
-						case *appsv1.Deployment:
-							if obj.GetName() != "some-deployment" {
-								return errors.New("unexpected deployment name")
-							}
-							return nil
+						if _, ok := obj.(*appsv1.Deployment); ok {
+							return errors.New("deployment should not be deleted")
 						}
-						return errors.New("unexpected object type")
+						return nil
+					},
+				},
+			},
+			want: want{
+				rev: &v1.FunctionRevision{
+					ObjectMeta: metav1.ObjectMeta{
+						UID: "inactive-uid",
 					},
 				},
 			},

--- a/internal/controller/pkg/runtime/runtime_provider.go
+++ b/internal/controller/pkg/runtime/runtime_provider.go
@@ -167,7 +167,7 @@ func (h *ProviderHooks) Deactivate(ctx context.Context, pr v1.PackageRevisionWit
 	// Different from the Post runtimeHook, we don't need to pass the
 	// "providerDeploymentOverrides()" here, because we're only interested
 	// in the name and namespace of the deployment to delete it.
-	if err := h.client.Delete(ctx, build.Deployment(sa.Name)); resource.IgnoreNotFound(err) != nil {
+	if err := deleteRuntimeObjectControlledBy(ctx, h.client.Client, pr, build.Deployment(sa.Name)); err != nil {
 		return errors.Wrap(err, errDeleteProviderDeployment)
 	}
 

--- a/internal/controller/pkg/runtime/runtime_provider_test.go
+++ b/internal/controller/pkg/runtime/runtime_provider_test.go
@@ -635,6 +635,7 @@ func TestProviderDeactivateHook(t *testing.T) {
 		"ErrDeleteDeployment": {
 			reason: "Should return error if we fail to delete deployment.",
 			args: args{
+				rev: &v1.ProviderRevision{},
 				manifests: &MockManifestBuilder{
 					ServiceAccountFn: func(_ ...ServiceAccountOverride) *corev1.ServiceAccount {
 						return &corev1.ServiceAccount{}
@@ -644,6 +645,10 @@ func TestProviderDeactivateHook(t *testing.T) {
 					},
 				},
 				client: &test.MockClient{
+					MockGet: test.NewMockGetFn(nil, func(obj client.Object) error {
+						obj.SetOwnerReferences([]metav1.OwnerReference{{Controller: ptr.To(true)}})
+						return nil
+					}),
 					MockDelete: func(_ context.Context, obj client.Object, _ ...client.DeleteOption) error {
 						if _, ok := obj.(*appsv1.Deployment); ok {
 							return errBoom
@@ -654,6 +659,7 @@ func TestProviderDeactivateHook(t *testing.T) {
 			},
 			want: want{
 				err: errors.Wrap(errBoom, errDeleteProviderDeployment),
+				rev: &v1.ProviderRevision{},
 			},
 		},
 		"Successful": {
@@ -692,6 +698,10 @@ func TestProviderDeactivateHook(t *testing.T) {
 					},
 				},
 				client: &test.MockClient{
+					MockGet: test.NewMockGetFn(nil, func(obj client.Object) error {
+						obj.SetOwnerReferences([]metav1.OwnerReference{{Controller: ptr.To(true)}})
+						return nil
+					}),
 					MockDelete: func(_ context.Context, obj client.Object, _ ...client.DeleteOption) error {
 						switch obj.(type) {
 						case *corev1.ServiceAccount:
@@ -716,6 +726,52 @@ func TestProviderDeactivateHook(t *testing.T) {
 				rev: &v1.ProviderRevision{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "some-name",
+					},
+				},
+			},
+		},
+		"DeploymentControlledByDifferentRevision": {
+			reason: "Should not delete deployment controlled by a different package revision.",
+			args: args{
+				rev: &v1.ProviderRevision{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "some-name",
+						UID:  "inactive-uid",
+					},
+				},
+				manifests: &MockManifestBuilder{
+					ServiceAccountFn: func(_ ...ServiceAccountOverride) *corev1.ServiceAccount {
+						return &corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: "some-sa"}}
+					},
+					DeploymentFn: func(_ string, _ ...DeploymentOverride) *appsv1.Deployment {
+						return &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "some-deployment"}}
+					},
+					ServiceFn: func(overrides ...ServiceOverride) *corev1.Service {
+						s := &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "some-service"}}
+						for _, o := range overrides {
+							o(s)
+						}
+						return s
+					},
+				},
+				client: &test.MockClient{
+					MockGet: test.NewMockGetFn(nil, func(obj client.Object) error {
+						obj.SetOwnerReferences([]metav1.OwnerReference{{UID: "active-uid", Controller: ptr.To(true)}})
+						return nil
+					}),
+					MockDelete: func(_ context.Context, obj client.Object, _ ...client.DeleteOption) error {
+						if _, ok := obj.(*appsv1.Deployment); ok {
+							return errors.New("deployment should not be deleted")
+						}
+						return nil
+					},
+				},
+			},
+			want: want{
+				rev: &v1.ProviderRevision{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "some-name",
+						UID:  "inactive-uid",
 					},
 				},
 			},


### PR DESCRIPTION
### Description of your changes

Fixes #7550.

Package runtime deactivation currently deletes provider and function Deployments by name. When a `DeploymentRuntimeConfig` sets a stable `deploymentTemplate.metadata.name`, an inactive package revision can resolve the same Deployment name as the active revision and delete the active runtime Deployment during deactivation.

This updates provider and function deactivation to read the live Deployment first and delete it only if it is controlled by the revision being deactivated. If the live Deployment is controlled by another revision, deactivation skips deleting it.

Tests cover provider and function deactivation when the Deployment is controlled by a different package revision, while preserving the existing successful deactivation behavior.

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [ ] ~Run `./nix.sh flake check` to ensure this PR is ready for review.~
- [x] Added or updated unit tests.
- [ ] ~Added or updated e2e tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~
- [ ] ~Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md
