### PR TITLE
fix(ci): serialize Nix builds in Renovate entrypoint

### DIFF
--- a/.github/renovate-entrypoint.sh
+++ b/.github/renovate-entrypoint.sh
@@ -22,8 +22,10 @@ experimental-features = nix-command flakes
 # needing to create the nixbld group and users in this ephemeral container.
 build-users-group =
 
-# Build derivations in parallel, one per CPU core.
-max-jobs = auto
+# Build derivations serially. Running one build per core races on the shared
+# HOME (/homeless-shelter) in this rootless, single-user container, which makes
+# Renovate's Nix artifact updates fail intermittently.
+max-jobs = 1
 
 # Use the Crossplane Cachix cache to download pre-built binaries from CI.
 extra-substituters = https://crossplane.cachix.org


### PR DESCRIPTION
## Description of your changes

Renovate runs fail intermittently with:

```
error: home directory '/homeless-shelter' exists
```

The Renovate entrypoint (`.github/renovate-entrypoint.sh`) installs Nix and runs it rootless as a single user with a shared `HOME` (`/homeless-shelter`). Because `nix.conf` sets `max-jobs = auto`, derivations build in parallel, one per core, and those concurrent builds race on that shared HOME — which surfaces as the error above and breaks Renovate's Nix artifact updates.

Setting `max-jobs = 1` serializes the builds and eliminates the race.

Fixes #7390

I have:
- [x] Read and followed Crossplane's [contribution process](https://github.com/crossplane/crossplane/blob/main/CONTRIBUTING.md).
- [x] Run `earthly +reviewable` to ensure this PR is ready for review. (N/A — CI entrypoint shell config only.)
- [x] Added or updated unit tests. (N/A — CI configuration change.)
- [x] Added backport release-note labels as needed.

### How has this code been tested?

Shell syntax checked with `bash -n`. The change only alters the generated `nix.conf` (`max-jobs = auto` → `max-jobs = 1`); behavior is exercised by the Renovate workflow itself.
