### PR TITLE
Align user-facing RBAC aggregation with Kubernetes standard conventions

### DIFF
--- a/cluster/charts/crossplane/templates/rbac-manager-managed-clusterroles.yaml
+++ b/cluster/charts/crossplane/templates/rbac-manager-managed-clusterroles.yaml
@@ -34,6 +34,7 @@ metadata:
   name: {{ template "crossplane.name" . }}-edit
   labels:
     app: {{ template "crossplane.name" . }}
+    rbac.crossplane.io/aggregate-to-admin: "true"
     {{- include "crossplane.labels" . | indent 4 }}
 aggregationRule:
   clusterRoleSelectors:
@@ -46,6 +47,7 @@ metadata:
   name: {{ template "crossplane.name" . }}-view
   labels:
     app: {{ template "crossplane.name" . }}
+    rbac.crossplane.io/aggregate-to-edit: "true"
     {{- include "crossplane.labels" . | indent 4 }}
 aggregationRule:
   clusterRoleSelectors:

--- a/internal/controller/rbac/definition/roles.go
+++ b/internal/controller/rbac/definition/roles.go
@@ -111,7 +111,6 @@ func RenderClusterRoles(d *v1.CompositeResourceDefinition) []rbacv1.ClusterRole 
 				APIGroups: []string{d.Spec.Group},
 				Resources: []string{
 					d.Spec.Names.Plural,
-					d.Spec.Names.Plural + suffixStatus,
 				},
 				Verbs: verbsEdit,
 			},
@@ -186,7 +185,6 @@ func RenderClusterRoles(d *v1.CompositeResourceDefinition) []rbacv1.ClusterRole 
 			APIGroups: []string{d.Spec.Group},
 			Resources: []string{
 				d.Spec.ClaimNames.Plural,
-				d.Spec.ClaimNames.Plural + suffixStatus,
 			},
 			Verbs: verbsEdit,
 		})

--- a/internal/controller/rbac/definition/roles.go
+++ b/internal/controller/rbac/definition/roles.go
@@ -53,7 +53,8 @@ const (
 
 //nolint:gochecknoglobals // We treat these as constants.
 var (
-	verbsEdit   = []string{rbacv1.VerbAll}
+	verbsAll    = []string{rbacv1.VerbAll}
+	verbsEdit   = []string{"create", "update", "patch", "delete", "deletecollection"}
 	verbsView   = []string{"get", "list", "watch"}
 	verbsBrowse = []string{"get", "list", "watch"}
 	verbsUpdate = []string{"update"}
@@ -75,7 +76,7 @@ func RenderClusterRoles(d *v1.CompositeResourceDefinition) []rbacv1.ClusterRole 
 					d.Spec.Names.Plural,
 					d.Spec.Names.Plural + suffixStatus,
 				},
-				Verbs: verbsEdit,
+				Verbs: verbsAll,
 			},
 			{
 				// Crossplane reconciles an XR by creating one or more composed resources.
@@ -95,13 +96,14 @@ func RenderClusterRoles(d *v1.CompositeResourceDefinition) []rbacv1.ClusterRole 
 		ObjectMeta: metav1.ObjectMeta{
 			Name: namePrefix + d.GetName() + nameSuffixEdit,
 			Labels: map[string]string{
-				// Edit rules aggregate to admin too. Currently edit and admin
-				// differ only in their base roles.
-				keyAggregateToAdmin:   valTrue,
-				keyAggregateToNSAdmin: valTrue,
+				// Cluster-scoped admin inherits edit transitively: the crossplane-admin
+				// aggregationRule selects aggregate-to-edit (set in the Helm chart), so
+				// the cluster-scoped aggregate-to-admin label is intentionally omitted here.
+				keyAggregateToEdit: valTrue,
 
-				keyAggregateToEdit:   valTrue,
-				keyAggregateToNSEdit: valTrue,
+				// Edit rules still aggregate directly to the namespaced admin role.
+				keyAggregateToNSEdit:  valTrue,
+				keyAggregateToNSAdmin: valTrue,
 			},
 		},
 		Rules: []rbacv1.PolicyRule{
@@ -120,8 +122,13 @@ func RenderClusterRoles(d *v1.CompositeResourceDefinition) []rbacv1.ClusterRole 
 		ObjectMeta: metav1.ObjectMeta{
 			Name: namePrefix + d.GetName() + nameSuffixView,
 			Labels: map[string]string{
-				keyAggregateToView:   valTrue,
-				keyAggregateToNSView: valTrue,
+				// Cluster-scoped edit and admin inherit view transitively via the view role.
+				keyAggregateToView: valTrue,
+
+				// View rules still aggregate directly to the namespaced edit and admin roles.
+				keyAggregateToNSView:  valTrue,
+				keyAggregateToNSEdit:  valTrue,
+				keyAggregateToNSAdmin: valTrue,
 			},
 		},
 		Rules: []rbacv1.PolicyRule{
@@ -162,7 +169,7 @@ func RenderClusterRoles(d *v1.CompositeResourceDefinition) []rbacv1.ClusterRole 
 				d.Spec.ClaimNames.Plural,
 				d.Spec.ClaimNames.Plural + suffixStatus,
 			},
-			Verbs: verbsEdit,
+			Verbs: verbsAll,
 		},
 			rbacv1.PolicyRule{
 				// Crossplane needs permission to set finalizers on Claims in order to create resources

--- a/internal/controller/rbac/definition/roles_test.go
+++ b/internal/controller/rbac/definition/roles_test.go
@@ -72,7 +72,7 @@ func TestRenderClusterRoles(t *testing.T) {
 						{
 							APIGroups: []string{group},
 							Resources: []string{pluralXR, pluralXR + suffixStatus},
-							Verbs:     verbsEdit,
+							Verbs:     verbsAll,
 						},
 						{
 							APIGroups: []string{group},
@@ -86,9 +86,8 @@ func TestRenderClusterRoles(t *testing.T) {
 						Name:            namePrefix + name + nameSuffixEdit,
 						OwnerReferences: []metav1.OwnerReference{owner},
 						Labels: map[string]string{
-							keyAggregateToAdmin:   valTrue,
-							keyAggregateToNSAdmin: valTrue,
 							keyAggregateToEdit:    valTrue,
+							keyAggregateToNSAdmin: valTrue,
 							keyAggregateToNSEdit:  valTrue,
 						},
 					},
@@ -105,8 +104,10 @@ func TestRenderClusterRoles(t *testing.T) {
 						Name:            namePrefix + name + nameSuffixView,
 						OwnerReferences: []metav1.OwnerReference{owner},
 						Labels: map[string]string{
-							keyAggregateToView:   valTrue,
-							keyAggregateToNSView: valTrue,
+							keyAggregateToView:    valTrue,
+							keyAggregateToNSAdmin: valTrue,
+							keyAggregateToNSEdit:  valTrue,
+							keyAggregateToNSView:  valTrue,
 						},
 					},
 					Rules: []rbacv1.PolicyRule{
@@ -158,7 +159,7 @@ func TestRenderClusterRoles(t *testing.T) {
 						{
 							APIGroups: []string{group},
 							Resources: []string{pluralXR, pluralXR + suffixStatus},
-							Verbs:     verbsEdit,
+							Verbs:     verbsAll,
 						},
 						{
 							APIGroups: []string{group},
@@ -168,7 +169,7 @@ func TestRenderClusterRoles(t *testing.T) {
 						{
 							APIGroups: []string{group},
 							Resources: []string{pluralXRC, pluralXRC + suffixStatus},
-							Verbs:     verbsEdit,
+							Verbs:     verbsAll,
 						},
 						{
 							APIGroups: []string{group},
@@ -182,9 +183,8 @@ func TestRenderClusterRoles(t *testing.T) {
 						Name:            namePrefix + name + nameSuffixEdit,
 						OwnerReferences: []metav1.OwnerReference{owner},
 						Labels: map[string]string{
-							keyAggregateToAdmin:   valTrue,
-							keyAggregateToNSAdmin: valTrue,
 							keyAggregateToEdit:    valTrue,
+							keyAggregateToNSAdmin: valTrue,
 							keyAggregateToNSEdit:  valTrue,
 						},
 					},
@@ -206,8 +206,10 @@ func TestRenderClusterRoles(t *testing.T) {
 						Name:            namePrefix + name + nameSuffixView,
 						OwnerReferences: []metav1.OwnerReference{owner},
 						Labels: map[string]string{
-							keyAggregateToView:   valTrue,
-							keyAggregateToNSView: valTrue,
+							keyAggregateToView:    valTrue,
+							keyAggregateToNSAdmin: valTrue,
+							keyAggregateToNSEdit:  valTrue,
+							keyAggregateToNSView:  valTrue,
 						},
 					},
 					Rules: []rbacv1.PolicyRule{

--- a/internal/controller/rbac/definition/roles_test.go
+++ b/internal/controller/rbac/definition/roles_test.go
@@ -94,7 +94,7 @@ func TestRenderClusterRoles(t *testing.T) {
 					Rules: []rbacv1.PolicyRule{
 						{
 							APIGroups: []string{group},
-							Resources: []string{pluralXR, pluralXR + suffixStatus},
+							Resources: []string{pluralXR},
 							Verbs:     verbsEdit,
 						},
 					},
@@ -191,12 +191,12 @@ func TestRenderClusterRoles(t *testing.T) {
 					Rules: []rbacv1.PolicyRule{
 						{
 							APIGroups: []string{group},
-							Resources: []string{pluralXR, pluralXR + suffixStatus},
+							Resources: []string{pluralXR},
 							Verbs:     verbsEdit,
 						},
 						{
 							APIGroups: []string{group},
-							Resources: []string{pluralXRC, pluralXRC + suffixStatus},
+							Resources: []string{pluralXRC},
 							Verbs:     verbsEdit,
 						},
 					},


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane! Please read the contribution docs
(linked below) if this is your first Crossplane pull request.
-->

### Description of your changes

Today, the user-facing roles do not aggregate hierarchically in the same way as the built-in Kubernetes roles. This means permissions granted to the crossplane-view role are not automatically included in the crossplane-edit and crossplane-admin roles.

This PR updates the aggregation so that:

crossplane-view aggregates to crossplane-edit (and crossplane-admin)
crossplane-edit aggregates to crossplane-admin

As a result, the roles behave like the standard Kubernetes user-facing roles, where administrators automatically inherit all permissions granted to editors (and viewers).

After making the aggregation hierarchical (the main motivation of this PR), there is no need to grant verbs already granted to crossplane-view to crossplane-edit/crossplane-admin. But Crossplane should have full access (`verbs: ["*"]`). Changing this should not alter behavior in any way, but the user-facing roles will look more explicit and to the point.

I kept the custom namespace aggregating roles unchanged otherwise, as I was not sure if this feature is still in use.

#### Why?

Kubernetes documents the user-facing RBAC roles as hierarchical, with ClusterRole aggregation used to extend the built-in view, edit, and admin roles for custom resources. Following this convention makes Crossplane's RBAC more predictable for cluster administrators and consistent with the rest of the Kubernetes ecosystem.

In https://github.com/crossplane/crossplane/issues/1852#issuecomment-4833860267, I describe how we were hit by this after granting some new permissions to crossplane-view. After this change, a subject in the role crossplane-admin was unable to grant crossplane-view to someone else. 😒 

<!--
Briefly describe what this pull request does, and how it is covered by tests.
Be proactive - direct your reviewers' attention to anything that needs special
consideration.

We love pull requests that fix an open issue. If yours does, use the below line
to indicate which issue it fixes, for example "Fixes #500".
-->

Fixes #1852

### Optional additional change in a separate commit

While looking through the code to fix this issue, I discovered an additional issue:

The user-facing crossplane-edit and crossplane-admin roles grant full access to Crossplane status subresources. This is not normal in the operator ecosystem, as the status subresource is for users to view but for **controllers** to edit. I would consider this a bug that should be fixed.

I would be happy to move this second commit into a separate follow-up PR, but it's also related to the desired change that motivated this PR. Let me know what you think!

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [ ] ~Run `./nix.sh flake check` to ensure this PR is ready for review.~
- [x] Added or updated unit tests.
- [ ] ~Added or updated e2e tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~
- [ ] ~Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md
