### PR TITLE
build(deps): bump Go to 1.25.12 [security] [release-2.1]

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -3,7 +3,7 @@ VERSION --try --raw-output 0.8
 
 PROJECT crossplane/crossplane
 
-ARG --global GO_VERSION=1.25.11
+ARG --global GO_VERSION=1.25.12
 
 # reviewable checks that a branch is ready for review. Run it before opening a
 # pull request. It will catch a lot of the things our CI workflow will catch.

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/crossplane/crossplane/v2
 
-go 1.25.11
+go 1.25.12
 
 require (
 	dario.cat/mergo v1.0.2


### PR DESCRIPTION
Bumps the Go toolchain to **1.25.12** to pick up the latest Go stdlib security fixes.

Clears **CVE-2026-39822** (fixed in Go 1.25.12), flagged on this release line by the UXP security scanner (`upbound/cve-scan-action#56`).

- `Earthfile` `GO_VERSION`: 1.25.11 → 1.25.12
- `go.mod` `go` directive: 1.25.11 → 1.25.12
