### PR TITLE
feat(pkg): scale safe-start provider runtimes to zero until their first MRD is activated

### DIFF
--- a/apis/pkg/v1/conditions.go
+++ b/apis/pkg/v1/conditions.go
@@ -27,27 +27,35 @@ import (
 
 // Condition types.
 const (
-	// A TypeInstalled indicates whether a package has been installed.
+	// TypeInstalled indicates whether a package has been installed.
 	TypeInstalled xpv2.ConditionType = "Installed"
 
-	// A TypeHealthy indicates whether a package is healthy.
+	// TypeHealthy indicates whether a package is healthy.
 	TypeHealthy xpv2.ConditionType = "Healthy"
 
-	// A TypeRevisionHealthy indicates whether a package revision is healthy.
+	// TypeRevisionHealthy indicates whether a package revision is healthy.
 	TypeRevisionHealthy xpv2.ConditionType = "RevisionHealthy"
 
-	// A TypeRuntimeHealthy indicates whether a package revision runtime is healthy.
+	// TypeRuntimeHealthy indicates whether a package revision runtime is healthy.
 	TypeRuntimeHealthy xpv2.ConditionType = "RuntimeHealthy"
+
+	// TypeRuntimeActive indicates whether a package revision runtime is
+	// scaled up. It is false while the runtime is intentionally scaled to
+	// zero, awaiting activation of the first ManagedResourceDefinition owned
+	// by the revision.
+	TypeRuntimeActive xpv2.ConditionType = "RuntimeActive"
 )
 
 // Reasons a package is or is not installed.
 const (
-	ReasonUnpacking     xpv2.ConditionReason = "UnpackingPackage"
-	ReasonInactive      xpv2.ConditionReason = "InactivePackageRevision"
-	ReasonActive        xpv2.ConditionReason = "ActivePackageRevision"
-	ReasonUnhealthy     xpv2.ConditionReason = "UnhealthyPackageRevision"
-	ReasonHealthy       xpv2.ConditionReason = "HealthyPackageRevision"
-	ReasonUnknownHealth xpv2.ConditionReason = "UnknownPackageRevisionHealth"
+	ReasonUnpacking          xpv2.ConditionReason = "UnpackingPackage"
+	ReasonInactive           xpv2.ConditionReason = "InactivePackageRevision"
+	ReasonActive             xpv2.ConditionReason = "ActivePackageRevision"
+	ReasonUnhealthy          xpv2.ConditionReason = "UnhealthyPackageRevision"
+	ReasonHealthy            xpv2.ConditionReason = "HealthyPackageRevision"
+	ReasonUnknownHealth      xpv2.ConditionReason = "UnknownPackageRevisionHealth"
+	ReasonActiveRuntime      xpv2.ConditionReason = "ActiveRuntime"
+	ReasonAwaitingActivation xpv2.ConditionReason = "AwaitingActivation"
 )
 
 // Unpacking indicates that the package manager is waiting for a package
@@ -100,6 +108,18 @@ func Healthy() xpv2.Condition {
 		Status:             corev1.ConditionTrue,
 		LastTransitionTime: metav1.Now(),
 		Reason:             ReasonHealthy,
+	}
+}
+
+// HealthyAwaitingActivation indicates that the current revision is healthy
+// and its runtime is intentionally scaled to zero until the first
+// ManagedResourceDefinition owned by the revision becomes Active.
+func HealthyAwaitingActivation() xpv2.Condition {
+	return xpv2.Condition{
+		Type:               TypeHealthy,
+		Status:             corev1.ConditionTrue,
+		LastTransitionTime: metav1.Now(),
+		Reason:             ReasonAwaitingActivation,
 	}
 }
 
@@ -163,6 +183,30 @@ func RuntimeHealthy() xpv2.Condition {
 	}
 }
 
+// RuntimeActive indicates that the current package revision runtime is
+// scaled up.
+func RuntimeActive() xpv2.Condition {
+	return xpv2.Condition{
+		Type:               TypeRuntimeActive,
+		Status:             corev1.ConditionTrue,
+		LastTransitionTime: metav1.Now(),
+		Reason:             ReasonActiveRuntime,
+	}
+}
+
+// RuntimeAwaitingActivation indicates that the current package revision
+// runtime is intentionally scaled to zero until the first
+// ManagedResourceDefinition owned by the revision becomes Active. The runtime
+// is considered healthy.
+func RuntimeAwaitingActivation() xpv2.Condition {
+	return xpv2.Condition{
+		Type:               TypeRuntimeActive,
+		Status:             corev1.ConditionFalse,
+		LastTransitionTime: metav1.Now(),
+		Reason:             ReasonAwaitingActivation,
+	}
+}
+
 // RuntimeUnknownHealth indicates that the health of the current package revision runtime is unknown.
 func RuntimeUnknownHealth() xpv2.Condition {
 	return xpv2.Condition{
@@ -186,12 +230,7 @@ func PackageHealth(pr PackageRevision) xpv2.Condition {
 
 	runtimeHealthy := runtimeHealth.Status == corev1.ConditionTrue
 	if _, hasRuntime := pr.(PackageRevisionWithRuntime); !hasRuntime {
-		// If the package revision does not have a runtime, we skip checking the runtime health.
 		runtimeHealthy = true
-	}
-
-	if revisionHealthy && runtimeHealthy {
-		return Healthy()
 	}
 
 	if !revisionHealthy {
@@ -208,9 +247,16 @@ func PackageHealth(pr PackageRevision) xpv2.Condition {
 		if runtimeHealth.Message != "" {
 			m += " with message: " + runtimeHealth.Message
 		}
+		if runtimeActive := pr.GetCondition(TypeRuntimeActive); runtimeActive.Reason == ReasonAwaitingActivation {
+			m += "; runtime is scaled to zero awaiting activation"
+		}
 
 		return Unhealthy().WithMessage(m)
 	}
 
-	return UnknownHealth()
+	if runtimeActive := pr.GetCondition(TypeRuntimeActive); runtimeActive.Reason == ReasonAwaitingActivation {
+		return HealthyAwaitingActivation().WithMessage(runtimeActive.Message)
+	}
+
+	return Healthy()
 }

--- a/apis/pkg/v1/conditions_test.go
+++ b/apis/pkg/v1/conditions_test.go
@@ -75,6 +75,41 @@ func TestPackageHealth(t *testing.T) {
 				condition: Healthy(),
 			},
 		},
+		"HealthyRuntimeAwaitingActivation": {
+			reason: "Should return a healthy awaiting activation condition when the runtime is intentionally scaled to zero",
+			args: args{
+				pr: &ProviderRevision{
+					Status: ProviderRevisionStatus{
+						PackageRevisionStatus: PackageRevisionStatus{
+							ConditionedStatus: xpv2.ConditionedStatus{
+								Conditions: []xpv2.Condition{
+									{
+										Type:    TypeRevisionHealthy,
+										Status:  corev1.ConditionTrue,
+										Reason:  ReasonHealthy,
+										Message: "Package revision is healthy",
+									},
+									{
+										Type:   TypeRuntimeHealthy,
+										Status: corev1.ConditionTrue,
+										Reason: ReasonHealthy,
+									},
+									{
+										Type:    TypeRuntimeActive,
+										Status:  corev1.ConditionFalse,
+										Reason:  ReasonAwaitingActivation,
+										Message: "Package runtime is scaled to zero; awaiting the first ManagedResourceDefinition to be activated",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: want{
+				condition: HealthyAwaitingActivation().WithMessage("Package runtime is scaled to zero; awaiting the first ManagedResourceDefinition to be activated"),
+			},
+		},
 		"UnhealthyRevision": {
 			reason: "Should return unhealthy condition when revision is unhealthy",
 			args: args{
@@ -125,6 +160,11 @@ func TestPackageHealth(t *testing.T) {
 										Reason:  ReasonUnhealthy,
 										Message: "Runtime deployment is not ready",
 									},
+									{
+										Type:   TypeRuntimeActive,
+										Status: corev1.ConditionTrue,
+										Reason: ReasonActiveRuntime,
+									},
 								},
 							},
 						},
@@ -133,6 +173,42 @@ func TestPackageHealth(t *testing.T) {
 			},
 			want: want{
 				condition: Unhealthy().WithMessage("Package runtime health is \"False\" with message: Runtime deployment is not ready"),
+			},
+		},
+		"UnhealthyRuntimeAwaitingActivation": {
+			reason: "Should include awaiting activation context when runtime is unhealthy and scaled to zero",
+			args: args{
+				pr: &ProviderRevision{
+					Status: ProviderRevisionStatus{
+						PackageRevisionStatus: PackageRevisionStatus{
+							ConditionedStatus: xpv2.ConditionedStatus{
+								Conditions: []xpv2.Condition{
+									{
+										Type:    TypeRevisionHealthy,
+										Status:  corev1.ConditionTrue,
+										Reason:  ReasonHealthy,
+										Message: "Package revision is healthy",
+									},
+									{
+										Type:    TypeRuntimeHealthy,
+										Status:  corev1.ConditionFalse,
+										Reason:  ReasonUnhealthy,
+										Message: "Runtime deployment is not ready",
+									},
+									{
+										Type:    TypeRuntimeActive,
+										Status:  corev1.ConditionFalse,
+										Reason:  ReasonAwaitingActivation,
+										Message: "Package runtime is scaled to zero; awaiting the first ManagedResourceDefinition to be activated",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: want{
+				condition: Unhealthy().WithMessage("Package runtime health is \"False\" with message: Runtime deployment is not ready; runtime is scaled to zero awaiting activation"),
 			},
 		},
 		"BothUnhealthy": {

--- a/apis/pkg/v1/function_types.go
+++ b/apis/pkg/v1/function_types.go
@@ -87,7 +87,8 @@ type FunctionRevisionSpec struct {
 // +kubebuilder:subresource:status
 // +kubebuilder:storageversion
 // +kubebuilder:printcolumn:name="HEALTHY",type="string",JSONPath=".status.conditions[?(@.type=='RevisionHealthy')].status"
-// +kubebuilder:printcolumn:name="RUNTIME",type="string",JSONPath=".status.conditions[?(@.type=='RuntimeHealthy')].status"
+// +kubebuilder:printcolumn:name="RUNTIME-HEALTHY",type="string",JSONPath=".status.conditions[?(@.type=='RuntimeHealthy')].status"
+// +kubebuilder:printcolumn:name="RUNTIME-ACTIVE",type="string",JSONPath=".status.conditions[?(@.type=='RuntimeActive')].status"
 // +kubebuilder:printcolumn:name="IMAGE",type="string",JSONPath=".spec.image"
 // +kubebuilder:printcolumn:name="STATE",type="string",JSONPath=".spec.desiredState"
 // +kubebuilder:printcolumn:name="AGE",type="date",JSONPath=".metadata.creationTimestamp"

--- a/apis/pkg/v1/provider_types.go
+++ b/apis/pkg/v1/provider_types.go
@@ -93,7 +93,8 @@ type ProviderRevisionStatus struct {
 // +kubebuilder:subresource:status
 // +kubebuilder:storageversion
 // +kubebuilder:printcolumn:name="HEALTHY",type="string",JSONPath=".status.conditions[?(@.type=='RevisionHealthy')].status"
-// +kubebuilder:printcolumn:name="RUNTIME",type="string",JSONPath=".status.conditions[?(@.type=='RuntimeHealthy')].status"
+// +kubebuilder:printcolumn:name="RUNTIME-HEALTHY",type="string",JSONPath=".status.conditions[?(@.type=='RuntimeHealthy')].status"
+// +kubebuilder:printcolumn:name="RUNTIME-ACTIVE",type="string",JSONPath=".status.conditions[?(@.type=='RuntimeActive')].status"
 // +kubebuilder:printcolumn:name="IMAGE",type="string",JSONPath=".spec.image"
 // +kubebuilder:printcolumn:name="STATE",type="string",JSONPath=".spec.desiredState"
 // +kubebuilder:printcolumn:name="AGE",type="date",JSONPath=".metadata.creationTimestamp"

--- a/apis/pkg/v1beta1/zz_generated.function_types.go
+++ b/apis/pkg/v1beta1/zz_generated.function_types.go
@@ -87,7 +87,8 @@ type FunctionRevisionSpec struct {
 // FunctionRevisions.
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="HEALTHY",type="string",JSONPath=".status.conditions[?(@.type=='RevisionHealthy')].status"
-// +kubebuilder:printcolumn:name="RUNTIME",type="string",JSONPath=".status.conditions[?(@.type=='RuntimeHealthy')].status"
+// +kubebuilder:printcolumn:name="RUNTIME-HEALTHY",type="string",JSONPath=".status.conditions[?(@.type=='RuntimeHealthy')].status"
+// +kubebuilder:printcolumn:name="RUNTIME-ACTIVE",type="string",JSONPath=".status.conditions[?(@.type=='RuntimeActive')].status"
 // +kubebuilder:printcolumn:name="IMAGE",type="string",JSONPath=".spec.image"
 // +kubebuilder:printcolumn:name="STATE",type="string",JSONPath=".spec.desiredState"
 // +kubebuilder:printcolumn:name="AGE",type="date",JSONPath=".metadata.creationTimestamp"

--- a/cluster/crds/pkg.crossplane.io_functionrevisions.yaml
+++ b/cluster/crds/pkg.crossplane.io_functionrevisions.yaml
@@ -22,7 +22,10 @@ spec:
       name: HEALTHY
       type: string
     - jsonPath: .status.conditions[?(@.type=='RuntimeHealthy')].status
-      name: RUNTIME
+      name: RUNTIME-HEALTHY
+      type: string
+    - jsonPath: .status.conditions[?(@.type=='RuntimeActive')].status
+      name: RUNTIME-ACTIVE
       type: string
     - jsonPath: .spec.image
       name: IMAGE
@@ -332,7 +335,10 @@ spec:
       name: HEALTHY
       type: string
     - jsonPath: .status.conditions[?(@.type=='RuntimeHealthy')].status
-      name: RUNTIME
+      name: RUNTIME-HEALTHY
+      type: string
+    - jsonPath: .status.conditions[?(@.type=='RuntimeActive')].status
+      name: RUNTIME-ACTIVE
       type: string
     - jsonPath: .spec.image
       name: IMAGE

--- a/cluster/crds/pkg.crossplane.io_providerrevisions.yaml
+++ b/cluster/crds/pkg.crossplane.io_providerrevisions.yaml
@@ -22,7 +22,10 @@ spec:
       name: HEALTHY
       type: string
     - jsonPath: .status.conditions[?(@.type=='RuntimeHealthy')].status
-      name: RUNTIME
+      name: RUNTIME-HEALTHY
+      type: string
+    - jsonPath: .status.conditions[?(@.type=='RuntimeActive')].status
+      name: RUNTIME-ACTIVE
       type: string
     - jsonPath: .spec.image
       name: IMAGE

--- a/internal/controller/pkg/runtime/reconciler.go
+++ b/internal/controller/pkg/runtime/reconciler.go
@@ -25,8 +25,10 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -40,6 +42,8 @@ import (
 	"github.com/crossplane/crossplane-runtime/v2/pkg/resource"
 	"github.com/crossplane/crossplane-runtime/v2/pkg/xpkg"
 
+	extv1alpha1 "github.com/crossplane/crossplane/apis/v2/apiextensions/v1alpha1"
+	pkgmetav1 "github.com/crossplane/crossplane/apis/v2/pkg/meta/v1"
 	v1 "github.com/crossplane/crossplane/apis/v2/pkg/v1"
 	"github.com/crossplane/crossplane/apis/v2/pkg/v1beta1"
 	"github.com/crossplane/crossplane/v2/internal/controller/pkg/controller"
@@ -65,6 +69,8 @@ const (
 	errGetRuntimeConfig         = "cannot get referenced deployment runtime config"
 	errUnknownKindRuntimeConfig = "runtime config is set but is an unknown apiVersion and kind"
 	errGetServiceAccount        = "cannot get Crossplane service account"
+
+	errListMRDs = "cannot list managed resource definitions"
 )
 
 // Event reasons.
@@ -179,7 +185,7 @@ func SetupProviderRevision(mgr ctrl.Manager, o controller.Options) error {
 		cb = cb.Watches(&v1beta1.DeploymentRuntimeConfig{}, EnqueuePackageRevisionsForRuntimeConfig(mgr.GetClient(), &v1.ProviderRevisionList{}, log))
 	}
 
-	r := NewReconciler(mgr,
+	rOpts := []ReconcilerOption{
 		WithNewPackageRevisionWithRuntimeFn(nr),
 		WithLogger(log),
 		WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name), o.EventFilterFunctions...)),
@@ -189,7 +195,13 @@ func SetupProviderRevision(mgr ctrl.Manager, o controller.Options) error {
 		WithFeatureFlags(o.Features),
 		WithDeploymentSelectorMigrator(NewDeletingDeploymentSelectorMigrator(mgr.GetClient(), log)),
 		WithConfigStore(xpkg.NewImageConfigStore(mgr.GetClient(), o.Namespace)),
-	)
+	}
+
+	// Watch MRDs so we can scale up a safe-start provider's runtime the moment
+	// its first MRD becomes active, without waiting for the next scheduled sync.
+	cb = cb.Watches(&extv1alpha1.ManagedResourceDefinition{}, EnqueueProviderRevisionsForMRDs(log), builder.WithPredicates(mrdActivated()))
+
+	r := NewReconciler(mgr, rOpts...)
 
 	return cb.WithOptions(o.ForControllerRuntime()).
 		Complete(errors.WithSilentRequeueOnConflict(r))
@@ -324,6 +336,17 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 		opts = append(opts, BuilderWithPullSecrets(pullSecretFromConfig))
 	}
 
+	ownedMRDs, err := r.ownedMRDs(ctx, pr)
+	if err != nil {
+		status.MarkConditions(v1.RuntimeUnhealthy().WithMessage(err.Error()))
+
+		_ = r.client.Status().Update(ctx, pr)
+		r.record.Event(pr, event.Warning(reasonSync, err))
+
+		return reconcile.Result{}, err
+	}
+
+	opts = append(opts, BuilderWithMRDs(ownedMRDs))
 	builder := NewDeploymentRuntimeBuilder(pr, r.namespace, opts...)
 
 	// Deactivate revision if it is inactive.
@@ -394,9 +417,34 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 		r.record.Event(pr, event.Normal(reasonSync, "Successfully configured package revision"))
 	}
 
-	status.MarkConditions(v1.RuntimeHealthy())
+	if builder.AwaitingActivation() {
+		status.MarkConditions(v1.RuntimeHealthy(), v1.RuntimeAwaitingActivation().WithMessage("Package runtime is scaled to zero; awaiting the first ManagedResourceDefinition to be activated"))
+	} else {
+		status.MarkConditions(v1.RuntimeHealthy(), v1.RuntimeActive())
+	}
 
 	return reconcile.Result{Requeue: false}, errors.Wrap(r.client.Status().Update(ctx, pr), errUpdateStatus)
+}
+
+// ownedMRDs returns the ManagedResourceDefinitions controlled by pr.
+// Returns nil without listing if pr does not have the safe-start capability.
+func (r *Reconciler) ownedMRDs(ctx context.Context, pr v1.PackageRevisionWithRuntime) ([]extv1alpha1.ManagedResourceDefinition, error) {
+	if !pkgmetav1.CapabilitiesContainFuzzyMatch(pr.GetCapabilities(), pkgmetav1.ProviderCapabilitySafeStart) {
+		return nil, nil
+	}
+
+	mrds := &extv1alpha1.ManagedResourceDefinitionList{}
+	if err := r.client.List(ctx, mrds); err != nil {
+		return nil, errors.Wrap(err, errListMRDs)
+	}
+
+	var owned []extv1alpha1.ManagedResourceDefinition
+	for i := range mrds.Items {
+		if metav1.IsControlledBy(&mrds.Items[i], pr) {
+			owned = append(owned, mrds.Items[i])
+		}
+	}
+	return owned, nil
 }
 
 func (r *Reconciler) builderOptions(ctx context.Context, pwr v1.PackageRevisionWithRuntime) ([]BuilderOption, error) {

--- a/internal/controller/pkg/runtime/reconciler.go
+++ b/internal/controller/pkg/runtime/reconciler.go
@@ -70,7 +70,7 @@ const (
 	errUnknownKindRuntimeConfig = "runtime config is set but is an unknown apiVersion and kind"
 	errGetServiceAccount        = "cannot get Crossplane service account"
 
-	errListMRDs = "cannot list managed resource definitions"
+	errListMRDs = "cannot list ManagedResourceDefinitions to determine whether the provider runtime can start"
 )
 
 // Event reasons.

--- a/internal/controller/pkg/runtime/reconciler.go
+++ b/internal/controller/pkg/runtime/reconciler.go
@@ -185,7 +185,11 @@ func SetupProviderRevision(mgr ctrl.Manager, o controller.Options) error {
 		cb = cb.Watches(&v1beta1.DeploymentRuntimeConfig{}, EnqueuePackageRevisionsForRuntimeConfig(mgr.GetClient(), &v1.ProviderRevisionList{}, log))
 	}
 
-	rOpts := []ReconcilerOption{
+	// Watch MRDs so we can scale up a safe-start provider's runtime the moment
+	// its first MRD becomes active, without waiting for the next scheduled sync.
+	cb = cb.Watches(&extv1alpha1.ManagedResourceDefinition{}, EnqueueProviderRevisionsForMRDs(log), builder.WithPredicates(mrdActivated()))
+
+	r := NewReconciler(mgr,
 		WithNewPackageRevisionWithRuntimeFn(nr),
 		WithLogger(log),
 		WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name), o.EventFilterFunctions...)),
@@ -195,13 +199,7 @@ func SetupProviderRevision(mgr ctrl.Manager, o controller.Options) error {
 		WithFeatureFlags(o.Features),
 		WithDeploymentSelectorMigrator(NewDeletingDeploymentSelectorMigrator(mgr.GetClient(), log)),
 		WithConfigStore(xpkg.NewImageConfigStore(mgr.GetClient(), o.Namespace)),
-	}
-
-	// Watch MRDs so we can scale up a safe-start provider's runtime the moment
-	// its first MRD becomes active, without waiting for the next scheduled sync.
-	cb = cb.Watches(&extv1alpha1.ManagedResourceDefinition{}, EnqueueProviderRevisionsForMRDs(log), builder.WithPredicates(mrdActivated()))
-
-	r := NewReconciler(mgr, rOpts...)
+	)
 
 	return cb.WithOptions(o.ForControllerRuntime()).
 		Complete(errors.WithSilentRequeueOnConflict(r))

--- a/internal/controller/pkg/runtime/reconciler_test.go
+++ b/internal/controller/pkg/runtime/reconciler_test.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -1175,6 +1176,70 @@ func TestReconcile(t *testing.T) {
 				r: reconcile.Result{Requeue: false},
 			},
 		},
+		"RuntimeActivationAwaitingWithDRCExplicitReplicas": {
+			reason: "A safe-start revision with all-inactive MRDs but a DRC that sets explicit replicas should run " +
+				"its runtime (DRC wins over defaultReplicas=0) and be marked RuntimeActive, not AwaitingActivation.",
+			args: args{
+				mgr: &fake.Manager{
+					Client: &test.MockClient{
+						MockGet: test.NewMockGetFn(nil, func(o client.Object) error {
+							switch obj := o.(type) {
+							case *v1.ProviderRevision:
+								setRuntimeActivationRevision(obj, pkgmetav1.ProviderCapabilitySafeStart)
+								obj.SetRuntimeConfigRef(&v1.RuntimeConfigReference{Name: "explicit-replicas-rc"})
+								return nil
+							case *v1beta1.DeploymentRuntimeConfig:
+								obj.Spec.DeploymentTemplate = &v1beta1.DeploymentTemplate{
+									Spec: &appsv1.DeploymentSpec{
+										Replicas: ptr.To[int32](2),
+									},
+								}
+								return nil
+							case *corev1.ServiceAccount:
+								obj.Name = crossplaneName
+								obj.Namespace = testNamespace
+								return nil
+							}
+							return nil
+						}),
+						MockList: test.NewMockListFn(nil, func(l client.ObjectList) error {
+							mrds := l.(*extv1alpha1.ManagedResourceDefinitionList)
+							mrds.Items = []extv1alpha1.ManagedResourceDefinition{
+								mrdControlledBy(runtimeActivationUID, extv1alpha1.ManagedResourceDefinitionInactive),
+							}
+							return nil
+						}),
+						MockStatusUpdate: test.NewMockSubResourceUpdateFn(nil, func(o client.Object) error {
+							want := &v1.ProviderRevision{}
+							setRuntimeActivationRevision(want, pkgmetav1.ProviderCapabilitySafeStart)
+							want.SetRuntimeConfigRef(&v1.RuntimeConfigReference{Name: "explicit-replicas-rc"})
+							want.SetConditions(v1.RuntimeHealthy(), v1.RuntimeActive())
+
+							if diff := cmp.Diff(want, o); diff != "" {
+								t.Errorf("-want, +got:\n%s", diff)
+							}
+							return nil
+						}),
+					},
+				},
+				rec: []ReconcilerOption{
+					WithNewPackageRevisionWithRuntimeFn(func() v1.PackageRevisionWithRuntime { return &v1.ProviderRevision{} }),
+					WithLogger(testLog),
+					WithRecorder(event.NewNopRecorder()),
+					WithNamespace(testNamespace),
+					WithServiceAccount(crossplaneName),
+					WithRuntimeHooks(&MockHooks{}),
+					WithFeatureFlags(flagsWithFeatures(features.EnableBetaDeploymentRuntimeConfigs)),
+					WithDeploymentSelectorMigrator(NewNopDeploymentSelectorMigrator()),
+					WithConfigStore(&fakexpkg.MockConfigStore{
+						MockRuntimeConfigFor: fakexpkg.NewMockRuntimeConfigForFn("", nil, nil),
+					}),
+				},
+			},
+			want: want{
+				r: reconcile.Result{Requeue: false},
+			},
+		},
 		"RuntimeActivationErrListMRDs": {
 			reason: "Should return an error and mark the runtime unhealthy when MRDs cannot be listed.",
 			args: args{
@@ -1196,7 +1261,7 @@ func TestReconcile(t *testing.T) {
 						MockStatusUpdate: test.NewMockSubResourceUpdateFn(nil, func(o client.Object) error {
 							want := &v1.ProviderRevision{}
 							setRuntimeActivationRevision(want, pkgmetav1.ProviderCapabilitySafeStart)
-							want.SetConditions(v1.RuntimeUnhealthy().WithMessage("cannot list managed resource definitions: boom"))
+							want.SetConditions(v1.RuntimeUnhealthy().WithMessage("cannot list ManagedResourceDefinitions to determine whether the provider runtime can start: boom"))
 
 							if diff := cmp.Diff(want, o); diff != "" {
 								t.Errorf("-want, +got:\n%s", diff)

--- a/internal/controller/pkg/runtime/reconciler_test.go
+++ b/internal/controller/pkg/runtime/reconciler_test.go
@@ -27,6 +27,7 @@ import (
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
@@ -42,6 +43,8 @@ import (
 	"github.com/crossplane/crossplane-runtime/v2/pkg/test"
 	fakexpkg "github.com/crossplane/crossplane-runtime/v2/pkg/xpkg/fake"
 
+	extv1alpha1 "github.com/crossplane/crossplane/apis/v2/apiextensions/v1alpha1"
+	pkgmetav1 "github.com/crossplane/crossplane/apis/v2/pkg/meta/v1"
 	v1 "github.com/crossplane/crossplane/apis/v2/pkg/v1"
 	"github.com/crossplane/crossplane/apis/v2/pkg/v1beta1"
 	"github.com/crossplane/crossplane/v2/internal/features"
@@ -574,7 +577,7 @@ func TestReconcile(t *testing.T) {
 							want.SetDesiredState(v1.PackageRevisionActive)
 							want.SetLabels(map[string]string{v1.LabelParentPackage: "test-function"})
 							want.SetConditions(v1.RevisionHealthy())
-							want.SetConditions(v1.RuntimeHealthy())
+							want.SetConditions(v1.RuntimeHealthy(), v1.RuntimeActive())
 
 							if diff := cmp.Diff(want, o); diff != "" {
 								t.Errorf("-want, +got:\n%s", diff)
@@ -681,7 +684,7 @@ func TestReconcile(t *testing.T) {
 							want.SetDesiredState(v1.PackageRevisionActive)
 							want.SetLabels(map[string]string{v1.LabelParentPackage: "test-provider"})
 							want.SetConditions(v1.RevisionHealthy())
-							want.SetConditions(v1.RuntimeHealthy())
+							want.SetConditions(v1.RuntimeHealthy(), v1.RuntimeActive())
 
 							if diff := cmp.Diff(want, o); diff != "" {
 								t.Errorf("-want, +got:\n%s", diff)
@@ -756,7 +759,7 @@ func TestReconcile(t *testing.T) {
 							want.SetDesiredState(v1.PackageRevisionActive)
 							want.SetLabels(map[string]string{v1.LabelParentPackage: "test-provider"})
 							want.SetConditions(v1.RevisionHealthy())
-							want.SetConditions(v1.RuntimeHealthy())
+							want.SetConditions(v1.RuntimeHealthy(), v1.RuntimeActive())
 							want.SetAppliedImageConfigRefs(v1.ImageConfigRef{
 								Name:   "test-image-config",
 								Reason: v1.ImageConfigReasonSetPullSecret,
@@ -834,7 +837,7 @@ func TestReconcile(t *testing.T) {
 							want.SetDesiredState(v1.PackageRevisionActive)
 							want.SetLabels(map[string]string{v1.LabelParentPackage: "test-provider"})
 							want.SetConditions(v1.RevisionHealthy())
-							want.SetConditions(v1.RuntimeHealthy())
+							want.SetConditions(v1.RuntimeHealthy(), v1.RuntimeActive())
 							want.SetRuntimeConfigRef(&v1.RuntimeConfigReference{Name: "default-runtime-config"})
 							want.SetResolvedSource("example.com/test-provider:v1.0.0")
 							want.SetAppliedImageConfigRefs(v1.ImageConfigRef{
@@ -932,6 +935,290 @@ func TestReconcile(t *testing.T) {
 				r: reconcile.Result{Requeue: false},
 			},
 		},
+		"RuntimeActivationAwaiting": {
+			reason: "A safe-start revision with only inactive MRDs should be scaled to zero and marked as awaiting activation.",
+			args: args{
+				mgr: &fake.Manager{
+					Client: &test.MockClient{
+						MockGet: test.NewMockGetFn(nil, func(o client.Object) error {
+							switch obj := o.(type) {
+							case *v1.ProviderRevision:
+								setRuntimeActivationRevision(obj, pkgmetav1.ProviderCapabilitySafeStart)
+								return nil
+							case *corev1.ServiceAccount:
+								obj.Name = crossplaneName
+								obj.Namespace = testNamespace
+								return nil
+							}
+							return nil
+						}),
+						MockList: test.NewMockListFn(nil, func(l client.ObjectList) error {
+							mrds := l.(*extv1alpha1.ManagedResourceDefinitionList)
+							mrds.Items = []extv1alpha1.ManagedResourceDefinition{
+								mrdControlledBy(runtimeActivationUID, extv1alpha1.ManagedResourceDefinitionInactive),
+								// An active MRD controlled by another revision
+								// must not activate this revision's runtime.
+								mrdControlledBy("other-revision-uid", extv1alpha1.ManagedResourceDefinitionActive),
+							}
+							return nil
+						}),
+						MockStatusUpdate: test.NewMockSubResourceUpdateFn(nil, func(o client.Object) error {
+							want := &v1.ProviderRevision{}
+							setRuntimeActivationRevision(want, pkgmetav1.ProviderCapabilitySafeStart)
+							want.SetConditions(v1.RuntimeHealthy(), v1.RuntimeAwaitingActivation().WithMessage("Package runtime is scaled to zero; awaiting the first ManagedResourceDefinition to be activated"))
+
+							if diff := cmp.Diff(want, o); diff != "" {
+								t.Errorf("-want, +got:\n%s", diff)
+							}
+							return nil
+						}),
+					},
+				},
+				rec: []ReconcilerOption{
+					WithNewPackageRevisionWithRuntimeFn(func() v1.PackageRevisionWithRuntime { return &v1.ProviderRevision{} }),
+					WithLogger(testLog),
+					WithRecorder(event.NewNopRecorder()),
+					WithNamespace(testNamespace),
+					WithServiceAccount(crossplaneName),
+					WithRuntimeHooks(&MockHooks{}),
+					WithDeploymentSelectorMigrator(NewNopDeploymentSelectorMigrator()),
+				},
+			},
+			want: want{
+				r: reconcile.Result{Requeue: false},
+			},
+		},
+		"RuntimeActivationActiveMRD": {
+			reason: "A safe-start revision with an active MRD should run its runtime and be marked healthy.",
+			args: args{
+				mgr: &fake.Manager{
+					Client: &test.MockClient{
+						MockGet: test.NewMockGetFn(nil, func(o client.Object) error {
+							switch obj := o.(type) {
+							case *v1.ProviderRevision:
+								setRuntimeActivationRevision(obj, pkgmetav1.ProviderCapabilitySafeStart)
+								return nil
+							case *corev1.ServiceAccount:
+								obj.Name = crossplaneName
+								obj.Namespace = testNamespace
+								return nil
+							}
+							return nil
+						}),
+						MockList: test.NewMockListFn(nil, func(l client.ObjectList) error {
+							mrds := l.(*extv1alpha1.ManagedResourceDefinitionList)
+							mrds.Items = []extv1alpha1.ManagedResourceDefinition{
+								mrdControlledBy(runtimeActivationUID, extv1alpha1.ManagedResourceDefinitionActive),
+							}
+							return nil
+						}),
+						MockStatusUpdate: test.NewMockSubResourceUpdateFn(nil, func(o client.Object) error {
+							want := &v1.ProviderRevision{}
+							setRuntimeActivationRevision(want, pkgmetav1.ProviderCapabilitySafeStart)
+							want.SetConditions(v1.RuntimeHealthy(), v1.RuntimeActive())
+
+							if diff := cmp.Diff(want, o); diff != "" {
+								t.Errorf("-want, +got:\n%s", diff)
+							}
+							return nil
+						}),
+					},
+				},
+				rec: []ReconcilerOption{
+					WithNewPackageRevisionWithRuntimeFn(func() v1.PackageRevisionWithRuntime { return &v1.ProviderRevision{} }),
+					WithLogger(testLog),
+					WithRecorder(event.NewNopRecorder()),
+					WithNamespace(testNamespace),
+					WithServiceAccount(crossplaneName),
+					WithRuntimeHooks(&MockHooks{}),
+					WithDeploymentSelectorMigrator(NewNopDeploymentSelectorMigrator()),
+				},
+			},
+			want: want{
+				r: reconcile.Result{Requeue: false},
+			},
+		},
+		"RuntimeActivationNoSafeStart": {
+			reason: "A revision without the safe-start capability should run its runtime as usual.",
+			args: args{
+				mgr: &fake.Manager{
+					Client: &test.MockClient{
+						MockGet: test.NewMockGetFn(nil, func(o client.Object) error {
+							switch obj := o.(type) {
+							case *v1.ProviderRevision:
+								setRuntimeActivationRevision(obj)
+								return nil
+							case *corev1.ServiceAccount:
+								obj.Name = crossplaneName
+								obj.Namespace = testNamespace
+								return nil
+							}
+							return nil
+						}),
+						MockStatusUpdate: test.NewMockSubResourceUpdateFn(nil, func(o client.Object) error {
+							want := &v1.ProviderRevision{}
+							setRuntimeActivationRevision(want)
+							want.SetConditions(v1.RuntimeHealthy(), v1.RuntimeActive())
+
+							if diff := cmp.Diff(want, o); diff != "" {
+								t.Errorf("-want, +got:\n%s", diff)
+							}
+							return nil
+						}),
+					},
+				},
+				rec: []ReconcilerOption{
+					WithNewPackageRevisionWithRuntimeFn(func() v1.PackageRevisionWithRuntime { return &v1.ProviderRevision{} }),
+					WithLogger(testLog),
+					WithRecorder(event.NewNopRecorder()),
+					WithNamespace(testNamespace),
+					WithServiceAccount(crossplaneName),
+					WithRuntimeHooks(&MockHooks{}),
+					WithDeploymentSelectorMigrator(NewNopDeploymentSelectorMigrator()),
+				},
+			},
+			want: want{
+				r: reconcile.Result{Requeue: false},
+			},
+		},
+		"RuntimeActivationNoOwnedMRDs": {
+			reason: "A safe-start revision that owns no MRDs should run its runtime, as nothing could ever activate it.",
+			args: args{
+				mgr: &fake.Manager{
+					Client: &test.MockClient{
+						MockGet: test.NewMockGetFn(nil, func(o client.Object) error {
+							switch obj := o.(type) {
+							case *v1.ProviderRevision:
+								setRuntimeActivationRevision(obj, pkgmetav1.ProviderCapabilitySafeStart)
+								return nil
+							case *corev1.ServiceAccount:
+								obj.Name = crossplaneName
+								obj.Namespace = testNamespace
+								return nil
+							}
+							return nil
+						}),
+						MockList: test.NewMockListFn(nil),
+						MockStatusUpdate: test.NewMockSubResourceUpdateFn(nil, func(o client.Object) error {
+							want := &v1.ProviderRevision{}
+							setRuntimeActivationRevision(want, pkgmetav1.ProviderCapabilitySafeStart)
+							want.SetConditions(v1.RuntimeHealthy(), v1.RuntimeActive())
+
+							if diff := cmp.Diff(want, o); diff != "" {
+								t.Errorf("-want, +got:\n%s", diff)
+							}
+							return nil
+						}),
+					},
+				},
+				rec: []ReconcilerOption{
+					WithNewPackageRevisionWithRuntimeFn(func() v1.PackageRevisionWithRuntime { return &v1.ProviderRevision{} }),
+					WithLogger(testLog),
+					WithRecorder(event.NewNopRecorder()),
+					WithNamespace(testNamespace),
+					WithServiceAccount(crossplaneName),
+					WithRuntimeHooks(&MockHooks{}),
+					WithDeploymentSelectorMigrator(NewNopDeploymentSelectorMigrator()),
+				},
+			},
+			want: want{
+				r: reconcile.Result{Requeue: false},
+			},
+		},
+		"RuntimeActivationAlreadyRunning": {
+			reason: "A safe-start revision with all-inactive MRDs scales its runtime to zero even if the deployment was previously running.",
+			args: args{
+				mgr: &fake.Manager{
+					Client: &test.MockClient{
+						MockGet: test.NewMockGetFn(nil, func(o client.Object) error {
+							switch obj := o.(type) {
+							case *v1.ProviderRevision:
+								setRuntimeActivationRevision(obj, pkgmetav1.ProviderCapabilitySafeStart)
+								return nil
+							case *corev1.ServiceAccount:
+								obj.Name = crossplaneName
+								obj.Namespace = testNamespace
+								return nil
+							}
+							return nil
+						}),
+						MockList: test.NewMockListFn(nil, func(l client.ObjectList) error {
+							mrds := l.(*extv1alpha1.ManagedResourceDefinitionList)
+							mrds.Items = []extv1alpha1.ManagedResourceDefinition{
+								mrdControlledBy(runtimeActivationUID, extv1alpha1.ManagedResourceDefinitionInactive),
+							}
+							return nil
+						}),
+						MockStatusUpdate: test.NewMockSubResourceUpdateFn(nil, func(o client.Object) error {
+							want := &v1.ProviderRevision{}
+							setRuntimeActivationRevision(want, pkgmetav1.ProviderCapabilitySafeStart)
+							want.SetConditions(v1.RuntimeHealthy(), v1.RuntimeAwaitingActivation().WithMessage("Package runtime is scaled to zero; awaiting the first ManagedResourceDefinition to be activated"))
+
+							if diff := cmp.Diff(want, o); diff != "" {
+								t.Errorf("-want, +got:\n%s", diff)
+							}
+							return nil
+						}),
+					},
+				},
+				rec: []ReconcilerOption{
+					WithNewPackageRevisionWithRuntimeFn(func() v1.PackageRevisionWithRuntime { return &v1.ProviderRevision{} }),
+					WithLogger(testLog),
+					WithRecorder(event.NewNopRecorder()),
+					WithNamespace(testNamespace),
+					WithServiceAccount(crossplaneName),
+					WithRuntimeHooks(&MockHooks{}),
+					WithDeploymentSelectorMigrator(NewNopDeploymentSelectorMigrator()),
+				},
+			},
+			want: want{
+				r: reconcile.Result{Requeue: false},
+			},
+		},
+		"RuntimeActivationErrListMRDs": {
+			reason: "Should return an error and mark the runtime unhealthy when MRDs cannot be listed.",
+			args: args{
+				mgr: &fake.Manager{
+					Client: &test.MockClient{
+						MockGet: test.NewMockGetFn(nil, func(o client.Object) error {
+							switch obj := o.(type) {
+							case *v1.ProviderRevision:
+								setRuntimeActivationRevision(obj, pkgmetav1.ProviderCapabilitySafeStart)
+								return nil
+							case *corev1.ServiceAccount:
+								obj.Name = crossplaneName
+								obj.Namespace = testNamespace
+								return nil
+							}
+							return nil
+						}),
+						MockList: test.NewMockListFn(errBoom),
+						MockStatusUpdate: test.NewMockSubResourceUpdateFn(nil, func(o client.Object) error {
+							want := &v1.ProviderRevision{}
+							setRuntimeActivationRevision(want, pkgmetav1.ProviderCapabilitySafeStart)
+							want.SetConditions(v1.RuntimeUnhealthy().WithMessage("cannot list managed resource definitions: boom"))
+
+							if diff := cmp.Diff(want, o); diff != "" {
+								t.Errorf("-want, +got:\n%s", diff)
+							}
+							return nil
+						}),
+					},
+				},
+				rec: []ReconcilerOption{
+					WithNewPackageRevisionWithRuntimeFn(func() v1.PackageRevisionWithRuntime { return &v1.ProviderRevision{} }),
+					WithLogger(testLog),
+					WithRecorder(event.NewNopRecorder()),
+					WithNamespace(testNamespace),
+					WithServiceAccount(crossplaneName),
+					WithRuntimeHooks(&MockHooks{}),
+					WithDeploymentSelectorMigrator(NewNopDeploymentSelectorMigrator()),
+				},
+			},
+			want: want{
+				err: errors.Wrap(errBoom, errListMRDs),
+			},
+		},
 	}
 
 	for name, tc := range cases {
@@ -948,6 +1235,37 @@ func TestReconcile(t *testing.T) {
 				t.Errorf("\n%s\nr.Reconcile(...): -want, +got:\n%s", tc.reason, diff)
 			}
 		})
+	}
+}
+
+const runtimeActivationUID = "12345678-1234-1234-1234-123456789012"
+
+// setRuntimeActivationRevision configures a healthy, active provider revision
+// with the given capabilities for runtime activation test cases.
+func setRuntimeActivationRevision(obj *v1.ProviderRevision, capabilities ...string) {
+	obj.SetGroupVersionKind(v1.ProviderRevisionGroupVersionKind)
+	obj.SetUID(runtimeActivationUID)
+	obj.SetDesiredState(v1.PackageRevisionActive)
+	obj.SetLabels(map[string]string{v1.LabelParentPackage: "test-provider"})
+	obj.SetConditions(v1.RevisionHealthy())
+	obj.SetCapabilities(capabilities)
+}
+
+// mrdControlledBy returns an MRD in the given state controlled by a provider
+// revision with the given UID.
+func mrdControlledBy(uid types.UID, state extv1alpha1.ManagedResourceDefinitionState) extv1alpha1.ManagedResourceDefinition {
+	return extv1alpha1.ManagedResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "buckets.example.org",
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: v1.SchemeGroupVersion.String(),
+				Kind:       v1.ProviderRevisionKind,
+				Name:       "test-provider-1234",
+				UID:        uid,
+				Controller: ptr.To(true),
+			}},
+		},
+		Spec: extv1alpha1.ManagedResourceDefinitionSpec{State: state},
 	}
 }
 

--- a/internal/controller/pkg/runtime/runtime.go
+++ b/internal/controller/pkg/runtime/runtime.go
@@ -25,6 +25,8 @@ import (
 
 	"github.com/crossplane/crossplane-runtime/v2/pkg/meta"
 
+	extv1alpha1 "github.com/crossplane/crossplane/apis/v2/apiextensions/v1alpha1"
+	pkgmetav1 "github.com/crossplane/crossplane/apis/v2/pkg/meta/v1"
 	v1 "github.com/crossplane/crossplane/apis/v2/pkg/v1"
 	"github.com/crossplane/crossplane/apis/v2/pkg/v1beta1"
 )
@@ -121,6 +123,7 @@ type DeploymentRuntimeBuilder struct {
 	serviceAccountPullSecrets []corev1.LocalObjectReference
 	runtimeConfig             *v1beta1.DeploymentRuntimeConfig
 	pullSecrets               []string
+	defaultReplicas           int32
 }
 
 // BuilderOption is used to configure a DeploymentRuntimeBuilder.
@@ -150,11 +153,41 @@ func BuilderWithPullSecrets(secrets ...string) BuilderOption {
 	}
 }
 
+// BuilderWithMRDs configures the builder with the ManagedResourceDefinitions
+// owned by the package revision. If the revision has the safe-start capability
+// and all its owned MRDs are inactive, the builder defaults the Deployment to
+// zero replicas until the first MRD is activated. Explicit replicas from a
+// deployment runtime config still win.
+func BuilderWithMRDs(mrds []extv1alpha1.ManagedResourceDefinition) BuilderOption {
+	return func(b *DeploymentRuntimeBuilder) {
+		if !pkgmetav1.CapabilitiesContainFuzzyMatch(b.revision.GetCapabilities(), pkgmetav1.ProviderCapabilitySafeStart) {
+			return
+		}
+		if len(mrds) == 0 {
+			return
+		}
+		for _, mrd := range mrds {
+			if mrd.Spec.State.IsActive() {
+				return
+			}
+		}
+		b.defaultReplicas = 0
+	}
+}
+
+// AwaitingActivation reports whether the builder has determined that the
+// package runtime should be scaled to zero, awaiting activation of its first
+// ManagedResourceDefinition.
+func (b *DeploymentRuntimeBuilder) AwaitingActivation() bool {
+	return b.defaultReplicas == 0
+}
+
 // NewDeploymentRuntimeBuilder returns a new DeploymentRuntimeBuilder.
 func NewDeploymentRuntimeBuilder(pwr v1.PackageRevisionWithRuntime, namespace string, opts ...BuilderOption) *DeploymentRuntimeBuilder {
 	b := &DeploymentRuntimeBuilder{
-		namespace: namespace,
-		revision:  pwr,
+		namespace:       namespace,
+		revision:        pwr,
+		defaultReplicas: 1,
 	}
 
 	for _, o := range opts {
@@ -211,7 +244,7 @@ func (b *DeploymentRuntimeBuilder) Deployment(serviceAccount string, overrides .
 		// Optional defaults, will be used only if the runtime config does not
 		// specify them.
 		DeploymentWithOptionalName(b.revision.GetName()),
-		DeploymentWithOptionalReplicas(1),
+		DeploymentWithOptionalReplicas(b.defaultReplicas),
 		DeploymentWithOptionalPodSecurityContext(&corev1.PodSecurityContext{
 			RunAsNonRoot: &RunAsNonRoot,
 			RunAsUser:    &RunAsUser,

--- a/internal/controller/pkg/runtime/runtime.go
+++ b/internal/controller/pkg/runtime/runtime.go
@@ -163,6 +163,12 @@ func BuilderWithMRDs(mrds []extv1alpha1.ManagedResourceDefinition) BuilderOption
 		if !pkgmetav1.CapabilitiesContainFuzzyMatch(b.revision.GetCapabilities(), pkgmetav1.ProviderCapabilitySafeStart) {
 			return
 		}
+		// One-way latch: once the runtime has been activated, never scale it
+		// back to zero even if MRDs later appear inactive (deactivation is not
+		// yet supported, but guard against manual edits or future changes).
+		if b.revision.GetCondition(v1.TypeRuntimeActive).Reason == v1.ReasonActiveRuntime {
+			return
+		}
 		if len(mrds) == 0 {
 			return
 		}
@@ -179,7 +185,19 @@ func BuilderWithMRDs(mrds []extv1alpha1.ManagedResourceDefinition) BuilderOption
 // package runtime should be scaled to zero, awaiting activation of its first
 // ManagedResourceDefinition.
 func (b *DeploymentRuntimeBuilder) AwaitingActivation() bool {
-	return b.defaultReplicas == 0
+	if b.defaultReplicas != 0 {
+		return false
+	}
+	// DeploymentWithOptionalReplicas is a no-op when the runtime config
+	// already supplies spec.replicas, so the deployment won't actually run at
+	// zero replicas in that case.
+	if b.runtimeConfig != nil &&
+		b.runtimeConfig.Spec.DeploymentTemplate != nil &&
+		b.runtimeConfig.Spec.DeploymentTemplate.Spec != nil &&
+		b.runtimeConfig.Spec.DeploymentTemplate.Spec.Replicas != nil {
+		return false
+	}
+	return true
 }
 
 // NewDeploymentRuntimeBuilder returns a new DeploymentRuntimeBuilder.

--- a/internal/controller/pkg/runtime/runtime_provider_test.go
+++ b/internal/controller/pkg/runtime/runtime_provider_test.go
@@ -450,6 +450,70 @@ func TestProviderPostHook(t *testing.T) {
 				},
 			},
 		},
+		"SuccessfulScaledToZero": {
+			reason: "Should not return error for a deployment scaled to zero replicas, which Kubernetes marks as available.",
+			args: args{
+				pkg: &pkgmetav1.Provider{},
+				rev: &v1.ProviderRevision{
+					Spec: v1.ProviderRevisionSpec{
+						PackageRevisionSpec: v1.PackageRevisionSpec{
+							Package:      providerImage,
+							DesiredState: v1.PackageRevisionActive,
+						},
+					},
+					Status: v1.ProviderRevisionStatus{
+						PackageRevisionStatus: v1.PackageRevisionStatus{
+							ResolvedPackage: providerImage,
+						},
+					},
+				},
+				manifests: &MockManifestBuilder{
+					ServiceAccountFn: func(_ ...ServiceAccountOverride) *corev1.ServiceAccount {
+						return &corev1.ServiceAccount{}
+					},
+					DeploymentFn: func(_ string, _ ...DeploymentOverride) *appsv1.Deployment {
+						return &appsv1.Deployment{
+							Spec: appsv1.DeploymentSpec{
+								Replicas: ptr.To[int32](0),
+							},
+						}
+					},
+				},
+				client: &test.MockClient{
+					MockGet: func(_ context.Context, _ client.ObjectKey, _ client.Object) error {
+						return nil
+					},
+					MockPatch: func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) error {
+						if d, ok := obj.(*appsv1.Deployment); ok {
+							// A deployment with zero replicas has a minimum
+							// availability of zero, so Kubernetes marks it
+							// available.
+							d.Status.Conditions = []appsv1.DeploymentCondition{{
+								Type:   appsv1.DeploymentAvailable,
+								Status: corev1.ConditionTrue,
+							}}
+							return nil
+						}
+						return nil
+					},
+				},
+			},
+			want: want{
+				rev: &v1.ProviderRevision{
+					Spec: v1.ProviderRevisionSpec{
+						PackageRevisionSpec: v1.PackageRevisionSpec{
+							Package:      providerImage,
+							DesiredState: v1.PackageRevisionActive,
+						},
+					},
+					Status: v1.ProviderRevisionStatus{
+						PackageRevisionStatus: v1.PackageRevisionStatus{
+							ResolvedPackage: providerImage,
+						},
+					},
+				},
+			},
+		},
 		"SuccessWithExtraSecret": {
 			reason: "Should not return error if successfully applied service account with additional secret.",
 			args: args{

--- a/internal/controller/pkg/runtime/runtime_test.go
+++ b/internal/controller/pkg/runtime/runtime_test.go
@@ -29,6 +29,8 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/ptr"
 
+	extv1alpha1 "github.com/crossplane/crossplane/apis/v2/apiextensions/v1alpha1"
+	pkgmetav1 "github.com/crossplane/crossplane/apis/v2/pkg/meta/v1"
 	v1 "github.com/crossplane/crossplane/apis/v2/pkg/v1"
 	"github.com/crossplane/crossplane/apis/v2/pkg/v1beta1"
 	"github.com/crossplane/crossplane/v2/internal/controller/pkg/revision"
@@ -832,4 +834,94 @@ func (b *MockManifestBuilder) TLSClientSecret() *corev1.Secret {
 // TLSServerSecret returns the result of calling TLSServerSecretFn.
 func (b *MockManifestBuilder) TLSServerSecret() *corev1.Secret {
 	return b.TLSServerSecretFn()
+}
+
+func TestBuilderWithMRDs(t *testing.T) {
+	inactiveMRD := extv1alpha1.ManagedResourceDefinition{
+		Spec: extv1alpha1.ManagedResourceDefinitionSpec{
+			State: extv1alpha1.ManagedResourceDefinitionInactive,
+		},
+	}
+
+	safeStartRevision := func() *v1.ProviderRevision {
+		pr := &v1.ProviderRevision{}
+		pr.SetCapabilities([]string{pkgmetav1.ProviderCapabilitySafeStart})
+		return pr
+	}
+
+	safeStartRevisionActive := func() *v1.ProviderRevision {
+		pr := safeStartRevision()
+		pr.SetConditions(v1.RuntimeActive())
+		return pr
+	}
+
+	cases := map[string]struct {
+		revision        v1.PackageRevisionWithRuntime
+		mrds            []extv1alpha1.ManagedResourceDefinition
+		runtimeConfig   *v1beta1.DeploymentRuntimeConfig
+		wantScaleToZero bool
+	}{
+		"NoSafeStartCapability": {
+			revision:        &v1.ProviderRevision{},
+			mrds:            []extv1alpha1.ManagedResourceDefinition{inactiveMRD},
+			wantScaleToZero: false,
+		},
+		"NoMRDs": {
+			revision:        safeStartRevision(),
+			mrds:            nil,
+			wantScaleToZero: false,
+		},
+		"ActiveMRD": {
+			revision: safeStartRevision(),
+			mrds: []extv1alpha1.ManagedResourceDefinition{{
+				Spec: extv1alpha1.ManagedResourceDefinitionSpec{State: extv1alpha1.ManagedResourceDefinitionActive},
+			}},
+			wantScaleToZero: false,
+		},
+		"AllInactiveMRDs": {
+			revision:        safeStartRevision(),
+			mrds:            []extv1alpha1.ManagedResourceDefinition{inactiveMRD},
+			wantScaleToZero: true,
+		},
+		"AlreadyActivatedRuntimeWithInactiveMRDs": {
+			// Once TypeRuntimeActive is True the runtime must not be scaled
+			// back to zero, even if MRDs later appear inactive (e.g. via a
+			// manual edit). This guards the one-way activation latch.
+			revision:        safeStartRevisionActive(),
+			mrds:            []extv1alpha1.ManagedResourceDefinition{inactiveMRD},
+			wantScaleToZero: false,
+		},
+		"RuntimeConfigWithExplicitReplicasNotAwaiting": {
+			// A DeploymentRuntimeConfig that sets spec.replicas wins over
+			// defaultReplicas=0 via DeploymentWithOptionalReplicas, so the
+			// deployment is not actually scaled to zero — AwaitingActivation
+			// must reflect that.
+			revision: safeStartRevision(),
+			mrds:     []extv1alpha1.ManagedResourceDefinition{inactiveMRD},
+			runtimeConfig: &v1beta1.DeploymentRuntimeConfig{
+				Spec: v1beta1.DeploymentRuntimeConfigSpec{
+					DeploymentTemplate: &v1beta1.DeploymentTemplate{
+						Spec: &appsv1.DeploymentSpec{
+							Replicas: ptr.To[int32](2),
+						},
+					},
+				},
+			},
+			wantScaleToZero: false,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			opts := []BuilderOption{BuilderWithMRDs(tc.mrds)}
+			if tc.runtimeConfig != nil {
+				opts = append(opts, BuilderWithRuntimeConfig(tc.runtimeConfig))
+			}
+			b := NewDeploymentRuntimeBuilder(tc.revision, namespace, opts...)
+			got := b.AwaitingActivation()
+			if diff := cmp.Diff(tc.wantScaleToZero, got); diff != "" {
+				t.Errorf("BuilderWithMRDs(...): AwaitingActivation() -want, +got:\n%s", diff)
+			}
+		})
+	}
 }

--- a/internal/controller/pkg/runtime/runtime_test.go
+++ b/internal/controller/pkg/runtime/runtime_test.go
@@ -122,8 +122,9 @@ func TestRuntimeManifestBuilderDeployment(t *testing.T) {
 			reason: "No overrides should result in a deployment with default values",
 			args: args{
 				builder: &DeploymentRuntimeBuilder{
-					revision:  providerRevision,
-					namespace: namespace,
+					revision:        providerRevision,
+					namespace:       namespace,
+					defaultReplicas: 1,
 				},
 				serviceAccountName: providerRevisionName,
 				overrides:          providerDeploymentOverrides(providerRevision, providerImage),
@@ -135,12 +136,62 @@ func TestRuntimeManifestBuilderDeployment(t *testing.T) {
 				})),
 			},
 		},
+		"ProviderDeploymentScaleToZero": {
+			reason: "Scale to zero should default the deployment to zero replicas",
+			args: args{
+				builder: &DeploymentRuntimeBuilder{
+					revision:        providerRevision,
+					namespace:       namespace,
+					defaultReplicas: 0,
+				},
+				serviceAccountName: providerRevisionName,
+				overrides:          providerDeploymentOverrides(providerRevision, providerImage),
+			},
+			want: want{
+				want: deploymentProvider(providerName, providerRevisionName, providerImage, DeploymentWithSelectors(map[string]string{
+					v1.LabelProvider: providerName,
+					v1.LabelRevision: providerRevisionName,
+				}), func(deployment *appsv1.Deployment) {
+					deployment.Spec.Replicas = ptr.To[int32](0)
+				}),
+			},
+		},
+		"ProviderDeploymentScaleToZeroWithRuntimeConfigReplicas": {
+			reason: "Explicit replicas from the runtime config should win over scale to zero",
+			args: args{
+				builder: &DeploymentRuntimeBuilder{
+					revision:        providerRevision,
+					namespace:       namespace,
+					defaultReplicas: 0,
+					runtimeConfig: &v1beta1.DeploymentRuntimeConfig{
+						Spec: v1beta1.DeploymentRuntimeConfigSpec{
+							DeploymentTemplate: &v1beta1.DeploymentTemplate{
+								Spec: &appsv1.DeploymentSpec{
+									Replicas: ptr.To[int32](3),
+								},
+							},
+						},
+					},
+				},
+				serviceAccountName: providerRevisionName,
+				overrides:          providerDeploymentOverrides(providerRevision, providerImage),
+			},
+			want: want{
+				want: deploymentProvider(providerName, providerRevisionName, providerImage, DeploymentWithSelectors(map[string]string{
+					v1.LabelProvider: providerName,
+					v1.LabelRevision: providerRevisionName,
+				}), func(deployment *appsv1.Deployment) {
+					deployment.Spec.Replicas = ptr.To[int32](3)
+				}),
+			},
+		},
 		"ProviderDeploymentWithRuntimeConfig": {
 			reason: "Baseline provided by the runtime config should be applied to the deployment",
 			args: args{
 				builder: &DeploymentRuntimeBuilder{
-					revision:  providerRevision,
-					namespace: namespace,
+					revision:        providerRevision,
+					namespace:       namespace,
+					defaultReplicas: 1,
 					runtimeConfig: &v1beta1.DeploymentRuntimeConfig{
 						Spec: v1beta1.DeploymentRuntimeConfigSpec{
 							DeploymentTemplate: &v1beta1.DeploymentTemplate{
@@ -199,8 +250,9 @@ func TestRuntimeManifestBuilderDeployment(t *testing.T) {
 			reason: "It should be possible to disable default scrape annotations",
 			args: args{
 				builder: &DeploymentRuntimeBuilder{
-					revision:  providerRevision,
-					namespace: namespace,
+					revision:        providerRevision,
+					namespace:       namespace,
+					defaultReplicas: 1,
 					runtimeConfig: &v1beta1.DeploymentRuntimeConfig{
 						Spec: v1beta1.DeploymentRuntimeConfigSpec{
 							DeploymentTemplate: &v1beta1.DeploymentTemplate{
@@ -236,8 +288,9 @@ func TestRuntimeManifestBuilderDeployment(t *testing.T) {
 			reason: "Baseline provided by the runtime config should be applied to the deployment for advanced use cases",
 			args: args{
 				builder: &DeploymentRuntimeBuilder{
-					revision:  providerRevision,
-					namespace: namespace,
+					revision:        providerRevision,
+					namespace:       namespace,
+					defaultReplicas: 1,
 					runtimeConfig: &v1beta1.DeploymentRuntimeConfig{
 						Spec: v1beta1.DeploymentRuntimeConfigSpec{
 							DeploymentTemplate: &v1beta1.DeploymentTemplate{
@@ -335,8 +388,9 @@ func TestRuntimeManifestBuilderDeployment(t *testing.T) {
 			reason: "No overrides should result in a deployment with default values",
 			args: args{
 				builder: &DeploymentRuntimeBuilder{
-					revision:  functionRevision,
-					namespace: namespace,
+					revision:        functionRevision,
+					namespace:       namespace,
+					defaultReplicas: 1,
 				},
 				serviceAccountName: functionRevisionName,
 				overrides:          functionDeploymentOverrides(functionRevision, functionImage),
@@ -376,8 +430,9 @@ func TestRuntimeManifestBuilderService(t *testing.T) {
 			reason: "No runtime config on the builder should result in a service with default values",
 			args: args{
 				builder: &DeploymentRuntimeBuilder{
-					revision:  providerRevision,
-					namespace: namespace,
+					revision:        providerRevision,
+					namespace:       namespace,
+					defaultReplicas: 1,
 				},
 				serviceAccountName: providerRevisionName,
 				overrides: []ServiceOverride{

--- a/internal/controller/pkg/runtime/watch.go
+++ b/internal/controller/pkg/runtime/watch.go
@@ -3,13 +3,18 @@ package runtime
 import (
 	"context"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/crossplane/crossplane-runtime/v2/pkg/logging"
 
+	extv1alpha1 "github.com/crossplane/crossplane/apis/v2/apiextensions/v1alpha1"
 	v1 "github.com/crossplane/crossplane/apis/v2/pkg/v1"
 	"github.com/crossplane/crossplane/apis/v2/pkg/v1beta1"
 )
@@ -45,4 +50,55 @@ func EnqueuePackageRevisionsForRuntimeConfig(kube client.Client, l v1.PackageRev
 
 		return matches
 	})
+}
+
+// EnqueueProviderRevisionsForMRDs enqueues a reconcile for the provider
+// revision that controls a ManagedResourceDefinition when that MRD is active.
+func EnqueueProviderRevisionsForMRDs(log logging.Logger) handler.EventHandler {
+	return handler.EnqueueRequestsFromMapFunc(func(_ context.Context, o client.Object) []reconcile.Request {
+		mrd, ok := o.(*extv1alpha1.ManagedResourceDefinition)
+		if !ok {
+			return nil
+		}
+
+		if !mrd.Spec.State.IsActive() {
+			return nil
+		}
+
+		owner := metav1.GetControllerOf(mrd)
+		if owner == nil || owner.Kind != v1.ProviderRevisionKind {
+			return nil
+		}
+
+		if gv, err := schema.ParseGroupVersion(owner.APIVersion); err != nil || gv.Group != v1.Group {
+			return nil
+		}
+
+		log.Debug("Enqueuing provider revision for activated managed resource definition", "mrd", mrd.GetName(), "provider-revision", owner.Name)
+
+		return []reconcile.Request{{NamespacedName: types.NamespacedName{Name: owner.Name}}}
+	})
+}
+
+// mrdActivated returns a predicate that only lets events for active
+// ManagedResourceDefinitions through. Update events additionally require the
+// state to have changed, to avoid enqueuing reconciles for MRD status churn.
+// Create events for already active MRDs matter to replay activations after an
+// informer restart.
+func mrdActivated() predicate.Funcs {
+	isActive := func(o client.Object) bool {
+		mrd, ok := o.(*extv1alpha1.ManagedResourceDefinition)
+		return ok && mrd.Spec.State.IsActive()
+	}
+
+	return predicate.Funcs{
+		CreateFunc: func(e event.CreateEvent) bool {
+			return isActive(e.Object)
+		},
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			return !isActive(e.ObjectOld) && isActive(e.ObjectNew)
+		},
+		DeleteFunc:  func(event.DeleteEvent) bool { return false },
+		GenericFunc: func(event.GenericEvent) bool { return false },
+	}
 }

--- a/internal/controller/pkg/runtime/watch_test.go
+++ b/internal/controller/pkg/runtime/watch_test.go
@@ -1,0 +1,197 @@
+/*
+Copyright 2025 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package runtime
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/workqueue"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"github.com/crossplane/crossplane-runtime/v2/pkg/logging"
+
+	extv1alpha1 "github.com/crossplane/crossplane/apis/v2/apiextensions/v1alpha1"
+	v1 "github.com/crossplane/crossplane/apis/v2/pkg/v1"
+)
+
+func TestEnqueueProviderRevisionsForMRDs(t *testing.T) {
+	revisionName := "provider-foo-1234"
+
+	mrd := func(state extv1alpha1.ManagedResourceDefinitionState, owner *metav1.OwnerReference) *extv1alpha1.ManagedResourceDefinition {
+		m := &extv1alpha1.ManagedResourceDefinition{
+			ObjectMeta: metav1.ObjectMeta{Name: "buckets.example.org"},
+			Spec:       extv1alpha1.ManagedResourceDefinitionSpec{State: state},
+		}
+		if owner != nil {
+			m.OwnerReferences = []metav1.OwnerReference{*owner}
+		}
+
+		return m
+	}
+
+	controller := &metav1.OwnerReference{
+		APIVersion: v1.SchemeGroupVersion.String(),
+		Kind:       v1.ProviderRevisionKind,
+		Name:       revisionName,
+		UID:        types.UID("some-uid"),
+		Controller: ptr.To(true),
+	}
+
+	cases := map[string]struct {
+		reason string
+		obj    client.Object
+		want   []reconcile.Request
+	}{
+		"ActiveMRDControlledByProviderRevision": {
+			reason: "An active MRD controlled by a provider revision should enqueue that revision.",
+			obj:    mrd(extv1alpha1.ManagedResourceDefinitionActive, controller),
+			want:   []reconcile.Request{{NamespacedName: types.NamespacedName{Name: revisionName}}},
+		},
+		"InactiveMRD": {
+			reason: "An inactive MRD should not enqueue anything.",
+			obj:    mrd(extv1alpha1.ManagedResourceDefinitionInactive, controller),
+			want:   nil,
+		},
+		"NoController": {
+			reason: "An active MRD without a controller owner should not enqueue anything.",
+			obj:    mrd(extv1alpha1.ManagedResourceDefinitionActive, nil),
+			want:   nil,
+		},
+		"NonProviderRevisionController": {
+			reason: "An active MRD controlled by something other than a provider revision should not enqueue anything.",
+			obj: mrd(extv1alpha1.ManagedResourceDefinitionActive, &metav1.OwnerReference{
+				APIVersion: "example.org/v1",
+				Kind:       "Composite",
+				Name:       "some-owner",
+				UID:        types.UID("some-uid"),
+				Controller: ptr.To(true),
+			}),
+			want: nil,
+		},
+		"ProviderRevisionKindInOtherGroup": {
+			reason: "An active MRD controlled by a ProviderRevision kind in another API group should not enqueue anything.",
+			obj: mrd(extv1alpha1.ManagedResourceDefinitionActive, &metav1.OwnerReference{
+				APIVersion: "example.org/v1",
+				Kind:       v1.ProviderRevisionKind,
+				Name:       "some-owner",
+				UID:        types.UID("some-uid"),
+				Controller: ptr.To(true),
+			}),
+			want: nil,
+		},
+		"NotAnMRD": {
+			reason: "An object that is not an MRD should not enqueue anything.",
+			obj:    &v1.ProviderRevision{},
+			want:   nil,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			q := workqueue.NewTypedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[reconcile.Request]())
+			defer q.ShutDown()
+			EnqueueProviderRevisionsForMRDs(logging.NewNopLogger()).Create(context.Background(), event.CreateEvent{Object: tc.obj}, q)
+
+			var got []reconcile.Request
+			for q.Len() > 0 {
+				i, _ := q.Get()
+				got = append(got, i)
+				q.Done(i)
+			}
+
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("\n%s\nEnqueueProviderRevisionsForMRDs(...): -want, +got:\n%s", tc.reason, diff)
+			}
+		})
+	}
+}
+
+func TestMRDActivatedPredicate(t *testing.T) {
+	mrd := func(state extv1alpha1.ManagedResourceDefinitionState) *extv1alpha1.ManagedResourceDefinition {
+		return &extv1alpha1.ManagedResourceDefinition{
+			Spec: extv1alpha1.ManagedResourceDefinitionSpec{State: state},
+		}
+	}
+
+	p := mrdActivated()
+
+	cases := map[string]struct {
+		reason string
+		got    bool
+		want   bool
+	}{
+		"CreateActive": {
+			reason: "Creating an active MRD should pass, to replay activations after an informer restart.",
+			got:    p.Create(event.CreateEvent{Object: mrd(extv1alpha1.ManagedResourceDefinitionActive)}),
+			want:   true,
+		},
+		"CreateInactive": {
+			reason: "Creating an inactive MRD should not pass.",
+			got:    p.Create(event.CreateEvent{Object: mrd(extv1alpha1.ManagedResourceDefinitionInactive)}),
+			want:   false,
+		},
+		"UpdateActivated": {
+			reason: "An MRD transitioning from inactive to active should pass.",
+			got: p.Update(event.UpdateEvent{
+				ObjectOld: mrd(extv1alpha1.ManagedResourceDefinitionInactive),
+				ObjectNew: mrd(extv1alpha1.ManagedResourceDefinitionActive),
+			}),
+			want: true,
+		},
+		"UpdateStillActive": {
+			reason: "An update to an already active MRD should not pass, to avoid reconciles on status churn.",
+			got: p.Update(event.UpdateEvent{
+				ObjectOld: mrd(extv1alpha1.ManagedResourceDefinitionActive),
+				ObjectNew: mrd(extv1alpha1.ManagedResourceDefinitionActive),
+			}),
+			want: false,
+		},
+		"UpdateStillInactive": {
+			reason: "An update to an inactive MRD should not pass.",
+			got: p.Update(event.UpdateEvent{
+				ObjectOld: mrd(extv1alpha1.ManagedResourceDefinitionInactive),
+				ObjectNew: mrd(extv1alpha1.ManagedResourceDefinitionInactive),
+			}),
+			want: false,
+		},
+		"Delete": {
+			reason: "Deleting an MRD should not pass. MRD activation is one-way.",
+			got:    p.Delete(event.DeleteEvent{Object: mrd(extv1alpha1.ManagedResourceDefinitionActive)}),
+			want:   false,
+		},
+		"Generic": {
+			reason: "Generic events should not pass.",
+			got:    p.Generic(event.GenericEvent{Object: mrd(extv1alpha1.ManagedResourceDefinitionActive)}),
+			want:   false,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			if diff := cmp.Diff(tc.want, tc.got); diff != "" {
+				t.Errorf("\n%s\nmrdActivated(): -want, +got:\n%s", tc.reason, diff)
+			}
+		})
+	}
+}

--- a/nix/apps.nix
+++ b/nix/apps.nix
@@ -84,6 +84,7 @@
         name = "crossplane-generate";
         runtimeInputs = [
           pkgs.coreutils
+          pkgs.gnugrep
           pkgs.gnused
           pkgs.unstable.go_1_25
           pkgs.kubectl

--- a/test/e2e/manifests/pkg/runtime-activation/mrap.yaml
+++ b/test/e2e/manifests/pkg/runtime-activation/mrap.yaml
@@ -1,0 +1,7 @@
+apiVersion: apiextensions.crossplane.io/v1alpha1
+kind: ManagedResourceActivationPolicy
+metadata:
+  name: runtime-activation
+spec:
+  activate:
+  - "*.nop.crossplane.io"

--- a/test/e2e/manifests/pkg/runtime-activation/provider.yaml
+++ b/test/e2e/manifests/pkg/runtime-activation/provider.yaml
@@ -1,0 +1,7 @@
+apiVersion: pkg.crossplane.io/v1
+kind: Provider
+metadata:
+  name: provider-nop-runtime-activation
+spec:
+  package: xpkg.crossplane.io/crossplane-contrib/provider-nop:v0.5.0
+  ignoreCrossplaneConstraints: true

--- a/test/e2e/pkg_runtime_activation_test.go
+++ b/test/e2e/pkg_runtime_activation_test.go
@@ -1,0 +1,196 @@
+/*
+Copyright 2025 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	k8sapiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/e2e-framework/klient/k8s"
+	"sigs.k8s.io/e2e-framework/klient/k8s/resources"
+	"sigs.k8s.io/e2e-framework/pkg/features"
+	"sigs.k8s.io/e2e-framework/third_party/helm"
+
+	apiextensionsv1alpha1 "github.com/crossplane/crossplane/apis/v2/apiextensions/v1alpha1"
+	pkgv1 "github.com/crossplane/crossplane/apis/v2/pkg/v1"
+	"github.com/crossplane/crossplane/v2/test/e2e/config"
+	"github.com/crossplane/crossplane/v2/test/e2e/funcs"
+)
+
+// SuiteProviderRuntimeActivation is the test suite for provider runtime
+// activation, which is part of the CRD to MRD conversion feature. The chart's
+// default activation policy is disabled so that the safe-start provider's
+// MRDs stay inactive until the test activates them.
+const SuiteProviderRuntimeActivation = "provider-runtime-activation"
+
+func init() {
+	environment.AddTestSuite(SuiteProviderRuntimeActivation,
+		config.WithHelmInstallOpts(
+			helm.WithArgs(
+				"--set args={--debug}",
+				"--set provider.defaultActivations=null",
+			),
+		),
+		config.WithLabelsToSelect(features.Labels{
+			config.LabelTestSuite: []string{SuiteProviderRuntimeActivation, config.TestSuiteDefault},
+		}),
+	)
+}
+
+func TestProviderRuntimeActivation(t *testing.T) {
+	manifests := "test/e2e/manifests/pkg/runtime-activation"
+
+	providerName := "provider-nop-runtime-activation"
+	parentPackageSelector := resources.WithLabelSelector(pkgv1.LabelParentPackage + "=" + providerName)
+
+	environment.Test(t,
+		features.NewWithDescription(t.Name(),
+			"Tests that the runtime of a provider with the safe-start capability is scaled to zero until its first ManagedResourceDefinition is activated.").
+			WithLabel(LabelArea, LabelAreaPkg).
+			WithLabel(LabelStage, LabelStageBeta).
+			WithLabel(LabelSize, LabelSizeLarge).
+			WithLabel(config.LabelTestSuite, SuiteProviderRuntimeActivation).
+
+			// Install a provider with the safe-start capability. With the
+			// chart's default activations disabled, all of its MRDs are
+			// created inactive, so the runtime must not run.
+			WithSetup("InstallSafeStartProvider", funcs.AllOf(
+				funcs.ApplyResources(FieldManager, manifests, "provider.yaml"),
+				funcs.ResourcesCreatedWithin(1*time.Minute, manifests, "provider.yaml"),
+				funcs.ResourcesHaveConditionWithin(3*time.Minute, manifests, "provider.yaml", pkgv1.HealthyAwaitingActivation(), pkgv1.Active()),
+			)).
+
+			// The provider's MRDs exist but are inactive.
+			Assess("MRDsAreInactive",
+				funcs.ListedResourcesValidatedWithin(2*time.Minute,
+					&apiextensionsv1alpha1.ManagedResourceDefinitionList{},
+					1,
+					func(o k8s.Object) bool {
+						mrd, ok := o.(*apiextensionsv1alpha1.ManagedResourceDefinition)
+						if !ok || mrd.Spec.State.IsActive() {
+							return false
+						}
+						for _, ref := range mrd.GetOwnerReferences() {
+							if ref.Kind == pkgv1.ProviderRevisionKind && strings.HasPrefix(ref.Name, providerName) {
+								return true
+							}
+						}
+						return false
+					},
+				),
+			).
+
+			// The provider revision is intentionally awaiting activation
+			// rather than unhealthy.
+			Assess("RevisionAwaitsActivation",
+				funcs.ListedResourcesValidatedWithin(2*time.Minute,
+					&pkgv1.ProviderRevisionList{},
+					1,
+					func(o k8s.Object) bool {
+						pr, ok := o.(*pkgv1.ProviderRevision)
+						if !ok {
+							return false
+						}
+						healthy := pr.GetCondition(pkgv1.TypeRuntimeHealthy)
+						active := pr.GetCondition(pkgv1.TypeRuntimeActive)
+						return healthy.Status == corev1.ConditionTrue &&
+							active.Status == corev1.ConditionFalse && active.Reason == pkgv1.ReasonAwaitingActivation
+					},
+					parentPackageSelector,
+				),
+			).
+
+			// The runtime deployment exists but is scaled to zero.
+			Assess("RuntimeScaledToZero",
+				funcs.ListedResourcesValidatedWithin(2*time.Minute,
+					&appsv1.DeploymentList{},
+					1,
+					func(o k8s.Object) bool {
+						d, ok := o.(*appsv1.Deployment)
+						if !ok || !strings.HasPrefix(d.GetName(), providerName) {
+							return false
+						}
+						return d.Spec.Replicas != nil && *d.Spec.Replicas == 0
+					},
+				),
+			).
+
+			// Activate the provider's MRDs.
+			Assess("ActivateMRDs", funcs.AllOf(
+				funcs.ApplyResources(FieldManager, manifests, "mrap.yaml"),
+				funcs.ResourcesCreatedWithin(30*time.Second, manifests, "mrap.yaml"),
+				funcs.ResourcesHaveConditionWithin(1*time.Minute, manifests, "mrap.yaml", apiextensionsv1alpha1.Healthy()),
+			)).
+
+			// The runtime scales up and becomes available.
+			Assess("RuntimeScalesUp",
+				funcs.ListedResourcesValidatedWithin(3*time.Minute,
+					&appsv1.DeploymentList{},
+					1,
+					func(o k8s.Object) bool {
+						d, ok := o.(*appsv1.Deployment)
+						if !ok || !strings.HasPrefix(d.GetName(), providerName) {
+							return false
+						}
+						return d.Spec.Replicas != nil && *d.Spec.Replicas == 1 && d.Status.AvailableReplicas == 1
+					},
+				),
+			).
+
+			// The revision reports a healthy, active runtime and the provider
+			// stays healthy throughout.
+			Assess("RevisionRuntimeIsHealthyAndActive",
+				funcs.ListedResourcesValidatedWithin(2*time.Minute,
+					&pkgv1.ProviderRevisionList{},
+					1,
+					func(o k8s.Object) bool {
+						pr, ok := o.(*pkgv1.ProviderRevision)
+						if !ok {
+							return false
+						}
+						healthy := pr.GetCondition(pkgv1.TypeRuntimeHealthy)
+						active := pr.GetCondition(pkgv1.TypeRuntimeActive)
+						return healthy.Status == corev1.ConditionTrue && healthy.Reason == pkgv1.ReasonHealthy &&
+							active.Status == corev1.ConditionTrue
+					},
+					parentPackageSelector,
+				),
+			).
+			Assess("ProviderIsHealthy",
+				funcs.ResourcesHaveConditionWithin(1*time.Minute, manifests, "provider.yaml", pkgv1.Healthy(), pkgv1.Active()),
+			).
+
+			// Cleanup.
+			WithTeardown("DeleteMRAP", funcs.AllOf(
+				funcs.DeleteResources(manifests, "mrap.yaml"),
+				funcs.ResourcesDeletedWithin(1*time.Minute, manifests, "mrap.yaml"),
+			)).
+			WithTeardown("DeleteProvider", funcs.AllOf(
+				funcs.DeleteResourcesWithPropagationPolicy(manifests, "provider.yaml", metav1.DeletePropagationForeground),
+				funcs.ResourcesDeletedWithin(2*time.Minute, manifests, "provider.yaml"),
+				funcs.ResourceDeletedWithin(2*time.Minute, &k8sapiextensionsv1.CustomResourceDefinition{
+					ObjectMeta: metav1.ObjectMeta{Name: "nopresources.nop.crossplane.io"},
+				}),
+			)).
+			Feature(),
+	)
+}


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane! Please read the contribution docs
(linked below) if this is your first Crossplane pull request.
-->

### Description of your changes

This PR teaches the package runtime reconciler to create the runtime Deployment of providers with the safe-start capability with zero replicas until the first ManagedResourceDefinition owned by the provider revision becomes Active. Providers that support safe-start run no managed resource controllers while all of their MRDs are inactive, so there is no reason to run their pods. Once an MRD is activated, for example by a matching ManagedResourceActivationPolicy, the reconciler scales the runtime up and never scales it back to zero. Explicit replica counts from a DeploymentRuntimeConfig always take precedence, and revisions that own no MRDs are not affected.

To make this state visible, the PR introduces a new `RuntimeActive` condition on ProviderRevisions and FunctionRevisions. It is `True` when the runtime is scaled up and `False` with reason `AwaitingActivation` while the runtime is intentionally scaled to zero. The `RuntimeHealthy` condition stays plainly healthy in both cases, and the package's `Healthy` condition surfaces the awaiting state with the same reason and message. The `RUNTIME` printer column was renamed to `RUNTIME-HEALTHY` and a new `RUNTIME-ACTIVE` printer column was added, so `kubectl get pkgrev` now shows `HEALTHY`, `RUNTIME-HEALTHY` and `RUNTIME-ACTIVE` at a glance. Note that `RUNTIME-ACTIVE` describes the runtime Deployment and is unrelated to the existing `STATE` column, which shows the revision's desired state.



<!--
Briefly describe what this pull request does, and how it is covered by tests.
Be proactive - direct your reviewers' attention to anything that needs special
consideration.

We love pull requests that fix an open issue. If yours does, use the below line
to indicate which issue it fixes, for example "Fixes #500".
-->

Fixes #7573

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `./nix.sh flake check` to ensure this PR is ready for review.
- [x] Added or updated unit tests.
- [x] Added or updated e2e tests.
- [x] Linked a PR or a [docs tracking issue] to [document this change].
- [x] Added `backport release-x.y` labels to auto-backport this PR.
- [x] Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md

### How has this code been tested

Unit tests cover the new reconciler logic, the manifest builder defaulting, the MRD watch handler and predicates, and the package health aggregation. A new e2e test installs a safe-start provider with the chart's default activation policies disabled, asserts that the runtime Deployment exists with zero replicas and that the revision reports `RuntimeActive=False` with reason `AwaitingActivation`, then applies a ManagedResourceActivationPolicy and asserts that the runtime scales up, becomes available and the revision and provider report healthy and active conditions.

```
kubectl get pkgrev
NAME                                                                              HEALTHY   RUNTIME-HEALTHY   RUNTIME-ACTIVE   IMAGE                                                       STATE    AGE
providerrevision.pkg.crossplane.io/provider-nop-runtime-activation-0fc5409bc38b   True      True              True             xpkg.crossplane.io/crossplane-contrib/provider-nop:v0.5.0   Active   38s
```

```
kubectl get pkgrev
NAME                                                                              HEALTHY   RUNTIME-HEALTHY   RUNTIME-ACTIVE   IMAGE                                                       STATE    AGE
providerrevision.pkg.crossplane.io/provider-nop-runtime-activation-0fc5409bc38b   True      False             True             xpkg.crossplane.io/crossplane-contrib/provider-nop:v0.5.0   Active   36s
```