### PR TITLE
fix(chart): use nameOverride-aware helper for container names

### DIFF
--- a/cluster/charts/crossplane/templates/deployment.yaml
+++ b/cluster/charts/crossplane/templates/deployment.yaml
@@ -56,7 +56,7 @@ spec:
       {{- end }}
       hostNetwork: {{ .Values.hostNetwork }}
       initContainers:
-        - name: {{ .Chart.Name }}-init
+        - name: {{ template "crossplane.name" . }}-init
           {{- if .Values.image.ignoreTag }}
           image: "{{ .Values.image.repository }}"
           {{- else }}
@@ -92,13 +92,13 @@ spec:
           - name: GOMAXPROCS
             valueFrom:
               resourceFieldRef:
-                containerName: {{ .Chart.Name }}-init
+                containerName: {{ template "crossplane.name" . }}-init
                 resource: limits.cpu
                 divisor: "1"
           - name: GOMEMLIMIT
             valueFrom:
               resourceFieldRef:
-                containerName: {{ .Chart.Name }}-init
+                containerName: {{ template "crossplane.name" . }}-init
                 resource: limits.memory
                 divisor: "1"
           - name: POD_NAMESPACE
@@ -133,7 +133,7 @@ spec:
             value: {{ $value | quote }}
           {{- end}}
       containers:
-      - name: {{ .Chart.Name }}
+      - name: {{ template "crossplane.name" . }}
         {{- if .Values.image.ignoreTag }}
         image: "{{ .Values.image.repository }}"
         {{- else }}
@@ -172,13 +172,13 @@ spec:
           - name: GOMAXPROCS
             valueFrom:
               resourceFieldRef:
-                containerName: {{ .Chart.Name }}
+                containerName: {{ template "crossplane.name" . }}
                 resource: limits.cpu
                 divisor: "1"
           - name: GOMEMLIMIT
             valueFrom:
               resourceFieldRef:
-                containerName: {{ .Chart.Name }}
+                containerName: {{ template "crossplane.name" . }}
                 resource: limits.memory
                 divisor: "1"
           - name: POD_NAMESPACE

--- a/cluster/charts/crossplane/templates/rbac-manager-deployment.yaml
+++ b/cluster/charts/crossplane/templates/rbac-manager-deployment.yaml
@@ -52,7 +52,7 @@ spec:
       runtimeClassName: {{ .Values.runtimeClassName | quote }}
       {{- end }}
       initContainers:
-      - name: {{ .Chart.Name }}-init
+      - name: {{ template "crossplane.name" . }}-init
         {{- if .Values.image.ignoreTag }}
         image: "{{ .Values.image.repository }}"
         {{- else }}
@@ -72,17 +72,17 @@ spec:
           - name: GOMAXPROCS
             valueFrom:
               resourceFieldRef:
-                containerName: {{ .Chart.Name }}-init
+                containerName: {{ template "crossplane.name" . }}-init
                 resource: limits.cpu
                 divisor: "1"
           - name: GOMEMLIMIT
             valueFrom:
               resourceFieldRef:
-                containerName: {{ .Chart.Name }}-init
+                containerName: {{ template "crossplane.name" . }}-init
                 resource: limits.memory
                 divisor: "1"
       containers:
-      - name: {{ .Chart.Name }}
+      - name: {{ template "crossplane.name" . }}
         {{- if .Values.image.ignoreTag }}
         image: "{{ .Values.image.repository }}"
         {{- else }}
@@ -111,13 +111,13 @@ spec:
           - name: GOMAXPROCS
             valueFrom:
               resourceFieldRef:
-                containerName: {{ .Chart.Name }}
+                containerName: {{ template "crossplane.name" . }}
                 resource: limits.cpu
                 divisor: "1"
           - name: GOMEMLIMIT
             valueFrom:
               resourceFieldRef:
-                containerName: {{ .Chart.Name }}
+                containerName: {{ template "crossplane.name" . }}
                 resource: limits.memory
                 divisor: "1"
           - name: LEADER_ELECTION


### PR DESCRIPTION
Container and init container names in both deployments use `.Chart.Name` directly, ignoring the `nameOverride` value. All other name references in these templates already use the `crossplane.name` template helper, which respects `nameOverride`. This inconsistency means setting `nameOverride` produces mismatched names between the deployment and its containers.

Assisted-by: Claude claude-opus-4-6

<!--
Thank you for helping to improve Crossplane! Please read the contribution docs
(linked below) if this is your first Crossplane pull request.
-->

### Description of your changes

<!--
Briefly describe what this pull request does, and how it is covered by tests.
Be proactive - direct your reviewers' attention to anything that needs special
consideration.

We love pull requests that fix an open issue. If yours does, use the below line
to indicate which issue it fixes, for example "Fixes #500".
-->

Fixes #7588

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `./nix.sh flake check` to ensure this PR is ready for review.
- [ ] ~Added or updated unit tests.~
- [ ] ~Added or updated e2e tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~
- [ ] ~Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md
