### PR TITLE
fix: avoid repeated owner updates for composed Usages

### DIFF
--- a/internal/controller/protection/usage/reconciler.go
+++ b/internal/controller/protection/usage/reconciler.go
@@ -20,12 +20,14 @@ package usage
 import (
 	"context"
 	"fmt"
+	"slices"
 	"strings"
 	"time"
 
 	"github.com/google/go-cmp/cmp"
 	v1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -512,7 +514,9 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 		}
 
 		// usageResource should have a finalizer and be owned by the using resource.
-		if owners := uu.GetOwnerReferences(); len(owners) == 0 || owners[0].UID != using.GetUID() {
+		if !slices.ContainsFunc(uu.GetOwnerReferences(), func(owner metav1.OwnerReference) bool {
+			return owner.UID == using.GetUID()
+		}) {
 			meta.AddOwnerReference(uu, meta.AsOwner(
 				meta.TypedReferenceTo(using, using.GetObjectKind().GroupVersionKind()),
 			))

--- a/internal/controller/protection/usage/reconciler_test.go
+++ b/internal/controller/protection/usage/reconciler_test.go
@@ -464,8 +464,7 @@ func TestReconcile(t *testing.T) {
 								return nil
 							}),
 							MockUpdate: test.NewMockUpdateFn(nil, func(_ client.Object) error {
-								t.Error("unexpected update")
-								return nil
+								return errors.New("unexpected update")
 							}),
 							MockStatusUpdate: test.NewMockSubResourceUpdateFn(nil),
 						},

--- a/internal/controller/protection/usage/reconciler_test.go
+++ b/internal/controller/protection/usage/reconciler_test.go
@@ -427,6 +427,63 @@ func TestReconcile(t *testing.T) {
 				r: reconcile.Result{},
 			},
 		},
+		"SuccessWithUsingResourceOwnerReferenceAfterCompositionOwner": {
+			reason: "We should not update a Usage when the using resource is already an owner but is not the first owner.",
+			args: args{
+				mgr: &fake.Manager{},
+				u:   func() protection.Usage { return &protection.InternalUsage{} },
+				opts: []ReconcilerOption{
+					WithClientApplicator(xpresource.ClientApplicator{
+						Client: &test.MockClient{
+							MockGet: test.NewMockGetFn(nil, func(obj client.Object) error {
+								switch o := obj.(type) {
+								case *v1beta1.Usage:
+									o.SetUID("usage-uid")
+									o.SetAnnotations(map[string]string{detailsAnnotationKey: reason})
+									o.SetOwnerReferences([]metav1.OwnerReference{
+										{UID: "composition-owner-uid"},
+										{UID: "using-owner-uid"},
+									})
+									o.Spec.Of.ResourceRef = &v1beta1.NamespacedResourceRef{Name: "used"}
+									o.Spec.By = &v1beta1.Resource{
+										Kind:        "AnotherKind",
+										ResourceRef: &v1beta1.ResourceRef{Name: "using"},
+									}
+									o.Spec.Reason = &reason
+								case *composed.Unstructured:
+									switch o.GetName() {
+									case "used":
+										o.SetLabels(map[string]string{inUseLabelKey: "true"})
+										o.SetOwnerReferences([]metav1.OwnerReference{{UID: "usage-uid"}})
+									case "using":
+										o.SetUID("using-owner-uid")
+									}
+								default:
+									return errors.New("unexpected object type")
+								}
+								return nil
+							}),
+							MockUpdate: test.NewMockUpdateFn(nil, func(_ client.Object) error {
+								t.Error("unexpected update")
+								return nil
+							}),
+							MockStatusUpdate: test.NewMockSubResourceUpdateFn(nil),
+						},
+					}),
+					WithSelectorResolver(fakeSelectorResolver{
+						resourceSelectorFn: func(_ context.Context, _ protection.Usage) error {
+							return nil
+						},
+					}),
+					WithFinalizer(xpresource.FinalizerFns{AddFinalizerFn: func(_ context.Context, _ xpresource.Object) error {
+						return nil
+					}}),
+				},
+			},
+			want: want{
+				r: reconcile.Result{},
+			},
+		},
 		"SuccessNoUsingResource": {
 			reason: "We should return no error once we have successfully reconciled the usage resource.",
 			args: args{

--- a/internal/controller/protection/usage/reconciler_test.go
+++ b/internal/controller/protection/usage/reconciler_test.go
@@ -61,6 +61,7 @@ func (fn FinderFn) FindUsageOf(ctx context.Context, o usage.Object) ([]protectio
 func TestReconcile(t *testing.T) {
 	now := metav1.Now()
 	reason := "protected"
+	const usingName = "using"
 
 	type args struct {
 		mgr  manager.Manager
@@ -291,10 +292,10 @@ func TestReconcile(t *testing.T) {
 								case *v1beta1.Usage:
 									o.Spec.Of.ResourceRef = &v1beta1.NamespacedResourceRef{Name: "used"}
 									o.Spec.By = &v1beta1.Resource{
-										ResourceRef: &v1beta1.ResourceRef{Name: "using"},
+										ResourceRef: &v1beta1.ResourceRef{Name: usingName},
 									}
 								case *composed.Unstructured:
-									if o.GetName() == "using" {
+									if o.GetName() == usingName {
 										return errBoom
 									}
 								}
@@ -329,12 +330,12 @@ func TestReconcile(t *testing.T) {
 								if o, ok := obj.(*v1beta1.Usage); ok {
 									o.Spec.Of.ResourceRef = &v1beta1.NamespacedResourceRef{Name: "used"}
 									o.Spec.By = &v1beta1.Resource{
-										ResourceRef: &v1beta1.ResourceRef{Name: "using"},
+										ResourceRef: &v1beta1.ResourceRef{Name: usingName},
 									}
 									return nil
 								}
 								if o, ok := obj.(*composed.Unstructured); ok {
-									if o.GetName() == "using" {
+									if o.GetName() == usingName {
 										o.SetAPIVersion("v1")
 										o.SetKind("AnotherKind")
 										o.SetUID("some-uid")
@@ -379,12 +380,12 @@ func TestReconcile(t *testing.T) {
 								if o, ok := obj.(*v1beta1.Usage); ok {
 									o.Spec.Of.ResourceRef = &v1beta1.NamespacedResourceRef{Name: "used"}
 									o.Spec.By = &v1beta1.Resource{
-										ResourceRef: &v1beta1.ResourceRef{Name: "using"},
+										ResourceRef: &v1beta1.ResourceRef{Name: usingName},
 									}
 									return nil
 								}
 								if o, ok := obj.(*composed.Unstructured); ok {
-									if o.GetName() == "using" {
+									if o.GetName() == usingName {
 										o.SetAPIVersion("v1")
 										o.SetKind("AnotherKind")
 										o.SetUID("some-uid")
@@ -447,7 +448,7 @@ func TestReconcile(t *testing.T) {
 									o.Spec.Of.ResourceRef = &v1beta1.NamespacedResourceRef{Name: "used"}
 									o.Spec.By = &v1beta1.Resource{
 										Kind:        "AnotherKind",
-										ResourceRef: &v1beta1.ResourceRef{Name: "using"},
+										ResourceRef: &v1beta1.ResourceRef{Name: usingName},
 									}
 									o.Spec.Reason = &reason
 								case *composed.Unstructured:
@@ -455,7 +456,7 @@ func TestReconcile(t *testing.T) {
 									case "used":
 										o.SetLabels(map[string]string{inUseLabelKey: "true"})
 										o.SetOwnerReferences([]metav1.OwnerReference{{UID: "usage-uid"}})
-									case "using":
+									case usingName:
 										o.SetUID("using-owner-uid")
 									}
 								default:
@@ -619,7 +620,7 @@ func TestReconcile(t *testing.T) {
 									o.Spec.By = &v1beta1.Resource{
 										APIVersion:  "v1",
 										Kind:        "AnotherKind",
-										ResourceRef: &v1beta1.ResourceRef{Name: "using"},
+										ResourceRef: &v1beta1.ResourceRef{Name: usingName},
 									}
 									return nil
 								}
@@ -665,12 +666,12 @@ func TestReconcile(t *testing.T) {
 									o.Spec.By = &v1beta1.Resource{
 										APIVersion:  "v1",
 										Kind:        "AnotherKind",
-										ResourceRef: &v1beta1.ResourceRef{Name: "using"},
+										ResourceRef: &v1beta1.ResourceRef{Name: usingName},
 									}
 									return nil
 								}
 								if o, ok := obj.(*composed.Unstructured); ok {
-									if o.GetName() == "using" {
+									if o.GetName() == usingName {
 										return errors.New("unexpected call, should not get using resource")
 									}
 									return nil
@@ -927,7 +928,7 @@ func TestReconcile(t *testing.T) {
 									o.Spec.By = &v1beta1.Resource{
 										APIVersion:  "v1",
 										Kind:        "AnotherKind",
-										ResourceRef: &v1beta1.ResourceRef{Name: "using"},
+										ResourceRef: &v1beta1.ResourceRef{Name: usingName},
 									}
 									return nil
 								}


### PR DESCRIPTION
### Description of your changes

The Usage controller checked only the first `ownerReference` when determining
whether the resource referenced by `spec.by` already owned the Usage.

A Usage created by a Composition already has the composite resource as its first
owner. The `spec.by` resource can therefore be a later owner, causing the
controller to issue an unnecessary update on every reconciliation. These updates
can repeatedly trigger composition reconciliation and eventually open the XR
circuit breaker.

This change checks all owner references before adding the `spec.by` owner.

A regression test covers a composed Usage where the composite owner is first and
the `spec.by` owner is second.

Fixes #7590

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `./nix.sh flake check` to ensure this PR is ready for review.
- [x] Added or updated unit tests.
- [ ] ~Added or updated e2e tests.~ The behavior is isolated to the Usage reconciler and is covered by a regression unit test.
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~ This internal bug fix does not change documented behavior.
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~ I do not have permission to add labels; maintainers may add the appropriate supported-release backport labels.
- [ ] ~Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~ This change does not modify an API.

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md