### PR TITLE
fix: surface XRD status condition when CRD apply fails

### DIFF
--- a/apis/apiextensions/v1/conditions.go
+++ b/apis/apiextensions/v1/conditions.go
@@ -56,6 +56,8 @@ const (
 
 	ReasonWatchCircuitOpen   xpv2.ConditionReason = "WatchCircuitOpen"
 	ReasonWatchCircuitClosed xpv2.ConditionReason = "WatchCircuitClosed"
+
+	ReasonCannotEstablishComposite xpv2.ConditionReason = "CannotEstablishCompositeResource"
 )
 
 // WatchingComposite indicates that Crossplane has defined and is watching for a
@@ -66,6 +68,19 @@ func WatchingComposite() xpv2.Condition {
 		Status:             corev1.ConditionTrue,
 		LastTransitionTime: metav1.Now(),
 		Reason:             ReasonWatchingComposite,
+	}
+}
+
+// CannotEstablishComposite indicates that Crossplane could not establish
+// (i.e. create and start watching) a new kind of composite resource - for
+// example because the apiserver rejected the CustomResourceDefinition
+// derived from the XRD's schema.
+func CannotEstablishComposite() xpv2.Condition {
+	return xpv2.Condition{
+		Type:               TypeEstablished,
+		Status:             corev1.ConditionFalse,
+		LastTransitionTime: metav1.Now(),
+		Reason:             ReasonCannotEstablishComposite,
 	}
 }
 

--- a/internal/controller/apiextensions/definition/reconciler.go
+++ b/internal/controller/apiextensions/definition/reconciler.go
@@ -302,11 +302,11 @@ type Reconciler struct {
 
 // Reconcile a CompositeResourceDefinition by defining a new kind of composite
 // resource and starting a controller to reconcile it.
-func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) { //nolint:gocognit // Reconcilers are complex. Be wary of adding more.
+func (r *Reconciler) Reconcile(ogctx context.Context, req reconcile.Request) (reconcile.Result, error) { //nolint:gocognit // Reconcilers are complex. Be wary of adding more.
 	log := r.log.WithValues("request", req)
 	log.Debug("Reconciling")
 
-	ctx, cancel := context.WithTimeout(ctx, timeout)
+	ctx, cancel := context.WithTimeout(ogctx, timeout)
 	defer cancel()
 
 	d := &v1.CompositeResourceDefinition{}
@@ -483,7 +483,10 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 		err = errors.Wrap(err, errApplyCRD)
 		r.record.Event(d, event.Warning(reasonEstablishXR, err))
 		status.MarkConditions(v1.CannotEstablishComposite().WithMessage(err.Error()))
-		_ = r.client.Status().Update(ctx, d)
+
+		if updateErr := r.client.Status().Update(ogctx, d); updateErr != nil {
+			log.Debug(errUpdateStatus, "error", updateErr)
+		}
 
 		return reconcile.Result{}, err
 	}

--- a/internal/controller/apiextensions/definition/reconciler.go
+++ b/internal/controller/apiextensions/definition/reconciler.go
@@ -482,6 +482,8 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 
 		err = errors.Wrap(err, errApplyCRD)
 		r.record.Event(d, event.Warning(reasonEstablishXR, err))
+		status.MarkConditions(v1.CannotEstablishComposite().WithMessage(err.Error()))
+		_ = r.client.Status().Update(ctx, d)
 
 		return reconcile.Result{}, err
 	}

--- a/internal/controller/apiextensions/definition/reconciler.go
+++ b/internal/controller/apiextensions/definition/reconciler.go
@@ -302,11 +302,12 @@ type Reconciler struct {
 
 // Reconcile a CompositeResourceDefinition by defining a new kind of composite
 // resource and starting a controller to reconcile it.
-func (r *Reconciler) Reconcile(ogctx context.Context, req reconcile.Request) (reconcile.Result, error) { //nolint:gocognit // Reconcilers are complex. Be wary of adding more.
+func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) { //nolint:gocognit // Reconcilers are complex. Be wary of adding more.
 	log := r.log.WithValues("request", req)
 	log.Debug("Reconciling")
 
-	ctx, cancel := context.WithTimeout(ogctx, timeout)
+	ogctx := ctx
+	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
 	d := &v1.CompositeResourceDefinition{}

--- a/internal/controller/apiextensions/definition/reconciler_test.go
+++ b/internal/controller/apiextensions/definition/reconciler_test.go
@@ -562,6 +562,16 @@ func TestReconcile(t *testing.T) {
 				ca: resource.ClientApplicator{
 					Client: &test.MockClient{
 						MockGet: test.NewMockGetFn(nil),
+						MockStatusUpdate: test.NewMockSubResourceUpdateFn(nil, func(got client.Object) error {
+							d := got.(*v1.CompositeResourceDefinition)
+							c := d.GetCondition(v1.TypeEstablished)
+
+							if c.Reason != v1.ReasonCannotEstablishComposite {
+								t.Errorf("MockStatusUpdate: got Established condition reason %q, want %q", c.Reason, v1.ReasonCannotEstablishComposite)
+							}
+
+							return nil
+						}),
 					},
 					Applicator: resource.ApplyFn(func(_ context.Context, _ client.Object, _ ...resource.ApplyOption) error {
 						return errBoom


### PR DESCRIPTION
Motivation

When a CompositeResourceDefinition's derived CustomResourceDefinition
is rejected by the apiserver (for example because a CEL
x-kubernetes-validations rule exceeds the estimated cost budget), the
XRD reconciler only emitted a Kubernetes Warning Event. The XRD's own
status.conditions stayed empty and Established remained blank, so the
composite resource silently never established. Users had to search
cluster-wide Events instead of simply describing the XRD to find the
error, per crossplane/crossplane#7516.

Approach

Add a new Established=False condition, CannotEstablishComposite, with
its error message, and set it on the XRD whenever applying the derived
CRD fails. This mirrors the existing best-effort status update pattern
already used for the equivalent CRD-apply failure path in the sibling
ManagedResourceDefinition reconciler (BlockedManaged in
internal/controller/apiextensions/managed/reconciler.go). The
underlying error is still recorded as a Warning Event and returned as
before, so existing behavior (retries, requeue-on-conflict) is
unchanged; the status update is best-effort and its own error is
intentionally ignored, exactly like the existing precedent.

Validation

go build ./...
go test ./internal/controller/apiextensions/... (all packages pass,
including the updated ApplyCustomResourceDefinitionError test case
which now asserts the Established condition reason)
cd apis && go test ./... (all packages pass)

Fixes #7516

I have:

- [x] Read and followed Crossplane's [contribution process].
- [ ] ~~Run `./nix.sh flake check` to ensure this PR is ready for review.~~ Didn't run this locally, but the equivalent CI jobs (lint, build-artifacts, check-diff, unit-tests) are all green.
- [x] Added or updated unit tests.
- [ ] ~~Added or updated e2e tests.~~ This is a status-reporting change on an existing failure path; the unit test covers it. Happy to add e2e coverage if a maintainer wants it.
- [ ] ~~Linked a PR or a [docs tracking issue] to [document this change].~~ No user-facing docs beyond the condition itself, which is self-explanatory.
- [ ] ~~Added `backport release-x.y` labels to auto-backport this PR.~~ Left to a maintainer to decide/apply.
- [ ] ~~Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~~ No API promotion; this only adds a condition reason to an existing v1 type.

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md

Signed-off-by: Pujitha Paladugu <10557236+pujitha24@users.noreply.github.com>
