### PR TITLE
[Bugfix][Part1]: Minor issues noticed while reading code

### DIFF
--- a/cmd/crossplane/core/core.go
+++ b/cmd/crossplane/core/core.go
@@ -370,7 +370,7 @@ func (c *startCommand) Run(s *runtime.Scheme, log logging.Logger) error { //noli
 		// the informer within 60 seconds. This handler tries to make the error
 		// a little more informative, and less scary.
 		DefaultWatchErrorHandler: func(_ context.Context, _ *kcache.Reflector, err error) {
-			if errors.Is(io.EOF, err) {
+			if errors.Is(err, io.EOF) {
 				// Watch closed normally.
 				return
 			}

--- a/internal/controller/apiextensions/activationpolicy/reconciler.go
+++ b/internal/controller/apiextensions/activationpolicy/reconciler.go
@@ -109,7 +109,10 @@ func (r *Reconciler) Reconcile(ogctx context.Context, req reconcile.Request) (re
 		log.Debug("cannot list ManagedResourceDefinition", "error", err)
 
 		status.MarkConditions(v1alpha1.BlockedActivationPolicy().WithMessage("cannot list ManagedResourceDefinition"))
-		_ = r.Status().Update(ogctx, mrap)
+		if err := r.Status().Update(ogctx, mrap); err != nil {
+			log.Debug("Error when Updating mrd", "err", err)
+			r.record.Event(mrap, event.Warning("BlockedManagedResourceActivationPolicy", err))
+		}
 
 		return reconcile.Result{}, errors.Wrap(err, "cannot list ManagedResourceDefinition")
 	}

--- a/internal/controller/pkg/resolver/reconciler.go
+++ b/internal/controller/pkg/resolver/reconciler.go
@@ -294,14 +294,14 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 	// be requeued when it adds itself to the Lock, at which point we will
 	// check for missing nodes again.
 	dep, ok := implied[0].(*internaldag.DependencyNode)
-
-	depID := dep.Identifier()
 	if !ok {
-		log.Debug(errInvalidDependency, "error", errors.Errorf(errFmtMissingDependency, depID))
-		status.MarkConditions(v1beta1.ResolutionFailed(errors.Errorf(errFmtMissingDependency, depID)))
+		invalidID := implied[0].Identifier()
+		log.Debug(errInvalidDependency, "error", errors.Errorf(errFmtMissingDependency, invalidID))
+		status.MarkConditions(v1beta1.ResolutionFailed(errors.Errorf(errFmtMissingDependency, invalidID)))
 
 		return reconcile.Result{}, errors.Wrap(r.kube.Status().Update(ctx, lock), errCannotUpdateStatus)
 	}
+	depID := dep.Identifier()
 
 	// NOTE(phisco): dependencies identifiers are without registry and tag, so we can't enforce strict validation.
 	ref, err := name.ParseReference(depID)
@@ -432,7 +432,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 
 	newVer, err := r.findDependencyVersionToUpdate(ctx, ref, installedVersion, n, log)
 	if err != nil {
-		log.Debug(errFindDependencyUpgrade, "error", errors.Wrapf(err, depID, dep.Constraints))
+		log.Debug(errFindDependencyUpgrade, "error", errors.Wrapf(err, "dependencyID: %s constraint %v", depID, dep.Constraints))
 		status.MarkConditions(v1beta1.ResolutionFailed(errors.Wrap(err, errFindDependencyUpgrade)))
 
 		_ = r.kube.Status().Update(ctx, lock)

--- a/internal/controller/pkg/resolver/reconciler_test.go
+++ b/internal/controller/pkg/resolver/reconciler_test.go
@@ -364,6 +364,53 @@ func TestReconcile(t *testing.T) {
 				err: errors.Wrap(errors.Wrap(errors.New("improper constraint: \"\""), errInvalidConstraint), errFindDependency),
 			},
 		},
+		"ErrorImpliedNodeNotDependencyNode": {
+			reason: "We should return without error if an implied node is not a DependencyNode (guards the nil pointer dereference).",
+			args: args{
+				mgr: &fake.Manager{
+					Client: &test.MockClient{
+						MockGet: test.NewMockGetFn(nil, func(o client.Object) error {
+							l := o.(*v1beta1.Lock)
+							l.Packages = append(l.Packages, v1beta1.LockPackage{
+								Name:    "cool-package",
+								Type:    ptr.To(v1beta1.ProviderPackageType),
+								Source:  "xpkg.crossplane.io/cool-repo/cool-image",
+								Version: "v0.0.1",
+							})
+							return nil
+						}),
+						MockUpdate:       test.NewMockUpdateFn(nil),
+						MockStatusUpdate: test.NewMockSubResourceUpdateFn(nil),
+					},
+				},
+				req: reconcile.Request{NamespacedName: types.NamespacedName{Name: "test"}},
+				rec: []ReconcilerOption{
+					WithNewDagFn(func() dag.DAG {
+						return &fakedag.MockDag{
+							MockInit: func(_ []dag.Node) ([]dag.Node, error) {
+								// Return a PackageNode, not a DependencyNode.
+								// Before the fix, this would panic; now it
+								// returns without error.
+								return []dag.Node{
+									&dag.PackageNode{
+										LockPackage: v1beta1.LockPackage{
+											Name:   "cool-package",
+											Source: "xpkg.crossplane.io/cool-repo/cool-image",
+										},
+									},
+								}, nil
+							},
+							MockSort: func() ([]string, error) {
+								return nil, nil
+							},
+						}
+					}),
+				},
+			},
+			want: want{
+				r: reconcile.Result{},
+			},
+		},
 		"ErrorListVersions": {
 			reason: "We should return an error if fail to list package versions.",
 			args: args{


### PR DESCRIPTION


<!--
Thank you for helping to improve Crossplane! Please read the contribution docs
(linked below) if this is your first Crossplane pull request.
-->

### Description of your changes

This PR fixes four bugs found during a code audit of the internal, cmd, and apis directories.

1. Nil pointer dereference in package resolver (reconciler.go)
dep.Identifier() was called before checking whether the type assertion to *internaldag.DependencyNode succeeded. If the assertion failed, dep would be nil and calling .Identifier() would panic at runtime.

2. Reversed errors.Is arguments in watch error handler (core.go)
errors.Is(io.EOF, err) has the arguments in the wrong order — the function signature is errors.Is(err, target).

3. Silently swallowed status update error (reconciler.go)
When listing ManagedResourceDefinitions failed, the reconciler set a BlockedActivationPolicy condition but discarded the subsequent status update error with _ = r.Status().Update(...). A failed status update would leave the resource with stale status silently.


4. errors.Wrapf format string misuse in package resolver (reconciler.go)
errors.Wrapf(err, depID, dep.Constraints) passed a package identifier (depID) as the format string, causing dep.Constraints to be silently dropped from the debug log message since depID contains no format verbs.

Fixes #

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `./nix.sh flake check` to ensure this PR is ready for review.
- [x] Added or updated unit tests.
- [ ] Added or updated e2e tests.
- [ ] Linked a PR or a [docs tracking issue] to [document this change].
- [ ] Added `backport release-x.y` labels to auto-backport this PR.
- [ ] Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md
