### PR TITLE
[Backport release-2.1] fix: avoid repeated owner updates for composed Usages

### DIFF
--- a/internal/controller/protection/usage/reconciler.go
+++ b/internal/controller/protection/usage/reconciler.go
@@ -20,12 +20,14 @@ package usage
 import (
 	"context"
 	"fmt"
+	"slices"
 	"strings"
 	"time"
 
 	"github.com/google/go-cmp/cmp"
 	v1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -505,7 +507,9 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 		}
 
 		// usageResource should have a finalizer and be owned by the using resource.
-		if owners := u.GetOwnerReferences(); len(owners) == 0 || owners[0].UID != using.GetUID() {
+		if !slices.ContainsFunc(u.GetOwnerReferences(), func(owner metav1.OwnerReference) bool {
+			return owner.UID == using.GetUID()
+		}) {
 			meta.AddOwnerReference(u, meta.AsOwner(
 				meta.TypedReferenceTo(using, using.GetObjectKind().GroupVersionKind()),
 			))

--- a/internal/controller/protection/usage/reconciler_test.go
+++ b/internal/controller/protection/usage/reconciler_test.go
@@ -61,6 +61,7 @@ func (fn FinderFn) FindUsageOf(ctx context.Context, o usage.Object) ([]protectio
 func TestReconcile(t *testing.T) {
 	now := metav1.Now()
 	reason := "protected"
+	const usingName = "using"
 
 	type args struct {
 		mgr  manager.Manager
@@ -291,10 +292,10 @@ func TestReconcile(t *testing.T) {
 								case *v1beta1.Usage:
 									o.Spec.Of.ResourceRef = &v1beta1.NamespacedResourceRef{Name: "used"}
 									o.Spec.By = &v1beta1.Resource{
-										ResourceRef: &v1beta1.ResourceRef{Name: "using"},
+										ResourceRef: &v1beta1.ResourceRef{Name: usingName},
 									}
 								case *composed.Unstructured:
-									if o.GetName() == "using" {
+									if o.GetName() == usingName {
 										return errBoom
 									}
 								}
@@ -329,12 +330,12 @@ func TestReconcile(t *testing.T) {
 								if o, ok := obj.(*v1beta1.Usage); ok {
 									o.Spec.Of.ResourceRef = &v1beta1.NamespacedResourceRef{Name: "used"}
 									o.Spec.By = &v1beta1.Resource{
-										ResourceRef: &v1beta1.ResourceRef{Name: "using"},
+										ResourceRef: &v1beta1.ResourceRef{Name: usingName},
 									}
 									return nil
 								}
 								if o, ok := obj.(*composed.Unstructured); ok {
-									if o.GetName() == "using" {
+									if o.GetName() == usingName {
 										o.SetAPIVersion("v1")
 										o.SetKind("AnotherKind")
 										o.SetUID("some-uid")
@@ -379,12 +380,12 @@ func TestReconcile(t *testing.T) {
 								if o, ok := obj.(*v1beta1.Usage); ok {
 									o.Spec.Of.ResourceRef = &v1beta1.NamespacedResourceRef{Name: "used"}
 									o.Spec.By = &v1beta1.Resource{
-										ResourceRef: &v1beta1.ResourceRef{Name: "using"},
+										ResourceRef: &v1beta1.ResourceRef{Name: usingName},
 									}
 									return nil
 								}
 								if o, ok := obj.(*composed.Unstructured); ok {
-									if o.GetName() == "using" {
+									if o.GetName() == usingName {
 										o.SetAPIVersion("v1")
 										o.SetKind("AnotherKind")
 										o.SetUID("some-uid")
@@ -411,6 +412,62 @@ func TestReconcile(t *testing.T) {
 								}
 								return nil
 							}),
+						},
+					}),
+					WithSelectorResolver(fakeSelectorResolver{
+						resourceSelectorFn: func(_ context.Context, _ protection.Usage) error {
+							return nil
+						},
+					}),
+					WithFinalizer(xpresource.FinalizerFns{AddFinalizerFn: func(_ context.Context, _ xpresource.Object) error {
+						return nil
+					}}),
+				},
+			},
+			want: want{
+				r: reconcile.Result{},
+			},
+		},
+		"SuccessWithUsingResourceOwnerReferenceAfterCompositionOwner": {
+			reason: "We should not update a Usage when the using resource is already an owner but is not the first owner.",
+			args: args{
+				mgr: &fake.Manager{},
+				u:   &v1beta1.Usage{},
+				opts: []ReconcilerOption{
+					WithClientApplicator(xpresource.ClientApplicator{
+						Client: &test.MockClient{
+							MockGet: test.NewMockGetFn(nil, func(obj client.Object) error {
+								switch o := obj.(type) {
+								case *v1beta1.Usage:
+									o.SetUID("usage-uid")
+									o.SetAnnotations(map[string]string{detailsAnnotationKey: reason})
+									o.SetOwnerReferences([]metav1.OwnerReference{
+										{UID: "composition-owner-uid"},
+										{UID: "using-owner-uid"},
+									})
+									o.Spec.Of.ResourceRef = &v1beta1.NamespacedResourceRef{Name: "used"}
+									o.Spec.By = &v1beta1.Resource{
+										Kind:        "AnotherKind",
+										ResourceRef: &v1beta1.ResourceRef{Name: usingName},
+									}
+									o.Spec.Reason = &reason
+								case *composed.Unstructured:
+									switch o.GetName() {
+									case "used":
+										o.SetLabels(map[string]string{inUseLabelKey: "true"})
+										o.SetOwnerReferences([]metav1.OwnerReference{{UID: "usage-uid"}})
+									case usingName:
+										o.SetUID("using-owner-uid")
+									}
+								default:
+									return errors.New("unexpected object type")
+								}
+								return nil
+							}),
+							MockUpdate: test.NewMockUpdateFn(nil, func(_ client.Object) error {
+								return errors.New("unexpected update")
+							}),
+							MockStatusUpdate: test.NewMockSubResourceUpdateFn(nil),
 						},
 					}),
 					WithSelectorResolver(fakeSelectorResolver{
@@ -563,7 +620,7 @@ func TestReconcile(t *testing.T) {
 									o.Spec.By = &v1beta1.Resource{
 										APIVersion:  "v1",
 										Kind:        "AnotherKind",
-										ResourceRef: &v1beta1.ResourceRef{Name: "using"},
+										ResourceRef: &v1beta1.ResourceRef{Name: usingName},
 									}
 									return nil
 								}
@@ -609,12 +666,12 @@ func TestReconcile(t *testing.T) {
 									o.Spec.By = &v1beta1.Resource{
 										APIVersion:  "v1",
 										Kind:        "AnotherKind",
-										ResourceRef: &v1beta1.ResourceRef{Name: "using"},
+										ResourceRef: &v1beta1.ResourceRef{Name: usingName},
 									}
 									return nil
 								}
 								if o, ok := obj.(*composed.Unstructured); ok {
-									if o.GetName() == "using" {
+									if o.GetName() == usingName {
 										return errors.New("unexpected call, should not get using resource")
 									}
 									return nil
@@ -871,7 +928,7 @@ func TestReconcile(t *testing.T) {
 									o.Spec.By = &v1beta1.Resource{
 										APIVersion:  "v1",
 										Kind:        "AnotherKind",
-										ResourceRef: &v1beta1.ResourceRef{Name: "using"},
+										ResourceRef: &v1beta1.ResourceRef{Name: usingName},
 									}
 									return nil
 								}


### PR DESCRIPTION
Backport of #7591 to `release-2.1`.

Not a clean cherry-pick: on `release-2.1` the reconciler uses the variable name `u` (renamed to `uu` in later branches), and the added test case was adapted to this branch's `args.u protection.Usage` field (`&v1beta1.Usage{}`, since `protection.InternalUsage` does not exist here). The fix and its regression test are otherwise identical. Package builds and `go test ./internal/controller/protection/usage/...` passes locally.