### PR TITLE
fix: wait for pipeline inspector sidecar to be ready before running functions

### DIFF
--- a/cmd/crossplane/core/core.go
+++ b/cmd/crossplane/core/core.go
@@ -516,6 +516,17 @@ func (c *startCommand) Run(s *runtime.Scheme, log logging.Logger) error { //noli
 			}
 		}()
 
+		// The inspector connects lazily, so the first emit calls race the
+		// sidecar's own startup and time out if its gRPC server isn't
+		// accepting connections yet. Wait briefly for it to be ready before
+		// functions start running. Inspection is best effort, so start
+		// anyway if it isn't ready in time.
+		wctx, wcancel := context.WithTimeout(ctx, 10*time.Second)
+		if err := inspector.WaitUntilReady(wctx); err != nil {
+			log.Info("Pipeline inspector sidecar is not ready, pipeline data may not be inspected until it is", "error", err)
+		}
+		wcancel()
+
 		runner = inspected.NewRunner(runner, inspector,
 			inspected.WithMetrics(ifrm),
 			inspected.WithLogger(log))

--- a/internal/xfn/inspected/socket.go
+++ b/internal/xfn/inspected/socket.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/connectivity"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
@@ -74,6 +75,29 @@ func NewSocketPipelineInspector(socketPath string, o ...SocketPipelineInspectorO
 	}
 
 	return e, nil
+}
+
+// WaitUntilReady blocks until the underlying gRPC connection to the inspector
+// sidecar is ready, or the supplied context is done. The connection is
+// otherwise established lazily by the first emit call, which races the
+// sidecar's own startup and can make early emit calls time out. Returns the
+// context's error if the connection isn't ready before the context is done.
+func (e *SocketPipelineInspector) WaitUntilReady(ctx context.Context) error {
+	for {
+		s := e.conn.GetState()
+		if s == connectivity.Ready {
+			return nil
+		}
+		if s == connectivity.Idle {
+			// The channel starts out idle, and returns to idle when a
+			// connection attempt fails. Ask it to connect, since nothing
+			// else will until the first RPC.
+			e.conn.Connect()
+		}
+		if !e.conn.WaitForStateChange(ctx, s) {
+			return ctx.Err()
+		}
+	}
 }
 
 // EmitRequest emits the function request before execution. Credentials are

--- a/internal/xfn/inspected/socket_test.go
+++ b/internal/xfn/inspected/socket_test.go
@@ -18,6 +18,9 @@ package inspected
 import (
 	"context"
 	"errors"
+	"net"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -550,6 +553,93 @@ func TestSocketPipelineInspectorEmitResponse(t *testing.T) {
 				if diff := cmp.Diff(tc.want.expectedRsp, &gotRsp, protocmp.Transform()); diff != "" {
 					t.Errorf("\n%s\nEmitResponse(...) sanitized response: -want, +got:\n%s", tc.reason, diff)
 				}
+			}
+		})
+	}
+}
+
+func TestSocketPipelineInspectorWaitUntilReady(t *testing.T) {
+	type want struct {
+		err error
+	}
+
+	cases := map[string]struct {
+		reason string
+		// serveAfter is how long to wait before the sidecar's gRPC server
+		// starts serving on the socket. Negative means it never serves.
+		serveAfter time.Duration
+		timeout    time.Duration
+		want       want
+	}{
+		"SidecarAlreadyServing": {
+			reason:     "Should return nil when the sidecar is already serving.",
+			serveAfter: 0,
+			timeout:    10 * time.Second,
+		},
+		"SidecarServesLate": {
+			reason:     "Should recover when the sidecar starts serving after a delay, as it can when its container is still starting.",
+			serveAfter: 200 * time.Millisecond,
+			timeout:    10 * time.Second,
+		},
+		"SidecarNeverServes": {
+			reason:     "Should return the context's error when the sidecar never starts serving.",
+			serveAfter: -1,
+			timeout:    100 * time.Millisecond,
+			want:       want{err: context.DeadlineExceeded},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			// Keep the socket name short. Unix socket paths have a low
+			// length limit on some platforms (e.g. 104 bytes on darwin),
+			// and t.TempDir() embeds the full test and subtest name, which
+			// can exceed that. Use a short-named temp dir instead.
+			dir, err := os.MkdirTemp("", "pi") //nolint:usetesting // t.TempDir() embeds the test name and can exceed the darwin unix socket path limit.
+			if err != nil {
+				t.Fatalf("os.MkdirTemp(...): %v", err)
+			}
+			t.Cleanup(func() { _ = os.RemoveAll(dir) })
+			socketPath := filepath.Join(dir, "pi.sock")
+
+			if tc.serveAfter >= 0 {
+				s := grpc.NewServer()
+				t.Cleanup(s.Stop)
+
+				serve := func() {
+					lis, err := net.Listen("unix", socketPath)
+					if err != nil {
+						t.Errorf("net.Listen(...): %v", err)
+						return
+					}
+					go func() {
+						_ = s.Serve(lis)
+					}()
+				}
+
+				if tc.serveAfter == 0 {
+					serve()
+				} else {
+					timer := time.AfterFunc(tc.serveAfter, serve)
+					t.Cleanup(func() { timer.Stop() })
+				}
+			}
+
+			inspector, err := NewSocketPipelineInspector(socketPath)
+			if err != nil {
+				t.Fatalf("NewSocketPipelineInspector(...): %v", err)
+			}
+			t.Cleanup(func() {
+				_ = inspector.Close()
+			})
+
+			ctx, cancel := context.WithTimeout(context.Background(), tc.timeout)
+			defer cancel()
+
+			err = inspector.WaitUntilReady(ctx)
+
+			if diff := cmp.Diff(tc.want.err, err, cmpopts.EquateErrors()); diff != "" {
+				t.Errorf("\n%s\nWaitUntilReady(...): -want err, +got err:\n%s", tc.reason, diff)
 			}
 		})
 	}


### PR DESCRIPTION
### Description of your changes

With `--enable-pipeline-inspector`, Crossplane logs a burst of `failed to inspect request/response for function ... context deadline exceeded` on startup. `SocketPipelineInspector`'s gRPC connection is established lazily by the first emit call, and every emit has a fixed 100ms timeout, so early emits race the sidecar's own startup and time out.

This adds `WaitUntilReady` to `SocketPipelineInspector` and calls it in `core.go` with a 10 second bound before wrapping the function runner. If the sidecar is not ready in time, Crossplane logs once and starts anyway. Steady state is unchanged. `internal/xfn/function_runner.go` has handled the same race for function servers since #6125.

Unit tests cover the sidecar being ready at start, becoming ready after a delay, and never serving.

`ClientConn.Connect` is experimental, but it is the documented way to trigger connection on an idle `grpc.NewClient` channel. The 10 second bound is a constant; happy to make it a flag.

Fixes #7218

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [ ] ~Run `./nix.sh flake check` to ensure this PR is ready for review.~ Nix is not available on my machine; I ran `gofmt`, `go build`, `go vet` and `go test -race` on the touched packages.
- [x] Added or updated unit tests.
- [ ] ~Added or updated e2e tests.~ Startup timing against a sidecar is not observable from the e2e harness.
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~ No flag or default changes.
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~ The inspector is alpha; happy to backport if you want it.
- [ ] ~Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~ No API changes.

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md
