### PR TITLE
fix(claim): don't propagate XR machinery fields from claims

### DIFF
--- a/internal/controller/apiextensions/claim/syncer_csa.go
+++ b/internal/controller/apiextensions/claim/syncer_csa.go
@@ -19,6 +19,7 @@ package claim
 import (
 	"context"
 	"fmt"
+	"maps"
 
 	"dario.cat/mergo"
 	"github.com/google/go-cmp/cmp"
@@ -95,26 +96,38 @@ func (s *ClientSideCompositeSyncer) Sync(ctx context.Context, cm *claim.Unstruct
 	}
 
 	// We want to propagate the claim's spec to the composite's spec, but first
-	// we must filter out any well-known fields that are unique to claims. We do
-	// this by:
-	// 1. Grabbing a map whose keys represent all well-known claim fields.
-	// 2. Deleting any well-known fields that we want to propagate.
-	// 3. Using the resulting map keys to filter the claim's spec.
-	wellKnownClaimFields := xcrd.CompositeResourceClaimSpecProps(nil)
+	// we must filter out fields that must not be copied from a claim. We strip
+	// two sets of well-known fields:
+	//
+	//  1. Fields that are unique to claims (e.g. resourceRef), which are
+	//     meaningless on an XR.
+	//  2. XR machinery fields (e.g. resourceRefs and the crossplane stanza)
+	//     that only the XR controller may set. These are not part of a claim's
+	//     API, but a claim whose XRD schema sets
+	//     x-kubernetes-preserve-unknown-fields: true can smuggle them past CRD
+	//     validation. Propagating them would let a claim author inject e.g.
+	//     spec.resourceRefs into the XR, which the XR controller would then act
+	//     on - deleting composed resources or adopting arbitrary ones.
+	//
+	// We do this by building a map whose keys are all of those well-known
+	// fields, deleting the ones we do want to propagate (PropagateSpecProps,
+	// e.g. compositionRef), then using the resulting keys to filter the spec.
+	fieldsToStrip := xcrd.CompositeResourceClaimSpecProps(nil)
+	maps.Copy(fieldsToStrip, xcrd.CompositeResourceSpecProps(v1.CompositeResourceScopeLegacyCluster, nil))
 	for _, field := range xcrd.PropagateSpecProps {
 		// Skip propagating compositionRef if enforcedCompositionRef is set
 		if field == "compositionRef" && hasEnforcedComposition {
 			continue
 		}
-		delete(wellKnownClaimFields, field)
+		delete(fieldsToStrip, field)
 	}
 
 	// CompositionRevisionRef is a special field which needs to be propagated
 	// based on the Update policy. If the policy is `Manual`, we need to remove
-	// CompositionRevisionRef from wellKnownClaimFields, so it is propagated
-	// from the claim to the XR.
+	// CompositionRevisionRef from fieldsToStrip, so it is propagated from the
+	// claim to the XR.
 	if xr.GetCompositionUpdatePolicy() != nil && *xr.GetCompositionUpdatePolicy() == xpv2.UpdateManual {
-		delete(wellKnownClaimFields, xcrd.CompositionRevisionRef)
+		delete(fieldsToStrip, xcrd.CompositionRevisionRef)
 	}
 
 	cmSpec, ok := cm.Object["spec"].(map[string]any)
@@ -122,8 +135,8 @@ func (s *ClientSideCompositeSyncer) Sync(ctx context.Context, cm *claim.Unstruct
 		return errors.New(errUnsupportedClaimSpec)
 	}
 
-	// Propagate the claim's spec (minus well known fields) to the XR's spec.
-	xr.Object["spec"] = withoutKeys(cmSpec, xcrd.GetPropFields(wellKnownClaimFields)...)
+	// Propagate the claim's spec (minus the filtered fields) to the XR's spec.
+	xr.Object["spec"] = withoutKeys(cmSpec, xcrd.GetPropFields(fieldsToStrip)...)
 
 	// We overwrite the entire XR spec above, so we wait until this point to set
 	// the claim reference.

--- a/internal/controller/apiextensions/claim/syncer_csa_test.go
+++ b/internal/controller/apiextensions/claim/syncer_csa_test.go
@@ -393,6 +393,84 @@ func TestClientSideSync(t *testing.T) {
 				err: nil,
 			},
 		},
+		"DoNotPropagateInjectedMachineryFields": {
+			reason: "XR machinery fields (e.g. resourceRefs) injected into a claim's spec must not be propagated to the XR.",
+			params: params{
+				ng: names.NameGeneratorFn(func(_ context.Context, cd resource.Object) error {
+					cd.SetName("cool-claim-random")
+					return nil
+				}),
+				c: &test.MockClient{
+					MockUpdate:       test.NewMockUpdateFn(nil),
+					MockGet:          test.NewMockGetFn(nil),
+					MockStatusUpdate: test.NewMockSubResourceUpdateFn(nil),
+				},
+			},
+			args: args{
+				cm: NewClaim(func(cm *claim.Unstructured) {
+					cm.SetNamespace("default")
+					cm.SetName("cool-claim")
+
+					// Make the claim spec an object.
+					cm.SetCompositionReference(&corev1.ObjectReference{
+						Name: "some-composition",
+					})
+
+					// A user-defined spec field we should propagate.
+					cm.Object["spec"].(map[string]any)["propagateMe"] = "user-value"
+
+					// XR machinery injected into the claim's spec, e.g. via an
+					// XRD schema with x-kubernetes-preserve-unknown-fields: true.
+					// It must not be propagated to the XR.
+					cm.Object["spec"].(map[string]any)["resourceRefs"] = []any{
+						map[string]any{"apiVersion": "v1", "kind": "Secret", "name": "victim"},
+					}
+				}),
+				xr: NewComposite(),
+			},
+			want: want{
+				cm: NewClaim(func(cm *claim.Unstructured) {
+					cm.SetNamespace("default")
+					cm.SetName("cool-claim")
+
+					cm.SetCompositionReference(&corev1.ObjectReference{
+						Name: "some-composition",
+					})
+					cm.SetResourceReference(&reference.Composite{
+						Name: "cool-claim-random",
+					})
+
+					cm.Object["spec"].(map[string]any)["propagateMe"] = "user-value"
+					// The injected field stays on the claim - we only refuse to
+					// copy it onward to the XR.
+					cm.Object["spec"].(map[string]any)["resourceRefs"] = []any{
+						map[string]any{"apiVersion": "v1", "kind": "Secret", "name": "victim"},
+					}
+				}),
+				xr: NewComposite(func(xr *composite.Unstructured) {
+					xr.SetGenerateName("cool-claim-")
+					xr.SetName("cool-claim-random")
+
+					xr.SetLabels(map[string]string{
+						xcrd.LabelKeyClaimNamespace: "default",
+						xcrd.LabelKeyClaimName:      "cool-claim",
+					})
+
+					xr.SetClaimReference(&reference.Claim{
+						Namespace: "default",
+						Name:      "cool-claim",
+					})
+					xr.SetCompositionReference(&corev1.ObjectReference{
+						Name: "some-composition",
+					})
+
+					xr.Object["spec"].(map[string]any)["propagateMe"] = "user-value"
+					// resourceRefs is deliberately absent: it must not be
+					// propagated from the claim.
+				}),
+				err: nil,
+			},
+		},
 	}
 
 	for name, tc := range cases {

--- a/internal/controller/apiextensions/claim/syncer_ssa.go
+++ b/internal/controller/apiextensions/claim/syncer_ssa.go
@@ -19,6 +19,7 @@ package claim
 import (
 	"context"
 	"fmt"
+	"maps"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -116,26 +117,38 @@ func (s *ServerSideCompositeSyncer) Sync(ctx context.Context, cm *claim.Unstruct
 	}
 
 	// We want to propagate the claim's spec to the composite's spec, but first
-	// we must filter out any well-known fields that are unique to claims. We do
-	// this by:
-	// 1. Grabbing a map whose keys represent all well-known claim fields.
-	// 2. Deleting any well-known fields that we want to propagate.
-	// 3. Using the resulting map keys to filter the claim's spec.
-	wellKnownClaimFields := xcrd.CompositeResourceClaimSpecProps(nil)
+	// we must filter out fields that must not be copied from a claim. We strip
+	// two sets of well-known fields:
+	//
+	//  1. Fields that are unique to claims (e.g. resourceRef), which are
+	//     meaningless on an XR.
+	//  2. XR machinery fields (e.g. resourceRefs and the crossplane stanza)
+	//     that only the XR controller may set. These are not part of a claim's
+	//     API, but a claim whose XRD schema sets
+	//     x-kubernetes-preserve-unknown-fields: true can smuggle them past CRD
+	//     validation. Propagating them would let a claim author inject e.g.
+	//     spec.resourceRefs into the XR, which the XR controller would then act
+	//     on - deleting composed resources or adopting arbitrary ones.
+	//
+	// We do this by building a map whose keys are all of those well-known
+	// fields, deleting the ones we do want to propagate (PropagateSpecProps,
+	// e.g. compositionRef), then using the resulting keys to filter the spec.
+	fieldsToStrip := xcrd.CompositeResourceClaimSpecProps(nil)
+	maps.Copy(fieldsToStrip, xcrd.CompositeResourceSpecProps(v1.CompositeResourceScopeLegacyCluster, nil))
 
 	for _, field := range xcrd.PropagateSpecProps {
 		// Skip propagating compositionRef if enforcedCompositionRef is set
 		if field == "compositionRef" && hasEnforcedComposition {
 			continue
 		}
-		delete(wellKnownClaimFields, field)
+		delete(fieldsToStrip, field)
 	}
 
 	// Propagate composition revision ref from the claim if the update policy is
 	// manual. When the update policy is manual the claim controller is
 	// authoritative for this field. See below for the automatic case.
 	if xr.GetCompositionUpdatePolicy() != nil && *xr.GetCompositionUpdatePolicy() == xpv2.UpdateManual {
-		delete(wellKnownClaimFields, xcrd.CompositionRevisionRef)
+		delete(fieldsToStrip, xcrd.CompositionRevisionRef)
 	}
 
 	cmSpec, ok := cm.Object["spec"].(map[string]any)
@@ -143,8 +156,8 @@ func (s *ServerSideCompositeSyncer) Sync(ctx context.Context, cm *claim.Unstruct
 		return errors.New(errUnsupportedClaimSpec)
 	}
 
-	// Propagate the claim's spec (minus well known fields) to the XR's spec.
-	xrPatch.Object["spec"] = withoutKeys(cmSpec, xcrd.GetPropFields(wellKnownClaimFields)...)
+	// Propagate the claim's spec (minus the filtered fields) to the XR's spec.
+	xrPatch.Object["spec"] = withoutKeys(cmSpec, xcrd.GetPropFields(fieldsToStrip)...)
 
 	// We overwrite the entire XR spec above, so we wait until this point to set
 	// the claim reference.

--- a/internal/controller/apiextensions/claim/syncer_ssa_test.go
+++ b/internal/controller/apiextensions/claim/syncer_ssa_test.go
@@ -430,6 +430,83 @@ func TestServerSideSync(t *testing.T) {
 				}),
 			},
 		},
+		"DoNotPropagateInjectedMachineryFields": {
+			reason: "XR machinery fields (e.g. resourceRefs) injected into a claim's spec must not be propagated to the XR.",
+			params: params{
+				c: &test.MockClient{
+					MockUpdate: test.NewMockUpdateFn(nil),
+					MockPatch: test.NewMockPatchFn(nil, func(obj client.Object) error {
+						obj.(*composite.Unstructured).Object["status"] = map[string]any{
+							"userDefinedField": "status",
+						}
+						return nil
+					}),
+					MockStatusUpdate: test.NewMockSubResourceUpdateFn(nil),
+				},
+				ng: names.NameGeneratorFn(func(_ context.Context, cd resource.Object) error {
+					cd.SetName("cool-claim-random")
+					return nil
+				}),
+			},
+			args: args{
+				cm: NewClaim(func(cm *claim.Unstructured) {
+					cm.SetNamespace("default")
+					cm.SetName("cool-claim")
+
+					// A user-defined field we should propagate, plus XR
+					// machinery injected via an XRD schema with
+					// x-kubernetes-preserve-unknown-fields: true. The machinery
+					// must not be propagated to the XR.
+					cm.Object["spec"] = map[string]any{
+						"userDefinedField": "spec",
+						"resourceRefs": []any{
+							map[string]any{"apiVersion": "v1", "kind": "Secret", "name": "victim"},
+						},
+					}
+				}),
+				xr: NewComposite(),
+			},
+			want: want{
+				cm: NewClaim(func(cm *claim.Unstructured) {
+					cm.SetNamespace("default")
+					cm.SetName("cool-claim")
+					cm.Object["spec"] = map[string]any{
+						"userDefinedField": "spec",
+						// The injected field stays on the claim; we only refuse
+						// to copy it onward to the XR.
+						"resourceRefs": []any{
+							map[string]any{"apiVersion": "v1", "kind": "Secret", "name": "victim"},
+						},
+					}
+					cm.SetResourceReference(&reference.Composite{
+						Name: "cool-claim-random",
+					})
+					cm.Object["status"] = map[string]any{
+						"userDefinedField": "status",
+					}
+				}),
+				xr: NewComposite(func(xr *composite.Unstructured) {
+					xr.SetGenerateName("cool-claim-")
+					xr.SetName("cool-claim-random")
+					xr.SetLabels(map[string]string{
+						xcrd.LabelKeyClaimNamespace: "default",
+						xcrd.LabelKeyClaimName:      "cool-claim",
+					})
+					xr.Object["spec"] = map[string]any{
+						"userDefinedField": "spec",
+						// resourceRefs deliberately absent: it must not be
+						// propagated from the claim.
+					}
+					xr.SetClaimReference(&reference.Claim{
+						Namespace: "default",
+						Name:      "cool-claim",
+					})
+					xr.Object["status"] = map[string]any{
+						"userDefinedField": "status",
+					}
+				}),
+			},
+		},
 		"XRExists": {
 			reason: "When the XR already exists, we should ensure we preserve any custom status conditions.",
 			params: params{


### PR DESCRIPTION
### Description of your changes

The claim→XR syncers copy the claim's spec to the XR after stripping only
well-known *claim* fields. Well-known *XR machinery* fields — notably
`resourceRefs` and the `crossplane` stanza — are not part of a claim's API and
so were never stripped. A claim can't normally carry them, but a claim whose XRD
schema sets `x-kubernetes-preserve-unknown-fields: true` can smuggle them past
CRD validation. A claim author could therefore inject e.g. `spec.resourceRefs`
into the XR, which the XR controller would then act on.

This strips the well-known XR spec fields (minus the ones we deliberately
propagate, e.g. `compositionRef`) when copying a claim's spec to its XR, in both
the client-side and server-side syncers. It's a defense-in-depth guardrail on
the v1 legacy-claim path — the real fix is XRD authors scoping their free-form
region to a dedicated sub-field rather than opening the whole spec root. Related
to the (closed, non-vulnerability) advisory GHSA-77cv-mrm6-fr3c.

New unit tests in both syncers cover that `resourceRefs` and the `crossplane`
stanza are not propagated from a claim to its XR.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [ ] ~~Run `./nix.sh flake check` to ensure this PR is ready for review.~~ Ran `go build ./...`, `go test` on the changed packages, `go vet`, and `gofmt` locally (all clean); the full flake check runs in CI.
- [x] Added or updated unit tests.
- [ ] ~~Added or updated e2e tests.~~ Unit-level guardrail; no new e2e surface.
- [ ] ~~Linked a PR or a [docs tracking issue] to [document this change].~~ Internal behavior only, no user-facing docs change.
- [ ] ~~Added `backport release-x.y` labels to auto-backport this PR.~~ `main` only, no backports.
- [ ] ~~Followed the [API promotion workflow]~~ — no API change.

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md
