### PR TITLE
fix(composite): only garbage collect resources we control

### DIFF
--- a/internal/controller/apiextensions/composite/composition_functions.go
+++ b/internal/controller/apiextensions/composite/composition_functions.go
@@ -970,16 +970,24 @@ func (d *DeletingComposedResourceGarbageCollector) GarbageCollectComposedResourc
 	do := &client.DeleteOptions{}
 	client.PropagationPolicy(metav1.DeletePropagationForeground).ApplyToDelete(do)
 	for name, cd := range del {
-		// Don't garbage collect composed resources that someone else controls.
+		// Only garbage collect composed resources that we actually control.
 		//
-		// We do garbage collect composed resources that no-one controls. If a
-		// composed resource appears in observed (i.e. appears in the XR's
-		// spec.resourceRefs) but doesn't have a controller ref, most likely we
-		// created it but its controller ref was stripped. In this situation it
-		// would be permissible for us to adopt the composed resource by setting
-		// our XR as the controller ref, then delete it. So we may as well just
-		// go straight to deleting it.
-		if c := metav1.GetControllerOf(cd.Resource); c != nil && c.UID != owner.GetUID() {
+		// We set ourselves as the controller reference of every resource we
+		// compose, so a resource whose controller reference isn't ours is not
+		// ours to delete - even though it appears in observed because it's
+		// referenced by the XR's spec.resourceRefs. Deleting a resource we don't
+		// control would let anyone able to edit spec.resourceRefs use us as a
+		// confused deputy to delete arbitrary resources (see
+		// GHSA-77cv-mrm6-fr3c).
+		switch c := metav1.GetControllerOf(cd.Resource); {
+		case c == nil:
+			// No controller reference: we can't prove we composed this resource,
+			// so we never delete it. A resource we did compose can transiently
+			// lose its controller reference - e.g. a backup/restore that doesn't
+			// preserve owner UIDs - and will be re-adopted and collected on a
+			// later reconcile once the reference is restored.
+			continue
+		case c.UID != owner.GetUID():
 			return errors.Errorf(errFmtControllerMismatch, name, c.Kind, c.Name)
 		}
 

--- a/internal/controller/apiextensions/composite/composition_functions_test.go
+++ b/internal/controller/apiextensions/composite/composition_functions_test.go
@@ -1938,6 +1938,35 @@ func TestGarbageCollectComposedResources(t *testing.T) {
 				err: errors.New(`refusing to delete composed resource "undesired-resource" that is controlled by XR "different"`),
 			},
 		},
+		"OrphanedResourceNotDeleted": {
+			reason: "A referenced resource with no controller reference is not one we can prove we composed, so we must not delete it - even though it's observed and undesired.",
+			params: params{
+				client: &test.MockClient{
+					// Update and Delete are nil functions and would panic if
+					// called, proving we neither cleaned up labels nor deleted.
+				},
+			},
+			args: args{
+				owner: &fake.Composite{
+					ObjectMeta: metav1.ObjectMeta{
+						UID: "cool-xr",
+					},
+				},
+				observed: ComposedResourceStates{
+					"undesired-resource": ComposedResourceState{Resource: &fake.Composed{
+						ObjectMeta: metav1.ObjectMeta{
+							// This resource has no controller reference. It could
+							// be an arbitrary resource smuggled into the XR's
+							// spec.resourceRefs, so we leave it alone.
+							Name: "orphan",
+						},
+					}},
+				},
+			},
+			want: want{
+				err: nil,
+			},
+		},
 		"UpdateError": {
 			reason: "We should return any error encountered updating the resource with removed labels.",
 			params: params{

--- a/internal/render/composite/render_test.go
+++ b/internal/render/composite/render_test.go
@@ -305,7 +305,7 @@ func TestRender(t *testing.T) {
 				CompositeResource: mustStruct(map[string]any{
 					"apiVersion": "example.org/v1alpha1",
 					"kind":       "XLegacyResource",
-					"metadata":   map[string]any{"name": "my-xr"},
+					"metadata":   map[string]any{"name": "my-xr", "uid": "xr-uid"},
 				}),
 				Composition: mustStruct(map[string]any{
 					"metadata": map[string]any{"name": "legacy-composition"},
@@ -325,6 +325,16 @@ func TestRender(t *testing.T) {
 							"name": "obs-1",
 							"annotations": map[string]any{
 								"crossplane.io/composition-resource-name": "obs-1",
+							},
+							"ownerReferences": []any{
+								map[string]any{
+									"apiVersion":         "example.org/v1alpha1",
+									"kind":               "XLegacyResource",
+									"name":               "my-xr",
+									"uid":                "xr-uid",
+									"controller":         true,
+									"blockOwnerDeletion": true,
+								},
 							},
 						},
 					}),
@@ -374,6 +384,16 @@ func TestRender(t *testing.T) {
 								"name": "obs-1",
 								"annotations": map[string]any{
 									"crossplane.io/composition-resource-name": "obs-1",
+								},
+								"ownerReferences": []any{
+									map[string]any{
+										"apiVersion":         "example.org/v1alpha1",
+										"kind":               "XLegacyResource",
+										"name":               "my-xr",
+										"uid":                "xr-uid",
+										"controller":         true,
+										"blockOwnerDeletion": true,
+									},
 								},
 							},
 						}),


### PR DESCRIPTION
### Description of your changes

The composed-resource garbage collector deleted any observed resource that
wasn't in the desired state and had no controller reference, on the assumption
we'd created it and its reference had been stripped. Since observed resources
come straight from the XR's `spec.resourceRefs`, this let anyone able to edit
`resourceRefs` use the composite controller as a confused deputy to delete
arbitrary resources carrying the composition-resource-name annotation but no
controller owner. Related to the (closed, non-vulnerability) advisory
GHSA-77cv-mrm6-fr3c.

Now we only garbage collect a resource whose controller reference points back
to the XR, and never delete one with no controller reference at all. We still
observe every referenced resource, so a composed resource that transiently
loses its controller reference (e.g. across a backup/restore that doesn't
preserve owner UIDs) keeps being tracked and is collected once the reference is
restored — it's just never deleted while unowned.

A new unit test covers that an observed, undesired resource with no controller
reference is left alone rather than deleted.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [ ] ~~Run `./nix.sh flake check` to ensure this PR is ready for review.~~ Ran `go build ./...`, `go test` on the changed packages, `go vet`, and `gofmt` locally (all clean); the full flake check runs in CI.
- [x] Added or updated unit tests.
- [ ] ~~Added or updated e2e tests.~~ Behavior is covered at the unit level.
- [ ] ~~Linked a PR or a [docs tracking issue] to [document this change].~~ Internal behavior only, no user-facing docs change.
- [ ] ~~Added `backport release-x.y` labels to auto-backport this PR.~~ `main` only, no backports.
- [ ] ~~Followed the [API promotion workflow]~~ — no API change.

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md
