### PR TITLE
Scale safe-start runtimes to zero even when a DRC sets replicas

### DIFF
--- a/internal/controller/pkg/runtime/reconciler_test.go
+++ b/internal/controller/pkg/runtime/reconciler_test.go
@@ -1177,8 +1177,8 @@ func TestReconcile(t *testing.T) {
 			},
 		},
 		"RuntimeActivationAwaitingWithDRCExplicitReplicas": {
-			reason: "A safe-start revision with all-inactive MRDs but a DRC that sets explicit replicas should run " +
-				"its runtime (DRC wins over defaultReplicas=0) and be marked RuntimeActive, not AwaitingActivation.",
+			reason: "A safe-start revision with all-inactive MRDs should scale its runtime to zero and be marked " +
+				"AwaitingActivation even when a DRC sets an explicit replica count.",
 			args: args{
 				mgr: &fake.Manager{
 					Client: &test.MockClient{
@@ -1213,7 +1213,7 @@ func TestReconcile(t *testing.T) {
 							want := &v1.ProviderRevision{}
 							setRuntimeActivationRevision(want, pkgmetav1.ProviderCapabilitySafeStart)
 							want.SetRuntimeConfigRef(&v1.RuntimeConfigReference{Name: "explicit-replicas-rc"})
-							want.SetConditions(v1.RuntimeHealthy(), v1.RuntimeActive())
+							want.SetConditions(v1.RuntimeHealthy(), v1.RuntimeAwaitingActivation().WithMessage("Package runtime is scaled to zero; awaiting the first ManagedResourceDefinition to be activated"))
 
 							if diff := cmp.Diff(want, o); diff != "" {
 								t.Errorf("-want, +got:\n%s", diff)

--- a/internal/controller/pkg/runtime/runtime.go
+++ b/internal/controller/pkg/runtime/runtime.go
@@ -153,7 +153,7 @@ type DeploymentRuntimeBuilder struct {
 	serviceAccountPullSecrets []corev1.LocalObjectReference
 	runtimeConfig             *v1beta1.DeploymentRuntimeConfig
 	pullSecrets               []string
-	defaultReplicas           int32
+	awaitingActivation        bool
 }
 
 // BuilderOption is used to configure a DeploymentRuntimeBuilder.
@@ -185,9 +185,8 @@ func BuilderWithPullSecrets(secrets ...string) BuilderOption {
 
 // BuilderWithMRDs configures the builder with the ManagedResourceDefinitions
 // owned by the package revision. If the revision has the safe-start capability
-// and all its owned MRDs are inactive, the builder defaults the Deployment to
-// zero replicas until the first MRD is activated. Explicit replicas from a
-// deployment runtime config still win.
+// and all its owned MRDs are inactive, the builder scales the Deployment to
+// zero replicas until the first MRD is activated.
 func BuilderWithMRDs(mrds []extv1alpha1.ManagedResourceDefinition) BuilderOption {
 	return func(b *DeploymentRuntimeBuilder) {
 		if !pkgmetav1.CapabilitiesContainFuzzyMatch(b.revision.GetCapabilities(), pkgmetav1.ProviderCapabilitySafeStart) {
@@ -207,7 +206,7 @@ func BuilderWithMRDs(mrds []extv1alpha1.ManagedResourceDefinition) BuilderOption
 				return
 			}
 		}
-		b.defaultReplicas = 0
+		b.awaitingActivation = true
 	}
 }
 
@@ -215,27 +214,14 @@ func BuilderWithMRDs(mrds []extv1alpha1.ManagedResourceDefinition) BuilderOption
 // package runtime should be scaled to zero, awaiting activation of its first
 // ManagedResourceDefinition.
 func (b *DeploymentRuntimeBuilder) AwaitingActivation() bool {
-	if b.defaultReplicas != 0 {
-		return false
-	}
-	// DeploymentWithOptionalReplicas is a no-op when the runtime config
-	// already supplies spec.replicas, so the deployment won't actually run at
-	// zero replicas in that case.
-	if b.runtimeConfig != nil &&
-		b.runtimeConfig.Spec.DeploymentTemplate != nil &&
-		b.runtimeConfig.Spec.DeploymentTemplate.Spec != nil &&
-		b.runtimeConfig.Spec.DeploymentTemplate.Spec.Replicas != nil {
-		return false
-	}
-	return true
+	return b.awaitingActivation
 }
 
 // NewDeploymentRuntimeBuilder returns a new DeploymentRuntimeBuilder.
 func NewDeploymentRuntimeBuilder(pwr v1.PackageRevisionWithRuntime, namespace string, opts ...BuilderOption) *DeploymentRuntimeBuilder {
 	b := &DeploymentRuntimeBuilder{
-		namespace:       namespace,
-		revision:        pwr,
-		defaultReplicas: 1,
+		namespace: namespace,
+		revision:  pwr,
 	}
 
 	for _, o := range opts {
@@ -292,7 +278,7 @@ func (b *DeploymentRuntimeBuilder) Deployment(serviceAccount string, overrides .
 		// Optional defaults, will be used only if the runtime config does not
 		// specify them.
 		DeploymentWithOptionalName(b.revision.GetName()),
-		DeploymentWithOptionalReplicas(b.defaultReplicas),
+		DeploymentWithOptionalReplicas(1),
 		DeploymentWithOptionalPodSecurityContext(&corev1.PodSecurityContext{
 			RunAsNonRoot: &RunAsNonRoot,
 			RunAsUser:    &RunAsUser,
@@ -320,6 +306,15 @@ func (b *DeploymentRuntimeBuilder) Deployment(serviceAccount string, overrides .
 			},
 		}),
 	)
+
+	if b.awaitingActivation {
+		// Scale the runtime to zero while awaiting activation, overriding any
+		// replica count from the deployment runtime config. A provider only
+		// asks for multiple replicas for leader-election standby or webhook
+		// redundancy, neither of which matters while none of its managed
+		// resources are being reconciled.
+		allOverrides = append(allOverrides, DeploymentWithReplicas(0))
+	}
 
 	for _, s := range b.pullSecrets {
 		allOverrides = append(allOverrides, DeploymentWithAdditionalPullSecret(corev1.LocalObjectReference{Name: s}))

--- a/internal/controller/pkg/runtime/runtime_override_options.go
+++ b/internal/controller/pkg/runtime/runtime_override_options.go
@@ -123,6 +123,13 @@ func DeploymentWithOptionalReplicas(replicas int32) DeploymentOverride {
 	}
 }
 
+// DeploymentWithReplicas sets the replicas, overriding any existing value.
+func DeploymentWithReplicas(replicas int32) DeploymentOverride {
+	return func(d *appsv1.Deployment) {
+		d.Spec.Replicas = &replicas
+	}
+}
+
 // DeploymentWithSelectors overrides the selectors of a Deployment. It also
 // ensures that the pod template labels always contains the deployment selector.
 func DeploymentWithSelectors(selectors map[string]string) DeploymentOverride {

--- a/internal/controller/pkg/runtime/runtime_test.go
+++ b/internal/controller/pkg/runtime/runtime_test.go
@@ -124,9 +124,8 @@ func TestRuntimeManifestBuilderDeployment(t *testing.T) {
 			reason: "No overrides should result in a deployment with default values",
 			args: args{
 				builder: &DeploymentRuntimeBuilder{
-					revision:        providerRevision,
-					namespace:       namespace,
-					defaultReplicas: 1,
+					revision:  providerRevision,
+					namespace: namespace,
 				},
 				serviceAccountName: providerRevisionName,
 				overrides:          providerDeploymentOverrides(providerRevision, providerImage),
@@ -139,12 +138,12 @@ func TestRuntimeManifestBuilderDeployment(t *testing.T) {
 			},
 		},
 		"ProviderDeploymentScaleToZero": {
-			reason: "Scale to zero should default the deployment to zero replicas",
+			reason: "Awaiting activation should scale the deployment to zero replicas",
 			args: args{
 				builder: &DeploymentRuntimeBuilder{
-					revision:        providerRevision,
-					namespace:       namespace,
-					defaultReplicas: 0,
+					revision:           providerRevision,
+					namespace:          namespace,
+					awaitingActivation: true,
 				},
 				serviceAccountName: providerRevisionName,
 				overrides:          providerDeploymentOverrides(providerRevision, providerImage),
@@ -159,12 +158,12 @@ func TestRuntimeManifestBuilderDeployment(t *testing.T) {
 			},
 		},
 		"ProviderDeploymentScaleToZeroWithRuntimeConfigReplicas": {
-			reason: "Explicit replicas from the runtime config should win over scale to zero",
+			reason: "Awaiting activation should scale to zero even when the runtime config sets an explicit replica count",
 			args: args{
 				builder: &DeploymentRuntimeBuilder{
-					revision:        providerRevision,
-					namespace:       namespace,
-					defaultReplicas: 0,
+					revision:           providerRevision,
+					namespace:          namespace,
+					awaitingActivation: true,
 					runtimeConfig: &v1beta1.DeploymentRuntimeConfig{
 						Spec: v1beta1.DeploymentRuntimeConfigSpec{
 							DeploymentTemplate: &v1beta1.DeploymentTemplate{
@@ -183,7 +182,7 @@ func TestRuntimeManifestBuilderDeployment(t *testing.T) {
 					v1.LabelProvider: providerName,
 					v1.LabelRevision: providerRevisionName,
 				}), func(deployment *appsv1.Deployment) {
-					deployment.Spec.Replicas = ptr.To[int32](3)
+					deployment.Spec.Replicas = ptr.To[int32](0)
 				}),
 			},
 		},
@@ -191,9 +190,8 @@ func TestRuntimeManifestBuilderDeployment(t *testing.T) {
 			reason: "Baseline provided by the runtime config should be applied to the deployment",
 			args: args{
 				builder: &DeploymentRuntimeBuilder{
-					revision:        providerRevision,
-					namespace:       namespace,
-					defaultReplicas: 1,
+					revision:  providerRevision,
+					namespace: namespace,
 					runtimeConfig: &v1beta1.DeploymentRuntimeConfig{
 						Spec: v1beta1.DeploymentRuntimeConfigSpec{
 							DeploymentTemplate: &v1beta1.DeploymentTemplate{
@@ -252,9 +250,8 @@ func TestRuntimeManifestBuilderDeployment(t *testing.T) {
 			reason: "It should be possible to disable default scrape annotations",
 			args: args{
 				builder: &DeploymentRuntimeBuilder{
-					revision:        providerRevision,
-					namespace:       namespace,
-					defaultReplicas: 1,
+					revision:  providerRevision,
+					namespace: namespace,
 					runtimeConfig: &v1beta1.DeploymentRuntimeConfig{
 						Spec: v1beta1.DeploymentRuntimeConfigSpec{
 							DeploymentTemplate: &v1beta1.DeploymentTemplate{
@@ -290,9 +287,8 @@ func TestRuntimeManifestBuilderDeployment(t *testing.T) {
 			reason: "Baseline provided by the runtime config should be applied to the deployment for advanced use cases",
 			args: args{
 				builder: &DeploymentRuntimeBuilder{
-					revision:        providerRevision,
-					namespace:       namespace,
-					defaultReplicas: 1,
+					revision:  providerRevision,
+					namespace: namespace,
 					runtimeConfig: &v1beta1.DeploymentRuntimeConfig{
 						Spec: v1beta1.DeploymentRuntimeConfigSpec{
 							DeploymentTemplate: &v1beta1.DeploymentTemplate{
@@ -390,9 +386,8 @@ func TestRuntimeManifestBuilderDeployment(t *testing.T) {
 			reason: "No overrides should result in a deployment with default values",
 			args: args{
 				builder: &DeploymentRuntimeBuilder{
-					revision:        functionRevision,
-					namespace:       namespace,
-					defaultReplicas: 1,
+					revision:  functionRevision,
+					namespace: namespace,
 				},
 				serviceAccountName: functionRevisionName,
 				overrides:          functionDeploymentOverrides(functionRevision, functionImage),
@@ -432,9 +427,8 @@ func TestRuntimeManifestBuilderService(t *testing.T) {
 			reason: "No runtime config on the builder should result in a service with default values",
 			args: args{
 				builder: &DeploymentRuntimeBuilder{
-					revision:        providerRevision,
-					namespace:       namespace,
-					defaultReplicas: 1,
+					revision:  providerRevision,
+					namespace: namespace,
 				},
 				serviceAccountName: providerRevisionName,
 				overrides: []ServiceOverride{
@@ -891,11 +885,10 @@ func TestBuilderWithMRDs(t *testing.T) {
 			mrds:            []extv1alpha1.ManagedResourceDefinition{inactiveMRD},
 			wantScaleToZero: false,
 		},
-		"RuntimeConfigWithExplicitReplicasNotAwaiting": {
-			// A DeploymentRuntimeConfig that sets spec.replicas wins over
-			// defaultReplicas=0 via DeploymentWithOptionalReplicas, so the
-			// deployment is not actually scaled to zero — AwaitingActivation
-			// must reflect that.
+		"RuntimeConfigWithExplicitReplicas": {
+			// Awaiting activation scales the runtime to zero regardless of an
+			// explicit replica count in the DeploymentRuntimeConfig. The
+			// configured count only takes effect once the runtime is activated.
 			revision: safeStartRevision(),
 			mrds:     []extv1alpha1.ManagedResourceDefinition{inactiveMRD},
 			runtimeConfig: &v1beta1.DeploymentRuntimeConfig{
@@ -907,7 +900,7 @@ func TestBuilderWithMRDs(t *testing.T) {
 					},
 				},
 			},
-			wantScaleToZero: false,
+			wantScaleToZero: true,
 		},
 	}
 


### PR DESCRIPTION
### Description of your changes

Follow-up to #7586.

That PR taught the package runtime reconciler to scale a safe-start provider's runtime Deployment to zero replicas until its first ManagedResourceDefinition becomes active. As merged, an explicit `spec.replicas` in a `DeploymentRuntimeConfig` took precedence and kept the runtime running while awaiting activation.

I think it's safe to scale inactive providers to zero, even when their DRC asks for multiple replicas. A provider only asks for multiple replicas for leader-election standby or webhook redundancy, neither of which matters while none of its managed resources are being reconciled. A replica count in a `DeploymentRuntimeConfig` would now be read as "how many replicas to run *when running*", not a demand to always be running.

This PR makes scale-to-zero win over an explicit replica count. A safe-start revision with no active MRDs now scales to zero regardless of the runtime config, then scales to the configured count (or the default of one) once its first MRD is activated.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `./nix.sh flake check` to ensure this PR is ready for review.
- [x] Added or updated unit tests.
- [ ] ~Added or updated e2e tests.~ The existing runtime activation e2e test still covers the feature; this changes only the runtime-config interaction.
- [ ] ~Linked a PR or a docs tracking issue to document this change.~ Refines behaviour of a feature that has not yet shipped.
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~ Follow-up to an unreleased feature.
- [ ] ~Followed the API promotion workflow if this PR introduces, removes, or promotes an API.~ No API change.

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md
