### PR TITLE
Reject namespaced Usages of cluster-scoped resources

### DIFF
--- a/cluster/webhookconfigurations/usage.yaml
+++ b/cluster/webhookconfigurations/usage.yaml
@@ -29,3 +29,32 @@ webhooks:
         resources:
           - '*'
     sideEffects: None
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: crossplane-usage-scope
+webhooks:
+  - admissionReviewVersions:
+      - v1
+    clientConfig:
+      service:
+        name: webhook-service
+        namespace: system
+        path: /validate-usage-scope
+    # This webhook only exists to give faster feedback than the Usage
+    # controller, which rejects a namespaced Usage of a cluster-scoped
+    # resource at reconcile time. It's therefore safe to ignore failures.
+    failurePolicy: Ignore
+    name: usagescope.protection.crossplane.io
+    rules:
+      - apiGroups:
+          - protection.crossplane.io
+        apiVersions:
+          - '*'
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - usages
+    sideEffects: None

--- a/cluster/webhookconfigurations/usage.yaml
+++ b/cluster/webhookconfigurations/usage.yaml
@@ -57,4 +57,5 @@ webhooks:
           - UPDATE
         resources:
           - usages
+        scope: Namespaced
     sideEffects: None

--- a/internal/controller/protection/usage/reconciler.go
+++ b/internal/controller/protection/usage/reconciler.go
@@ -76,6 +76,8 @@ const (
 	errRemoveFinalizer      = "cannot remove finalizer"
 	errUpdateStatus         = "cannot update status of usage"
 	errParseAPIVersion      = "cannot parse APIVersion"
+
+	errFmtUnsupportedUsage = "a namespaced Usage cannot protect the cluster-scoped resource %s %q - use a ClusterUsage instead"
 )
 
 // Event reasons.
@@ -88,6 +90,7 @@ const (
 	reasonOwnerRefToUsage  event.Reason = "AddOwnerRefToUsage"
 	reasonAddInUseLabel    event.Reason = "AddInUseLabel"
 	reasonRemoveInUseLabel event.Reason = "RemoveInUseLabel"
+	reasonUnsupportedUsage event.Reason = "UnsupportedUsage"
 	reasonAddFinalizer     event.Reason = "AddFinalizer"
 	reasonRemoveFinalizer  event.Reason = "RemoveFinalizer"
 	reasonReplayDeletion   event.Reason = "ReplayDeletion"
@@ -472,6 +475,62 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 		r.record.Event(uu, event.Warning(reasonGetUsed, err))
 
 		return reconcile.Result{}, err
+	}
+
+	// A namespaced Usage can't block deletion of a cluster-scoped resource.
+	// The deletion webhook looks up usages of a cluster-scoped resource by an
+	// index value with an empty namespace, while a namespaced Usage is indexed
+	// under its own namespace, so the webhook would never find this Usage.
+	// Reject the Usage instead of applying an in-use label that misleadingly
+	// suggests the used resource is protected. The API server ignores the
+	// namespace when a cluster-scoped resource is fetched, so we detect this
+	// by the used resource being returned without a namespace.
+	if uu.GetNamespace() != "" && used.GetNamespace() == "" {
+		// Remove a misleading in-use label, unless a usage the deletion
+		// webhook can actually find still needs it.
+		if used.GetLabels()[inUseLabelKey] == "true" {
+			usages, err := r.resource.FindUsageOf(ctx, used)
+			if err != nil {
+				log.Debug(errFindUsages, "error", err)
+				err = errors.Wrap(err, errFindUsages)
+				r.record.Event(uu, event.Warning(reasonFindUsages, err))
+
+				return reconcile.Result{}, err
+			}
+
+			if len(usages) == 0 {
+				meta.RemoveLabels(used, inUseLabelKey)
+
+				if err := r.client.Update(ctx, used); err != nil {
+					log.Debug(errRemoveInUseLabel, "error", err)
+
+					if kerrors.IsConflict(err) {
+						return reconcile.Result{Requeue: true}, nil
+					}
+
+					err = errors.Wrap(err, errRemoveInUseLabel)
+					r.record.Event(uu, event.Warning(reasonRemoveInUseLabel, err))
+
+					return reconcile.Result{}, err
+				}
+			}
+		}
+
+		werr := errors.Errorf(errFmtUnsupportedUsage, used.GetObjectKind().GroupVersionKind(), used.GetName())
+		r.record.Event(uu, event.Warning(reasonUnsupportedUsage, werr))
+		// Mark the Usage Unavailable, not just its sync failed. It might have
+		// (misleadingly) become Available before we started rejecting this
+		// unsupported configuration, and it doesn't protect anything.
+		status.MarkConditions(xpv2.Unavailable(), xpv2.ReconcileError(werr))
+
+		if !cmp.Equal(uu, orig) {
+			if err := r.client.Status().Update(ctx, uu); err != nil {
+				log.Debug(errUpdateStatus, "error", err)
+				return reconcile.Result{}, errors.Wrap(err, errUpdateStatus)
+			}
+		}
+
+		return reconcile.Result{}, werr
 	}
 
 	// Used resource should have in-use label.

--- a/internal/controller/protection/usage/reconciler.go
+++ b/internal/controller/protection/usage/reconciler.go
@@ -530,7 +530,9 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 			}
 		}
 
-		return reconcile.Result{}, werr
+		// Nothing we can retry will fix this - the user must change spec.of,
+		// which triggers a new reconcile. Don't requeue and hot-loop on it.
+		return reconcile.Result{}, nil
 	}
 
 	// Used resource should have in-use label.

--- a/internal/controller/protection/usage/reconciler_test.go
+++ b/internal/controller/protection/usage/reconciler_test.go
@@ -341,9 +341,7 @@ func TestReconcile(t *testing.T) {
 					}}),
 				},
 			},
-			want: want{
-				err: errors.Errorf(errFmtUnsupportedUsage, schema.FromAPIVersionAndKind("example.org/v1", "ClusterThing"), "cluster-resource"),
-			},
+			want: want{},
 		},
 		"RejectsNamespacedUsageOfClusterScopedResourceKeepsLabel": {
 			reason: "We should reject a namespaced Usage of a cluster-scoped resource, but keep the in-use label if other usages of the used resource exist.",
@@ -392,9 +390,7 @@ func TestReconcile(t *testing.T) {
 					}}),
 				},
 			},
-			want: want{
-				err: errors.Errorf(errFmtUnsupportedUsage, schema.FromAPIVersionAndKind("example.org/v1", "ClusterThing"), "cluster-resource"),
-			},
+			want: want{},
 		},
 		"RejectsNamespacedUsageOfClusterScopedResourceNoLabel": {
 			reason: "We should reject a namespaced Usage of a cluster-scoped resource without updating the used resource if it doesn't have the in-use label.",
@@ -442,9 +438,7 @@ func TestReconcile(t *testing.T) {
 					}}),
 				},
 			},
-			want: want{
-				err: errors.Errorf(errFmtUnsupportedUsage, schema.FromAPIVersionAndKind("example.org/v1", "ClusterThing"), "cluster-resource"),
-			},
+			want: want{},
 		},
 		"CannotFindUsagesOnUnsupportedUsage": {
 			reason: "We should return an error if we cannot find usages when rejecting a namespaced Usage of a cluster-scoped resource.",

--- a/internal/controller/protection/usage/reconciler_test.go
+++ b/internal/controller/protection/usage/reconciler_test.go
@@ -446,6 +446,97 @@ func TestReconcile(t *testing.T) {
 				err: errors.Errorf(errFmtUnsupportedUsage, schema.FromAPIVersionAndKind("example.org/v1", "ClusterThing"), "cluster-resource"),
 			},
 		},
+		"CannotFindUsagesOnUnsupportedUsage": {
+			reason: "We should return an error if we cannot find usages when rejecting a namespaced Usage of a cluster-scoped resource.",
+			args: args{
+				mgr: &fake.Manager{},
+				u:   func() protection.Usage { return &protection.InternalUsage{} },
+				f: FinderFn(func(_ context.Context, _ usage.Object) ([]protection.Usage, error) {
+					return nil, errBoom
+				}),
+				opts: []ReconcilerOption{
+					WithClientApplicator(xpresource.ClientApplicator{
+						Client: &test.MockClient{
+							MockGet: test.NewMockGetFn(nil, func(obj client.Object) error {
+								switch o := obj.(type) {
+								case *v1beta1.Usage:
+									o.SetName("protect-cluster-thing")
+									o.SetNamespace("default")
+									o.SetAnnotations(map[string]string{detailsAnnotationKey: "undefined"})
+									o.Spec.Of.APIVersion = "example.org/v1"
+									o.Spec.Of.Kind = "ClusterThing"
+									o.Spec.Of.ResourceRef = &v1beta1.NamespacedResourceRef{Name: "cluster-resource"}
+								case *composed.Unstructured:
+									o.SetNamespace("")
+									o.SetLabels(map[string]string{inUseLabelKey: "true"})
+								default:
+									return errors.New("unexpected object type")
+								}
+								return nil
+							}),
+						},
+					}),
+					WithSelectorResolver(fakeSelectorResolver{
+						resourceSelectorFn: func(_ context.Context, _ protection.Usage) error {
+							return nil
+						},
+					}),
+					WithFinalizer(xpresource.FinalizerFns{AddFinalizerFn: func(_ context.Context, _ xpresource.Object) error {
+						return nil
+					}}),
+				},
+			},
+			want: want{
+				err: errors.Wrap(errBoom, errFindUsages),
+			},
+		},
+		"CannotRemoveLabelOnUnsupportedUsage": {
+			reason: "We should return an error if we cannot remove in use label when rejecting a namespaced Usage of a cluster-scoped resource.",
+			args: args{
+				mgr: &fake.Manager{},
+				u:   func() protection.Usage { return &protection.InternalUsage{} },
+				f: FinderFn(func(_ context.Context, _ usage.Object) ([]protection.Usage, error) {
+					return nil, nil
+				}),
+				opts: []ReconcilerOption{
+					WithClientApplicator(xpresource.ClientApplicator{
+						Client: &test.MockClient{
+							MockGet: test.NewMockGetFn(nil, func(obj client.Object) error {
+								switch o := obj.(type) {
+								case *v1beta1.Usage:
+									o.SetName("protect-cluster-thing")
+									o.SetNamespace("default")
+									o.SetAnnotations(map[string]string{detailsAnnotationKey: "undefined"})
+									o.Spec.Of.APIVersion = "example.org/v1"
+									o.Spec.Of.Kind = "ClusterThing"
+									o.Spec.Of.ResourceRef = &v1beta1.NamespacedResourceRef{Name: "cluster-resource"}
+								case *composed.Unstructured:
+									o.SetNamespace("")
+									o.SetLabels(map[string]string{inUseLabelKey: "true"})
+								default:
+									return errors.New("unexpected object type")
+								}
+								return nil
+							}),
+							MockUpdate: test.NewMockUpdateFn(nil, func(_ client.Object) error {
+								return errBoom
+							}),
+						},
+					}),
+					WithSelectorResolver(fakeSelectorResolver{
+						resourceSelectorFn: func(_ context.Context, _ protection.Usage) error {
+							return nil
+						},
+					}),
+					WithFinalizer(xpresource.FinalizerFns{AddFinalizerFn: func(_ context.Context, _ xpresource.Object) error {
+						return nil
+					}}),
+				},
+			},
+			want: want{
+				err: errors.Wrap(errBoom, errRemoveInUseLabel),
+			},
+		},
 		"CannotGetUsingResource": {
 			reason: "We should return an error if we cannot get using resource.",
 			args: args{

--- a/internal/controller/protection/usage/reconciler_test.go
+++ b/internal/controller/protection/usage/reconciler_test.go
@@ -279,6 +279,173 @@ func TestReconcile(t *testing.T) {
 				err: errors.Wrap(errBoom, errAddInUseLabel),
 			},
 		},
+		"RejectsNamespacedUsageOfClusterScopedResource": {
+			reason: "We should reject a namespaced Usage of a cluster-scoped resource, and remove the misleading in-use label from the used resource.",
+			args: args{
+				mgr: &fake.Manager{},
+				u:   func() protection.Usage { return &protection.InternalUsage{} },
+				f: FinderFn(func(_ context.Context, _ usage.Object) ([]protection.Usage, error) {
+					return nil, nil
+				}),
+				opts: []ReconcilerOption{
+					WithClientApplicator(xpresource.ClientApplicator{
+						Client: &test.MockClient{
+							MockGet: test.NewMockGetFn(nil, func(obj client.Object) error {
+								switch o := obj.(type) {
+								case *v1beta1.Usage:
+									o.SetName("protect-cluster-thing")
+									o.SetNamespace("default")
+									o.SetAnnotations(map[string]string{detailsAnnotationKey: "undefined"})
+									o.Spec.Of.APIVersion = "example.org/v1"
+									o.Spec.Of.Kind = "ClusterThing"
+									o.Spec.Of.ResourceRef = &v1beta1.NamespacedResourceRef{Name: "cluster-resource"}
+								case *composed.Unstructured:
+									// The API server ignores the namespace when
+									// a cluster-scoped resource is fetched, and
+									// returns the resource without one.
+									o.SetNamespace("")
+									o.SetLabels(map[string]string{inUseLabelKey: "true"})
+								default:
+									return errors.New("unexpected object type")
+								}
+								return nil
+							}),
+							MockUpdate: test.NewMockUpdateFn(nil, func(obj client.Object) error {
+								if o, ok := obj.(*composed.Unstructured); ok {
+									if _, ok := o.GetLabels()[inUseLabelKey]; ok {
+										t.Errorf("expected %s label to be removed", inUseLabelKey)
+									}
+									return nil
+								}
+								return errors.New("unexpected object type")
+							}),
+							MockStatusUpdate: test.NewMockSubResourceUpdateFn(nil, func(obj client.Object) error {
+								o := obj.(*v1beta1.Usage)
+								if got := o.Status.GetCondition(xpv2.TypeSynced); got.Reason != xpv2.ReasonReconcileError {
+									t.Errorf("expected synced condition with reason %s, got %s", xpv2.ReasonReconcileError, got.Reason)
+								}
+								if got := o.Status.GetCondition(xpv2.TypeReady); got.Reason != xpv2.ReasonUnavailable {
+									t.Errorf("expected ready condition with reason %s, got %s", xpv2.ReasonUnavailable, got.Reason)
+								}
+								return nil
+							}),
+						},
+					}),
+					WithSelectorResolver(fakeSelectorResolver{
+						resourceSelectorFn: func(_ context.Context, _ protection.Usage) error {
+							return nil
+						},
+					}),
+					WithFinalizer(xpresource.FinalizerFns{AddFinalizerFn: func(_ context.Context, _ xpresource.Object) error {
+						return nil
+					}}),
+				},
+			},
+			want: want{
+				err: errors.Errorf(errFmtUnsupportedUsage, schema.FromAPIVersionAndKind("example.org/v1", "ClusterThing"), "cluster-resource"),
+			},
+		},
+		"RejectsNamespacedUsageOfClusterScopedResourceKeepsLabel": {
+			reason: "We should reject a namespaced Usage of a cluster-scoped resource, but keep the in-use label if other usages of the used resource exist.",
+			args: args{
+				mgr: &fake.Manager{},
+				u:   func() protection.Usage { return &protection.InternalUsage{} },
+				f: FinderFn(func(_ context.Context, _ usage.Object) ([]protection.Usage, error) {
+					return []protection.Usage{&protection.InternalClusterUsage{}}, nil
+				}),
+				opts: []ReconcilerOption{
+					WithClientApplicator(xpresource.ClientApplicator{
+						Client: &test.MockClient{
+							MockGet: test.NewMockGetFn(nil, func(obj client.Object) error {
+								switch o := obj.(type) {
+								case *v1beta1.Usage:
+									o.SetName("protect-cluster-thing")
+									o.SetNamespace("default")
+									o.SetAnnotations(map[string]string{detailsAnnotationKey: "undefined"})
+									o.Spec.Of.APIVersion = "example.org/v1"
+									o.Spec.Of.Kind = "ClusterThing"
+									o.Spec.Of.ResourceRef = &v1beta1.NamespacedResourceRef{Name: "cluster-resource"}
+								case *composed.Unstructured:
+									o.SetNamespace("")
+									o.SetLabels(map[string]string{inUseLabelKey: "true"})
+								default:
+									return errors.New("unexpected object type")
+								}
+								return nil
+							}),
+							MockUpdate: test.NewMockUpdateFn(nil, func(obj client.Object) error {
+								if _, ok := obj.(*composed.Unstructured); ok {
+									t.Errorf("expected in-use label to be kept - another usage needs it")
+								}
+								return nil
+							}),
+							MockStatusUpdate: test.NewMockSubResourceUpdateFn(nil),
+						},
+					}),
+					WithSelectorResolver(fakeSelectorResolver{
+						resourceSelectorFn: func(_ context.Context, _ protection.Usage) error {
+							return nil
+						},
+					}),
+					WithFinalizer(xpresource.FinalizerFns{AddFinalizerFn: func(_ context.Context, _ xpresource.Object) error {
+						return nil
+					}}),
+				},
+			},
+			want: want{
+				err: errors.Errorf(errFmtUnsupportedUsage, schema.FromAPIVersionAndKind("example.org/v1", "ClusterThing"), "cluster-resource"),
+			},
+		},
+		"RejectsNamespacedUsageOfClusterScopedResourceNoLabel": {
+			reason: "We should reject a namespaced Usage of a cluster-scoped resource without updating the used resource if it doesn't have the in-use label.",
+			args: args{
+				mgr: &fake.Manager{},
+				u:   func() protection.Usage { return &protection.InternalUsage{} },
+				f: FinderFn(func(_ context.Context, _ usage.Object) ([]protection.Usage, error) {
+					return nil, errors.New("unexpected call to FindUsageOf")
+				}),
+				opts: []ReconcilerOption{
+					WithClientApplicator(xpresource.ClientApplicator{
+						Client: &test.MockClient{
+							MockGet: test.NewMockGetFn(nil, func(obj client.Object) error {
+								switch o := obj.(type) {
+								case *v1beta1.Usage:
+									o.SetName("protect-cluster-thing")
+									o.SetNamespace("default")
+									o.SetAnnotations(map[string]string{detailsAnnotationKey: "undefined"})
+									o.Spec.Of.APIVersion = "example.org/v1"
+									o.Spec.Of.Kind = "ClusterThing"
+									o.Spec.Of.ResourceRef = &v1beta1.NamespacedResourceRef{Name: "cluster-resource"}
+								case *composed.Unstructured:
+									o.SetNamespace("")
+								default:
+									return errors.New("unexpected object type")
+								}
+								return nil
+							}),
+							MockUpdate: test.NewMockUpdateFn(nil, func(obj client.Object) error {
+								if _, ok := obj.(*composed.Unstructured); ok {
+									t.Errorf("unexpected update of the used resource")
+								}
+								return nil
+							}),
+							MockStatusUpdate: test.NewMockSubResourceUpdateFn(nil),
+						},
+					}),
+					WithSelectorResolver(fakeSelectorResolver{
+						resourceSelectorFn: func(_ context.Context, _ protection.Usage) error {
+							return nil
+						},
+					}),
+					WithFinalizer(xpresource.FinalizerFns{AddFinalizerFn: func(_ context.Context, _ xpresource.Object) error {
+						return nil
+					}}),
+				},
+			},
+			want: want{
+				err: errors.Errorf(errFmtUnsupportedUsage, schema.FromAPIVersionAndKind("example.org/v1", "ClusterThing"), "cluster-resource"),
+			},
+		},
 		"CannotGetUsingResource": {
 			reason: "We should return an error if we cannot get using resource.",
 			args: args{

--- a/internal/webhook/protection/usage/handler.go
+++ b/internal/webhook/protection/usage/handler.go
@@ -51,6 +51,9 @@ const (
 func SetupWebhookWithManager(mgr ctrl.Manager, f Finder, options controller.Options) {
 	h := NewHandler(xpunstructured.NewClient(mgr.GetClient()), f, WithLogger(options.Logger.WithValues("webhook", "no-usages")))
 	mgr.GetWebhookServer().Register("/validate-no-usages", &webhook.Admission{Handler: h})
+
+	s := NewScopeHandler(mgr.GetRESTMapper(), WithScopeLogger(options.Logger.WithValues("webhook", "usage-scope")))
+	mgr.GetWebhookServer().Register("/validate-usage-scope", &webhook.Admission{Handler: s})
 }
 
 // A Finder finds usages.

--- a/internal/webhook/protection/usage/scope.go
+++ b/internal/webhook/protection/usage/scope.go
@@ -1,0 +1,143 @@
+/*
+Copyright 2026 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package usage
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	admissionv1 "k8s.io/api/admission/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	"github.com/crossplane/crossplane-runtime/v2/pkg/errors"
+	"github.com/crossplane/crossplane-runtime/v2/pkg/logging"
+	xpmeta "github.com/crossplane/crossplane-runtime/v2/pkg/meta"
+
+	"github.com/crossplane/crossplane/apis/v2/protection/v1beta1"
+)
+
+// Error strings.
+const (
+	errFmtUnexpectedScopeOp = "unexpected operation %q, expected \"CREATE\" or \"UPDATE\""
+	errFmtClusterScopedOf   = "a namespaced Usage cannot protect the cluster-scoped resource kind %s - use a ClusterUsage instead"
+)
+
+// A ScopeHandler validates that a namespaced Usage only uses namespaced
+// resources. A namespaced Usage can't block deletion of a cluster-scoped
+// resource, so we reject it at admission time. This gives faster feedback
+// than the error condition the Usage controller would set.
+type ScopeHandler struct {
+	mapper meta.RESTMapper
+	log    logging.Logger
+}
+
+// ScopeHandlerOption is used to configure the ScopeHandler.
+type ScopeHandlerOption func(*ScopeHandler)
+
+// WithScopeLogger configures the logger for the ScopeHandler.
+func WithScopeLogger(l logging.Logger) ScopeHandlerOption {
+	return func(h *ScopeHandler) {
+		h.log = l
+	}
+}
+
+// NewScopeHandler returns a new ScopeHandler.
+func NewScopeHandler(mapper meta.RESTMapper, opts ...ScopeHandlerOption) *ScopeHandler {
+	h := &ScopeHandler{
+		mapper: mapper,
+		log:    logging.NewNopLogger(),
+	}
+
+	for _, opt := range opts {
+		opt(h)
+	}
+
+	return h
+}
+
+// Handle handles the admission request, validating that a namespaced Usage
+// doesn't use a cluster-scoped resource.
+func (h *ScopeHandler) Handle(_ context.Context, request admission.Request) admission.Response {
+	switch request.Operation {
+	case admissionv1.Create, admissionv1.Update:
+		// The only operations we validate.
+	case admissionv1.Delete, admissionv1.Connect:
+		return admission.Errored(http.StatusBadRequest, errors.Errorf(errFmtUnexpectedScopeOp, request.Operation))
+	default:
+		return admission.Errored(http.StatusBadRequest, errors.Errorf(errFmtUnexpectedScopeOp, request.Operation))
+	}
+
+	u := &v1beta1.Usage{}
+	if err := json.Unmarshal(request.Object.Raw, u); err != nil {
+		return admission.Errored(http.StatusBadRequest, err)
+	}
+
+	// Never deny an update to a Usage that's being deleted. Denying it would
+	// block removing the Usage's finalizers - notably the one the Usage
+	// controller adds - leaving the Usage stuck terminating. A Usage that's
+	// being deleted can't begin to protect anything, so there's nothing to
+	// validate.
+	if xpmeta.WasDeleted(u) {
+		return admission.Allowed("")
+	}
+
+	// Only deny an update that changes what resource the Usage uses. A Usage
+	// that uses a cluster-scoped resource might predate this webhook. Denying
+	// every update would make such a Usage impossible to mutate or delete -
+	// even removing a finalizer is an update. The Usage controller rejects
+	// what we allow here; this webhook only prevents introducing new usages
+	// of cluster-scoped resources.
+	if request.Operation == admissionv1.Update {
+		old := &v1beta1.Usage{}
+		if err := json.Unmarshal(request.OldObject.Raw, old); err != nil {
+			return admission.Errored(http.StatusBadRequest, err)
+		}
+
+		if u.Spec.Of.APIVersion == old.Spec.Of.APIVersion && u.Spec.Of.Kind == old.Spec.Of.Kind {
+			return admission.Allowed("")
+		}
+	}
+
+	gv, err := schema.ParseGroupVersion(u.Spec.Of.APIVersion)
+	if err != nil {
+		// The Usage controller returns an error for an APIVersion it can't
+		// parse. Allow the Usage so the controller can surface it.
+		return admission.Allowed("")
+	}
+
+	gvk := gv.WithKind(u.Spec.Of.Kind)
+
+	m, err := h.mapper.RESTMapping(gvk.GroupKind(), gvk.Version)
+	if err != nil {
+		// We can't determine the scope of a kind we don't know about, for
+		// example a kind whose CRD isn't installed yet. Allow the Usage - the
+		// Usage controller will reject it if its used resource turns out to
+		// be cluster-scoped.
+		h.log.Debug("Cannot determine scope of the used resource. Allowing the request.", "gvk", gvk, "error", err)
+		return admission.Allowed("")
+	}
+
+	if m.Scope.Name() == meta.RESTScopeNameRoot {
+		return admission.Denied(fmt.Sprintf(errFmtClusterScopedOf, gvk))
+	}
+
+	return admission.Allowed("")
+}

--- a/internal/webhook/protection/usage/scope_test.go
+++ b/internal/webhook/protection/usage/scope_test.go
@@ -1,0 +1,336 @@
+/*
+Copyright 2026 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package usage
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	admissionv1 "k8s.io/api/admission/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	"github.com/crossplane/crossplane-runtime/v2/pkg/errors"
+
+	"github.com/crossplane/crossplane/apis/v2/protection/v1beta1"
+)
+
+var _ admission.Handler = &ScopeHandler{}
+
+type mockRESTMapper struct {
+	meta.RESTMapper
+
+	fn func(gk schema.GroupKind, versions ...string) (*meta.RESTMapping, error)
+}
+
+func (m *mockRESTMapper) RESTMapping(gk schema.GroupKind, versions ...string) (*meta.RESTMapping, error) {
+	return m.fn(gk, versions...)
+}
+
+func TestScopeHandle(t *testing.T) {
+	type params struct {
+		mapper meta.RESTMapper
+		opts   []ScopeHandlerOption
+	}
+
+	type args struct {
+		request admission.Request
+	}
+
+	type want struct {
+		resp admission.Response
+	}
+
+	cases := map[string]struct {
+		reason string
+		params params
+		args   args
+		want   want
+	}{
+		"UnexpectedDelete": {
+			reason: "We should return an error if the request is a delete (not a create or update).",
+			args: args{
+				request: admission.Request{
+					AdmissionRequest: admissionv1.AdmissionRequest{
+						Operation: admissionv1.Delete,
+					},
+				},
+			},
+			want: want{
+				resp: admission.Errored(http.StatusBadRequest, errors.Errorf(errFmtUnexpectedScopeOp, admissionv1.Delete)),
+			},
+		},
+		"UnexpectedConnect": {
+			reason: "We should return an error if the request is a connect (not a create or update).",
+			args: args{
+				request: admission.Request{
+					AdmissionRequest: admissionv1.AdmissionRequest{
+						Operation: admissionv1.Connect,
+					},
+				},
+			},
+			want: want{
+				resp: admission.Errored(http.StatusBadRequest, errors.Errorf(errFmtUnexpectedScopeOp, admissionv1.Connect)),
+			},
+		},
+		"UnexpectedOperation": {
+			reason: "We should return an error if the request is unknown (not a create or update).",
+			args: args{
+				request: admission.Request{
+					AdmissionRequest: admissionv1.AdmissionRequest{
+						Operation: admissionv1.Operation("unknown"),
+					},
+				},
+			},
+			want: want{
+				resp: admission.Errored(http.StatusBadRequest, errors.Errorf(errFmtUnexpectedScopeOp, admissionv1.Operation("unknown"))),
+			},
+		},
+		"UnmarshalError": {
+			reason: "We should return an error if we cannot unmarshal the Usage.",
+			args: args{
+				request: admission.Request{
+					AdmissionRequest: admissionv1.AdmissionRequest{
+						Operation: admissionv1.Create,
+						Object:    runtime.RawExtension{Raw: []byte("not-json")},
+					},
+				},
+			},
+			want: want{
+				resp: admission.Errored(http.StatusBadRequest, json.Unmarshal([]byte("not-json"), &v1beta1.Usage{})),
+			},
+		},
+		"AllowedUnparseableAPIVersion": {
+			reason: "We should allow a Usage with an unparseable APIVersion. The Usage controller returns an error for it.",
+			args: args{
+				request: admission.Request{
+					AdmissionRequest: admissionv1.AdmissionRequest{
+						Operation: admissionv1.Create,
+						Object: runtime.RawExtension{Raw: []byte(`{
+							"apiVersion": "protection.crossplane.io/v1beta1",
+							"kind": "Usage",
+							"metadata": {"name": "protect", "namespace": "default"},
+							"spec": {"of": {"apiVersion": "/invalid/", "kind": "Thing", "resourceRef": {"name": "thing"}}}
+						}`)},
+					},
+				},
+			},
+			want: want{
+				resp: admission.Allowed(""),
+			},
+		},
+		"AllowedUnknownKind": {
+			reason: "We should allow a Usage of a kind whose scope we can't determine, e.g. because its CRD isn't installed yet.",
+			params: params{
+				mapper: &mockRESTMapper{fn: func(_ schema.GroupKind, _ ...string) (*meta.RESTMapping, error) {
+					return nil, errBoom
+				}},
+			},
+			args: args{
+				request: admission.Request{
+					AdmissionRequest: admissionv1.AdmissionRequest{
+						Operation: admissionv1.Create,
+						Object: runtime.RawExtension{Raw: []byte(`{
+							"apiVersion": "protection.crossplane.io/v1beta1",
+							"kind": "Usage",
+							"metadata": {"name": "protect", "namespace": "default"},
+							"spec": {"of": {"apiVersion": "example.org/v1", "kind": "Unknown", "resourceRef": {"name": "thing"}}}
+						}`)},
+					},
+				},
+			},
+			want: want{
+				resp: admission.Allowed(""),
+			},
+		},
+		"AllowedNamespacedResource": {
+			reason: "We should allow a namespaced Usage of a namespaced resource.",
+			params: params{
+				mapper: &mockRESTMapper{fn: func(_ schema.GroupKind, _ ...string) (*meta.RESTMapping, error) {
+					return &meta.RESTMapping{Scope: meta.RESTScopeNamespace}, nil
+				}},
+			},
+			args: args{
+				request: admission.Request{
+					AdmissionRequest: admissionv1.AdmissionRequest{
+						Operation: admissionv1.Create,
+						Object: runtime.RawExtension{Raw: []byte(`{
+							"apiVersion": "protection.crossplane.io/v1beta1",
+							"kind": "Usage",
+							"metadata": {"name": "protect", "namespace": "default"},
+							"spec": {"of": {"apiVersion": "example.org/v1", "kind": "Thing", "resourceRef": {"name": "thing"}}}
+						}`)},
+					},
+				},
+			},
+			want: want{
+				resp: admission.Allowed(""),
+			},
+		},
+		"DeniedClusterScopedResource": {
+			reason: "We should deny a namespaced Usage of a cluster-scoped resource.",
+			params: params{
+				mapper: &mockRESTMapper{fn: func(_ schema.GroupKind, _ ...string) (*meta.RESTMapping, error) {
+					return &meta.RESTMapping{Scope: meta.RESTScopeRoot}, nil
+				}},
+			},
+			args: args{
+				request: admission.Request{
+					AdmissionRequest: admissionv1.AdmissionRequest{
+						Operation: admissionv1.Create,
+						Object: runtime.RawExtension{Raw: []byte(`{
+							"apiVersion": "protection.crossplane.io/v1beta1",
+							"kind": "Usage",
+							"metadata": {"name": "protect", "namespace": "default"},
+							"spec": {"of": {"apiVersion": "example.org/v1", "kind": "ClusterThing", "resourceRef": {"name": "cluster-resource"}}}
+						}`)},
+					},
+				},
+			},
+			want: want{
+				resp: admission.Denied(fmt.Sprintf(errFmtClusterScopedOf, schema.FromAPIVersionAndKind("example.org/v1", "ClusterThing"))),
+			},
+		},
+		"DeniedUpdatedToClusterScopedResourceBySelector": {
+			reason: "We should deny an update that changes a namespaced Usage to use a cluster-scoped resource, even if it uses a resource selector rather than a resource ref.",
+			params: params{
+				mapper: &mockRESTMapper{fn: func(_ schema.GroupKind, _ ...string) (*meta.RESTMapping, error) {
+					return &meta.RESTMapping{Scope: meta.RESTScopeRoot}, nil
+				}},
+			},
+			args: args{
+				request: admission.Request{
+					AdmissionRequest: admissionv1.AdmissionRequest{
+						Operation: admissionv1.Update,
+						Object: runtime.RawExtension{Raw: []byte(`{
+							"apiVersion": "protection.crossplane.io/v1beta1",
+							"kind": "Usage",
+							"metadata": {"name": "protect", "namespace": "default"},
+							"spec": {"of": {"apiVersion": "example.org/v1", "kind": "ClusterThing", "resourceSelector": {"matchLabels": {"env": "prod"}}}}
+						}`)},
+						OldObject: runtime.RawExtension{Raw: []byte(`{
+							"apiVersion": "protection.crossplane.io/v1beta1",
+							"kind": "Usage",
+							"metadata": {"name": "protect", "namespace": "default"},
+							"spec": {"of": {"apiVersion": "example.org/v1", "kind": "Thing", "resourceSelector": {"matchLabels": {"env": "prod"}}}}
+						}`)},
+					},
+				},
+			},
+			want: want{
+				resp: admission.Denied(fmt.Sprintf(errFmtClusterScopedOf, schema.FromAPIVersionAndKind("example.org/v1", "ClusterThing"))),
+			},
+		},
+		"UnmarshalOldObjectError": {
+			reason: "We should return an error if we cannot unmarshal the old Usage on an update.",
+			args: args{
+				request: admission.Request{
+					AdmissionRequest: admissionv1.AdmissionRequest{
+						Operation: admissionv1.Update,
+						Object: runtime.RawExtension{Raw: []byte(`{
+							"apiVersion": "protection.crossplane.io/v1beta1",
+							"kind": "Usage",
+							"metadata": {"name": "protect", "namespace": "default"},
+							"spec": {"of": {"apiVersion": "example.org/v1", "kind": "ClusterThing", "resourceRef": {"name": "cluster-resource"}}}
+						}`)},
+						OldObject: runtime.RawExtension{Raw: []byte("not-json")},
+					},
+				},
+			},
+			want: want{
+				resp: admission.Errored(http.StatusBadRequest, json.Unmarshal([]byte("not-json"), &v1beta1.Usage{})),
+			},
+		},
+		"AllowedUpdateOfDeletedUsage": {
+			reason: "We should allow updates to a Usage that's being deleted, so that its finalizers can be removed. Denying them would leave the Usage stuck terminating - the Usage controller removes its finalizer with an update.",
+			params: params{
+				mapper: &mockRESTMapper{fn: func(_ schema.GroupKind, _ ...string) (*meta.RESTMapping, error) {
+					return &meta.RESTMapping{Scope: meta.RESTScopeRoot}, nil
+				}},
+			},
+			args: args{
+				request: admission.Request{
+					AdmissionRequest: admissionv1.AdmissionRequest{
+						Operation: admissionv1.Update,
+						Object: runtime.RawExtension{Raw: []byte(`{
+							"apiVersion": "protection.crossplane.io/v1beta1",
+							"kind": "Usage",
+							"metadata": {"name": "protect", "namespace": "default", "deletionTimestamp": "2026-07-24T00:00:00Z"},
+							"spec": {"of": {"apiVersion": "example.org/v1", "kind": "ClusterThing", "resourceRef": {"name": "cluster-resource"}}}
+						}`)},
+						OldObject: runtime.RawExtension{Raw: []byte(`{
+							"apiVersion": "protection.crossplane.io/v1beta1",
+							"kind": "Usage",
+							"metadata": {"name": "protect", "namespace": "default", "deletionTimestamp": "2026-07-24T00:00:00Z", "finalizers": ["usage.apiextensions.crossplane.io"]},
+							"spec": {"of": {"apiVersion": "example.org/v1", "kind": "ClusterThing", "resourceRef": {"name": "cluster-resource"}}}
+						}`)},
+					},
+				},
+			},
+			want: want{
+				resp: admission.Allowed(""),
+			},
+		},
+		"AllowedUpdateWithUnchangedOf": {
+			reason: "We should allow an update that doesn't change what resource a Usage uses, even if that resource is cluster-scoped. A Usage that uses a cluster-scoped resource might predate this webhook - it must remain mutable and deletable. The Usage controller surfaces the error.",
+			params: params{
+				mapper: &mockRESTMapper{fn: func(_ schema.GroupKind, _ ...string) (*meta.RESTMapping, error) {
+					return &meta.RESTMapping{Scope: meta.RESTScopeRoot}, nil
+				}},
+			},
+			args: args{
+				request: admission.Request{
+					AdmissionRequest: admissionv1.AdmissionRequest{
+						Operation: admissionv1.Update,
+						Object: runtime.RawExtension{Raw: []byte(`{
+							"apiVersion": "protection.crossplane.io/v1beta1",
+							"kind": "Usage",
+							"metadata": {"name": "protect", "namespace": "default", "annotations": {"example.org/note": "updated"}},
+							"spec": {"of": {"apiVersion": "example.org/v1", "kind": "ClusterThing", "resourceRef": {"name": "cluster-resource"}}}
+						}`)},
+						OldObject: runtime.RawExtension{Raw: []byte(`{
+							"apiVersion": "protection.crossplane.io/v1beta1",
+							"kind": "Usage",
+							"metadata": {"name": "protect", "namespace": "default"},
+							"spec": {"of": {"apiVersion": "example.org/v1", "kind": "ClusterThing", "resourceRef": {"name": "cluster-resource"}}}
+						}`)},
+					},
+				},
+			},
+			want: want{
+				resp: admission.Allowed(""),
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			h := NewScopeHandler(tc.params.mapper, tc.params.opts...)
+
+			got := h.Handle(context.Background(), tc.args.request)
+			if diff := cmp.Diff(tc.want.resp, got); diff != "" {
+				t.Errorf("%s\nh.Handle(...): -want response, +got:\n%s", tc.reason, diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Description of your changes

A namespaced `Usage` that references a cluster-scoped resource in `spec.of` appears to work — the reconciler applies the `crossplane.io/in-use` label — but the deletion webhook doesn't actually block deletion. The root cause is the index-key mismatch described in #7249: the Finder indexes a namespaced `Usage` under its own namespace (`finder.go`'s `ptr.Deref(of.ResourceRef.Namespace, u.GetNamespace())`), while `FindUsageOf` looks up usages of a cluster-scoped resource with an empty namespace, so the webhook never finds the `Usage` and the protection is silently ineffective.

Since a namespaced `Usage` isn't intended to be able to block deletion of cluster-scoped resources (that would let anyone who can create a `Usage` in any namespace block deletion of arbitrary cluster-scoped resources), this PR rejects the unsupported configuration, following the two remedies proposed in the issue:

1. **The `Usage` reconciler rejects it.** After resolving the used resource, if the `Usage` has a namespace but the used resource comes back without one (the API server ignores the namespace when fetching a cluster-scoped resource, so an empty namespace on the fetched resource is the scope signal), the reconciler:
   * removes the misleading `crossplane.io/in-use` label — but only if `FindUsageOf` reports no other usages that still need it (e.g. a valid `ClusterUsage` of the same resource keeps the label),
   * emits an `UnsupportedUsage` warning event, and sets `Ready=False` with reason `Unavailable` and `Synced=False` with reason `ReconcileError` and message `a namespaced Usage cannot protect the cluster-scoped resource <gvk> "<name>" - use a ClusterUsage instead` (the status write is skipped when nothing changed, matching the reconciler's existing pattern).

2. **A new validating admission webhook gives faster feedback.** `ScopeHandler` (registered at `/validate-usage-scope`, applied via a new `crossplane-usage-scope` `ValidatingWebhookConfiguration`) rejects CREATE/UPDATE of a namespaced `Usage` whose `spec.of` kind resolves to cluster scope via the manager's REST mapper. It intentionally fails open when the scope can't be determined (e.g. the used kind's CRD isn't installed yet, or the APIVersion is unparseable) — the reconciler remains the enforcing backstop. Two deliberate exemptions keep pre-existing `Usage` objects in this unsupported configuration (which may predate the webhook, or have been created while it was unavailable) mutable and deletable rather than stuck:
   * it never denies an update to a `Usage` that's being deleted — the `Usage` controller removes its finalizer with a plain update, which would otherwise be denied and leave the `Usage` terminating forever,
   * on UPDATE it only validates when `spec.of`'s `apiVersion`/`kind` changed relative to the old object, so metadata-only and status-adjacent updates (finalizer add/removal, annotations, etc.) of an already-invalid `Usage` are allowed and the reconciler surfaces the error instead.

Things reviewers may want to weigh in on:

* **`failurePolicy: Ignore`** on the new webhook configuration (unlike `crossplane-no-usages`, which uses `Fail`). The webhook is fast-feedback only — the reconciler rejects the configuration regardless — while `Fail` would make all `Usage` creates/updates (including composition-created ones) depend on webhook availability, and would block `Usage` writes entirely if Crossplane runs with `--enable-usages=false` (the init container applies the configuration, but the handler is only registered when usages are enabled). Happy to flip to `Fail` if you'd prefer consistency.
* Pre-existing `Usage` objects in this unsupported configuration will transition from (misleadingly) `Ready=True` to `Ready=False/Unavailable` plus `Synced=False/ReconcileError` after upgrading, and the misleading in-use label is removed. That's the intent of #7249, but it is a user-visible change. Thanks to the webhook exemptions above they remain freely updatable and deletable — following the condition's advice ("use a ClusterUsage instead") just works.
* The pre-existing deletion-path edge discussed in #7253 (deleting an invalid namespaced `Usage` while a valid `ClusterUsage` references the same resource can briefly remove the in-use label until the `ClusterUsage` reconciles) is untouched and out of scope here.
* No e2e tests added since the contributing guide asks to add them only for important cases that can't be covered by unit tests, and to check with maintainers first — happy to add one to the protection e2e suite if you'd like.

Both the reconciler rejection and the webhook are covered by new table-driven unit tests. The reconciler tests fail without the fix (the label was applied, no error condition was set, and reconciliation reported success). The webhook tests include the deletion-in-progress and unchanged-`spec.of` update exemptions, which fail against a naive deny-all-updates handler.

Fixes #7249

Related: #7123 (feature request to support cross-scope usages; per the discussion in #7249 this PR assumes that's not the chosen direction and makes the failure explicit instead of silent)

I have:

- [x] Read and followed Crossplane's [contribution process].
- [ ] Run `./nix.sh flake check` to ensure this PR is ready for review. <!-- TODO(user): run it, then tick this box before opening the PR -->

- [x] Added or updated unit tests.
- [ ] ~Added or updated e2e tests.~ (See note above — happy to add one if desired.)
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~ (No docs change: this makes behavior match the already-documented intent that namespaced Usages protect namespaced resources and ClusterUsages protect cluster-scoped ones.)
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~ (Bug-only fix; I can't add labels — maintainers may want to backport to the supported 2.x releases.)
- [ ] ~Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~ (No API changes.)

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md
