### PR TITLE
chore(renovate): group security-fix PRs into one per branch

### DIFF
--- a/.github/renovate-base.json5
+++ b/.github/renovate-base.json5
@@ -66,6 +66,9 @@
     addLabels: [
       'security',
     ],
+    // Set a static groupName for security fixes so they all get batched into a
+    // single PR per base branch, instead of one per CVE.
+    groupName: 'vulnerable dependencies',
   },
   osvVulnerabilityAlerts: true,
   // Renovate evaluates all packageRules in order, so low priority rules should


### PR DESCRIPTION
### Description of your changes

Renovate raises a separate PR for every vulnerability fix — each CVE gets its own branch (`renovate/<branch>-<dep>-vulnerability`), because `vulnerabilityAlerts` defaults to `groupName: null` with a per-dependency `branchTopic`, and the `packageRules` grouping doesn't apply to vulnerability alerts. Right now that means eight open security PRs across four base branches, three of them on `release-2.1` alone (#7634, #7635, #7636).

Setting `groupName` inside `vulnerabilityAlerts` pulls in Renovate's `group` preset, whose `branchTopic` (`{{groupSlug}}`) overrides the per-dependency topic, so all outstanding security fixes for a branch collapse into a single `vulnerable dependencies` PR. This mirrors what we already run in upbound/uxp and upbound/crossplane.

Config-only change; validated with `npx renovate@43.272.8 renovate-config-validator` (the same command CI runs).

### Reviewer notes

- `local>` presets resolve from the default branch, so this main-only change governs every base branch — no backport needed.
- Trade-off: a grouped PR shares one CI run, so one broken fix blocks the batch — but it removes the sequential rebase train where merging one `go.mod` bump conflicts its siblings.

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [ ] ~~Run `./nix.sh flake check` to ensure this PR is ready for review — config-only change, no code.~~
- [ ] ~~Added or updated unit tests.~~
- [ ] ~~Added or updated e2e tests.~~
- [ ] ~~Linked a PR or a [docs tracking issue] to [document this change].~~
- [ ] ~~Added `backport release-x.y` labels — Renovate reads config from the default branch only; main-only is intentional.~~
- [ ] ~~Followed the [API promotion workflow] — no API change.~~

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md
