### PR TITLE
fix(ci): remove leftover /homeless-shelter before Renovate

### DIFF
--- a/.github/renovate-entrypoint.sh
+++ b/.github/renovate-entrypoint.sh
@@ -17,8 +17,9 @@ experimental-features = nix-command flakes
 build-users-group =
 
 # Build derivations serially. Running one build per core races on the shared
-# HOME (/homeless-shelter) in this rootless, single-user container, which makes
-# Renovate's Nix artifact updates fail intermittently.
+# HOME (/homeless-shelter) in this rootless, single-user container. This stops
+# concurrent builds from colliding; a leftover /homeless-shelter is cleaned up
+# separately below, before Renovate runs.
 max-jobs = 1
 
 # Use the Crossplane Cachix cache to download pre-built binaries from CI.
@@ -36,5 +37,12 @@ echo "Installing Earthly..."
 nix profile install github:crossplane/crossplane#earthly
 export PATH="$HOME/.nix-profile/bin:$PATH"
 earthly bootstrap
+
+# The Earthly install above triggers a Nix build. With the sandbox disabled in
+# this container, Nix uses /homeless-shelter as $HOME and leaves it behind, and
+# then refuses every later non-sandbox build with "home directory
+# '/homeless-shelter' exists". Remove it so Renovate's `nix run .#tidy` and
+# `.#generate` artifact updates start from a clean slate.
+rm -rf /homeless-shelter
 
 renovate


### PR DESCRIPTION
### Description of your changes

Follow-up to #7564, which did not fully fix #7390 — the `home directory '/homeless-shelter' exists` error still reproduces (e.g. #7638 / [this Renovate run](https://github.com/crossplane/crossplane/actions/runs/30130639032/job/89604141095)).

**What the logs actually show.** On the failing run, `nix run .#generate` and `nix run .#tidy` fail even when only a **single** derivation is being built and nothing else is running — so this is not the concurrent-build race we fixed in #7564. `/homeless-shelter` already exists *before* those builds start. It is created earlier, during the `nix profile install …#earthly` step in this entrypoint (that step builds one derivation; with the sandbox disabled Nix uses `/homeless-shelter` as `$HOME` and leaves it behind). Nix then refuses every subsequent non-sandbox build with the purity error.

`max-jobs = 1` prevents concurrent builds from *colliding* on the shared HOME, but it cannot clear a `/homeless-shelter` that a prior step already left behind — which is why the error persists after #7564.

**Fix.** Remove `/homeless-shelter` after the Earthly install, before `renovate` runs. Renovate's own `nix run .#tidy`/`.#generate` builds run serially (with `max-jobs = 1`) and succeed from a clean state, as they do on the runs where Earthly is fully cached and nothing has to build (e.g. the all-green [Apr 20 run](https://github.com/crossplane/crossplane/actions/runs/24657718617)).

I can't reproduce the Renovate container locally, so this is best confirmed by a real Renovate run on this branch. If the error ever recurs from a build *inside* the Renovate step itself (I don't see evidence it does), the fully general fallback is to clean `/homeless-shelter` before every build via a `pre-build-hook` — happy to switch to that if preferred.

This should also land in `crossplane/crossplane-runtime`, which shares this entrypoint.

Fixes #7390

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [ ] ~Run `./nix.sh flake check` to ensure this PR is ready for review.~ (shell-only change, not covered by `flake check`)
- [ ] ~Added or updated unit tests.~
- [ ] ~Added or updated e2e tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~
- [ ] ~Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md