### PR TITLE
build: give every Go build its own writable HOME

### DIFF
--- a/.github/renovate-entrypoint.sh
+++ b/.github/renovate-entrypoint.sh
@@ -16,10 +16,8 @@ experimental-features = nix-command flakes
 # needing to create the nixbld group and users in this ephemeral container.
 build-users-group =
 
-# Build derivations serially. Running one build per core races on the shared
-# HOME (/homeless-shelter) in this rootless, single-user container, which makes
-# Renovate's Nix artifact updates fail intermittently.
-max-jobs = 1
+# Build derivations in parallel, one per CPU core.
+max-jobs = auto
 
 # Use the Crossplane Cachix cache to download pre-built binaries from CI.
 extra-substituters = https://crossplane.cachix.org

--- a/nix/checks.nix
+++ b/nix/checks.nix
@@ -32,7 +32,6 @@ in
 
       checkPhase = ''
         runHook preCheck
-        export HOME=$TMPDIR
         go test -covermode=count -coverprofile=coverage.txt ./cmd/... ./internal/...
         runHook postCheck
       '';
@@ -57,7 +56,6 @@ in
 
       checkPhase = ''
         runHook preCheck
-        export HOME=$TMPDIR
         go test -covermode=count -coverprofile=coverage.txt ./...
         runHook postCheck
       '';
@@ -84,7 +82,6 @@ in
 
       checkPhase = ''
         runHook preCheck
-        export HOME=$TMPDIR
         export GOLANGCI_LINT_CACHE=$TMPDIR/.cache/golangci-lint
         golangci-lint run
         runHook postCheck
@@ -112,7 +109,6 @@ in
 
       checkPhase = ''
         runHook preCheck
-        export HOME=$TMPDIR
         export GOLANGCI_LINT_CACHE=$TMPDIR/.cache/golangci-lint
         golangci-lint run --config=${self}/.golangci.yml
         runHook postCheck
@@ -161,7 +157,6 @@ in
 
       checkPhase = ''
         runHook preCheck
-        export HOME=$TMPDIR
 
         echo "Running go generate..."
         go generate -tags generate .
@@ -210,7 +205,6 @@ in
 
       checkPhase = ''
         runHook preCheck
-        export HOME=$TMPDIR
 
         # cluster/webhookconfigurations contains some non-generated files. Copy
         # the existing version into our build context so we can detect changes

--- a/nix/go-builders.nix
+++ b/nix/go-builders.nix
@@ -20,6 +20,14 @@ let
   vendorHashes = import ./vendor-hashes.nix;
   go = pkgs.unstable.go_1_25;
 
+  # If the Nix sandbox isn't available (e.g. Renovate's container), Nix falls back to building
+  # without it, and $HOME is set to /homeless-shelter on the real filesystem. Give every Go build
+  # its own HOME so we don't ever use /homeless-shelter.
+  goHome = ''
+    export HOME="$NIX_BUILD_TOP/home"
+    mkdir -p "$HOME"
+  '';
+
   # One shared module-download cache per module. Built with the native toolchain
   # (`go mod download` is platform-independent), so every consumer - including
   # cross-compiled binaries - shares the same derivation.
@@ -37,13 +45,19 @@ let
     (mkVendor "crossplane-root" {
       src = self;
       vendorHash = vendorHashes.root;
-    }).goModules;
+    }).goModules.overrideAttrs
+      (o: {
+        preConfigure = (o.preConfigure or "") + goHome;
+      });
 
   apisVendor =
     (mkVendor "crossplane-apis" {
       src = "${self}/apis";
       vendorHash = vendorHashes.apis;
-    }).goModules;
+    }).goModules.overrideAttrs
+      (o: {
+        preConfigure = (o.preConfigure or "") + goHome;
+      });
 
   # Build for a module, injecting that module's shared vendor cache so no
   # per-derivation goModules is built. `goAttrs` lets callers cross-compile by
@@ -64,8 +78,9 @@ let
       }
       // args
     )).overrideAttrs
-      (_: {
+      (o: {
         goModules = modules;
+        preConfigure = (o.preConfigure or "") + goHome;
       });
 in
 {


### PR DESCRIPTION
### Description of your changes

This PR fixes Renovate's post-upgrade tasks, which fail with `error: home directory '/homeless-shelter' exists`, so `nix run .#tidy` and `nix run .#generate` never update our Nix artifacts.

Nix builds without its sandbox in Renovate's container, and `$HOME` is then `/homeless-shelter` on the real filesystem. Once a build creates that directory, Nix refuses to start any later build in the same container. `nix run .#tidy` trips on this by itself, because it refreshes the root and apis vendor hashes as two separate builds and the first breaks the second. The only error that surfaces is `could not determine vendor hash for 'apis'`, which hides what actually went wrong.

This PR gives every Go build its own `HOME` under `$NIX_BUILD_TOP`, from `mkVendor` and `mkBuild` in `nix/go-builders.nix`, which every Go derivation funnels through.

Specific changes:
- `nix/go-builders.nix`: a shared `goHome` snippet appended to `preConfigure` in both vendor derivations and in `mkBuild`
- `nix/checks.nix`: removed the per-check `export HOME=$TMPDIR` lines, which are no longer needed
- `.github/renovate-entrypoint.sh`: set `max-jobs` back to `auto`, reverting #7564

Fixes #7390

### How has this code been tested

I have reproduced the failure and then verified the fix in the real `renovate/renovate:43` image, running this repo's entrypoint the same way [renovate.yml](https://github.com/crossplane/crossplane/blob/main/.github/workflows/renovate.yml) does.

On `main`, we see a `nix trun .#tidy` sets up the `nix run .#generate` to fail:
```
>>> /homeless-shelter: absent
=== nix run .#tidy ===
  root = sha256-eyxrOh2bwxc1rGucHtDkrEvyWMm3fkcOE/adcxl2PYA=
ERROR: could not determine vendor hash for 'apis' (restored previous value)
>>> /homeless-shelter: EXISTS
=== nix run .#generate ===
error: home directory '/homeless-shelter' exists; please remove it to assure purity of builds without sandboxing
```

Then with the fixes in this PR, they can both run successfully:
```
>>> /homeless-shelter: absent
=== nix run .#tidy ===
  root = sha256-eyxrOh2bwxc1rGucHtDkrEvyWMm3fkcOE/adcxl2PYA=
  apis = sha256-LBPg9GFga3rvI5D487ydw+AyE7ezHP07ukxX3PcWLUA=
Done
>>> /homeless-shelter: absent
=== nix run .#generate ===
Done
>>> /homeless-shelter: absent
```

The `nix/vendor-hashes.nix` remains unchanged, so this change keeps that output stable.

I've also tried some commands through the `nix.sh` wrapper, e.g., `./nix.sh build` produces all expected cross-compiled binaries and their images.

### Backport notes

Even though the Renovate job only runs from main, when it's opening PRs and running post-upgrade tasks for previous release branches, it uses the build logic from the release branch it's targeting.  Therefore, we should backport these changes to all Nix based branches, e.g. `release-2.3` and `release-2.2`, but not until we've shown this change to be working on main first.

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `./nix.sh flake check` to ensure this PR is ready for review.
- [ ] ~Added or updated unit tests.~
- [ ] ~Added or updated e2e tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [ ] Added `backport release-x.y` labels to auto-backport this PR.
- [ ] ~Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md
