### PR TITLE
build: give every Go build its own writable HOME

### DIFF
--- a/nix/checks.nix
+++ b/nix/checks.nix
@@ -32,7 +32,6 @@ in
 
       checkPhase = ''
         runHook preCheck
-        export HOME=$TMPDIR
         go test -covermode=count -coverprofile=coverage.txt ./apis/... ./cmd/... ./internal/...
         runHook postCheck
       '';
@@ -59,7 +58,6 @@ in
 
       checkPhase = ''
         runHook preCheck
-        export HOME=$TMPDIR
         export GOLANGCI_LINT_CACHE=$TMPDIR/.cache/golangci-lint
         golangci-lint run
         runHook postCheck
@@ -108,7 +106,6 @@ in
 
       checkPhase = ''
         runHook preCheck
-        export HOME=$TMPDIR
 
         echo "Running go generate..."
         go generate -tags generate .

--- a/nix/go-builders.nix
+++ b/nix/go-builders.nix
@@ -18,6 +18,14 @@ let
   vendorHashes = import ./vendor-hashes.nix;
   go = pkgs.go-unstable;
 
+  # If the Nix sandbox isn't available (e.g. Renovate's container), Nix falls back to building
+  # without it, and $HOME is set to /homeless-shelter on the real filesystem. Give every Go build
+  # its own HOME so we don't ever use /homeless-shelter.
+  goHome = ''
+    export HOME="$NIX_BUILD_TOP/home"
+    mkdir -p "$HOME"
+  '';
+
   # One shared module-download cache per module. Built with the native toolchain
   # (`go mod download` is platform-independent), so every consumer - including
   # cross-compiled binaries - shares the same derivation.
@@ -35,7 +43,10 @@ let
     (mkVendor "crossplane-root" {
       src = self;
       vendorHash = vendorHashes.root;
-    }).goModules;
+    }).goModules.overrideAttrs
+      (o: {
+        preConfigure = (o.preConfigure or "") + goHome;
+      });
 
   # Build for a module, injecting that module's shared vendor cache so no
   # per-derivation goModules is built. `goAttrs` lets callers cross-compile by
@@ -56,8 +67,9 @@ let
       }
       // args
     )).overrideAttrs
-      (_: {
+      (o: {
         goModules = modules;
+        preConfigure = (o.preConfigure or "") + goHome;
       });
 in
 {


### PR DESCRIPTION
### Description of your changes

This PR cherry picks 1c48667be3c825f5aefdc4eb00abce8c8ba415e4 to the release-2.2 branch.

This branch has no apis Go module, so the conflicts were resolved by keeping the same structure but only applied to the single root module instead of both root and apis.

The original commit also set max-jobs back to auto in .github/renovate-entrypoint.sh, which is left out here. This branch never took the max-jobs = 1 change, so it is already using auto and has nothing to revert. The scheduled Renovate workflow also checks out the default branch, so the entrypoint that runs always comes from main no matter which base branch is being updated. Only the nix/ build logic comes from the base branch.

Related to #7390

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `./nix.sh flake check` to ensure this PR is ready for review.
- [ ] ~Added or updated unit tests.~
- [ ] ~Added or updated e2e tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~
- [ ] ~Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md
