### PR TITLE
pkg: Use the real DAG in dependency resolver tests

### DIFF
--- a/internal/controller/pkg/revision/dependency_test.go
+++ b/internal/controller/pkg/revision/dependency_test.go
@@ -161,17 +161,8 @@ func TestResolve(t *testing.T) {
 							return nil
 						}),
 					},
-					newDag: func() dag.DAG {
-						return &dagfake.MockDag{
-							MockInit: func(_ []dag.Node) ([]dag.Node, error) {
-								return nil, nil
-							},
-							MockTraceNode: func(_ string) (map[string]dag.Node, error) {
-								return nil, nil
-							},
-						}
-					},
-					log: logging.NewNopLogger(),
+					newDag: dag.NewMapDag,
+					log:    logging.NewNopLogger(),
 				},
 				meta: &pkgmetav1.Configuration{},
 				pr: &v1.ConfigurationRevision{
@@ -212,18 +203,8 @@ func TestResolve(t *testing.T) {
 							return nil
 						}),
 					},
-					newDag: func() dag.DAG {
-						return &dagfake.MockDag{
-							MockInit: func(_ []dag.Node) ([]dag.Node, error) {
-								return nil, nil
-							},
-							MockTraceNode: func(_ string) (map[string]dag.Node, error) {
-								return nil, nil
-							},
-							MockAddOrUpdateNodes: func(_ ...dag.Node) {},
-						}
-					},
-					log: logging.NewNopLogger(),
+					newDag: dag.NewMapDag,
+					log:    logging.NewNopLogger(),
 				},
 				meta: &pkgmetav1.Configuration{},
 				pr: &v1.ConfigurationRevision{
@@ -248,21 +229,8 @@ func TestResolve(t *testing.T) {
 						}),
 						MockUpdate: test.NewMockUpdateFn(nil),
 					},
-					newDag: func() dag.DAG {
-						return &dagfake.MockDag{
-							MockInit: func(_ []dag.Node) ([]dag.Node, error) {
-								return nil, nil
-							},
-							MockNodeExists: func(_ string) bool {
-								return false
-							},
-							MockAddNode: func(_ dag.Node) error {
-								return nil
-							},
-							MockAddOrUpdateNodes: func(_ ...dag.Node) {},
-						}
-					},
-					log: logging.NewNopLogger(),
+					newDag: dag.NewMapDag,
+					log:    logging.NewNopLogger(),
 				},
 				meta: &pkgmetav1.Configuration{
 					Spec: pkgmetav1.ConfigurationSpec{
@@ -331,32 +299,8 @@ func TestResolve(t *testing.T) {
 						}),
 						MockUpdate: test.NewMockUpdateFn(nil),
 					},
-					newDag: func() dag.DAG {
-						return &dagfake.MockDag{
-							MockInit: func(_ []dag.Node) ([]dag.Node, error) {
-								return []dag.Node{
-									&dag.DependencyNode{
-										Dependency: v1beta1.Dependency{
-											Package: "not-here-2",
-										},
-									},
-									&dag.DependencyNode{
-										Dependency: v1beta1.Dependency{
-											Package: "not-here-3",
-										},
-									},
-								}, nil
-							},
-							MockTraceNode: func(_ string) (map[string]dag.Node, error) {
-								return map[string]dag.Node{
-									"not-here-1": &dag.DependencyNode{},
-									"not-here-2": &dag.DependencyNode{},
-									"not-here-3": &dag.DependencyNode{},
-								}, nil
-							},
-						}
-					},
-					log: logging.NewNopLogger(),
+					newDag: dag.NewMapDag,
+					log:    logging.NewNopLogger(),
 				},
 				meta: &pkgmetav1.Configuration{
 					Spec: pkgmetav1.ConfigurationSpec{
@@ -389,7 +333,7 @@ func TestResolve(t *testing.T) {
 			},
 		},
 		"ErrorSelfExistInvalidDependencies": {
-			reason: "Should return error if self exists and missing dependencies.",
+			reason: "Should return error if self exists and dependencies have incompatible versions.",
 			args: args{
 				dep: &PackageDependencyManager{
 					client: &test.MockClient{
@@ -412,7 +356,8 @@ func TestResolve(t *testing.T) {
 									},
 								},
 								{
-									Source: "not-here-1",
+									Source:  "not-here-1",
+									Version: "v0.0.1",
 									Dependencies: []v1beta1.Dependency{
 										{
 											Package: "not-here-3",
@@ -420,45 +365,21 @@ func TestResolve(t *testing.T) {
 										},
 									},
 								},
+								{
+									Source:  "not-here-2",
+									Version: "v0.0.1",
+								},
+								{
+									Source:  "not-here-3",
+									Version: "v0.0.1",
+								},
 							}
 							return nil
 						}),
 						MockUpdate: test.NewMockUpdateFn(nil),
 					},
-					newDag: func() dag.DAG {
-						return &dagfake.MockDag{
-							MockInit: func(_ []dag.Node) ([]dag.Node, error) {
-								return nil, nil
-							},
-							MockTraceNode: func(_ string) (map[string]dag.Node, error) {
-								return map[string]dag.Node{
-									"not-here-1": &dag.DependencyNode{},
-									"not-here-2": &dag.DependencyNode{},
-									"not-here-3": &dag.DependencyNode{},
-								}, nil
-							},
-							MockGetNode: func(s string) (dag.Node, error) {
-								if s == "not-here-1" {
-									return &dag.PackageNode{
-										LockPackage: v1beta1.LockPackage{
-											Source:  "not-here-1",
-											Version: "v0.0.1",
-										},
-									}, nil
-								}
-								if s == "not-here-2" {
-									return &dag.PackageNode{
-										LockPackage: v1beta1.LockPackage{
-											Source:  "not-here-2",
-											Version: "v0.0.1",
-										},
-									}, nil
-								}
-								return nil, nil
-							},
-						}
-					},
-					log: logging.NewNopLogger(),
+					newDag: dag.NewMapDag,
+					log:    logging.NewNopLogger(),
 				},
 				meta: &pkgmetav1.Configuration{
 					Spec: pkgmetav1.ConfigurationSpec{
@@ -521,7 +442,8 @@ func TestResolve(t *testing.T) {
 									},
 								},
 								{
-									Source: "not-here-1",
+									Source:  "not-here-1",
+									Version: "v0.20.0",
 									Dependencies: []v1beta1.Dependency{
 										{
 											Package: "not-here-3",
@@ -529,58 +451,25 @@ func TestResolve(t *testing.T) {
 										},
 									},
 								},
+								{
+									Source:  "not-here-2",
+									Version: "v0.100.1",
+								},
+								{
+									Source:  "not-here-3",
+									Version: "v0.20.0",
+								},
+								{
+									Source:  "function-not-here-1",
+									Version: "v0.1.0",
+								},
 							}
 							return nil
 						}),
 						MockUpdate: test.NewMockUpdateFn(nil),
 					},
-					newDag: func() dag.DAG {
-						return &dagfake.MockDag{
-							MockInit: func(_ []dag.Node) ([]dag.Node, error) {
-								return nil, nil
-							},
-							MockNodeExists: func(_ string) bool {
-								return true
-							},
-							MockTraceNode: func(_ string) (map[string]dag.Node, error) {
-								return map[string]dag.Node{
-									"not-here-1":          &dag.DependencyNode{},
-									"not-here-2":          &dag.DependencyNode{},
-									"not-here-3":          &dag.DependencyNode{},
-									"function-not-here-1": &dag.DependencyNode{},
-								}, nil
-							},
-							MockGetNode: func(s string) (dag.Node, error) {
-								if s == "not-here-1" {
-									return &dag.PackageNode{
-										LockPackage: v1beta1.LockPackage{
-											Source:  "not-here-1",
-											Version: "v0.20.0",
-										},
-									}, nil
-								}
-								if s == "not-here-2" {
-									return &dag.PackageNode{
-										LockPackage: v1beta1.LockPackage{
-											Source:  "not-here-2",
-											Version: "v0.100.1",
-										},
-									}, nil
-								}
-								if s == "function-not-here-1" {
-									return &dag.PackageNode{
-										LockPackage: v1beta1.LockPackage{
-											Source:  "function-not-here-1",
-											Version: "v0.1.0",
-										},
-									}, nil
-								}
-
-								return nil, nil
-							},
-						}
-					},
-					log: logging.NewNopLogger(),
+					newDag: dag.NewMapDag,
+					log:    logging.NewNopLogger(),
 				},
 				meta: &pkgmetav1.Configuration{
 					Spec: pkgmetav1.ConfigurationSpec{
@@ -643,23 +532,8 @@ func TestResolve(t *testing.T) {
 							return nil
 						},
 					},
-					newDag: func() dag.DAG {
-						return &dagfake.MockDag{
-							MockInit: func(_ []dag.Node) ([]dag.Node, error) {
-								return []dag.Node{}, nil
-							},
-							MockTraceNode: func(s string) (map[string]dag.Node, error) {
-								if s == "xpkg.crossplane.io/hasheddan/config-nop-a" {
-									return map[string]dag.Node{
-										s: &dag.DependencyNode{},
-									}, nil
-								}
-								return nil, errors.New("missing node in tree")
-							},
-							MockAddOrUpdateNodes: func(_ ...dag.Node) {},
-						}
-					},
-					log: logging.NewNopLogger(),
+					newDag: dag.NewMapDag,
+					log:    logging.NewNopLogger(),
 				},
 				meta: &pkgmetav1.Configuration{},
 				pr: &v1.ConfigurationRevision{
@@ -672,10 +546,7 @@ func TestResolve(t *testing.T) {
 					},
 				},
 			},
-			want: want{
-				total:     1,
-				installed: 1,
-			},
+			want: want{},
 		},
 	}
 


### PR DESCRIPTION
### Description of your changes

Previously, the dependency resolver tests used a mock DAG implementation, which had two problems:

1. It required careful setup of the DAG to match the real DAG's desired behavior in order for tests to pass.
2. It allowed for input states that are impossible in real life (e.g., packages in the DAG that didn't exist in the Lock from which the DAG is built), making the tests fragile and non-representative of real behavior.

Keep the mock for simulating error cases that are hard to produce with the real DAG code, but use the real DAG everywhere else. Update inputs to be consistent where necessary to make the tests pass.

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `./nix.sh flake check` to ensure this PR is ready for review.
- [x] Added or updated unit tests.
~- [ ] Added or updated e2e tests.~
~- [ ] Linked a PR or a [docs tracking issue] to [document this change].~
~- [ ] Added `backport release-x.y` labels to auto-backport this PR.~
~- [ ] Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md
