### PR TITLE
fix: Use server-side apply for composite status updates

### DIFF
--- a/internal/controller/apiextensions/composite/composition_functions.go
+++ b/internal/controller/apiextensions/composite/composition_functions.go
@@ -719,17 +719,22 @@ func (c *FunctionComposer) Compose(ctx context.Context, xr *composite.Unstructur
 	}
 
 	// Our goal here is to patch our XR's status using server-side apply. We
-	// want the resulting, patched object loaded into uxr. We need to pass in
+	// want the resulting, patched object loaded into xr. We need to pass in
 	// only our "fully specified intent" - i.e. only the fields that we actually
-	// care about. FromStruct will replace uxr's backing map[string]any with the
+	// care about. FromStruct will replace xr's backing map[string]any with the
 	// content of GetResource (i.e. the desired status). We then need to set its
 	// GVK and name so that our client knows what resource to patch.
+	// This also guards against the RunFunctionResponse returning an incorrect GVK or Name.
+	// Note: We are explicitly not setting any existing status fields from the incoming xr.
+	// If we were to include them, we would take ownership of them, and this would cause problems
+	// for the owning controller of those other fields/conditions.
+	// Server-side apply will merge our new desired state with other fields, and return the merged
+	// state into xr.
 	v := xr.GetAPIVersion()
 	k := xr.GetKind()
 	ns := xr.GetNamespace()
 	n := xr.GetName()
 	u := xr.GetUID()
-	cs := xr.GetConditions()
 
 	if err := xfn.FromStruct(xr, d.GetComposite().GetResource()); err != nil {
 		return CompositionResult{}, errors.Wrap(err, errUnmarshalDesiredXRStatus)
@@ -740,14 +745,6 @@ func (c *FunctionComposer) Compose(ctx context.Context, xr *composite.Unstructur
 	xr.SetNamespace(ns)
 	xr.SetName(n)
 	xr.SetUID(u)
-
-	// Include any pending conditions so we don't lose them. SetConditions
-	// will set conditions to nil if it's not passed any arguments. SSA
-	// interprets this as null and rejects it, so we only set them if
-	// there's actually some to set.
-	if len(cs) > 0 {
-		xr.SetConditions(cs...)
-	}
 
 	// NOTE(phisco): Here we are fine using a hardcoded field owner as there is
 	// no risk of conflict between different XRs.

--- a/internal/controller/apiextensions/composite/composition_functions_test.go
+++ b/internal/controller/apiextensions/composite/composition_functions_test.go
@@ -1454,6 +1454,82 @@ func TestFunctionCompose(t *testing.T) {
 				err: nil,
 			},
 		},
+		"StatusPatchesDon'tIncludeExtraParameters": {
+			reason: "We should not take ownership of fields owned by other controllers during a status update. This includes fields from the outer Reconciler, which may be out of date at this point.",
+			params: params{
+				c: &test.MockClient{
+					MockPatch: test.NewMockPatchFn(nil),
+					MockStatusPatch: test.NewMockSubResourcePatchFn(nil, func(obj client.Object) error {
+						// Check if the status patch includes any extra conditions from the source object.
+						// If these are present then we're not doing server-side apply correctly.
+						if xr, ok := obj.(*composite.Unstructured); ok {
+							if len(xr.GetConditions()) != 0 {
+								// If conditions are present, then we're incorrectly including extra fields in the status patch.
+								return errors.Errorf("BUG: Status Patch included an existing condition")
+							}
+						}
+						return nil
+					}),
+				},
+				r: FunctionRunnerFn(func(_ context.Context, _ string, _ *fnv1.RunFunctionRequest) (*fnv1.RunFunctionResponse, error) {
+					rsp := &fnv1.RunFunctionResponse{
+						Desired: &fnv1.State{
+							Composite: &fnv1.Resource{
+								Resource: MustStruct(map[string]any{
+									"status": map[string]any{
+										"widgets": 42,
+									},
+								}),
+							},
+						},
+					}
+					return rsp, nil
+				}),
+				o: []FunctionComposerOption{
+					WithCompositeConnectionDetailsFetcher(ConnectionDetailsFetcherFn(func(_ context.Context, _ ConnectionSecretOwner) (managed.ConnectionDetails, error) {
+						return nil, nil
+					})),
+					WithComposedResourceObserver(ComposedResourceObserverFn(func(_ context.Context, _ resource.Composite) (ComposedResourceStates, error) {
+						return nil, nil
+					})),
+					WithComposedResourceGarbageCollector(ComposedResourceGarbageCollectorFn(func(_ context.Context, _ metav1.Object, _, _ ComposedResourceStates) error {
+						return nil
+					})),
+				},
+			},
+			args: args{
+				xr: func() *composite.Unstructured {
+					// Our XR needs a GVK to survive round-tripping through a
+					// protobuf struct (which involves using the Kubernetes-aware
+					// JSON unmarshaller that requires a GVK).
+					xr := composite.New(composite.WithGroupVersionKind(schema.GroupVersionKind{
+						Group:   "test.crossplane.io",
+						Version: "v1",
+						Kind:    "CoolComposite",
+					}))
+					xr.SetLabels(map[string]string{
+						xcrd.LabelKeyNamePrefixForComposed: "parent-xr",
+					})
+					xr.SetConditions(v1.WatchCircuitClosed())
+					return xr
+				}(),
+				req: CompositionRequest{
+					Revision: &v1.CompositionRevision{
+						Spec: v1.CompositionRevisionSpec{
+							Pipeline: []v1.PipelineStep{
+								{
+									Step:        "run-cool-function",
+									FunctionRef: v1.FunctionReference{Name: "cool-function"},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: want{
+				err: nil,
+			},
+		},
 	}
 
 	for name, tc := range cases {

--- a/internal/controller/apiextensions/composite/reconciler.go
+++ b/internal/controller/apiextensions/composite/reconciler.go
@@ -24,7 +24,6 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/google/go-cmp/cmp"
 	corev1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -99,6 +98,13 @@ const (
 // Condition reasons.
 const (
 	reasonFatalError xpv2.ConditionReason = "FatalError"
+)
+
+// Server-side-apply field owners.
+const (
+	// FieldOwnerReconciler owns the fields this controller mutates on composite
+	// resources (XR).
+	FieldOwnerReconciler = "apiextensions.crossplane.io/reconciler"
 )
 
 // ControllerName returns the recommended name for controllers that use this
@@ -588,15 +594,20 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 		return reconcile.Result{}, errors.Wrap(resource.IgnoreNotFound(err), errGet)
 	}
 
-	statusBefore, _, _ := kunstructured.NestedFieldCopy(xr.Object, "status")
-
 	log = log.WithValues(
 		"uid", xr.GetUID(),
 		"version", xr.GetResourceVersion(),
 		"name", xr.GetName(),
 	)
 
-	status := r.conditions.For(xr)
+	// Store the current set of conditions, so we can detect if any are missed during a Compose error
+	startingConditions := xr.GetConditions()
+
+	// Set up an xr status object to use for server-side apply.
+	xrStatus := composite.New(composite.WithSchema(xr.Schema), composite.WithGroupVersionKind(xr.GroupVersionKind()))
+	xrStatus.SetNamespace(xr.GetNamespace())
+	xrStatus.SetName(xr.GetName())
+	status := r.conditions.For(xrStatus)
 
 	// Check circuit breaker state and set condition accordingly.
 	condition := v1.WatchCircuitClosed()
@@ -613,7 +624,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 		status.MarkConditions(xpv2.ReconcilePaused().WithMessage(reconcilePausedMsg))
 		// If the pause annotation is removed, we will have a chance to reconcile again and resume
 		// and if status update fails, we will reconcile again to retry to update the status
-		return reconcile.Result{}, errors.Wrap(r.client.Status().Update(updateCtx, xr), errUpdateStatus)
+		return reconcile.Result{}, errors.Wrap(r.client.Status().Patch(updateCtx, xrStatus, client.Apply, client.ForceOwnership, client.FieldOwner(FieldOwnerReconciler)), errUpdateStatus)
 	}
 
 	// Record the reconcile-requested-at annotation token in status so
@@ -622,7 +633,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 		if xr.GetLastHandledReconcileAt() != token {
 			log.Debug("Processing reconcile request", "token", token)
 			r.record.Event(xr, event.Normal(reasonReconcileRequestHandled, "Handling reconcile request", "token", token))
-			xr.SetLastHandledReconcileAt(token)
+			xrStatus.SetLastHandledReconcileAt(token)
 		}
 	}
 
@@ -639,7 +650,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 			err = errors.Wrap(err, errRemoveFinalizer)
 			r.record.Event(xr, event.Warning(reasonDelete, err))
 			status.MarkConditions(xpv2.ReconcileError(err))
-			_ = r.client.Status().Update(updateCtx, xr)
+			_ = r.client.Status().Patch(updateCtx, xrStatus, client.Apply, client.ForceOwnership, client.FieldOwner(FieldOwnerReconciler))
 
 			return reconcile.Result{}, err
 		}
@@ -651,7 +662,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 		log.Debug("Successfully deleted composite resource")
 		status.MarkConditions(xpv2.ReconcileSuccess())
 
-		return reconcile.Result{Requeue: false}, errors.Wrap(r.client.Status().Update(updateCtx, xr), errUpdateStatus)
+		return reconcile.Result{Requeue: false}, errors.Wrap(r.client.Status().Patch(updateCtx, xrStatus, client.Apply, client.ForceOwnership, client.FieldOwner(FieldOwnerReconciler)), errUpdateStatus)
 	}
 
 	if err := r.composite.AddFinalizer(ctx, xr); err != nil {
@@ -662,7 +673,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 		err = errors.Wrap(err, errAddFinalizer)
 		r.record.Event(xr, event.Warning(reasonInit, err))
 		status.MarkConditions(xpv2.ReconcileError(err))
-		_ = r.client.Status().Update(updateCtx, xr)
+		_ = r.client.Status().Patch(updateCtx, xrStatus, client.Apply, client.ForceOwnership, client.FieldOwner(FieldOwnerReconciler))
 
 		return reconcile.Result{}, err
 	}
@@ -676,7 +687,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 		err = errors.Wrap(err, errSelectComp)
 		r.record.Event(xr, event.Warning(reasonResolve, err))
 		status.MarkConditions(xpv2.ReconcileError(err))
-		_ = r.client.Status().Update(updateCtx, xr)
+		_ = r.client.Status().Patch(updateCtx, xrStatus, client.Apply, client.ForceOwnership, client.FieldOwner(FieldOwnerReconciler))
 
 		return reconcile.Result{}, err
 	}
@@ -693,7 +704,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 		err = errors.Wrap(err, errSelectCompRev)
 		r.record.Event(xr, event.Warning(reasonResolve, err))
 		status.MarkConditions(xpv2.ReconcileError(err))
-		_ = r.client.Status().Update(updateCtx, xr)
+		_ = r.client.Status().Patch(updateCtx, xrStatus, client.Apply, client.ForceOwnership, client.FieldOwner(FieldOwnerReconciler))
 
 		return reconcile.Result{}, err
 	}
@@ -716,7 +727,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 		err = errors.Wrap(err, errFetchComp)
 		r.record.Event(xr, event.Warning(reasonCompose, err))
 		status.MarkConditions(xpv2.ReconcileError(err))
-		_ = r.client.Status().Update(updateCtx, xr)
+		_ = r.client.Status().Patch(updateCtx, xrStatus, client.Apply, client.ForceOwnership, client.FieldOwner(FieldOwnerReconciler))
 
 		return reconcile.Result{}, err
 	}
@@ -737,7 +748,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 
 		r.record.Event(xr, event.Warning(reasonCompose, err))
 		status.MarkConditions(xpv2.ReconcileError(err))
-		_ = r.client.Status().Update(updateCtx, xr)
+		_ = r.client.Status().Patch(updateCtx, xrStatus, client.Apply, client.ForceOwnership, client.FieldOwner(FieldOwnerReconciler))
 
 		return reconcile.Result{}, err
 	}
@@ -752,7 +763,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 		err = errors.Wrap(err, errConfigure)
 		r.record.Event(xr, event.Warning(reasonCompose, err))
 		status.MarkConditions(xpv2.ReconcileError(err))
-		_ = r.client.Status().Update(updateCtx, xr)
+		_ = r.client.Status().Patch(updateCtx, xrStatus, client.Apply, client.ForceOwnership, client.FieldOwner(FieldOwnerReconciler))
 
 		return reconcile.Result{}, err
 	}
@@ -788,10 +799,10 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 		}
 		status.MarkConditions(xpv2.ReconcileError(err))
 
-		resultMeta := r.handleCommonCompositionResult(updateCtx, res, xr)
+		resultMeta := r.handleCommonCompositionResult(updateCtx, res, xr, xrStatus)
 		// We encountered a fatal error. For any custom status conditions that were
 		// not received due to the fatal error, mark them as unknown.
-		for _, c := range xr.GetConditions() {
+		for _, c := range startingConditions {
 			if v1.IsSystemConditionType(c.Type) {
 				continue
 			}
@@ -802,7 +813,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 				status.MarkConditions(c)
 			}
 		}
-		_ = r.client.Status().Update(updateCtx, xr)
+		_ = r.client.Status().Patch(updateCtx, xrStatus, client.Apply, client.ForceOwnership, client.FieldOwner(FieldOwnerReconciler))
 		return reconcile.Result{}, err
 	}
 
@@ -824,7 +835,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 		err = errors.Wrap(err, errWatch)
 		r.record.Event(xr, event.Warning(reasonWatch, err))
 		status.MarkConditions(xpv2.ReconcileError(err))
-		_ = r.client.Status().Update(updateCtx, xr)
+		_ = r.client.Status().Patch(updateCtx, xrStatus, client.Apply, client.ForceOwnership, client.FieldOwner(FieldOwnerReconciler))
 
 		return reconcile.Result{}, err
 	}
@@ -840,18 +851,18 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 		err = errors.Wrap(err, errPublish)
 		r.record.Event(xr, event.Warning(reasonPublish, err))
 		status.MarkConditions(xpv2.ReconcileError(err))
-		_ = r.client.Status().Update(updateCtx, xr)
+		_ = r.client.Status().Patch(updateCtx, xrStatus, client.Apply, client.ForceOwnership, client.FieldOwner(FieldOwnerReconciler))
 
 		return reconcile.Result{}, err
 	}
 
 	if published {
-		xr.SetConnectionDetailsLastPublishedTime(&metav1.Time{Time: time.Now()})
+		xrStatus.SetConnectionDetailsLastPublishedTime(&metav1.Time{Time: time.Now()})
 		log.Debug("Successfully published connection details")
 		r.record.Event(xr, event.Normal(reasonPublish, "Successfully published connection details"))
 	}
 
-	meta := r.handleCommonCompositionResult(updateCtx, res, xr)
+	meta := r.handleCommonCompositionResult(updateCtx, res, xr, xrStatus)
 
 	if meta.numWarningEvents == 0 {
 		// We don't consider warnings severe enough to prevent the XR from being
@@ -926,10 +937,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 		result = reconcile.Result{RequeueAfter: jitter(res.TTL)}
 	}
 
-	if !cmp.Equal(statusBefore, xr.Object["status"]) {
-		return result, errors.Wrap(r.client.Status().Update(updateCtx, xr), errUpdateStatus)
-	}
-	return result, nil
+	return result, errors.Wrap(r.client.Status().Patch(updateCtx, xrStatus, client.Apply, client.ForceOwnership, client.FieldOwner(FieldOwnerReconciler)), errUpdateStatus)
 }
 
 type compositionResultMeta struct {
@@ -937,7 +945,7 @@ type compositionResultMeta struct {
 	conditionTypesSeen map[xpv2.ConditionType]bool
 }
 
-func (r *Reconciler) handleCommonCompositionResult(ctx context.Context, res CompositionResult, xr *composite.Unstructured) compositionResultMeta {
+func (r *Reconciler) handleCommonCompositionResult(ctx context.Context, res CompositionResult, xr *composite.Unstructured, xrStatus *composite.Unstructured) compositionResultMeta {
 	log := r.log.WithValues(
 		"uid", xr.GetUID(),
 		"version", xr.GetResourceVersion(),
@@ -973,11 +981,11 @@ func (r *Reconciler) handleCommonCompositionResult(ctx context.Context, res Comp
 		}
 
 		conditionTypesSeen[c.Type] = true
-		xr.SetConditions(c.Condition)
+		xrStatus.SetConditions(c.Condition)
 
 		if c.Target == CompositionTargetCompositeAndClaim {
 			// We can ignore the error as it only occurs if given a system condition.
-			_ = xr.SetClaimConditionTypes(c.Type)
+			_ = xrStatus.SetClaimConditionTypes(c.Type)
 		}
 	}
 

--- a/internal/controller/apiextensions/composite/reconciler.go
+++ b/internal/controller/apiextensions/composite/reconciler.go
@@ -608,6 +608,13 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 	xrStatus.SetNamespace(xr.GetNamespace())
 	xrStatus.SetName(xr.GetName())
 	status := r.conditions.For(xrStatus)
+	// Keep these values, even if we don't set them this time around through the reconcile loop
+	if x := xr.GetConnectionDetailsLastPublishedTime(); x != nil {
+		xrStatus.SetConnectionDetailsLastPublishedTime(x)
+	}
+	if x := xr.GetLastHandledReconcileAt(); x != "" {
+		xrStatus.SetLastHandledReconcileAt(x)
+	}
 
 	// Check circuit breaker state and set condition accordingly.
 	condition := v1.WatchCircuitClosed()

--- a/internal/controller/apiextensions/composite/reconciler.go
+++ b/internal/controller/apiextensions/composite/reconciler.go
@@ -662,7 +662,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 		err = errors.Wrap(err, errAddFinalizer)
 		r.record.Event(xr, event.Warning(reasonInit, err))
 		status.MarkConditions(xpv2.ReconcileError(err))
-		_ = r.client.Status().Update(ctx, xr)
+		_ = r.client.Status().Update(updateCtx, xr)
 
 		return reconcile.Result{}, err
 	}
@@ -737,7 +737,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 
 		r.record.Event(xr, event.Warning(reasonCompose, err))
 		status.MarkConditions(xpv2.ReconcileError(err))
-		_ = r.client.Status().Update(ctx, xr)
+		_ = r.client.Status().Update(updateCtx, xr)
 
 		return reconcile.Result{}, err
 	}

--- a/internal/controller/apiextensions/composite/reconciler_test.go
+++ b/internal/controller/apiextensions/composite/reconciler_test.go
@@ -104,8 +104,7 @@ func TestReconcile(t *testing.T) {
 					MockGet: WithComposite(t, NewComposite(func(cr *composite.Unstructured) {
 						cr.SetDeletionTimestamp(&now)
 					})),
-					MockStatusUpdate: WantComposite(t, NewComposite(func(cr *composite.Unstructured) {
-						cr.SetDeletionTimestamp(&now)
+					MockStatusPatch: WantComposite(t, NewComposite(func(cr *composite.Unstructured) {
 						cr.SetConditions(v1.WatchCircuitClosed(), xpv2.Deleting(), xpv2.ReconcileError(errors.Wrap(errBoom, errRemoveFinalizer)))
 					})),
 				},
@@ -129,8 +128,7 @@ func TestReconcile(t *testing.T) {
 					MockGet: WithComposite(t, NewComposite(func(cr *composite.Unstructured) {
 						cr.SetDeletionTimestamp(&now)
 					})),
-					MockStatusUpdate: WantComposite(t, NewComposite(func(cr *composite.Unstructured) {
-						cr.SetDeletionTimestamp(&now)
+					MockStatusPatch: WantComposite(t, NewComposite(func(cr *composite.Unstructured) {
 						cr.SetConditions(v1.WatchCircuitClosed(), xpv2.Deleting(), xpv2.ReconcileSuccess())
 					})),
 				},
@@ -151,7 +149,7 @@ func TestReconcile(t *testing.T) {
 			args: args{
 				c: &test.MockClient{
 					MockGet: test.NewMockGetFn(nil),
-					MockStatusUpdate: WantComposite(t, NewComposite(func(cr *composite.Unstructured) {
+					MockStatusPatch: WantComposite(t, NewComposite(func(cr *composite.Unstructured) {
 						cr.SetConditions(v1.WatchCircuitClosed(), xpv2.ReconcileError(errors.Wrap(errBoom, errAddFinalizer)))
 					})),
 				},
@@ -173,7 +171,7 @@ func TestReconcile(t *testing.T) {
 			args: args{
 				c: &test.MockClient{
 					MockGet: test.NewMockGetFn(nil),
-					MockStatusUpdate: WantComposite(t, NewComposite(func(cr *composite.Unstructured) {
+					MockStatusPatch: WantComposite(t, NewComposite(func(cr *composite.Unstructured) {
 						cr.SetConditions(v1.WatchCircuitClosed(), xpv2.ReconcileError(errors.Wrap(errBoom, errSelectComp)))
 					})),
 				},
@@ -194,8 +192,7 @@ func TestReconcile(t *testing.T) {
 			args: args{
 				c: &test.MockClient{
 					MockGet: test.NewMockGetFn(nil),
-					MockStatusUpdate: WantComposite(t, NewComposite(func(cr *composite.Unstructured) {
-						cr.SetCompositionReference(&corev1.ObjectReference{})
+					MockStatusPatch: WantComposite(t, NewComposite(func(cr *composite.Unstructured) {
 						cr.SetConditions(v1.WatchCircuitClosed(), xpv2.ReconcileError(errors.Wrap(errBoom, errFetchComp)))
 					})),
 				},
@@ -220,8 +217,7 @@ func TestReconcile(t *testing.T) {
 			args: args{
 				c: &test.MockClient{
 					MockGet: test.NewMockGetFn(nil),
-					MockStatusUpdate: WantComposite(t, NewComposite(func(cr *composite.Unstructured) {
-						cr.SetCompositionReference(&corev1.ObjectReference{})
+					MockStatusPatch: WantComposite(t, NewComposite(func(cr *composite.Unstructured) {
 						cr.SetConditions(v1.WatchCircuitClosed(), xpv2.ReconcileError(errors.New("selected CompositionRevision test-revision does not have a valid function pipeline: pipeline status unknown")))
 					})),
 				},
@@ -249,8 +245,7 @@ func TestReconcile(t *testing.T) {
 			args: args{
 				c: &test.MockClient{
 					MockGet: test.NewMockGetFn(nil),
-					MockStatusUpdate: WantComposite(t, NewComposite(func(cr *composite.Unstructured) {
-						cr.SetCompositionReference(&corev1.ObjectReference{})
+					MockStatusPatch: WantComposite(t, NewComposite(func(cr *composite.Unstructured) {
 						cr.SetConditions(v1.WatchCircuitClosed(), xpv2.ReconcileError(errors.New("selected CompositionRevision test-revision does not have a valid function pipeline: function foo-function does not have the required composition capability")))
 					})),
 				},
@@ -278,8 +273,7 @@ func TestReconcile(t *testing.T) {
 			args: args{
 				c: &test.MockClient{
 					MockGet: test.NewMockGetFn(nil),
-					MockStatusUpdate: WantComposite(t, NewComposite(func(cr *composite.Unstructured) {
-						cr.SetCompositionReference(&corev1.ObjectReference{})
+					MockStatusPatch: WantComposite(t, NewComposite(func(cr *composite.Unstructured) {
 						cr.SetConditions(v1.WatchCircuitClosed(), xpv2.ReconcileError(errors.Wrap(errBoom, errConfigure)))
 					})),
 				},
@@ -307,8 +301,7 @@ func TestReconcile(t *testing.T) {
 			args: args{
 				c: &test.MockClient{
 					MockGet: test.NewMockGetFn(nil),
-					MockStatusUpdate: WantComposite(t, NewComposite(func(cr *composite.Unstructured) {
-						cr.SetCompositionReference(&corev1.ObjectReference{})
+					MockStatusPatch: WantComposite(t, NewComposite(func(cr *composite.Unstructured) {
 						cr.SetConditions(v1.WatchCircuitClosed(), xpv2.ReconcileError(errors.Wrap(errBoom, errCompose)))
 					})),
 				},
@@ -339,8 +332,7 @@ func TestReconcile(t *testing.T) {
 			args: args{
 				c: &test.MockClient{
 					MockGet: test.NewMockGetFn(nil),
-					MockStatusUpdate: WantComposite(t, NewComposite(func(cr *composite.Unstructured) {
-						cr.SetCompositionReference(&corev1.ObjectReference{})
+					MockStatusPatch: WantComposite(t, NewComposite(func(cr *composite.Unstructured) {
 						cr.SetConditions(v1.WatchCircuitClosed(), xpv2.ReconcileError(errors.Wrap(errBoom, errPublish)))
 					})),
 				},
@@ -374,8 +366,7 @@ func TestReconcile(t *testing.T) {
 			args: args{
 				c: &test.MockClient{
 					MockGet: test.NewMockGetFn(nil),
-					MockStatusUpdate: WantComposite(t, NewComposite(func(xr *composite.Unstructured) {
-						xr.SetCompositionReference(&corev1.ObjectReference{})
+					MockStatusPatch: WantComposite(t, NewComposite(func(xr *composite.Unstructured) {
 						xr.SetConditions(v1.WatchCircuitClosed(), xpv2.ReconcileSuccess(), xpv2.Available())
 					})),
 				},
@@ -415,8 +406,7 @@ func TestReconcile(t *testing.T) {
 			args: args{
 				c: &test.MockClient{
 					MockGet: test.NewMockGetFn(nil),
-					MockStatusUpdate: WantComposite(t, NewComposite(func(cr *composite.Unstructured) {
-						cr.SetCompositionReference(&corev1.ObjectReference{})
+					MockStatusPatch: WantComposite(t, NewComposite(func(cr *composite.Unstructured) {
 						cr.SetConditions(v1.WatchCircuitClosed(), xpv2.ReconcileSuccess(), xpv2.Creating().WithMessage("Unready resources: cat, cow, elephant, and 1 more"))
 					})),
 				},
@@ -480,12 +470,7 @@ func TestReconcile(t *testing.T) {
 							Kind:       "ComposedResource",
 						}})
 					})),
-					MockStatusUpdate: WantComposite(t, NewComposite(func(cr *composite.Unstructured) {
-						cr.SetCompositionReference(&corev1.ObjectReference{})
-						cr.SetResourceReferences([]corev1.ObjectReference{{
-							APIVersion: "example.org/v1",
-							Kind:       "ComposedResource",
-						}})
+					MockStatusPatch: WantComposite(t, NewComposite(func(cr *composite.Unstructured) {
 						cr.SetConditions(v1.WatchCircuitClosed(), xpv2.ReconcileSuccess(), xpv2.Available())
 						cr.SetConnectionDetailsLastPublishedTime(&now)
 					})),
@@ -545,8 +530,7 @@ func TestReconcile(t *testing.T) {
 					MockGet: WithComposite(t, NewComposite(func(cr *composite.Unstructured) {
 						cr.SetAnnotations(map[string]string{meta.AnnotationKeyReconciliationPaused: "true"})
 					})),
-					MockStatusUpdate: WantComposite(t, NewComposite(func(cr *composite.Unstructured) {
-						cr.SetAnnotations(map[string]string{meta.AnnotationKeyReconciliationPaused: "true"})
+					MockStatusPatch: WantComposite(t, NewComposite(func(cr *composite.Unstructured) {
 						cr.SetConditions(v1.WatchCircuitClosed(), xpv2.ReconcilePaused().WithMessage(reconcilePausedMsg))
 					})),
 				},
@@ -562,7 +546,7 @@ func TestReconcile(t *testing.T) {
 					MockGet: WithComposite(t, NewComposite(func(cr *composite.Unstructured) {
 						cr.SetAnnotations(map[string]string{meta.AnnotationKeyReconciliationPaused: "true"})
 					})),
-					MockStatusUpdate: test.NewMockSubResourceUpdateFn(errBoom),
+					MockStatusPatch: test.NewMockSubResourcePatchFn(errBoom),
 				},
 			},
 			want: want{
@@ -578,11 +562,9 @@ func TestReconcile(t *testing.T) {
 						cr.SetAnnotations(map[string]string{meta.AnnotationKeyReconciliationPaused: ""})
 						cr.SetConditions(v1.WatchCircuitClosed(), xpv2.ReconcilePaused())
 					})),
-					MockStatusUpdate: WantComposite(t, NewComposite(func(cr *composite.Unstructured) {
-						cr.SetAnnotations(map[string]string{meta.AnnotationKeyReconciliationPaused: ""})
+					MockStatusPatch: WantComposite(t, NewComposite(func(cr *composite.Unstructured) {
 						cr.SetConditions(v1.WatchCircuitClosed(), xpv2.ReconcileSuccess(), xpv2.Available())
 						cr.SetConnectionDetailsLastPublishedTime(&now)
-						cr.SetCompositionReference(&corev1.ObjectReference{})
 					})),
 				},
 				opts: []ReconcilerOption{
@@ -618,10 +600,9 @@ func TestReconcile(t *testing.T) {
 						// (but reconciliations were already paused)
 						cr.SetConditions(v1.WatchCircuitClosed(), xpv2.ReconcilePaused())
 					})),
-					MockStatusUpdate: WantComposite(t, NewComposite(func(cr *composite.Unstructured) {
+					MockStatusPatch: WantComposite(t, NewComposite(func(cr *composite.Unstructured) {
 						cr.SetConditions(v1.WatchCircuitClosed(), xpv2.ReconcileSuccess(), xpv2.Available())
 						cr.SetConnectionDetailsLastPublishedTime(&now)
-						cr.SetCompositionReference(&corev1.ObjectReference{})
 					})),
 				},
 				opts: []ReconcilerOption{
@@ -664,9 +645,8 @@ func TestReconcile(t *testing.T) {
 						}
 						return nil
 					}),
-					MockStatusUpdate: WantComposite(t, NewComposite(func(cr *composite.Unstructured) {
+					MockStatusPatch: WantComposite(t, NewComposite(func(cr *composite.Unstructured) {
 						cr.Schema = composite.SchemaLegacy
-						cr.SetCompositionReference(&corev1.ObjectReference{})
 						cr.SetConditions(
 							v1.WatchCircuitClosed(),
 							xpv2.Condition{
@@ -687,7 +667,6 @@ func TestReconcile(t *testing.T) {
 							xpv2.Available(),
 						)
 						cr.SetClaimConditionTypes("DatabaseReady")
-						cr.SetClaimReference(&reference.Claim{})
 					})),
 				},
 				opts: []ReconcilerOption{
@@ -823,16 +802,9 @@ func TestReconcile(t *testing.T) {
 						}
 						return nil
 					}),
-					MockStatusUpdate: WantComposite(t, NewComposite(func(cr *composite.Unstructured) {
+					MockStatusPatch: WantComposite(t, NewComposite(func(cr *composite.Unstructured) {
 						cr.Schema = composite.SchemaLegacy
-						cr.SetCompositionReference(&corev1.ObjectReference{})
 						cr.SetConditions(
-							xpv2.Condition{
-								Type:    "DatabaseReady",
-								Status:  corev1.ConditionUnknown,
-								Reason:  "FatalError",
-								Message: "A fatal error occurred before the status of this condition could be determined.",
-							},
 							v1.WatchCircuitClosed(),
 							xpv2.ReconcileError(fmt.Errorf("cannot compose resources: %w", errBoom)),
 							xpv2.Condition{
@@ -851,13 +823,17 @@ func TestReconcile(t *testing.T) {
 								Message:            "This is a condition for bucket availability.",
 								ObservedGeneration: 0,
 							},
+							xpv2.Condition{
+								Type:    "DatabaseReady",
+								Status:  corev1.ConditionUnknown,
+								Reason:  "FatalError",
+								Message: "A fatal error occurred before the status of this condition could be determined.",
+							},
 						)
 
 						cr.SetClaimConditionTypes(
-							"DatabaseReady",
 							"BucketReady",
 						)
-						cr.SetClaimReference(&reference.Claim{})
 					})),
 				},
 				opts: []ReconcilerOption{
@@ -995,7 +971,7 @@ func TestReconcile(t *testing.T) {
 			},
 		},
 		"CustomConditionUpdate": {
-			reason: "Custom conditions should be updated if they already exist. Additionally, if a condition already exists in the status but was not included in the response, it should remain in the status.",
+			reason: "Custom conditions should be updated if they already exist. Additionally, if a condition already exists in the status but was not included in the response, it should be removed from the status.",
 			args: args{
 				c: &test.MockClient{
 					MockGet: test.NewMockGetFn(nil, func(obj client.Object) error {
@@ -1026,17 +1002,19 @@ func TestReconcile(t *testing.T) {
 						}
 						return nil
 					}),
-					MockStatusUpdate: WantComposite(t, NewComposite(func(cr *composite.Unstructured) {
+					MockStatusPatch: WantComposite(t, NewComposite(func(cr *composite.Unstructured) {
 						cr.Schema = composite.SchemaLegacy
-						cr.SetCompositionReference(&corev1.ObjectReference{})
 						cr.SetConditions(
-							// The database condition should exist even though it was not seen
-							// during this reconcile.
+							// The database condition should be removed, to reflect standard server-side apply semantics
+
+							v1.WatchCircuitClosed(),
 							xpv2.Condition{
-								Type:    "DatabaseReady",
-								Status:  corev1.ConditionTrue,
-								Reason:  "Available",
-								Message: "This is a condition for database availability.",
+								Type:               "InternalSync",
+								Status:             corev1.ConditionTrue,
+								LastTransitionTime: metav1.Time{},
+								Reason:             "SyncSuccess",
+								Message:            "This is a condition representing an internal sync process.",
+								ObservedGeneration: 0,
 							},
 							// The bucket condition should be updated to reflect the latest
 							// condition which is available.
@@ -1048,25 +1026,12 @@ func TestReconcile(t *testing.T) {
 								Message:            "This is a condition for bucket availability.",
 								ObservedGeneration: 0,
 							},
-							v1.WatchCircuitClosed(),
-							xpv2.Condition{
-								Type:               "InternalSync",
-								Status:             corev1.ConditionTrue,
-								LastTransitionTime: metav1.Time{},
-								Reason:             "SyncSuccess",
-								Message:            "This is a condition representing an internal sync process.",
-								ObservedGeneration: 0,
-							},
 							xpv2.ReconcileSuccess(),
 							xpv2.Available(),
 						)
 						cr.SetClaimConditionTypes(
-							// The database claim condition should exist even though it was
-							// not seen during this reconcile.
-							"DatabaseReady",
 							"BucketReady",
 						)
-						cr.SetClaimReference(&reference.Claim{})
 					})),
 				},
 				opts: []ReconcilerOption{
@@ -1149,11 +1114,9 @@ func TestReconcile(t *testing.T) {
 						}
 						return nil
 					}),
-					MockStatusUpdate: WantComposite(t, NewComposite(func(cr *composite.Unstructured) {
+					MockStatusPatch: WantComposite(t, NewComposite(func(cr *composite.Unstructured) {
 						cr.Schema = composite.SchemaLegacy
-						cr.SetCompositionReference(&corev1.ObjectReference{})
 						cr.SetConditions(v1.WatchCircuitClosed(), xpv2.ReconcileSuccess(), xpv2.Creating())
-						cr.SetClaimReference(&reference.Claim{})
 					})),
 				},
 				opts: []ReconcilerOption{
@@ -1212,11 +1175,9 @@ func TestReconcile(t *testing.T) {
 						}
 						return nil
 					}),
-					MockStatusUpdate: WantComposite(t, NewComposite(func(cr *composite.Unstructured) {
+					MockStatusPatch: WantComposite(t, NewComposite(func(cr *composite.Unstructured) {
 						cr.Schema = composite.SchemaLegacy
-						cr.SetCompositionReference(&corev1.ObjectReference{})
 						cr.SetConditions(v1.WatchCircuitClosed(), xpv2.ReconcileSuccess(), xpv2.Available())
-						cr.SetClaimReference(&reference.Claim{})
 					})),
 				},
 				opts: []ReconcilerOption{
@@ -1282,7 +1243,7 @@ func TestReconcile(t *testing.T) {
 			args: args{
 				c: &test.MockClient{
 					MockGet: test.NewMockGetFn(nil),
-					MockStatusUpdate: WantComposite(t, NewComposite(func(cr *composite.Unstructured) {
+					MockStatusPatch: WantComposite(t, NewComposite(func(cr *composite.Unstructured) {
 						cr.SetConditions(v1.WatchCircuitOpen("ConfigMap/test-config (default)"), xpv2.ReconcileError(errors.Wrap(errBoom, errAddFinalizer)))
 					})),
 				},
@@ -1314,7 +1275,7 @@ func TestReconcile(t *testing.T) {
 			args: args{
 				c: &test.MockClient{
 					MockGet: test.NewMockGetFn(nil),
-					MockStatusUpdate: WantComposite(t, NewComposite(func(cr *composite.Unstructured) {
+					MockStatusPatch: WantComposite(t, NewComposite(func(cr *composite.Unstructured) {
 						cr.SetConditions(v1.WatchCircuitClosed(), xpv2.ReconcileError(errors.Wrap(errBoom, errAddFinalizer)))
 					})),
 				},
@@ -1485,11 +1446,7 @@ func TestReconcilePollIntervalAnnotation(t *testing.T) {
 						cr.SetAnnotations(annotations)
 					}
 				})),
-				MockStatusUpdate: WantComposite(t, NewComposite(func(cr *composite.Unstructured) {
-					cr.SetCompositionReference(&corev1.ObjectReference{})
-					if len(annotations) > 0 {
-						cr.SetAnnotations(annotations)
-					}
+				MockStatusPatch: WantComposite(t, NewComposite(func(cr *composite.Unstructured) {
 					cr.SetConditions(v1.WatchCircuitClosed(), xpv2.ReconcileSuccess(), xpv2.Available())
 					cr.SetConnectionDetailsLastPublishedTime(&now)
 				})),
@@ -1563,11 +1520,7 @@ func TestReconcileRequestAnnotation(t *testing.T) {
 							meta.AnnotationKeyReconcileRequestedAt: "1705312200",
 						})
 					})),
-					MockStatusUpdate: WantComposite(t, NewComposite(func(cr *composite.Unstructured) {
-						cr.SetAnnotations(map[string]string{
-							meta.AnnotationKeyReconcileRequestedAt: "1705312200",
-						})
-						cr.SetCompositionReference(&corev1.ObjectReference{})
+					MockStatusPatch: WantComposite(t, NewComposite(func(cr *composite.Unstructured) {
 						cr.SetConditions(v1.WatchCircuitClosed(), xpv2.ReconcileSuccess(), xpv2.Available())
 						cr.SetConnectionDetailsLastPublishedTime(&now)
 						cr.SetLastHandledReconcileAt("1705312200")
@@ -1633,14 +1586,9 @@ func TestReconcileRequestAnnotation(t *testing.T) {
 						})
 						cr.SetLastHandledReconcileAt("already-handled")
 					})),
-					MockStatusUpdate: WantComposite(t, NewComposite(func(cr *composite.Unstructured) {
-						cr.SetAnnotations(map[string]string{
-							meta.AnnotationKeyReconcileRequestedAt: "already-handled",
-						})
-						cr.SetCompositionReference(&corev1.ObjectReference{})
+					MockStatusPatch: WantComposite(t, NewComposite(func(cr *composite.Unstructured) {
 						cr.SetConditions(v1.WatchCircuitClosed(), xpv2.ReconcileSuccess(), xpv2.Available())
 						cr.SetConnectionDetailsLastPublishedTime(&now)
-						cr.SetLastHandledReconcileAt("already-handled")
 					})),
 				},
 				opts: []ReconcilerOption{
@@ -1765,11 +1713,11 @@ func WithComposite(_ *testing.T, cr *composite.Unstructured) func(_ context.Cont
 	}
 }
 
-// A status update function that ensures the supplied object is the XR we want.
-func WantComposite(t *testing.T, want resource.Composite) func(_ context.Context, obj client.Object, _ ...client.SubResourceUpdateOption) error {
+// A status patch function that ensures the supplied object is the XR we want.
+func WantComposite(t *testing.T, want resource.Composite) func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.SubResourcePatchOption) error {
 	t.Helper()
 
-	return func(_ context.Context, got client.Object, _ ...client.SubResourceUpdateOption) error {
+	return func(_ context.Context, got client.Object, _ client.Patch, _ ...client.SubResourcePatchOption) error {
 		t.Helper()
 		// Normally we use a custom Equal method on conditions to ignore the
 		// lastTransitionTime, but we may be using unstructured types here where

--- a/internal/controller/apiextensions/composite/reconciler_test.go
+++ b/internal/controller/apiextensions/composite/reconciler_test.go
@@ -1577,7 +1577,7 @@ func TestReconcileRequestAnnotation(t *testing.T) {
 			},
 		},
 		"AlreadyHandledReconcileRequestIsNoOp": {
-			reason: "When the token matches lastHandledReconcileAt, status should remain unchanged.",
+			reason: "When the token matches lastHandledReconcileAt, we should still set it so it's not removed by server-side apply.",
 			args: args{
 				c: &test.MockClient{
 					MockGet: WithComposite(t, NewComposite(func(cr *composite.Unstructured) {
@@ -1589,6 +1589,7 @@ func TestReconcileRequestAnnotation(t *testing.T) {
 					MockStatusPatch: WantComposite(t, NewComposite(func(cr *composite.Unstructured) {
 						cr.SetConditions(v1.WatchCircuitClosed(), xpv2.ReconcileSuccess(), xpv2.Available())
 						cr.SetConnectionDetailsLastPublishedTime(&now)
+						cr.SetLastHandledReconcileAt("already-handled")
 					})),
 				},
 				opts: []ReconcilerOption{

--- a/internal/render/client.go
+++ b/internal/render/client.go
@@ -207,6 +207,11 @@ func (c *InMemoryClient) Patch(_ context.Context, obj client.Object, patch clien
 
 	if patch.Type() == types.ApplyPatchType {
 		c.applied = append(c.applied, *u.DeepCopy())
+
+		if stored, ok := c.store[key]; ok {
+			u.Object = hackApply(stored.Object, u.Object)
+		}
+
 		c.store[key] = *u
 		return nil
 	}
@@ -288,10 +293,9 @@ func (c *InMemoryClient) IsObjectNamespaced(_ runtime.Object) (bool, error) {
 // This writer mimics that behavior: it takes the stored version of the
 // resource (which still has the full spec from when it was loaded) and
 // replaces only its top-level "status" key with the incoming object's status.
-// It then writes the merged result back into the caller's object. This is not
-// a general-purpose SSA merge -- it's a single key replacement that is
-// sufficient because the reconciler only has one status writer producing one
-// status blob.
+// It then writes the merged result back into the caller's object.
+// We do a best-effort merge of the status during Patch, as some fields are set
+// using SSA in Compose and some are set in Reconcile.
 type inMemoryStatusWriter struct {
 	client *InMemoryClient
 }
@@ -303,7 +307,7 @@ func (w *inMemoryStatusWriter) Update(_ context.Context, obj client.Object, _ ..
 	u := toUnstructured(obj, w.client.scheme)
 	key := keyForUnstructured(u)
 
-	merged := w.mergeStatus(key, u)
+	merged := w.mergeStatus(key, u, false)
 	w.client.store[key] = *merged
 	w.client.updated = append(w.client.updated, *merged.DeepCopy())
 
@@ -317,11 +321,11 @@ func (w *inMemoryStatusWriter) Update(_ context.Context, obj client.Object, _ ..
 // Patch replaces the stored resource's status with the incoming object's
 // status, then writes the full merged resource (original spec + new status)
 // back into obj.
-func (w *inMemoryStatusWriter) Patch(_ context.Context, obj client.Object, _ client.Patch, _ ...client.SubResourcePatchOption) error {
+func (w *inMemoryStatusWriter) Patch(_ context.Context, obj client.Object, patch client.Patch, _ ...client.SubResourcePatchOption) error {
 	u := toUnstructured(obj, w.client.scheme)
 	key := keyForUnstructured(u)
 
-	merged := w.mergeStatus(key, u)
+	merged := w.mergeStatus(key, u, patch.Type() == types.ApplyPatchType)
 	w.client.store[key] = *merged
 	w.client.applied = append(w.client.applied, *merged.DeepCopy())
 
@@ -343,12 +347,8 @@ func (w *inMemoryStatusWriter) Apply(_ context.Context, _ runtime.ApplyConfigura
 
 // mergeStatus replaces the stored resource's top-level "status" key with the
 // incoming resource's "status" key. Everything else (spec, metadata, etc.)
-// comes from the stored version. This isn't a deep merge or an SSA-style
-// field-ownership merge -- it's a wholesale replacement of one top-level key.
-// That's sufficient here because the reconciler has a single status writer
-// producing a complete status blob; there are no concurrent partial status
-// updates to reconcile.
-func (w *inMemoryStatusWriter) mergeStatus(key storeKey, incoming *unstructured.Unstructured) *unstructured.Unstructured {
+// comes from the stored version.
+func (w *inMemoryStatusWriter) mergeStatus(key storeKey, incoming *unstructured.Unstructured, doApply bool) *unstructured.Unstructured {
 	stored, ok := w.client.store[key]
 	if !ok {
 		// No stored version; use the incoming as-is.
@@ -359,6 +359,13 @@ func (w *inMemoryStatusWriter) mergeStatus(key storeKey, incoming *unstructured.
 
 	// Replace the stored status with the incoming status.
 	if status, ok := incoming.Object["status"]; ok {
+		if originalStatus, ok := merged.Object["status"]; ok && doApply {
+			if statusMap, ok := status.(map[string]interface{}); ok {
+				if originalStatusMap, ok := originalStatus.(map[string]interface{}); ok {
+					status = hackApply(originalStatusMap, statusMap)
+				}
+			}
+		}
 		merged.Object["status"] = status
 	}
 
@@ -369,6 +376,63 @@ func (w *inMemoryStatusWriter) mergeStatus(key storeKey, incoming *unstructured.
 	}
 
 	return merged
+}
+
+// hackApply does a best-effort merge of the object, as some fields are set using SSA in Compose
+// and some are set in Reconcile.
+// This won't cover all cases, but should be sufficient for the render use-case.
+func hackApply(original map[string]interface{}, incoming map[string]interface{}) map[string]interface{} {
+	for k, v := range incoming {
+		if k == "conditions" {
+			incomingConditions, ok := v.([]interface{})
+			if !ok {
+				// Couldn't parse incoming conditions; just set them.
+				original[k] = v
+				continue
+			}
+
+			existingConditions, ok := original["conditions"].([]interface{})
+			if !ok {
+				// Couldn't parse existing conditions; just set the new ones.
+				original[k] = v
+				continue
+			}
+
+			// Collect new types
+			newConditionTypes := []string{}
+			for c := range incomingConditions {
+				if t, ok := incomingConditions[c].(map[string]interface{})["type"].(string); ok {
+					newConditionTypes = append(newConditionTypes, t)
+				}
+			}
+
+			// Keep only existing conditions that don't match a new type
+			conditions := []interface{}{}
+			for _, c := range existingConditions {
+				if t, ok := c.(map[string]interface{})["type"].(string); ok {
+					if !slices.Contains(newConditionTypes, t) {
+						conditions = append(conditions, c)
+					}
+				}
+			}
+
+			// Add all incoming conditions
+			conditions = append(conditions, incomingConditions...)
+
+			original[k] = conditions
+			continue
+		}
+
+		if ov, ok := original[k].(map[string]interface{}); ok {
+			if iv, ok := v.(map[string]interface{}); ok {
+				original[k] = hackApply(ov, iv)
+				continue
+			}
+		}
+		original[k] = v
+	}
+
+	return original
 }
 
 // inMemorySubResourceClient satisfies client.SubResourceClient.

--- a/internal/render/client_test.go
+++ b/internal/render/client_test.go
@@ -309,7 +309,7 @@ func TestInMemoryClientList(t *testing.T) {
 	}
 }
 
-func TestInMemoryClientStatusMerge(t *testing.T) {
+func TestInMemoryClientStatusUpdate(t *testing.T) {
 	type want struct {
 		obj unstructured.Unstructured
 		err error
@@ -376,6 +376,142 @@ func TestInMemoryClientStatusMerge(t *testing.T) {
 			}
 			if diff := cmp.Diff(tc.want.obj, *obj); diff != "" {
 				t.Errorf("\n%s\nStatus().Update(...): -want, +got:\n%s", tc.reason, diff)
+			}
+		})
+	}
+}
+
+func TestInMemoryClientStatusPatch(t *testing.T) {
+	type want struct {
+		obj unstructured.Unstructured
+		err error
+	}
+
+	cases := map[string]struct {
+		reason    string
+		store     []unstructured.Unstructured
+		statusObj unstructured.Unstructured
+		want      want
+	}{
+		"MergesStatusIntoStoredSpec": {
+			reason: "Status().Patch() should set the status on the stored object while preserving its spec.",
+			store: []unstructured.Unstructured{{Object: map[string]any{
+				"apiVersion": "example.org/v1",
+				"kind":       "XR",
+				"metadata":   map[string]any{"name": "my-xr"},
+				"spec":       map[string]any{"region": "us-east-1"},
+			}}},
+			statusObj: unstructured.Unstructured{Object: map[string]any{
+				"apiVersion": "example.org/v1",
+				"kind":       "XR",
+				"metadata":   map[string]any{"name": "my-xr"},
+				"status":     map[string]any{"phase": "ready"},
+			}},
+			want: want{
+				obj: unstructured.Unstructured{Object: map[string]any{
+					"apiVersion": "example.org/v1",
+					"kind":       "XR",
+					"metadata":   map[string]any{"name": "my-xr"},
+					"spec":       map[string]any{"region": "us-east-1"},
+					"status":     map[string]any{"phase": "ready"},
+				}},
+			},
+		},
+		"NoStoredVersion": {
+			reason: "When there is no stored version, the incoming object should be returned as-is.",
+			statusObj: unstructured.Unstructured{Object: map[string]any{
+				"apiVersion": "example.org/v1",
+				"kind":       "XR",
+				"metadata":   map[string]any{"name": "new-xr"},
+				"status":     map[string]any{"phase": "creating"},
+			}},
+			want: want{
+				obj: unstructured.Unstructured{Object: map[string]any{
+					"apiVersion": "example.org/v1",
+					"kind":       "XR",
+					"metadata":   map[string]any{"name": "new-xr"},
+					"status":     map[string]any{"phase": "creating"},
+				}},
+			},
+		},
+		"MergeStatusFields": {
+			reason: "When there are existing status fields, the incoming status should be merged with them.",
+			store: []unstructured.Unstructured{{Object: map[string]any{
+				"apiVersion": "example.org/v1",
+				"kind":       "XR",
+				"metadata":   map[string]any{"name": "my-xr"},
+				"spec":       map[string]any{"region": "us-east-2"},
+				"status":     map[string]any{"existing": "is-set"},
+			}}},
+			statusObj: unstructured.Unstructured{Object: map[string]any{
+				"apiVersion": "example.org/v1",
+				"kind":       "XR",
+				"metadata":   map[string]any{"name": "my-xr"},
+				"status":     map[string]any{"phase": "creating"},
+			}},
+			want: want{
+				obj: unstructured.Unstructured{Object: map[string]any{
+					"apiVersion": "example.org/v1",
+					"kind":       "XR",
+					"metadata":   map[string]any{"name": "my-xr"},
+					"spec":       map[string]any{"region": "us-east-2"},
+					"status": map[string]any{
+						"existing": "is-set",
+						"phase":    "creating",
+					},
+				}},
+			},
+		},
+		"MergeStatusConditions": {
+			reason: "When there are existing status conditions, the incoming status conditions should be merged with them.",
+			store: []unstructured.Unstructured{{Object: map[string]any{
+				"apiVersion": "example.org/v1",
+				"kind":       "XR",
+				"metadata":   map[string]any{"name": "my-xr"},
+				"spec":       map[string]any{"region": "us-east-3"},
+				"status": map[string]any{"conditions": []any{
+					map[string]any{"type": "Keep", "status": "Existing"},
+					map[string]any{"type": "Replace", "status": "Existing"},
+				}},
+			}}},
+			statusObj: unstructured.Unstructured{Object: map[string]any{
+				"apiVersion": "example.org/v1",
+				"kind":       "XR",
+				"metadata":   map[string]any{"name": "my-xr"},
+				"status": map[string]any{"conditions": []any{
+					map[string]any{"type": "Replace", "status": "New"},
+					map[string]any{"type": "New", "status": "New"},
+				}},
+			}},
+			want: want{
+				obj: unstructured.Unstructured{Object: map[string]any{
+					"apiVersion": "example.org/v1",
+					"kind":       "XR",
+					"metadata":   map[string]any{"name": "my-xr"},
+					"spec":       map[string]any{"region": "us-east-3"},
+					"status": map[string]any{"conditions": []any{
+						map[string]any{"type": "Keep", "status": "Existing"},
+						map[string]any{"type": "Replace", "status": "New"},
+						map[string]any{"type": "New", "status": "New"},
+					}},
+				}},
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			c := NewInMemoryClient(runtime.NewScheme(), tc.store...)
+
+			obj := tc.statusObj.DeepCopy()
+			//nolint:staticcheck // TODO(adamwg) Stop using client.Apply after the v2.2 release.
+			err := c.Status().Patch(context.Background(), obj, client.Apply)
+
+			if diff := cmp.Diff(tc.want.err, err, cmpopts.EquateErrors()); diff != "" {
+				t.Errorf("\n%s\nStatus().Patch(...): -want error, +got error:\n%s", tc.reason, diff)
+			}
+			if diff := cmp.Diff(tc.want.obj, *obj); diff != "" {
+				t.Errorf("\n%s\nStatus().Patch(...): -want, +got:\n%s", tc.reason, diff)
 			}
 		})
 	}

--- a/internal/render/composite/render.go
+++ b/internal/render/composite/render.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/crossplane/crossplane-runtime/v2/pkg/errors"
@@ -232,11 +233,7 @@ func Render(ctx context.Context, log logging.Logger, in *renderv1alpha1.Composit
 	// useful state — in particular the resource selectors a function
 	// requested before returning a fatal result — that callers iterating on
 	// requirements need to make progress. See issue #7446.
-	out, berr := BuildOutput(c, func(u kunstructured.Unstructured) bool {
-		return u.GroupVersionKind() == gvk &&
-			u.GetNamespace() == xr.GetNamespace() &&
-			u.GetName() == xr.GetName()
-	}, rec, rrf, rsf)
+	out, berr := BuildOutput(ctx, c, xr, rec, rrf, rsf)
 	switch {
 	case berr != nil:
 		// Surface BuildOutput's failure. If reconcile also failed, join
@@ -402,38 +399,25 @@ func CompositionSelector(comp *apiextensionsv1.Composition) composite.Compositio
 // BuildOutput assembles a CompositeOutput from the fake client's captured
 // state and the event recorder. The isPrimary predicate identifies the
 // primary resource (the XR) so it can be separated from composed resources.
-func BuildOutput(c *render.InMemoryClient, isPrimary func(kunstructured.Unstructured) bool, rec *render.EventRecorder, rrf *render.RecordingRequiredResourcesFetcher, rsf *render.RecordingRequiredSchemasFetcher) (*renderv1alpha1.CompositeOutput, error) {
+func BuildOutput(ctx context.Context, c *render.InMemoryClient, primary *ucomposite.Unstructured, rec *render.EventRecorder, rrf *render.RecordingRequiredResourcesFetcher, rsf *render.RecordingRequiredSchemasFetcher) (*renderv1alpha1.CompositeOutput, error) {
 	out := &renderv1alpha1.CompositeOutput{}
 
-	// Find the final XR state. It's the last Status().Update or
-	// Status().Patch call for the XR.
-	for i := len(c.Updated()) - 1; i >= 0; i-- {
-		u := c.Updated()[i]
-		if isPrimary(u) {
-			s, err := xfn.AsStruct(&u)
-			if err != nil {
-				return nil, errors.Wrap(err, "cannot convert composite resource to protobuf")
-			}
-			out.CompositeResource = s
-			break
-		}
+	isPrimary := func(u kunstructured.Unstructured) bool {
+		return u.GroupVersionKind() == primary.GroupVersionKind() &&
+			u.GetNamespace() == primary.GetNamespace() &&
+			u.GetName() == primary.GetName()
 	}
 
-	// If the XR wasn't in the updated list, check applied (from
-	// Status().Patch, which records to applied).
-	if out.GetCompositeResource() == nil {
-		for i := len(c.Applied()) - 1; i >= 0; i-- {
-			u := c.Applied()[i]
-			if isPrimary(u) {
-				s, err := xfn.AsStruct(&u)
-				if err != nil {
-					return nil, errors.Wrap(err, "cannot convert composite resource to protobuf")
-				}
-				out.CompositeResource = s
-				break
-			}
-		}
+	// Get the final XR state.
+	primary = primary.DeepCopy()
+	if err := c.Get(ctx, client.ObjectKeyFromObject(primary), primary); err != nil {
+		return nil, errors.Wrap(err, "cannot get composite resource")
 	}
+	s, err := xfn.AsStruct(primary)
+	if err != nil {
+		return nil, errors.Wrap(err, "cannot convert composite resource to protobuf")
+	}
+	out.CompositeResource = s
 
 	// Collect composed resources from applied (SSA Patch). Exclude the XR
 	// itself and the XR resourceRefs patch.

--- a/internal/render/composite/render_test.go
+++ b/internal/render/composite/render_test.go
@@ -93,9 +93,19 @@ func TestRender(t *testing.T) {
 					CompositeResource: mustStruct(map[string]any{
 						"apiVersion": "example.org/v1alpha1",
 						"kind":       "XBucket",
-						"metadata":   map[string]any{"name": "my-bucket"},
+						"metadata": map[string]any{
+							"labels": map[string]any{
+								"crossplane.io/composite": "my-bucket",
+							},
+							"name":            "my-bucket",
+							"resourceVersion": "999",
+							"uid":             "f70ef0ce-2b73-5b7b-a497-0ba62f7c6f04",
+						},
 						"spec": map[string]any{
 							"crossplane": map[string]any{
+								"compositionRef": map[string]any{
+									"name": "bucket-composition",
+								},
 								"resourceRefs": []any{},
 							},
 						},
@@ -156,9 +166,20 @@ func TestRender(t *testing.T) {
 					CompositeResource: mustStruct(map[string]any{
 						"apiVersion": "example.org/v1alpha1",
 						"kind":       "XModernResource",
-						"metadata":   map[string]any{"name": "my-xr", "namespace": "default"},
+						"metadata": map[string]any{
+							"labels": map[string]any{
+								"crossplane.io/composite": "my-xr",
+							},
+							"name":            "my-xr",
+							"namespace":       "default",
+							"resourceVersion": "999",
+							"uid":             "6ca6696e-4135-5475-ad53-40843d379b20",
+						},
 						"spec": map[string]any{
 							"crossplane": map[string]any{
+								"compositionRef": map[string]any{
+									"name": "modern-composition",
+								},
 								"resourceRefs": []any{},
 							},
 						},
@@ -219,8 +240,18 @@ func TestRender(t *testing.T) {
 					CompositeResource: mustStruct(map[string]any{
 						"apiVersion": "example.org/v1alpha1",
 						"kind":       "XLegacyResource",
-						"metadata":   map[string]any{"name": "my-xr"},
+						"metadata": map[string]any{
+							"labels": map[string]any{
+								"crossplane.io/composite": "my-xr",
+							},
+							"name":            "my-xr",
+							"resourceVersion": "999",
+							"uid":             "be425815-11b0-5dea-99a2-7cda7e71e973",
+						},
 						"spec": map[string]any{
+							"compositionRef": map[string]any{
+								"name": "legacy-composition",
+							},
 							"resourceRefs": []any{},
 						},
 						"status": map[string]any{
@@ -281,8 +312,18 @@ func TestRender(t *testing.T) {
 					CompositeResource: mustStruct(map[string]any{
 						"apiVersion": "example.org/v1alpha1",
 						"kind":       "XLegacyResource",
-						"metadata":   map[string]any{"name": "my-xr"},
+						"metadata": map[string]any{
+							"labels": map[string]any{
+								"crossplane.io/composite": "my-xr",
+							},
+							"name":            "my-xr",
+							"resourceVersion": "999",
+							"uid":             "be425815-11b0-5dea-99a2-7cda7e71e973",
+						},
 						"spec": map[string]any{
+							"compositionRef": map[string]any{
+								"name": "legacy-composition",
+							},
 							"resourceRefs": []any{},
 						},
 						"status": map[string]any{
@@ -364,8 +405,18 @@ func TestRender(t *testing.T) {
 					CompositeResource: mustStruct(map[string]any{
 						"apiVersion": "example.org/v1alpha1",
 						"kind":       "XLegacyResource",
-						"metadata":   map[string]any{"name": "my-xr"},
+						"metadata": map[string]any{
+							"labels": map[string]any{
+								"crossplane.io/composite": "my-xr",
+							},
+							"name":            "my-xr",
+							"resourceVersion": "999",
+							"uid":             "xr-uid",
+						},
 						"spec": map[string]any{
+							"compositionRef": map[string]any{
+								"name": "legacy-composition",
+							},
 							"resourceRefs": []any{},
 						},
 						"status": map[string]any{


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane! Please read the contribution docs
(linked below) if this is your first Crossplane pull request.
-->

### Description of your changes

Before this change, the current conditions from the XR were being set on the status. Due to informer lag, this might be an older generation of the status conditi
ons, leading to the status flapping.

Now, we use server-side apply for all status updates. This means that conditions will be set or removed based on whether the relevant bit of the controller still
 wishes to set them.

Any conditions set by a third-party controller on the XR will still be respected - as Server-Side apply won't remove them. Indeed, prior to this change any conditions set by another controller were having their field manager reset by crossplane. This is a separate bug, which has also been fixed.

This also fixes the issue where a composition which previously set a condition, and then removed it, would still have the condition be present forever after.

Tests:
- Existing tests have been updated
- A new test has been added to verify we're not trying to overwrite the field manager for third-party conditions

<!--
Briefly describe what this pull request does, and how it is covered by tests.
Be proactive - direct your reviewers' attention to anything that needs special
consideration.

We love pull requests that fix an open issue. If yours does, use the below line
to indicate which issue it fixes, for example "Fixes #500".
-->

Fixes #7062

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [ ] Run `./nix.sh flake check` to ensure this PR is ready for review.
- [x] Added or updated unit tests.
- [ ] ~Added or updated e2e tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~
- [ ] ~Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md
