### PR TITLE
build: Calculate checksums after the nix fixup phase

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -259,6 +259,17 @@ jobs:
       - name: Build Artifacts
         run: nix build --option warn-dirty false --print-build-logs
 
+      - name: Validate Artifacts
+        run: |
+          for f in $(find result/bin/ -type f -not -name '*.sha256'); do
+            want=$(sha256sum "${f}" | head -c 64)
+            got=$(cat "${f}.sha256")
+            if [[ "${want}" != "${got}" ]]; then
+              echo "File ${f} has incorrect checksum; want ${want}, got ${got}"
+              exit 1
+            fi
+          done
+
       - name: Upload Artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:

--- a/nix/build.nix
+++ b/nix/build.nix
@@ -49,6 +49,9 @@ let
           mv $out/bin/${platform.os}_${platform.arch}/* $out/bin/
           rmdir $out/bin/${platform.os}_${platform.arch}
         fi
+      '';
+
+      postFixup = ''
         cd $out/bin
         sha256sum ${pname}${ext} | head -c 64 > ${pname}${ext}.sha256
       '';


### PR DESCRIPTION
### Description of your changes

Nix strips binaries in its `fixup` build phase, which runs after our `postInstall` hook. The stripping applies only to binaries for the host architecture, which in our release actions is always amd64. This results in the checksum files for amd64 binaries being incorrect.

Calculate checksums in the `postFixup` phase so that we checksum the already stripped binary. Add a checksum verification step before uploading artifacts to catch any similar issues in the future.

Fixes #7467

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `./nix.sh flake check` to ensure this PR is ready for review.
~- [ ] Added or updated unit tests.~
~- [ ] Added or updated e2e tests.~
~- [ ] Linked a PR or a [docs tracking issue] to [document this change].~
- [x] Added `backport release-x.y` labels to auto-backport this PR.
~- [ ] Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md
