### PR TITLE
fix(ci): make the flake.lock schedule reachable and cover release branches

### DIFF
--- a/.github/renovate-base.json5
+++ b/.github/renovate-base.json5
@@ -8,8 +8,9 @@
   // We only want renovate to rebase PRs when they have conflicts, default
   // "auto" mode is not required.
   rebaseWhen: 'conflicted',
-  // The maximum number of PRs to be created in parallel
-  prConcurrentLimit: 5,
+  // The maximum number of PRs to be created in parallel - branchConcurrentLimit
+  // inherits this value as well
+  prConcurrentLimit: 10,
   // Disable the default 2 per hour PR creation limit. prConcurrentLimit already caps how many PRs
   // can be open at once and our renovate job runs on a daily schedule, so having any hourly
   // throttling can actually slow us down.

--- a/.github/renovate-nix.json5
+++ b/.github/renovate-nix.json5
@@ -1,20 +1,41 @@
 {
-  // Nix-specific configuration for main branch.
-  // Release branches use Earthly - see renovate-earthly.json5.
+  // Nix-specific configuration. Applies to main and to release-2.2 and newer;
+  // older release branches use Earthly - see renovate-earthly.json5.
 
   // Enable the nix manager to detect flake.nix/flake.lock files.
   nix: {
     enabled: true,
   },
 
-  // Update flake.lock weekly by running 'nix flake update'.
-  // This also affects other lock files, so we disable it for gomod below.
+  // Allow Renovate to update lock files, so we get new updates in Nix inputs
+  // (e.g., nixpkgs, nixpkgs-unstable) regularly.
+  //
+  // Note that we use a schedule of "on monday", because "schedule:weekly" only
+  // allows a window of 00:00 to 03:59, which we can't guarantee our Renovate
+  // workflow will run during. Using "on monday" is better since it doesn't
+  // require the workflow to run at a specific time.
   lockFileMaintenance: {
     enabled: true,
-    extends: ['schedule:weekly'],
+    schedule: ['on monday'],
   },
 
   packageRules: [
+    {
+      // The base config disables all non-security updates on release branches,
+      // but we still want Nix flake.lock to get updated there, since that's how
+      // we get newer versions of Go, which could have security fixes.
+      description: 'Refresh flake.lock on nix release branches too',
+      matchManagers: [
+        'nix',
+      ],
+      matchUpdateTypes: [
+        'lockFileMaintenance',
+      ],
+      matchBaseBranches: [
+        '/^release-2\.([2-9]|..+)$/',
+      ],
+      enabled: true,
+    },
     {
       description: 'Refresh Go vendor hashes and generated code after upgrading go dependencies (Nix)',
       matchDatasources: [


### PR DESCRIPTION
### Description of your changes

This PR updates our Renovate config so that it will be better able to update our Nix lock file and we'll get updated Go versions. This is the same config update made in https://github.com/crossplane/crossplane-runtime/pull/1087

Overview of the changes:

#### Change schedule of lock file maintenance

`schedule:weekly` resolves to "* 0-3 * * 1", a window of 00:00 to 03:59 UTC on Monday. Our Renovate workflow's cron fires at 08:00 UTC, and GitHub only delays scheduled runs rather than advancing them, so our job will never hit that window. A literal 'on monday' covers the whole day, so it stays reachable however late the run starts.

#### Enable lock file maintenance for Nix release branches

The blanket release-branch opt-out in the base config also suppressed the refresh on release-2.2 and newer. Those branches build with nix and pin the Go toolchain in flake.lock the same way main does, so a rule re-enables lock file maintenance for them. release-2.1 and older use Earthly and have no flake.lock, so they stay excluded.

The comment about disabling lock file maintenance for gomod goes away too, since gomod doesn't support lockFileMaintenance in the first place.

#### Bump `prConcurrentLimit`

While we're at it, bump the prConcurrentLimit back up to Renovate's default of 10, so we get more throughput when there's a backlog.

Related to:
* https://github.com/crossplane/crossplane-runtime/issues/1086
* https://github.com/crossplane/crossplane-runtime/pull/1087


I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `./nix.sh flake check` to ensure this PR is ready for review.
- [ ] ~Added or updated unit tests.~
- [ ] ~Added or updated e2e tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~
- [ ] ~Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md
