### PR TITLE
Backport #7660 to release-2.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -249,6 +249,17 @@ jobs:
       - name: Build Artifacts
         run: nix build --option warn-dirty false --print-build-logs
 
+      - name: Validate Artifacts
+        run: |
+          for f in $(find result/bin/ -type f -not -name '*.sha256'); do
+            want=$(sha256sum "${f}" | head -c 64)
+            got=$(cat "${f}.sha256")
+            if [[ "${want}" != "${got}" ]]; then
+              echo "File ${f} has incorrect checksum; want ${want}, got ${got}"
+              exit 1
+            fi
+          done
+
       - name: Upload Artifacts
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:

--- a/nix/build.nix
+++ b/nix/build.nix
@@ -48,6 +48,9 @@ let
           mv $out/bin/${platform.os}_${platform.arch}/* $out/bin/
           rmdir $out/bin/${platform.os}_${platform.arch}
         fi
+      '';
+
+      postFixup = ''
         cd $out/bin
         sha256sum ${pname}${ext} | head -c 64 > ${pname}${ext}.sha256
       '';


### PR DESCRIPTION
### Description of your changes

Manual backport since the automated backport failed due to permission issues.

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `./nix.sh flake check` to ensure this PR is ready for review.
~- [ ] Added or updated unit tests.~
~- [ ] Added or updated e2e tests.~
~- [ ] Linked a PR or a [docs tracking issue] to [document this change].~
~- [ ] Added `backport release-x.y` labels to auto-backport this PR.~
~- [ ] Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md
