### PR TITLE
pkg: Allow for multiple active versions of a package in dependency resolution

### DIFF
--- a/internal/controller/pkg/revision/dependency.go
+++ b/internal/controller/pkg/revision/dependency.go
@@ -19,6 +19,7 @@ package revision
 import (
 	"context"
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/Masterminds/semver/v3"
@@ -261,10 +262,12 @@ func (m *PackageDependencyManager) Resolve(ctx context.Context, meta pkgmetav1.P
 			return found, installed, invalid, errors.New(errDependencyNotLockPackage)
 		}
 
+		versions := lp.GetVersions()
+
 		// Check if the constraint is a digest, if so, compare it directly.
 		if d, err := conregv1.NewHash(dep.Constraints); err == nil {
-			if lp.Version != d.String() {
-				return found, installed, invalid, errors.Errorf("existing package %s@%s is incompatible with constraint %s", lp.Identifier(), lp.Version, strings.TrimSpace(dep.Constraints))
+			if !slices.Contains(versions, d.String()) {
+				return found, installed, invalid, errors.Errorf("existing package %s@%s is incompatible with constraint %s", lp.Identifier(), strings.Join(versions, ","), strings.TrimSpace(dep.Constraints))
 			}
 
 			continue
@@ -275,13 +278,8 @@ func (m *PackageDependencyManager) Resolve(ctx context.Context, meta pkgmetav1.P
 			return found, installed, invalid, err
 		}
 
-		v, err := semver.NewVersion(lp.Version)
-		if err != nil {
-			return found, installed, invalid, err
-		}
-
-		if !c.Check(v) {
-			s := fmt.Sprintf("existing package %s@%s", lp.Identifier(), lp.Version)
+		if !anyVersionSatisfies(versions, c) {
+			s := fmt.Sprintf("existing package %s@%s", lp.Identifier(), strings.Join(versions, ","))
 			if dep.Constraints != "" {
 				s = fmt.Sprintf("%s is incompatible with constraint %s", s, strings.TrimSpace(dep.Constraints))
 			}
@@ -325,6 +323,24 @@ func (m *PackageDependencyManager) RemoveSelf(ctx context.Context, pr v1.Package
 	}
 
 	return nil
+}
+
+// anyVersionSatisfies reports whether any of the supplied versions satisfies
+// the constraint. Versions that aren't valid semantic versions (e.g. digests)
+// are skipped.
+func anyVersionSatisfies(versions []string, c *semver.Constraints) bool {
+	for _, v := range versions {
+		sv, err := semver.NewVersion(v)
+		if err != nil {
+			continue
+		}
+
+		if c.Check(sv) {
+			return true
+		}
+	}
+
+	return false
 }
 
 // NDependenciesAndSomeMore returns the first n dependencies in detail, and a

--- a/internal/dag/pkg.go
+++ b/internal/dag/pkg.go
@@ -17,6 +17,8 @@ limitations under the License.
 package dag
 
 import (
+	"fmt"
+
 	"github.com/crossplane/crossplane/apis/v2/pkg/v1beta1"
 )
 
@@ -45,26 +47,38 @@ func (d *DependencyNode) AddNeighbors(nodes ...Node) error {
 	return nil
 }
 
-// PackageNode is a DAG node representing a package.
+// PackageNode is a DAG node representing a package. More than one version of a
+// package may be installed at once, in which case a single PackageNode
+// represents all of them: the embedded LockPackage holds the first observed
+// version, while versions holds all installed versions and dependencies holds
+// the union of all installed versions' dependencies.
 type PackageNode struct {
 	v1beta1.LockPackage
+
+	versions     []string
+	dependencies []v1beta1.Dependency
+}
+
+// GetVersions returns every installed version this node represents.
+func (l *PackageNode) GetVersions() []string {
+	return l.versions
 }
 
 // Neighbors returns dependencies of a LockPackage.
 func (l *PackageNode) Neighbors() []Node {
-	nodes := make([]Node, len(l.Dependencies))
-	for i, r := range l.Dependencies {
+	nodes := make([]Node, len(l.dependencies))
+	for i, r := range l.dependencies {
 		nodes[i] = &DependencyNode{r}
 	}
 
 	return nodes
 }
 
-// AddNeighbors adds dependencies to a LockPackage and
-// updates the parent constraints of the dependencies in the DAG.
+// AddNeighbors adds dependencies to a LockPackage and updates the parent
+// constraints of the dependencies in the DAG.
 func (l *PackageNode) AddNeighbors(nodes ...Node) error {
 	for _, n := range nodes {
-		for _, dep := range l.Dependencies {
+		for _, dep := range l.dependencies {
 			if dep.Identifier() == n.Identifier() {
 				n.AddParentConstraints([]string{dep.Constraints})
 				break
@@ -75,11 +89,49 @@ func (l *PackageNode) AddNeighbors(nodes ...Node) error {
 	return nil
 }
 
-// PackagesToNodes converts LockPackages to DAG nodes.
+// PackagesToNodes converts LockPackages to DAG nodes. Packages that share a
+// source are merged into a single node.
 func PackagesToNodes(pkgs ...v1beta1.LockPackage) []Node {
-	nodes := make([]Node, len(pkgs))
-	for i, r := range pkgs {
-		nodes[i] = &PackageNode{r}
+	// Preserve first-seen order so the result is deterministic.
+	order := make([]string, 0, len(pkgs))
+	bySource := make(map[string]*PackageNode, len(pkgs))
+	seenDep := make(map[string]map[string]bool, len(pkgs))
+	seenVer := make(map[string]map[string]bool, len(pkgs))
+
+	for i := range pkgs {
+		pkg := pkgs[i]
+		src := pkg.Identifier()
+
+		n, ok := bySource[src]
+		if !ok {
+			n = &PackageNode{LockPackage: pkg}
+			bySource[src] = n
+			seenDep[src] = make(map[string]bool)
+			seenVer[src] = make(map[string]bool)
+			order = append(order, src)
+		}
+
+		for _, dep := range pkg.Dependencies {
+			// Dedupe on the (package, constraints) pair so distinct constraints
+			// from different versions are all preserved.
+			key := fmt.Sprintf("%s@%s", dep.Package, dep.Constraints)
+			if seenDep[src][key] {
+				continue
+			}
+
+			seenDep[src][key] = true
+			n.dependencies = append(n.dependencies, dep)
+		}
+
+		if pkg.Version != "" && !seenVer[src][pkg.Version] {
+			seenVer[src][pkg.Version] = true
+			n.versions = append(n.versions, pkg.Version)
+		}
+	}
+
+	nodes := make([]Node, 0, len(order))
+	for _, src := range order {
+		nodes = append(nodes, bySource[src])
 	}
 
 	return nodes

--- a/internal/dag/pkg_test.go
+++ b/internal/dag/pkg_test.go
@@ -1,0 +1,166 @@
+/*
+Copyright 2026 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dag
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	"github.com/crossplane/crossplane/apis/v2/pkg/v1beta1"
+)
+
+func TestPackagesToNodes(t *testing.T) {
+	const (
+		src = "example.com/fn"
+		v1  = "v1.0.0"
+		v2  = "v2.0.0"
+	)
+
+	type want struct {
+		// identifier -> versions
+		versions map[string][]string
+		// identifier -> dependency identifiers (in order)
+		deps map[string][]string
+		// number of nodes
+		count int
+	}
+
+	cases := map[string]struct {
+		reason string
+		pkgs   []v1beta1.LockPackage
+		want   want
+	}{
+		"DistinctSources": {
+			reason: "Packages with distinct sources should each become their own node.",
+			pkgs: []v1beta1.LockPackage{
+				{Name: "a", Source: "example.com/a", Version: v1},
+				{Name: "b", Source: "example.com/b", Version: v2},
+			},
+			want: want{
+				count:    2,
+				versions: map[string][]string{"example.com/a": {v1}, "example.com/b": {v2}},
+				deps:     map[string][]string{"example.com/a": {}, "example.com/b": {}},
+			},
+		},
+		"MergesSameSource": {
+			reason: "Multiple versions of the same source should merge into one node tracking all versions with a deduplicated union of dependencies.",
+			pkgs: []v1beta1.LockPackage{
+				{
+					Name:    "fn-v1",
+					Source:  src,
+					Version: v1,
+					Dependencies: []v1beta1.Dependency{
+						{Package: "example.com/dep-a", Constraints: ">=1.0.0"},
+					},
+				},
+				{
+					Name:    "fn-v2",
+					Source:  src,
+					Version: v2,
+					Dependencies: []v1beta1.Dependency{
+						{Package: "example.com/dep-a", Constraints: ">=1.0.0"}, // duplicate
+						{Package: "example.com/dep-b", Constraints: ">=2.0.0"}, // unique
+					},
+				},
+			},
+			want: want{
+				count:    1,
+				versions: map[string][]string{src: {v1, v2}},
+				deps:     map[string][]string{src: {"example.com/dep-a", "example.com/dep-b"}},
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			nodes := PackagesToNodes(tc.pkgs...)
+
+			if len(nodes) != tc.want.count {
+				t.Fatalf("\n%s\nPackagesToNodes(...): want %d nodes, got %d", tc.reason, tc.want.count, len(nodes))
+			}
+
+			for _, n := range nodes {
+				pn, ok := n.(*PackageNode)
+				if !ok {
+					t.Fatalf("node %q is not a *PackageNode", n.Identifier())
+				}
+
+				if diff := cmp.Diff(tc.want.versions[n.Identifier()], pn.GetVersions()); diff != "" {
+					t.Errorf("\n%s\nversions for %q: -want, +got:\n%s", tc.reason, n.Identifier(), diff)
+				}
+
+				depIDs := make([]string, len(n.Neighbors()))
+				for i, ne := range n.Neighbors() {
+					depIDs[i] = ne.Identifier()
+				}
+
+				if diff := cmp.Diff(tc.want.deps[n.Identifier()], depIDs); diff != "" {
+					t.Errorf("\n%s\ndependencies for %q: -want, +got:\n%s", tc.reason, n.Identifier(), diff)
+				}
+			}
+		})
+	}
+}
+
+func TestIsValidConstraints(t *testing.T) {
+	const (
+		src = "example.com/fn"
+		v1  = "v1.0.0"
+		v2  = "v2.0.0"
+	)
+
+	cases := map[string]struct {
+		reason    string
+		installed Node
+		wanted    Node
+		want      bool
+	}{
+		"SingleVersionSatisfies": {
+			reason:    "A single installed version that satisfies the constraint is valid.",
+			installed: &PackageNode{LockPackage: v1beta1.LockPackage{Source: src, Version: "v1.5.0"}},
+			wanted:    &DependencyNode{Dependency: v1beta1.Dependency{Package: src, Constraints: ">=1.0.0"}},
+			want:      true,
+		},
+		"SingleVersionDoesNotSatisfy": {
+			reason:    "A single installed version that doesn't satisfy the constraint is invalid.",
+			installed: &PackageNode{LockPackage: v1beta1.LockPackage{Source: src, Version: "v1.5.0"}},
+			wanted:    &DependencyNode{Dependency: v1beta1.Dependency{Package: src, Constraints: ">=2.0.0"}},
+			want:      false,
+		},
+		"AnyVersionSatisfies": {
+			reason:    "When multiple versions are installed, the constraint is satisfied if any version satisfies it.",
+			installed: &PackageNode{LockPackage: v1beta1.LockPackage{Source: src, Version: v1}, versions: []string{v1, v2}},
+			wanted:    &DependencyNode{Dependency: v1beta1.Dependency{Package: src, Constraints: ">=2.0.0"}},
+			want:      true,
+		},
+		"NoVersionSatisfies": {
+			reason:    "When no installed version satisfies the constraint it is invalid.",
+			installed: &PackageNode{LockPackage: v1beta1.LockPackage{Source: src, Version: v1}, versions: []string{v1, v2}},
+			wanted:    &DependencyNode{Dependency: v1beta1.Dependency{Package: src, Constraints: ">=3.0.0"}},
+			want:      false,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			if got := isValidConstraints(tc.installed, tc.wanted); got != tc.want {
+				t.Errorf("\n%s\nisValidConstraints(...): want %v, got %v", tc.reason, tc.want, got)
+			}
+		})
+	}
+}

--- a/internal/dag/upgrading_dag.go
+++ b/internal/dag/upgrading_dag.go
@@ -247,25 +247,45 @@ func (d *MapUpgradingDag) visit(name string, neighbors []Node, stack map[string]
 	return nil
 }
 
+// isValidConstraints reports whether the installed node satisfies the wanted
+// node's constraint. A package may have more than one version installed at
+// once (e.g. multiple active function revisions), so the constraint is
+// considered satisfied if any installed version satisfies it.
 func isValidConstraints(installed, wanted Node) bool {
-	// NOTE(ezgidemirel): This condition also satisfies digests
-	if installed.GetConstraints() == wanted.GetConstraints() {
-		return true
+	c, cErr := semver.NewConstraint(wanted.GetConstraints())
+
+	for _, iv := range installedVersions(installed) {
+		// NOTE(ezgidemirel): This condition also satisfies digests.
+		if iv == wanted.GetConstraints() {
+			return true
+		}
+
+		if cErr != nil {
+			continue
+		}
+
+		v, err := semver.NewVersion(iv)
+		if err != nil {
+			continue
+		}
+
+		if c.Check(v) {
+			return true
+		}
 	}
 
-	c, err := semver.NewConstraint(wanted.GetConstraints())
-	if err != nil {
-		return false
+	return false
+}
+
+// installedVersions returns the installed versions a node represents. A merged
+// PackageNode may represent several versions; any other node represents the
+// single version or constraint returned by GetConstraints.
+func installedVersions(n Node) []string {
+	if pn, ok := n.(*PackageNode); ok {
+		if vs := pn.GetVersions(); len(vs) > 0 {
+			return vs
+		}
 	}
 
-	v, err := semver.NewVersion(installed.GetConstraints())
-	if err != nil {
-		return false
-	}
-
-	if !c.Check(v) {
-		return false
-	}
-
-	return true
+	return []string{n.GetConstraints()}
 }


### PR DESCRIPTION
### Description of your changes

It's not possible yet, but soon we will allow multiple versions of a function to be active at once in order to support progressive rollout. Update the DAG we use for dependency resolution to allow for this: track all active versions of a package. Update the dependency resolver in the revision controller to consider a dependency constraint satisfied if any active version satisfies it. The resolver controller continues to work as it always has.

In addition to preparing for multiple active function revisions, this change prevents the resolver from getting stuck if a user tries to install multiple instances of the same package, or an upgrade results in a duplicate package being created. Two instances of the same provider or configuration can never become healthy simultaneously (since only one can own its CRDs), but this change prevents the dependency resolver from getting stuck in such a scenario; the duplicate package will sit unhealthy forever while package management otherwise continues normally.

Fixes #7454

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `./nix.sh flake check` to ensure this PR is ready for review.
- [x] Added or updated unit tests.
~- [ ] Added or updated e2e tests.~
~- [ ] Linked a PR or a [docs tracking issue] to [document this change].~
~- [ ] Added `backport release-x.y` labels to auto-backport this PR.~
~- [ ] Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md
