### PR TITLE
lint: Tell the goconst linter to ignore tests

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -117,6 +117,7 @@ linters:
     goconst:
       min-len: 3
       min-occurrences: 5
+      ignore-tests: true
     gocritic:
       enabled-tags:
         - performance


### PR DESCRIPTION
### Description of your changes

The goconst linter requires that any string of length greater than or equal to 3 with at least 5 occurrences in a given package be made a const. This is reasonable for real code, but flags a lot of consts in tests that aren't really worth declaring consts for.

Add the `ignore-tests: true` option to the goconst config so that it ignores test files.

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `./nix.sh flake check` to ensure this PR is ready for review.
~- [ ] Added or updated unit tests.~
~- [ ] Added or updated e2e tests.~
~- [ ] Linked a PR or a [docs tracking issue] to [document this change].~
~- [ ] Added `backport release-x.y` labels to auto-backport this PR.~
~- [ ] Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md
