### PR TITLE
fix(dag): report missing from node in UpgradingDag AddEdge

### DIFF
--- a/internal/dag/upgrading_dag.go
+++ b/internal/dag/upgrading_dag.go
@@ -175,7 +175,7 @@ func (d *MapUpgradingDag) AddEdges(edges map[string][]Node) ([]Node, error) {
 // AddEdge adds an edge to the graph and returns if we need to check for updates.
 func (d *MapUpgradingDag) AddEdge(from string, to Node) (bool, error) {
 	if _, ok := d.nodes[from]; !ok {
-		return false, errors.Errorf("node %s does not exist", to)
+		return false, errors.Errorf("node %s does not exist", from)
 	}
 
 	implied := false

--- a/internal/dag/upgrading_dag_test.go
+++ b/internal/dag/upgrading_dag_test.go
@@ -208,3 +208,46 @@ func TestUpgradingDag(_ *testing.T) {
 	d := NewUpgradingMapDag()
 	d.AddNode(&simpleNode{identifier: "hi"})
 }
+
+func TestUpgradingAddEdgeMissingFrom(t *testing.T) {
+	type args struct {
+		from string
+		to   *simpleNode
+	}
+
+	type want struct {
+		err error
+	}
+
+	cases := map[string]struct {
+		reason string
+		args   args
+		want   want
+	}{
+		"MissingFromReportsFromIdentifier": {
+			reason: "AddEdge should report the missing from node identifier, not the destination node.",
+			args: args{
+				from: "missing-from",
+				to:   &simpleNode{identifier: "cool-to", neighbors: map[string]simpleNode{}},
+			},
+			want: want{
+				err: errors.Errorf("node %s does not exist", "missing-from"),
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			d := NewUpgradingMapDag()
+			_, err := d.AddEdge(tc.args.from, tc.args.to)
+			if diff := cmp.Diff(tc.want.err, err, cmp.Comparer(func(a, b error) bool {
+				if a == nil || b == nil {
+					return a == nil && b == nil
+				}
+				return a.Error() == b.Error()
+			})); diff != "" {
+				t.Errorf("\n%s\nAddEdge(...): -want err, +got err:\n%s", tc.reason, diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Description of your changes

`MapUpgradingDag.AddEdge` validates that the `from` node exists, but the error used the destination `Node` value with `%s`, producing messages like `node &{cool-to map[]} does not exist` instead of the missing source identifier.

This is the same mistake as in `MapDag.AddEdge` (covered by #7600); that PR does not touch `upgrading_dag.go`.

Added a unit test that fails before and passes after the one-line fix.

I have:

- [x] Read and followed Crossplane's [contribution process](https://github.com/crossplane/crossplane/tree/main/contributing).
- [ ] Run `./nix.sh flake check` to ensure this PR is ready for review.
- [x] Added or updated unit tests.
- [ ] Added or updated e2e tests.
- [ ] Linked a PR or a [docs tracking issue](https://github.com/crossplane/docs/issues/new/choose) to [document this change](https://docs.crossplane.io/contribute/documentation/).
- [ ] Added `backport release-x.y` labels to auto-backport this PR.
- [ ] Followed the [API promotion workstream](https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md) for API changes.

Verified: `go test ./internal/dag/ -count=1` (fail-before / pass-after on `TestUpgradingAddEdgeMissingFrom`, full package green after).
