### PR TITLE
ci: skip BuildPulse flake publishing when credentials are absent

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,6 +126,11 @@ jobs:
   # E2E tests run outside the Nix sandbox (needs Docker)
   e2e-tests:
     runs-on: ubuntu-24.04
+    env:
+      # Resolved here because the secrets context isn't available in a
+      # step-level if. Empty on pull requests from forks, which don't receive
+      # secrets, and on forks of this repository.
+      BUILDPULSE_CONFIGURED: ${{ secrets.BUILDPULSE_ACCESS_KEY_ID != '' && secrets.BUILDPULSE_SECRET_ACCESS_KEY != '' }}
     strategy:
       fail-fast: false
       matrix:
@@ -198,7 +203,7 @@ jobs:
               -labels area=${{ matrix.test-area }}
 
       - name: Publish E2E Test Flakes
-        if: '!cancelled()'
+        if: "!cancelled() && env.BUILDPULSE_CONFIGURED == 'true'"
         uses: buildpulse/buildpulse-action@76dbedc6585e8731b40a19da1ebc3f6609dbbb83 # v3
         with:
           account: 45158470


### PR DESCRIPTION
### Description of your changes

Since #7500 bumped `buildpulse/buildpulse-action` to v3, every `e2e-tests` job that runs without BuildPulse credentials fails — *after* the E2E suite itself has passed. All 11 matrix jobs go red on any pull request from a fork, because fork PRs don't receive secrets.

v0.12.0 and earlier were composite actions whose only step carried `continue-on-error: true`, so absent credentials were swallowed. An approved fork-PR run from before the bump shows the step rendering with no `key`/`secret` inputs and `outcome=failure;conclusion=success`. v3 is a JavaScript action without that guard, so the same absent credentials now surface as `Authentication required: provide api-token OR (account + repository + key + secret)` and fail the job.

This skips publishing when the credentials aren't configured. The `secrets` context isn't available in a step-level `if`, so the check is resolved into a job-level `env` boolean first. Behaviour on `crossplane/crossplane` is unchanged. Only `main` is affected — the release branches still pin v0.11.0/v0.12.0, where the failure is swallowed.

This PR is itself from a fork, so its own `e2e-tests` jobs exercise the fix: the publish step should be skipped rather than failing the job.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [ ] ~Run `./nix.sh flake check` to ensure this PR is ready for review.~ CI-only change, no Go or Nix code touched.
- [ ] ~Added or updated unit tests.~ Not applicable to a workflow change.
- [ ] ~Added or updated e2e tests.~ Not applicable; this changes how E2E results are published, not the tests.
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~ No user-facing change.
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~ Release branches pin v0.11.0/v0.12.0 and aren't affected.
- [ ] ~Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~ No API change.

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md
