### PR TITLE
build: point docker-client at docker_29 in the nix overlay

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -89,6 +89,12 @@
                 unstable = import nixpkgs-unstable {
                   inherit (prev.stdenv.hostPlatform) system;
                 };
+
+                # nixpkgs' default docker is still docker_28, which nixos-25.11
+                # marks unmaintained and refuses to evaluate. We override here
+                # so every pkgs.docker-client call site picks up docker_29, we
+                # can remove this when the nixpkgs default moves forward.
+                docker-client = prev.docker_29.override { clientOnly = true; };
               })
             ];
           };


### PR DESCRIPTION
### Description of your changes

nixpkgs' nixos-25.11 branch now marks docker_28 as unmaintained since November 2025, and Nix refuses to evaluate a package carrying knownVulnerabilities. The default docker attribute on that branch is still docker_28, so pkgs.docker-client fails to evaluate. That breaks nix develop, and with it every CI job that sets up the nix environment. 

See some examples in https://github.com/crossplane/crossplane/pull/7696, e.g. https://github.com/crossplane/crossplane/actions/runs/30847645696/job/91799759524?pr=7696:
```
         error: Package ‘docker-28.5.2’ in /nix/store/4k79ns9drp02wyvcix81c7nnz4hn8psi-source/pkgs/applications/virtualization/docker/default.nix:372 is marked as insecure, refusing to evaluate.

```

This commit overrides docker-client in the flake's existing overlay, so every pkgs.docker-client call site picks up docker_29, which nixpkgs still maintains.

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `./nix.sh flake check` to ensure this PR is ready for review.
- [ ] ~Added or updated unit tests.~
- [ ] ~Added or updated e2e tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [x] Added `backport release-x.y` labels to auto-backport this PR.
- [ ] ~Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md
