### PR TITLE
build: point docker-client at docker_29 in the nix overlay [release-2.3]

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -89,6 +89,12 @@
                 unstable = import nixpkgs-unstable {
                   inherit (prev.stdenv.hostPlatform) system;
                 };
+
+                # nixpkgs' default docker is still docker_28, which nixos-25.11
+                # marks unmaintained and refuses to evaluate. We override here
+                # so every pkgs.docker-client call site picks up docker_29, we
+                # can remove this when the nixpkgs default moves forward.
+                docker-client = prev.docker_29.override { clientOnly = true; };
               })
             ];
           };


### PR DESCRIPTION
### Description of your changes

Backport of #7701 to `release-2.3`.

`nixpkgs`' default docker is still docker_28, which nixos-25.11 marks unmaintained
and refuses to evaluate, so `pkgs.docker-client` cannot be evaluated. This
overrides it to `docker_29`.

Motivation: the pending `lock file maintenance` PR for this branch (#7700) moves
the stable `nixpkgs` input from `d04d8548` (2026-02-02) to `b6018f87`. At that rev
`docker-client` is docker **28.5.2** and marked insecure, so nix refuses to
evaluate the flake and **all 12 CI jobs on #7700 fail during environment setup** —
every `e2e-tests` variant plus `codeql`, identically, after 3 retries and before
any test executes:

```
error: Package 'docker-28.5.2' in .../virtualization/docker/default.nix:372 is
marked as insecure, refusing to evaluate.
```

That also blocks the Go toolchain fix this branch needs. #7700 is what moves
`nixpkgs-unstable` to a rev providing Go **1.25.12**, which clears
**CVE-2026-39822** (High). The Earthly-built lines took that as a direct
`GO_VERSION` edit (#7577, #7578), but the nix-built lines can only get it via the
lock bump, so `release-2.2` and `release-2.3` are still on Go 1.25.11.

This is safe to land ahead of that bump: at the currently pinned nixpkgs
`docker_29` already exists (29.1.5) and today's `docker-client` (28.5.2) is not
yet marked insecure, so the override is inert for CI today and becomes load
bearing the moment #7700 lands.

This branch already binds `prev` in its overlay lambda, so the change is
byte-identical to #7701. The `release-2.2` companion (#7704) additionally renames
`_prev` to `prev`, which that branch needs for the override to resolve.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `./nix.sh flake check` to ensure this PR is ready for review. — ran
      `nix flake check --no-build` (x86_64-linux): `all checks passed!`. Also
      confirmed the override takes effect rather than merely evaluating: the
      devShell closure resolves `docker-29.1.5` in place of `docker-28.5.2`.
- [ ] ~Added or updated unit tests.~ — build configuration only.
- [ ] ~Added or updated e2e tests.~ — build configuration only; the existing e2e
      matrix is what exercises this, and is currently what fails without it.
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~ — no
      user-facing change.
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~ — this *is*
      the backport, opened directly against the release branch.
- [ ] ~Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~ — no API change.

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md
