### PR TITLE
fix(ci): pin which Nix Renovate's post-upgrade tasks use

### DIFF
--- a/.github/renovate-entrypoint.sh
+++ b/.github/renovate-entrypoint.sh
@@ -24,14 +24,24 @@ extra-substituters = https://crossplane.cachix.org
 extra-trusted-public-keys = crossplane.cachix.org-1:NJluVUN9TX0rY/zAxHYaT19Y5ik4ELH4uFuxje+62d4=
 EOF
 
-echo "Nix $(nix --version) installed successfully"
+# Renovate installs its own Nix when it updates flake.lock. It goes earlier on
+# PATH than ours and ignores the config above, so all nix commands we run (e.g.
+# postUpgradeTasks) will go through this launcher, which pins both the binary
+# and the config it reads.
+cat >/usr/local/bin/crossplane-nix <<'EOF'
+#!/bin/bash
+exec env NIX_CONF_DIR=/etc/nix /usr/bin/nix "$@"
+EOF
+chmod +x /usr/local/bin/crossplane-nix
+
+echo "Nix $(crossplane-nix --version) installed successfully"
 
 # Install Earthly (for release branches) from the repository flake on main,
 # pinned by main's flake.lock. The flake is referenced by URL because this
 # entrypoint runs in the Renovate container before the target repo is checked
 # out, so the working directory does not yet contain a flake.nix.
 echo "Installing Earthly..."
-nix profile install github:crossplane/crossplane#earthly
+crossplane-nix profile install github:crossplane/crossplane#earthly
 export PATH="$HOME/.nix-profile/bin:$PATH"
 earthly bootstrap
 

--- a/.github/renovate-nix.json5
+++ b/.github/renovate-nix.json5
@@ -56,8 +56,8 @@
       ],
       postUpgradeTasks: {
         commands: [
-          'nix run .#tidy',
-          'nix run .#generate',
+          'crossplane-nix run .#tidy',
+          'crossplane-nix run .#generate',
         ],
         fileFilters: [
           '**/*',
@@ -77,7 +77,7 @@
       ],
       postUpgradeTasks: {
         commands: [
-          'nix run .#lint',
+          'crossplane-nix run .#lint',
         ],
         fileFilters: [
           '**/*',

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -46,7 +46,7 @@ jobs:
           # Use GitHub API to create commits
           RENOVATE_PLATFORM_COMMIT: "true"
           LOG_LEVEL: ${{ github.event.inputs.logLevel || env.LOG_LEVEL }}
-          RENOVATE_ALLOWED_COMMANDS: '["^nix .+", "^earthly .+"]'
+          RENOVATE_ALLOWED_COMMANDS: '["^crossplane-nix .+", "^earthly .+"]'
         with:
           configurationFile: .github/renovate.json5
           token: '${{ steps.get-github-app-token.outputs.token }}'


### PR DESCRIPTION
### Description of your changes

Renovate's Go dependency PRs fail their post-upgrade tasks with `error: experimental Nix feature 'nix-command' is disabled`, so `nix run .#tidy` and `nix run .#generate` never refresh our vendor hashes or generated code.

This entrypoint installs Nix from apt and configures it via `/etc/nix/nix.conf`. Renovate's Nix manager installs its own through containerbase whenever it updates `flake.lock`, and that one goes earlier on `PATH` and therefore conflicts with the `nix` installed by the entrypoint.

This has always been possible but giving lock file maintenance a higher priority in #7695 moved those updates to the front of the run, where they now poison every post-upgrade task after them 😇 

This PR has the entrypoint publish a `crossplane-nix` launcher that pins both the binary and the config directory it reads, and points the post-upgrade tasks at it. `RENOVATE_ALLOWED_COMMANDS` no longer permits a bare nix, so a command still spelled that way fails on the allowlist instead of silently running against the wrong Nix.

Fixes #7707 

### How has this code been tested

I ran this repo's actual entrypoint inside `ghcr.io/renovatebot/renovate:44`, the same image the action pulls, then installed Renovate's Nix the way its manager does for `flake.lock`. That reproduces the shadowing just like on a real real Renovate run, and a bare `nix run` in that container gives the expected error message, so I have confidence the repro scenario was set up correctly.

Then using the `crossplane-nix` launcher, both postUpgradeTasks tasks complete OK:

```
===== nix run .#tidy =====
Refreshing Go vendor hashes...
  root = sha256-Jk1gG7tGpYnK7fs+B4jTrMsu5V6ihn8YozV/z9BNlHQ=
  apis = sha256-LBPg9GFga3rvI5D487ydw+AyE7ezHP07ukxX3PcWLUA=
Done

===== nix run .#generate =====
Done
```

Both hashes match [`nix/vendor-hashes.nix`](https://github.com/crossplane/crossplane/blob/main/nix/vendor-hashes.nix), and a diff on the worktree shows no changes, so the tasks seemed to do the correct work 🎉 

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `./nix.sh flake check` to ensure this PR is ready for review.
- [ ] ~Added or updated unit tests.~
- [ ] ~Added or updated e2e tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~
- [ ] ~Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md
