### PR TITLE
fix: give the closed watch circuit condition a message so SSA can clear orphans

### DIFF
--- a/apis/apiextensions/v1/conditions.go
+++ b/apis/apiextensions/v1/conditions.go
@@ -143,6 +143,15 @@ func WatchCircuitClosed() xpv2.Condition {
 		Status:             corev1.ConditionTrue,
 		LastTransitionTime: metav1.Now(),
 		Reason:             ReasonWatchCircuitClosed,
+		// The message must be non-empty. The XR status is written with
+		// server-side apply, which only owns fields present in the patch.
+		// Message is serialized with omitempty, so an empty message here would
+		// leave the key out of the patch and a message written by
+		// WatchCircuitOpen (or any other field manager) could never be
+		// cleared. Condition.Equal compares messages, so that orphan makes
+		// SetConditions rewrite the XR status on every reconcile, and the XR's
+		// self-watch turns the rewrite into an infinite reconcile loop.
+		Message: "Watch events are within limits. Allowing all events.",
 	}
 }
 

--- a/apis/apiextensions/v1/conditions_test.go
+++ b/apis/apiextensions/v1/conditions_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package v1
 
 import (
+	"bytes"
+	"encoding/json"
 	"testing"
 
 	xpv2 "github.com/crossplane/crossplane/apis/v2/core/v2"
@@ -62,5 +64,22 @@ func TestIsSystemConditionType(t *testing.T) {
 				t.Errorf("%s: IsSystemConditionType(%q) = %v, want %v", tc.reason, tc.conditionType, got, tc.want)
 			}
 		})
+	}
+}
+
+func TestWatchCircuitClosedSerializesMessage(t *testing.T) {
+	// The XR status is written with server-side apply, which only takes
+	// ownership of fields present in the patch. Condition.Message is
+	// json:"message,omitempty", so if the closed condition has no message the
+	// key is absent from the patch and a message left behind by
+	// WatchCircuitOpen can never be cleared. Condition.Equal compares Message,
+	// so the orphaned message makes SetConditions rewrite the XR on every
+	// reconcile, and the XR's self-watch turns that into an infinite loop.
+	got, err := json.Marshal(WatchCircuitClosed())
+	if err != nil {
+		t.Fatalf("json.Marshal(WatchCircuitClosed()): %v", err)
+	}
+	if !bytes.Contains(got, []byte(`"message"`)) {
+		t.Errorf("WatchCircuitClosed() must serialize a message key so server-side apply owns (and can clear) the field, got %s", got)
 	}
 }

--- a/internal/render/composite/render_test.go
+++ b/internal/render/composite/render_test.go
@@ -101,7 +101,7 @@ func TestRender(t *testing.T) {
 						},
 						"status": map[string]any{
 							"conditions": []any{
-								map[string]any{"type": "Responsive", "status": "True", "reason": "WatchCircuitClosed"},
+								map[string]any{"type": "Responsive", "status": "True", "reason": "WatchCircuitClosed", "message": "Watch events are within limits. Allowing all events."},
 								map[string]any{"type": "Synced", "status": "True", "reason": "ReconcileSuccess"},
 								map[string]any{"type": "Ready", "status": "True", "reason": "Available"},
 							},
@@ -164,7 +164,7 @@ func TestRender(t *testing.T) {
 						},
 						"status": map[string]any{
 							"conditions": []any{
-								map[string]any{"type": "Responsive", "status": "True", "reason": "WatchCircuitClosed"},
+								map[string]any{"type": "Responsive", "status": "True", "reason": "WatchCircuitClosed", "message": "Watch events are within limits. Allowing all events."},
 								map[string]any{"type": "Synced", "status": "True", "reason": "ReconcileSuccess"},
 								map[string]any{"type": "Ready", "status": "True", "reason": "Available"},
 							},
@@ -225,7 +225,7 @@ func TestRender(t *testing.T) {
 						},
 						"status": map[string]any{
 							"conditions": []any{
-								map[string]any{"type": "Responsive", "status": "True", "reason": "WatchCircuitClosed"},
+								map[string]any{"type": "Responsive", "status": "True", "reason": "WatchCircuitClosed", "message": "Watch events are within limits. Allowing all events."},
 								map[string]any{"type": "Synced", "status": "True", "reason": "ReconcileSuccess"},
 								map[string]any{"type": "Ready", "status": "True", "reason": "Available"},
 							},
@@ -287,7 +287,7 @@ func TestRender(t *testing.T) {
 						},
 						"status": map[string]any{
 							"conditions": []any{
-								map[string]any{"type": "Responsive", "status": "True", "reason": "WatchCircuitClosed"},
+								map[string]any{"type": "Responsive", "status": "True", "reason": "WatchCircuitClosed", "message": "Watch events are within limits. Allowing all events."},
 								map[string]any{"type": "Synced", "status": "True", "reason": "ReconcileSuccess"},
 								map[string]any{"type": "Ready", "status": "True", "reason": "Available"},
 							},
@@ -370,7 +370,7 @@ func TestRender(t *testing.T) {
 						},
 						"status": map[string]any{
 							"conditions": []any{
-								map[string]any{"type": "Responsive", "status": "True", "reason": "WatchCircuitClosed"},
+								map[string]any{"type": "Responsive", "status": "True", "reason": "WatchCircuitClosed", "message": "Watch events are within limits. Allowing all events."},
 								map[string]any{"type": "Synced", "status": "True", "reason": "ReconcileSuccess"},
 								map[string]any{"type": "Ready", "status": "True", "reason": "Available"},
 							},


### PR DESCRIPTION
### Description of your changes

`WatchCircuitClosed()` sets no message, and `Condition.Message` is serialized with `omitempty`. The XR status is written with server-side apply, which only takes ownership of fields present in the patch, so once `WatchCircuitOpen()` (or any other field manager) has written a `Responsive` message, Crossplane can never clear it. `Condition.Equal` compares messages, so the orphaned message makes `SetConditions` stamp a fresh `LastTransitionTime` and rewrite the XR status on every reconcile. The XR's self-watch turns that into an infinite loop that runs the full composition function pipeline every few seconds, exactly as traced in #7692.

The fix gives the closed condition a non-empty message, so the `message` key is always present in the patch, owned by Crossplane, and any orphan gets overwritten on the next reconcile. XRs already stuck in the loop self-heal on their next write.

Covered by a unit test that marshals `WatchCircuitClosed()` and asserts the `message` key is present (fails on main). The two `internal/render` fixture expectations that assert the rendered `Responsive` condition are updated for the new message.

I could not run `./nix.sh flake check` locally (no nix); I ran `go test` for the `apis` module and `internal/render`/`internal/controller/apiextensions` plus `go vet` and `gofmt`, all clean.

Fixes #7692

I have:

- [x] Read and followed Crossplane's [contribution process].
- [ ] ~Run `./nix.sh flake check` to ensure this PR is ready for review.~
- [x] Added or updated unit tests.
- [ ] ~Added or updated e2e tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~
- [ ] ~Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/knowledge-base/guides/contributing/
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md