### PR TITLE
pkg: Make deactivated revisions relinquish control of runtime resources

### DIFF
--- a/internal/controller/pkg/runtime/reconciler.go
+++ b/internal/controller/pkg/runtime/reconciler.go
@@ -64,6 +64,7 @@ const (
 	errManifestBuilderOptions = "cannot prepare runtime manifest builder options"
 	errPreHook                = "pre establish runtime hook failed for package"
 	errPostHook               = "post establish runtime hook failed for package"
+	errDeactivateHook         = "deactivation runtime hook failed for package"
 
 	errNoRuntimeConfig          = "no deployment runtime config set"
 	errGetRuntimeConfig         = "cannot get referenced deployment runtime config"
@@ -77,6 +78,7 @@ const (
 const (
 	reasonImageConfig event.Reason = "FetchResolvedImageConfig"
 	reasonSync        event.Reason = "SyncPackage"
+	reasonDeactivate  event.Reason = "DeactivateRevision"
 )
 
 // ReconcilerOption is used to configure the Reconciler.
@@ -350,8 +352,19 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 	// Deactivate revision if it is inactive.
 	if pr.GetDesiredState() == v1.PackageRevisionInactive {
 		if err := r.runtimeHook.Deactivate(ctx, pr, builder); err != nil {
-			err := errors.Wrap(err, "failed to run deactivation hook")
-			r.log.Info("Error", "error", err)
+			if kerrors.IsConflict(err) {
+				return reconcile.Result{Requeue: true}, nil
+			}
+
+			err = errors.Wrap(err, errDeactivateHook)
+			// A revision whose deactivation fails still has a runtime deployment
+			// running, so it keeps serving requests it should have handed over.
+			// Say so, rather than leaving the conditions it reported while it
+			// was still the active revision.
+			status.MarkConditions(v1.RuntimeUnhealthy().WithMessage(err.Error()))
+
+			_ = r.client.Status().Update(ctx, pr)
+			r.record.Event(pr, event.Warning(reasonDeactivate, err))
 
 			return reconcile.Result{}, err
 		}

--- a/internal/controller/pkg/runtime/reconciler.go
+++ b/internal/controller/pkg/runtime/reconciler.go
@@ -369,7 +369,9 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 			return reconcile.Result{}, err
 		}
 
-		return reconcile.Result{Requeue: false}, nil
+		status.MarkConditions(v1.RuntimeHealthy())
+
+		return reconcile.Result{Requeue: false}, errors.Wrap(r.client.Status().Update(ctx, pr), errUpdateStatus)
 	}
 
 	// Migrate provider deployment selector, if needed.

--- a/internal/controller/pkg/runtime/reconciler_test.go
+++ b/internal/controller/pkg/runtime/reconciler_test.go
@@ -949,7 +949,7 @@ func TestReconcile(t *testing.T) {
 			},
 		},
 		"SuccessfulInactiveRevision": {
-			reason: "An inactive revision should deactivate successfully.",
+			reason: "An inactive revision should deactivate successfully and report a healthy runtime.",
 			args: args{
 				mgr: &fake.Manager{
 					Client: &test.MockClient{
@@ -959,11 +959,26 @@ func TestReconcile(t *testing.T) {
 								obj.SetGroupVersionKind(v1.ProviderRevisionGroupVersionKind)
 								obj.SetDesiredState(v1.PackageRevisionInactive)
 								obj.SetLabels(map[string]string{v1.LabelParentPackage: "test-provider"})
+								// set a previous RuntimeUnhealthy condition on the object, so we
+								// know the later status update clears it back to healthy
+								obj.SetConditions(v1.RuntimeUnhealthy().WithMessage("deactivation runtime hook failed for package: boom"))
 								return nil
 							case *corev1.ServiceAccount:
 								obj.Name = crossplaneName
 								obj.Namespace = testNamespace
 								return nil
+							}
+							return nil
+						}),
+						MockStatusUpdate: test.NewMockSubResourceUpdateFn(nil, func(o client.Object) error {
+							want := &v1.ProviderRevision{}
+							want.SetGroupVersionKind(v1.ProviderRevisionGroupVersionKind)
+							want.SetDesiredState(v1.PackageRevisionInactive)
+							want.SetLabels(map[string]string{v1.LabelParentPackage: "test-provider"})
+							want.SetConditions(v1.RuntimeHealthy())
+
+							if diff := cmp.Diff(want, o); diff != "" {
+								t.Errorf("-want, +got:\n%s", diff)
 							}
 							return nil
 						}),
@@ -985,6 +1000,46 @@ func TestReconcile(t *testing.T) {
 			},
 			want: want{
 				r: reconcile.Result{Requeue: false},
+			},
+		},
+		"ErrUpdateStatusInactiveRevision": {
+			reason: "We should return an error if we cannot report a deactivated revision's healthy runtime.",
+			args: args{
+				mgr: &fake.Manager{
+					Client: &test.MockClient{
+						MockGet: test.NewMockGetFn(nil, func(o client.Object) error {
+							switch obj := o.(type) {
+							case *v1.ProviderRevision:
+								obj.SetGroupVersionKind(v1.ProviderRevisionGroupVersionKind)
+								obj.SetDesiredState(v1.PackageRevisionInactive)
+								obj.SetLabels(map[string]string{v1.LabelParentPackage: "test-provider"})
+								return nil
+							case *corev1.ServiceAccount:
+								obj.Name = crossplaneName
+								obj.Namespace = testNamespace
+								return nil
+							}
+							return nil
+						}),
+						MockStatusUpdate: test.NewMockSubResourceUpdateFn(errBoom),
+					},
+				},
+				rec: []ReconcilerOption{
+					WithNewPackageRevisionWithRuntimeFn(func() v1.PackageRevisionWithRuntime { return &v1.ProviderRevision{} }),
+					WithLogger(testLog),
+					WithRecorder(event.NewNopRecorder()),
+					WithNamespace(testNamespace),
+					WithServiceAccount(crossplaneName),
+					WithRuntimeHooks(&MockHooks{
+						MockDeactivate: func(_ context.Context, _ v1.PackageRevisionWithRuntime, _ ManifestBuilder) error {
+							return nil
+						},
+					}),
+					WithDeploymentSelectorMigrator(NewNopDeploymentSelectorMigrator()),
+				},
+			},
+			want: want{
+				err: errors.Wrap(errBoom, errUpdateStatus),
 			},
 		},
 		"RuntimeActivationAwaiting": {

--- a/internal/controller/pkg/runtime/reconciler_test.go
+++ b/internal/controller/pkg/runtime/reconciler_test.go
@@ -373,7 +373,58 @@ func TestReconcile(t *testing.T) {
 			},
 		},
 		"ErrDeactivateRevision": {
-			reason: "We should return an error if deactivation fails.",
+			reason: "We should report an unhealthy runtime and return an error if deactivation fails.",
+			args: args{
+				mgr: &fake.Manager{
+					Client: &test.MockClient{
+						MockGet: test.NewMockGetFn(nil, func(o client.Object) error {
+							switch obj := o.(type) {
+							case *v1.ProviderRevision:
+								obj.SetGroupVersionKind(v1.ProviderRevisionGroupVersionKind)
+								obj.SetDesiredState(v1.PackageRevisionInactive)
+								obj.SetLabels(map[string]string{v1.LabelParentPackage: "test-provider"})
+								return nil
+							case *corev1.ServiceAccount:
+								obj.Name = crossplaneName
+								obj.Namespace = testNamespace
+								return nil
+							}
+							return nil
+						}),
+						MockStatusUpdate: test.NewMockSubResourceUpdateFn(nil, func(o client.Object) error {
+							want := &v1.ProviderRevision{}
+							want.SetGroupVersionKind(v1.ProviderRevisionGroupVersionKind)
+							want.SetDesiredState(v1.PackageRevisionInactive)
+							want.SetLabels(map[string]string{v1.LabelParentPackage: "test-provider"})
+							want.SetConditions(v1.RuntimeUnhealthy().WithMessage("deactivation runtime hook failed for package: boom"))
+
+							if diff := cmp.Diff(want, o); diff != "" {
+								t.Errorf("-want, +got:\n%s", diff)
+							}
+							return nil
+						}),
+					},
+				},
+				rec: []ReconcilerOption{
+					WithNewPackageRevisionWithRuntimeFn(func() v1.PackageRevisionWithRuntime { return &v1.ProviderRevision{} }),
+					WithLogger(testLog),
+					WithRecorder(event.NewNopRecorder()),
+					WithNamespace(testNamespace),
+					WithServiceAccount(crossplaneName),
+					WithRuntimeHooks(&MockHooks{
+						MockDeactivate: func(_ context.Context, _ v1.PackageRevisionWithRuntime, _ ManifestBuilder) error {
+							return errBoom
+						},
+					}),
+					WithDeploymentSelectorMigrator(NewNopDeploymentSelectorMigrator()),
+				},
+			},
+			want: want{
+				err: errors.Wrap(errBoom, errDeactivateHook),
+			},
+		},
+		"DeactivateRevisionConflict": {
+			reason: "We should requeue without an error if we lose a race while deactivating.",
 			args: args{
 				mgr: &fake.Manager{
 					Client: &test.MockClient{
@@ -401,14 +452,14 @@ func TestReconcile(t *testing.T) {
 					WithServiceAccount(crossplaneName),
 					WithRuntimeHooks(&MockHooks{
 						MockDeactivate: func(_ context.Context, _ v1.PackageRevisionWithRuntime, _ ManifestBuilder) error {
-							return errBoom
+							return kerrors.NewConflict(schema.GroupResource{Resource: "services"}, "test-provider", errBoom)
 						},
 					}),
 					WithDeploymentSelectorMigrator(NewNopDeploymentSelectorMigrator()),
 				},
 			},
 			want: want{
-				err: errors.Wrap(errBoom, "failed to run deactivation hook"),
+				r: reconcile.Result{Requeue: true},
 			},
 		},
 		"ErrNoRuntimeConfig": {

--- a/internal/controller/pkg/runtime/runtime.go
+++ b/internal/controller/pkg/runtime/runtime.go
@@ -22,6 +22,8 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -180,6 +182,38 @@ func applyRuntimeObject(ctx context.Context, c client.Client, obj client.Object)
 		client.FieldOwner(FieldOwnerRuntime),
 		client.ForceOwnership,
 	)
+}
+
+// relinquishControllership finds obj's owner reference to owner and makes it
+// non-controlling. It is a no-op if owner is not an owner of obj or if its
+// owner reference is already non-controlling.
+func relinquishControllership(ctx context.Context, c client.Client, obj client.Object, owner client.Object) error {
+	key := types.NamespacedName{Namespace: obj.GetNamespace(), Name: obj.GetName()}
+	var u unstructured.Unstructured
+	u.SetGroupVersionKind(obj.GetObjectKind().GroupVersionKind())
+
+	if err := c.Get(ctx, key, &u); err != nil {
+		return err
+	}
+
+	for _, or := range u.GetOwnerReferences() {
+		// Ignore any other owner refs.
+		if or.UID != owner.GetUID() {
+			continue
+		}
+		// Ignore any non-controlling owner refs.
+		if !ptr.Deref(or.Controller, false) {
+			continue
+		}
+
+		or.Controller = ptr.To(false)
+		meta.AddOwnerReference(&u, or)
+		return applyRuntimeObject(ctx, c, &u)
+	}
+
+	// If we didn't find a relevant owner ref above, or it was already
+	// non-controlling, that's fine.
+	return nil
 }
 
 // BuilderWithServiceAccountPullSecrets sets the service account

--- a/internal/controller/pkg/runtime/runtime.go
+++ b/internal/controller/pkg/runtime/runtime.go
@@ -22,8 +22,6 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -125,8 +123,9 @@ type Hooks interface {
 }
 
 const (
-	errCopyRuntimeObject    = "cannot copy package runtime object for deletion"
-	errGetRuntimeDeployment = "cannot get package runtime deployment for deletion"
+	errCopyRuntimeObject      = "cannot copy package runtime object for deletion"
+	errGetRuntimeDeployment   = "cannot get package runtime deployment for deletion"
+	errGetSharedRuntimeObject = "cannot get existing package runtime object"
 )
 
 func deleteRuntimeObjectControlledBy(ctx context.Context, c client.Client, owner metav1.Object, obj client.Object) error {
@@ -184,36 +183,60 @@ func applyRuntimeObject(ctx context.Context, c client.Client, obj client.Object)
 	)
 }
 
-// relinquishControllership finds obj's owner reference to owner and makes it
-// non-controlling. It is a no-op if owner is not an owner of obj or if its
-// owner reference is already non-controlling.
-func relinquishControllership(ctx context.Context, c client.Client, obj client.Object, owner client.Object) error {
-	key := types.NamespacedName{Namespace: obj.GetNamespace(), Name: obj.GetName()}
-	var u unstructured.Unstructured
-	u.SetGroupVersionKind(obj.GetObjectKind().GroupVersionKind())
-
-	if err := c.Get(ctx, key, &u); err != nil {
-		return err
+// applySharedRuntimeObject applies one of the runtime objects that every revision of a package
+// shares (e.g. service and TLS secrets), and takes ownership of it by making the given owner (the
+// incoming/active revision) the controller owner.
+//
+// The handover is done in two steps so that we correctly handle cases where a previous field
+// manager owned these fields (e.g. an earlier version of Crossplane that didn't use SSA):
+//
+// 1) The first declares our own controlling reference alongside whichever controlling reference the
+// live object already had, but demoted to a plain owner. This sets the new controller and demotes
+// the old one in one write while also giving our field manager exclusive ownership.
+// 2) The second apply finds no competing controller left to demote, declares only our own
+// reference, and server-side apply prunes the demoted one.
+//
+// The incoming revision does this so the handover needs no coordination between revisions. The
+// revision that wants control just takes it, instead of waiting on another revision to reconcile
+// and give it up first.
+func applySharedRuntimeObject(ctx context.Context, c client.Client, owner metav1.Object, obj client.Object) error {
+	current, ok := obj.DeepCopyObject().(client.Object)
+	if !ok {
+		return errors.Errorf("%s: %T", errCopyRuntimeObject, obj)
 	}
 
-	for _, or := range u.GetOwnerReferences() {
-		// Ignore any other owner refs.
-		if or.UID != owner.GetUID() {
-			continue
-		}
-		// Ignore any non-controlling owner refs.
-		if !ptr.Deref(or.Controller, false) {
+	// Get the latest state of the object, but clear owner refs before the Get, so we get
+	// exactly what the API server has
+	current.SetOwnerReferences(nil)
+	err := c.Get(ctx, client.ObjectKeyFromObject(obj), current)
+	if resource.IgnoreNotFound(err) != nil {
+		return errors.Wrap(err, errGetSharedRuntimeObject)
+	}
+
+	if err == nil {
+		// The object does already exist, demote any controller owner ref from a previous revision
+		obj.SetOwnerReferences(append(obj.GetOwnerReferences(), demotedControllers(current, owner)...))
+	}
+
+	return applyRuntimeObject(ctx, c, obj)
+}
+
+// demotedControllers returns the controlling owner references of obj that don't belong to owner,
+// made non-controlling. References that are already non-controlling are left out, which is what
+// lets SSA prune them.
+func demotedControllers(obj metav1.Object, owner metav1.Object) []metav1.OwnerReference {
+	ors := make([]metav1.OwnerReference, 0, len(obj.GetOwnerReferences()))
+
+	for _, or := range obj.GetOwnerReferences() {
+		if or.UID == owner.GetUID() || !ptr.Deref(or.Controller, false) {
 			continue
 		}
 
 		or.Controller = ptr.To(false)
-		meta.AddOwnerReference(&u, or)
-		return applyRuntimeObject(ctx, c, &u)
+		ors = append(ors, or)
 	}
 
-	// If we didn't find a relevant owner ref above, or it was already
-	// non-controlling, that's fine.
-	return nil
+	return ors
 }
 
 // BuilderWithServiceAccountPullSecrets sets the service account

--- a/internal/controller/pkg/runtime/runtime_function.go
+++ b/internal/controller/pkg/runtime/runtime_function.go
@@ -78,7 +78,7 @@ func (h *FunctionHooks) Pre(ctx context.Context, pr v1.PackageRevisionWithRuntim
 	// we're creating the service here but service account and deployment in the
 	// post-establish.
 	svc := build.Service(functionServiceOverrides()...)
-	if err := applyRuntimeObject(ctx, h.client.Client, svc); err != nil {
+	if err := applySharedRuntimeObject(ctx, h.client.Client, pr, svc); err != nil {
 		return errors.Wrap(err, errApplyFunctionService)
 	}
 
@@ -92,7 +92,14 @@ func (h *FunctionHooks) Pre(ctx context.Context, pr v1.PackageRevisionWithRuntim
 
 	secServer := build.TLSServerSecret()
 
-	if err := applyRuntimeObject(ctx, h.client.Client, secServer); err != nil {
+	if secServer == nil {
+		// We should wait for the package manager to set the secret name on the
+		// revision before proceeding creating the TLS secret. This mirrors the
+		// provider hooks, which wait on the same field.
+		return nil
+	}
+
+	if err := applySharedRuntimeObject(ctx, h.client.Client, pr, secServer); err != nil {
 		return errors.Wrap(err, errApplyFunctionSecret)
 	}
 
@@ -159,21 +166,6 @@ func (h *FunctionHooks) Deactivate(ctx context.Context, pr v1.PackageRevisionWit
 		return errors.Wrap(err, errDeleteFunctionDeployment)
 	}
 
-	// Relinquish control of the service and secret, so that a new active
-	// revision can control them.
-	objs := []client.Object{
-		build.Service(functionServiceOverrides()...),
-		build.TLSServerSecret(),
-	}
-	for _, obj := range objs {
-		if obj == nil {
-			continue
-		}
-		if err := relinquishControllership(ctx, h.client.Client, obj, pr); err != nil {
-			return errors.Wrapf(err, "cannot relinquish control of %T for inactive function revision", obj)
-		}
-	}
-
 	// NOTE(turkenh): We don't delete the service account here because it might
 	// be used by other package revisions, e.g. user might have specified a
 	// service account name in the runtime config. This should not be a problem
@@ -183,6 +175,10 @@ func (h *FunctionHooks) Deactivate(ctx context.Context, pr v1.PackageRevisionWit
 
 	// NOTE(ezgidemirel): Service and secret are created per package. Therefore,
 	// we're not deleting them here.
+
+	// NOTE(jbw976): We leave our owner references on those shared objects alone, controlling flag
+	// included. The revision taking over demotes us as part of claiming them, which keeps the
+	// handover to a single writer.
 	return nil
 }
 

--- a/internal/controller/pkg/runtime/runtime_function.go
+++ b/internal/controller/pkg/runtime/runtime_function.go
@@ -77,21 +77,7 @@ func (h *FunctionHooks) Pre(ctx context.Context, pr v1.PackageRevisionWithRuntim
 	// generating certificates requires the service to be defined. This is why
 	// we're creating the service here but service account and deployment in the
 	// post-establish.
-	svc := build.Service(
-		// We want a headless service so that our gRPC client (i.e. the Crossplane
-		// FunctionComposer) can load balance across the endpoints.
-		// https://kubernetes.io/docs/concepts/services-networking/service/#headless-services
-		ServiceWithClusterIP(corev1.ClusterIPNone),
-		ServiceWithAdditionalPorts([]corev1.ServicePort{
-			{
-				Name:        GRPCPortName,
-				Protocol:    corev1.ProtocolTCP,
-				Port:        GRPCPort,
-				TargetPort:  intstr.FromString(GRPCPortName),
-				AppProtocol: &AppProtocolTLS,
-			},
-		}))
-
+	svc := build.Service(functionServiceOverrides()...)
 	if err := applyRuntimeObject(ctx, h.client.Client, svc); err != nil {
 		return errors.Wrap(err, errApplyFunctionService)
 	}
@@ -173,6 +159,21 @@ func (h *FunctionHooks) Deactivate(ctx context.Context, pr v1.PackageRevisionWit
 		return errors.Wrap(err, errDeleteFunctionDeployment)
 	}
 
+	// Relinquish control of the service and secret, so that a new active
+	// revision can control them.
+	objs := []client.Object{
+		build.Service(functionServiceOverrides()...),
+		build.TLSServerSecret(),
+	}
+	for _, obj := range objs {
+		if obj == nil {
+			continue
+		}
+		if err := relinquishControllership(ctx, h.client.Client, obj, pr); err != nil {
+			return errors.Wrapf(err, "cannot relinquish control of %T for inactive function revision", obj)
+		}
+	}
+
 	// NOTE(turkenh): We don't delete the service account here because it might
 	// be used by other package revisions, e.g. user might have specified a
 	// service account name in the runtime config. This should not be a problem
@@ -183,6 +184,24 @@ func (h *FunctionHooks) Deactivate(ctx context.Context, pr v1.PackageRevisionWit
 	// NOTE(ezgidemirel): Service and secret are created per package. Therefore,
 	// we're not deleting them here.
 	return nil
+}
+
+func functionServiceOverrides() []ServiceOverride {
+	return []ServiceOverride{
+		// We want a headless service so that our gRPC client (i.e. the Crossplane
+		// FunctionComposer) can load balance across the endpoints.
+		// https://kubernetes.io/docs/concepts/services-networking/service/#headless-services
+		ServiceWithClusterIP(corev1.ClusterIPNone),
+		ServiceWithAdditionalPorts([]corev1.ServicePort{
+			{
+				Name:        GRPCPortName,
+				Protocol:    corev1.ProtocolTCP,
+				Port:        GRPCPort,
+				TargetPort:  intstr.FromString(GRPCPortName),
+				AppProtocol: &AppProtocolTLS,
+			},
+		}),
+	}
 }
 
 func functionDeploymentOverrides(pr v1.PackageRevisionWithRuntime, image string) []DeploymentOverride {

--- a/internal/controller/pkg/runtime/runtime_function_test.go
+++ b/internal/controller/pkg/runtime/runtime_function_test.go
@@ -117,6 +117,115 @@ func TestFunctionPreHook(t *testing.T) {
 				},
 			},
 		},
+		"WaitsForTLSServerSecretName": {
+			reason: "Should wait, rather than panic, when the package manager has not set the revision's TLS server secret name yet.",
+			args: args{
+				pkg: &pkgmetav1.Function{},
+				rev: &v1.FunctionRevision{
+					ObjectMeta: metav1.ObjectMeta{Name: incoming.Name, UID: incoming.UID},
+					Spec: v1.FunctionRevisionSpec{
+						PackageRevisionSpec: v1.PackageRevisionSpec{DesiredState: v1.PackageRevisionActive},
+					},
+				},
+				manifests: &MockManifestBuilder{
+					ServiceFn: func(_ ...ServiceOverride) *corev1.Service {
+						return &corev1.Service{ObjectMeta: metav1.ObjectMeta{
+							Name:      "shared-service",
+							Namespace: "some-namespace",
+						}}
+					},
+					// The builder returns nil for the secret until the revision knows
+					// what its secret is called.
+					TLSServerSecretFn: func() *corev1.Secret {
+						return nil
+					},
+				},
+				client: &test.MockClient{
+					MockGet: test.NewMockGetFn(nil),
+					MockPatch: func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) error {
+						if _, ok := obj.(*corev1.Secret); ok {
+							return errors.New("should not apply a secret before we know its name")
+						}
+						return nil
+					},
+				},
+			},
+			want: want{
+				rev: &v1.FunctionRevision{
+					ObjectMeta: metav1.ObjectMeta{Name: incoming.Name, UID: incoming.UID},
+					Spec: v1.FunctionRevisionSpec{
+						PackageRevisionSpec: v1.PackageRevisionSpec{DesiredState: v1.PackageRevisionActive},
+					},
+					Status: v1.FunctionRevisionStatus{
+						Endpoint: fmt.Sprintf(ServiceEndpointFmt, "shared-service", "some-namespace", revision.ServicePort),
+					},
+				},
+			},
+		},
+		"TakesControlFromOutgoingRevision": {
+			reason: "Should demote the outgoing revision's owner reference in the same apply that claims the shared object.",
+			args: args{
+				pkg: &pkgmetav1.Function{},
+				rev: &v1.FunctionRevision{
+					ObjectMeta: metav1.ObjectMeta{Name: incoming.Name, UID: incoming.UID},
+					Spec: v1.FunctionRevisionSpec{
+						PackageRevisionSpec: v1.PackageRevisionSpec{DesiredState: v1.PackageRevisionActive},
+						PackageRevisionRuntimeSpec: v1.PackageRevisionRuntimeSpec{
+							TLSServerSecretName: ptr.To("server-tls"),
+						},
+					},
+				},
+				manifests: &MockManifestBuilder{
+					ServiceFn: func(_ ...ServiceOverride) *corev1.Service {
+						return &corev1.Service{ObjectMeta: metav1.ObjectMeta{
+							Name:            "shared-service",
+							Namespace:       "some-namespace",
+							OwnerReferences: []metav1.OwnerReference{incoming},
+						}}
+					},
+					TLSServerSecretFn: func() *corev1.Secret {
+						return &corev1.Secret{ObjectMeta: metav1.ObjectMeta{
+							Name:            "server-tls",
+							OwnerReferences: []metav1.OwnerReference{incoming},
+						}}
+					},
+				},
+				client: &test.MockClient{
+					MockGet: func(_ context.Context, key client.ObjectKey, obj client.Object) error {
+						if key.Name == "shared-service" || key.Name == "server-tls" {
+							obj.SetOwnerReferences([]metav1.OwnerReference{outgoing})
+						}
+						return nil
+					},
+					MockPatch: func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) error {
+						// The incoming revision should claim the shared objects,
+						// demoting the outgoing revision in the same apply.
+						if diff := cmp.Diff([]metav1.OwnerReference{incoming, demoted}, obj.GetOwnerReferences()); diff != "" {
+							t.Errorf("h.Pre(...): %s: -want owner references, +got:\n%s", obj.GetName(), diff)
+						}
+						return nil
+					},
+					MockUpdate: test.NewMockUpdateFn(nil),
+				},
+			},
+			want: want{
+				rev: &v1.FunctionRevision{
+					ObjectMeta: metav1.ObjectMeta{Name: incoming.Name, UID: incoming.UID},
+					Spec: v1.FunctionRevisionSpec{
+						PackageRevisionSpec: v1.PackageRevisionSpec{DesiredState: v1.PackageRevisionActive},
+						PackageRevisionRuntimeSpec: v1.PackageRevisionRuntimeSpec{
+							TLSServerSecretName: ptr.To("server-tls"),
+						},
+					},
+					Status: v1.FunctionRevisionStatus{
+						Endpoint: fmt.Sprintf(ServiceEndpointFmt, "shared-service", "some-namespace", revision.ServicePort),
+						PackageRevisionRuntimeStatus: v1.PackageRevisionRuntimeStatus{
+							TLSServerSecretName: ptr.To("server-tls"),
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for name, tc := range cases {
@@ -789,16 +898,11 @@ func TestFunctionDeactivateHook(t *testing.T) {
 						}
 						return nil
 					},
+					// Deactivation doesn't touch owner references. The
+					// revision taking over demotes ours when it claims the
+					// objects we share with it.
 					MockPatch: func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) error {
-						owners := obj.GetOwnerReferences()
-						if len(owners) != 1 {
-							return errors.Errorf("incorrect number of owner references on %T, expected 1 got %d", obj, len(owners))
-						}
-						if owners[0].Controller != nil && *owners[0].Controller {
-							return errors.Errorf("%T owner reference is controlling", obj)
-						}
-
-						return nil
+						return errors.Errorf("deactivation should not have patched %s", obj.GetName())
 					},
 				},
 			},

--- a/internal/controller/pkg/runtime/runtime_function_test.go
+++ b/internal/controller/pkg/runtime/runtime_function_test.go
@@ -711,6 +711,13 @@ func TestFunctionDeactivateHook(t *testing.T) {
 						}
 						return s
 					},
+					TLSServerSecretFn: func() *corev1.Secret {
+						return &corev1.Secret{
+							ObjectMeta: metav1.ObjectMeta{
+								Name: "server-tls",
+							},
+						}
+					},
 				},
 				client: &test.MockClient{
 					MockGet: test.NewMockGetFn(nil, func(obj client.Object) error {
@@ -718,6 +725,17 @@ func TestFunctionDeactivateHook(t *testing.T) {
 						return nil
 					}),
 					MockDelete: func(_ context.Context, _ client.Object, _ ...client.DeleteOption) error {
+						return nil
+					},
+					MockPatch: func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) error {
+						owners := obj.GetOwnerReferences()
+						if len(owners) != 1 {
+							return errors.Errorf("incorrect number of owner references on %T, expected 1 got %d", obj, len(owners))
+						}
+						if owners[0].Controller != nil && *owners[0].Controller {
+							return errors.Errorf("%T has unexpected controlling owner reference %v", obj, owners[0])
+						}
+
 						return nil
 					},
 				},
@@ -741,6 +759,24 @@ func TestFunctionDeactivateHook(t *testing.T) {
 					DeploymentFn: func(_ string, _ ...DeploymentOverride) *appsv1.Deployment {
 						return &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "some-deployment"}}
 					},
+					ServiceFn: func(overrides ...ServiceOverride) *corev1.Service {
+						s := &corev1.Service{
+							ObjectMeta: metav1.ObjectMeta{
+								Name: "some-service",
+							},
+						}
+						for _, o := range overrides {
+							o(s)
+						}
+						return s
+					},
+					TLSServerSecretFn: func() *corev1.Secret {
+						return &corev1.Secret{
+							ObjectMeta: metav1.ObjectMeta{
+								Name: "server-tls",
+							},
+						}
+					},
 				},
 				client: &test.MockClient{
 					MockGet: test.NewMockGetFn(nil, func(obj client.Object) error {
@@ -751,6 +787,17 @@ func TestFunctionDeactivateHook(t *testing.T) {
 						if _, ok := obj.(*appsv1.Deployment); ok {
 							return errors.New("deployment should not be deleted")
 						}
+						return nil
+					},
+					MockPatch: func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) error {
+						owners := obj.GetOwnerReferences()
+						if len(owners) != 1 {
+							return errors.Errorf("incorrect number of owner references on %T, expected 1 got %d", obj, len(owners))
+						}
+						if owners[0].Controller != nil && *owners[0].Controller {
+							return errors.Errorf("%T owner reference is controlling", obj)
+						}
+
 						return nil
 					},
 				},
@@ -771,11 +818,11 @@ func TestFunctionDeactivateHook(t *testing.T) {
 
 			err := h.Deactivate(context.TODO(), tc.args.rev, tc.args.manifests)
 			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
-				t.Errorf("\n%s\nh.Pre(...): -want error, +got error:\n%s", tc.reason, diff)
+				t.Errorf("\n%s\nh.Deactivate(...): -want error, +got error:\n%s", tc.reason, diff)
 			}
 
 			if diff := cmp.Diff(tc.want.rev, tc.args.rev, test.EquateErrors()); diff != "" {
-				t.Errorf("\n%s\nh.Pre(...): -want, +got:\n%s", tc.reason, diff)
+				t.Errorf("\n%s\nh.Deactivate(...): -want, +got:\n%s", tc.reason, diff)
 			}
 		})
 	}

--- a/internal/controller/pkg/runtime/runtime_provider.go
+++ b/internal/controller/pkg/runtime/runtime_provider.go
@@ -23,11 +23,13 @@ import (
 	"github.com/google/go-containerregistry/pkg/name"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/crossplane/crossplane-runtime/v2/pkg/errors"
+	"github.com/crossplane/crossplane-runtime/v2/pkg/meta"
 	"github.com/crossplane/crossplane-runtime/v2/pkg/resource"
 
 	v1 "github.com/crossplane/crossplane/apis/v2/pkg/v1"
@@ -78,15 +80,7 @@ func (h *ProviderHooks) Pre(ctx context.Context, pr v1.PackageRevisionWithRuntim
 	// generating certificates requires the service to be defined. This is why
 	// we're creating the service here but service account and deployment in the
 	// post-establish.
-	svc := build.Service(ServiceWithAdditionalPorts([]corev1.ServicePort{
-		{
-			Name:       WebhookPortName,
-			Protocol:   corev1.ProtocolTCP,
-			Port:       revision.ServicePort,
-			TargetPort: intstr.FromString(WebhookPortName),
-		},
-	}))
-
+	svc := build.Service(providerServiceOverrides()...)
 	if err := applyRuntimeObject(ctx, h.client.Client, svc); err != nil {
 		return errors.Wrap(err, errApplyProviderService)
 	}
@@ -100,19 +94,16 @@ func (h *ProviderHooks) Pre(ctx context.Context, pr v1.PackageRevisionWithRuntim
 		return nil
 	}
 
-	// Provider TLS secrets are ultimately owned by the parent Provider. Keep using
-	// the applicator here because SSA merges ownerReferences and can retain both
-	// the Provider and ProviderRevision controller references.
-	if err := h.client.Applicator.Apply(ctx, secClient); err != nil {
+	if err := applyRuntimeObject(ctx, h.client.Client, secClient); err != nil {
+		return errors.Wrap(err, errApplyProviderSecret)
+	}
+	if err := applyRuntimeObject(ctx, h.client.Client, secServer); err != nil {
 		return errors.Wrap(err, errApplyProviderSecret)
 	}
 
-	if err := h.client.Applicator.Apply(ctx, secServer); err != nil {
-		return errors.Wrap(err, errApplyProviderSecret)
-	}
-
+	owner := meta.AsController(meta.TypedReferenceTo(pr, pr.GetObjectKind().GroupVersionKind()))
 	if err := initializer.NewTLSCertificateGenerator(secClient.Namespace, initializer.RootCACertSecretName,
-		initializer.TLSCertificateGeneratorWithOwner(pr.GetOwnerReferences()),
+		initializer.TLSCertificateGeneratorWithOwner([]metav1.OwnerReference{owner}),
 		initializer.TLSCertificateGeneratorWithServerSecretName(secServer.GetName(), initializer.DNSNamesForService(svc.Name, svc.Namespace)),
 		initializer.TLSCertificateGeneratorWithClientSecretName(secClient.GetName(), []string{pr.GetName()})).Run(ctx, h.client.Client); err != nil {
 		return errors.Wrapf(err, "cannot generate TLS certificates for %q", pr.GetLabels()[v1.LabelParentPackage])
@@ -182,6 +173,22 @@ func (h *ProviderHooks) Deactivate(ctx context.Context, pr v1.PackageRevisionWit
 		return errors.Wrap(err, errDeleteProviderService)
 	}
 
+	// Relinquish control of the service and secrets, so that a new active
+	// revision can control them.
+	objs := []client.Object{
+		build.Service(providerServiceOverrides()...),
+		build.TLSServerSecret(),
+		build.TLSClientSecret(),
+	}
+	for _, obj := range objs {
+		if obj == nil {
+			continue
+		}
+		if err := relinquishControllership(ctx, h.client.Client, obj, pr); err != nil {
+			return errors.Wrapf(err, "cannot relinquish control of %T for inactive provider revision", obj)
+		}
+	}
+
 	// NOTE(turkenh): We don't delete the service account here because it might
 	// be used by other package revisions, e.g. user might have specified a
 	// service account name in the runtime config. This should not be a problem
@@ -192,6 +199,19 @@ func (h *ProviderHooks) Deactivate(ctx context.Context, pr v1.PackageRevisionWit
 	// NOTE(phisco): Service and TLS secrets are created per package. Therefore,
 	// we're not deleting them here.
 	return nil
+}
+
+func providerServiceOverrides() []ServiceOverride {
+	return []ServiceOverride{
+		ServiceWithAdditionalPorts([]corev1.ServicePort{
+			{
+				Name:       WebhookPortName,
+				Protocol:   corev1.ProtocolTCP,
+				Port:       revision.ServicePort,
+				TargetPort: intstr.FromString(WebhookPortName),
+			},
+		}),
+	}
 }
 
 func providerDeploymentOverrides(pr v1.PackageRevisionWithRuntime, image string) []DeploymentOverride {

--- a/internal/controller/pkg/runtime/runtime_provider.go
+++ b/internal/controller/pkg/runtime/runtime_provider.go
@@ -81,7 +81,7 @@ func (h *ProviderHooks) Pre(ctx context.Context, pr v1.PackageRevisionWithRuntim
 	// we're creating the service here but service account and deployment in the
 	// post-establish.
 	svc := build.Service(providerServiceOverrides()...)
-	if err := applyRuntimeObject(ctx, h.client.Client, svc); err != nil {
+	if err := applySharedRuntimeObject(ctx, h.client.Client, pr, svc); err != nil {
 		return errors.Wrap(err, errApplyProviderService)
 	}
 
@@ -94,10 +94,10 @@ func (h *ProviderHooks) Pre(ctx context.Context, pr v1.PackageRevisionWithRuntim
 		return nil
 	}
 
-	if err := applyRuntimeObject(ctx, h.client.Client, secClient); err != nil {
+	if err := applySharedRuntimeObject(ctx, h.client.Client, pr, secClient); err != nil {
 		return errors.Wrap(err, errApplyProviderSecret)
 	}
-	if err := applyRuntimeObject(ctx, h.client.Client, secServer); err != nil {
+	if err := applySharedRuntimeObject(ctx, h.client.Client, pr, secServer); err != nil {
 		return errors.Wrap(err, errApplyProviderSecret)
 	}
 
@@ -173,22 +173,6 @@ func (h *ProviderHooks) Deactivate(ctx context.Context, pr v1.PackageRevisionWit
 		return errors.Wrap(err, errDeleteProviderService)
 	}
 
-	// Relinquish control of the service and secrets, so that a new active
-	// revision can control them.
-	objs := []client.Object{
-		build.Service(providerServiceOverrides()...),
-		build.TLSServerSecret(),
-		build.TLSClientSecret(),
-	}
-	for _, obj := range objs {
-		if obj == nil {
-			continue
-		}
-		if err := relinquishControllership(ctx, h.client.Client, obj, pr); err != nil {
-			return errors.Wrapf(err, "cannot relinquish control of %T for inactive provider revision", obj)
-		}
-	}
-
 	// NOTE(turkenh): We don't delete the service account here because it might
 	// be used by other package revisions, e.g. user might have specified a
 	// service account name in the runtime config. This should not be a problem
@@ -198,6 +182,10 @@ func (h *ProviderHooks) Deactivate(ctx context.Context, pr v1.PackageRevisionWit
 
 	// NOTE(phisco): Service and TLS secrets are created per package. Therefore,
 	// we're not deleting them here.
+
+	// NOTE(jbw976): We leave our owner references on those shared objects alone, controlling flag
+	// included. The revision taking over demotes us as part of claiming them, which keeps the
+	// handover to a single writer.
 	return nil
 }
 

--- a/internal/controller/pkg/runtime/runtime_provider_test.go
+++ b/internal/controller/pkg/runtime/runtime_provider_test.go
@@ -771,6 +771,20 @@ func TestProviderDeactivateHook(t *testing.T) {
 						}
 						return s
 					},
+					TLSClientSecretFn: func() *corev1.Secret {
+						return &corev1.Secret{
+							ObjectMeta: metav1.ObjectMeta{
+								Name: "client-tls",
+							},
+						}
+					},
+					TLSServerSecretFn: func() *corev1.Secret {
+						return &corev1.Secret{
+							ObjectMeta: metav1.ObjectMeta{
+								Name: "server-tls",
+							},
+						}
+					},
 				},
 				client: &test.MockClient{
 					MockGet: test.NewMockGetFn(nil, func(obj client.Object) error {
@@ -794,6 +808,17 @@ func TestProviderDeactivateHook(t *testing.T) {
 							return nil
 						}
 						return errors.New("unexpected object type")
+					},
+					MockPatch: func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) error {
+						owners := obj.GetOwnerReferences()
+						if len(owners) != 1 {
+							return errors.Errorf("incorrect number of owner references on %T, expected 1 got %d", obj, len(owners))
+						}
+						if owners[0].Controller != nil && *owners[0].Controller {
+							return errors.Errorf("%T owner reference is controlling", obj)
+						}
+
+						return nil
 					},
 				},
 			},
@@ -828,6 +853,12 @@ func TestProviderDeactivateHook(t *testing.T) {
 						}
 						return s
 					},
+					TLSClientSecretFn: func() *corev1.Secret {
+						return &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "client-tls"}}
+					},
+					TLSServerSecretFn: func() *corev1.Secret {
+						return &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "server-tls"}}
+					},
 				},
 				client: &test.MockClient{
 					MockGet: test.NewMockGetFn(nil, func(obj client.Object) error {
@@ -838,6 +869,17 @@ func TestProviderDeactivateHook(t *testing.T) {
 						if _, ok := obj.(*appsv1.Deployment); ok {
 							return errors.New("deployment should not be deleted")
 						}
+						return nil
+					},
+					MockPatch: func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) error {
+						owners := obj.GetOwnerReferences()
+						if len(owners) != 1 {
+							return errors.Errorf("incorrect number of owner references on %T, expected 1 got %d", obj, len(owners))
+						}
+						if owners[0].Controller != nil && *owners[0].Controller {
+							return errors.Errorf("%T owner reference is controlling", obj)
+						}
+
 						return nil
 					},
 				},
@@ -859,11 +901,11 @@ func TestProviderDeactivateHook(t *testing.T) {
 
 			err := h.Deactivate(context.TODO(), tc.args.rev, tc.args.manifests)
 			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
-				t.Errorf("\n%s\nh.Pre(...): -want error, +got error:\n%s", tc.reason, diff)
+				t.Errorf("\n%s\nh.Deactivate(...): -want error, +got error:\n%s", tc.reason, diff)
 			}
 
 			if diff := cmp.Diff(tc.want.rev, tc.args.rev, test.EquateErrors()); diff != "" {
-				t.Errorf("\n%s\nh.Pre(...): -want, +got:\n%s", tc.reason, diff)
+				t.Errorf("\n%s\nh.Deactivate(...): -want, +got:\n%s", tc.reason, diff)
 			}
 		})
 	}

--- a/internal/controller/pkg/runtime/runtime_provider_test.go
+++ b/internal/controller/pkg/runtime/runtime_provider_test.go
@@ -26,6 +26,7 @@ import (
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -54,6 +55,34 @@ func TestProviderPreHook(t *testing.T) {
 	type want struct {
 		err error
 		rev v1.PackageRevisionWithRuntime
+	}
+
+	// A test provider revision, along with the manifests it builds for the three objects it shares
+	// with its package's other revisions.
+	sharedRev := &v1.ProviderRevision{
+		ObjectMeta: metav1.ObjectMeta{Name: incoming.Name, UID: incoming.UID},
+		Spec: v1.ProviderRevisionSpec{
+			PackageRevisionSpec: v1.PackageRevisionSpec{DesiredState: v1.PackageRevisionActive},
+			PackageRevisionRuntimeSpec: v1.PackageRevisionRuntimeSpec{
+				TLSClientSecretName: ptr.To("client-tls"),
+				TLSServerSecretName: ptr.To("server-tls"),
+			},
+		},
+	}
+	sharedRevSynced := sharedRev.DeepCopy()
+	sharedRevSynced.Status.TLSClientSecretName = ptr.To("client-tls")
+	sharedRevSynced.Status.TLSServerSecretName = ptr.To("server-tls")
+
+	sharedManifests := &MockManifestBuilder{
+		ServiceFn: func(_ ...ServiceOverride) *corev1.Service {
+			return &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "shared-service", OwnerReferences: []metav1.OwnerReference{incoming}}}
+		},
+		TLSClientSecretFn: func() *corev1.Secret {
+			return &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "client-tls", OwnerReferences: []metav1.OwnerReference{incoming}}}
+		},
+		TLSServerSecretFn: func() *corev1.Secret {
+			return &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "server-tls", OwnerReferences: []metav1.OwnerReference{incoming}}}
+		},
 	}
 
 	cases := map[string]struct {
@@ -119,6 +148,91 @@ func TestProviderPreHook(t *testing.T) {
 						},
 					},
 				},
+			},
+		},
+		"TakesControlFromOutgoingRevision": {
+			reason: "Should demote the outgoing revision's owner reference in the same apply that claims the shared object.",
+			args: args{
+				pkg:       &pkgmetav1.Provider{},
+				rev:       sharedRev.DeepCopy(),
+				manifests: sharedManifests,
+				client: &test.MockClient{
+					MockGet: func(_ context.Context, key client.ObjectKey, obj client.Object) error {
+						if key.Name == "shared-service" || key.Name == "client-tls" || key.Name == "server-tls" {
+							obj.SetOwnerReferences([]metav1.OwnerReference{outgoing})
+						}
+						return nil
+					},
+					MockPatch: func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) error {
+						if diff := cmp.Diff([]metav1.OwnerReference{incoming, demoted}, obj.GetOwnerReferences()); diff != "" {
+							t.Errorf("h.Pre(...): %s: -want owner references, +got:\n%s", obj.GetName(), diff)
+						}
+						return nil
+					},
+					MockUpdate: test.NewMockUpdateFn(nil),
+				},
+			},
+			want: want{rev: sharedRevSynced.DeepCopy()},
+		},
+		"DropsOwnerReferencesThatNoLongerControl": {
+			reason: "Should stop declaring an owner reference once it is non-controlling, so that server-side apply prunes it.",
+			args: args{
+				pkg:       &pkgmetav1.Provider{},
+				rev:       sharedRev.DeepCopy(),
+				manifests: sharedManifests,
+				client: &test.MockClient{
+					MockGet: func(_ context.Context, key client.ObjectKey, obj client.Object) error {
+						if key.Name == "shared-service" || key.Name == "client-tls" || key.Name == "server-tls" {
+							obj.SetOwnerReferences([]metav1.OwnerReference{demoted, incoming})
+						}
+						return nil
+					},
+					MockPatch: func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) error {
+						if diff := cmp.Diff([]metav1.OwnerReference{incoming}, obj.GetOwnerReferences()); diff != "" {
+							t.Errorf("h.Pre(...): %s: -want owner references, +got:\n%s", obj.GetName(), diff)
+						}
+						return nil
+					},
+					MockUpdate: test.NewMockUpdateFn(nil),
+				},
+			},
+			want: want{rev: sharedRevSynced.DeepCopy()},
+		},
+		"CreatesSharedObjectsThatDoNotExist": {
+			reason: "Should apply the shared objects with only our owner reference when there is no incumbent to displace.",
+			args: args{
+				pkg:       &pkgmetav1.Provider{},
+				rev:       sharedRev.DeepCopy(),
+				manifests: sharedManifests,
+				client: &test.MockClient{
+					MockGet:    test.NewMockGetFn(kerrors.NewNotFound(schema.GroupResource{}, "")),
+					MockCreate: test.NewMockCreateFn(nil),
+					MockPatch: func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) error {
+						if diff := cmp.Diff([]metav1.OwnerReference{incoming}, obj.GetOwnerReferences()); diff != "" {
+							t.Errorf("h.Pre(...): %s: -want owner references, +got:\n%s", obj.GetName(), diff)
+						}
+						return nil
+					},
+				},
+			},
+			want: want{rev: sharedRevSynced.DeepCopy()},
+		},
+		"ErrGetSharedObject": {
+			reason: "Should return an error if we cannot read the shared object to see who controls it.",
+			args: args{
+				pkg:       &pkgmetav1.Provider{},
+				rev:       sharedRev.DeepCopy(),
+				manifests: sharedManifests,
+				client: &test.MockClient{
+					MockGet: test.NewMockGetFn(errBoom),
+					MockPatch: func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) error {
+						return errors.Errorf("%s should not be applied when we can't tell who controls it", obj.GetName())
+					},
+				},
+			},
+			want: want{
+				err: errors.Wrap(errors.Wrap(errBoom, errGetSharedRuntimeObject), errApplyProviderService),
+				rev: sharedRevSynced.DeepCopy(),
 			},
 		},
 	}
@@ -809,16 +923,10 @@ func TestProviderDeactivateHook(t *testing.T) {
 						}
 						return errors.New("unexpected object type")
 					},
+					// Deactivation doesn't touch owner references. The revision taking over demotes
+					// ours when it claims the objects we share with it.
 					MockPatch: func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) error {
-						owners := obj.GetOwnerReferences()
-						if len(owners) != 1 {
-							return errors.Errorf("incorrect number of owner references on %T, expected 1 got %d", obj, len(owners))
-						}
-						if owners[0].Controller != nil && *owners[0].Controller {
-							return errors.Errorf("%T owner reference is controlling", obj)
-						}
-
-						return nil
+						return errors.Errorf("deactivation should not have patched %s", obj.GetName())
 					},
 				},
 			},
@@ -871,16 +979,10 @@ func TestProviderDeactivateHook(t *testing.T) {
 						}
 						return nil
 					},
+					// Deactivation doesn't touch owner references. The revision taking over demotes
+					// ours when it claims the objects we share with it.
 					MockPatch: func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) error {
-						owners := obj.GetOwnerReferences()
-						if len(owners) != 1 {
-							return errors.Errorf("incorrect number of owner references on %T, expected 1 got %d", obj, len(owners))
-						}
-						if owners[0].Controller != nil && *owners[0].Controller {
-							return errors.Errorf("%T owner reference is controlling", obj)
-						}
-
-						return nil
+						return errors.Errorf("deactivation should not have patched %s", obj.GetName())
 					},
 				},
 			},

--- a/internal/controller/pkg/runtime/runtime_test.go
+++ b/internal/controller/pkg/runtime/runtime_test.go
@@ -102,6 +102,13 @@ var (
 			},
 		},
 	}
+
+	// An incoming (active) revision that will claim ownership of the objects shared by other revisions of the package.
+	incoming = metav1.OwnerReference{Name: "incoming", UID: "incoming-uid", Controller: ptr.To(true), BlockOwnerDeletion: ptr.To(true)}
+	// an outgoing (inactive) revision that will be demoted/removed from ownership of shared objects.
+	outgoing = metav1.OwnerReference{Name: "outgoing", UID: "outgoing-uid", Controller: ptr.To(true), BlockOwnerDeletion: ptr.To(true)}
+	// the same outgoing (inactive) revision that has now been demoted from ownership of shared objects.
+	demoted = metav1.OwnerReference{Name: "outgoing", UID: "outgoing-uid", Controller: ptr.To(false), BlockOwnerDeletion: ptr.To(true)}
 )
 
 func TestRuntimeManifestBuilderDeployment(t *testing.T) {

--- a/test/e2e/funcs/feature.go
+++ b/test/e2e/funcs/feature.go
@@ -1521,6 +1521,38 @@ func FilterByGK(gk schema.GroupKind) func(o k8s.Object) bool {
 	}
 }
 
+// SolelyControlledBy returns a FieldValueChecker for the "metadata.ownerReferences" field path. It
+// matches when exactly one of the references is controlling, and that reference names the given
+// owner. Kubernetes allows an object only one controlling owner reference, so this asserts both
+// that the named owner is in control and that nothing else claims to be.
+//
+// It reads the unstructured form of the field, a []any of map[string]any, so it will not match at
+// any other field path.
+func SolelyControlledBy(name string) FieldValueChecker {
+	return func(got any) bool {
+		ors, ok := got.([]any)
+		if !ok {
+			return false
+		}
+
+		controllers := []string{}
+
+		for _, or := range ors {
+			r, ok := or.(map[string]any)
+			if !ok {
+				return false
+			}
+
+			if c, ok := r["controller"].(bool); ok && c {
+				n, _ := r["name"].(string)
+				controllers = append(controllers, n)
+			}
+		}
+
+		return len(controllers) == 1 && controllers[0] == name
+	}
+}
+
 func toYAML(objs ...client.Object) string {
 	docs := make([]string, 0, len(objs))
 	for _, obj := range objs {

--- a/test/e2e/funcs/feature.go
+++ b/test/e2e/funcs/feature.go
@@ -1521,35 +1521,28 @@ func FilterByGK(gk schema.GroupKind) func(o k8s.Object) bool {
 	}
 }
 
-// SolelyControlledBy returns a FieldValueChecker for the "metadata.ownerReferences" field path. It
-// matches when exactly one of the references is controlling, and that reference names the given
-// owner. Kubernetes allows an object only one controlling owner reference, so this asserts both
-// that the named owner is in control and that nothing else claims to be.
+// SolelyOwnedBy returns a FieldValueChecker for the "metadata.ownerReferences" field path. It
+// matches when the object has exactly one owner reference, that reference names the given owner,
+// and it is controlling.
 //
 // It reads the unstructured form of the field, a []any of map[string]any, so it will not match at
 // any other field path.
-func SolelyControlledBy(name string) FieldValueChecker {
+func SolelyOwnedBy(name string) FieldValueChecker {
 	return func(got any) bool {
 		ors, ok := got.([]any)
+		if !ok || len(ors) != 1 {
+			return false
+		}
+
+		r, ok := ors[0].(map[string]any)
 		if !ok {
 			return false
 		}
 
-		controllers := []string{}
+		n, _ := r["name"].(string)
+		c, _ := r["controller"].(bool)
 
-		for _, or := range ors {
-			r, ok := or.(map[string]any)
-			if !ok {
-				return false
-			}
-
-			if c, ok := r["controller"].(bool); ok && c {
-				n, _ := r["name"].(string)
-				controllers = append(controllers, n)
-			}
-		}
-
-		return len(controllers) == 1 && controllers[0] == name
+		return n == name && c
 	}
 }
 

--- a/test/e2e/manifests/pkg/activation/automatic/configuration-1.yaml
+++ b/test/e2e/manifests/pkg/activation/automatic/configuration-1.yaml
@@ -1,0 +1,8 @@
+apiVersion: pkg.crossplane.io/v1
+kind: Configuration
+metadata:
+  name: e2e-activation
+spec:
+  # NOTE: This package is manually built and pushed to the registry.
+  package: xpkg.crossplane.io/crossplane/e2e-activation:v0.1.0
+  revisionActivationPolicy: Automatic

--- a/test/e2e/manifests/pkg/activation/automatic/configuration-2.yaml
+++ b/test/e2e/manifests/pkg/activation/automatic/configuration-2.yaml
@@ -1,0 +1,8 @@
+apiVersion: pkg.crossplane.io/v1
+kind: Configuration
+metadata:
+  name: e2e-activation
+spec:
+  # NOTE: This package is manually built and pushed to the registry.
+  package: xpkg.crossplane.io/crossplane/e2e-activation:v0.2.0
+  revisionActivationPolicy: Automatic

--- a/test/e2e/manifests/pkg/activation/automatic/function-1.yaml
+++ b/test/e2e/manifests/pkg/activation/automatic/function-1.yaml
@@ -1,0 +1,7 @@
+apiVersion: pkg.crossplane.io/v1
+kind: Function
+metadata:
+  name: e2e-activation-function-dummy
+spec:
+  package: xpkg.crossplane.io/crossplane-contrib/function-dummy:v0.4.0
+  revisionActivationPolicy: Automatic

--- a/test/e2e/manifests/pkg/activation/automatic/function-2.yaml
+++ b/test/e2e/manifests/pkg/activation/automatic/function-2.yaml
@@ -1,0 +1,7 @@
+apiVersion: pkg.crossplane.io/v1
+kind: Function
+metadata:
+  name: e2e-activation-function-dummy
+spec:
+  package: xpkg.crossplane.io/crossplane-contrib/function-dummy:v0.4.1
+  revisionActivationPolicy: Automatic

--- a/test/e2e/manifests/pkg/activation/automatic/provider-1.yaml
+++ b/test/e2e/manifests/pkg/activation/automatic/provider-1.yaml
@@ -1,0 +1,7 @@
+apiVersion: pkg.crossplane.io/v1
+kind: Provider
+metadata:
+  name: e2e-activation-provider-nop
+spec:
+  package: xpkg.crossplane.io/crossplane-contrib/provider-nop:v0.3.1
+  revisionActivationPolicy: Automatic

--- a/test/e2e/manifests/pkg/activation/automatic/provider-2.yaml
+++ b/test/e2e/manifests/pkg/activation/automatic/provider-2.yaml
@@ -1,0 +1,7 @@
+apiVersion: pkg.crossplane.io/v1
+kind: Provider
+metadata:
+  name: e2e-activation-provider-nop
+spec:
+  package: xpkg.crossplane.io/crossplane-contrib/provider-nop:v0.4.0
+  revisionActivationPolicy: Automatic

--- a/test/e2e/manifests/pkg/activation/package1/composition.yaml
+++ b/test/e2e/manifests/pkg/activation/package1/composition.yaml
@@ -1,0 +1,15 @@
+apiVersion: apiextensions.crossplane.io/v1
+kind: Composition
+metadata:
+  name: xnopresources.nop.example.org
+  labels:
+    e2eTestRevision: one
+spec:
+  compositeTypeRef:
+    apiVersion: nop.example.org/v1alpha1
+    kind: XNopResource
+  mode: Pipeline
+  pipeline:
+  - step: detect-readiness
+    functionRef:
+      name: function-auto-ready

--- a/test/e2e/manifests/pkg/activation/package1/crossplane.yaml
+++ b/test/e2e/manifests/pkg/activation/package1/crossplane.yaml
@@ -1,0 +1,6 @@
+# This is the package metadata for the Configuration installed by
+# configuration-1.yaml.
+apiVersion: meta.pkg.crossplane.io/v1
+kind: Configuration
+metadata:
+  name: e2e-activation

--- a/test/e2e/manifests/pkg/activation/package1/definition.yaml
+++ b/test/e2e/manifests/pkg/activation/package1/definition.yaml
@@ -1,0 +1,34 @@
+apiVersion: apiextensions.crossplane.io/v1
+kind: CompositeResourceDefinition
+metadata:
+  name: xnopresources.nop.example.org
+spec:
+  group: nop.example.org
+  names:
+    kind: XNopResource
+    plural: xnopresources
+  claimNames:
+    kind: NopResource
+    plural: nopresources
+  connectionSecretKeys:
+  - test
+  versions:
+  - name: v1alpha1
+    served: true
+    referenceable: true
+    schema:
+     openAPIV3Schema:
+       type: object
+       properties:
+        spec:
+          type: object
+          properties:
+            coolField:
+              type: string
+          required:
+          - coolField
+        status:
+          type: object
+          properties:
+            coolerField:
+              type: string

--- a/test/e2e/manifests/pkg/activation/package2/composition.yaml
+++ b/test/e2e/manifests/pkg/activation/package2/composition.yaml
@@ -1,0 +1,15 @@
+apiVersion: apiextensions.crossplane.io/v1
+kind: Composition
+metadata:
+  name: xnopresources.nop.example.org
+  labels:
+    e2eTestRevision: two
+spec:
+  compositeTypeRef:
+    apiVersion: nop.example.org/v1alpha1
+    kind: XNopResource
+  mode: Pipeline
+  pipeline:
+  - step: detect-readiness
+    functionRef:
+      name: function-auto-ready

--- a/test/e2e/manifests/pkg/activation/package2/crossplane.yaml
+++ b/test/e2e/manifests/pkg/activation/package2/crossplane.yaml
@@ -1,0 +1,6 @@
+# This is the package metadata for the Configuration installed by
+# configuration-2.yaml.
+apiVersion: meta.pkg.crossplane.io/v1
+kind: Configuration
+metadata:
+  name: e2e-activation

--- a/test/e2e/manifests/pkg/activation/package2/definition.yaml
+++ b/test/e2e/manifests/pkg/activation/package2/definition.yaml
@@ -1,0 +1,34 @@
+apiVersion: apiextensions.crossplane.io/v1
+kind: CompositeResourceDefinition
+metadata:
+  name: xnopresources.nop.example.org
+spec:
+  group: nop.example.org
+  names:
+    kind: XNopResource
+    plural: xnopresources
+  claimNames:
+    kind: NopResource
+    plural: nopresources
+  connectionSecretKeys:
+  - test
+  versions:
+  - name: v1alpha1
+    served: true
+    referenceable: true
+    schema:
+     openAPIV3Schema:
+       type: object
+       properties:
+        spec:
+          type: object
+          properties:
+            coolField:
+              type: string
+          required:
+          - coolField
+        status:
+          type: object
+          properties:
+            coolerField:
+              type: string

--- a/test/e2e/pkg_test.go
+++ b/test/e2e/pkg_test.go
@@ -32,6 +32,7 @@ import (
 	"sigs.k8s.io/e2e-framework/third_party/helm"
 
 	apiextensionsv1 "github.com/crossplane/crossplane/apis/v2/apiextensions/v1"
+	apiextensionsv1alpha1 "github.com/crossplane/crossplane/apis/v2/apiextensions/v1alpha1"
 	xpv2 "github.com/crossplane/crossplane/apis/v2/core/v2"
 	pkgv1 "github.com/crossplane/crossplane/apis/v2/pkg/v1"
 	"github.com/crossplane/crossplane/apis/v2/pkg/v1beta1"
@@ -1246,3 +1247,134 @@ func TestCommonAnnotationsAndLabels(t *testing.T) {
 			Feature(),
 	)
 }
+
+// TestActivationPolicyAutomatic tests that the automatic revision activation
+// policy works correctly.
+func TestActivationPolicyAutomatic(t *testing.T) {
+	manifests := "test/e2e/manifests/pkg/activation/automatic"
+
+	cfgrev1 := &pkgv1.ConfigurationRevision{ObjectMeta: metav1.ObjectMeta{Name: "e2e-activation-73591874542d"}}
+	cfgrev2 := &pkgv1.ConfigurationRevision{ObjectMeta: metav1.ObjectMeta{Name: "e2e-activation-5a414a4fc3b8"}}
+
+	provrev1 := &pkgv1.ProviderRevision{ObjectMeta: metav1.ObjectMeta{Name: "e2e-activation-provider-nop-e956f0998e8f"}}
+	provrev2 := &pkgv1.ProviderRevision{ObjectMeta: metav1.ObjectMeta{Name: "e2e-activation-provider-nop-bb2f70dd2d3d"}}
+
+	funcrev1 := &pkgv1.FunctionRevision{ObjectMeta: metav1.ObjectMeta{Name: "e2e-activation-function-dummy-b9bf9f183c5a"}}
+	funcrev2 := &pkgv1.FunctionRevision{ObjectMeta: metav1.ObjectMeta{Name: "e2e-activation-function-dummy-b5b7d53a27d3"}}
+
+	deployment := func(name string) *appsv1.Deployment {
+		return &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: name}}
+	}
+	service := func(name string) *corev1.Service {
+		return &corev1.Service{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: name}}
+	}
+
+	environment.Test(t,
+		features.NewWithDescription(t.Name(), "Tests that the automatic revision activation policy works correctly.").
+			WithLabel(LabelArea, LabelAreaPkg).
+			WithLabel(LabelSize, LabelSizeSmall).
+			WithLabel(config.LabelTestSuite, config.TestSuiteDefault).
+			Assess("InstallConfiguration", funcs.AllOf(
+				funcs.ApplyResources(FieldManager, manifests, "configuration-1.yaml"),
+				funcs.ResourcesHaveConditionWithin(2*time.Minute, manifests, "configuration-1.yaml", pkgv1.Healthy(), pkgv1.Active()),
+
+				funcs.ResourceCreatedWithin(2*time.Minute, cfgrev1),
+				funcs.ResourceHasFieldValueWithin(2*time.Minute, cfgrev1, "spec.revision", int64(1)),
+				funcs.ResourceHasFieldValueWithin(2*time.Minute, cfgrev1, "spec.desiredState", "Active"),
+				// Check that the composition in the configuration was created.
+				funcs.ResourceHasFieldValueWithin(2*time.Minute, &apiextensionsv1.Composition{ObjectMeta: metav1.ObjectMeta{Name: "xnopresources.nop.example.org"}}, "metadata.labels[e2eTestRevision]", "one"),
+			)).
+			Assess("InstallFunction", funcs.AllOf(
+				funcs.ApplyResources(FieldManager, manifests, "function-1.yaml"),
+				funcs.ResourcesHaveConditionWithin(2*time.Minute, manifests, "function-1.yaml", pkgv1.Healthy(), pkgv1.Active()),
+
+				funcs.ResourceCreatedWithin(2*time.Minute, funcrev1),
+				funcs.ResourceHasFieldValueWithin(2*time.Minute, funcrev1, "spec.revision", int64(1)),
+				funcs.ResourceHasFieldValueWithin(2*time.Minute, funcrev1, "spec.desiredState", "Active"),
+				// Check that the function's deployment uses the correct image
+				// and its service targets the correct deployment.
+				funcs.ResourceHasFieldValueWithin(2*time.Minute, deployment(funcrev1.Name), "spec.template.spec.containers[0].image", "xpkg.crossplane.io/crossplane-contrib/function-dummy:v0.4.0"),
+				funcs.ResourceHasFieldValueWithin(2*time.Minute, service("e2e-activation-function-dummy"), "spec.selector[pkg.crossplane.io/revision]", funcrev1.Name),
+			)).
+			Assess("InstallProvider", funcs.AllOf(
+				funcs.ApplyResources(FieldManager, manifests, "provider-1.yaml"),
+				funcs.ResourcesHaveConditionWithin(2*time.Minute, manifests, "provider-1.yaml", pkgv1.Healthy(), pkgv1.Active()),
+
+				funcs.ResourceCreatedWithin(2*time.Minute, provrev1),
+				funcs.ResourceHasFieldValueWithin(2*time.Minute, provrev1, "spec.revision", int64(1)),
+				funcs.ResourceHasFieldValueWithin(2*time.Minute, provrev1, "spec.desiredState", "Active"),
+				// Check that the provider's MRD was created.
+				funcs.ResourceHasConditionWithin(2*time.Minute,
+					&apiextensionsv1alpha1.ManagedResourceDefinition{ObjectMeta: metav1.ObjectMeta{Name: "nopresources.nop.crossplane.io"}},
+					apiextensionsv1alpha1.EstablishedManaged(),
+				),
+				// Check that the providers's deployment uses the correct image
+				// and its service targets the correct deployment.
+				funcs.ResourceHasFieldValueWithin(2*time.Minute, deployment(provrev1.Name), "spec.template.spec.containers[0].image", "xpkg.crossplane.io/crossplane-contrib/provider-nop:v0.3.1"),
+				funcs.ResourceHasFieldValueWithin(2*time.Minute, service("e2e-activation-provider-nop"), "spec.selector[pkg.crossplane.io/revision]", provrev1.Name),
+			)).
+			Assess("UpdateConfiguration", funcs.AllOf(
+				funcs.ApplyResources(FieldManager, manifests, "configuration-2.yaml"),
+				funcs.ResourcesHaveConditionWithin(2*time.Minute, manifests, "configuration-2.yaml", pkgv1.Healthy(), pkgv1.Active()),
+
+				funcs.ResourceCreatedWithin(2*time.Minute, cfgrev2),
+				funcs.ResourceHasFieldValueWithin(2*time.Minute, cfgrev2, "spec.revision", int64(2)),
+				funcs.ResourceHasFieldValueWithin(2*time.Minute, cfgrev2, "spec.desiredState", "Active"),
+				// Check that the old revision was deactivated.
+				funcs.ResourceHasFieldValueWithin(2*time.Minute, cfgrev1, "spec.desiredState", "Inactive"),
+				// Check that the composition in the configuration was updated.
+				funcs.ResourceHasFieldValueWithin(2*time.Minute, &apiextensionsv1.Composition{ObjectMeta: metav1.ObjectMeta{Name: "xnopresources.nop.example.org"}}, "metadata.labels[e2eTestRevision]", "two"),
+			)).
+			Assess("UpdateFunction", funcs.AllOf(
+				funcs.ApplyResources(FieldManager, manifests, "function-2.yaml"),
+				funcs.ResourcesHaveConditionWithin(2*time.Minute, manifests, "function-2.yaml", pkgv1.Healthy(), pkgv1.Active()),
+
+				funcs.ResourceCreatedWithin(2*time.Minute, funcrev2),
+				funcs.ResourceHasFieldValueWithin(2*time.Minute, funcrev2, "spec.revision", int64(2)),
+				funcs.ResourceHasFieldValueWithin(2*time.Minute, funcrev2, "spec.desiredState", "Active"),
+				// Check that the old revision was deactivated.
+				funcs.ResourceHasFieldValueWithin(2*time.Minute, funcrev1, "spec.desiredState", "Inactive"),
+				// Check that the function's deployment uses the correct image
+				// and its service targets the correct deployment.
+				funcs.ResourceHasFieldValueWithin(2*time.Minute, deployment(funcrev2.Name), "spec.template.spec.containers[0].image", "xpkg.crossplane.io/crossplane-contrib/function-dummy:v0.4.1"),
+				funcs.ResourceHasFieldValueWithin(2*time.Minute, service("e2e-activation-function-dummy"), "spec.selector[pkg.crossplane.io/revision]", funcrev2.Name),
+			)).
+			Assess("UpdateProvider", funcs.AllOf(
+				funcs.ApplyResources(FieldManager, manifests, "provider-2.yaml"),
+				funcs.ResourcesHaveConditionWithin(2*time.Minute, manifests, "provider-2.yaml", pkgv1.Healthy(), pkgv1.Active()),
+
+				funcs.ResourceCreatedWithin(2*time.Minute, provrev2),
+				funcs.ResourceHasFieldValueWithin(2*time.Minute, provrev2, "spec.revision", int64(2)),
+				funcs.ResourceHasFieldValueWithin(2*time.Minute, provrev2, "spec.desiredState", "Active"),
+				// Check that the old revision was deactivated.
+				funcs.ResourceHasFieldValueWithin(2*time.Minute, provrev1, "spec.desiredState", "Inactive"),
+				// Check that the provider's MRD is still established.
+				funcs.ResourceHasConditionWithin(2*time.Minute,
+					&apiextensionsv1alpha1.ManagedResourceDefinition{ObjectMeta: metav1.ObjectMeta{Name: "nopresources.nop.crossplane.io"}},
+					apiextensionsv1alpha1.EstablishedManaged(),
+				),
+				// Check that the providers's deployment uses the correct image
+				// and its service targets the correct deployment.
+				funcs.ResourceHasFieldValueWithin(2*time.Minute, deployment(provrev2.Name), "spec.template.spec.containers[0].image", "xpkg.crossplane.io/crossplane-contrib/provider-nop:v0.4.0"),
+				funcs.ResourceHasFieldValueWithin(2*time.Minute, service("e2e-activation-provider-nop"), "spec.selector[pkg.crossplane.io/revision]", provrev2.Name),
+			)).
+			WithTeardown("Cleanup", funcs.AllOf(
+				funcs.DeleteResources(manifests, "configuration-2.yaml"),
+				funcs.ResourceDeletedWithin(2*time.Minute, cfgrev1),
+				funcs.ResourceDeletedWithin(2*time.Minute, cfgrev2),
+				funcs.ResourceDeletedWithin(2*time.Minute, &apiextensionsv1.Composition{ObjectMeta: metav1.ObjectMeta{Name: "xnopresources.nop.example.org"}}),
+
+				funcs.DeleteResources(manifests, "function-2.yaml"),
+				funcs.ResourceDeletedWithin(2*time.Minute, funcrev1),
+				funcs.ResourceDeletedWithin(2*time.Minute, funcrev2),
+
+				funcs.DeleteResources(manifests, "provider-2.yaml"),
+				funcs.ResourceDeletedWithin(2*time.Minute, provrev1),
+				funcs.ResourceDeletedWithin(2*time.Minute, provrev2),
+				funcs.ResourceDeletedWithin(2*time.Minute, &apiextensionsv1alpha1.ManagedResourceDefinition{ObjectMeta: metav1.ObjectMeta{Name: "nopresources.nop.crossplane.io"}}),
+			)).Feature(),
+	)
+}
+
+// TODO(adamwg): Add an equivalent test for the manual revision activation
+// policy.

--- a/test/e2e/pkg_test.go
+++ b/test/e2e/pkg_test.go
@@ -1298,10 +1298,10 @@ func TestActivationPolicyAutomatic(t *testing.T) {
 				// and its service targets the correct deployment.
 				funcs.ResourceHasFieldValueWithin(2*time.Minute, deployment(funcrev1.Name), "spec.template.spec.containers[0].image", "xpkg.crossplane.io/crossplane-contrib/function-dummy:v0.4.0"),
 				funcs.ResourceHasFieldValueWithin(2*time.Minute, service("e2e-activation-function-dummy"), "spec.selector[pkg.crossplane.io/revision]", funcrev1.Name),
-				// Check that the active revision controls the objects that are
-				// shared by every revision of the function.
-				funcs.ResourceHasFieldValueWithin(2*time.Minute, service("e2e-activation-function-dummy"), "metadata.ownerReferences", funcs.SolelyControlledBy(funcrev1.Name)),
-				funcs.ResourceHasFieldValueWithin(2*time.Minute, secret("e2e-activation-function-dummy-tls-server"), "metadata.ownerReferences", funcs.SolelyControlledBy(funcrev1.Name)),
+				// Check that the active revision is the sole owner of the
+				// objects that are shared by every revision of the function.
+				funcs.ResourceHasFieldValueWithin(2*time.Minute, service("e2e-activation-function-dummy"), "metadata.ownerReferences", funcs.SolelyOwnedBy(funcrev1.Name)),
+				funcs.ResourceHasFieldValueWithin(2*time.Minute, secret("e2e-activation-function-dummy-tls-server"), "metadata.ownerReferences", funcs.SolelyOwnedBy(funcrev1.Name)),
 			)).
 			Assess("InstallProvider", funcs.AllOf(
 				funcs.ApplyResources(FieldManager, manifests, "provider-1.yaml"),
@@ -1319,11 +1319,11 @@ func TestActivationPolicyAutomatic(t *testing.T) {
 				// and its service targets the correct deployment.
 				funcs.ResourceHasFieldValueWithin(2*time.Minute, deployment(provrev1.Name), "spec.template.spec.containers[0].image", "xpkg.crossplane.io/crossplane-contrib/provider-nop:v0.3.1"),
 				funcs.ResourceHasFieldValueWithin(2*time.Minute, service("e2e-activation-provider-nop"), "spec.selector[pkg.crossplane.io/revision]", provrev1.Name),
-				// Check that the active revision controls the objects that are
-				// shared by every revision of the provider.
-				funcs.ResourceHasFieldValueWithin(2*time.Minute, service("e2e-activation-provider-nop"), "metadata.ownerReferences", funcs.SolelyControlledBy(provrev1.Name)),
-				funcs.ResourceHasFieldValueWithin(2*time.Minute, secret("e2e-activation-provider-nop-tls-server"), "metadata.ownerReferences", funcs.SolelyControlledBy(provrev1.Name)),
-				funcs.ResourceHasFieldValueWithin(2*time.Minute, secret("e2e-activation-provider-nop-tls-client"), "metadata.ownerReferences", funcs.SolelyControlledBy(provrev1.Name)),
+				// Check that the active revision is the sole owner of the
+				// objects that are shared by every revision of the provider.
+				funcs.ResourceHasFieldValueWithin(2*time.Minute, service("e2e-activation-provider-nop"), "metadata.ownerReferences", funcs.SolelyOwnedBy(provrev1.Name)),
+				funcs.ResourceHasFieldValueWithin(2*time.Minute, secret("e2e-activation-provider-nop-tls-server"), "metadata.ownerReferences", funcs.SolelyOwnedBy(provrev1.Name)),
+				funcs.ResourceHasFieldValueWithin(2*time.Minute, secret("e2e-activation-provider-nop-tls-client"), "metadata.ownerReferences", funcs.SolelyOwnedBy(provrev1.Name)),
 			)).
 			Assess("UpdateConfiguration", funcs.AllOf(
 				funcs.ApplyResources(FieldManager, manifests, "configuration-2.yaml"),
@@ -1350,10 +1350,11 @@ func TestActivationPolicyAutomatic(t *testing.T) {
 				// and its service targets the correct deployment.
 				funcs.ResourceHasFieldValueWithin(2*time.Minute, deployment(funcrev2.Name), "spec.template.spec.containers[0].image", "xpkg.crossplane.io/crossplane-contrib/function-dummy:v0.4.1"),
 				funcs.ResourceHasFieldValueWithin(2*time.Minute, service("e2e-activation-function-dummy"), "spec.selector[pkg.crossplane.io/revision]", funcrev2.Name),
-				// Check that the incoming revision took control of the objects
-				// it shares with the revision it replaced.
-				funcs.ResourceHasFieldValueWithin(2*time.Minute, service("e2e-activation-function-dummy"), "metadata.ownerReferences", funcs.SolelyControlledBy(funcrev2.Name)),
-				funcs.ResourceHasFieldValueWithin(2*time.Minute, secret("e2e-activation-function-dummy-tls-server"), "metadata.ownerReferences", funcs.SolelyControlledBy(funcrev2.Name)),
+				// Check that the incoming revision took sole ownership of the
+				// objects it shares with the revision it replaced, leaving the
+				// outgoing revision no owner reference at all.
+				funcs.ResourceHasFieldValueWithin(2*time.Minute, service("e2e-activation-function-dummy"), "metadata.ownerReferences", funcs.SolelyOwnedBy(funcrev2.Name)),
+				funcs.ResourceHasFieldValueWithin(2*time.Minute, secret("e2e-activation-function-dummy-tls-server"), "metadata.ownerReferences", funcs.SolelyOwnedBy(funcrev2.Name)),
 			)).
 			Assess("UpdateProvider", funcs.AllOf(
 				funcs.ApplyResources(FieldManager, manifests, "provider-2.yaml"),
@@ -1373,11 +1374,12 @@ func TestActivationPolicyAutomatic(t *testing.T) {
 				// and its service targets the correct deployment.
 				funcs.ResourceHasFieldValueWithin(2*time.Minute, deployment(provrev2.Name), "spec.template.spec.containers[0].image", "xpkg.crossplane.io/crossplane-contrib/provider-nop:v0.4.0"),
 				funcs.ResourceHasFieldValueWithin(2*time.Minute, service("e2e-activation-provider-nop"), "spec.selector[pkg.crossplane.io/revision]", provrev2.Name),
-				// Check that the incoming revision took control of the objects
-				// it shares with the revision it replaced.
-				funcs.ResourceHasFieldValueWithin(2*time.Minute, service("e2e-activation-provider-nop"), "metadata.ownerReferences", funcs.SolelyControlledBy(provrev2.Name)),
-				funcs.ResourceHasFieldValueWithin(2*time.Minute, secret("e2e-activation-provider-nop-tls-server"), "metadata.ownerReferences", funcs.SolelyControlledBy(provrev2.Name)),
-				funcs.ResourceHasFieldValueWithin(2*time.Minute, secret("e2e-activation-provider-nop-tls-client"), "metadata.ownerReferences", funcs.SolelyControlledBy(provrev2.Name)),
+				// Check that the incoming revision took sole ownership of the
+				// objects it shares with the revision it replaced, leaving the
+				// outgoing revision no owner reference at all.
+				funcs.ResourceHasFieldValueWithin(2*time.Minute, service("e2e-activation-provider-nop"), "metadata.ownerReferences", funcs.SolelyOwnedBy(provrev2.Name)),
+				funcs.ResourceHasFieldValueWithin(2*time.Minute, secret("e2e-activation-provider-nop-tls-server"), "metadata.ownerReferences", funcs.SolelyOwnedBy(provrev2.Name)),
+				funcs.ResourceHasFieldValueWithin(2*time.Minute, secret("e2e-activation-provider-nop-tls-client"), "metadata.ownerReferences", funcs.SolelyOwnedBy(provrev2.Name)),
 			)).
 			WithTeardown("Cleanup", funcs.AllOf(
 				funcs.DeleteResources(manifests, "configuration-2.yaml"),

--- a/test/e2e/pkg_test.go
+++ b/test/e2e/pkg_test.go
@@ -1268,6 +1268,9 @@ func TestActivationPolicyAutomatic(t *testing.T) {
 	service := func(name string) *corev1.Service {
 		return &corev1.Service{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: name}}
 	}
+	secret := func(name string) *corev1.Secret {
+		return &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: name}}
+	}
 
 	environment.Test(t,
 		features.NewWithDescription(t.Name(), "Tests that the automatic revision activation policy works correctly.").
@@ -1295,6 +1298,10 @@ func TestActivationPolicyAutomatic(t *testing.T) {
 				// and its service targets the correct deployment.
 				funcs.ResourceHasFieldValueWithin(2*time.Minute, deployment(funcrev1.Name), "spec.template.spec.containers[0].image", "xpkg.crossplane.io/crossplane-contrib/function-dummy:v0.4.0"),
 				funcs.ResourceHasFieldValueWithin(2*time.Minute, service("e2e-activation-function-dummy"), "spec.selector[pkg.crossplane.io/revision]", funcrev1.Name),
+				// Check that the active revision controls the objects that are
+				// shared by every revision of the function.
+				funcs.ResourceHasFieldValueWithin(2*time.Minute, service("e2e-activation-function-dummy"), "metadata.ownerReferences", funcs.SolelyControlledBy(funcrev1.Name)),
+				funcs.ResourceHasFieldValueWithin(2*time.Minute, secret("e2e-activation-function-dummy-tls-server"), "metadata.ownerReferences", funcs.SolelyControlledBy(funcrev1.Name)),
 			)).
 			Assess("InstallProvider", funcs.AllOf(
 				funcs.ApplyResources(FieldManager, manifests, "provider-1.yaml"),
@@ -1312,6 +1319,11 @@ func TestActivationPolicyAutomatic(t *testing.T) {
 				// and its service targets the correct deployment.
 				funcs.ResourceHasFieldValueWithin(2*time.Minute, deployment(provrev1.Name), "spec.template.spec.containers[0].image", "xpkg.crossplane.io/crossplane-contrib/provider-nop:v0.3.1"),
 				funcs.ResourceHasFieldValueWithin(2*time.Minute, service("e2e-activation-provider-nop"), "spec.selector[pkg.crossplane.io/revision]", provrev1.Name),
+				// Check that the active revision controls the objects that are
+				// shared by every revision of the provider.
+				funcs.ResourceHasFieldValueWithin(2*time.Minute, service("e2e-activation-provider-nop"), "metadata.ownerReferences", funcs.SolelyControlledBy(provrev1.Name)),
+				funcs.ResourceHasFieldValueWithin(2*time.Minute, secret("e2e-activation-provider-nop-tls-server"), "metadata.ownerReferences", funcs.SolelyControlledBy(provrev1.Name)),
+				funcs.ResourceHasFieldValueWithin(2*time.Minute, secret("e2e-activation-provider-nop-tls-client"), "metadata.ownerReferences", funcs.SolelyControlledBy(provrev1.Name)),
 			)).
 			Assess("UpdateConfiguration", funcs.AllOf(
 				funcs.ApplyResources(FieldManager, manifests, "configuration-2.yaml"),
@@ -1338,6 +1350,10 @@ func TestActivationPolicyAutomatic(t *testing.T) {
 				// and its service targets the correct deployment.
 				funcs.ResourceHasFieldValueWithin(2*time.Minute, deployment(funcrev2.Name), "spec.template.spec.containers[0].image", "xpkg.crossplane.io/crossplane-contrib/function-dummy:v0.4.1"),
 				funcs.ResourceHasFieldValueWithin(2*time.Minute, service("e2e-activation-function-dummy"), "spec.selector[pkg.crossplane.io/revision]", funcrev2.Name),
+				// Check that the incoming revision took control of the objects
+				// it shares with the revision it replaced.
+				funcs.ResourceHasFieldValueWithin(2*time.Minute, service("e2e-activation-function-dummy"), "metadata.ownerReferences", funcs.SolelyControlledBy(funcrev2.Name)),
+				funcs.ResourceHasFieldValueWithin(2*time.Minute, secret("e2e-activation-function-dummy-tls-server"), "metadata.ownerReferences", funcs.SolelyControlledBy(funcrev2.Name)),
 			)).
 			Assess("UpdateProvider", funcs.AllOf(
 				funcs.ApplyResources(FieldManager, manifests, "provider-2.yaml"),
@@ -1357,6 +1373,11 @@ func TestActivationPolicyAutomatic(t *testing.T) {
 				// and its service targets the correct deployment.
 				funcs.ResourceHasFieldValueWithin(2*time.Minute, deployment(provrev2.Name), "spec.template.spec.containers[0].image", "xpkg.crossplane.io/crossplane-contrib/provider-nop:v0.4.0"),
 				funcs.ResourceHasFieldValueWithin(2*time.Minute, service("e2e-activation-provider-nop"), "spec.selector[pkg.crossplane.io/revision]", provrev2.Name),
+				// Check that the incoming revision took control of the objects
+				// it shares with the revision it replaced.
+				funcs.ResourceHasFieldValueWithin(2*time.Minute, service("e2e-activation-provider-nop"), "metadata.ownerReferences", funcs.SolelyControlledBy(provrev2.Name)),
+				funcs.ResourceHasFieldValueWithin(2*time.Minute, secret("e2e-activation-provider-nop-tls-server"), "metadata.ownerReferences", funcs.SolelyControlledBy(provrev2.Name)),
+				funcs.ResourceHasFieldValueWithin(2*time.Minute, secret("e2e-activation-provider-nop-tls-client"), "metadata.ownerReferences", funcs.SolelyControlledBy(provrev2.Name)),
 			)).
 			WithTeardown("Cleanup", funcs.AllOf(
 				funcs.DeleteResources(manifests, "configuration-2.yaml"),


### PR DESCRIPTION
### Description of your changes

Previously, newly activated revisions would set a controlling owner reference on the runtime objects they control using `Update`. Now that we've switched to SSA, the specified owner reference gets merged into the existing owner references, which includes a controlling owner reference from the previously active revision. This causes an error since an object can't have two controlling owner references.

Make the existing `Deactivate` hooks for function and provider revisions update the owner references for deactivated revisions such that they are no longer controlling. It is still possible for there to be a race between the reconciles of the deactivated revision and the activated revision, where the activated revision will fail to take ownership of the objects, but it will resolve eventually since the deactivation succeeds regardless of what the activation has done.

To help validate the change, and prevent similar regressions in the future, add an e2e test that exercises upgrades of all package types.

Fixes #7708

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `./nix.sh flake check` to ensure this PR is ready for review.
- [x] Added or updated unit tests.
- [x] Added or updated e2e tests.
~- [ ] Linked a PR or a [docs tracking issue] to [document this change].~
~- [ ] Added `backport release-x.y` labels to auto-backport this PR.~
~- [ ] Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md
