### PR TITLE
Requeue while the circuit breaker is open so XRs don't get stuck

### DIFF
--- a/internal/circuit/token_bucket.go
+++ b/internal/circuit/token_bucket.go
@@ -247,7 +247,12 @@ func (b *TokenBucketBreaker) GetState(_ context.Context, target types.Namespaced
 	state.mu.RLock()
 	defer state.mu.RUnlock()
 
-	if !state.isOpen {
+	// Mirror the cooldown expiry check RecordEvent uses to close the
+	// circuit. Without this, a target that stops receiving events (e.g.
+	// because its dependencies settled and stopped changing) would report
+	// IsOpen: true forever - RecordEvent is the only place that closes the
+	// circuit, and it only runs when a new event arrives.
+	if !state.isOpen || time.Since(state.openedAt) >= b.config.cooldownTime {
 		return State{IsOpen: false}
 	}
 

--- a/internal/circuit/token_bucket_test.go
+++ b/internal/circuit/token_bucket_test.go
@@ -242,6 +242,32 @@ func TestTokenBucketBreakerGetState(t *testing.T) {
 				},
 			},
 		},
+		"CooldownExpiredWithoutFurtherEvents": {
+			reason: "Once the cooldown period has elapsed, GetState should report a closed circuit even without an intervening RecordEvent call, so callers that only poll GetState (e.g. a reconciler waking itself up on a timer) can observe the circuit closing.",
+			breaker: NewTokenBucketBreaker(
+				"test-controller",
+				WithBurst(1),
+				WithRefillRatePerSecond(0.1),
+				WithOpenDuration(50*time.Millisecond),
+				WithHalfOpenInterval(30*time.Second),
+			),
+			setup: func(b *TokenBucketBreaker) {
+				ctx := context.Background()
+				// Open circuit by exhausting tokens.
+				b.RecordEvent(ctx, target, source, EventAllowed)
+				b.RecordEvent(ctx, target, source, EventAllowed)
+				// Let the cooldown expire without recording any further
+				// events.
+				time.Sleep(100 * time.Millisecond)
+			},
+			args: args{
+				ctx:    context.Background(),
+				target: target,
+			},
+			want: want{
+				state: State{IsOpen: false},
+			},
+		},
 		"HalfOpenUpdatesNextAllowedAt": {
 			reason: "Recording half-open allowed event should update NextAllowedAt forward",
 			breaker: NewTokenBucketBreaker(

--- a/internal/controller/apiextensions/composite/reconciler.go
+++ b/internal/controller/apiextensions/composite/reconciler.go
@@ -600,9 +600,10 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 
 	// Check circuit breaker state and set condition accordingly.
 	condition := v1.WatchCircuitClosed()
-	if s := r.circuit.GetState(ctx, req.NamespacedName); s.IsOpen {
-		condition = v1.WatchCircuitOpen(s.TriggeredBy)
-		log.Info("Circuit breaker is open", "triggered-by", s.TriggeredBy, "next-allowed-at", s.NextAllowedAt)
+	circuitState := r.circuit.GetState(ctx, req.NamespacedName)
+	if circuitState.IsOpen {
+		condition = v1.WatchCircuitOpen(circuitState.TriggeredBy)
+		log.Info("Circuit breaker is open", "triggered-by", circuitState.TriggeredBy, "next-allowed-at", circuitState.NextAllowedAt)
 	}
 	status.MarkConditions(condition)
 
@@ -926,6 +927,8 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 		result = reconcile.Result{RequeueAfter: jitter(res.TTL)}
 	}
 
+	result = boundRequeueByCircuitBreaker(result, circuitState, time.Now())
+
 	if !cmp.Equal(statusBefore, xr.Object["status"]) {
 		return result, errors.Wrap(r.client.Status().Update(updateCtx, xr), errUpdateStatus)
 	}
@@ -1011,4 +1014,31 @@ func getClaimFromXR(ctx context.Context, c client.Client, xr *composite.Unstruct
 // Jitter the supplied duration by up to +/- 10%.
 func jitter(d time.Duration) time.Duration {
 	return d + time.Duration((rand.Float64()-0.5)*2*(float64(d)*0.1)) //nolint:gosec // No need for secure randomness
+}
+
+// boundRequeueByCircuitBreaker ensures the supplied result requeues no later
+// than the circuit breaker's next half-open probe, if it's open. Without
+// this, an XR whose watch events are being dropped by an open circuit
+// breaker could miss its dependencies settling (e.g. becoming ready) while
+// the circuit is open - there would be no more events left to trigger
+// another reconcile once the circuit closes.
+func boundRequeueByCircuitBreaker(result reconcile.Result, cs circuit.State, now time.Time) reconcile.Result {
+	if result.Requeue || !cs.IsOpen {
+		return result
+	}
+
+	until := cs.NextAllowedAt.Sub(now)
+	switch {
+	case until <= 0:
+		// The circuit's next half-open probe is already due. We can't
+		// express "requeue now" with RequeueAfter: 0 - controller-runtime
+		// only requeues when RequeueAfter > 0 or Requeue is true - so
+		// request an immediate (rate-limited) requeue instead.
+		result.RequeueAfter = 0
+		result.Requeue = true
+	case result.RequeueAfter <= 0 || until < result.RequeueAfter:
+		result.RequeueAfter = until
+	}
+
+	return result
 }

--- a/internal/controller/apiextensions/composite/reconciler_test.go
+++ b/internal/controller/apiextensions/composite/reconciler_test.go
@@ -1364,6 +1364,63 @@ func TestReconcile(t *testing.T) {
 	}
 }
 
+func TestBoundRequeueByCircuitBreaker(t *testing.T) {
+	now := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	cases := map[string]struct {
+		reason string
+		result reconcile.Result
+		state  circuit.State
+		want   reconcile.Result
+	}{
+		"ClosedLeavesResultUnchanged": {
+			reason: "A closed circuit shouldn't affect the requeue - there's nothing to correct for.",
+			result: reconcile.Result{RequeueAfter: time.Hour},
+			state:  circuit.State{IsOpen: false},
+			want:   reconcile.Result{RequeueAfter: time.Hour},
+		},
+		"ImmediateRequeueLeftUnchanged": {
+			reason: "An immediate requeue (e.g. to retry a conflict) is already sooner than any circuit breaker probe, so it's left alone.",
+			result: reconcile.Result{Requeue: true},
+			state:  circuit.State{IsOpen: true, NextAllowedAt: now.Add(time.Minute)},
+			want:   reconcile.Result{Requeue: true},
+		},
+		"OpenWithNoOtherRequeueUsesNextAllowedAt": {
+			reason: "If we wouldn't otherwise requeue (e.g. realtime compositions with no TTL), we must still wake up when the circuit's next half-open probe opens - otherwise we could miss dependencies settling while events are being dropped.",
+			result: reconcile.Result{},
+			state:  circuit.State{IsOpen: true, NextAllowedAt: now.Add(30 * time.Second)},
+			want:   reconcile.Result{RequeueAfter: 30 * time.Second},
+		},
+		"OpenSoonerThanExistingRequeueOverrides": {
+			reason: "If the circuit's next probe is sooner than our normal poll interval, we should wake up for the probe instead of waiting for the poll interval.",
+			result: reconcile.Result{RequeueAfter: time.Hour},
+			state:  circuit.State{IsOpen: true, NextAllowedAt: now.Add(30 * time.Second)},
+			want:   reconcile.Result{RequeueAfter: 30 * time.Second},
+		},
+		"OpenLaterThanExistingRequeueLeftUnchanged": {
+			reason: "If our normal poll interval already fires before the circuit's next probe, there's no need to requeue sooner.",
+			result: reconcile.Result{RequeueAfter: 10 * time.Second},
+			state:  circuit.State{IsOpen: true, NextAllowedAt: now.Add(30 * time.Second)},
+			want:   reconcile.Result{RequeueAfter: 10 * time.Second},
+		},
+		"OpenWithPastNextAllowedAtRequeuesImmediately": {
+			reason: "If the circuit's next probe time has already passed, we should requeue right away. RequeueAfter: 0 wouldn't do that - controller-runtime treats it as 'no requeue' unless Requeue is also true.",
+			result: reconcile.Result{},
+			state:  circuit.State{IsOpen: true, NextAllowedAt: now.Add(-time.Minute)},
+			want:   reconcile.Result{Requeue: true},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got := boundRequeueByCircuitBreaker(tc.result, tc.state, now)
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("\n%s\nboundRequeueByCircuitBreaker(...): -want, +got:\n%s", tc.reason, diff)
+			}
+		})
+	}
+}
+
 func TestEffectivePollInterval(t *testing.T) {
 	cases := map[string]struct {
 		reason          string


### PR DESCRIPTION
### Description of your changes

XRs can get stuck reflecting stale status for a long time when the circuit
breaker that guards watch-driven reconciliation opens (crossplane/crossplane#7703):

1. The circuit breaker's `TokenBucketBreaker.GetState` only closed a
   stale circuit inside `RecordEvent`, which is only called when a new
   watch event actually arrives. If a burst of events opened the circuit
   and then events stopped entirely (e.g. because the XR's dependencies
   became ready and stopped changing), `GetState` kept reporting
   `IsOpen: true` forever, even long after the configured cooldown had
   elapsed - there was no more event to trigger the lazy close.
2. The composite reconciler only checked circuit breaker state to set a
   status condition; it never adjusted its own requeue behaviour. With
   watch events being dropped while the circuit is open, and (with
   realtime compositions enabled) no periodic poll to fall back on, there
   was nothing left to wake the reconciler up and let it notice the
   circuit had closed.

This change:

- Makes `TokenBucketBreaker.GetState` evaluate cooldown expiry itself,
  mirroring the check `RecordEvent` already performs, so any caller that
  only polls `GetState` (not just `RecordEvent`) can observe a circuit
  closing once its cooldown has elapsed.
- Makes the composite reconciler bound its requeue result so that, while
  the circuit is open, it requeues no later than the circuit's next
  half-open probe - instead of relying solely on watch events that may
  never arrive - via a new `boundRequeueByCircuitBreaker` helper.

Together these bound how long an XR can be stuck to the circuit
breaker's own cooldown window (5 minutes by default), instead of the
controller's regular poll interval or cache resync period.

Fixes #

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [ ] ~Run `./nix.sh flake check` to ensure this PR is ready for review.~
- [x] Added or updated unit tests.
- [ ] ~Added or updated e2e tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~
- [ ] ~Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md

Fixes #7703