### PR TITLE
drop secret last-applied annotation from pipeline inspector output

### DIFF
--- a/internal/xfn/inspected/socket.go
+++ b/internal/xfn/inspected/socket.go
@@ -37,6 +37,11 @@ const (
 
 	// redactedValue is used to replace sensitive data values while preserving keys.
 	redactedValue = "**REDACTED**"
+
+	// lastAppliedConfigAnnotation is written by kubectl apply. Its value is the
+	// entire applied object as JSON, so on a Secret it embeds a verbatim copy
+	// of the data we redact.
+	lastAppliedConfigAnnotation = "kubectl.kubernetes.io/last-applied-configuration"
 )
 
 // A SocketPipelineInspector emits pipeline execution data to a Pipeline
@@ -200,8 +205,9 @@ func redactConnectionDetails(connectionDetails map[string][]byte) {
 }
 
 // stripSecretData redacts the data and stringData field values from a resource
-// if it is a Kubernetes Secret. The keys are preserved but values are replaced
-// with redactedValue.
+// if it is a Kubernetes Secret, preserving their keys but replacing their
+// values with redactedValue, and drops its kubectl last-applied-configuration
+// annotation entirely.
 func stripSecretData(resource *structpb.Struct) {
 	if resource == nil {
 		return
@@ -224,5 +230,13 @@ func stripSecretData(resource *structpb.Struct) {
 				}
 			}
 		}
+
+		// Secrets applied with kubectl carry the whole object, data included,
+		// in the last-applied-configuration annotation. Redacting only the
+		// fields above would leave that copy of them behind. We drop the
+		// annotation rather than redact it: it duplicates state the inspector
+		// already shows, so its key isn't worth surfacing.
+		a := fields["metadata"].GetStructValue().GetFields()["annotations"].GetStructValue()
+		delete(a.GetFields(), lastAppliedConfigAnnotation)
 	}
 }

--- a/internal/xfn/inspected/socket_test.go
+++ b/internal/xfn/inspected/socket_test.go
@@ -18,6 +18,7 @@ package inspected
 import (
 	"context"
 	"errors"
+	"maps"
 	"testing"
 	"time"
 
@@ -723,6 +724,109 @@ func TestSanitizeState(t *testing.T) {
 				},
 			},
 		},
+		"DropsSecretLastAppliedConfiguration": {
+			reason: "Should drop the kubectl last-applied-configuration annotation from Secret resources, since it embeds the data we just redacted.",
+			state: &fnv1.State{
+				Resources: map[string]*fnv1.Resource{
+					"my-secret": {
+						Resource: &structpb.Struct{
+							Fields: map[string]*structpb.Value{
+								"apiVersion": structpb.NewStringValue("v1"),
+								"kind":       structpb.NewStringValue("Secret"),
+								"metadata": structpb.NewStructValue(&structpb.Struct{
+									Fields: map[string]*structpb.Value{
+										"name": structpb.NewStringValue("my-secret"),
+										"annotations": structpb.NewStructValue(&structpb.Struct{
+											Fields: map[string]*structpb.Value{
+												lastAppliedConfigAnnotation:   structpb.NewStringValue(`{"apiVersion":"v1","kind":"Secret","data":{"password":"c2VjcmV0"}}`),
+												"crossplane.io/external-name": structpb.NewStringValue("my-secret"),
+											},
+										}),
+									},
+								}),
+								"data": structpb.NewStructValue(&structpb.Struct{
+									Fields: map[string]*structpb.Value{
+										"password": structpb.NewStringValue("c2VjcmV0"), // base64 encoded
+									},
+								}),
+							},
+						},
+					},
+				},
+			},
+			want: &fnv1.State{
+				Resources: map[string]*fnv1.Resource{
+					"my-secret": {
+						Resource: &structpb.Struct{
+							Fields: map[string]*structpb.Value{
+								"apiVersion": structpb.NewStringValue("v1"),
+								"kind":       structpb.NewStringValue("Secret"),
+								"metadata": structpb.NewStructValue(&structpb.Struct{
+									Fields: map[string]*structpb.Value{
+										"name": structpb.NewStringValue("my-secret"),
+										"annotations": structpb.NewStructValue(&structpb.Struct{
+											Fields: map[string]*structpb.Value{
+												"crossplane.io/external-name": structpb.NewStringValue("my-secret"),
+											},
+										}),
+									},
+								}),
+								"data": structpb.NewStructValue(&structpb.Struct{
+									Fields: map[string]*structpb.Value{
+										"password": structpb.NewStringValue(redactedValue),
+									},
+								}),
+							},
+						},
+					},
+				},
+			},
+		},
+		"PreservesNonSecretAnnotations": {
+			reason: "Should preserve the last-applied-configuration annotation on non-Secret resources.",
+			state: &fnv1.State{
+				Resources: map[string]*fnv1.Resource{
+					"my-config": {
+						Resource: &structpb.Struct{
+							Fields: map[string]*structpb.Value{
+								"apiVersion": structpb.NewStringValue("v1"),
+								"kind":       structpb.NewStringValue("ConfigMap"),
+								"metadata": structpb.NewStructValue(&structpb.Struct{
+									Fields: map[string]*structpb.Value{
+										"annotations": structpb.NewStructValue(&structpb.Struct{
+											Fields: map[string]*structpb.Value{
+												lastAppliedConfigAnnotation: structpb.NewStringValue(`{"apiVersion":"v1","kind":"ConfigMap"}`),
+											},
+										}),
+									},
+								}),
+							},
+						},
+					},
+				},
+			},
+			want: &fnv1.State{
+				Resources: map[string]*fnv1.Resource{
+					"my-config": {
+						Resource: &structpb.Struct{
+							Fields: map[string]*structpb.Value{
+								"apiVersion": structpb.NewStringValue("v1"),
+								"kind":       structpb.NewStringValue("ConfigMap"),
+								"metadata": structpb.NewStructValue(&structpb.Struct{
+									Fields: map[string]*structpb.Value{
+										"annotations": structpb.NewStructValue(&structpb.Struct{
+											Fields: map[string]*structpb.Value{
+												lastAppliedConfigAnnotation: structpb.NewStringValue(`{"apiVersion":"v1","kind":"ConfigMap"}`),
+											},
+										}),
+									},
+								}),
+							},
+						},
+					},
+				},
+			},
+		},
 		"PreservesNonSecretData": {
 			reason: "Should preserve data-like fields on non-Secret resources.",
 			state: &fnv1.State{
@@ -972,6 +1076,61 @@ func TestSanitizeRequiredResources(t *testing.T) {
 				},
 			},
 		},
+		"DropsSecretLastAppliedConfiguration": {
+			reason: "Should drop the kubectl last-applied-configuration annotation from required Secret resources.",
+			resources: map[string]*fnv1.Resources{
+				"credentials": {
+					Items: []*fnv1.Resource{
+						{
+							Resource: &structpb.Struct{
+								Fields: map[string]*structpb.Value{
+									"apiVersion": structpb.NewStringValue("v1"),
+									"kind":       structpb.NewStringValue("Secret"),
+									"metadata": structpb.NewStructValue(&structpb.Struct{
+										Fields: map[string]*structpb.Value{
+											"annotations": structpb.NewStructValue(&structpb.Struct{
+												Fields: map[string]*structpb.Value{
+													lastAppliedConfigAnnotation: structpb.NewStringValue(`{"apiVersion":"v1","kind":"Secret","data":{"password":"c2VjcmV0"}}`),
+												},
+											}),
+										},
+									}),
+									"data": structpb.NewStructValue(&structpb.Struct{
+										Fields: map[string]*structpb.Value{
+											"password": structpb.NewStringValue("c2VjcmV0"), // base64 encoded
+										},
+									}),
+								},
+							},
+						},
+					},
+				},
+			},
+			want: map[string]*fnv1.Resources{
+				"credentials": {
+					Items: []*fnv1.Resource{
+						{
+							Resource: &structpb.Struct{
+								Fields: map[string]*structpb.Value{
+									"apiVersion": structpb.NewStringValue("v1"),
+									"kind":       structpb.NewStringValue("Secret"),
+									"metadata": structpb.NewStructValue(&structpb.Struct{
+										Fields: map[string]*structpb.Value{
+											"annotations": structpb.NewStructValue(&structpb.Struct{}),
+										},
+									}),
+									"data": structpb.NewStructValue(&structpb.Struct{
+										Fields: map[string]*structpb.Value{
+											"password": structpb.NewStringValue(redactedValue),
+										},
+									}),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
 		"PreservesNonSecretData": {
 			reason: "Should preserve data-like fields on non-Secret resources.",
 			resources: map[string]*fnv1.Resources{
@@ -1142,6 +1301,85 @@ func TestRedactConnectionDetails(t *testing.T) {
 
 			if diff := cmp.Diff(tc.want, tc.connectionDetails); diff != "" {
 				t.Errorf("\n%s\nredactConnectionDetails(...): -want, +got:\n%s", tc.reason, diff)
+			}
+		})
+	}
+}
+
+// The last-applied-configuration lookup walks metadata and then annotations,
+// neither of which a function is obliged to send us. Every level must degrade
+// to a no-op rather than panic, and the data redaction must still happen when
+// it does.
+func TestStripSecretDataMalformedMetadata(t *testing.T) {
+	metadata := func(v *structpb.Value) map[string]*structpb.Value {
+		return map[string]*structpb.Value{"metadata": v}
+	}
+	annotations := func(v *structpb.Value) *structpb.Value {
+		return structpb.NewStructValue(&structpb.Struct{
+			Fields: map[string]*structpb.Value{"annotations": v},
+		})
+	}
+
+	cases := map[string]struct {
+		reason string
+		// Merged over a minimal Secret carrying data.password.
+		extra map[string]*structpb.Value
+	}{
+		"NoMetadata": {
+			reason: "A Secret with no metadata at all should still have its data redacted.",
+			extra:  nil,
+		},
+		"NilMetadataValue": {
+			reason: "A nil metadata value should be treated as absent.",
+			extra:  metadata(nil),
+		},
+		"MetadataNotAStruct": {
+			reason: "A metadata value that isn't a struct should be treated as absent.",
+			extra:  metadata(structpb.NewStringValue("not-a-struct")),
+		},
+		"MetadataNilStruct": {
+			reason: "A metadata value wrapping a nil struct should be treated as absent.",
+			extra:  metadata(structpb.NewStructValue(nil)),
+		},
+		"NoAnnotations": {
+			reason: "Metadata without annotations should be treated as absent.",
+			extra: metadata(structpb.NewStructValue(&structpb.Struct{
+				Fields: map[string]*structpb.Value{"name": structpb.NewStringValue("my-secret")},
+			})),
+		},
+		"NilAnnotationsValue": {
+			reason: "A nil annotations value should be treated as absent.",
+			extra:  metadata(annotations(nil)),
+		},
+		"AnnotationsNotAStruct": {
+			reason: "An annotations value that isn't a struct should be treated as absent.",
+			extra:  metadata(annotations(structpb.NewStringValue("not-a-struct"))),
+		},
+		"EmptyAnnotations": {
+			reason: "Annotations with no entries should be treated as absent.",
+			extra:  metadata(annotations(structpb.NewStructValue(&structpb.Struct{}))),
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			fields := map[string]*structpb.Value{
+				"apiVersion": structpb.NewStringValue("v1"),
+				"kind":       structpb.NewStringValue("Secret"),
+				"data": structpb.NewStructValue(&structpb.Struct{
+					Fields: map[string]*structpb.Value{
+						"password": structpb.NewStringValue("c2VjcmV0"), // base64 encoded
+					},
+				}),
+			}
+			maps.Copy(fields, tc.extra)
+
+			// Must not panic, whatever shape metadata is in.
+			stripSecretData(&structpb.Struct{Fields: fields})
+
+			got := fields["data"].GetStructValue().GetFields()["password"].GetStringValue()
+			if got != redactedValue {
+				t.Errorf("\n%s\nstripSecretData(...): want data.password %q, got %q", tc.reason, redactedValue, got)
 			}
 		})
 	}


### PR DESCRIPTION
### Description of your changes

Follow-up to #7476, which closed the `stringData` half of this same gap.

1. `stripSecretData` redacts a Secret's `data` and `stringData` before the request/response is emitted to the pipeline inspector sidecar, but leaves `metadata.annotations` untouched.
2. Secrets applied with `kubectl` carry `kubectl.kubernetes.io/last-applied-configuration`, whose value is the whole applied object as JSON — including the `data` we just redacted. So for a kubectl-applied Secret (provider credentials fetched as a required resource, or a composed Secret that retains the annotation) the plaintext still reached the inspector, sitting right next to the `**REDACTED**` markers.

Dropped that annotation in the same helper, so the one sanitizer keeps covering every caller (`sanitizeState` and `sanitizeRequiredResources`). It's deleted rather than redacted: unlike `data`, the annotation duplicates state the inspector already shows, so there's no key worth surfacing. Other annotations are left alone deliberately — `crossplane.io/external-name` and friends are what make inspector output readable, and `last-applied-configuration` is the one annotation that mirrors `data` by construction.

Added `DropsSecretLastAppliedConfiguration` cases to `TestSanitizeState` and `TestSanitizeRequiredResources`, both of which fail before the change and pass after, plus a `PreservesNonSecretAnnotations` case pinning that non-Secret resources keep the annotation intact.

The annotation lookup walks `metadata` and then `annotations`, neither of which a function is obliged to send us, so `TestStripSecretDataMalformedMetadata` covers the shapes in between — metadata absent, nil, wrapping a nil struct, or not a struct at all, and the same for annotations. Each asserts we don't panic and that `data` is still redacted. Swapping `a.GetFields()` for `a.Fields` makes it panic, so it's pinning something real.

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `./nix.sh flake check` to ensure this PR is ready for review.
- [x] Added or updated unit tests.
- [ ] ~Added or updated e2e tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [x] Added `backport release-x.y` labels to auto-backport this PR.
- [ ] ~Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md
