### PR TITLE
Don't let a failed controller stop the one that replaced it

### DIFF
--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -374,9 +374,9 @@ func (e *ControllerEngine) Stop(ctx context.Context, name string) error {
 	return e.stop(ctx, name, nil)
 }
 
-// stop the named controller. If only is supplied the call is a no-op unless the
-// named controller is still that one, so a controller that fails after being
-// restarted doesn't stop its own replacement.
+// stop the named controller. When only is supplied it is a no-op unless the
+// named controller is still that one. A controller that fails after the engine
+// replaced it must not stop its replacement.
 func (e *ControllerEngine) stop(ctx context.Context, name string, only *controller) error {
 	e.mx.Lock()
 	defer e.mx.Unlock()

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -322,6 +322,12 @@ func (e *ControllerEngine) Start(name string, o ...ControllerOption) error {
 	// instead of taking one as an argument.
 	ctx, cancel := context.WithCancel(context.Background())
 
+	r := &controller{
+		ctrl:    c,
+		cancel:  cancel,
+		sources: make(map[WatchID]*StoppableSource),
+	}
+
 	go func() {
 		// Don't start the controller until the manager is elected.
 		<-e.mgr.Elected()
@@ -335,7 +341,7 @@ func (e *ControllerEngine) Start(name string, o ...ControllerOption) error {
 
 			// Make a best effort attempt to cleanup the controller so that
 			// IsRunning will return false.
-			_ = e.Stop(ctx, name)
+			_ = e.stop(ctx, name, r)
 
 			return
 		}
@@ -358,12 +364,6 @@ func (e *ControllerEngine) Start(name string, o ...ControllerOption) error {
 		}()
 	}
 
-	r := &controller{
-		ctrl:    c,
-		cancel:  cancel,
-		sources: make(map[WatchID]*StoppableSource),
-	}
-
 	e.controllers[name] = r
 
 	return nil
@@ -371,13 +371,21 @@ func (e *ControllerEngine) Start(name string, o ...ControllerOption) error {
 
 // Stop a controller.
 func (e *ControllerEngine) Stop(ctx context.Context, name string) error {
+	return e.stop(ctx, name, nil)
+}
+
+// stop the named controller. If only is supplied the call is a no-op unless the
+// named controller is still that one, so a controller that fails after being
+// restarted doesn't stop its own replacement.
+func (e *ControllerEngine) stop(ctx context.Context, name string, only *controller) error {
 	e.mx.Lock()
 	defer e.mx.Unlock()
 
 	c, running := e.controllers[name]
 
-	// Stop is a no-op if the controller isn't running.
-	if !running {
+	// Nothing to do if the controller isn't running, or isn't the one the
+	// caller wants to stop.
+	if !running || (only != nil && c != only) {
 		return nil
 	}
 

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -536,8 +536,8 @@ func TestFailedControllerCleanup(t *testing.T) {
 
 			err := e.Start(tc.args.name, WithNewControllerFn(func(_ string, _ kcontroller.Options) (kcontroller.Controller, error) {
 				return &MockController{MockStart: func(_ context.Context) error {
+					defer close(failed)
 					<-fail
-					close(failed)
 
 					return errors.New("boom")
 				}}, nil

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -465,68 +465,126 @@ func TestStopController(t *testing.T) {
 	}
 }
 
-// A controller that fails to start cleans itself up, so that IsRunning reports
-// it as stopped. The engine restarts controllers under the same name whenever
-// their XRD changes, so that cleanup must leave the replacement alone.
-func TestFailedControllerDoesNotStopReplacement(t *testing.T) {
-	elected := make(chan struct{})
-	close(elected)
-
-	mgr := &MockManager{MockElected: func() <-chan struct{} { return elected }}
-	e := New(mgr, &MockTrackingInformers{}, nil, nil)
-
-	const name = "cool-controller"
-
-	// A controller fails while it's adding its sources to their informers,
-	// before it starts watching its context, so this one ignores its context
-	// and fails when we tell it to.
-	fail := make(chan struct{})
-	failed := make(chan struct{})
-
-	err := e.Start(name, WithNewControllerFn(func(_ string, _ kcontroller.Options) (kcontroller.Controller, error) {
-		return &MockController{MockStart: func(_ context.Context) error {
-			<-fail
-			close(failed)
-
-			return errors.New("boom")
-		}}, nil
-	}))
-	if err != nil {
-		t.Fatalf("e.Start(...): %v", err)
+func TestFailedControllerCleanup(t *testing.T) {
+	type params struct {
+		mgr  manager.Manager
+		infs TrackingInformers
+		c    client.Client
+		uc   client.Client
+		opts []ControllerEngineOption
 	}
 
-	// Restart the controller, like the XRD reconciler does when its XRD changes.
-	if err := e.Stop(context.Background(), name); err != nil {
-		t.Fatalf("e.Stop(...): %v", err)
+	type args struct {
+		name    string
+		replace bool
 	}
 
-	replacementStopped := make(chan struct{})
-
-	err = e.Start(name, WithNewControllerFn(func(_ string, _ kcontroller.Options) (kcontroller.Controller, error) {
-		return &MockController{MockStart: func(ctx context.Context) error {
-			<-ctx.Done()
-			close(replacementStopped)
-
-			return nil
-		}}, nil
-	}))
-	if err != nil {
-		t.Fatalf("e.Start(...): %v", err)
+	type want struct {
+		running bool
 	}
 
-	if !e.IsRunning(name) {
-		t.Fatal("the replacement isn't running, so this test can't tell whether it gets stopped")
+	elected := func() <-chan struct{} {
+		e := make(chan struct{})
+		close(e)
+		return e
 	}
 
-	close(fail)
-	<-failed
+	cases := map[string]struct {
+		reason string
+		params params
+		args   args
+		want   want
+	}{
+		"NotReplaced": {
+			reason: "A controller that stops with an error should be cleaned up, so IsRunning reports it as stopped.",
+			params: params{
+				mgr:  &MockManager{MockElected: elected},
+				infs: &MockTrackingInformers{},
+			},
+			args: args{
+				name: "cool-controller",
+			},
+			want: want{
+				running: false,
+			},
+		},
+		"Replaced": {
+			reason: "A controller that stops with an error after the engine restarted it should leave the replacement running.",
+			params: params{
+				mgr:  &MockManager{MockElected: elected},
+				infs: &MockTrackingInformers{},
+			},
+			args: args{
+				name:    "cool-controller",
+				replace: true,
+			},
+			want: want{
+				running: true,
+			},
+		},
+	}
 
-	// The first controller cleans up in the goroutine the engine started it in.
-	// Nothing reports that it finished, so we watch for the damage instead.
-	select {
-	case <-replacementStopped:
-		t.Error("the failed controller stopped its replacement")
-	case <-time.After(time.Second):
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			e := New(tc.params.mgr, tc.params.infs, tc.params.c, tc.params.uc, tc.params.opts...)
+
+			// A controller fails while it's adding its sources to their
+			// informers, before it starts watching its context, so this one
+			// ignores its context and fails when we tell it to.
+			fail := make(chan struct{})
+			failed := make(chan struct{})
+
+			err := e.Start(tc.args.name, WithNewControllerFn(func(_ string, _ kcontroller.Options) (kcontroller.Controller, error) {
+				return &MockController{MockStart: func(_ context.Context) error {
+					<-fail
+					close(failed)
+
+					return errors.New("boom")
+				}}, nil
+			}))
+			if diff := cmp.Diff(nil, err, cmpopts.EquateErrors()); diff != "" {
+				t.Fatalf("\n%s\ne.Start(...): -want error, +got error:\n%s", tc.reason, diff)
+			}
+
+			if tc.args.replace {
+				// Restart the controller, like the XRD reconciler does when its
+				// XRD changes.
+				err = e.Stop(context.Background(), tc.args.name)
+				if diff := cmp.Diff(nil, err, cmpopts.EquateErrors()); diff != "" {
+					t.Fatalf("\n%s\ne.Stop(...): -want error, +got error:\n%s", tc.reason, diff)
+				}
+
+				err = e.Start(tc.args.name, WithNewControllerFn(func(_ string, _ kcontroller.Options) (kcontroller.Controller, error) {
+					return &MockController{MockStart: func(ctx context.Context) error {
+						<-ctx.Done()
+						return nil
+					}}, nil
+				}))
+				if diff := cmp.Diff(nil, err, cmpopts.EquateErrors()); diff != "" {
+					t.Fatalf("\n%s\ne.Start(...): -want error, +got error:\n%s", tc.reason, diff)
+				}
+			}
+
+			close(fail)
+			<-failed
+
+			// Give the failed controller's goroutine a little time to clean up.
+			time.Sleep(1 * time.Second)
+
+			running := e.IsRunning(tc.args.name)
+			if diff := cmp.Diff(tc.want.running, running); diff != "" {
+				t.Errorf("\n%s\ne.IsRunning(...): -want, +got:\n%s", tc.reason, diff)
+			}
+
+			// Stop the controller. Will be a no-op if it never started.
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+
+			err = e.Stop(ctx, tc.args.name)
+			if diff := cmp.Diff(nil, err, cmpopts.EquateErrors()); diff != "" {
+				t.Errorf("\n%s\ne.Stop(...): -want error, +got error:\n%s", tc.reason, diff)
+			}
+		})
 	}
 }
 

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -465,6 +465,71 @@ func TestStopController(t *testing.T) {
 	}
 }
 
+// A controller that fails to start cleans itself up, so that IsRunning reports
+// it as stopped. The engine restarts controllers under the same name whenever
+// their XRD changes, so that cleanup must leave the replacement alone.
+func TestFailedControllerDoesNotStopReplacement(t *testing.T) {
+	elected := make(chan struct{})
+	close(elected)
+
+	mgr := &MockManager{MockElected: func() <-chan struct{} { return elected }}
+	e := New(mgr, &MockTrackingInformers{}, nil, nil)
+
+	const name = "cool-controller"
+
+	// A controller fails while it's adding its sources to their informers,
+	// before it starts watching its context, so this one ignores its context
+	// and fails when we tell it to.
+	fail := make(chan struct{})
+	failed := make(chan struct{})
+
+	err := e.Start(name, WithNewControllerFn(func(_ string, _ kcontroller.Options) (kcontroller.Controller, error) {
+		return &MockController{MockStart: func(_ context.Context) error {
+			<-fail
+			close(failed)
+
+			return errors.New("boom")
+		}}, nil
+	}))
+	if err != nil {
+		t.Fatalf("e.Start(...): %v", err)
+	}
+
+	// Restart the controller, like the XRD reconciler does when its XRD changes.
+	if err := e.Stop(context.Background(), name); err != nil {
+		t.Fatalf("e.Stop(...): %v", err)
+	}
+
+	replacementStopped := make(chan struct{})
+
+	err = e.Start(name, WithNewControllerFn(func(_ string, _ kcontroller.Options) (kcontroller.Controller, error) {
+		return &MockController{MockStart: func(ctx context.Context) error {
+			<-ctx.Done()
+			close(replacementStopped)
+
+			return nil
+		}}, nil
+	}))
+	if err != nil {
+		t.Fatalf("e.Start(...): %v", err)
+	}
+
+	if !e.IsRunning(name) {
+		t.Fatal("the replacement isn't running, so this test can't tell whether it gets stopped")
+	}
+
+	close(fail)
+	<-failed
+
+	// The first controller cleans up in the goroutine the engine started it in.
+	// Nothing reports that it finished, so we watch for the damage instead.
+	select {
+	case <-replacementStopped:
+		t.Error("the failed controller stopped its replacement")
+	case <-time.After(time.Second):
+	}
+}
+
 func TestStartWatches(t *testing.T) {
 	type params struct {
 		mgr  manager.Manager

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/google/go-cmp/cmp"
@@ -526,64 +527,68 @@ func TestFailedControllerCleanup(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			e := New(tc.params.mgr, tc.params.infs, tc.params.c, tc.params.uc, tc.params.opts...)
+			synctest.Test(t, func(t *testing.T) {
+				e := New(tc.params.mgr, tc.params.infs, tc.params.c, tc.params.uc, tc.params.opts...)
 
-			// A controller fails while it's adding its sources to their
-			// informers, before it starts watching its context, so this one
-			// ignores its context and fails when we tell it to.
-			fail := make(chan struct{})
-			failed := make(chan struct{})
+				// A controller fails while it's adding its sources to their
+				// informers, before it starts watching its context, so this one
+				// ignores its context and fails when we tell it to.
+				fail := make(chan struct{})
+				failed := make(chan struct{})
 
-			err := e.Start(tc.args.name, WithNewControllerFn(func(_ string, _ kcontroller.Options) (kcontroller.Controller, error) {
-				return &MockController{MockStart: func(_ context.Context) error {
-					defer close(failed)
-					<-fail
+				err := e.Start(tc.args.name, WithNewControllerFn(func(_ string, _ kcontroller.Options) (kcontroller.Controller, error) {
+					return &MockController{MockStart: func(_ context.Context) error {
+						defer close(failed)
+						<-fail
 
-					return errors.New("boom")
-				}}, nil
-			}))
-			if diff := cmp.Diff(nil, err, cmpopts.EquateErrors()); diff != "" {
-				t.Fatalf("\n%s\ne.Start(...): -want error, +got error:\n%s", tc.reason, diff)
-			}
-
-			if tc.args.replace {
-				// Restart the controller, like the XRD reconciler does when its
-				// XRD changes.
-				err = e.Stop(context.Background(), tc.args.name)
-				if diff := cmp.Diff(nil, err, cmpopts.EquateErrors()); diff != "" {
-					t.Fatalf("\n%s\ne.Stop(...): -want error, +got error:\n%s", tc.reason, diff)
-				}
-
-				err = e.Start(tc.args.name, WithNewControllerFn(func(_ string, _ kcontroller.Options) (kcontroller.Controller, error) {
-					return &MockController{MockStart: func(ctx context.Context) error {
-						<-ctx.Done()
-						return nil
+						return errors.New("boom")
 					}}, nil
 				}))
 				if diff := cmp.Diff(nil, err, cmpopts.EquateErrors()); diff != "" {
 					t.Fatalf("\n%s\ne.Start(...): -want error, +got error:\n%s", tc.reason, diff)
 				}
-			}
 
-			close(fail)
-			<-failed
+				if tc.args.replace {
+					// Restart the controller, like the XRD reconciler does when its
+					// XRD changes.
+					err = e.Stop(context.Background(), tc.args.name)
+					if diff := cmp.Diff(nil, err, cmpopts.EquateErrors()); diff != "" {
+						t.Fatalf("\n%s\ne.Stop(...): -want error, +got error:\n%s", tc.reason, diff)
+					}
 
-			// Give the failed controller's goroutine a little time to clean up.
-			time.Sleep(1 * time.Second)
+					err = e.Start(tc.args.name, WithNewControllerFn(func(_ string, _ kcontroller.Options) (kcontroller.Controller, error) {
+						return &MockController{MockStart: func(ctx context.Context) error {
+							<-ctx.Done()
+							return nil
+						}}, nil
+					}))
+					if diff := cmp.Diff(nil, err, cmpopts.EquateErrors()); diff != "" {
+						t.Fatalf("\n%s\ne.Start(...): -want error, +got error:\n%s", tc.reason, diff)
+					}
+				}
 
-			running := e.IsRunning(tc.args.name)
-			if diff := cmp.Diff(tc.want.running, running); diff != "" {
-				t.Errorf("\n%s\ne.IsRunning(...): -want, +got:\n%s", tc.reason, diff)
-			}
+				close(fail)
+				<-failed
 
-			// Stop the controller. Will be a no-op if it never started.
-			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-			defer cancel()
+				// The failed controller cleans up in the goroutine the engine started
+				// it in, and that goroutine returns once it has. Waiting for the bubble
+				// to settle waits for exactly that.
+				synctest.Wait()
 
-			err = e.Stop(ctx, tc.args.name)
-			if diff := cmp.Diff(nil, err, cmpopts.EquateErrors()); diff != "" {
-				t.Errorf("\n%s\ne.Stop(...): -want error, +got error:\n%s", tc.reason, diff)
-			}
+				running := e.IsRunning(tc.args.name)
+				if diff := cmp.Diff(tc.want.running, running); diff != "" {
+					t.Errorf("\n%s\ne.IsRunning(...): -want, +got:\n%s", tc.reason, diff)
+				}
+
+				// Stop the controller. Will be a no-op if it never started.
+				ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+				defer cancel()
+
+				err = e.Stop(ctx, tc.args.name)
+				if diff := cmp.Diff(nil, err, cmpopts.EquateErrors()); diff != "" {
+					t.Errorf("\n%s\ne.Stop(...): -want error, +got error:\n%s", tc.reason, diff)
+				}
+			})
 		})
 	}
 }


### PR DESCRIPTION
### Description of your changes

`ControllerEngine.Start` runs each dynamic controller in its own goroutine, and that goroutine cleans up after the controller if it stops with an error, so that `IsRunning` stops reporting it:

```go
if err := c.Start(ctx); err != nil {
    e.log.Info("Controller stopped with an error", "name", name, "error", err)

    // Make a best effort attempt to cleanup the controller so that
    // IsRunning will return false.
    _ = e.Stop(ctx, name)

    return
}
```

`Stop` finds what to stop by name. That is the right contract for the reconcilers that call it, but not for this caller, because a name does not stay attached to the same controller. When an XRD changes, `definition.Reconciler` stops the composite resource controller and then starts a new one under the same name:

```go
if ControllerNeedsRestart(d) {
    ...
    if err := r.engine.Stop(ctx, name); err != nil {
```

```go
// Start is idempotent - it's a no-op if the controller is already running.
if err := r.engine.Start(controllerName, co...); err != nil {
```

So a controller that fails while a restart is in flight stops whichever controller holds its name by then, which is its replacement. The engine is left with no controller for that XRD. `IsRunning` reports that correctly, but nothing acts on it until the XRD reconciles again and calls `Start`, and for an XRD that is not changing that can be a while.

That failure is reachable against the versions we pin. controller-runtime v0.23.1 starts queued sources from `startEventSourcesAndQueueLocked` before `Start` waits on its context, and returns a source's start error straight out of `Start`. `StoppableSource.Start` calls `AddEventHandler`, which client-go v0.35.3 refuses once the informer has stopped:

```go
if s.stopped {
    return nil, fmt.Errorf("handler %v was not added to shared informer because it has stopped already", handler)
}
```

`GarbageCollectCustomResourceInformers` calls `RemoveInformer` when a CRD is deleted, so a source queued by `StartWatches` can be started against an informer that is already gone. I have not reproduced that racing a restart on a cluster, only the mishandling it leads to, which is what the test covers.

The change keeps `Stop` as it is and hands the internal cleanup path the controller it started with, so it only stops that one. `Stop` passes `nil`, which still means whatever is running under the name.

I found this reading the engine for #7477, which reports a composite resource controller that stops converging after an XRD update. I cannot show that this is that issue's cause, and this PR does not claim to fix it. It looked like a defect worth sending on its own rather than folding into a guess about that issue.

### Tests

`TestFailedControllerCleanup` covers both directions of the changed condition. Each case starts a controller that fails on command, optionally restarts it the way the XRD reconciler does, then releases the failure and asserts `IsRunning`:

| Case | Restarted first | Wants |
| --- | --- | --- |
| `NotReplaced` | no | not running, the failed controller cleaned itself up |
| `Replaced` | yes | running, the replacement was left alone |

`Replaced` fails on `main`:

```
--- FAIL: TestFailedControllerCleanup/Replaced (0.00s)
    engine_test.go:580:
        A controller that stops with an error after the engine restarted it should leave the replacement running.
        e.IsRunning(...): -want, +got:
          bool(
        - 	true,
        + 	false,
```

To check both cases fail for the right reasons I mutated the fix four ways. Each one is caught by this test alone, and three of them are also caught by `TestIsRunning`:

| Mutation | Caught by |
| --- | --- |
| Restore the by-name cleanup, `e.Stop(ctx, name)` | `Replaced` |
| Invert the identity comparison, `c == only` | `Replaced`, `NotReplaced` |
| Drop the `only != nil` guard, so `Stop` matches nothing | `Replaced` |
| Always skip when an identity is given, so nothing is cleaned up | `NotReplaced` |

The test runs in a `synctest` bubble. After it releases the failure it calls `synctest.Wait()`, which returns once every other goroutine in the bubble has either finished or durably blocked, so the assertion sees the engine after the cleanup goroutine has run rather than after a wall clock guess. The engine has no signal for "the cleanup finished", and the fixed case is a no-op by construction, so this was the alternative to adding a hook to production code for the test's benefit.

### Notes for reviewers

While reading this I noticed a neighbouring lifecycle problem that this PR does **not** address, and that I would rather not widen its scope with. `StoppableSource.Stop` returns early when `reg == nil`, which is the case for a source `StartWatches` handed to `Controller.Watch` before the controller started, since v0.23.1 queues those in `startWatches`. `startEventSourcesAndQueueLocked` then starts them without checking whether the context has been cancelled, so a source stopped during that window still adds its event handler afterwards, and by then the engine has dropped it from `c.sources` and nothing will remove it. It predates this change and this change does not make it worse, so I have written it up separately as #7728 rather than growing this PR.

The cleanup call dates to #5651, and the reconciler has replaced controllers under the same name since before #6806 widened when that restart fires. I have not worked out which releases are worth a backport, so I have left the labels alone.

`./nix.sh flake check` passes locally, including `generate`, `generate-apis`, `go-lint`, `go-lint-apis`, `test`, `test-apis`, `helm-lint`, `shell-lint` and `nix-lint`. CI itself is waiting on a maintainer to approve workflows, since this is my first PR here.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `./nix.sh flake check` to ensure this PR is ready for review.
- [x] Added or updated unit tests.
- [ ] ~Added or updated e2e tests.~ This is engine lifecycle, covered by unit tests.
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~ No user visible change.
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~ Happy to, if you would like it backported.
- [ ] ~Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~ No API change.

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md

