### PR TITLE
Don't add an event handler to a source that was stopped

### DIFF
--- a/internal/engine/source.go
+++ b/internal/engine/source.go
@@ -60,8 +60,9 @@ func (s *StoppableSource) Start(ctx context.Context, q workqueue.TypedRateLimiti
 	s.mx.Lock()
 	defer s.mx.Unlock()
 
-	// The controller can start a source we have already stopped. Nothing holds
-	// the source by then, so a handler added now would never be removed.
+	// Controller.Watch can retain a source and start it after the engine has
+	// stopped tracking it. Don't register a handler after Stop, because there
+	// may be no later caller left to remove it.
 	if s.stopped {
 		return nil
 	}

--- a/internal/engine/source.go
+++ b/internal/engine/source.go
@@ -47,7 +47,7 @@ type StoppableSource struct {
 	handler    handler.EventHandler
 	predicates []predicate.Predicate
 
-	// Guards the below. The controller decides when to start a source, so it
+	// Protects the below. The controller decides when to start a source, so it
 	// can do so while a reconcile is stopping it.
 	mx      sync.Mutex
 	reg     kcache.ResourceEventHandlerRegistration
@@ -60,9 +60,8 @@ func (s *StoppableSource) Start(ctx context.Context, q workqueue.TypedRateLimiti
 	s.mx.Lock()
 	defer s.mx.Unlock()
 
-	// The controller holds sources it hasn't started yet, so it can start this
-	// one after we were stopped. Nothing holds the source by then, so a handler
-	// added now would never be removed.
+	// The controller can start a source we have already stopped. Nothing holds
+	// the source by then, so a handler added now would never be removed.
 	if s.stopped {
 		return nil
 	}

--- a/internal/engine/source.go
+++ b/internal/engine/source.go
@@ -18,6 +18,7 @@ package engine
 
 import (
 	"context"
+	"sync"
 
 	kcache "k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
@@ -46,12 +47,26 @@ type StoppableSource struct {
 	handler    handler.EventHandler
 	predicates []predicate.Predicate
 
-	reg kcache.ResourceEventHandlerRegistration
+	// Guards the below. The controller decides when to start a source, so it
+	// can do so while a reconcile is stopping it.
+	mx      sync.Mutex
+	reg     kcache.ResourceEventHandlerRegistration
+	stopped bool
 }
 
 // Start is internal and should be called only by the Controller to register
 // an EventHandler with the Informer to enqueue reconcile.Requests.
 func (s *StoppableSource) Start(ctx context.Context, q workqueue.TypedRateLimitingInterface[reconcile.Request]) error {
+	s.mx.Lock()
+	defer s.mx.Unlock()
+
+	// The controller holds sources it hasn't started yet, so it can start this
+	// one after we were stopped. Nothing holds the source by then, so a handler
+	// added now would never be removed.
+	if s.stopped {
+		return nil
+	}
+
 	// TODO(negz): Should we check if the informer is stopped first?
 	reg, err := s.inf.AddEventHandler(NewEventHandler(ctx, q, s.handler, s.predicates...).HandlerFuncs())
 	if err != nil {
@@ -66,6 +81,11 @@ func (s *StoppableSource) Start(ctx context.Context, q workqueue.TypedRateLimiti
 // Stop removes the EventHandler from the source's Informer. The Informer will
 // stop sending events to the source.
 func (s *StoppableSource) Stop(_ context.Context) error {
+	s.mx.Lock()
+	defer s.mx.Unlock()
+
+	s.stopped = true
+
 	if s.reg == nil || s.inf.IsStopped() {
 		return nil
 	}

--- a/internal/engine/source_test.go
+++ b/internal/engine/source_test.go
@@ -19,7 +19,9 @@ package engine
 import (
 	"context"
 	"errors"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -283,5 +285,62 @@ func TestStartStoppedSource(t *testing.T) {
 				t.Errorf("\n%s\ns.Start(...) added an event handler: -want, +got:\n%s", tc.reason, diff)
 			}
 		})
+	}
+}
+
+// Start holds the source lock while it registers the handler, so a Stop that
+// arrives in the middle has to wait for the registration before it can remove
+// it. Without that, Stop finds nothing to remove and the handler is left behind.
+func TestConcurrentStartStopSource(t *testing.T) {
+	var added, removed atomic.Int32
+
+	registering := make(chan struct{})
+	finishRegistering := make(chan struct{})
+
+	inf := &MockInformer{
+		MockAddEventHandler: func(_ kcache.ResourceEventHandler) (kcache.ResourceEventHandlerRegistration, error) {
+			added.Add(1)
+			close(registering)
+			<-finishRegistering
+
+			return &MockRegistration{}, nil
+		},
+		MockRemoveEventHandler: func(_ kcache.ResourceEventHandlerRegistration) error {
+			removed.Add(1)
+			return nil
+		},
+		MockIsStopped: func() bool { return false },
+	}
+
+	s := NewStoppableSource(inf, nil)
+
+	started := make(chan error, 1)
+	go func() { started <- s.Start(context.Background(), nil) }()
+
+	<-registering
+
+	stopped := make(chan error, 1)
+	go func() { stopped <- s.Stop(context.Background()) }()
+
+	// Give Stop a moment to reach the lock. It waits there however long we take,
+	// so this only decides whether the two calls overlap, not what they do. A
+	// Stop that ran to completion here would find no handler to remove, which is
+	// what this test is looking for.
+	time.Sleep(100 * time.Millisecond)
+
+	close(finishRegistering)
+
+	if diff := cmp.Diff(nil, <-started, cmpopts.EquateErrors()); diff != "" {
+		t.Errorf("s.Start(...): -want error, +got error:\n%s", diff)
+	}
+	if diff := cmp.Diff(nil, <-stopped, cmpopts.EquateErrors()); diff != "" {
+		t.Errorf("s.Stop(...): -want error, +got error:\n%s", diff)
+	}
+
+	if got := added.Load(); got != 1 {
+		t.Errorf("s.Start(...) added %d event handler(s), want 1", got)
+	}
+	if got := removed.Load(); got != 1 {
+		t.Errorf("s.Stop(...) removed %d event handler(s), want 1", got)
 	}
 }

--- a/internal/engine/source_test.go
+++ b/internal/engine/source_test.go
@@ -211,3 +211,77 @@ func TestStopSource(t *testing.T) {
 		})
 	}
 }
+
+func TestStartStoppedSource(t *testing.T) {
+	type args struct {
+		stopFirst bool
+	}
+
+	type want struct {
+		err   error
+		added bool
+	}
+
+	cases := map[string]struct {
+		reason string
+		args   args
+		want   want
+	}{
+		"NotStopped": {
+			reason: "Start should add an event handler to the informer.",
+			args: args{
+				stopFirst: false,
+			},
+			want: want{
+				err:   nil,
+				added: true,
+			},
+		},
+		"StoppedFirst": {
+			reason: "Start should not add an event handler once the source has been stopped, because nothing would remove it.",
+			args: args{
+				stopFirst: true,
+			},
+			want: want{
+				err:   nil,
+				added: false,
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			added := false
+			inf := &MockInformer{
+				MockAddEventHandler: func(_ kcache.ResourceEventHandler) (kcache.ResourceEventHandlerRegistration, error) {
+					added = true
+					return &MockRegistration{}, nil
+				},
+				MockRemoveEventHandler: func(_ kcache.ResourceEventHandlerRegistration) error {
+					return nil
+				},
+				MockIsStopped: func() bool { return false },
+			}
+
+			s := NewStoppableSource(inf, nil)
+
+			if tc.args.stopFirst {
+				// The engine stops a watch it started, whether or not the
+				// controller got around to starting the source behind it.
+				err := s.Stop(context.Background())
+				if diff := cmp.Diff(nil, err, cmpopts.EquateErrors()); diff != "" {
+					t.Fatalf("\n%s\ns.Stop(...): -want error, +got error:\n%s", tc.reason, diff)
+				}
+			}
+
+			err := s.Start(context.Background(), nil)
+			if diff := cmp.Diff(tc.want.err, err, cmpopts.EquateErrors()); diff != "" {
+				t.Errorf("\n%s\ns.Start(...): -want error, +got error:\n%s", tc.reason, diff)
+			}
+
+			if diff := cmp.Diff(tc.want.added, added); diff != "" {
+				t.Errorf("\n%s\ns.Start(...) added an event handler: -want, +got:\n%s", tc.reason, diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Description of your changes

`StoppableSource.Stop` removes the source's event handler from its informer, and returns early when there is no handler to remove:

```go
func (s *StoppableSource) Stop(_ context.Context) error {
	if s.reg == nil || s.inf.IsStopped() {
		return nil
	}
	...
}
```

`reg` is set by `Start`, and the engine does not decide when that runs. `StartWatches` hands the source to `Controller.Watch`, which in controller-runtime v0.23.1 only starts it if the controller is already running:

```go
	// Sources weren't started yet, store the watches locally and return.
	// These sources are going to be held until either Warmup() or Start(...) is called.
	if !c.startedEventSourcesAndQueue {
		c.startWatches = append(c.startWatches, src)
		return nil
	}
```

The engine starts each controller in a goroutine that first waits on `<-e.mgr.Elected()`, so between `Start` returning and that goroutine reaching `c.Start(ctx)` every watch we add is only queued. A `Stop` in that window takes the early return, removes nothing, drops the source from `c.sources` and cancels the controller's context. That reads like a clean stop.

It isn't, because `startEventSourcesAndQueueLocked` then starts the queued sources without looking at the context:

```go
			errGroup.Go(func() error {
				sourceStartCtx, cancel := context.WithTimeout(ctx, c.CacheSyncTimeout)
				defer cancel()

				sourceStartErrChan := make(chan error, 1)
				go func() {
					defer close(sourceStartErrChan)
					log.Info("Starting EventSource")

					if err := watch.Start(ctx, c.Queue); err != nil {
```

With the context already cancelled the outer `select` takes `<-sourceStartCtx.Done()`, sees `ctx.Err() != nil` and returns nil, so `Start` reports success. The inner goroutine still calls `watch.Start`, which adds the event handler. `c.startWatches` is then set to nil and the engine dropped the source in `Stop`, so nothing holds it any more and `RemoveEventHandler` will never be called for it.

That costs more than the wasted wakeups. client-go replays the existing objects to a newly added handler, so it does a burst of work straight away, and after that it runs its predicates and map function on every event for that kind, for as long as the shared informer is running. The queue it feeds was shut down when the context was cancelled, so none of that work goes anywhere. The informer keeps the listener, and through it the event handler, the queue, the predicates and whatever the map function captured. I have not traced a reference back from those to the `Controller` itself, so I would not claim the whole controller is retained.

One more reason to put the flag on the source rather than check the context: `StopWatches` retires a single watch without cancelling the controller, so a source being stopped is not the same thing as its controller being done. The invariant is that a source which has been stopped does not quietly become active again.

I have not seen this happen on a cluster and the window is narrow, since `StartWatches` calls `GetInformer` with `cache.BlockUntilSynced(true)` before `Watch`, which usually leaves the controller's goroutine enough time to start. It needs the informer to be synced already and the goroutine to lose the race. What I did check is that each step is what the pinned dependencies do, at controller-runtime v0.23.1 and client-go v0.35.3.

This adds a `stopped` flag so a source that has been stopped refuses to add a handler afterwards. It also puts both calls behind a mutex, which they were missing: `Start` writes `reg` from the controller's goroutine while `Stop` reads and writes it from a reconcile, so today that is a data race as well as a leak.

I raised this as #7728 while working on #7727, which touches the same area but is unrelated. This is the concrete version of the question I asked there about where the boundary belongs. If you would rather the engine tracked it, or `Start` returned an error instead of quietly doing nothing, I am happy to move it.

### Tests

`TestStartStoppedSource` covers both orders:

| Case | Stopped first | Wants |
| --- | --- | --- |
| `NotStopped` | no | `Start` adds an event handler |
| `StoppedFirst` | yes | `Start` adds nothing |

`StoppedFirst` fails on `main`:

```
--- FAIL: TestStartStoppedSource/StoppedFirst (0.00s)
    source_test.go:283:
        Start should not add an event handler once the source has been stopped, because nothing would remove it.
        s.Start(...) added an event handler: -want, +got:
          bool(
        - 	false,
        + 	true,
          )
```

Removing the guard, never setting `stopped`, and inverting the guard each fail that case, and the existing `TestStartSource` and `TestStopSource` still pass, so the ordinary start and stop paths are unchanged.

Those two cases only cover the flag, though. They still pass with the mutex removed, which would leave the data race this also fixes. `TestConcurrentStartStopSource` covers that: it holds `Start` inside `AddEventHandler`, runs `Stop` alongside it, and then lets the registration finish. With the lock, `Stop` waits and removes the handler. Without it, `Stop` sees no registration, returns, and the handler is left behind:

```
--- FAIL: TestConcurrentStartStopSource (0.10s)
    source_test.go:344: s.Stop(...) removed 0 event handler(s), want 1
```

That one needs the race detector to be meaningful, and the Nix unit test check runs with `CGO_ENABLED=0`, so it does not use it. I ran `CGO_ENABLED=1 go test -race ./internal/engine` separately.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `./nix.sh flake check` to ensure this PR is ready for review.
- [x] Added or updated unit tests.
- [ ] ~Added or updated e2e tests.~ This is watch lifecycle, covered by unit tests.
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~ No user visible change.
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~ Happy to, if you would like it backported.
- [ ] ~Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~ No API change.

Fixes #7728

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md
