### PR TITLE
Don't add a watch to a controller the engine already stopped

### DIFF
--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -397,9 +397,12 @@ func (e *ControllerEngine) Stop(ctx context.Context, name string) error {
 		e.log.Debug("Stopped watching GVK", "controller", name, "watch-type", wid.Type, "watched-gvk", wid.GVK)
 	}
 
-	// Stop and delete the controller. StartWatches may be part way through
-	// adding a watch to it, holding a pointer we're about to drop.
+	// Record the stop before dropping the controller. A StartWatches that
+	// looked this one up is still holding it, and reads this once it takes the
+	// lock we're holding.
 	c.stopped = true
+
+	// Stop and delete the controller.
 	c.cancel()
 	delete(e.controllers, name)
 

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -397,12 +397,9 @@ func (e *ControllerEngine) Stop(ctx context.Context, name string) error {
 		e.log.Debug("Stopped watching GVK", "controller", name, "watch-type", wid.Type, "watched-gvk", wid.GVK)
 	}
 
-	// Record the stop before dropping the controller. A StartWatches that
-	// looked this one up is still holding it, and reads this once it takes the
-	// lock we're holding.
+	// Stop and delete the controller. A StartWatches that looked it up is still
+	// holding it, and reads this once it takes the lock we hold.
 	c.stopped = true
-
-	// Stop and delete the controller.
 	c.cancel()
 	delete(e.controllers, name)
 
@@ -532,9 +529,7 @@ func (e *ControllerEngine) StartWatches(ctx context.Context, name string, ws ...
 	c.mx.Lock()
 	defer c.mx.Unlock()
 
-	// The engine may have stopped this controller since we looked it up, and by
-	// now be running a replacement under the same name. Watches we added here
-	// would be attached to a controller nothing can stop again.
+	// Watches added now would go to a controller nothing can stop again.
 	if c.stopped {
 		return errors.Errorf("controller %q is not running", name)
 	}

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -158,11 +158,14 @@ type controller struct {
 	// Called to stop the controller.
 	cancel context.CancelFunc
 
-	// Protects the below map.
+	// Protects the below.
 	mx sync.RWMutex
 
 	// The controller's sources, by watched GVK.
 	sources map[WatchID]*StoppableSource
+
+	// Whether the engine has stopped this controller.
+	stopped bool
 }
 
 // A WatchGarbageCollector periodically garbage collects watches.
@@ -394,7 +397,9 @@ func (e *ControllerEngine) Stop(ctx context.Context, name string) error {
 		e.log.Debug("Stopped watching GVK", "controller", name, "watch-type", wid.Type, "watched-gvk", wid.GVK)
 	}
 
-	// Stop and delete the controller.
+	// Stop and delete the controller. StartWatches may be part way through
+	// adding a watch to it, holding a pointer we're about to drop.
+	c.stopped = true
 	c.cancel()
 	delete(e.controllers, name)
 
@@ -523,6 +528,13 @@ func (e *ControllerEngine) StartWatches(ctx context.Context, name string, ws ...
 	// read lock, so we compute everything again.
 	c.mx.Lock()
 	defer c.mx.Unlock()
+
+	// The engine may have stopped this controller since we looked it up, and by
+	// now be running a replacement under the same name. Watches we added here
+	// would be attached to a controller nothing can stop again.
+	if c.stopped {
+		return errors.Errorf("controller %q is not running", name)
+	}
 
 	// Refresh active informers in case they changed between when we lost
 	// the read lock and took the write lock.

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -20,6 +20,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -944,5 +946,106 @@ func TestStopWatches(t *testing.T) {
 				t.Errorf("\n%s\ne.Stop(...): -want error, +got error:\n%s", tc.reason, diff)
 			}
 		})
+	}
+}
+
+// StartWatches looks the controller up under the engine lock and drops it long
+// before it takes the controller's own lock. It calls ActiveInformers in that
+// gap, which is where this test stops the controller and starts a replacement
+// under the same name.
+func TestStartWatchesStoppedController(t *testing.T) {
+	elected := make(chan struct{})
+	close(elected)
+
+	const name = "cool-controller"
+
+	inGap := make(chan struct{})
+	leaveGap := make(chan struct{})
+	var once sync.Once
+
+	infs := &MockTrackingInformers{
+		MockActiveInformers: func() []schema.GroupVersionKind {
+			once.Do(func() {
+				close(inGap)
+				<-leaveGap
+			})
+			return nil
+		},
+		MockGetInformer: func(_ context.Context, _ client.Object, _ ...cache.InformerGetOption) (cache.Informer, error) {
+			return nil, nil
+		},
+	}
+	mgr := &MockManager{
+		MockElected:   func() <-chan struct{} { return elected },
+		MockGetScheme: runtime.NewScheme,
+	}
+
+	e := New(mgr, infs, nil, nil)
+
+	var stale, replacement atomic.Int32
+	newController := func(watched *atomic.Int32) NewControllerFn {
+		return func(_ string, _ kcontroller.Options) (kcontroller.Controller, error) {
+			return &MockController{
+				MockStart: func(ctx context.Context) error {
+					<-ctx.Done()
+					return nil
+				},
+				MockWatch: func(_ source.Source) error {
+					watched.Add(1)
+					return nil
+				},
+			}, nil
+		}
+	}
+
+	if err := e.Start(name, WithNewControllerFn(newController(&stale))); err != nil {
+		t.Fatalf("e.Start(...): %v", err)
+	}
+
+	u := &unstructured.Unstructured{}
+	u.SetAPIVersion("test.crossplane.io/v1")
+	u.SetKind("Composed")
+
+	started := make(chan error, 1)
+	go func() {
+		started <- e.StartWatches(context.Background(), name, WatchFor(u, WatchTypeDependency, nil))
+	}()
+
+	// The call above is now holding the controller we are about to throw away.
+	<-inGap
+
+	if err := e.Stop(context.Background(), name); err != nil {
+		t.Fatalf("e.Stop(...): %v", err)
+	}
+	if err := e.Start(name, WithNewControllerFn(newController(&replacement))); err != nil {
+		t.Fatalf("e.Start(...): %v", err)
+	}
+
+	close(leaveGap)
+
+	if diff := cmp.Diff(cmpopts.AnyError, <-started, cmpopts.EquateErrors()); diff != "" {
+		t.Errorf("e.StartWatches(...) resumed against a stopped controller: -want error, +got error:\n%s", diff)
+	}
+	if got := stale.Load(); got != 0 {
+		t.Errorf("e.StartWatches(...) added %d watch(es) to the stopped controller, want 0", got)
+	}
+	if got := replacement.Load(); got != 0 {
+		t.Errorf("e.StartWatches(...) added %d watch(es) to the replacement, want 0; the stale call should not be redirected", got)
+	}
+
+	// The replacement still takes watches from a fresh call.
+	if err := e.StartWatches(context.Background(), name, WatchFor(u, WatchTypeDependency, nil)); err != nil {
+		t.Fatalf("e.StartWatches(...) on the replacement: %v", err)
+	}
+	if got := replacement.Load(); got != 1 {
+		t.Errorf("e.StartWatches(...) added %d watch(es) to the replacement, want 1", got)
+	}
+
+	// Stop the controller. Will be a no-op if it never started.
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	if err := e.Stop(ctx, name); err != nil {
+		t.Errorf("e.Stop(...): %v", err)
 	}
 }


### PR DESCRIPTION
### Description of your changes

`StartWatches` looks up the controller it is about to add watches to under the engine lock, releases it, and only takes that controller's own lock once it knows it has a watch to start:

```go
	e.mx.RLock()
	c, running := e.controllers[name]
	e.mx.RUnlock()

	if !running {
		return errors.Errorf("controller %q is not running", name)
	}
```

```go
	c.mx.Lock()
	defer c.mx.Unlock()
	...
		src := NewStoppableSource(inf, w.handler, w.predicates...)
		if err := c.ctrl.Watch(src); err != nil {
```

`Stop` holds both locks for its whole body, so it cannot interleave with that critical section. It can interleave with the gap between the two, and an XRD change is exactly the thing that does: `definition.Reconciler` stops the composite resource controller and starts a replacement under the same name, while the XR reconciler is calling `StartWatches` on it for a kind one of its XRs just started composing.

`StartWatches` then resumes against the controller it looked up, which the engine has since dropped, and adds a brand new watch to it. Nothing can take that watch off again: no later `Stop` or `StopWatches` can reach a controller that is no longer in `e.controllers`. The handler stays registered for as long as the shared informer is running, running its predicates and map function on every event to feed a queue that was shut down when the controller's context was cancelled. The informer keeps the listener, and through it the handler, the queue, the predicates and whatever the map function captured. I have not traced a reference from those back to the `Controller` itself, so I am not claiming the whole controller is retained.

The caller does recover. `StartWatches` returned nil, so the XR reconciler believes its watches are running, but the next reconcile calls `StartWatches` again, finds the replacement, and starts them there. The leak does not recover.

This is a different failure from #7728, and the fix in #7729 does not cover it: there the source exists before the stop and is started afterwards, so refusing to start a stopped source is enough. Here the source is created after the stop has finished, so it has never been stopped.

The fix records on the controller that the engine has stopped it, under the lock `Stop` already holds, and has `StartWatches` check that once it has the write lock. Rechecking `e.controllers[name]` inside the critical section would be the obvious alternative, but `Stop` takes `e.mx` then `c.mx`, so taking `e.mx` while holding `c.mx` inverts that order. Returning the same "controller is not running" error the function already returns aborts the stale reconcile rather than letting it attach a watch to a stopped controller. It does not hand the work to the replacement: the reconcile is running on the controller that was just stopped, so the requeue lands on a queue that is shutting down. The replacement picks the XRs up on its own, because it registers its own XR watch and client-go replays the informer's existing objects to a newly added handler.

Splitting the name lookup out of `StartWatches` is what makes the race testable: the test needs to hold the controller across the stop, which no caller of the exported function can do.

### Tests

`TestStartWatchesStoppedController` takes the controller the way `StartWatches` does, optionally stops it, and then runs the rest:

| Case | Stopped first | Wants |
| --- | --- | --- |
| `Running` | no | the watch is started |
| `Stopped` | yes | an error, and no watch started |

Removing the guard and never setting the flag each fail the `Stopped` case.

### Notes for reviewers

This touches `Stop`, which #7727 also changes. I put the two on one tree to check: they cherry-pick onto each other without conflict, and `c.stopped = true` ends up inside the identity aware `stop` helper, after the watches have come down and before the cancel. That is where it needs to be, because the cleanup after a failed controller goes through the same helper and has to make the same transition. `go test -race ./internal/engine` passes on the combined tree. I kept them apart because they are unrelated failures.

`./nix.sh flake check` passes locally. CI is waiting on workflow approval for a first-time contributor.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `./nix.sh flake check` to ensure this PR is ready for review.
- [x] Added or updated unit tests.
- [ ] ~Added or updated e2e tests.~ This is watch lifecycle, covered by unit tests.
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~ No user visible change.
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~ Happy to, if you would like it backported.
- [ ] ~Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~ No API change.

Fixes #7730

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md
