### PR TITLE
fix: add Message to WatchCircuitClosed to prevent infinite reconcile loop under SSA

### DIFF
--- a/apis/apiextensions/v1/conditions.go
+++ b/apis/apiextensions/v1/conditions.go
@@ -143,6 +143,7 @@ func WatchCircuitClosed() xpv2.Condition {
 		Status:             corev1.ConditionTrue,
 		LastTransitionTime: metav1.Now(),
 		Reason:             ReasonWatchCircuitClosed,
+		Message:            "The circuit breaker is closed. Watching for changes normally.",
 	}
 }
 
@@ -158,3 +159,4 @@ func IsSystemConditionType(t xpv2.ConditionType) bool {
 	// Then check Crossplane-specific system conditions
 	return t == TypeResponsive
 }
+


### PR DESCRIPTION
### Description

Fixes #7692

### Root Cause

`WatchCircuitClosed()` sets no `Message`, while `Condition.Message` has `json:"message,omitempty"`. When the XR status is written via server-side apply (SSA), the `message` field is never included in the patch, so SSA cannot take ownership of it. This leaves the orphaned `message` from `WatchCircuitOpen()` behind permanently.

Since `Condition.Equal` compares `Message`, `SetConditions` detects a difference on every reconcile, stamps a fresh `LastTransitionTime`, and writes — triggering the self-watch and another reconcile. The result is an infinite loop.

### Fix

Add a non-empty `Message` to `WatchCircuitClosed()` so that SSA includes the `message` field in the patch, takes ownership of it, and clears the stale message from `WatchCircuitOpen()`.

### Testing

- Existing tests continue to pass
- See issue #7692 for reproduction steps (manually write an orphaned message, then observe the loop stops)

### Related Issues

Closes #7692