### PR TITLE
fix(ci): pin negz/create-tag to v2 so apis/ submodule tagging works again

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Create Tag
-        uses: negz/create-tag@39bae1e0932567a58c20dea5a1a0d18358503320 # v1
+        uses: negz/create-tag@8dce6c9d9b12d161abe01c02d2b03f19e2e9e9bb # v2
         with:
           version: ${{ github.event.inputs.version }}
           message: ${{ github.event.inputs.message }}
@@ -34,7 +34,7 @@ jobs:
       # requires submodules to be tagged with their subdirectory prefix so
       # consumers can `go get github.com/crossplane/crossplane/apis/v2@vX.Y.Z`.
       - name: Create apis/ Submodule Tag
-        uses: negz/create-tag@39bae1e0932567a58c20dea5a1a0d18358503320 # v1
+        uses: negz/create-tag@8dce6c9d9b12d161abe01c02d2b03f19e2e9e9bb # v2
         with:
           version: apis/${{ github.event.inputs.version }}
           message: ${{ github.event.inputs.message }}


### PR DESCRIPTION
### Description of your changes

The [Tag workflow](https://github.com/crossplane/crossplane/actions/runs/31733868856/job/94560670015) is currently failing its `apis/` submodule step with `Tag apis/vX.Y.Z does not appear to be a valid semantic version`. We fixed this already, but Renovate "updated" us to a much older tag in #7488 

* #7488

This is blocking the v2.4 RC release since we can't tag the release branch ([failed tag job](https://github.com/crossplane/crossplane/actions/runs/31755150153))

The pin previously held a sha from create-tag's main branch alongside a "# v1" comment. Renovate treats that comment as the ref to track and pins whatever digest it resolves to, which is how it replaced the sha with v1's actual commit from 2020.

https://github.com/negz/create-tag/ now has a [v2 tag](https://github.com/negz/create-tag/releases/tag/v2) on the working commit we were using, so this commit restores that digest and updates our comment to "v2" so Renovate won't try to revert it back again.

We'll backport this to release-2.4 and release-2.3 since they both need this modern version of the create-tag action since they both have the `apis/` submodule.

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `./nix.sh flake check` to ensure this PR is ready for review.
- [ ] ~Added or updated unit tests.~
- [ ] ~Added or updated e2e tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~
- [ ] ~Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md
