### PR TITLE
build(deps): bump Go to 1.25.13 [security] [release-1.20]

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -3,7 +3,7 @@ VERSION --try --raw-output 0.8
 
 PROJECT crossplane/crossplane
 
-ARG --global GO_VERSION=1.25.12
+ARG --global GO_VERSION=1.25.13
 
 # reviewable checks that a branch is ready for review. Run it before opening a
 # pull request. It will catch a lot of the things our CI workflow will catch.

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/crossplane/crossplane
 
-go 1.25.12
+go 1.25.13
 
 require (
 	dario.cat/mergo v1.0.1


### PR DESCRIPTION
### Description of your changes

Bumps the Go toolchain to **1.25.13** to pick up the latest Go stdlib security fixes.

Clears **CVE-2026-33818**, **CVE-2026-39821**, **CVE-2026-56853**, **CVE-2026-56859** and
**CVE-2026-56862** (all fixed in Go 1.25.13), flagged on this release line by the UXP
security scanner (`upbound/uxp-cve-scan#56`).

- `Earthfile` `GO_VERSION`: 1.25.12 → 1.25.13
- `go.mod` `go` directive: 1.25.12 → 1.25.13

`earthly +reviewable` wasn't run locally; the CI jobs on this PR (lint, unit tests,
check-diff, e2e) cover the same ground for a toolchain-only change.

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [ ] ~Run `earthly +reviewable` to ensure this PR is ready for review.~
- [ ] ~Added or updated unit tests.~
- [ ] ~Added or updated e2e tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~
- [ ] ~Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md
