### PR TITLE
fix: share creating condition timestamp in UpdateClaimStatusError test

### DIFF
--- a/internal/controller/apiextensions/claim/syncer_ssa_test.go
+++ b/internal/controller/apiextensions/claim/syncer_ssa_test.go
@@ -41,6 +41,7 @@ import (
 func TestServerSideSync(t *testing.T) {
 	errBoom := errors.New("boom")
 	now := metav1.Now()
+	creating := xpv2.Creating()
 
 	type params struct {
 		c  client.Client
@@ -282,7 +283,7 @@ func TestServerSideSync(t *testing.T) {
 
 					// Patch the XR. Make sure it has a valid status.
 					MockPatch: test.NewMockPatchFn(nil, func(obj client.Object) error {
-						obj.(*composite.Unstructured).SetConditions(xpv2.Creating())
+						obj.(*composite.Unstructured).SetConditions(creating)
 						return nil
 					}),
 
@@ -326,7 +327,7 @@ func TestServerSideSync(t *testing.T) {
 						Namespace: "default",
 						Name:      "cool-claim",
 					})
-					xr.SetConditions(xpv2.Creating())
+					xr.SetConditions(creating)
 				}),
 				err: errors.Wrap(errBoom, errUpdateClaimStatus),
 			},


### PR DESCRIPTION
Fixes #7757

The `TestServerSideSync/UpdateClaimStatusError` test case calls `xpv2.Creating()` twice — once in the `MockPatch` callback and once when building the `want` XR. Each call creates a fresh `metav1.Now()` for `LastTransitionTime`, so the test flakes when the two calls land on different wall-clock seconds.

Fix by declaring a shared `creating` condition alongside the existing `now` variable, and using it in both places.

Signed-off-by: waterWang <waterwang@proton.me>