### PR TITLE
chore(deps): bump crossplane-runtime to v2.2.4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/alecthomas/kong v1.14.0
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/containerd/errdefs v1.0.0
-	github.com/crossplane/crossplane-runtime/v2 v2.2.3
+	github.com/crossplane/crossplane-runtime/v2 v2.2.4
 	github.com/docker/docker v28.5.2+incompatible
 	github.com/docker/go-connections v0.7.0
 	github.com/emicklei/dot v1.10.0

--- a/go.sum
+++ b/go.sum
@@ -178,8 +178,8 @@ github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSV
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/creack/pty v1.1.24 h1:bJrF4RRfyJnbTJqzRLHzcGaZK1NeM5kTC9jGgovnR1s=
 github.com/creack/pty v1.1.24/go.mod h1:08sCNb52WyoAwi2QDyzUCTgcvVFhUzewun7wtTfvcwE=
-github.com/crossplane/crossplane-runtime/v2 v2.2.3 h1:/ACD1n1ukspHUDj5NXi8yMpyYsrLDCy7I5x5VTiwlcM=
-github.com/crossplane/crossplane-runtime/v2 v2.2.3/go.mod h1:4hjtObq7yln3BweiFCuSB4j0/a/pHUn6vSuY+Bb8Qf0=
+github.com/crossplane/crossplane-runtime/v2 v2.2.4 h1:ygyR9fuE88T5JRVBeR1bJksaEf2yFEjOMKjvf8aS+yM=
+github.com/crossplane/crossplane-runtime/v2 v2.2.4/go.mod h1:kSYRy04thJfNQSBTLtD8p8z7l4QNWY98kLq8iuhp/LM=
 github.com/cyberphone/json-canonicalization v0.0.0-20241213102144-19d51d7fe467 h1:uX1JmpONuD549D73r6cgnxyUu18Zb7yHAy5AYU0Pm4Q=
 github.com/cyberphone/json-canonicalization v0.0.0-20241213102144-19d51d7fe467/go.mod h1:uzvlm1mxhHkdfqitSA92i7Se+S9ksOn3a3qmv/kyOCw=
 github.com/cyphar/filepath-securejoin v0.6.1 h1:5CeZ1jPXEiYt3+Z6zqprSAgSWiggmpVyciv8syjIpVE=

--- a/nix/vendor-hashes.nix
+++ b/nix/vendor-hashes.nix
@@ -12,5 +12,5 @@
 # by hand.)
 {
   # Root module: github.com/crossplane/crossplane/v2
-  root = "sha256-fgYp+k4QHVJgh8dAWPALgx1JKp1XykSFrOfrIfa+Peo=";
+  root = "sha256-lLWY/eRUv7u4fprC2vgdHg4/94lqmBUMG5GDkBixj8E=";
 }


### PR DESCRIPTION
### Description of your changes

For https://github.com/crossplane/release/issues/97:

> [In Core Crossplane]: (On the Release Branch) Open and merge a PR updating the Crossplane Runtime dependency to v2.2.4.

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `./nix.sh flake check` to ensure this PR is ready for review.
- [ ] ~Added or updated unit tests.~
- [ ] ~Added or updated e2e tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~
- [ ] ~Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.`

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md
