### PR TITLE
chore(deps): bump crossplane-runtime to v1.20.11

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/Masterminds/semver v1.5.0
 	github.com/alecthomas/kong v1.4.0
 	github.com/containerd/errdefs v1.0.0
-	github.com/crossplane/crossplane-runtime v1.20.10
+	github.com/crossplane/crossplane-runtime v1.20.11
 	github.com/docker/docker v28.5.2+incompatible
 	github.com/docker/go-connections v0.7.0
 	github.com/emicklei/dot v1.6.2

--- a/go.sum
+++ b/go.sum
@@ -166,8 +166,8 @@ github.com/cpuguy83/go-md2man/v2 v2.0.1/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46t
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/creack/pty v1.1.24 h1:bJrF4RRfyJnbTJqzRLHzcGaZK1NeM5kTC9jGgovnR1s=
 github.com/creack/pty v1.1.24/go.mod h1:08sCNb52WyoAwi2QDyzUCTgcvVFhUzewun7wtTfvcwE=
-github.com/crossplane/crossplane-runtime v1.20.10 h1:NyfZXaG3hNlD/ZyBRN3kXCSYmZ18gERh3jsZJKCGNjw=
-github.com/crossplane/crossplane-runtime v1.20.10/go.mod h1:EbFC7+3EDUlEmOkDOA0QNwwpen3sfzAUJVquCK9juyY=
+github.com/crossplane/crossplane-runtime v1.20.11 h1:SSaSv7pCHnZ+aWGQ/y9Gp+YlzfMMTdOCZeFlHovHpds=
+github.com/crossplane/crossplane-runtime v1.20.11/go.mod h1:BMzTKvPFBHOSHzAM+1mHTDXH7+kj8fiLqpww62evxis=
 github.com/cyberphone/json-canonicalization v0.0.0-20241213102144-19d51d7fe467 h1:uX1JmpONuD549D73r6cgnxyUu18Zb7yHAy5AYU0Pm4Q=
 github.com/cyberphone/json-canonicalization v0.0.0-20241213102144-19d51d7fe467/go.mod h1:uzvlm1mxhHkdfqitSA92i7Se+S9ksOn3a3qmv/kyOCw=
 github.com/cyphar/filepath-securejoin v0.6.1 h1:5CeZ1jPXEiYt3+Z6zqprSAgSWiggmpVyciv8syjIpVE=


### PR DESCRIPTION
### Description of your changes

From https://github.com/crossplane/release/issues/98:

> [In Core Crossplane]: (On the Release Branch) Open and merge a PR updating the Crossplane Runtime dependency to v1.20.11.

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `./nix.sh flake check` to ensure this PR is ready for review.
- [ ] ~Added or updated unit tests.~
- [ ] ~Added or updated e2e tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~
- [ ] ~Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md
