### PR TITLE
fix(helm): use metrics port for scrape annotation

### DIFF
--- a/cluster/charts/crossplane/templates/deployment.yaml
+++ b/cluster/charts/crossplane/templates/deployment.yaml
@@ -28,7 +28,7 @@ spec:
       {{- end }}
       {{- if .Values.metrics.enabled }}
         prometheus.io/path: /metrics
-        prometheus.io/port: "8080"
+        prometheus.io/port: {{ .Values.metrics.port | default 8080 | quote }}
         prometheus.io/scrape: "true"
       {{- end }}
       {{- with .Values.customAnnotations }}


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane! Please read the contribution docs
(linked below) if this is your first Crossplane pull request.
-->

### Description of your changes

At the moment you can configure the metrics port in the helm chart with metrics.port but the port in the scrape annotation prometheus.io/port is 8080 fixed. 

So when you change the port you have to override the annotation via customAnnotations.

With this change the annotation receives the correct port when you change it in the helm chart

Fixes #

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [ ] Run `./nix.sh flake check` to ensure this PR is ready for review.
- [ ] Added or updated unit tests.
- [ ] Added or updated e2e tests.
- [ ] Linked a PR or a [docs tracking issue] to [document this change].
- [ ] Added `backport release-x.y` labels to auto-backport this PR.
- [ ] Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md
