### PR TITLE
Add events.k8s.io to RBAC rules for provider event recording

### DIFF
--- a/cluster/charts/crossplane/templates/clusterrole.yaml
+++ b/cluster/charts/crossplane/templates/clusterrole.yaml
@@ -24,6 +24,7 @@ metadata:
 rules:
 - apiGroups:
   - ""
+  - events.k8s.io
   resources:
   - events
   verbs:

--- a/cluster/charts/crossplane/templates/rbac-manager-managed-clusterroles.yaml
+++ b/cluster/charts/crossplane/templates/rbac-manager-managed-clusterroles.yaml
@@ -75,7 +75,7 @@ metadata:
     {{- include "crossplane.labels" . | indent 4 }}
 rules:
 # Crossplane administrators have access to view events.
-- apiGroups: [""]
+- apiGroups: ["", "events.k8s.io"]
   resources: [events]
   verbs: [get, list, watch]
 # Crossplane administrators must create provider credential secrets, and may
@@ -130,7 +130,7 @@ metadata:
     {{- include "crossplane.labels" . | indent 4 }}
 rules:
 # Crossplane editors have access to view events.
-- apiGroups: [""]
+- apiGroups: ["", "events.k8s.io"]
   resources: [events]
   verbs: [get, list, watch]
 # Crossplane editors must create provider credential secrets, and may need to
@@ -174,7 +174,7 @@ metadata:
     {{- include "crossplane.labels" . | indent 4 }}
 rules:
 # Crossplane viewers have access to view events.
-- apiGroups: [""]
+- apiGroups: ["", "events.k8s.io"]
   resources: [events]
   verbs: [get, list, watch]
 # Crossplane viewers may see which namespaces exist.
@@ -213,7 +213,7 @@ metadata:
     {{- include "crossplane.labels" . | indent 4 }}
 rules:
 # Crossplane browsers have access to view events.
-- apiGroups: [""]
+- apiGroups: ["", "events.k8s.io"]
   resources: [events]
   verbs: [get, list, watch]
 # Crossplane browsers have read-only access to compositions and XRDs. This

--- a/internal/controller/rbac/provider/roles/roles.go
+++ b/internal/controller/rbac/provider/roles/roles.go
@@ -72,7 +72,7 @@ var (
 //nolint:gochecknoglobals // We treat this as a constant.
 var rulesSystemExtra = []rbacv1.PolicyRule{
 	{
-		APIGroups: []string{"", coordinationv1.GroupName},
+		APIGroups: []string{"", coordinationv1.GroupName, "events.k8s.io"},
 		Resources: []string{pluralSecrets, pluralConfigmaps, pluralEvents, pluralLeases},
 		Verbs:     verbsEdit,
 	},

--- a/internal/controller/rbac/provider/roles/roles_test.go
+++ b/internal/controller/rbac/provider/roles/roles_test.go
@@ -233,7 +233,7 @@ func TestRenderClusterRoles(t *testing.T) {
 							Verbs:     verbsUpdate,
 						},
 						{
-							APIGroups: []string{"", coordinationv1.GroupName},
+							APIGroups: []string{"", coordinationv1.GroupName, "events.k8s.io"},
 							Resources: []string{pluralSecrets, pluralConfigmaps, pluralEvents, pluralLeases},
 							Verbs:     verbsEdit,
 						},


### PR DESCRIPTION
## Summary

The migration to events.k8s.io/v1 API requires corresponding RBAC permissions. Without this, providers will get 403 errors and events will silently stop working.

## Changes

- Add events.k8s.io to the dynamic system role (rulesSystemExtra)
- Add events.k8s.io to the static Helm chart ClusterRole
- Add events.k8s.io to admin/editor/viewer/browser aggregate roles
- Update unit test expectations to match

Fixes #7469

## Note

This is a prerequisite extracted from the larger events API migration work in crossplane-runtime#1052 (crossplane/crossplane#7643). It's self-contained and can be merged independently.