### PR TITLE
Backport xpkg signature verification fix to release-1.20

### DIFF
--- a/internal/controller/pkg/revision/imageback.go
+++ b/internal/controller/pkg/revision/imageback.go
@@ -29,11 +29,15 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/parser"
 
 	v1 "github.com/crossplane/crossplane/apis/pkg/v1"
+	"github.com/crossplane/crossplane/apis/pkg/v1beta1"
 	"github.com/crossplane/crossplane/internal/xpkg"
 )
 
 const (
 	errBadReference            = "package tag is not a valid reference"
+	errResolveDigest           = "failed to resolve package reference to a digest"
+	errGetVerificationConfig   = "failed to get image verification config"
+	errVerifyPackage           = "package signature verification failed"
 	errFetchPackage            = "failed to fetch package from remote"
 	errGetManifest             = "failed to get package image manifest from remote"
 	errFetchLayer              = "failed to fetch annotated base layer from remote"
@@ -52,10 +56,17 @@ const (
 	maxLayers = 256
 )
 
+// A Validator validates the signature of a package image.
+type Validator interface {
+	Validate(ctx context.Context, ref name.Reference, config *v1beta1.ImageVerification, pullSecrets ...string) error
+}
+
 // ImageBackend is a backend for parser.
 type ImageBackend struct {
-	registry string
-	fetcher  xpkg.Fetcher
+	registry  string
+	fetcher   xpkg.Fetcher
+	config    xpkg.ConfigStore
+	validator Validator
 }
 
 // An ImageBackendOption sets configuration for an image backend.
@@ -68,6 +79,18 @@ func WithDefaultRegistry(registry string) ImageBackendOption {
 	}
 }
 
+// WithVerification makes the backend verify the signature of the image it is
+// about to install. The signature controller reports verification status on the
+// package revision, but it resolves the package reference independently of this
+// backend. Verifying here as well means the bytes we check are the bytes we
+// install, whatever the tag resolves to in between.
+func WithVerification(c xpkg.ConfigStore, v Validator) ImageBackendOption {
+	return func(i *ImageBackend) {
+		i.config = c
+		i.validator = v
+	}
+}
+
 // NewImageBackend creates a new image backend.
 func NewImageBackend(fetcher xpkg.Fetcher, opts ...ImageBackendOption) *ImageBackend {
 	i := &ImageBackend{
@@ -77,6 +100,49 @@ func NewImageBackend(fetcher xpkg.Fetcher, opts ...ImageBackendOption) *ImageBac
 		opt(i)
 	}
 	return i
+}
+
+// resolveAndVerify resolves ref to a digest and, if signature verification is
+// enabled, verifies the signature of the image that digest points to. Resolving
+// once and returning the digest is what makes the bytes we verify the bytes the
+// caller installs: verifying a tag and then pulling it again would let a
+// registry serve different content to each call.
+//
+// The signature controller reports verification status on the package revision,
+// but it resolves the reference independently of this backend, so it cannot
+// give us that guarantee on its own.
+func (i *ImageBackend) resolveAndVerify(ctx context.Context, source string, ref name.Reference, secrets ...string) (name.Digest, error) {
+	digest, ok := ref.(name.Digest)
+	if !ok {
+		desc, err := i.fetcher.Head(ctx, ref, secrets...)
+		if err != nil {
+			return name.Digest{}, errors.Wrap(err, errResolveDigest)
+		}
+
+		digest = ref.Context().Digest(desc.Digest.String())
+	}
+
+	if i.validator == nil {
+		return digest, nil
+	}
+
+	// Match the image config on the source rather than on the digest reference,
+	// so prefixes keep matching the image path the way they do everywhere else,
+	// including prefixes that carry a tag.
+	_, vc, err := i.config.ImageVerificationConfigFor(ctx, source)
+	if err != nil {
+		return name.Digest{}, errors.Wrap(err, errGetVerificationConfig)
+	}
+
+	if vc == nil || vc.Cosign == nil {
+		return digest, nil
+	}
+
+	if err := i.validator.Validate(ctx, digest, vc, secrets...); err != nil {
+		return name.Digest{}, errors.Wrap(err, errVerifyPackage)
+	}
+
+	return digest, nil
 }
 
 // Init initializes an ImageBackend.
@@ -95,7 +161,8 @@ func (i *ImageBackend) Init(ctx context.Context, bo ...parser.BackendOption) (io
 	}
 	// Use the package recorded in the status rather than the one from the spec,
 	// since it may have been rewritten by an image config.
-	ref, err := name.ParseReference(n.pr.GetResolvedSource(), name.WithDefaultRegistry(i.registry))
+	source := n.pr.GetResolvedSource()
+	ref, err := name.ParseReference(source, name.WithDefaultRegistry(i.registry))
 	if err != nil {
 		return nil, errors.Wrap(err, errBadReference)
 	}
@@ -104,7 +171,16 @@ func (i *ImageBackend) Init(ctx context.Context, bo ...parser.BackendOption) (io
 	if n.pullSecretFromConfig != "" {
 		ps = append(ps, n.pullSecretFromConfig)
 	}
-	img, err := i.fetcher.Fetch(ctx, ref, ps...)
+	// Pin all subsequent registry interactions to the digest we verified.
+	// Pulling by the original tag would let a registry that serves different
+	// content between verification and the pull slip an unverified image into
+	// the package.
+	digest, err := i.resolveAndVerify(ctx, source, ref, ps...)
+	if err != nil {
+		return nil, err
+	}
+
+	img, err := i.fetcher.Fetch(ctx, digest, ps...)
 	if err != nil {
 		return nil, errors.Wrap(err, errFetchPackage)
 	}

--- a/internal/controller/pkg/revision/imageback_test.go
+++ b/internal/controller/pkg/revision/imageback_test.go
@@ -17,10 +17,13 @@ limitations under the License.
 package revision
 
 import (
+	"context"
 	"io"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-containerregistry/pkg/name"
+	ociv1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/empty"
 	"github.com/google/go-containerregistry/pkg/v1/mutate"
 	"github.com/google/go-containerregistry/pkg/v1/random"
@@ -31,9 +34,16 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/test"
 
 	v1 "github.com/crossplane/crossplane/apis/pkg/v1"
+	"github.com/crossplane/crossplane/apis/pkg/v1beta1"
 	"github.com/crossplane/crossplane/internal/xpkg"
 	"github.com/crossplane/crossplane/internal/xpkg/fake"
 )
+
+// testDigest is the digest the fake registry resolves every tag to.
+var testDigest = ociv1.Hash{
+	Algorithm: "sha256",
+	Hex:       "ecc4c9eff5b0c4de6dcb24b6c4c96d5e5f0f8ab0e5e58ea4d2c7d6e6bd2e5a11",
+}
 
 func TestImageBackend(t *testing.T) {
 	errBoom := errors.New("boom")
@@ -101,6 +111,7 @@ func TestImageBackend(t *testing.T) {
 			reason: "Should return error if image has multiple layers annotated as base.",
 			args: args{
 				f: &fake.MockFetcher{
+					MockHead:  fake.NewMockHeadFn(&ociv1.Descriptor{Digest: testDigest}, nil),
 					MockFetch: fake.NewMockFetchFn(randImgDup, nil),
 				},
 				opts: []parser.BackendOption{PackageRevision(&v1.ProviderRevision{
@@ -120,6 +131,7 @@ func TestImageBackend(t *testing.T) {
 			reason: "Should return error if image with contents does not have package.yaml.",
 			args: args{
 				f: &fake.MockFetcher{
+					MockHead:  fake.NewMockHeadFn(&ociv1.Descriptor{Digest: testDigest}, nil),
 					MockFetch: fake.NewMockFetchFn(randImg, nil),
 				},
 				opts: []parser.BackendOption{PackageRevision(&v1.ProviderRevision{
@@ -139,6 +151,7 @@ func TestImageBackend(t *testing.T) {
 			reason: "Should return error if image is empty.",
 			args: args{
 				f: &fake.MockFetcher{
+					MockHead:  fake.NewMockHeadFn(&ociv1.Descriptor{Digest: testDigest}, nil),
 					MockFetch: fake.NewMockFetchFn(empty.Image, nil),
 				},
 				opts: []parser.BackendOption{PackageRevision(&v1.ProviderRevision{
@@ -158,6 +171,7 @@ func TestImageBackend(t *testing.T) {
 			reason: "Should return error if package is not in cache and we fail to fetch it.",
 			args: args{
 				f: &fake.MockFetcher{
+					MockHead:  fake.NewMockHeadFn(&ociv1.Descriptor{Digest: testDigest}, nil),
 					MockFetch: fake.NewMockFetchFn(nil, errBoom),
 				},
 				opts: []parser.BackendOption{PackageRevision(&v1.ProviderRevision{
@@ -198,6 +212,156 @@ func TestImageBackend(t *testing.T) {
 			}
 			if diff := cmp.Diff(tc.want, err, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\nb.Init(...): -want error, +got error:\n%s", tc.reason, diff)
+			}
+		})
+	}
+}
+
+// refString renders a reference for comparison, tolerating the nil we get when
+// the backend never made the call at all.
+func refString(r name.Reference) string {
+	if r == nil {
+		return ""
+	}
+
+	return r.String()
+}
+
+// recordingFetcher records the reference it was asked to fetch, so we can
+// assert the backend never goes back to the registry by tag once it has
+// resolved a digest.
+type recordingFetcher struct {
+	desc     *ociv1.Descriptor
+	headErr  error
+	img      ociv1.Image
+	fetchErr error
+
+	headed  name.Reference
+	fetched name.Reference
+}
+
+func (f *recordingFetcher) Head(_ context.Context, ref name.Reference, _ ...string) (*ociv1.Descriptor, error) {
+	f.headed = ref
+	return f.desc, f.headErr
+}
+
+func (f *recordingFetcher) Fetch(_ context.Context, ref name.Reference, _ ...string) (ociv1.Image, error) {
+	f.fetched = ref
+	return f.img, f.fetchErr
+}
+
+func (f *recordingFetcher) Tags(_ context.Context, _ name.Reference, _ ...string) ([]string, error) {
+	return nil, nil
+}
+
+// recordingValidator records the reference whose signature it was asked to
+// validate.
+type recordingValidator struct {
+	err error
+
+	validated name.Reference
+}
+
+func (v *recordingValidator) Validate(_ context.Context, ref name.Reference, _ *v1beta1.ImageVerification, _ ...string) error {
+	v.validated = ref
+	return v.err
+}
+
+// TestImageBackendVerifiesAndFetchesSameDigest covers GHSA-wfqx-gjrf-g28r: a
+// registry that resolves a tag to signed content while it is verified and to
+// different content while it is pulled must not be able to get the unsigned
+// content installed. The backend resolves the tag once and pins both the
+// signature check and the pull to the resulting digest.
+func TestImageBackendVerifiesAndFetchesSameDigest(t *testing.T) {
+	errBoom := errors.New("boom")
+
+	const source = "xpkg.crossplane.io/test/test:latest"
+
+	wantRef := name.MustParseReference(source).Context().Digest(testDigest.String()).String()
+
+	pr := PackageRevision(&v1.ProviderRevision{
+		Spec: v1.ProviderRevisionSpec{
+			PackageRevisionSpec: v1.PackageRevisionSpec{Package: source},
+		},
+		Status: v1.PackageRevisionStatus{ResolvedPackage: source},
+	})
+
+	verified := &v1beta1.ImageVerification{Cosign: &v1beta1.CosignVerificationConfig{}}
+
+	cases := map[string]struct {
+		reason        string
+		fetcher       *recordingFetcher
+		validator     *recordingValidator
+		vc            *v1beta1.ImageVerification
+		vcErr         error
+		wantErr       error
+		wantValidated string
+		wantFetched   string
+	}{
+		"VerifyAndFetchByDigest": {
+			reason:        "Both the signature check and the pull should target the digest the tag resolved to.",
+			fetcher:       &recordingFetcher{desc: &ociv1.Descriptor{Digest: testDigest}, img: empty.Image},
+			validator:     &recordingValidator{},
+			vc:            verified,
+			wantErr:       errors.Wrapf(io.EOF, errFmtNoPackageFileFound, 0, false),
+			wantValidated: wantRef,
+			wantFetched:   wantRef,
+		},
+		"FetchByDigestWithoutVerification": {
+			reason:      "The pull should target the digest even when no verification config matches.",
+			fetcher:     &recordingFetcher{desc: &ociv1.Descriptor{Digest: testDigest}, img: empty.Image},
+			validator:   &recordingValidator{},
+			vc:          nil,
+			wantErr:     errors.Wrapf(io.EOF, errFmtNoPackageFileFound, 0, false),
+			wantFetched: wantRef,
+		},
+		"ErrVerificationFailed": {
+			reason:        "A failed signature check should stop us fetching the package at all.",
+			fetcher:       &recordingFetcher{desc: &ociv1.Descriptor{Digest: testDigest}, img: empty.Image},
+			validator:     &recordingValidator{err: errBoom},
+			vc:            verified,
+			wantErr:       errors.Wrap(errBoom, errVerifyPackage),
+			wantValidated: wantRef,
+		},
+		"ErrResolveDigest": {
+			reason:    "We should not verify or fetch anything if we cannot resolve the tag to a digest.",
+			fetcher:   &recordingFetcher{headErr: errBoom},
+			validator: &recordingValidator{},
+			vc:        verified,
+			wantErr:   errors.Wrap(errBoom, errResolveDigest),
+		},
+		"ErrGetVerificationConfig": {
+			reason:    "We should not fetch anything if we cannot tell whether the package needs verifying.",
+			fetcher:   &recordingFetcher{desc: &ociv1.Descriptor{Digest: testDigest}, img: empty.Image},
+			validator: &recordingValidator{},
+			vcErr:     errBoom,
+			wantErr:   errors.Wrap(errBoom, errGetVerificationConfig),
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			c := &fake.MockConfigStore{
+				MockImageVerificationConfigFor: fake.NewMockConfigStoreImageVerificationConfigForFn("test", tc.vc, tc.vcErr),
+			}
+
+			b := NewImageBackend(tc.fetcher, WithVerification(c, tc.validator))
+
+			rc, err := b.Init(t.Context(), pr)
+			if err == nil && rc != nil {
+				_, err = io.ReadAll(rc)
+			}
+
+			if diff := cmp.Diff(tc.wantErr, err, test.EquateErrors()); diff != "" {
+				t.Errorf("\n%s\nb.Init(...): -want error, +got error:\n%s", tc.reason, diff)
+			}
+
+			if diff := cmp.Diff(tc.wantValidated, refString(tc.validator.validated)); diff != "" {
+				t.Errorf("\n%s\nb.Init(...): -want validated ref, +got validated ref:\n%s", tc.reason, diff)
+			}
+
+			if diff := cmp.Diff(tc.wantFetched, refString(tc.fetcher.fetched)); diff != "" {
+				t.Errorf("\n%s\nb.Init(...): -want fetched ref, +got fetched ref:\n%s", tc.reason, diff)
 			}
 		})
 	}

--- a/internal/controller/pkg/revision/reconciler.go
+++ b/internal/controller/pkg/revision/reconciler.go
@@ -51,6 +51,7 @@ import (
 	"github.com/crossplane/crossplane/apis/pkg/v1alpha1"
 	"github.com/crossplane/crossplane/apis/pkg/v1beta1"
 	"github.com/crossplane/crossplane/internal/controller/pkg/controller"
+	"github.com/crossplane/crossplane/internal/controller/pkg/signature"
 	"github.com/crossplane/crossplane/internal/dag"
 	"github.com/crossplane/crossplane/internal/features"
 	"github.com/crossplane/crossplane/internal/version"
@@ -107,6 +108,7 @@ const (
 	errCannotBuildMetaSchema         = "cannot build meta scheme for package parser"
 	errCannotBuildObjectSchema       = "cannot build object scheme for package parser"
 	errCannotBuildFetcher            = "cannot build fetcher for package parser"
+	errCannotBuildValidator          = "cannot build cosign validator for package parser"
 
 	errGetControllerConfig = "cannot get referenced controller config"
 	errNoRuntimeConfig     = "no deployment runtime config set"
@@ -284,6 +286,23 @@ type Reconciler struct {
 	newPackageRevision func() v1.PackageRevision
 }
 
+// imageBackendOptions returns the options the image backend needs to verify the
+// signature of the image it installs. Verification is alpha, and building a
+// cosign validator fetches Fulcio roots and CT log keys, so this is a no-op
+// unless the feature is enabled.
+func imageBackendOptions(mgr ctrl.Manager, cs kubernetes.Interface, o controller.Options) ([]ImageBackendOption, error) {
+	if !o.Features.Enabled(features.EnableAlphaSignatureVerification) {
+		return nil, nil
+	}
+
+	v, err := signature.NewCosignValidator(mgr.GetClient(), cs, o.Namespace, o.ServiceAccount)
+	if err != nil {
+		return nil, errors.Wrap(err, errCannotBuildValidator)
+	}
+
+	return []ImageBackendOption{WithVerification(xpkg.NewImageConfigStore(mgr.GetClient(), o.Namespace), v)}, nil
+}
+
 // SetupProviderRevision adds a controller that reconciles ProviderRevisions.
 func SetupProviderRevision(mgr ctrl.Manager, o controller.Options) error {
 	name := "packages/" + strings.ToLower(v1.ProviderRevisionGroupKind)
@@ -307,6 +326,11 @@ func SetupProviderRevision(mgr ctrl.Manager, o controller.Options) error {
 		return errors.Wrap(err, errCannotBuildFetcher)
 	}
 
+	ibo, err := imageBackendOptions(mgr, clientset, o)
+	if err != nil {
+		return err
+	}
+
 	log := o.Logger.WithValues("controller", name)
 	cb := ctrl.NewControllerManagedBy(mgr).
 		Named(name).
@@ -326,7 +350,7 @@ func SetupProviderRevision(mgr ctrl.Manager, o controller.Options) error {
 		WithEstablisher(NewAPIEstablisher(mgr.GetClient(), o.Namespace, o.MaxConcurrentPackageEstablishers)),
 		WithNewPackageRevisionFn(nr),
 		WithParser(parser.New(metaScheme, objScheme)),
-		WithParserBackend(NewImageBackend(fetcher, WithDefaultRegistry(o.DefaultRegistry))),
+		WithParserBackend(NewImageBackend(fetcher, append(ibo, WithDefaultRegistry(o.DefaultRegistry))...)),
 		WithConfigStore(xpkg.NewImageConfigStore(mgr.GetClient(), o.Namespace)),
 		WithLinter(xpkg.NewProviderLinter()),
 		WithLogger(log),
@@ -373,6 +397,11 @@ func SetupConfigurationRevision(mgr ctrl.Manager, o controller.Options) error {
 		return errors.Wrap(err, errCannotBuildFetcher)
 	}
 
+	ibo, err := imageBackendOptions(mgr, cs, o)
+	if err != nil {
+		return err
+	}
+
 	log := o.Logger.WithValues("controller", name)
 	r := NewReconciler(mgr,
 		WithCache(o.Cache),
@@ -380,7 +409,7 @@ func SetupConfigurationRevision(mgr ctrl.Manager, o controller.Options) error {
 		WithNewPackageRevisionFn(nr),
 		WithEstablisher(NewAPIEstablisher(mgr.GetClient(), o.Namespace, o.MaxConcurrentPackageEstablishers)),
 		WithParser(parser.New(metaScheme, objScheme)),
-		WithParserBackend(NewImageBackend(f, WithDefaultRegistry(o.DefaultRegistry))),
+		WithParserBackend(NewImageBackend(f, append(ibo, WithDefaultRegistry(o.DefaultRegistry))...)),
 		WithConfigStore(xpkg.NewImageConfigStore(mgr.GetClient(), o.Namespace)),
 		WithLinter(xpkg.NewConfigurationLinter()),
 		WithLogger(log),
@@ -421,6 +450,11 @@ func SetupFunctionRevision(mgr ctrl.Manager, o controller.Options) error {
 		return errors.Wrap(err, errCannotBuildFetcher)
 	}
 
+	ibo, err := imageBackendOptions(mgr, clientset, o)
+	if err != nil {
+		return err
+	}
+
 	log := o.Logger.WithValues("controller", name)
 	cb := ctrl.NewControllerManagedBy(mgr).
 		Named(name).
@@ -440,7 +474,7 @@ func SetupFunctionRevision(mgr ctrl.Manager, o controller.Options) error {
 		WithEstablisher(NewAPIEstablisher(mgr.GetClient(), o.Namespace, o.MaxConcurrentPackageEstablishers)),
 		WithNewPackageRevisionFn(nr),
 		WithParser(parser.New(metaScheme, objScheme)),
-		WithParserBackend(NewImageBackend(fetcher, WithDefaultRegistry(o.DefaultRegistry))),
+		WithParserBackend(NewImageBackend(fetcher, append(ibo, WithDefaultRegistry(o.DefaultRegistry))...)),
 		WithConfigStore(xpkg.NewImageConfigStore(mgr.GetClient(), o.Namespace)),
 		WithLinter(xpkg.NewFunctionLinter()),
 		WithLogger(log),


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane! Please read the contribution docs
(linked below) if this is your first Crossplane pull request.
-->

### Description of your changes

<!--
Briefly describe what this pull request does, and how it is covered by tests.
Be proactive - direct your reviewers' attention to anything that needs special
consideration.
-->

Backports the fix for [GHSA-wfqx-gjrf-g28r] to `release-1.20`.

`ImageBackend` resolved the package tag and fetched it separately, so a registry
could serve one image to the signature controller and a different one to the
installer — the TOCTOU the advisory describes.

This branch has no `xpkg.CachedClient`, so verification is not in the fetch path
here and the `release-2.2` backport (crossplane/crossplane#7520) does not apply.
Instead `ImageBackend` gains an optional `ConfigStore` and `Validator` through
`WithVerification`: it resolves the tag to a digest once via `fetcher.Head`,
verifies that digest, then fetches by digest — so the bytes we verify are the
bytes we install. Wired in for Provider, Configuration and Function revisions
via `imageBackendOptions()`.

Building a cosign validator fetches Fulcio roots and CT log keys, so this stays
a no-op unless `EnableAlphaSignatureVerification` is enabled.

Covered by new unit tests in `imageback_test.go` (+165 lines).

[GHSA-wfqx-gjrf-g28r]: https://github.com/advisories/GHSA-wfqx-gjrf-g28r

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [ ] ~Run `earthly +reviewable` to ensure this PR is ready for review.~ Earthly is not available in my environment. I ran `go build ./...`, `go vet ./internal/controller/pkg/revision/...` and `go test ./internal/controller/pkg/revision/...` after rebasing — all clean. Relying on CI for the full check.
- [x] Added or updated unit tests.
- [ ] ~Added or updated e2e tests.~ Signature verification is alpha and off by default; the e2e suite does not exercise it.
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~ Security backport with no user-facing behaviour change.
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~ This PR *is* the backport, targeting the release branch directly.
- [ ] ~Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~ No API change.

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md
