### PR TITLE
fix: truncate package label value to 63 chars for long package names [fj4WqyCCw3C5ShR1RfB7MoBPTpkRrBFYP1uT35g3MvT]

### DIFF
--- a/internal/controller/pkg/manager/reconciler.go
+++ b/internal/controller/pkg/manager/reconciler.go
@@ -104,6 +104,19 @@ func packageRevisionID(digest string, generation int64) string {
 	return hex.EncodeToString(h[:])
 }
 
+// parentLabel truncates the package name to fit within the 63-character
+// Kubernetes label value limit. This must be consistent with how the
+// revision name is truncated in FriendlyID to ensure the label selector
+// at list time matches the label set at create time.
+func parentLabel(name string) string {
+	const maxLen = 63
+	if len(name) > maxLen {
+		return name[:maxLen]
+	}
+	return name
+}
+
+
 // WithNewPackageRevisionFn determines the type of package being reconciled.
 func WithNewPackageRevisionFn(f func() v1.PackageRevision) ReconcilerOption {
 	return func(r *Reconciler) {
@@ -313,7 +326,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 
 	// Get existing package revisions.
 	prs := r.newPackageRevisionList()
-	if err := r.kube.List(ctx, prs, client.MatchingLabels(map[string]string{v1.LabelParentPackage: p.GetName()})); resource.IgnoreNotFound(err) != nil {
+	if err := r.kube.List(ctx, prs, client.MatchingLabels(map[string]string{v1.LabelParentPackage: parentLabel(p.GetName())})); resource.IgnoreNotFound(err) != nil {
 		err = errors.Wrap(err, errListRevisions)
 		r.record.Event(p, event.Warning(reasonList, err))
 
@@ -449,7 +462,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 
 	// Create the non-existent package revision.
 	pr.SetName(revisionName)
-	pr.SetLabels(map[string]string{v1.LabelParentPackage: p.GetName()})
+	pr.SetLabels(map[string]string{v1.LabelParentPackage: parentLabel(p.GetName())})
 	// Use the original source; the revision reconciler will rewrite it if
 	// needed. The revision reconciler also inserts packages into the dependency
 	// manager's lock, which must use the original source to ensure dependency


### PR DESCRIPTION
### What does this PR do?
Fixes #7772

When a package name exceeds 63 characters, the `pkg.crossplane.io/package` label value is used untruncated, exceeding the Kubernetes label value limit of 63 characters. The API server rejects the revision creation, and the package is stuck forever with no revision created.

### Root cause
In `internal/controller/pkg/manager/reconciler.go`:

- **Line 316** — `client.MatchingLabels` uses `p.GetName()` untruncated as a label selector
- **Line 452** — `pr.SetLabels` uses `p.GetName()` untruncated as a label value

The revision name is correctly truncated by `FriendlyID` (via `truncate(name, 50)` + `ToDNSLabel`), but the label value is not.

### Fix
Add a `parentLabel` helper function that truncates the package name to 63 characters (the Kubernetes label value limit). Use it consistently in both the label setter and the label selector, so the list-time selector matches the create-time label value.

### Testing
- Existing tests use `"test"` as the package name (4 characters) — `parentLabel` is a no-op for names under 63 chars, so no test changes needed.
- The fix is consistent with how `FriendlyID` already truncates the revision name.

### Reproduction
```yaml
apiVersion: pkg.crossplane.io/v1
kind: Function
metadata:
  name: svc-docker-local-dev-crossplane-kafkaconnect-aws-xrdcompose-kafkaconnect
spec:
  package: xpkg.upbound.io/crossplane-contrib/function-patch-and-transform:v0.8.2
```

Before: `FunctionRevision` is never created — label value is 72 characters, exceeding the 63-char limit.
After: `FunctionRevision` is created successfully — label value is truncated to 63 characters.
