### PR TITLE
fix(deps): update module github.com/crossplane/crossplane/apis/v2 to v2.4.0 (release-2.4)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/Masterminds/semver/v3 v3.5.0
 	github.com/alecthomas/kong v1.16.0
 	github.com/crossplane/crossplane-runtime/v2 v2.4.0
-	github.com/crossplane/crossplane/apis/v2 v2.3.4
+	github.com/crossplane/crossplane/apis/v2 v2.4.0
 	github.com/google/go-cmp v0.7.0
 	github.com/google/go-containerregistry v0.21.8
 	github.com/robfig/cron/v3 v3.0.1


### PR DESCRIPTION
### Description of your changes

The same change as #7776, applied to `release-2.4`.

Renovate bumped the self-referential `github.com/crossplane/crossplane/apis/v2`
requirement from `v2.3.4` to `v2.4.0`, but only opened that PR against `main`.
`release-2.4` still requires `v2.3.4`, which is stale now that `v2.4.0` is tagged.

The module is `replace`d with `./apis`, so this only updates the version string
recorded in `go.mod`: the build still resolves the API types from the local
`apis/` directory and `go.sum` is unaffected.

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `./nix.sh flake check` to ensure this PR is ready for review.
- [ ] ~Added or updated unit tests.~ No behaviour change.
- [ ] ~Added or updated e2e tests.~ No behaviour change.
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~ Not user facing.
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~ This PR targets `release-2.4` directly.
- [ ] ~Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~ No API change.

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md
