### PR TITLE
fix(composite): preserve managed fields during composition

### DIFF
--- a/internal/controller/apiextensions/composite/composition_functions.go
+++ b/internal/controller/apiextensions/composite/composition_functions.go
@@ -731,9 +731,11 @@ func (c *FunctionComposer) Compose(ctx context.Context, xr *composite.Unstructur
 	u := xr.GetUID()
 	cs := xr.GetConditions()
 
+	mf := xr.GetManagedFields()
 	if err := xfn.FromStruct(xr, d.GetComposite().GetResource()); err != nil {
 		return CompositionResult{}, errors.Wrap(err, errUnmarshalDesiredXRStatus)
 	}
+	xr.SetManagedFields(mf)
 
 	xr.SetAPIVersion(v)
 	xr.SetKind(k)

--- a/internal/controller/apiextensions/composite/composition_functions_test.go
+++ b/internal/controller/apiextensions/composite/composition_functions_test.go
@@ -2300,72 +2300,116 @@ func TestPipelineFatalErrorAs(t *testing.T) {
 }
 
 func TestComposePreservesManagedFields(t *testing.T) {
-	// Arrange
-	xr := &composite.Unstructured{
-		Unstructured: unstructured.Unstructured{
-			Object: map[string]any{
-				"metadata": map[string]any{
-					"name": "my-xr",
-					"managedFields": []any{
-						map[string]any{
-							"manager": "test-manager",
+	type params struct {
+		c  client.Client
+		uc client.Client
+		r  FunctionRunner
+	}
+
+	type args struct {
+		ctx context.Context
+		xr  *composite.Unstructured
+		req CompositionRequest
+	}
+
+	type want struct {
+		xr  *composite.Unstructured
+		err error
+	}
+
+	cases := map[string]struct {
+		reason string
+		params params
+		args   args
+		want   want
+	}{
+		"ManagedFieldsArePreserved": {
+			reason: "Compose should preserve existing managedFields on the XR even when they are absent from the desired composite returned by the function runner.",
+			params: params{
+				c: &test.MockClient{
+					MockGet:         test.NewMockGetFn(nil),
+					MockPatch:       test.NewMockPatchFn(nil),
+					MockStatusPatch: test.NewMockSubResourcePatchFn(nil),
+				},
+				uc: &test.MockClient{
+					MockPatch:       test.NewMockPatchFn(nil),
+					MockStatusPatch: test.NewMockSubResourcePatchFn(nil),
+					MockGet:         test.NewMockGetFn(nil),
+				},
+				r: FunctionRunnerFn(func(_ context.Context, _ string, req *fnv1.RunFunctionRequest) (*fnv1.RunFunctionResponse, error) {
+					return &fnv1.RunFunctionResponse{
+						Desired: &fnv1.State{
+							Composite: &fnv1.Resource{
+								Resource: structpb.NewStructValue(&structpb.Struct{
+									Fields: map[string]*structpb.Value{
+										"metadata": structpb.NewStructValue(&structpb.Struct{
+											Fields: map[string]*structpb.Value{
+												"name": structpb.NewStringValue("my-xr"),
+											},
+										}),
+									},
+								}).GetStructValue(),
+							},
+						},
+					}, nil
+				}),
+			},
+			args: args{
+				ctx: context.Background(),
+				xr: &composite.Unstructured{
+					Unstructured: unstructured.Unstructured{
+						Object: map[string]any{
+							"metadata": map[string]any{
+								"name": "my-xr",
+								"managedFields": []any{
+									map[string]any{
+										"manager": "test-manager",
+									},
+								},
+							},
 						},
 					},
 				},
-			},
-		},
-	}
-
-	req := CompositionRequest{
-		Revision: &v1.CompositionRevision{},
-	}
-
-	mockRunner := FunctionRunnerFn(func(_ context.Context, _ string, req *fnv1.RunFunctionRequest) (*fnv1.RunFunctionResponse, error) {
-		// Mock response typically returned by xfn logic, omitting managedFields
-		return &fnv1.RunFunctionResponse{
-			Desired: &fnv1.State{
-				Composite: &fnv1.Resource{
-					Resource: structpb.NewStructValue(&structpb.Struct{
-						Fields: map[string]*structpb.Value{
-							"metadata": structpb.NewStructValue(&structpb.Struct{
-								Fields: map[string]*structpb.Value{
-									"name": structpb.NewStringValue("my-xr"),
-								},
-							}),
-						},
-					}).GetStructValue(),
+				req: CompositionRequest{
+					Revision: &v1.CompositionRevision{},
 				},
 			},
-		}, nil
-	})
-
-	c := NewFunctionComposer(
-		&test.MockClient{
-			MockGet:         test.NewMockGetFn(nil),
-			MockPatch:       test.NewMockPatchFn(nil),
-			MockStatusPatch: test.NewMockSubResourcePatchFn(nil),
+			want: want{
+				xr: &composite.Unstructured{
+					Unstructured: unstructured.Unstructured{
+						Object: map[string]any{
+							"apiVersion": "",
+							"kind":       "",
+							"metadata": map[string]any{
+								"name": "my-xr",
+								"managedFields": []any{
+									map[string]any{
+										"manager": "test-manager",
+									},
+								},
+							},
+						},
+					},
+				},
+				err: nil,
+			},
 		},
-		&test.MockClient{
-			MockPatch:       test.NewMockPatchFn(nil),
-			MockStatusPatch: test.NewMockSubResourcePatchFn(nil),
-			MockGet:         test.NewMockGetFn(nil),
-		},
-		mockRunner,
-	)
-
-	// Act
-	_, err := c.Compose(context.Background(), xr, req)
-
-	// Assert
-	if err != nil {
-		t.Fatalf("Compose() returned unexpected error: %v", err)
 	}
 
-	managedFields := xr.GetManagedFields()
-	if len(managedFields) == 0 {
-		t.Fatalf("Compose() dropped managedFields. Expected 1, got 0")
-	}
-	if len(managedFields) > 0 && managedFields[0].Manager != "test-manager" {
-		t.Errorf("Compose() modified managedFields. Expected 'test-manager', got '%s'", managedFields[0].Manager)
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			c := NewFunctionComposer(tc.params.c, tc.params.uc, tc.params.r)
+
+			_, err := c.Compose(tc.args.ctx, tc.args.xr, tc.args.req)
+
+			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
+				t.Errorf("\n%s\nCompose(...): -want error, +got error:\n%s", tc.reason, diff)
+			}
+
+			// Verify that managedFields (and the rest of the XR) matches our expectations
+			if diff := cmp.Diff(tc.want.xr, tc.args.xr); diff != "" {
+				t.Errorf("\n%s\nCompose(...) XR state: -want, +got:\n%s", tc.reason, diff)
+			}
+		})
 	}
 }

--- a/internal/controller/apiextensions/composite/composition_functions_test.go
+++ b/internal/controller/apiextensions/composite/composition_functions_test.go
@@ -2298,3 +2298,74 @@ func TestPipelineFatalErrorAs(t *testing.T) {
 		t.Errorf("errors.As recovered PipelineFatalError: -want, +got:\n%s", diff)
 	}
 }
+
+func TestComposePreservesManagedFields(t *testing.T) {
+	// Arrange
+	xr := &composite.Unstructured{
+		Unstructured: unstructured.Unstructured{
+			Object: map[string]any{
+				"metadata": map[string]any{
+					"name": "my-xr",
+					"managedFields": []any{
+						map[string]any{
+							"manager": "test-manager",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	req := CompositionRequest{
+		Revision: &v1.CompositionRevision{},
+	}
+
+	mockRunner := FunctionRunnerFn(func(_ context.Context, _ string, req *fnv1.RunFunctionRequest) (*fnv1.RunFunctionResponse, error) {
+		// Mock response typically returned by xfn logic, omitting managedFields
+		return &fnv1.RunFunctionResponse{
+			Desired: &fnv1.State{
+				Composite: &fnv1.Resource{
+					Resource: structpb.NewStructValue(&structpb.Struct{
+						Fields: map[string]*structpb.Value{
+							"metadata": structpb.NewStructValue(&structpb.Struct{
+								Fields: map[string]*structpb.Value{
+									"name": structpb.NewStringValue("my-xr"),
+								},
+							}),
+						},
+					}).GetStructValue(),
+				},
+			},
+		}, nil
+	})
+
+	c := NewFunctionComposer(
+		&test.MockClient{
+			MockGet:         test.NewMockGetFn(nil),
+			MockPatch:       test.NewMockPatchFn(nil),
+			MockStatusPatch: test.NewMockSubResourcePatchFn(nil),
+		},
+		&test.MockClient{
+			MockPatch:       test.NewMockPatchFn(nil),
+			MockStatusPatch: test.NewMockSubResourcePatchFn(nil),
+			MockGet:         test.NewMockGetFn(nil),
+		},
+		mockRunner,
+	)
+
+	// Act
+	_, err := c.Compose(context.Background(), xr, req)
+
+	// Assert
+	if err != nil {
+		t.Fatalf("Compose() returned unexpected error: %v", err)
+	}
+
+	managedFields := xr.GetManagedFields()
+	if len(managedFields) == 0 {
+		t.Fatalf("Compose() dropped managedFields. Expected 1, got 0")
+	}
+	if len(managedFields) > 0 && managedFields[0].Manager != "test-manager" {
+		t.Errorf("Compose() modified managedFields. Expected 'test-manager', got '%s'", managedFields[0].Manager)
+	}
+}


### PR DESCRIPTION
## Summary

- Preserve existing XR managedFields when applying the desired composite resource returned by a Composition Function.
- Add a regression test covering managedFields preservation through Compose().

## Testing

- go test -v ./internal/controller/apiextensions/composite -run TestComposePreservesManagedFields
  - Result: PASS
- go test ./internal/controller/apiextensions/composite
  - Result: ok

## Problem

FromStruct() replaces the XR object with the desired resource returned by the function pipeline, causing existing \managedFields\ to be lost unless explicitly preserved. This prevents proper SSA behavior for fields populated by external controllers on XRs.