### PR TITLE
feat(webhooks): make Usage webhook failurePolicy configurable and gate it on Usages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,6 +157,8 @@ jobs:
             test-suite: ops
           - test-area: mrap
             test-suite: mrap
+          - test-area: protection
+            test-suite: usage-webhook-ignore-failure-policy
 
     steps:
       - name: Checkout

--- a/cluster/charts/crossplane/README.md
+++ b/cluster/charts/crossplane/README.md
@@ -141,8 +141,10 @@ and their default values.
 | `sidecarsCrossplane` | Add sidecar containers to the Crossplane pod. Supports template expressions. | `[]` |
 | `tolerations` | Add `tolerations` to the Crossplane pod deployment. | `[]` |
 | `topologySpreadConstraints` | Add `topologySpreadConstraints` to the Crossplane pod deployment. | `[]` |
+| `usages.enabled` | Enable support for deletion ordering and resource protection with Usages (beta, enabled by default). When disabled, the Usage deletion protection webhook is not installed. | `true` |
 | `webhooks.enabled` | Enable webhooks for Crossplane and installed Provider packages. | `true` |
 | `webhooks.port` | The port the webhook server listens on. | `""` |
+| `webhooks.usage.failurePolicy` | The `failurePolicy` of the Usage deletion protection webhook (`crossplane-no-usages`). One of `Fail` or `Ignore`. Set to `Ignore` for compatibility with managed Kubernetes operations that reject `Fail`-policy webhooks with wildcard rules, such as Azure AKS cluster stop. | `"Fail"` |
 
 ### Command Line
 

--- a/cluster/charts/crossplane/templates/deployment.yaml
+++ b/cluster/charts/crossplane/templates/deployment.yaml
@@ -118,8 +118,17 @@ spec:
                 fieldPath: metadata.namespace
           - name: "WEBHOOK_SERVICE_PORT"
             value: "9443"
+          {{- if not (has .Values.webhooks.usage.failurePolicy (list "Fail" "Ignore")) }}
+          {{- fail "webhooks.usage.failurePolicy must be one of Fail or Ignore" }}
+          {{- end }}
+          - name: "USAGE_WEBHOOK_FAILURE_POLICY"
+            value: "{{ .Values.webhooks.usage.failurePolicy }}"
           {{- else }}
           - name: "ENABLE_WEBHOOKS"
+            value: "false"
+          {{- end }}
+          {{- if not .Values.usages.enabled }}
+          - name: "ENABLE_USAGES"
             value: "false"
           {{- end }}
           - name: "TLS_CA_SECRET_NAME"
@@ -197,6 +206,10 @@ spec:
           {{- end}}
           {{- if not .Values.webhooks.enabled }}
           - name: "ENABLE_WEBHOOKS"
+            value: "false"
+          {{- end }}
+          {{- if not .Values.usages.enabled }}
+          - name: "ENABLE_USAGES"
             value: "false"
           {{- end }}
           {{- if and .Values.webhooks.enabled .Values.webhooks.port }}

--- a/cluster/charts/crossplane/values.yaml
+++ b/cluster/charts/crossplane/values.yaml
@@ -90,6 +90,13 @@ webhooks:
   enabled: true
   # -- The port the webhook server listens on.
   port: ""
+  usage:
+    # -- The `failurePolicy` of the Usage deletion protection webhook (`crossplane-no-usages`). One of `Fail` or `Ignore`. Set to `Ignore` for compatibility with managed Kubernetes operations that reject `Fail`-policy webhooks with wildcard rules, such as Azure AKS cluster stop.
+    failurePolicy: Fail
+
+usages:
+  # -- Enable support for deletion ordering and resource protection with Usages (beta, enabled by default). When disabled, the Usage deletion protection webhook is not installed.
+  enabled: true
 
 rbacManager:
   # -- Deploy the RBAC Manager pod and its required roles.

--- a/cmd/crossplane/core/core.go
+++ b/cmd/crossplane/core/core.go
@@ -143,7 +143,7 @@ type startCommand struct {
 	PipelineInspectorSocket string        `default:"/var/run/pipeline-inspector/socket" env:"PIPELINE_INSPECTOR_SOCKET" group:"Alpha Features:" help:"Unix socket path for pipeline inspector sidecar. Requires --enable-pipeline-inspector."`
 
 	EnableDeploymentRuntimeConfigs          bool `default:"true" group:"Beta Features:" help:"Enable support for Deployment Runtime Configs."`
-	EnableUsages                            bool `default:"true" group:"Beta Features:" help:"Enable support for deletion ordering and resource protection with Usages."`
+	EnableUsages                            bool `default:"true" env:"ENABLE_USAGES" group:"Beta Features:" help:"Enable support for deletion ordering and resource protection with Usages."`
 	EnableSSAClaims                         bool `default:"true" group:"Beta Features:" help:"Enable support for using Kubernetes server-side apply to sync claims with composite resources (XRs)."`
 	EnableRealtimeCompositions              bool `default:"true" group:"Beta Features:" help:"Enable support for realtime compositions, i.e. watching composed resources and reconciling compositions immediately when any of the composed resources is updated."`
 	EnableCustomToManagedResourceConversion bool `default:"true" group:"Beta Features:" help:"Enable support CRD to MRD conversion when installing a package."`

--- a/cmd/crossplane/core/core.go
+++ b/cmd/crossplane/core/core.go
@@ -143,7 +143,7 @@ type startCommand struct {
 	PipelineInspectorSocket string        `default:"/var/run/pipeline-inspector/socket" env:"PIPELINE_INSPECTOR_SOCKET" group:"Alpha Features:" help:"Unix socket path for pipeline inspector sidecar. Requires --enable-pipeline-inspector."`
 
 	EnableDeploymentRuntimeConfigs          bool `default:"true" group:"Beta Features:" help:"Enable support for Deployment Runtime Configs."`
-	EnableUsages                            bool `default:"true" env:"ENABLE_USAGES" group:"Beta Features:" help:"Enable support for deletion ordering and resource protection with Usages."`
+	EnableUsages                            bool `default:"true" env:"ENABLE_USAGES"    group:"Beta Features:"                                                                                                                                                    help:"Enable support for deletion ordering and resource protection with Usages."`
 	EnableSSAClaims                         bool `default:"true" group:"Beta Features:" help:"Enable support for using Kubernetes server-side apply to sync claims with composite resources (XRs)."`
 	EnableRealtimeCompositions              bool `default:"true" group:"Beta Features:" help:"Enable support for realtime compositions, i.e. watching composed resources and reconciling compositions immediately when any of the composed resources is updated."`
 	EnableCustomToManagedResourceConversion bool `default:"true" group:"Beta Features:" help:"Enable support CRD to MRD conversion when installing a package."`

--- a/cmd/crossplane/core/init.go
+++ b/cmd/crossplane/core/init.go
@@ -47,6 +47,9 @@ type initCommand struct {
 
 	EnableWebhooks bool `aliases:"webhook-enabled" default:"true" env:"ENABLE_WEBHOOKS,WEBHOOK_ENABLED" help:"Enable webhook configuration."`
 
+	EnableUsages              bool   `default:"true" env:"ENABLE_USAGES"                 group:"Beta Features:" help:"Enable support for deletion ordering and resource protection with Usages. When disabled, the Usage deletion protection webhook configuration is not installed and any existing one is removed."`
+	UsageWebhookFailurePolicy string `default:"Fail" env:"USAGE_WEBHOOK_FAILURE_POLICY" enum:"Fail,Ignore"     help:"The failurePolicy of the Usage deletion protection webhook. Set to Ignore for compatibility with managed Kubernetes operations that reject Fail-policy webhooks with wildcard rules."`
+
 	WebhookServiceName      string `env:"WEBHOOK_SERVICE_NAME"      help:"The name of the Service object that the webhook service will be run."`
 	WebhookServiceNamespace string `env:"WEBHOOK_SERVICE_NAMESPACE" help:"The namespace of the Service object that the webhook service will be run."`
 	WebhookServicePort      int32  `env:"WEBHOOK_SERVICE_PORT"      help:"The port of the Service that the webhook service will be run."`
@@ -91,6 +94,24 @@ func (c *initCommand) Run(s *runtime.Scheme, log logging.Logger) error {
 			),
 		)
 
+		const (
+			usageWebhookConfigName = "crossplane-no-usages"
+			usageWebhookName       = "nousages.protection.crossplane.io"
+		)
+
+		var whOpts []initializer.WebhookConfigurationsOption
+		if c.EnableUsages {
+			whOpts = append(whOpts,
+				initializer.WithFailurePolicyOverride(usageWebhookConfigName, admv1.FailurePolicyType(c.UsageWebhookFailurePolicy)))
+		} else {
+			// Usages are disabled: don't install the Usage deletion protection
+			// webhook, and remove one left over from a previous install.
+			whOpts = append(whOpts,
+				initializer.WithSkippedConfigurations(usageWebhookConfigName))
+			steps = append(steps,
+				initializer.NewValidatingWebhookRemover(usageWebhookConfigName, usageWebhookName))
+		}
+
 		nn := types.NamespacedName{
 			Name:      c.TLSServerSecretName,
 			Namespace: c.Namespace,
@@ -102,7 +123,7 @@ func (c *initCommand) Run(s *runtime.Scheme, log logging.Logger) error {
 		}
 		steps = append(steps,
 			initializer.NewCoreCRDs(c.CRDsPath, s, initializer.WithWebhookTLSSecretRef(nn)),
-			initializer.NewWebhookConfigurations(c.WebhookConfigurationsPath, s, nn, svc))
+			initializer.NewWebhookConfigurations(c.WebhookConfigurationsPath, s, nn, svc, whOpts...))
 	} else {
 		log.Info("Warning: Webhooks are disabled, so deprecated ValidatingWebhookConfigurations will not be automatically deleted.")
 		steps = append(steps,

--- a/cmd/crossplane/core/init.go
+++ b/cmd/crossplane/core/init.go
@@ -47,8 +47,8 @@ type initCommand struct {
 
 	EnableWebhooks bool `aliases:"webhook-enabled" default:"true" env:"ENABLE_WEBHOOKS,WEBHOOK_ENABLED" help:"Enable webhook configuration."`
 
-	EnableUsages              bool   `default:"true" env:"ENABLE_USAGES"                 group:"Beta Features:" help:"Enable support for deletion ordering and resource protection with Usages. When disabled, the Usage deletion protection webhook configuration is not installed and any existing one is removed."`
-	UsageWebhookFailurePolicy string `default:"Fail" env:"USAGE_WEBHOOK_FAILURE_POLICY" enum:"Fail,Ignore"     help:"The failurePolicy of the Usage deletion protection webhook. Set to Ignore for compatibility with managed Kubernetes operations that reject Fail-policy webhooks with wildcard rules."`
+	EnableUsages              bool   `default:"true" env:"ENABLE_USAGES" group:"Beta Features:"             help:"Enable support for deletion ordering and resource protection with Usages. When disabled, the Usage deletion protection webhook configuration is not installed and any existing one is removed."`
+	UsageWebhookFailurePolicy string `default:"Fail" enum:"Fail,Ignore"  env:"USAGE_WEBHOOK_FAILURE_POLICY" help:"The failurePolicy of the Usage deletion protection webhook. Set to Ignore for compatibility with managed Kubernetes operations that reject Fail-policy webhooks with wildcard rules."`
 
 	WebhookServiceName      string `env:"WEBHOOK_SERVICE_NAME"      help:"The name of the Service object that the webhook service will be run."`
 	WebhookServiceNamespace string `env:"WEBHOOK_SERVICE_NAMESPACE" help:"The namespace of the Service object that the webhook service will be run."`

--- a/internal/initializer/webhook_configurations.go
+++ b/internal/initializer/webhook_configurations.go
@@ -45,6 +45,31 @@ func WithWebhookConfigurationsFs(fs afero.Fs) WebhookConfigurationsOption {
 	}
 }
 
+// WithSkippedConfigurations is used to skip applying the webhook
+// configurations with the supplied metadata names.
+func WithSkippedConfigurations(names ...string) WebhookConfigurationsOption {
+	return func(c *WebhookConfigurations) {
+		if c.skip == nil {
+			c.skip = make(map[string]bool, len(names))
+		}
+		for _, n := range names {
+			c.skip[n] = true
+		}
+	}
+}
+
+// WithFailurePolicyOverride is used to override the failurePolicy of every
+// webhook of the ValidatingWebhookConfiguration with the supplied metadata
+// name at apply time.
+func WithFailurePolicyOverride(configName string, p admv1.FailurePolicyType) WebhookConfigurationsOption {
+	return func(c *WebhookConfigurations) {
+		if c.failurePolicyOverrides == nil {
+			c.failurePolicyOverrides = make(map[string]admv1.FailurePolicyType, 1)
+		}
+		c.failurePolicyOverrides[configName] = p
+	}
+}
+
 // WebhookConfigurationsOption configures WebhookConfigurations step.
 type WebhookConfigurationsOption func(*WebhookConfigurations)
 
@@ -72,7 +97,9 @@ type WebhookConfigurations struct {
 	TLSSecretRef     types.NamespacedName
 	ServiceReference admv1.ServiceReference
 
-	fs afero.Fs
+	fs                     afero.Fs
+	skip                   map[string]bool
+	failurePolicyOverrides map[string]admv1.FailurePolicyType
 }
 
 // Run applies all webhook ValidatingWebhookConfigurations and
@@ -113,6 +140,10 @@ func (c *WebhookConfigurations) Run(ctx context.Context, kube client.Client) err
 	pa := resource.NewAPIPatchingApplicator(kube)
 
 	for _, obj := range pkg.GetObjects() {
+		if mo, ok := obj.(client.Object); ok && c.skip[mo.GetName()] {
+			continue
+		}
+
 		switch conf := obj.(type) {
 		case *admv1.ValidatingWebhookConfiguration:
 			for i := range conf.Webhooks {
@@ -120,6 +151,13 @@ func (c *WebhookConfigurations) Run(ctx context.Context, kube client.Client) err
 				conf.Webhooks[i].ClientConfig.Service.Name = c.ServiceReference.Name
 				conf.Webhooks[i].ClientConfig.Service.Namespace = c.ServiceReference.Namespace
 				conf.Webhooks[i].ClientConfig.Service.Port = c.ServiceReference.Port
+
+				// Note that the applicator uses a JSON merge patch of the full
+				// desired object, so an override set here (or reverted to the
+				// value in the packaged YAML) always takes effect on re-apply.
+				if p, ok := c.failurePolicyOverrides[conf.GetName()]; ok {
+					conf.Webhooks[i].FailurePolicy = &p
+				}
 			}
 		case *admv1.MutatingWebhookConfiguration:
 			for i := range conf.Webhooks {

--- a/internal/initializer/webhook_configurations_test.go
+++ b/internal/initializer/webhook_configurations_test.go
@@ -56,6 +56,12 @@ func TestWebhookConfigurations(t *testing.T) {
 	f, _ = fsWithMixedTypes.Create("/webhooks/manifests.yaml")
 	_, _ = f.WriteString(webhookCRD)
 
+	fsWithUsage := afero.NewMemMapFs()
+	f, _ = fsWithUsage.Create("/webhooks/manifests.yaml")
+	_, _ = f.WriteString(webhookConfigs)
+	f, _ = fsWithUsage.Create("/webhooks/usage.yaml")
+	_, _ = f.WriteString(usageWebhookConfig)
+
 	secret := &corev1.Secret{
 		Data: map[string][]byte{"tls.crt": []byte("CABUNDLE")},
 	}
@@ -162,6 +168,69 @@ func TestWebhookConfigurations(t *testing.T) {
 				err: errors.Wrap(errors.Wrap(errBoom, "cannot get object"), errApplyWebhookConfiguration),
 			},
 		},
+		"SuccessFailurePolicyOverride": {
+			reason: "The failurePolicy of the webhooks of only the targeted configuration should be overridden",
+			args: args{
+				opts: []WebhookConfigurationsOption{
+					WithWebhookConfigurationsFs(fsWithUsage),
+					WithFailurePolicyOverride("crossplane-no-usages", admv1.Ignore),
+				},
+				svc: svc,
+				kube: &test.MockClient{
+					MockGet: func(_ context.Context, _ client.ObjectKey, obj client.Object) error {
+						if s, ok := obj.(*corev1.Secret); ok {
+							secret.DeepCopyInto(s)
+							return nil
+						}
+						return kerrors.NewNotFound(schema.GroupResource{}, "")
+					},
+					MockCreate: func(_ context.Context, obj client.Object, _ ...client.CreateOption) error {
+						c, ok := obj.(*admv1.ValidatingWebhookConfiguration)
+						if !ok {
+							return nil
+						}
+						want := admv1.Fail
+						if c.GetName() == "crossplane-no-usages" {
+							want = admv1.Ignore
+						}
+						for _, w := range c.Webhooks {
+							if w.FailurePolicy == nil || *w.FailurePolicy != want {
+								t.Errorf("unexpected failurePolicy for %q: want %q", c.GetName(), want)
+							}
+							if !bytes.Equal(w.ClientConfig.CABundle, []byte("CABUNDLE")) {
+								t.Errorf("unexpected certificate bundle content: %s", string(w.ClientConfig.CABundle))
+							}
+						}
+						return nil
+					},
+				},
+			},
+		},
+		"SuccessSkippedConfiguration": {
+			reason: "A skipped configuration should not be applied while others still are",
+			args: args{
+				opts: []WebhookConfigurationsOption{
+					WithWebhookConfigurationsFs(fsWithUsage),
+					WithSkippedConfigurations("crossplane-no-usages"),
+				},
+				svc: svc,
+				kube: &test.MockClient{
+					MockGet: func(_ context.Context, _ client.ObjectKey, obj client.Object) error {
+						if s, ok := obj.(*corev1.Secret); ok {
+							secret.DeepCopyInto(s)
+							return nil
+						}
+						return kerrors.NewNotFound(schema.GroupResource{}, "")
+					},
+					MockCreate: func(_ context.Context, obj client.Object, _ ...client.CreateOption) error {
+						if obj.GetName() == "crossplane-no-usages" {
+							t.Error("crossplane-no-usages should have been skipped")
+						}
+						return nil
+					},
+				},
+			},
+		},
 		"NonWebhookType": {
 			reason: "Only webhook configuration types can be processed",
 			args: args{
@@ -256,6 +325,36 @@ webhooks:
     resources:
     - compositeresourcedefinitions
   sideEffects: None
+`
+
+	usageWebhookConfig = `
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: crossplane-no-usages
+webhooks:
+  - admissionReviewVersions:
+      - v1
+    clientConfig:
+      service:
+        name: webhook-service
+        namespace: system
+        path: /validate-no-usages
+    failurePolicy: Fail
+    name: nousages.protection.crossplane.io
+    objectSelector:
+      matchLabels:
+        crossplane.io/in-use: "true"
+    rules:
+      - apiGroups:
+          - '*'
+        apiVersions:
+          - '*'
+        operations:
+          - DELETE
+        resources:
+          - '*'
+    sideEffects: None
 `
 )
 
@@ -352,6 +451,26 @@ func TestRemoveValidatingWebhooks(t *testing.T) {
 			},
 			want: want{
 				err: cmpopts.AnyError,
+			},
+		},
+		"SuccessDeleteWholeConfig": {
+			reason: "We should delete the whole config when removing its last webhook.",
+			params: params{
+				configName:   "some-config",
+				webhookNames: []string{"delete-me"},
+			},
+			args: args{
+				kube: &test.MockClient{
+					MockGet: func(_ context.Context, _ client.ObjectKey, obj client.Object) error {
+						obj.(*admv1.ValidatingWebhookConfiguration).Webhooks = []admv1.ValidatingWebhook{
+							{Name: "delete-me"},
+						}
+						return nil
+					},
+					MockDelete: func(_ context.Context, _ client.Object, _ ...client.DeleteOption) error {
+						return nil
+					},
+				},
 			},
 		},
 		"Success": {

--- a/test/e2e/protection_usage_webhook_test.go
+++ b/test/e2e/protection_usage_webhook_test.go
@@ -1,0 +1,131 @@
+/*
+Copyright 2026 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"testing"
+	"time"
+
+	admv1 "k8s.io/api/admissionregistration/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/e2e-framework/pkg/features"
+	"sigs.k8s.io/e2e-framework/third_party/helm"
+
+	xpv2 "github.com/crossplane/crossplane/apis/v2/core/v2"
+	"github.com/crossplane/crossplane/v2/test/e2e/config"
+	"github.com/crossplane/crossplane/v2/test/e2e/funcs"
+)
+
+// SuiteUsageWebhookIgnoreFailurePolicy is the test suite for the configurable
+// failurePolicy of the Usage deletion protection webhook, which requires
+// installing the chart with webhooks.usage.failurePolicy=Ignore. Some managed
+// Kubernetes operations (e.g. Azure AKS cluster stop) reject Fail-policy
+// webhooks with wildcard rules, so users need to be able to relax the policy
+// without disabling the Usages feature.
+const SuiteUsageWebhookIgnoreFailurePolicy = "usage-webhook-ignore-failure-policy"
+
+func init() {
+	environment.AddTestSuite(SuiteUsageWebhookIgnoreFailurePolicy,
+		config.WithHelmInstallOpts(
+			helm.WithArgs("--set webhooks.usage.failurePolicy=Ignore"),
+		),
+		config.WithLabelsToSelect(features.Labels{
+			config.LabelTestSuite: []string{SuiteUsageWebhookIgnoreFailurePolicy},
+		}),
+	)
+}
+
+func TestUsageWebhookIgnoreFailurePolicy(t *testing.T) {
+	manifests := "test/e2e/manifests/protection/usage/standalone-cluster"
+
+	environment.Test(t,
+		features.NewWithDescription(t.Name(),
+			"Tests that the failurePolicy of the Usage deletion protection webhook is configurable via Helm, and that deletion protection still works with failurePolicy Ignore while the webhook is available.").
+			WithLabel(LabelStage, LabelStageBeta).
+			WithLabel(LabelArea, LabelAreaProtection).
+			WithLabel(LabelSize, LabelSizeSmall).
+			WithLabel(config.LabelTestSuite, SuiteUsageWebhookIgnoreFailurePolicy).
+
+			// The init container should have installed the webhook configuration
+			// with the failurePolicy set via webhooks.usage.failurePolicy.
+			Assess("WebhookHasIgnoreFailurePolicy",
+				funcs.ResourceHasFieldValueWithin(1*time.Minute,
+					&admv1.ValidatingWebhookConfiguration{ObjectMeta: metav1.ObjectMeta{Name: "crossplane-no-usages"}},
+					"webhooks[0].failurePolicy", "Ignore"),
+			).
+
+			// While the webhook is available the failurePolicy is irrelevant, so
+			// deletion protection should still work.
+			Assess("DeletionStillBlockedByUsage", funcs.AllOf(
+				funcs.ApplyResources(FieldManager, manifests, "with-reason/*.yaml"),
+				funcs.ResourcesCreatedWithin(30*time.Second, manifests, "with-reason/*.yaml"),
+				funcs.ResourcesHaveConditionWithin(1*time.Minute, manifests, "with-reason/usage.yaml", xpv2.Available()),
+				funcs.DeletionBlockedByUsageWebhook(manifests, "with-reason/used.yaml"),
+			)).
+			WithTeardown("DeleteResources", funcs.AllOf(
+				funcs.DeleteResources(manifests, "with-reason/usage.yaml"),
+				funcs.ResourcesDeletedWithin(30*time.Second, manifests, "with-reason/usage.yaml"),
+				funcs.DeleteResources(manifests, "with-reason/used.yaml"),
+				funcs.ResourcesDeletedWithin(30*time.Second, manifests, "with-reason/used.yaml"),
+			)).
+			Feature(),
+	)
+}
+
+func TestUsageWebhookGatedByUsagesFeature(t *testing.T) {
+	usageWebhookConfig := func() *admv1.ValidatingWebhookConfiguration {
+		return &admv1.ValidatingWebhookConfiguration{ObjectMeta: metav1.ObjectMeta{Name: "crossplane-no-usages"}}
+	}
+
+	environment.Test(t,
+		features.NewWithDescription(t.Name(),
+			"Tests that the Usage deletion protection webhook configuration is removed by the init container when the Usages feature is disabled, and reinstalled with the configured failurePolicy when it is re-enabled.").
+			WithLabel(LabelStage, LabelStageBeta).
+			WithLabel(LabelArea, LabelAreaProtection).
+			WithLabel(LabelSize, LabelSizeSmall).
+			WithLabel(LabelModifyCrossplaneInstallation, LabelModifyCrossplaneInstallationTrue).
+			WithLabel(config.LabelTestSuite, SuiteUsageWebhookIgnoreFailurePolicy).
+
+			// The webhook configuration exists because the suite installs with
+			// Usages enabled (the default).
+			WithSetup("WebhookConfigurationExists",
+				funcs.ResourceCreatedWithin(1*time.Minute, usageWebhookConfig()),
+			).
+			Assess("DisableUsages", funcs.AllOf(
+				funcs.AsFeaturesFunc(environment.HelmUpgradeCrossplaneToSuite(SuiteUsageWebhookIgnoreFailurePolicy,
+					helm.WithArgs("--set usages.enabled=false"))),
+				funcs.ReadyToTestWithin(1*time.Minute, namespace),
+				funcs.DeploymentBecomesAvailableWithin(2*time.Minute, namespace, "crossplane"),
+			)).
+
+			// The init container should have removed the pre-existing webhook
+			// configuration, so nothing blocks DELETEs while the feature is off.
+			Assess("WebhookConfigurationRemoved",
+				funcs.ResourceDeletedWithin(2*time.Minute, usageWebhookConfig()),
+			).
+			WithTeardown("EnableUsages", funcs.AllOf(
+				funcs.AsFeaturesFunc(environment.HelmUpgradeCrossplaneToBase()),
+				funcs.ReadyToTestWithin(1*time.Minute, namespace),
+				funcs.DeploymentBecomesAvailableWithin(2*time.Minute, namespace, "crossplane"),
+				// The webhook configuration should be reinstalled with the
+				// failurePolicy configured for this suite, not the packaged
+				// default.
+				funcs.ResourceHasFieldValueWithin(2*time.Minute, usageWebhookConfig(), "webhooks[0].failurePolicy", "Ignore"),
+			)).
+			Feature(),
+	)
+}


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane! Please read the contribution docs
(linked below) if this is your first Crossplane pull request.
-->

### Description of your changes

Azure's AKS stop/start preflight rejects `ValidatingWebhookConfigurations` with failurePolicy `Fail` and wildcard rules, which the crossplane-no-usages webhook has, so `az aks stop` fails on clusters running Crossplane. Manual
edits don't stick because the init container re-applies the packaged YAML on every pod start.

Add two Helm values, wired through init container env vars to new init flags, so they survive re-apply:

- `webhooks.usage.failurePolicy` (Fail|Ignore) sets the webhooks failurePolicy at apply time.
- `usages.enabled`, when false, skips installing the webhook configuration and removes an existing one.
Defaults are unchanged.

reference: https://learn.microsoft.com/en-us/azure/aks/start-stop-cluster?tabs=azure-cli#stop-an-aks-cluster


<!--
Briefly describe what this pull request does, and how it is covered by tests.
Be proactive - direct your reviewers' attention to anything that needs special
consideration.

We love pull requests that fix an open issue. If yours does, use the below line
to indicate which issue it fixes, for example "Fixes #500".
-->

Fixes #

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `./nix.sh flake check` to ensure this PR is ready for review.
- [x] Added or updated unit tests.
- [x] Added or updated e2e tests.
- [x] Linked a PR or a [docs tracking issue] to [document this change].
- [x] Added `backport release-x.y` labels to auto-backport this PR.
- [x] Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md
