### PR TITLE
docs: add AI contribution policy

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -19,6 +19,7 @@ Fixes #
 I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->
 
 - [ ] Read and followed Crossplane's [contribution process].
+- [ ] Read and followed Crossplane's [AI policy] and confirmed a human stands behind this PR.
 - [ ] Run `./nix.sh flake check` to ensure this PR is ready for review.
 - [ ] Added or updated unit tests.
 - [ ] Added or updated e2e tests.
@@ -29,6 +30,7 @@ I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->
 Need help with this checklist? See the [cheat sheet].
 
 [contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
+[AI policy]: https://github.com/crossplane/crossplane/blob/main/AI_POLICY.md
 [docs tracking issue]: https://github.com/crossplane/docs/issues/new
 [document this change]: https://docs.crossplane.io/contribute/contribute
 [cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet

--- a/AI_POLICY.md
+++ b/AI_POLICY.md
@@ -9,8 +9,11 @@ organizations, just like the project [governance](GOVERNANCE.md).
 ## AI usage is assumed
 
 The Crossplane team makes use of AI coding tools every day and we expect that almost all
-contributors will be doing the same. Therefore, we do not mandate any disclosure for the usage of AI
+contributors will be doing the same. Therefore, we do not require any disclosure for the usage of AI
 in any contributions.
+
+We discourage including attribution for your agent in your commits, e.g., a `Co-authored-by`
+trailer, as it pollutes contributor statistics.
 
 It is more important that we have high quality contributions and engagement with contributors, so
 this policy focuses on achieving that goal.
@@ -22,9 +25,9 @@ to produce it.
 
 - **Understand every line you are changing:** If you cannot explain the purpose and impact of every
   change without the assistance of an agent, it's not ready for submission.
-- **Think critically:** Review and test your entire change deeply, both when opening a new PR and
-  updating an existing one in response to feedback. The maintainer team should not be the first
-  human to start critiquing or verifying your changes.
+- **Think and verify critically:** Review and test your entire change deeply, both when opening a
+  new PR and updating an existing one in response to feedback. The maintainer team should not be the
+  first human to start critiquing or verifying your changes.
 - **Use the templates:** PRs and issues have templates, so use them and provide the information they
   are requesting. An incoming PR that doesn't even contain the template's checklist is a clear sign
   your agent opened the PR for you and you didn't take much care during the PR creation process.
@@ -43,16 +46,22 @@ We want to engage with human contributors, we do not want to feel like we are ju
 agent. We have our own agents that we can talk to and we can do that much faster than going through
 you. We'd much rather connect directly and intellectually with the human behind the submission.
 
-So please share your own reasoning behind your changes, e.g. why you framed the problem this way,
+So please share your own reasoning behind your changes, e.g., why you framed the problem this way,
 what you tried, what you are unsure about, or details about your use case that necessitates this
 change.
 
 ### Use the right level of detail
 
-Your comments should not make it **harder** to understand you. AI tools love to generate enormous
+Your writing should not make it **harder** to understand you. AI tools love to generate enormous
 walls of text that prematurely go into an exorbitant level of detail, which is challenging for the
 maintainer team to read and fully understand. These details often obscure the core problem and make
 it more challenging to align on the right path forward together.
+
+Code comments should help a future reader understand the reasoning behind implementation choices
+that may be subtle or difficult to see just from reading the code itself. Agents tend to write for
+the reviewer instead, narrating the alternatives they rejected or explaining why their change is
+correct. That context may be helpful while we review but becomes clutter once the change is merged,
+so it belongs in your pull request description instead of the codebase.
 
 ### Write naturally
 

--- a/AI_POLICY.md
+++ b/AI_POLICY.md
@@ -1,0 +1,111 @@
+# Crossplane AI Contribution Policy
+
+This policy defines how the Crossplane team expects contributors to engage with the project while
+using AI tools like agents and LLMs.
+
+This policy applies to all repositories in the `crossplane` and `crossplane-contrib` GitHub
+organizations, just like the project [governance](GOVERNANCE.md).
+
+## AI usage is assumed
+
+The Crossplane team makes use of AI coding tools every day and we expect that almost all
+contributors will be doing the same. Therefore, we do not mandate any disclosure for the usage of AI
+in any contributions.
+
+It is more important that we have high quality contributions and engagement with contributors, so
+this policy focuses on achieving that goal.
+
+## Own and understand your contribution
+
+Contributors are responsible for the entirety of their submission, no matter what tooling they used
+to produce it.
+
+- **Understand every line you are changing:** If you cannot explain the purpose and impact of every
+  change without the assistance of an agent, it's not ready for submission.
+- **Think critically:** Review and test your entire change deeply, both when opening a new PR and
+  updating an existing one in response to feedback. The maintainer team should not be the first
+  human to start critiquing or verifying your changes.
+- **Use the templates:** PRs and issues have templates, so use them and provide the information they
+  are requesting. An incoming PR that doesn't even contain the template's checklist is a clear sign
+  your agent opened the PR for you and you didn't take much care during the PR creation process.
+- **Don't blame your agent:** "My agent did/wrote that" is not a sufficient answer to review
+  comments, it's critical to understand your changes more deeply than that.
+
+AI tools are very capable of producing plausible looking changes for problems they don't deeply
+understand. It's your job as a contributor to own, understand, and verify your changes to a high
+degree of confidence.
+
+## Talk to us yourself
+
+### Express your reasoning naturally
+
+We want to engage with human contributors, we do not want to feel like we are just talking to your
+agent. We have our own agents that we can talk to and we can do that much faster than going through
+you. We'd much rather connect directly and intellectually with the human behind the submission.
+
+So please share your own reasoning behind your changes, e.g. why you framed the problem this way,
+what you tried, what you are unsure about, or details about your use case that necessitates this
+change.
+
+### Use the right level of detail
+
+Your comments should not make it **harder** to understand you. AI tools love to generate enormous
+walls of text that prematurely go into an exorbitant level of detail, which is challenging for the
+maintainer team to read and fully understand. These details often obscure the core problem and make
+it more challenging to align on the right path forward together.
+
+### Write naturally
+
+We highly encourage you to write your own issues, pull request descriptions, and comment replies.
+It's fine to use tools to help you get the words right, especially if English is not your first
+language, but the thinking has to be yours, and it should read like it. Blindly pasting clearly
+generated text while engaging with a maintainer is not the type of interaction we're looking for.
+
+### Review with your own judgment
+
+Reviewing pull requests is one of the best ways to learn this codebase, and it's a path toward
+becoming a maintainer, so we appreciate more people doing it. But that depends on you being the one
+doing the reviewing.
+
+Don't point an agent at someone else's pull request and just post what it produces. We already have
+automated AI reviewing tools set up and don't need your agents fabricating additional engagement.
+
+Using AI to help you understand a change you're reviewing is fine, but please make sure the review
+you post is your own.
+
+## Maintainer time is limited
+
+Time and energy from the human maintainers on this project are a limited resource. AI has made
+writing code and opening a pull request a very cheap operation, which can easily overwhelm the team
+responsible for reviewing and supporting those changes.
+
+- **Bias towards discussion first:** For anything beyond a clearly scoped fix, we encourage you to
+  open an issue and drive alignment on the direction before implementing the required changes. This
+  is not a hard requirement, but it is an effective way to avoid spending cycles on a change that we
+  won't accept.
+- **Keep changes small and focused:** This reduces the effort of reviewing the change and ensuring
+  its quality and makes it more likely to be accepted.
+- **Avoid flooding us with changes:** If you already have pull requests open that have not been
+  merged, avoid opening more pull requests that continue to grow the review backlog. This is most
+  important when you are a new contributor and we haven't yet built a trusting relationship.
+
+## Enforcement
+
+The maintainer team may close pull requests and issues that do not meet the spirit of the guidelines
+in this policy. We may even do so without first writing a detailed explanation or providing a
+technical critique. We will most likely not debate whether a contribution violated this policy.
+
+Contributors who continue to violate this policy will be blocked from further engagement in the
+project. Closing submissions is not the only tool we have, and we will use the others when we need
+to.
+
+This policy is not aimed at contributors who want to learn the project and authentically engage with
+the team. That's exactly the experience we are seeking to have. If you are new and trying to
+understand something, then we are happy to help and collaborate in meaningful ways with other
+humans.
+
+## Legal
+
+Crossplane is a CNCF project, which is part of the Linux Foundation. Therefore, the LF's [Generative
+AI policy](https://www.linuxfoundation.org/legal/generative-ai) applies to every contribution and
+must be adhered to.

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -30,6 +30,7 @@
 /CHARTER.md                          @crossplane/steering-committee
 /CODE_OF_CONDUCT.md                  @crossplane/steering-committee
 /GOVERNANCE.md                       @crossplane/steering-committee
+/AI_POLICY.md                        @crossplane/steering-committee
 /ROADMAP.md                          @crossplane/steering-committee
 /LICENSE                             @crossplane/steering-committee
 

--- a/contributing/README.md
+++ b/contributing/README.md
@@ -161,6 +161,8 @@ Wondering whether something on the pull request checklist applies to your PR?
 Generally:
 
 * Everyone must read and follow this contribution process.
+* Everyone must read and follow our [AI policy]. We want authentic collaboration
+  with other humans.
 * Every PR must run (and pass) `./nix.sh flake check`.
 * Most PRs that touch code should touch unit tests. We want ~80% coverage.
 * Any significant feature should be covered by E2E tests. If you're adding a new
@@ -252,6 +254,15 @@ Thank you for reading through our contributing guide! We appreciate you taking
 the time to ensure your contributions are high quality and easy for our
 community to review and accept. Please don't hesitate to [reach out to
 us][Slack] if you have any questions about contributing!
+
+## Using AI Tools
+
+We support contributors using AI tools to assist their contributions to the
+project. However, we highly value genuine engagement with other humans and we
+want collaboration with contributors to feel that way.
+
+Please review our [AI policy] before contributing to the Crossplane project and
+ensure that you adhere to all of its guidelines.
 
 ## Certificate of Origin
 
@@ -967,6 +978,7 @@ func TestExample(t *testing.T) {
 
 [Slack]: https://slack.crossplane.io/
 [code of conduct]: https://github.com/cncf/foundation/blob/main/code-of-conduct.md
+[AI policy]: ../AI_POLICY.md
 [Nix]: ../design/one-pager-build-with-nix.md
 [install-nix]: https://nixos.org/download/
 [enable-flakes]: https://wiki.nixos.org/wiki/Flakes#Nix_standalone


### PR DESCRIPTION
### Description of your changes

This PR adds a policy document for usage of AI in the Crossplane project. This policy applies to every repository in the crossplane and crossplane-contrib organizations.

The key themes of this policy:

* AI usage is assumed and does not need to be disclosed.
* Contributors own and understand their entire submissions.
* We want to engage and collaborate with other humans, not with your agent.
* Maintainer time is the project's scarcest resource, use AI tools in a way that best uses that time.
* Maintainers may close submissions that don't meet the policy, and block contributors who continue to violate it.

Fixes #6858 

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `./nix.sh flake check` to ensure this PR is ready for review.
- [ ] ~Added or updated unit tests.~
- [ ] ~Added or updated e2e tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~
- [ ] ~Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md
