### PR TITLE
fix: do not panic when ImageConfig pull secret fields are missing

### DIFF
--- a/internal/controller/pkg/runtime/reconciler.go
+++ b/internal/controller/pkg/runtime/reconciler.go
@@ -59,7 +59,8 @@ const (
 	errGetPackageRevision = "cannot get package revision"
 	errUpdateStatus       = "cannot update package revision status"
 
-	errGetPullConfig = "cannot get image pull secret from config"
+	errGetPullConfig     = "cannot get image pull secret from config"
+	errMissingPullSecret = "image config referenced for pull secret has no registry authentication"
 
 	errManifestBuilderOptions = "cannot prepare runtime manifest builder options"
 	errPreHook                = "pre establish runtime hook failed for package"
@@ -313,7 +314,16 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 				return reconcile.Result{}, err
 			}
 
-			pullSecretFromConfig = ic.Spec.Registry.Authentication.PullSecretRef.Name
+			pullSecretFromConfig = imageConfigPullSecret(ic)
+			if pullSecretFromConfig == "" {
+				err := errors.New(errMissingPullSecret)
+				status.MarkConditions(v1.RuntimeUnhealthy().WithMessage(err.Error()))
+
+				_ = r.client.Status().Update(ctx, pr)
+				r.record.Event(pr, event.Warning(reasonImageConfig, err))
+
+				return reconcile.Result{}, err
+			}
 
 			break
 		}
@@ -437,6 +447,14 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 	}
 
 	return reconcile.Result{Requeue: false}, errors.Wrap(r.client.Status().Update(ctx, pr), errUpdateStatus)
+}
+
+func imageConfigPullSecret(ic *v1beta1.ImageConfig) string {
+	if ic.Spec.Registry == nil || ic.Spec.Registry.Authentication == nil {
+		return ""
+	}
+
+	return ic.Spec.Registry.Authentication.PullSecretRef.Name
 }
 
 // ownedMRDs returns the ManagedResourceDefinitions controlled by pr.

--- a/internal/controller/pkg/runtime/reconciler_test.go
+++ b/internal/controller/pkg/runtime/reconciler_test.go
@@ -853,6 +853,129 @@ func TestReconcile(t *testing.T) {
 				r: reconcile.Result{Requeue: false},
 			},
 		},
+		"ImageConfigMissingRegistry": {
+			reason: "A SetImagePullSecret ImageConfig with a nil Registry must not panic.",
+			args: args{
+				mgr: &fake.Manager{
+					Client: &test.MockClient{
+						MockGet: test.NewMockGetFn(nil, func(o client.Object) error {
+							switch obj := o.(type) {
+							case *v1.ProviderRevision:
+								obj.SetGroupVersionKind(v1.ProviderRevisionGroupVersionKind)
+								obj.SetDesiredState(v1.PackageRevisionActive)
+								obj.SetLabels(map[string]string{v1.LabelParentPackage: "test-provider"})
+								obj.SetConditions(v1.RevisionHealthy())
+								obj.SetAppliedImageConfigRefs(v1.ImageConfigRef{
+									Name:   "test-image-config",
+									Reason: v1.ImageConfigReasonSetPullSecret,
+								})
+								return nil
+							case *corev1.ServiceAccount:
+								obj.Name = crossplaneName
+								obj.Namespace = testNamespace
+								return nil
+							case *v1beta1.ImageConfig:
+								obj.SetGroupVersionKind(v1beta1.ImageConfigGroupVersionKind)
+								obj.SetName("test-image-config")
+								return nil
+							}
+							return nil
+						}),
+						MockStatusUpdate: test.NewMockSubResourceUpdateFn(nil, func(o client.Object) error {
+							want := &v1.ProviderRevision{}
+							want.SetGroupVersionKind(v1.ProviderRevisionGroupVersionKind)
+							want.SetDesiredState(v1.PackageRevisionActive)
+							want.SetLabels(map[string]string{v1.LabelParentPackage: "test-provider"})
+							want.SetConditions(v1.RevisionHealthy())
+							want.SetAppliedImageConfigRefs(v1.ImageConfigRef{
+								Name:   "test-image-config",
+								Reason: v1.ImageConfigReasonSetPullSecret,
+							})
+							want.SetConditions(v1.RuntimeUnhealthy().WithMessage(errMissingPullSecret))
+
+							if diff := cmp.Diff(want, o); diff != "" {
+								t.Errorf("-want, +got:\n%s", diff)
+							}
+							return nil
+						}),
+					},
+				},
+				rec: []ReconcilerOption{
+					WithNewPackageRevisionWithRuntimeFn(func() v1.PackageRevisionWithRuntime { return &v1.ProviderRevision{} }),
+					WithLogger(testLog),
+					WithRecorder(event.NewNopRecorder()),
+					WithNamespace(testNamespace),
+					WithServiceAccount(crossplaneName),
+					WithRuntimeHooks(&MockHooks{}),
+					WithDeploymentSelectorMigrator(NewNopDeploymentSelectorMigrator()),
+				},
+			},
+			want: want{
+				err: errors.New(errMissingPullSecret),
+			},
+		},
+		"ImageConfigMissingAuthentication": {
+			reason: "A SetImagePullSecret ImageConfig with a nil Authentication must not panic.",
+			args: args{
+				mgr: &fake.Manager{
+					Client: &test.MockClient{
+						MockGet: test.NewMockGetFn(nil, func(o client.Object) error {
+							switch obj := o.(type) {
+							case *v1.ProviderRevision:
+								obj.SetGroupVersionKind(v1.ProviderRevisionGroupVersionKind)
+								obj.SetDesiredState(v1.PackageRevisionActive)
+								obj.SetLabels(map[string]string{v1.LabelParentPackage: "test-provider"})
+								obj.SetConditions(v1.RevisionHealthy())
+								obj.SetAppliedImageConfigRefs(v1.ImageConfigRef{
+									Name:   "test-image-config",
+									Reason: v1.ImageConfigReasonSetPullSecret,
+								})
+								return nil
+							case *corev1.ServiceAccount:
+								obj.Name = crossplaneName
+								obj.Namespace = testNamespace
+								return nil
+							case *v1beta1.ImageConfig:
+								obj.SetGroupVersionKind(v1beta1.ImageConfigGroupVersionKind)
+								obj.SetName("test-image-config")
+								obj.Spec.Registry = &v1beta1.RegistryConfig{}
+								return nil
+							}
+							return nil
+						}),
+						MockStatusUpdate: test.NewMockSubResourceUpdateFn(nil, func(o client.Object) error {
+							want := &v1.ProviderRevision{}
+							want.SetGroupVersionKind(v1.ProviderRevisionGroupVersionKind)
+							want.SetDesiredState(v1.PackageRevisionActive)
+							want.SetLabels(map[string]string{v1.LabelParentPackage: "test-provider"})
+							want.SetConditions(v1.RevisionHealthy())
+							want.SetAppliedImageConfigRefs(v1.ImageConfigRef{
+								Name:   "test-image-config",
+								Reason: v1.ImageConfigReasonSetPullSecret,
+							})
+							want.SetConditions(v1.RuntimeUnhealthy().WithMessage(errMissingPullSecret))
+
+							if diff := cmp.Diff(want, o); diff != "" {
+								t.Errorf("-want, +got:\n%s", diff)
+							}
+							return nil
+						}),
+					},
+				},
+				rec: []ReconcilerOption{
+					WithNewPackageRevisionWithRuntimeFn(func() v1.PackageRevisionWithRuntime { return &v1.ProviderRevision{} }),
+					WithLogger(testLog),
+					WithRecorder(event.NewNopRecorder()),
+					WithNamespace(testNamespace),
+					WithServiceAccount(crossplaneName),
+					WithRuntimeHooks(&MockHooks{}),
+					WithDeploymentSelectorMigrator(NewNopDeploymentSelectorMigrator()),
+				},
+			},
+			want: want{
+				err: errors.New(errMissingPullSecret),
+			},
+		},
 		"SuccessfulHealthyRevisionWithImageConfigRuntimeConfig": {
 			reason: "Builder should use DeploymentRuntimeConfig from ImageConfig when configured.",
 			args: args{


### PR DESCRIPTION
### Description of your changes

The package runtime reconciler panics when a package revision still has an applied `ImageConfig` ref with reason `SetImagePullSecret`, but the cluster `ImageConfig` no longer has `spec.registry.authentication.pullSecretRef`.

`spec.registry` and `spec.registry.authentication` are optional. After a successful Get, the reconciler used to read `ic.Spec.Registry.Authentication.PullSecretRef.Name` with no nil checks. Sibling ImageConfig watchers already treat those fields as optional via `hasPullSecret`.

This change reads the pull secret through a nil-safe helper. If the applied ref no longer yields a pull secret, the reconciler marks the revision `RuntimeUnhealthy`, records a warning, and returns the error. That matches the existing Get-failure path for the same ImageConfig.

Unit tests cover a missing `spec.registry` and a missing `spec.registry.authentication`. Both panicked on `main` before the fix.

Fixes #7479

This bug was introduced in [#6498](https://github.com/crossplane/crossplane/pull/6498) (2025-05-29) when the runtime reconciler was split out of the revision controller.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [ ] ~Run `./nix.sh flake check` to ensure this PR is ready for review.~ Local `gofmt`, `go vet`, and `go test ./internal/controller/pkg/runtime` passed. Full flake check is the CI job after workflow approval.
- [x] Added or updated unit tests.
- [ ] ~Added or updated e2e tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~ Please add `backport release-2.4` if this should ship in the current patch release. External contributors cannot add labels.
- [ ] ~Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md
