### PR TITLE
fix: fail closed when a claim cannot list its XRD

### DIFF
--- a/internal/controller/apiextensions/claim/reconciler.go
+++ b/internal/controller/apiextensions/claim/reconciler.go
@@ -58,6 +58,7 @@ const (
 	errDeleteCDs            = "cannot delete connection details"
 	errRemoveFinalizer      = "cannot remove finalizer from claim"
 	errAddFinalizer         = "cannot add finalizer to claim"
+	errListXRD              = "cannot list CompositeResourceDefinitions"
 	errUpgradeManagedFields = "cannot upgrade composite resource's managed fields from client-side to server-side apply"
 	errSync                 = "cannot bind and sync claim with composite resource"
 	errPropagateCDs         = "cannot propagate connection details from composite resource"
@@ -457,11 +458,17 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 	// We use an index to efficiently look up the XRD for this composite GVK.
 	hasEnforcedComposition := false
 	xrdList := &v1.CompositeResourceDefinitionList{}
-	if err := r.client.List(ctx, xrdList, client.MatchingFields{XRDByCompositeGVKIndex(): compositeGVKKeyFor(r.gvkXR)}); err == nil && len(xrdList.Items) > 0 {
-		// There should only be one XRD for a given composite GVK
-		if xrdList.Items[0].Spec.EnforcedCompositionRef != nil {
-			hasEnforcedComposition = true
-		}
+	if err := r.client.List(ctx, xrdList, client.MatchingFields{XRDByCompositeGVKIndex(): compositeGVKKeyFor(r.gvkXR)}); err != nil {
+		err = errors.Wrap(err, errListXRD)
+		record.Event(cm, event.Warning(reasonBind, err))
+		status.MarkConditions(xpv2.ReconcileError(err))
+		_ = r.client.Status().Update(ctx, cm)
+
+		return reconcile.Result{}, err
+	}
+	// There should only be one XRD for a given composite GVK
+	if len(xrdList.Items) > 0 && xrdList.Items[0].Spec.EnforcedCompositionRef != nil {
+		hasEnforcedComposition = true
 	}
 
 	// Create (if necessary), bind, and sync an XR with the claim.

--- a/internal/controller/apiextensions/claim/reconciler_test.go
+++ b/internal/controller/apiextensions/claim/reconciler_test.go
@@ -391,6 +391,31 @@ func TestReconcile(t *testing.T) {
 				err: cmpopts.AnyError,
 			},
 		},
+		"ListXRDError": {
+			reason: "We should fail the reconcile if we cannot list XRDs to determine whether composition is enforced",
+			args: args{
+				client: &test.MockClient{
+					MockGet:  test.NewMockGetFn(nil),
+					MockList: test.NewMockListFn(errBoom),
+					MockStatusUpdate: WantClaim(t, NewClaim(func(cm *claim.Unstructured) {
+						cm.SetConditions(xpv2.ReconcileError(errors.Wrap(errBoom, errListXRD)))
+					})),
+				},
+				opts: []ReconcilerOption{
+					WithClaimFinalizer(resource.FinalizerFns{
+						AddFinalizerFn: func(_ context.Context, _ resource.Object) error { return nil },
+					}),
+					WithCompositeSyncer(CompositeSyncerFn(func(_ context.Context, _ *claim.Unstructured, _ *composite.Unstructured, _ bool) error {
+						t.Error("Sync must not run when listing XRDs fails")
+						return nil
+					})),
+				},
+			},
+			want: want{
+				r:   reconcile.Result{},
+				err: cmpopts.AnyError,
+			},
+		},
 		"SyncCompositeError": {
 			reason: "We should fail the reconcile if we can't bind and sync the claim with a composite resource",
 			args: args{


### PR DESCRIPTION
### Description of your changes

The claim reconciler looks up the XRD for a composite GVK to decide whether `enforcedCompositionRef` is set. A `List` error (missing index or cache error) was treated as "no enforced composition".

`Sync` then ran with `hasEnforcedComposition=false`, so a claim `compositionRef` could be honored even when the XRD forbids selecting a composition.

This change fails closed on `List` errors: wrap the error, record a warning, set `ReconcileError`, and return. A successful empty list is unchanged (no XRD in cache still means no enforcement).

A unit test covers a `List` error. `Sync` must not run, and the claim status must be `ReconcileError`.

This bug was introduced in [#6881](https://github.com/crossplane/crossplane/pull/6881) (2025-10-31).

I have:

- [x] Read and followed Crossplane's [contribution process].
- [ ] ~Run `./nix.sh flake check` to ensure this PR is ready for review.~ Local `gofmt`, `go vet`, and `go test ./internal/controller/apiextensions/claim` passed. Full flake check is the CI job after workflow approval.
- [x] Added or updated unit tests.
- [ ] ~Added or updated e2e tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~ Please add `backport release-2.4` if this should ship in the current patch release. External contributors cannot add labels.
- [ ] ~Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md
