### PR TITLE
Treat an already deleted package revision as garbage collected

### DIFF
--- a/internal/controller/pkg/manager/reconciler.go
+++ b/internal/controller/pkg/manager/reconciler.go
@@ -429,8 +429,10 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 		*p.GetRevisionHistoryLimit() != 0 &&
 		len(revisions) > (int(*p.GetRevisionHistoryLimit())+1) {
 		gcRev := revisions[oldestRevisionIndex]
-		// Find the oldest revision and delete it.
-		if err := r.kube.Delete(ctx, gcRev); err != nil {
+		// Find the oldest revision and delete it. The cache can be behind the
+		// API server, so a revision that is already gone is collected as far
+		// as we are concerned.
+		if err := resource.IgnoreNotFound(r.kube.Delete(ctx, gcRev)); err != nil {
 			err = errors.Wrap(err, errGCPackageRevision)
 			r.record.Event(p, event.Warning(reasonGarbageCollect, err))
 

--- a/internal/controller/pkg/manager/reconciler_test.go
+++ b/internal/controller/pkg/manager/reconciler_test.go
@@ -899,6 +899,98 @@ func TestReconcile(t *testing.T) {
 				err: errors.Wrap(errBoom, errGCPackageRevision),
 			},
 		},
+		"SuccessfulGCRevisionAlreadyDeleted": {
+			reason: "We should treat a revision that is already gone as garbage collected.",
+			args: args{
+				req: reconcile.Request{NamespacedName: types.NamespacedName{Name: "test"}},
+				rec: &Reconciler{
+					newPackage:             func() v1.Package { return &v1.Configuration{} },
+					newPackageRevision:     func() v1.PackageRevision { return &v1.ConfigurationRevision{} },
+					newPackageRevisionList: func() v1.PackageRevisionList { return &v1.ConfigurationRevisionList{} },
+					kube: resource.ClientApplicator{
+						Client: &test.MockClient{
+							MockGet: test.NewMockGetFn(nil, func(o client.Object) error {
+								p := o.(*v1.Configuration)
+								p.SetName("test")
+								p.SetGroupVersionKind(v1.ConfigurationGroupVersionKind)
+								p.SetRevisionHistoryLimit(&revHistory)
+								return nil
+							}),
+							MockList: test.NewMockListFn(nil, func(o client.ObjectList) error {
+								l := o.(*v1.ConfigurationRevisionList)
+								cr := v1.ConfigurationRevision{
+									ObjectMeta: metav1.ObjectMeta{
+										Name: revisionName,
+									},
+								}
+								cr.SetRevision(3)
+								cr.SetGroupVersionKind(v1.ConfigurationRevisionGroupVersionKind)
+								cr.SetConditions(v1.RevisionHealthy())
+								cr.SetDesiredState(v1.PackageRevisionInactive)
+								c := v1.ConfigurationRevisionList{
+									Items: []v1.ConfigurationRevision{
+										cr,
+										{
+											ObjectMeta: metav1.ObjectMeta{
+												Name: "made-the-cut",
+											},
+											Spec: v1.PackageRevisionSpec{
+												Revision:     2,
+												DesiredState: v1.PackageRevisionInactive,
+											},
+										},
+										{
+											ObjectMeta: metav1.ObjectMeta{
+												Name: "missed-the-cut",
+											},
+											Spec: v1.PackageRevisionSpec{
+												Revision:     1,
+												DesiredState: v1.PackageRevisionInactive,
+											},
+										},
+									},
+								}
+								*l = c
+								return nil
+							}),
+							MockStatusUpdate: test.NewMockSubResourceUpdateFn(nil, func(o client.Object) error {
+								want := &v1.Configuration{}
+								want.SetName("test")
+								want.SetGroupVersionKind(v1.ConfigurationGroupVersionKind)
+								want.SetCurrentRevision(revisionName)
+								want.SetRevisionHistoryLimit(&revHistory)
+								want.SetConditions(v1.Healthy())
+								want.SetConditions(v1.Active())
+								want.SetResolvedSource("xpkg.crossplane.io/test:v1.0.0")
+								if diff := cmp.Diff(want, o, test.EquateConditions()); diff != "" {
+									t.Errorf("-want, +got:\n%s", diff)
+								}
+								return nil
+							}),
+							MockDelete: test.NewMockDeleteFn(kerrors.NewNotFound(schema.GroupResource{Group: v1.Group, Resource: "configurationrevisions"}, "missed-the-cut")),
+						},
+						Applicator: resource.ApplyFn(func(_ context.Context, _ client.Object, _ ...resource.ApplyOption) error {
+							return nil
+						}),
+					},
+					pkg: &fake.MockClient{
+						MockGet: fake.NewMockGetFn(&xpkg.Package{
+							Digest:          "sha256:1234567890123456789012345678901234567890123456789012345678901234",
+							Version:         "v1.0.0",
+							Source:          "xpkg.crossplane.io/test",
+							ResolvedVersion: "v1.0.0",
+							ResolvedSource:  "xpkg.crossplane.io/test",
+						}, nil),
+					},
+					log:        testLog,
+					record:     event.NewNopRecorder(),
+					conditions: conditions.ObservedGenerationPropagationManager{},
+				},
+			},
+			want: want{
+				r: reconcile.Result{Requeue: false},
+			},
+		},
 		"PauseReconcile": {
 			reason: "Pause reconciliation if the pause annotation is set",
 			args: args{


### PR DESCRIPTION
### Description of your changes

Fixes #7790.

The package manager lists a package's revisions from the cache and, once the history limit is exceeded, deletes the oldest one. If that revision was already removed, by an earlier reconcile or another actor, while the cache still lists it, the delete returns `NotFound` and the reconcile fails with `cannot garbage collect old package revision`, plus a warning event, for a revision that is already in the state GC wants. The read a few lines above already goes through `resource.IgnoreNotFound`, so this puts the delete on the same footing. Any other delete error still stops the reconcile as before.

While writing the test I noticed something worth flagging: `SuccessfulRevisionExistsNeedGC` never sets a revision history limit on the package it hands the reconciler, so `GetRevisionHistoryLimit()` returns nil and the GC branch is skipped entirely. That case passes whatever the delete does, including returning an error. `ErrGC` is the only case that actually reaches the delete, so the new case is built from that one, with an applicator added since the reconcile now runs to completion instead of stopping at GC. I have left `SuccessfulRevisionExistsNeedGC` alone rather than widen this pull request, but it is not testing what its name says.

The new case fails on main with `cannot garbage collect old package revision: configurationrevisions.pkg.crossplane.io "missed-the-cut" not found`.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Added or updated unit tests.
- [x] Run `go test ./internal/controller/pkg/...`, all passing.

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
