### PR TITLE
fix(manager): ignore NotFound on package revision garbage collection

### DIFF
--- a/internal/controller/pkg/manager/reconciler.go
+++ b/internal/controller/pkg/manager/reconciler.go
@@ -430,7 +430,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 		len(revisions) > (int(*p.GetRevisionHistoryLimit())+1) {
 		gcRev := revisions[oldestRevisionIndex]
 		// Find the oldest revision and delete it.
-		if err := r.kube.Delete(ctx, gcRev); err != nil {
+		if err := resource.IgnoreNotFound(r.kube.Delete(ctx, gcRev)); err != nil {
 			err = errors.Wrap(err, errGCPackageRevision)
 			r.record.Event(p, event.Warning(reasonGarbageCollect, err))
 

--- a/internal/controller/pkg/manager/reconciler_test.go
+++ b/internal/controller/pkg/manager/reconciler_test.go
@@ -813,6 +813,113 @@ func TestReconcile(t *testing.T) {
 				r: reconcile.Result{Requeue: false},
 			},
 		},
+		"SuccessfulRevisionExistsNeedGCNotFound": {
+			reason: "We should successfully garbage collect even if the old revision is not found during delete.",
+			args: args{
+				req: reconcile.Request{NamespacedName: types.NamespacedName{Name: "test"}},
+				rec: &Reconciler{
+					newPackage:             func() v1.Package { return &v1.Configuration{} },
+					newPackageRevision:     func() v1.PackageRevision { return &v1.ConfigurationRevision{} },
+					newPackageRevisionList: func() v1.PackageRevisionList { return &v1.ConfigurationRevisionList{} },
+					kube: resource.ClientApplicator{
+						Client: &test.MockClient{
+							MockGet: test.NewMockGetFn(nil, func(o client.Object) error {
+								p := o.(*v1.Configuration)
+								p.SetName("test")
+								p.SetGroupVersionKind(v1.ConfigurationGroupVersionKind)
+								p.SetRevisionHistoryLimit(&revHistory)
+								return nil
+							}),
+							MockList: test.NewMockListFn(nil, func(o client.ObjectList) error {
+								l := o.(*v1.ConfigurationRevisionList)
+								cr := v1.ConfigurationRevision{
+									ObjectMeta: metav1.ObjectMeta{
+										Name: revisionName,
+									},
+								}
+								cr.SetRevision(3)
+								cr.SetGroupVersionKind(v1.ConfigurationRevisionGroupVersionKind)
+								cr.SetConditions(v1.RevisionHealthy())
+								cr.SetDesiredState(v1.PackageRevisionInactive)
+								c := v1.ConfigurationRevisionList{
+									Items: []v1.ConfigurationRevision{
+										cr,
+										{
+											ObjectMeta: metav1.ObjectMeta{
+												Name: "made-the-cut",
+											},
+											Spec: v1.PackageRevisionSpec{
+												Revision: 2,
+											},
+										},
+										{
+											ObjectMeta: metav1.ObjectMeta{
+												Name: "missed-the-cut",
+											},
+											Spec: v1.PackageRevisionSpec{
+												Revision: 1,
+											},
+										},
+									},
+								}
+								*l = c
+								return nil
+							}),
+							MockStatusUpdate: test.NewMockSubResourceUpdateFn(nil, func(o client.Object) error {
+								want := &v1.Configuration{}
+								want.SetName("test")
+								want.SetGroupVersionKind(v1.ConfigurationGroupVersionKind)
+								want.SetRevisionHistoryLimit(&revHistory)
+								want.SetCurrentRevision(revisionName)
+								want.SetConditions(v1.Healthy())
+								want.SetConditions(v1.Active())
+								want.SetResolvedSource("xpkg.crossplane.io/test:v1.0.0")
+								if diff := cmp.Diff(want, o, test.EquateConditions()); diff != "" {
+									t.Errorf("-want, +got:\n%s", diff)
+								}
+								return nil
+							}),
+							MockDelete: test.NewMockDeleteFn(kerrors.NewNotFound(schema.GroupResource{}, "")),
+						},
+						Applicator: resource.ApplyFn(func(_ context.Context, o client.Object, _ ...resource.ApplyOption) error {
+							want := &v1.ConfigurationRevision{}
+							want.SetLabels(map[string]string{"pkg.crossplane.io/package": "test"})
+							want.SetName(revisionName)
+							want.SetOwnerReferences([]metav1.OwnerReference{{
+								APIVersion:         v1.SchemeGroupVersion.String(),
+								Kind:               v1.ConfigurationKind,
+								Name:               "test",
+								Controller:         &trueVal,
+								BlockOwnerDeletion: &trueVal,
+							}})
+							want.SetGroupVersionKind(v1.ConfigurationRevisionGroupVersionKind)
+							want.SetDesiredState(v1.PackageRevisionActive)
+							want.SetConditions(v1.RevisionHealthy())
+							want.SetRevision(3)
+							if diff := cmp.Diff(want, o, test.EquateConditions()); diff != "" {
+								t.Errorf("-want, +got:\n%s", diff)
+							}
+							return nil
+						}),
+					},
+					pkg: &fake.MockClient{
+						MockGet: fake.NewMockGetFn(&xpkg.Package{
+							Digest:          "sha256:1234567890123456789012345678901234567890123456789012345678901234",
+							Version:         "v1.0.0",
+							Source:          "xpkg.crossplane.io/test",
+							ResolvedVersion: "v1.0.0",
+							ResolvedSource:  "xpkg.crossplane.io/test",
+						}, nil),
+					},
+					log:        testLog,
+					record:     event.NewNopRecorder(),
+					conditions: conditions.ObservedGenerationPropagationManager{},
+				},
+			},
+			want: want{
+				r: reconcile.Result{Requeue: false},
+			},
+		},
 		"ErrGC": {
 			reason: "Failure to garbage collect old package revision should cause return an error.",
 			args: args{


### PR DESCRIPTION
### Description of your changes

In `internal/controller/pkg/manager/reconciler.go`, when cleaning up old revisions exceeding `RevisionHistoryLimit`, the package manager issues `r.kube.Delete(ctx, gcRev)`. If an old revision was deleted concurrently (or removed by another controller/finalizer), the Kubernetes API returns a `NotFound` error. Currently, this error fails the reconcile loop.

This PR wraps `r.kube.Delete` with `resource.IgnoreNotFound(err)` so that already-deleted package revisions are safely treated as successfully garbage-collected, preventing reconciliation failures.

Fixes #7790

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Read and followed Crossplane's [AI policy] and confirmed a human stands behind this PR.
- [x] Run `./nix.sh flake check` to ensure this PR is ready for review.
- [x] Added or updated unit tests.
- [x] Added or updated e2e tests. (Not applicable; covered by a focused unit regression test.)
- [x] Linked a PR or a [docs tracking issue] to [document this change]. (Not applicable; no user-facing behavior.)
- [x] Added `backport release-x.y` labels to auto-backport this PR. (Not applicable.)
- [x] Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API. (Not applicable; no API change.)

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[AI policy]: https://github.com/crossplane/crossplane/blob/main/AI_POLICY.md
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md

### Special notes for your reviewer:
- Added unit test `SuccessfulRevisionExistsNeedGCNotFound` in `internal/controller/pkg/manager/reconciler_test.go`.
