### PR TITLE
fix: correct typos in code comments

### DIFF
--- a/apis/pkg/v1/register.go
+++ b/apis/pkg/v1/register.go
@@ -40,7 +40,7 @@ var (
 	AddToScheme = SchemeBuilder.AddToScheme
 )
 
-// Configuation type metadata.
+// Configuration type metadata.
 var (
 	ConfigurationKind             = reflect.TypeFor[Configuration]().Name()
 	ConfigurationGroupKind        = schema.GroupKind{Group: Group, Kind: ConfigurationKind}.String()

--- a/internal/controller/apiextensions/claim/syncer_ssa.go
+++ b/internal/controller/apiextensions/claim/syncer_ssa.go
@@ -190,7 +190,7 @@ func (s *ServerSideCompositeSyncer) Sync(ctx context.Context, cm *claim.Unstruct
 	// 2. XR controller uses selectors to set XR's composition ref.
 	// 3. Claim controller propagates ref XR -> claim.
 	//
-	// When a claim sets a composition ref, it supercedes selectors. It should
+	// When a claim sets a composition ref, it supersedes selectors. It should
 	// only be propagated claim -> XR.
 	//
 	// EXCEPTION: When enforcedCompositionRef is set, we ALWAYS propagate
@@ -207,7 +207,7 @@ func (s *ServerSideCompositeSyncer) Sync(ctx context.Context, cm *claim.Unstruct
 	// Propagate composition revision ref from the XR if the update policy is
 	// automatic. When the update policy is automatic the XR controller is
 	// authoritative for this field. It will update the XR's ref as new
-	// revisions become available, and we want to propgate the ref XR -> claim.
+	// revisions become available, and we want to propagate the ref XR -> claim.
 	if p := xr.GetCompositionUpdatePolicy(); p != nil && *p == xpv2.UpdateAutomatic && xr.GetCompositionRevisionReference() != nil {
 		cm.SetCompositionRevisionReference(xr.GetCompositionRevisionReference())
 	}

--- a/internal/controller/rbac/provider/roles/roles.go
+++ b/internal/controller/rbac/provider/roles/roles.go
@@ -166,7 +166,7 @@ func RenderClusterRoles(pr *v1.ProviderRevision, rs []Resource) []rbacv1.Cluster
 	}
 
 	// The 'system' RBAC role does not aggregate; it is intended to be bound
-	// directly to the service account tha provider runs as.
+	// directly to the service account the provider runs as.
 	system := &rbacv1.ClusterRole{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: SystemClusterRoleName(pr.GetName()),

--- a/internal/converter/custom_to_managed.go
+++ b/internal/converter/custom_to_managed.go
@@ -60,7 +60,7 @@ func CustomToManagedResourceDefinitions(defaultActive bool, objects ...runtime.O
 			obj := obj.DeepCopyObject()
 			// The object has to be either an unstructured.Unstructured object or a CustomResourceDefinition
 			switch o := obj.(type) {
-			// to covert, all we need to worry about is the metadata and spec.state.
+			// to convert, all we need to worry about is the metadata and spec.state.
 			case *unstructured.Unstructured:
 				if !isManagedResource(o.Object) {
 					// Keep non-managed resources (like ProviderConfig) as regular CRDs

--- a/internal/render/composite/render.go
+++ b/internal/render/composite/render.go
@@ -468,7 +468,7 @@ func BuildOutput(c *render.InMemoryClient, isPrimary func(kunstructured.Unstruct
 		out.RequiredResources = append(out.RequiredResources, s)
 	}
 
-	// Collect required schmea selectors.
+	// Collect required schema selectors.
 	for _, ss := range rsf.GetSchemaSelectors() {
 		s, err := messageToStruct(ss)
 		if err != nil {

--- a/internal/render/operation/render.go
+++ b/internal/render/operation/render.go
@@ -236,7 +236,7 @@ func buildOutput(c *render.InMemoryClient, isPrimary func(kunstructured.Unstruct
 		out.RequiredResources = append(out.RequiredResources, s)
 	}
 
-	// Collect required schmea selectors.
+	// Collect required schema selectors.
 	for _, ss := range rsf.GetSchemaSelectors() {
 		s, err := messageToStruct(ss)
 		if err != nil {

--- a/internal/xfn/required_resources.go
+++ b/internal/xfn/required_resources.go
@@ -50,7 +50,7 @@ func (fn RequiredResourcesFetcherFn) Fetch(ctx context.Context, rs *fnv1.Resourc
 	return fn(ctx, rs)
 }
 
-// A FetchingFunctionRunner wraps an underlyin FunctionRunner, adding support
+// A FetchingFunctionRunner wraps an underlying FunctionRunner, adding support
 // for fetching any required resources requested by the function it runs.
 type FetchingFunctionRunner struct {
 	wrapped   FunctionRunner


### PR DESCRIPTION
### Description of your changes

Comment-only typo fixes across `apis/` and `internal/`: `Configuation`, `supercedes`, `propgate`, `tha`, `covert`, and a few others. No code, identifiers, or user-facing strings are touched, so there is nothing to test beyond the existing build/vet passing.

I hit a couple of these while reading through the claim syncer and grepped for similar misspellings in the rest of the tree.

Fixes #

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Read and followed Crossplane's [AI policy] and confirmed a human stands behind this PR.
- [ ] ~Run `./nix.sh flake check` to ensure this PR is ready for review.~
- [ ] ~Added or updated unit tests.~ Comments only.
- [ ] ~Added or updated e2e tests.~ Comments only.
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~ No behaviour change.
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~
- [ ] ~Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[AI policy]: https://github.com/crossplane/crossplane/blob/main/AI_POLICY.md
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md
