### PR TITLE
fix: repoint dependency packages when Create returns AlreadyExists

### DIFF
--- a/internal/controller/pkg/resolver/reconciler.go
+++ b/internal/controller/pkg/resolver/reconciler.go
@@ -445,9 +445,9 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 			// between two different packages, and repointing it would
 			// silently corrupt an unrelated, working dependency.
 			currentRef, refErr := name.ParseReference(current, name.WeakValidation)
-			if refErr != nil || currentRef.Context().RepositoryStr() != ref.Context().RepositoryStr() {
+			if refErr != nil || !sameRepository(currentRef, ref) {
 				err := errors.Errorf(errFmtNameCollision, pack.GetName(), ref.Context().RepositoryStr(), current)
-				log.Debug(errNameCollision, "error", err)
+				log.Info(errNameCollision, "error", err)
 				status.MarkConditions(v1beta1.ResolutionFailed(err))
 
 				_ = r.kube.Status().Update(ctx, lock)
@@ -760,6 +760,22 @@ func matchesAnyConstraint(version string, constraints []string) bool {
 	}
 
 	return false
+}
+
+// sameRepository reports whether a and b refer to the same OCI repository
+// path, ignoring registry host. A repository reference with no registry and
+// no namespace segment (e.g. "confignopc") is implicitly qualified as
+// "library/confignopc" by name.Repository.RepositoryStr, even though a
+// fully-qualified reference to the same repository on a non-default registry
+// (e.g. "xpkg.crossplane.io/confignopc") is not; the "library/" prefix is
+// trimmed from both sides before comparing so this defaulting quirk doesn't
+// cause a legitimate same-repository match to be misread as a collision.
+func sameRepository(a, b name.Reference) bool {
+	trim := func(r name.Reference) string {
+		return strings.TrimPrefix(r.Context().RepositoryStr(), "library/")
+	}
+
+	return trim(a) == trim(b)
 }
 
 // NewPackage creates a new package from the given dependency and version.

--- a/internal/controller/pkg/resolver/reconciler.go
+++ b/internal/controller/pkg/resolver/reconciler.go
@@ -83,6 +83,8 @@ const (
 	errFmtDiffConstraintTypes = "a dependency package has different types of parent constraints (%v)"
 	errFmtDiffDigests         = "a dependency package has different digests in parent constraints (%v)"
 	errCannotUpdateStatus     = "cannot update status"
+	errNameCollision          = "existing package name collides with a different dependency"
+	errFmtNameCollision       = "cannot resolve dependency: object %q already exists for repository %q but currently points at unrelated package %q; this is a package naming collision and requires manual intervention"
 )
 
 // ReconcilerOption is used to configure the Reconciler.
@@ -432,6 +434,26 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 
 			desired, _ := fieldpath.Pave(pack.Object).GetString("spec.package")
 			current, _ := fieldpath.Pave(existing.Object).GetString("spec.package")
+
+			// The derived name is a lossy hash of the repository path (e.g.
+			// underscores are dropped, long paths are truncated), so an
+			// unrelated dependency's repository can collide with this one's
+			// on the same name. Only treat the existing object as this
+			// dependency's own stale record - and safe to repoint - if it
+			// currently resolves to the same repository path we're
+			// resolving. Otherwise this is a genuine naming collision
+			// between two different packages, and repointing it would
+			// silently corrupt an unrelated, working dependency.
+			currentRef, refErr := name.ParseReference(current, name.WeakValidation)
+			if refErr != nil || currentRef.Context().RepositoryStr() != ref.Context().RepositoryStr() {
+				err := errors.Errorf(errFmtNameCollision, pack.GetName(), ref.Context().RepositoryStr(), current)
+				log.Debug(errNameCollision, "error", err)
+				status.MarkConditions(v1beta1.ResolutionFailed(err))
+
+				_ = r.kube.Status().Update(ctx, lock)
+
+				return reconcile.Result{}, err
+			}
 
 			if current != desired {
 				_ = fieldpath.Pave(existing.Object).SetString("spec.package", desired)

--- a/internal/controller/pkg/resolver/reconciler.go
+++ b/internal/controller/pkg/resolver/reconciler.go
@@ -30,6 +30,7 @@ import (
 	conregv1 "github.com/google/go-containerregistry/pkg/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -398,13 +399,52 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 
 		// NOTE(hasheddan): consider making the lock the controller of packages
 		// it creates.
-		if err := r.kube.Create(ctx, pack); err != nil && !kerrors.IsAlreadyExists(err) {
-			log.Debug(errCreateDependency, "error", err)
-			status.MarkConditions(v1beta1.ResolutionFailed(errors.Wrap(err, errCreateDependency)))
+		if err := r.kube.Create(ctx, pack); err != nil {
+			if !kerrors.IsAlreadyExists(err) {
+				log.Debug(errCreateDependency, "error", err)
+				status.MarkConditions(v1beta1.ResolutionFailed(errors.Wrap(err, errCreateDependency)))
 
-			_ = r.kube.Status().Update(ctx, lock)
+				_ = r.kube.Status().Update(ctx, lock)
 
-			return reconcile.Result{}, errors.Wrap(err, errCreateDependency)
+				return reconcile.Result{}, errors.Wrap(err, errCreateDependency)
+			}
+
+			// An object with this derived name already exists. Its name is
+			// derived only from the OCI repository path, so this is the
+			// expected outcome when a version bump for the same dependency
+			// races the requeue that follows it. But if the existing
+			// object's spec.package no longer matches what we just tried to
+			// create - e.g. because the image was relocated to a new
+			// registry host, or now resolves to a different digest - the
+			// collision is masking a stale, unresolved dependency rather
+			// than reflecting what's actually installed. Repoint the
+			// existing object at the desired reference instead of treating
+			// the AlreadyExists as satisfying the dependency.
+			existing := pack.DeepCopy()
+			if err := r.kube.Get(ctx, types.NamespacedName{Name: pack.GetName()}, existing); err != nil {
+				log.Debug(errGetDependency, "error", err)
+				status.MarkConditions(v1beta1.ResolutionFailed(errors.Wrap(err, errGetDependency)))
+
+				_ = r.kube.Status().Update(ctx, lock)
+
+				return reconcile.Result{}, errors.Wrap(err, errGetDependency)
+			}
+
+			desired, _ := fieldpath.Pave(pack.Object).GetString("spec.package")
+			current, _ := fieldpath.Pave(existing.Object).GetString("spec.package")
+
+			if current != desired {
+				_ = fieldpath.Pave(existing.Object).SetString("spec.package", desired)
+
+				if err := r.kube.Update(ctx, existing); err != nil {
+					log.Debug(errUpdateDependency, "error", err)
+					status.MarkConditions(v1beta1.ResolutionFailed(errors.Wrap(err, errUpdateDependency)))
+
+					_ = r.kube.Status().Update(ctx, lock)
+
+					return reconcile.Result{}, errors.Wrap(err, errUpdateDependency)
+				}
+			}
 		}
 
 		status.MarkConditions(v1beta1.ResolutionSucceeded())

--- a/internal/controller/pkg/resolver/reconciler_test.go
+++ b/internal/controller/pkg/resolver/reconciler_test.go
@@ -1054,6 +1054,106 @@ func TestReconcile(t *testing.T) {
 	}
 }
 
+// TestReconcileRepointsStaleDependencyOnRegistryRelocation covers the case
+// where a dependency's derived name collides with an existing package whose
+// spec.package points at a stale source - e.g. because the image was
+// relocated to a new registry host while the OCI repository path (and thus
+// the derived name) stayed the same. The reconciler must repoint the
+// existing object at the desired reference rather than treating the
+// resulting AlreadyExists error as proof the dependency is satisfied.
+//
+// This is asserted with a dedicated test, rather than a table case sharing
+// the generic result/error comparison above, because the bug this guards
+// against produces the exact same reconcile.Result and error as success: the
+// only observable difference is whether Update was ever called with the
+// corrected spec.package.
+func TestReconcileRepointsStaleDependencyOnRegistryRelocation(t *testing.T) {
+	const (
+		dependencyPackage = "hasheddan/provider-nop-c"
+		staleSource       = "old-registry.example.com/hasheddan/provider-nop-c@" + digest1
+		desiredSource     = dependencyPackage + "@" + digest1
+	)
+
+	var updated *unstructured.Unstructured
+
+	c := &test.MockClient{
+		MockGet: func(_ context.Context, _ client.ObjectKey, o client.Object) error {
+			switch v := o.(type) {
+			case *v1beta1.Lock:
+				v.Packages = append(v.Packages, v1beta1.LockPackage{
+					Name:    "cool-package",
+					Type:    ptr.To(v1beta1.ProviderPackageType),
+					Source:  "xpkg.crossplane.io/cool-repo/cool-image",
+					Version: "v0.0.1",
+				})
+				return nil
+			case *unstructured.Unstructured:
+				// Simulate the object that already occupies the derived
+				// name: it exists, but still points at the pre-relocation
+				// source.
+				_ = fieldpath.Pave(v.Object).SetString("spec.package", staleSource)
+				return nil
+			default:
+				return errors.Errorf("unexpected object type %T passed to Get", o)
+			}
+		},
+		MockCreate: test.NewMockCreateFn(kerrors.NewAlreadyExists(schema.GroupResource{}, "")),
+		MockUpdate: func(_ context.Context, o client.Object, _ ...client.UpdateOption) error {
+			// The finalizer add/remove path updates the Lock itself; only
+			// the stale dependency's repoint is interesting to this test.
+			if u, ok := o.(*unstructured.Unstructured); ok {
+				updated = u
+			}
+			return nil
+		},
+		MockStatusUpdate: test.NewMockSubResourceUpdateFn(nil),
+	}
+
+	r := NewReconciler(&fake.Manager{Client: c},
+		WithLogger(testLog),
+		WithNewDagFn(func() dag.DAG {
+			return &fakedag.MockDag{
+				MockInit: func(_ []dag.Node) ([]dag.Node, error) {
+					return []dag.Node{
+						&dag.DependencyNode{
+							Dependency: v1beta1.Dependency{
+								Package:     dependencyPackage,
+								Constraints: digest1,
+								Type:        ptr.To(v1beta1.ProviderPackageType),
+							},
+						},
+					}, nil
+				},
+				MockSort: func() ([]string, error) {
+					return nil, nil
+				},
+			}
+		}),
+	)
+
+	got, err := r.Reconcile(context.Background(), reconcile.Request{NamespacedName: types.NamespacedName{Name: "test"}})
+	if err != nil {
+		t.Fatalf("r.Reconcile(...): unexpected error: %v", err)
+	}
+
+	if diff := cmp.Diff(reconcile.Result{}, got); diff != "" {
+		t.Errorf("r.Reconcile(...): -want, +got:\n%s", diff)
+	}
+
+	if updated == nil {
+		t.Fatal("r.Reconcile(...): the stale dependency object was never updated; AlreadyExists was silently treated as success")
+	}
+
+	gotSource, err := fieldpath.Pave(updated.Object).GetString("spec.package")
+	if err != nil {
+		t.Fatalf("could not read spec.package from updated object: %v", err)
+	}
+
+	if gotSource != desiredSource {
+		t.Errorf("updated object has wrong spec.package: got %q, want %q", gotSource, desiredSource)
+	}
+}
+
 func TestFindDigestToUpdate(t *testing.T) {
 	type args struct {
 		node dag.Node

--- a/internal/controller/pkg/resolver/reconciler_test.go
+++ b/internal/controller/pkg/resolver/reconciler_test.go
@@ -1056,35 +1056,63 @@ func TestReconcile(t *testing.T) {
 
 // TestReconcileOnNameCollision covers what happens when a dependency's
 // derived name collides with an existing package object on Create. The
-// reconciler must repoint the existing object when its spec.package has
-// diverged from what's now required (e.g. after the image was relocated to a
-// new registry host), and must leave it untouched when it already matches.
+// derived name is a lossy hash of the repository path alone (e.g.
+// xpkg.ToDNSLabel drops underscores and truncates at 63 characters), so two
+// distinct repository paths can land on the same name - not just the same
+// path relocated to a different registry.
+//
+// The reconciler must:
+//   - repoint the existing object when it's the same repository path but a
+//     stale source (e.g. relocated to a new registry host);
+//   - leave it untouched when it already matches;
+//   - refuse to touch it, and fail resolution, when the existing object
+//     belongs to a genuinely different repository path - repointing that
+//     would silently corrupt an unrelated, working dependency.
 //
 // This isn't folded into the table above because that table only asserts
-// reconcile.Result and error, both of which are identical whether or not the
-// existing object gets repointed; the only observable difference is whether
-// Update was called, and with what value.
+// reconcile.Result and error, and for the repoint/no-op cases those are
+// identical whether or not the existing object gets touched; the only
+// observable difference is whether Update was called, and with what value.
 func TestReconcileOnNameCollision(t *testing.T) {
 	const (
 		dependencyPackage = "hasheddan/provider-nop-c"
 		desiredSource     = dependencyPackage + "@" + digest1
 		staleSource       = "old-registry.example.com/hasheddan/provider-nop-c@" + digest1
+
+		// hasheddan/config_nop_c and hasheddan/confignopc both derive to the
+		// DNS label "hasheddan-confignopc" via xpkg.ToDNSLabel, which drops
+		// underscores rather than treating them as separators. They are
+		// different repository paths, so an object already installed for
+		// one must never be repointed to satisfy the other.
+		collidingDependencyPackage = "hasheddan/config_nop_c"
+		unrelatedExistingSource    = "hasheddan/confignopc@" + digest2
 	)
 
 	cases := map[string]struct {
-		reason         string
-		existingSource string
-		wantUpdated    bool
+		reason            string
+		dependencyPackage string
+		existingSource    string
+		wantUpdated       bool
+		wantErr           bool
 	}{
 		"RepointsStaleSource": {
-			reason:         "An existing object at a different source than required must be repointed, not treated as satisfying the dependency.",
-			existingSource: staleSource,
-			wantUpdated:    true,
+			reason:            "An existing object at a different source than required must be repointed, not treated as satisfying the dependency.",
+			dependencyPackage: dependencyPackage,
+			existingSource:    staleSource,
+			wantUpdated:       true,
 		},
 		"NoopOnExactMatch": {
-			reason:         "An existing object that already matches the desired source is a true no-op and must not be updated.",
-			existingSource: desiredSource,
-			wantUpdated:    false,
+			reason:            "An existing object that already matches the desired source is a true no-op and must not be updated.",
+			dependencyPackage: dependencyPackage,
+			existingSource:    desiredSource,
+			wantUpdated:       false,
+		},
+		"FailsOnUnrelatedCollision": {
+			reason:            "An existing object belonging to a different repository path is an unrelated package that happens to collide on the derived name; it must not be repointed, and resolution must fail rather than silently succeed.",
+			dependencyPackage: collidingDependencyPackage,
+			existingSource:    unrelatedExistingSource,
+			wantUpdated:       false,
+			wantErr:           true,
 		},
 	}
 
@@ -1131,7 +1159,7 @@ func TestReconcileOnNameCollision(t *testing.T) {
 							return []dag.Node{
 								&dag.DependencyNode{
 									Dependency: v1beta1.Dependency{
-										Package:     dependencyPackage,
+										Package:     tc.dependencyPackage,
 										Constraints: digest1,
 										Type:        ptr.To(v1beta1.ProviderPackageType),
 									},
@@ -1146,12 +1174,21 @@ func TestReconcileOnNameCollision(t *testing.T) {
 			)
 
 			got, err := r.Reconcile(context.Background(), reconcile.Request{NamespacedName: types.NamespacedName{Name: "test"}})
-			if err != nil {
+			if tc.wantErr {
+				if err == nil {
+					// Not fatal: keep checking below whether the unrelated
+					// object was also wrongly updated, which is the more
+					// serious half of this failure mode.
+					t.Errorf("\n%s\nr.Reconcile(...): expected an error, got none", tc.reason)
+				}
+			} else if err != nil {
 				t.Fatalf("\n%s\nr.Reconcile(...): unexpected error: %v", tc.reason, err)
 			}
 
-			if diff := cmp.Diff(reconcile.Result{}, got); diff != "" {
-				t.Errorf("\n%s\nr.Reconcile(...): -want, +got:\n%s", tc.reason, diff)
+			if !tc.wantErr {
+				if diff := cmp.Diff(reconcile.Result{}, got); diff != "" {
+					t.Errorf("\n%s\nr.Reconcile(...): -want, +got:\n%s", tc.reason, diff)
+				}
 			}
 
 			if tc.wantUpdated && updated == nil {
@@ -1159,7 +1196,7 @@ func TestReconcileOnNameCollision(t *testing.T) {
 			}
 
 			if !tc.wantUpdated && updated != nil {
-				t.Fatalf("\n%s\nr.Reconcile(...): the dependency object was updated even though its source already matched", tc.reason)
+				t.Fatalf("\n%s\nr.Reconcile(...): the dependency object was updated even though it should not have been (either already matched, or belongs to an unrelated package)", tc.reason)
 			}
 
 			if updated == nil {
@@ -1171,8 +1208,9 @@ func TestReconcileOnNameCollision(t *testing.T) {
 				t.Fatalf("could not read spec.package from updated object: %v", err)
 			}
 
-			if gotSource != desiredSource {
-				t.Errorf("\n%s\nupdated object has wrong spec.package: got %q, want %q", tc.reason, gotSource, desiredSource)
+			wantSource := tc.dependencyPackage + "@" + digest1
+			if gotSource != wantSource {
+				t.Errorf("\n%s\nupdated object has wrong spec.package: got %q, want %q", tc.reason, gotSource, wantSource)
 			}
 		})
 	}

--- a/internal/controller/pkg/resolver/reconciler_test.go
+++ b/internal/controller/pkg/resolver/reconciler_test.go
@@ -1054,103 +1054,127 @@ func TestReconcile(t *testing.T) {
 	}
 }
 
-// TestReconcileRepointsStaleDependencyOnRegistryRelocation covers the case
-// where a dependency's derived name collides with an existing package whose
-// spec.package points at a stale source - e.g. because the image was
-// relocated to a new registry host while the OCI repository path (and thus
-// the derived name) stayed the same. The reconciler must repoint the
-// existing object at the desired reference rather than treating the
-// resulting AlreadyExists error as proof the dependency is satisfied.
+// TestReconcileOnNameCollision covers what happens when a dependency's
+// derived name collides with an existing package object on Create. The
+// reconciler must repoint the existing object when its spec.package has
+// diverged from what's now required (e.g. after the image was relocated to a
+// new registry host), and must leave it untouched when it already matches.
 //
-// This is asserted with a dedicated test, rather than a table case sharing
-// the generic result/error comparison above, because the bug this guards
-// against produces the exact same reconcile.Result and error as success: the
-// only observable difference is whether Update was ever called with the
-// corrected spec.package.
-func TestReconcileRepointsStaleDependencyOnRegistryRelocation(t *testing.T) {
+// This isn't folded into the table above because that table only asserts
+// reconcile.Result and error, both of which are identical whether or not the
+// existing object gets repointed; the only observable difference is whether
+// Update was called, and with what value.
+func TestReconcileOnNameCollision(t *testing.T) {
 	const (
 		dependencyPackage = "hasheddan/provider-nop-c"
-		staleSource       = "old-registry.example.com/hasheddan/provider-nop-c@" + digest1
 		desiredSource     = dependencyPackage + "@" + digest1
+		staleSource       = "old-registry.example.com/hasheddan/provider-nop-c@" + digest1
 	)
 
-	var updated *unstructured.Unstructured
-
-	c := &test.MockClient{
-		MockGet: func(_ context.Context, _ client.ObjectKey, o client.Object) error {
-			switch v := o.(type) {
-			case *v1beta1.Lock:
-				v.Packages = append(v.Packages, v1beta1.LockPackage{
-					Name:    "cool-package",
-					Type:    ptr.To(v1beta1.ProviderPackageType),
-					Source:  "xpkg.crossplane.io/cool-repo/cool-image",
-					Version: "v0.0.1",
-				})
-				return nil
-			case *unstructured.Unstructured:
-				// Simulate the object that already occupies the derived
-				// name: it exists, but still points at the pre-relocation
-				// source.
-				_ = fieldpath.Pave(v.Object).SetString("spec.package", staleSource)
-				return nil
-			default:
-				return errors.Errorf("unexpected object type %T passed to Get", o)
-			}
+	cases := map[string]struct {
+		reason         string
+		existingSource string
+		wantUpdated    bool
+	}{
+		"RepointsStaleSource": {
+			reason:         "An existing object at a different source than required must be repointed, not treated as satisfying the dependency.",
+			existingSource: staleSource,
+			wantUpdated:    true,
 		},
-		MockCreate: test.NewMockCreateFn(kerrors.NewAlreadyExists(schema.GroupResource{}, "")),
-		MockUpdate: func(_ context.Context, o client.Object, _ ...client.UpdateOption) error {
-			// The finalizer add/remove path updates the Lock itself; only
-			// the stale dependency's repoint is interesting to this test.
-			if u, ok := o.(*unstructured.Unstructured); ok {
-				updated = u
-			}
-			return nil
+		"NoopOnExactMatch": {
+			reason:         "An existing object that already matches the desired source is a true no-op and must not be updated.",
+			existingSource: desiredSource,
+			wantUpdated:    false,
 		},
-		MockStatusUpdate: test.NewMockSubResourceUpdateFn(nil),
 	}
 
-	r := NewReconciler(&fake.Manager{Client: c},
-		WithLogger(testLog),
-		WithNewDagFn(func() dag.DAG {
-			return &fakedag.MockDag{
-				MockInit: func(_ []dag.Node) ([]dag.Node, error) {
-					return []dag.Node{
-						&dag.DependencyNode{
-							Dependency: v1beta1.Dependency{
-								Package:     dependencyPackage,
-								Constraints: digest1,
-								Type:        ptr.To(v1beta1.ProviderPackageType),
-							},
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			var updated *unstructured.Unstructured
+
+			c := &test.MockClient{
+				MockGet: func(_ context.Context, _ client.ObjectKey, o client.Object) error {
+					switch v := o.(type) {
+					case *v1beta1.Lock:
+						v.Packages = append(v.Packages, v1beta1.LockPackage{
+							Name:    "cool-package",
+							Type:    ptr.To(v1beta1.ProviderPackageType),
+							Source:  "xpkg.crossplane.io/cool-repo/cool-image",
+							Version: "v0.0.1",
+						})
+						return nil
+					case *unstructured.Unstructured:
+						_ = fieldpath.Pave(v.Object).SetString("spec.package", tc.existingSource)
+						return nil
+					default:
+						return errors.Errorf("unexpected object type %T passed to Get", o)
+					}
+				},
+				MockCreate: test.NewMockCreateFn(kerrors.NewAlreadyExists(schema.GroupResource{}, "")),
+				MockUpdate: func(_ context.Context, o client.Object, _ ...client.UpdateOption) error {
+					// The finalizer add/remove path also updates the Lock
+					// itself; only the dependency object's repoint matters
+					// here.
+					if u, ok := o.(*unstructured.Unstructured); ok {
+						updated = u
+					}
+					return nil
+				},
+				MockStatusUpdate: test.NewMockSubResourceUpdateFn(nil),
+			}
+
+			r := NewReconciler(&fake.Manager{Client: c},
+				WithLogger(testLog),
+				WithNewDagFn(func() dag.DAG {
+					return &fakedag.MockDag{
+						MockInit: func(_ []dag.Node) ([]dag.Node, error) {
+							return []dag.Node{
+								&dag.DependencyNode{
+									Dependency: v1beta1.Dependency{
+										Package:     dependencyPackage,
+										Constraints: digest1,
+										Type:        ptr.To(v1beta1.ProviderPackageType),
+									},
+								},
+							}, nil
 						},
-					}, nil
-				},
-				MockSort: func() ([]string, error) {
-					return nil, nil
-				},
+						MockSort: func() ([]string, error) {
+							return nil, nil
+						},
+					}
+				}),
+			)
+
+			got, err := r.Reconcile(context.Background(), reconcile.Request{NamespacedName: types.NamespacedName{Name: "test"}})
+			if err != nil {
+				t.Fatalf("\n%s\nr.Reconcile(...): unexpected error: %v", tc.reason, err)
 			}
-		}),
-	)
 
-	got, err := r.Reconcile(context.Background(), reconcile.Request{NamespacedName: types.NamespacedName{Name: "test"}})
-	if err != nil {
-		t.Fatalf("r.Reconcile(...): unexpected error: %v", err)
-	}
+			if diff := cmp.Diff(reconcile.Result{}, got); diff != "" {
+				t.Errorf("\n%s\nr.Reconcile(...): -want, +got:\n%s", tc.reason, diff)
+			}
 
-	if diff := cmp.Diff(reconcile.Result{}, got); diff != "" {
-		t.Errorf("r.Reconcile(...): -want, +got:\n%s", diff)
-	}
+			if tc.wantUpdated && updated == nil {
+				t.Fatalf("\n%s\nr.Reconcile(...): the dependency object was never updated; AlreadyExists was silently treated as success", tc.reason)
+			}
 
-	if updated == nil {
-		t.Fatal("r.Reconcile(...): the stale dependency object was never updated; AlreadyExists was silently treated as success")
-	}
+			if !tc.wantUpdated && updated != nil {
+				t.Fatalf("\n%s\nr.Reconcile(...): the dependency object was updated even though its source already matched", tc.reason)
+			}
 
-	gotSource, err := fieldpath.Pave(updated.Object).GetString("spec.package")
-	if err != nil {
-		t.Fatalf("could not read spec.package from updated object: %v", err)
-	}
+			if updated == nil {
+				return
+			}
 
-	if gotSource != desiredSource {
-		t.Errorf("updated object has wrong spec.package: got %q, want %q", gotSource, desiredSource)
+			gotSource, err := fieldpath.Pave(updated.Object).GetString("spec.package")
+			if err != nil {
+				t.Fatalf("could not read spec.package from updated object: %v", err)
+			}
+
+			if gotSource != desiredSource {
+				t.Errorf("\n%s\nupdated object has wrong spec.package: got %q, want %q", tc.reason, gotSource, desiredSource)
+			}
+		})
 	}
 }
 

--- a/internal/controller/pkg/resolver/reconciler_test.go
+++ b/internal/controller/pkg/resolver/reconciler_test.go
@@ -1105,12 +1105,26 @@ func TestReconcileOnNameCollision(t *testing.T) {
 		singleSegmentExistingSource    = "confignopc@" + digest2
 	)
 
+	// The exact error the reconciler must return for the collision case,
+	// constructed the same way production code does, so the test verifies
+	// this specific failure occurred rather than merely that some error did.
+	collidingRef, parseErr := pkgName.ParseReference(collidingDependencyPackage)
+	if parseErr != nil {
+		t.Fatalf("test setup: could not parse %q: %v", collidingDependencyPackage, parseErr)
+	}
+
+	wantCollisionErr := errors.Errorf(errFmtNameCollision,
+		xpkg.ToDNSLabel(collidingRef.Context().RepositoryStr()),
+		collidingRef.Context().RepositoryStr(),
+		unrelatedExistingSource,
+	)
+
 	cases := map[string]struct {
 		reason            string
 		dependencyPackage string
 		existingSource    string
 		wantUpdated       bool
-		wantErr           bool
+		wantErr           error
 	}{
 		"RepointsStaleSource": {
 			reason:            "An existing object at a different source than required must be repointed, not treated as satisfying the dependency.",
@@ -1129,7 +1143,7 @@ func TestReconcileOnNameCollision(t *testing.T) {
 			dependencyPackage: collidingDependencyPackage,
 			existingSource:    unrelatedExistingSource,
 			wantUpdated:       false,
-			wantErr:           true,
+			wantErr:           wantCollisionErr,
 		},
 		"RepointsAcrossImplicitRegistryMultiSegment": {
 			reason:            "A multi-segment repository path is the same repository whether or not a registry is present in the recorded source, and must still be repointed.",
@@ -1203,18 +1217,14 @@ func TestReconcileOnNameCollision(t *testing.T) {
 			)
 
 			got, err := r.Reconcile(context.Background(), reconcile.Request{NamespacedName: types.NamespacedName{Name: "test"}})
-			if tc.wantErr {
-				if err == nil {
-					// Not fatal: keep checking below whether the unrelated
-					// object was also wrongly updated, which is the more
-					// serious half of this failure mode.
-					t.Errorf("\n%s\nr.Reconcile(...): expected an error, got none", tc.reason)
-				}
-			} else if err != nil {
-				t.Fatalf("\n%s\nr.Reconcile(...): unexpected error: %v", tc.reason, err)
+			if diff := cmp.Diff(tc.wantErr, err, test.EquateErrors()); diff != "" {
+				// Not fatal: keep checking below whether the unrelated object
+				// was also wrongly updated, which is the more serious half of
+				// this failure mode.
+				t.Errorf("\n%s\nr.Reconcile(...): -want error, +got error:\n%s", tc.reason, diff)
 			}
 
-			if !tc.wantErr {
+			if tc.wantErr == nil {
 				if diff := cmp.Diff(reconcile.Result{}, got); diff != "" {
 					t.Errorf("\n%s\nr.Reconcile(...): -want, +got:\n%s", tc.reason, diff)
 				}

--- a/internal/controller/pkg/resolver/reconciler_test.go
+++ b/internal/controller/pkg/resolver/reconciler_test.go
@@ -1086,6 +1086,23 @@ func TestReconcileOnNameCollision(t *testing.T) {
 		// one must never be repointed to satisfy the other.
 		collidingDependencyPackage = "hasheddan/config_nop_c"
 		unrelatedExistingSource    = "hasheddan/confignopc@" + digest2
+
+		// A multi-segment repository path's RepositoryStr is registry-agnostic,
+		// so an existing object recorded without a registry must still be
+		// recognized as the same repository as a dependency declared with one
+		// (this is the realistic shape of the original registry-migration bug).
+		multiSegmentDependencyPackage = "xpkg.crossplane.io/hasheddan/provider-nop-c"
+		multiSegmentExistingSource    = "hasheddan/provider-nop-c@" + digest2
+
+		// A single-segment repository path is where name.Reference's
+		// implicit Docker Hub namespacing kicks in: an existing object with
+		// no registry resolves to "library/confignopc", while the same
+		// repository declared with an explicit non-default registry resolves
+		// to "confignopc" - no "library/" prefix. Without normalizing that
+		// away, this legitimate same-repository case would be misclassified
+		// as an unrelated collision.
+		singleSegmentDependencyPackage = "xpkg.crossplane.io/confignopc"
+		singleSegmentExistingSource    = "confignopc@" + digest2
 	)
 
 	cases := map[string]struct {
@@ -1113,6 +1130,18 @@ func TestReconcileOnNameCollision(t *testing.T) {
 			existingSource:    unrelatedExistingSource,
 			wantUpdated:       false,
 			wantErr:           true,
+		},
+		"RepointsAcrossImplicitRegistryMultiSegment": {
+			reason:            "A multi-segment repository path is the same repository whether or not a registry is present in the recorded source, and must still be repointed.",
+			dependencyPackage: multiSegmentDependencyPackage,
+			existingSource:    multiSegmentExistingSource,
+			wantUpdated:       true,
+		},
+		"RepointsAcrossImplicitRegistrySingleSegment": {
+			reason:            "A single-segment repository path must not be misclassified as an unrelated collision just because name.Reference's implicit Docker Hub namespacing renders it as 'library/x' on one side and 'x' on the other.",
+			dependencyPackage: singleSegmentDependencyPackage,
+			existingSource:    singleSegmentExistingSource,
+			wantUpdated:       true,
 		},
 	}
 


### PR DESCRIPTION
### Description of your changes

Relocating a package to a new registry (same repository path, new host) silently gets stuck, and a naive fix for that can corrupt an unrelated dependency.

**Relocation gets stuck at `Resolved: True`.** The resolver names a dependency object from its repository path alone (`xpkg.ToDNSLabel(ref.Context().RepositoryStr())`), excluding registry host and digest/tag. When a package moves to a new registry host, the new dependency object collides on that derived name with the existing object, which still points at the old source. `Create` returns `AlreadyExists`, and the resolver has always treated that as success: the existing object is never checked or updated, no error or event is produced, and the Lock's `Resolved` condition stays `True` indefinitely while the dependency is never actually resolved. Since nothing about the Lock changes, nothing re-triggers reconciliation either.

`internal/controller/pkg/revision/dependency.go` already handles the analogous case on the self-registration side — a `PackageRevision` that finds a same-name, different-source lock entry removes it so the package can re-register. The resolver's create-if-missing path had no equivalent.

**The derived name isn't unique.** `ToDNSLabel` drops characters like `_` outright instead of substituting them, and truncates at 63 characters, so two unrelated repository paths can land on the same derived name with no registry relocation involved — `hasheddan/config_nop_c` and `hasheddan/confignopc` both derive to `hasheddan-confignopc`. Repointing on every `AlreadyExists` without checking what it's repointing would silently overwrite an unrelated, already-resolved dependency with a different package.

**This PR, on `AlreadyExists`:**

- **Same repository, different source** — updates the existing object to the desired reference. The comparison is registry-agnostic, so a relocation is recognized as the same dependency.
- **Different repository, same derived name** — leaves the existing object untouched and fails resolution explicitly instead of guessing.
- **Normalizes one comparison edge case** — `RepositoryStr()` implicitly namespaces a bare single-segment repository as `library/x`; without matching that on both sides, a legitimate relocation could misclassify as a collision.

#### Test coverage

`TestReconcileOnNameCollision` (`internal/controller/pkg/resolver/reconciler_test.go`): repoints a stale source, no-ops on an exact match, fails closed on a genuine collision between unrelated packages, and repoints correctly on both sides of the `library/`-namespacing edge case.

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Read and followed Crossplane's [AI policy] and confirmed a human stands behind this PR.
- [ ] ~Run `./nix.sh flake check` to ensure this PR is ready for review.~ Nix wasn't available in my environment; ran the equivalent directly instead — `go build`, `go vet`, `go test ./internal/controller/pkg/resolver/...`, and `golangci-lint run ./...` pinned to the flake's resolved version (`v2.12.2`). All clean.
- [x] Added or updated unit tests.
- [ ] ~Added or updated e2e tests.~ Correctness fix to existing dependency-resolution logic, covered by the resolver's existing unit-test harness.
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~ No user-facing or documented behavior change — this restores the resolver's existing dependency-resolution guarantee.
- [ ] Added `backport release-x.y` labels to auto-backport this PR. Leaving to maintainer discretion on which active release branches this should target.
- [ ] ~Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~ No API changes.

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[AI policy]: https://github.com/crossplane/crossplane/blob/main/AI_POLICY.md
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md
