### PR TITLE
Disambiguate colliding dependency names in resolver

### DIFF
--- a/internal/controller/pkg/resolver/reconciler.go
+++ b/internal/controller/pkg/resolver/reconciler.go
@@ -711,9 +711,11 @@ func NewPackage(dep *v1beta1.Dependency, version string, ref name.Reference) (*u
 	// character name limit, so two different repositories can truncate to
 	// the same name. Mixing in a hash of the full repository string (the
 	// same truncate-then-append-hash shape FriendlyID already uses for
-	// package revisions) keeps them distinct.
+	// package revisions) keeps them distinct. The hash covers the registry
+	// too, not just the repository path, so the same path on two different
+	// registries doesn't collide.
 	repo := ref.Context().RepositoryStr()
-	h := sha256.Sum256([]byte(repo))
+	h := sha256.Sum256([]byte(ref.Context().Name()))
 	pack.SetName(xpkg.FriendlyID(repo, hex.EncodeToString(h[:])))
 
 	format := packageTagFmt

--- a/internal/controller/pkg/resolver/reconciler.go
+++ b/internal/controller/pkg/resolver/reconciler.go
@@ -19,6 +19,8 @@ package resolver
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"slices"
 	"sort"
@@ -703,7 +705,16 @@ func matchesAnyConstraint(version string, constraints []string) bool {
 // NewPackage creates a new package from the given dependency and version.
 func NewPackage(dep *v1beta1.Dependency, version string, ref name.Reference) (*unstructured.Unstructured, error) {
 	pack := &unstructured.Unstructured{}
-	pack.SetName(xpkg.ToDNSLabel(ref.Context().RepositoryStr()))
+
+	// Two dependencies with different repositories can share a long common
+	// prefix. ToDNSLabel truncates its input to fit the Kubernetes 63
+	// character name limit, so two different repositories can truncate to
+	// the same name. Mixing in a hash of the full repository string (the
+	// same truncate-then-append-hash shape FriendlyID already uses for
+	// package revisions) keeps them distinct.
+	repo := ref.Context().RepositoryStr()
+	h := sha256.Sum256([]byte(repo))
+	pack.SetName(xpkg.FriendlyID(repo, hex.EncodeToString(h[:])))
 
 	format := packageTagFmt
 	if strings.HasPrefix(version, "sha256:") {

--- a/internal/controller/pkg/resolver/reconciler_test.go
+++ b/internal/controller/pkg/resolver/reconciler_test.go
@@ -1941,6 +1941,15 @@ func TestNewPackage(t *testing.T) {
 			},
 			want: want{namesDiffer: true},
 		},
+		"SameRepositoryOnDifferentRegistriesGetDistinctNames": {
+			reason: "The same repository path on two different registries is a different dependency and must not collapse to the same generated name.",
+			args: args{
+				version: "v1.0.0",
+				refA:    "registry-one.example.com/foo/bar",
+				refB:    "registry-two.example.com/foo/bar",
+			},
+			want: want{namesDiffer: true},
+		},
 	}
 
 	for name, tc := range cases {

--- a/internal/controller/pkg/resolver/reconciler_test.go
+++ b/internal/controller/pkg/resolver/reconciler_test.go
@@ -1903,3 +1903,72 @@ func TestPruneOutdatedDependencies(t *testing.T) {
 		})
 	}
 }
+
+func TestNewPackage(t *testing.T) {
+	type args struct {
+		version string
+		refA    string
+		refB    string
+	}
+
+	type want struct {
+		namesDiffer bool
+	}
+
+	fn := v1beta1.FunctionPackageType
+	dep := &v1beta1.Dependency{Type: &fn}
+
+	cases := map[string]struct {
+		reason string
+		args   args
+		want   want
+	}{
+		"LongSharedPrefixDependenciesGetDistinctNames": {
+			reason: "Two dependencies whose repositories share a prefix long enough to exhaust the Kubernetes 63 character name limit must not collapse to the same generated name (#7813).",
+			args: args{
+				version: "v1.0.0",
+				refA:    "reg.example.com/some-org/very-long-subgroup-path/that-is-definitely-longer-than-sixty-three-characters-total/foo",
+				refB:    "reg.example.com/some-org/very-long-subgroup-path/that-is-definitely-longer-than-sixty-three-characters-total/bar",
+			},
+			want: want{namesDiffer: true},
+		},
+		"ShortDistinctRepositoriesGetDistinctNames": {
+			reason: "Two short, obviously different repositories must also produce distinct names.",
+			args: args{
+				version: "v1.0.0",
+				refA:    "reg.example.com/foo",
+				refB:    "reg.example.com/bar",
+			},
+			want: want{namesDiffer: true},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			refA, err := pkgName.ParseReference(tc.args.refA)
+			if err != nil {
+				t.Fatalf("could not parse test reference %q: %v", tc.args.refA, err)
+			}
+
+			refB, err := pkgName.ParseReference(tc.args.refB)
+			if err != nil {
+				t.Fatalf("could not parse test reference %q: %v", tc.args.refB, err)
+			}
+
+			packA, err := NewPackage(dep, tc.args.version, refA)
+			if err != nil {
+				t.Fatalf("NewPackage(...): unexpected error for refA: %v", err)
+			}
+
+			packB, err := NewPackage(dep, tc.args.version, refB)
+			if err != nil {
+				t.Fatalf("NewPackage(...): unexpected error for refB: %v", err)
+			}
+
+			differ := packA.GetName() != packB.GetName()
+			if diff := cmp.Diff(tc.want.namesDiffer, differ); diff != "" {
+				t.Errorf("\n%s\nNewPackage(...): -want namesDiffer, +got:\n%s", tc.reason, diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Description of your changes

Previously NewPackage() in internal/controller/pkg/resolver/reconciler.go generated a dependency's kubernetes object name from its OCI repository path via bare xpkg.ToDNSLabel() call which truncates to 63 char limit with no disambiguation, so two different repositories that share a long enough prefix produce the same name

Fix : use xpkg.FriendlyID(repo,hash) instead of the bare ToDNSLabel(repo) - the same function that is used for package revision naming - where hash is a sha256 of the full repo path , so the two colliding name always diverge

Added TestNewPackage : a long-shared-prefix collision case (the actual bug) and a short-repo sanity case. Verified the collision case fails on unmodified main and passes with the fix.

Fixes #7813

I have:
- [x] Read and followed Crossplane's [contribution process].
- [x] Read and followed Crossplane's [AI policy] and confirmed a human stands behind this PR.
- [ ] Run `./nix.sh flake check` to ensure this PR is ready for review. My local environment couldn't get through the full flake check — it hit a disk space limit initially, and after clearing that, `go-lint` was OOM-killed inside the sandboxed build VM. I verified directly instead with `go build ./...`, `go vet ./...`, and `go test ./internal/controller/pkg/resolver/...`, all clean. Deferring the full lint/flake-check pass to CI.
- [x] Added or updated unit tests.
- [ ] ~~Added or updated e2e tests.~~ This is a correctness fix to existing dependency-resolution logic, not a new feature; it's covered by the resolver's existing unit-test harness.
- [ ] ~~Linked a PR or a [docs tracking issue] to [document this change].~~ No user-facing API or documented behavior changes; this restores the resolver's existing dependency-resolution guarantee rather than adding new surface.
- [ ] Added `backport release-x.y` labels to auto-backport this PR. Leaving this to maintainer discretion — I'm not sure which active release branches you'd want this backported to.
- [ ] ~~Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~~ No API changes.

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[AI policy]: https://github.com/crossplane/crossplane/blob/main/AI_POLICY.md
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md
