### PR TITLE
docs: update governance to use .project maintainer list

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -245,14 +245,7 @@ will then add them to the following locations:
 * `OWNERS.md` file at the root of the repo
 * The appropriate GitHub team that allows maintainer permissions to the repo,
   including merging pull requests into protected branches.
-* CNCF maintainer lists
-  * CNCF [project
-    maintainers](https://github.com/cncf/foundation/blob/main/project-maintainers.csv)
-    list
-  * `cncf-crossplane-maintainers@lists.cncf.io` mailing list
-  * See CNCF [new maintainer
-    guidance](https://github.com/cncf/foundation/blob/main/.github/pull_request_template.md)
-    for further details
+* Crossplane [`.project` maintainer list](https://github.com/crossplane/.project/blob/main/maintainers.yaml)
 
 #### Maintainers for New Repositories
 
@@ -373,10 +366,7 @@ policies throughout their lifecycle:
 * **Maintainer list:** The current list of maintainers must be kept up to date
   in the following places:
   * `OWNERS.md` file at the root of the repo
-  * CNCF [project
-    maintainers](https://github.com/cncf/foundation/blob/main/project-maintainers.csv)
-    list
-  * `cncf-crossplane-maintainers@lists.cncf.io` mailing list
+  * Crossplane [`.project` maintainer list](https://github.com/crossplane/.project/blob/main/maintainers.yaml)
 * **Project list:** Each extension should keep their entry in the [Community
   Extension Project
   list](https://docs.crossplane.io/latest/learn/community-extension-projects/)


### PR DESCRIPTION
### Description of your changes

The CNCF has rolled out the .project initiative for Crossplane now initiative https://github.com/crossplane/.project. This is the centralized list that should be updated with current maintainers. Further automation will then sync that list to other places for the CNCF, e.g. the maintainer mailing list.

This commit updates the project governance to specify that this is the maintainer list that needs to be updated as maintainers for each Crossplane project repository is updated.

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Read and followed Crossplane's [AI policy] and confirmed a human stands behind this PR.
- [x] Run `./nix.sh flake check` to ensure this PR is ready for review.
- [ ] ~Added or updated unit tests.~
- [ ] ~Added or updated e2e tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~
- [ ] ~Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[AI policy]: https://github.com/crossplane/crossplane/blob/main/AI_POLICY.md
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md
