### PR TITLE
[Backport release-2.3] fix(pkg): take control of established objects from replaced revisions

### DIFF
--- a/.github/renovate-base.json5
+++ b/.github/renovate-base.json5
@@ -23,6 +23,9 @@
     'design/**',
     // We test upgrades, so leave it on an older version on purpose.
     "test/e2e/manifests/pkg/provider/provider-initial.yaml",
+    // We test the revision control hand-off on upgrade, so both versions must
+    // remain as they are.
+    "test/e2e/manifests/pkg/provider-handoff/**",
     // We test dependencies' upgrades, manifests must remain unchanged to avoid breaking tests.
     "test/e2e/manifests/pkg/dependency-upgrade/**",
     // We test packages signature verifications also on upgrades, manifests must remain unchanged to avoid breaking tests.

--- a/internal/controller/apiextensions/managed/reconciler.go
+++ b/internal/controller/apiextensions/managed/reconciler.go
@@ -205,24 +205,22 @@ func (r *Reconciler) Reconcile(ogctx context.Context, req reconcile.Request) (re
 	return reconcile.Result{}, errors.Wrap(r.client.Status().Update(ogctx, mrd), "cannot update status of ManagedResourceDefinition")
 }
 
-// handOverControl prepares patch, the CRD we are about to apply, to take
-// control of crd, the live CRD, from the package revision that still controls
-// it, by declaring that revision's owner reference demoted to a plain owner.
+// handOverControl lets the CRD we are about to apply take control from the
+// package revision that still controls the live one, by declaring that
+// revision's owner reference alongside ours, demoted to a plain owner.
 //
-// Server-side apply can't complete the hand-off on its own when the outgoing
-// revision's reference was written by another field manager, as an older
-// Crossplane's establisher did client-side: owner references are merged by
-// UID and only entries we own are pruned, so the old entry survives our apply,
-// and declaring a second controller beside it is rejected, since only one
-// owner reference may control an object. Declaring the old entry demoted sets
-// the new controller and demotes the old one in one write, and gives our field
-// manager the entry, so a later apply that no longer declares it prunes it.
+// We need this because the old reference may have been written by another
+// field manager, for example client-side by the establisher of an older
+// Crossplane. Server-side apply merges owner references by UID and only prunes
+// entries we own, so that entry survives our apply, and adding a second
+// controller next to it is rejected. Declaring it demoted flips it in the same
+// write and makes it ours, so the next apply, which no longer declares it,
+// prunes it.
 //
-// Only a package revision of the same group and kind as the MRD's controller
-// is taken over. The MRD decides which revision controls what is derived from
-// it, and the establisher only hands it over between revisions of the same
-// package, so the CRD follows it. Anything else keeps control, and the apply
-// fails loudly rather than take the CRD from it.
+// We only do this for a revision of the same group and kind as the MRD's
+// controller. The establisher already decides which revision controls the
+// MRD, so the CRD just follows. Anything else keeps control and the apply
+// fails as it always has.
 func handOverControl(patch, crd metav1.Object) {
 	want := metav1.GetControllerOf(patch)
 	got := metav1.GetControllerOf(crd)

--- a/internal/controller/apiextensions/managed/reconciler.go
+++ b/internal/controller/apiextensions/managed/reconciler.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kunstructured "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -156,6 +157,11 @@ func (r *Reconciler) Reconcile(ogctx context.Context, req reconcile.Request) (re
 		return reconcile.Result{}, errors.Wrap(err, "cannot form CustomResourceDefinition")
 	}
 
+	// The CRD's controller follows the MRD's, so an upgrade hands the CRD
+	// over between package revisions just as it hands the MRD over. See
+	// handOverControl for why the apply below can't do that on its own.
+	handOverControl(patch, crd)
+
 	// Server-side apply the CRD. This handles both create and update.
 	// The Patch call updates patch in-place with the server response.
 	//
@@ -197,6 +203,42 @@ func (r *Reconciler) Reconcile(ogctx context.Context, req reconcile.Request) (re
 	}
 
 	return reconcile.Result{}, errors.Wrap(r.client.Status().Update(ogctx, mrd), "cannot update status of ManagedResourceDefinition")
+}
+
+// handOverControl prepares patch, the CRD we are about to apply, to take
+// control of crd, the live CRD, from the package revision that still controls
+// it, by declaring that revision's owner reference demoted to a plain owner.
+//
+// Server-side apply can't complete the hand-off on its own when the outgoing
+// revision's reference was written by another field manager, as an older
+// Crossplane's establisher did client-side: owner references are merged by
+// UID and only entries we own are pruned, so the old entry survives our apply,
+// and declaring a second controller beside it is rejected, since only one
+// owner reference may control an object. Declaring the old entry demoted sets
+// the new controller and demotes the old one in one write, and gives our field
+// manager the entry, so a later apply that no longer declares it prunes it.
+//
+// Only a package revision of the same group and kind as the MRD's controller
+// is taken over. The MRD decides which revision controls what is derived from
+// it, and the establisher only hands it over between revisions of the same
+// package, so the CRD follows it. Anything else keeps control, and the apply
+// fails loudly rather than take the CRD from it.
+func handOverControl(patch, crd metav1.Object) {
+	want := metav1.GetControllerOf(patch)
+	got := metav1.GetControllerOf(crd)
+
+	if want == nil || got == nil || got.UID == want.UID {
+		return
+	}
+
+	// Compare group and kind rather than the whole API version, since the API
+	// server may serve the revision's type at more than one.
+	if schema.FromAPIVersionAndKind(got.APIVersion, got.Kind).GroupKind() != schema.FromAPIVersionAndKind(want.APIVersion, want.Kind).GroupKind() {
+		return
+	}
+
+	got.Controller = new(false)
+	meta.AddOwnerReference(patch, *got)
 }
 
 // protectionEnabled returns true if provider deletion protection is enabled.

--- a/internal/controller/apiextensions/managed/reconciler_test.go
+++ b/internal/controller/apiextensions/managed/reconciler_test.go
@@ -481,6 +481,197 @@ func TestReconcile(t *testing.T) {
 	}
 }
 
+// TestReconcileCRDControllerHandoff covers the hand-off of a CRD between the
+// package revisions that control the ManagedResourceDefinition it's derived
+// from. The outgoing revision's controlling owner reference may have been
+// written by a field manager that isn't ours, in which case server-side apply
+// can't prune it and we have to declare it, demoted, to take it over.
+func TestReconcileCRDControllerHandoff(t *testing.T) {
+	// The revision that controls the MRD, and so should control its CRD.
+	incoming := metav1.OwnerReference{
+		APIVersion: "pkg.crossplane.io/v1",
+		Kind:       "ProviderRevision",
+		Name:       "cool-provider-b",
+		UID:        types.UID("uid-b"),
+		Controller: new(true),
+	}
+
+	// The revision it replaced, still controlling the live CRD.
+	outgoing := metav1.OwnerReference{
+		APIVersion: "pkg.crossplane.io/v1",
+		Kind:       "ProviderRevision",
+		Name:       "cool-provider-a",
+		UID:        types.UID("uid-a"),
+		Controller: new(true),
+	}
+
+	demoted := outgoing
+	demoted.Controller = new(false)
+
+	// The same outgoing revision, referenced through another served version.
+	outgoingV1beta1 := outgoing
+	outgoingV1beta1.APIVersion = "pkg.crossplane.io/v1beta1"
+
+	demotedV1beta1 := outgoingV1beta1
+	demotedV1beta1.Controller = new(false)
+
+	// Something that isn't a package revision at all.
+	xrd := metav1.OwnerReference{
+		APIVersion: "apiextensions.crossplane.io/v2",
+		Kind:       "CompositeResourceDefinition",
+		Name:       "databases.example.com",
+		UID:        types.UID("uid-xrd"),
+		Controller: new(true),
+	}
+
+	// The MRD's own reference, which CRDAsUnstructured always adds.
+	mrdOwner := metav1.OwnerReference{
+		APIVersion: v1alpha1.SchemeGroupVersion.String(),
+		Kind:       v1alpha1.ManagedResourceDefinitionKind,
+		Name:       "test-mrd",
+		UID:        types.UID("test-uid"),
+	}
+
+	mrd := func(refs ...metav1.OwnerReference) *v1alpha1.ManagedResourceDefinition {
+		return newMRD(func(mrd *v1alpha1.ManagedResourceDefinition) {
+			mrd.SetOwnerReferences(refs)
+			mrd.Spec.CustomResourceDefinitionSpec = v1alpha1.CustomResourceDefinitionSpec{
+				Group: "example.com",
+				Names: extv1.CustomResourceDefinitionNames{Plural: "databases", Kind: "Database"},
+				Scope: extv1.ClusterScoped,
+				Versions: []v1alpha1.CustomResourceDefinitionVersion{{
+					Name:    "v1",
+					Served:  true,
+					Storage: true,
+					Schema: &v1alpha1.CustomResourceValidation{
+						OpenAPIV3Schema: runtime.RawExtension{
+							Raw: []byte(`{"type": "object", "properties": {"spec": {"type": "object"}}}`),
+						},
+					},
+				}},
+			}
+		})
+	}
+
+	crd := func(refs ...metav1.OwnerReference) *extv1.CustomResourceDefinition {
+		return &extv1.CustomResourceDefinition{ObjectMeta: metav1.ObjectMeta{OwnerReferences: refs}}
+	}
+
+	type args struct {
+		mrd *v1alpha1.ManagedResourceDefinition
+
+		// The live CRD, or nil if it doesn't exist yet.
+		crd *extv1.CustomResourceDefinition
+	}
+
+	cases := map[string]struct {
+		reason string
+		args   args
+		want   []metav1.OwnerReference
+	}{
+		"DemoteReplacedRevision": {
+			reason: "We should declare the outgoing revision's reference demoted alongside our own, so one apply completes the hand-off.",
+			args: args{
+				mrd: mrd(incoming),
+				crd: crd(outgoing),
+			},
+			want: []metav1.OwnerReference{mrdOwner, incoming, demoted},
+		},
+		"DemoteAnotherAPIVersionOfSameKind": {
+			reason: "We should take the CRD from a revision of the same group and kind whose reference was written through another API version, since the API server may serve the type at more than one.",
+			args: args{
+				mrd: mrd(incoming),
+				crd: crd(outgoingV1beta1),
+			},
+			want: []metav1.OwnerReference{mrdOwner, incoming, demotedV1beta1},
+		},
+		"RefuseAnotherKind": {
+			reason: "We should not take the CRD from a controller that isn't a package revision of the kind that controls the MRD, so the apply fails loudly instead.",
+			args: args{
+				mrd: mrd(incoming),
+				crd: crd(xrd),
+			},
+			want: []metav1.OwnerReference{mrdOwner, incoming},
+		},
+		"AlreadyOurs": {
+			reason: "A CRD we already control needs no hand-off, so we should declare only our own references and let SSA prune anything else.",
+			args: args{
+				mrd: mrd(incoming),
+				crd: crd(incoming),
+			},
+			want: []metav1.OwnerReference{mrdOwner, incoming},
+		},
+		"AlreadyDemoted": {
+			reason: "Once the outgoing reference is a plain owner it's ours to prune, so the second apply should stop declaring it.",
+			args: args{
+				mrd: mrd(incoming),
+				crd: crd(incoming, demoted),
+			},
+			want: []metav1.OwnerReference{mrdOwner, incoming},
+		},
+		"CRDDoesNotExist": {
+			reason: "There's no incumbent to demote when we're creating the CRD.",
+			args: args{
+				mrd: mrd(incoming),
+			},
+			want: []metav1.OwnerReference{mrdOwner, incoming},
+		},
+		"MRDHasNoController": {
+			reason: "We should leave the CRD's controller alone when we're not claiming control of it ourselves.",
+			args: args{
+				mrd: mrd(),
+				crd: crd(outgoing),
+			},
+			want: []metav1.OwnerReference{mrdOwner},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			var got []metav1.OwnerReference
+
+			c := &test.MockClient{
+				MockGet: func(_ context.Context, _ client.ObjectKey, obj client.Object) error {
+					switch o := obj.(type) {
+					case *v1alpha1.ManagedResourceDefinition:
+						*o = *tc.args.mrd
+					case *extv1.CustomResourceDefinition:
+						if tc.args.crd == nil {
+							return kerrors.NewNotFound(schema.GroupResource{}, "test-mrd")
+						}
+
+						*o = *tc.args.crd
+					}
+
+					return nil
+				},
+				MockPatch: func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) error {
+					got = obj.GetOwnerReferences()
+
+					return nil
+				},
+				MockStatusUpdate: test.NewMockSubResourceUpdateFn(nil),
+			}
+
+			r := &Reconciler{
+				client:        c,
+				managedFields: &ssa.NopManagedFieldsUpgrader{},
+				log:           logging.NewNopLogger(),
+				record:        event.NewNopRecorder(),
+				conditions:    conditions.ObservedGenerationPropagationManager{},
+			}
+
+			if _, err := r.Reconcile(context.Background(), reconcile.Request{NamespacedName: types.NamespacedName{Name: "test-mrd"}}); err != nil {
+				t.Fatalf("\n%s\nr.Reconcile(...): unexpected error: %v", tc.reason, err)
+			}
+
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("\n%s\napplied CustomResourceDefinition owner references: -want, +got:\n%s", tc.reason, diff)
+			}
+		})
+	}
+}
+
 // Helper functions and types for testing
 
 type mrdModifier func(mrd *v1alpha1.ManagedResourceDefinition)

--- a/internal/controller/pkg/revision/establisher.go
+++ b/internal/controller/pkg/revision/establisher.go
@@ -54,6 +54,7 @@ const (
 	errWebhookSecretWithoutCABundle = "the value for the key tls.crt cannot be empty"
 	errFmtGetOwnedObject            = "cannot get owned object: %s/%s"
 	errFmtUpdateOwnedObject         = "cannot update owned object: %s/%s"
+	errFmtGetControllingRevision    = "cannot get %s %q that currently controls this object"
 )
 
 const (
@@ -92,14 +93,16 @@ func (*NopEstablisher) ReleaseObjects(_ context.Context, _ v1.PackageRevision) e
 type APIEstablisher struct {
 	client                           client.Client
 	namespace                        string
+	newPackageRevision               func() v1.PackageRevision
 	MaxConcurrentPackageEstablishers int
 }
 
 // NewAPIEstablisher creates a new APIEstablisher.
-func NewAPIEstablisher(client client.Client, namespace string, maxConcurrentPackageEstablishers int) *APIEstablisher {
+func NewAPIEstablisher(client client.Client, namespace string, newPackageRevision func() v1.PackageRevision, maxConcurrentPackageEstablishers int) *APIEstablisher {
 	return &APIEstablisher{
 		client:                           client,
 		namespace:                        namespace,
+		newPackageRevision:               newPackageRevision,
 		MaxConcurrentPackageEstablishers: maxConcurrentPackageEstablishers,
 	}
 }
@@ -564,7 +567,17 @@ func (e *APIEstablisher) update(ctx context.Context, current, desired resource.O
 	// version to that of the current.
 	desired.SetOwnerReferences(current.GetOwnerReferences())
 
-	if err := meta.AddControllerReference(desired, meta.AsController(meta.TypedReferenceTo(parent, parent.GetObjectKind().GroupVersionKind()))); err != nil {
+	ctrlRef := meta.AsController(meta.TypedReferenceTo(parent, parent.GetObjectKind().GroupVersionKind()))
+
+	// A revision we're replacing may still be the object's controller, because
+	// it hasn't relinquished control yet or because it was replaced or deleted
+	// before it could. Demote it to be just an owner, so the hand-off doesn't depend on
+	// the order in which the two revisions reconcile.
+	if err := e.demoteOldController(ctx, desired, parent, ctrlRef); err != nil {
+		return err
+	}
+
+	if err := meta.AddControllerReference(desired, ctrlRef); err != nil {
 		return err
 	}
 
@@ -577,6 +590,99 @@ func (e *APIEstablisher) update(ctx context.Context, current, desired resource.O
 
 	// This should be a server side apply?
 	return e.client.Update(ctx, desired, opts...)
+}
+
+// demoteOldController demotes obj's controller owner reference to a plain owner
+// reference, so that want's owner can become the controller instead. It only
+// does so when the current controller is a revision this parent may take over
+// from: another revision of the same package, or a revision that no longer
+// exists.
+//
+// We only get here for a revision whose desired state is active, and a package
+// has at most one active revision, so taking control from a sibling revision is
+// safe. It's what lets a package upgrade complete even if the outgoing revision
+// never relinquishes control, e.g. because it was deleted, replaced, or paused.
+func (e *APIEstablisher) demoteOldController(ctx context.Context, obj, parent resource.Object, want metav1.OwnerReference) error {
+	c := metav1.GetControllerOf(obj)
+	if c == nil || c.UID == want.UID {
+		return nil
+	}
+
+	// Only ever take control from the same kind of revision we are. We compare
+	// group and kind rather than the whole API version, so that we still
+	// recognise a controller reference written through another version of our
+	// own type, which the API server may well still serve.
+	got := schema.FromAPIVersionAndKind(c.APIVersion, c.Kind).GroupKind()
+	ours := schema.FromAPIVersionAndKind(want.APIVersion, want.Kind).GroupKind()
+
+	if got != ours {
+		return nil
+	}
+
+	ok, err := e.controlledByReplacedRevision(ctx, *c, parent)
+	if err != nil || !ok {
+		return err
+	}
+
+	// Keep the old revision as a plain owner rather than dropping it, so we
+	// don't change when the object gets garbage collected.
+	refs := slices.Clone(obj.GetOwnerReferences())
+	for i := range refs {
+		if refs[i].UID == c.UID {
+			refs[i].Controller = new(false)
+			break
+		}
+	}
+
+	obj.SetOwnerReferences(refs)
+
+	return nil
+}
+
+// controlledByReplacedRevision returns true if the supplied controller owner
+// reference belongs to a revision of the same package as parent, or to a
+// revision that no longer exists. Either way it will never relinquish control
+// of the objects it established.
+func (e *APIEstablisher) controlledByReplacedRevision(ctx context.Context, c metav1.OwnerReference, parent resource.Object) (bool, error) {
+	pkg := parent.GetLabels()[v1.LabelParentPackage]
+	if pkg == "" {
+		// We can't tell what package we belong to, so we can't tell whether the
+		// controller is a revision of it.
+		return false, nil
+	}
+
+	// The controller is a revision of our own kind, so this is the type we need
+	// to read it into.
+	rev := e.newPackageRevision()
+
+	err := e.client.Get(ctx, types.NamespacedName{Name: c.Name}, rev)
+	if kerrors.IsNotFound(err) {
+		// The revision that took control is gone. The API server garbage
+		// collects the dangling owner reference eventually, but we don't want to
+		// wait for it.
+		return true, nil
+	}
+
+	if err != nil {
+		return false, errors.Wrapf(err, errFmtGetControllingRevision, c.Kind, c.Name)
+	}
+
+	// A revision with the same name but a different UID replaced the one that
+	// took control, so the original is gone too.
+	if rev.GetUID() != c.UID {
+		return true, nil
+	}
+
+	// Only take control from a revision of our own package.
+	if rev.GetLabels()[v1.LabelParentPackage] != pkg {
+		return false, nil
+	}
+
+	// Only take control from a revision that is on its way out. An active
+	// revision should keep control of its objects, and taking it from one would
+	// let a stale reconcile of a revision that was just deactivated take control
+	// back from the revision that replaced it, and flap between the two.
+	return rev.GetDesiredState() == v1.PackageRevisionInactive, nil
 }
 
 func (e *APIEstablisher) merge(_ context.Context, c, d resource.Object) error {

--- a/internal/controller/pkg/revision/establisher.go
+++ b/internal/controller/pkg/revision/establisher.go
@@ -620,8 +620,15 @@ func (e *APIEstablisher) demoteOldController(ctx context.Context, obj, parent re
 	}
 
 	ok, err := e.controlledByReplacedRevision(ctx, *c, parent)
-	if err != nil || !ok {
+	if err != nil {
 		return err
+	}
+
+	if !ok {
+		// Leave the current controller in place. AddControllerReference then
+		// fails with the same error it always has, which is what we want for
+		// an object that belongs to something else.
+		return nil
 	}
 
 	// Keep the old revision as a plain owner rather than dropping it, so we

--- a/internal/controller/pkg/revision/establisher_test.go
+++ b/internal/controller/pkg/revision/establisher_test.go
@@ -1158,6 +1158,299 @@ func TestAPIEstablisherReleaseObjects(t *testing.T) {
 	}
 }
 
+func TestAPIEstablisherDemoteOldController(t *testing.T) {
+	errBoom := errors.New("boom")
+
+	prAPIVersion := v1.ProviderRevisionGroupVersionKind.GroupVersion().String()
+
+	// The revision that wants to take control.
+	newParent := func() *v1.ProviderRevision {
+		pr := &v1.ProviderRevision{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   "cool-package-b",
+				UID:    "uid-b",
+				Labels: map[string]string{v1.LabelParentPackage: "cool-package"},
+			},
+		}
+		pr.SetGroupVersionKind(v1.ProviderRevisionGroupVersionKind)
+
+		return pr
+	}
+
+	// The controlling owner reference newParent() wants.
+	want := metav1.OwnerReference{
+		APIVersion:         prAPIVersion,
+		Kind:               v1.ProviderRevisionGroupVersionKind.Kind,
+		Name:               "cool-package-b",
+		UID:                "uid-b",
+		Controller:         new(true),
+		BlockOwnerDeletion: new(true),
+	}
+
+	// A controlling owner reference held by the revision we're replacing.
+	outgoing := metav1.OwnerReference{
+		APIVersion:         prAPIVersion,
+		Kind:               v1.ProviderRevisionGroupVersionKind.Kind,
+		Name:               "cool-package-a",
+		UID:                "uid-a",
+		Controller:         new(true),
+		BlockOwnerDeletion: new(true),
+	}
+
+	// The parent package's owner reference, which every established object
+	// carries alongside the revision's, and which we must never touch.
+	pkgOwner := metav1.OwnerReference{
+		APIVersion:         v1.ProviderGroupVersionKind.GroupVersion().String(),
+		Kind:               v1.ProviderGroupVersionKind.Kind,
+		Name:               "cool-package",
+		UID:                "uid-pkg",
+		Controller:         new(false),
+		BlockOwnerDeletion: new(true),
+	}
+
+	// The same reference, as an older version of Crossplane would have written
+	// it, through the API version it served our type at back then.
+	outgoingOldAPIVersion := func() metav1.OwnerReference {
+		r := outgoing
+		r.APIVersion = "pkg.crossplane.io/v1beta1"
+
+		return r
+	}()
+
+	// The same reference, demoted to a plain owner.
+	released := func() metav1.OwnerReference {
+		r := outgoing
+		r.Controller = new(false)
+
+		return r
+	}()
+
+	// The older-API-version reference, demoted to a plain owner.
+	releasedOldAPIVersion := func() metav1.OwnerReference {
+		r := outgoingOldAPIVersion
+		r.Controller = new(false)
+
+		return r
+	}()
+
+	// Returns a revision with the supplied UID, package label, and desired state.
+	revision := func(uid types.UID, pkg string, state v1.PackageRevisionDesiredState) func(context.Context, client.ObjectKey, client.Object) error {
+		return func(_ context.Context, key client.ObjectKey, obj client.Object) error {
+			pr, ok := obj.(*v1.ProviderRevision)
+			if !ok {
+				t.Errorf("want *v1.ProviderRevision, got %T", obj)
+				return nil
+			}
+
+			pr.SetName(key.Name)
+			pr.SetUID(uid)
+			pr.SetLabels(map[string]string{v1.LabelParentPackage: pkg})
+			pr.SetDesiredState(state)
+
+			return nil
+		}
+	}
+
+	type args struct {
+		client client.Client
+		obj    resource.Object
+		parent resource.Object
+	}
+
+	type wantT struct {
+		err  error
+		refs []metav1.OwnerReference
+	}
+
+	cases := map[string]struct {
+		reason string
+		args   args
+		want   wantT
+	}{
+		"NoController": {
+			reason: "An object with no controller should be left alone, so we can simply become its controller.",
+			args: args{
+				obj: &extv1.CustomResourceDefinition{ObjectMeta: metav1.ObjectMeta{
+					OwnerReferences: []metav1.OwnerReference{released},
+				}},
+				parent: newParent(),
+			},
+			want: wantT{refs: []metav1.OwnerReference{released}},
+		},
+		"AlreadyOurs": {
+			reason: "An object we already control should be left alone.",
+			args: args{
+				obj: &extv1.CustomResourceDefinition{ObjectMeta: metav1.ObjectMeta{
+					OwnerReferences: []metav1.OwnerReference{want},
+				}},
+				parent: newParent(),
+			},
+			want: wantT{refs: []metav1.OwnerReference{want}},
+		},
+		"ControlledByAnotherKind": {
+			reason: "We should not take control from a controller that isn't a revision of our kind.",
+			args: args{
+				obj: &extv1.CustomResourceDefinition{ObjectMeta: metav1.ObjectMeta{
+					OwnerReferences: []metav1.OwnerReference{{
+						APIVersion: prAPIVersion,
+						Kind:       "Provider",
+						Name:       "cool-package",
+						UID:        "uid-pkg",
+						Controller: new(true),
+					}},
+				}},
+				parent: newParent(),
+			},
+			want: wantT{refs: []metav1.OwnerReference{{
+				APIVersion: prAPIVersion,
+				Kind:       "Provider",
+				Name:       "cool-package",
+				UID:        "uid-pkg",
+				Controller: new(true),
+			}}},
+		},
+		"ControlledByAnotherAPIVersionOfOurKind": {
+			reason: "We should take control from a revision of our own group and kind whose owner reference was written through another API version, since the API server may serve our type at more than one.",
+			args: args{
+				client: &test.MockClient{MockGet: revision("uid-a", "cool-package", v1.PackageRevisionInactive)},
+				obj: &extv1.CustomResourceDefinition{ObjectMeta: metav1.ObjectMeta{
+					OwnerReferences: []metav1.OwnerReference{outgoingOldAPIVersion},
+				}},
+				parent: newParent(),
+			},
+			want: wantT{refs: []metav1.OwnerReference{releasedOldAPIVersion}},
+		},
+		"ControlledByAnotherGroup": {
+			reason: "We should not take control from a controller of another group, even if it shares our kind.",
+			args: args{
+				obj: &extv1.CustomResourceDefinition{ObjectMeta: metav1.ObjectMeta{
+					OwnerReferences: []metav1.OwnerReference{{
+						APIVersion: "pkg.example.org/v1",
+						Kind:       v1.ProviderRevisionGroupVersionKind.Kind,
+						Name:       "cool-package-a",
+						UID:        "uid-a",
+						Controller: new(true),
+					}},
+				}},
+				parent: newParent(),
+			},
+			want: wantT{refs: []metav1.OwnerReference{{
+				APIVersion: "pkg.example.org/v1",
+				Kind:       v1.ProviderRevisionGroupVersionKind.Kind,
+				Name:       "cool-package-a",
+				UID:        "uid-a",
+				Controller: new(true),
+			}}},
+		},
+		"OtherOwnersAreLeftAlone": {
+			reason: "We should demote only the controller we're taking over from, leaving the parent package's owner reference untouched and in place.",
+			args: args{
+				client: &test.MockClient{MockGet: revision("uid-a", "cool-package", v1.PackageRevisionInactive)},
+				obj: &extv1.CustomResourceDefinition{ObjectMeta: metav1.ObjectMeta{
+					OwnerReferences: []metav1.OwnerReference{pkgOwner, outgoing},
+				}},
+				parent: newParent(),
+			},
+			want: wantT{refs: []metav1.OwnerReference{pkgOwner, released}},
+		},
+		"ControlledByInactiveRevisionOfSamePackage": {
+			reason: "We should take control from an inactive revision of our package, e.g. one that hasn't relinquished control yet.",
+			args: args{
+				client: &test.MockClient{MockGet: revision("uid-a", "cool-package", v1.PackageRevisionInactive)},
+				obj: &extv1.CustomResourceDefinition{ObjectMeta: metav1.ObjectMeta{
+					OwnerReferences: []metav1.OwnerReference{outgoing},
+				}},
+				parent: newParent(),
+			},
+			want: wantT{refs: []metav1.OwnerReference{released}},
+		},
+		"ControlledByDeletedRevision": {
+			reason: "We should take control from a revision that no longer exists, since it can never relinquish it.",
+			args: args{
+				client: &test.MockClient{MockGet: test.NewMockGetFn(kerrors.NewNotFound(schema.GroupResource{}, "cool-package-a"))},
+				obj: &extv1.CustomResourceDefinition{ObjectMeta: metav1.ObjectMeta{
+					OwnerReferences: []metav1.OwnerReference{outgoing},
+				}},
+				parent: newParent(),
+			},
+			want: wantT{refs: []metav1.OwnerReference{released}},
+		},
+		"ControlledByActiveRevisionOfSamePackage": {
+			reason: "We should not take control from a revision of our package that is still active, so that a stale reconcile can't take control back from the revision that replaced it.",
+			args: args{
+				client: &test.MockClient{MockGet: revision("uid-a", "cool-package", v1.PackageRevisionActive)},
+				obj: &extv1.CustomResourceDefinition{ObjectMeta: metav1.ObjectMeta{
+					OwnerReferences: []metav1.OwnerReference{outgoing},
+				}},
+				parent: newParent(),
+			},
+			want: wantT{refs: []metav1.OwnerReference{outgoing}},
+		},
+		"ControlledByReplacedRevision": {
+			reason: "We should take control from a revision that was replaced by one with the same name, as happens when Crossplane is upgraded, whatever state the replacement is in.",
+			args: args{
+				client: &test.MockClient{MockGet: revision("uid-a-new", "cool-package", v1.PackageRevisionActive)},
+				obj: &extv1.CustomResourceDefinition{ObjectMeta: metav1.ObjectMeta{
+					OwnerReferences: []metav1.OwnerReference{outgoing},
+				}},
+				parent: newParent(),
+			},
+			want: wantT{refs: []metav1.OwnerReference{released}},
+		},
+		"ControlledByRevisionOfAnotherPackage": {
+			reason: "We should not take control from a revision of a different package.",
+			args: args{
+				client: &test.MockClient{MockGet: revision("uid-a", "uncool-package", v1.PackageRevisionInactive)},
+				obj: &extv1.CustomResourceDefinition{ObjectMeta: metav1.ObjectMeta{
+					OwnerReferences: []metav1.OwnerReference{outgoing},
+				}},
+				parent: newParent(),
+			},
+			want: wantT{refs: []metav1.OwnerReference{outgoing}},
+		},
+		"ParentHasNoPackageLabel": {
+			reason: "We should not take control if we can't tell which package we belong to.",
+			args: args{
+				obj: &extv1.CustomResourceDefinition{ObjectMeta: metav1.ObjectMeta{
+					OwnerReferences: []metav1.OwnerReference{outgoing},
+				}},
+				parent: &v1.ProviderRevision{ObjectMeta: metav1.ObjectMeta{Name: "cool-package-b", UID: "uid-b"}},
+			},
+			want: wantT{refs: []metav1.OwnerReference{outgoing}},
+		},
+		"GetControllingRevisionError": {
+			reason: "We should return an error if we can't tell whether the controlling revision is one of ours.",
+			args: args{
+				client: &test.MockClient{MockGet: test.NewMockGetFn(errBoom)},
+				obj: &extv1.CustomResourceDefinition{ObjectMeta: metav1.ObjectMeta{
+					OwnerReferences: []metav1.OwnerReference{outgoing},
+				}},
+				parent: newParent(),
+			},
+			want: wantT{
+				err:  errors.Wrapf(errBoom, errFmtGetControllingRevision, v1.ProviderRevisionGroupVersionKind.Kind, "cool-package-a"),
+				refs: []metav1.OwnerReference{outgoing},
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			e := newAPIEstablisher(tc.args.client)
+
+			err := e.demoteOldController(context.TODO(), tc.args.obj, tc.args.parent, want)
+
+			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
+				t.Errorf("\n%s\ne.demoteOldController(...): -want error, +got error:\n%s", tc.reason, diff)
+			}
+
+			if diff := cmp.Diff(tc.want.refs, tc.args.obj.GetOwnerReferences()); diff != "" {
+				t.Errorf("\n%s\ne.demoteOldController(...): -want, +got:\n%s", tc.reason, diff)
+			}
+		})
+	}
+}
+
 func TestGetPackageOwnerReference(t *testing.T) {
 	type args struct {
 		revision resource.Object
@@ -1459,6 +1752,7 @@ func TestAddAnnotations(t *testing.T) {
 func newAPIEstablisher(client client.Client) *APIEstablisher {
 	return &APIEstablisher{
 		client:                           client,
+		newPackageRevision:               func() v1.PackageRevision { return &v1.ProviderRevision{} },
 		MaxConcurrentPackageEstablishers: 10, // Use the current default
 	}
 }

--- a/internal/controller/pkg/revision/reconciler.go
+++ b/internal/controller/pkg/revision/reconciler.go
@@ -234,7 +234,7 @@ func SetupProviderRevision(mgr ctrl.Manager, o controller.Options) error {
 		Watches(&v1beta1.ImageConfig{}, EnqueuePackageRevisionsForImageConfig(mgr.GetClient(), &v1.ProviderRevisionList{}, log))
 
 	est := NewFilteringEstablisher(
-		NewAPIEstablisher(mgr.GetClient(), o.Namespace, o.MaxConcurrentPackageEstablishers),
+		NewAPIEstablisher(mgr.GetClient(), o.Namespace, nr, o.MaxConcurrentPackageEstablishers),
 		extv1alpha1.ManagedResourceDefinitionGroupVersionKind.GroupKind(),
 		schema.GroupKind{Group: k8sextv1.SchemeGroupVersion.Group, Kind: "CustomResourceDefinition"},
 		schema.GroupKind{Group: admv1.SchemeGroupVersion.Group, Kind: "ValidatingWebhookConfiguration"},
@@ -267,7 +267,7 @@ func SetupConfigurationRevision(mgr ctrl.Manager, o controller.Options) error {
 	log := o.Logger.WithValues("controller", name)
 
 	est := NewFilteringEstablisher(
-		NewAPIEstablisher(mgr.GetClient(), o.Namespace, o.MaxConcurrentPackageEstablishers),
+		NewAPIEstablisher(mgr.GetClient(), o.Namespace, nr, o.MaxConcurrentPackageEstablishers),
 		extv2.CompositeResourceDefinitionGroupVersionKind.GroupKind(),
 		extv1.CompositionGroupVersionKind.GroupKind(),
 		extv1alpha1.ManagedResourceActivationPolicyGroupVersionKind.GroupKind(),
@@ -317,7 +317,7 @@ func SetupFunctionRevision(mgr ctrl.Manager, o controller.Options) error {
 	// any objects from function packages. Create an empty filtering establisher
 	// to filter them all out.
 	est := NewFilteringEstablisher(
-		NewAPIEstablisher(mgr.GetClient(), o.Namespace, o.MaxConcurrentPackageEstablishers),
+		NewAPIEstablisher(mgr.GetClient(), o.Namespace, nr, o.MaxConcurrentPackageEstablishers),
 	)
 
 	r := NewReconciler(mgr,

--- a/test/e2e/funcs/feature.go
+++ b/test/e2e/funcs/feature.go
@@ -1521,6 +1521,51 @@ func FilterByGK(gk schema.GroupKind) func(o k8s.Object) bool {
 	}
 }
 
+// ControlledBy returns a FieldValueChecker for the "metadata.ownerReferences" field path. It matches
+// when the object has a controlling owner reference naming the given owner. It tolerates other,
+// non-controlling owners.
+//
+// It reads the unstructured form of the field, a []any of map[string]any, so it will not match at
+// any other field path.
+func ControlledBy(name string) FieldValueChecker {
+	return func(got any) bool { return hasOwnerReference(got, name, true) }
+}
+
+// OwnedButNotControlledBy returns a FieldValueChecker for the "metadata.ownerReferences" field path.
+// It matches when the object has an owner reference naming the given owner that is not controlling,
+// as a revision that has handed control over to another one has. Other owners are allowed.
+//
+// It reads the unstructured form of the field, a []any of map[string]any, so it will not match at
+// any other field path.
+func OwnedButNotControlledBy(name string) FieldValueChecker {
+	return func(got any) bool { return hasOwnerReference(got, name, false) }
+}
+
+// hasOwnerReference returns true if the supplied unstructured owner references include one that
+// names the supplied owner and whose controller flag is the supplied value.
+func hasOwnerReference(got any, name string, controller bool) bool {
+	ors, ok := got.([]any)
+	if !ok {
+		return false
+	}
+
+	for _, or := range ors {
+		r, ok := or.(map[string]any)
+		if !ok {
+			continue
+		}
+
+		n, _ := r["name"].(string)
+		c, _ := r["controller"].(bool)
+
+		if n == name && c == controller {
+			return true
+		}
+	}
+
+	return false
+}
+
 func toYAML(objs ...client.Object) string {
 	docs := make([]string, 0, len(objs))
 	for _, obj := range objs {

--- a/test/e2e/manifests/pkg/provider-handoff/mr.yaml
+++ b/test/e2e/manifests/pkg/provider-handoff/mr.yaml
@@ -1,0 +1,15 @@
+apiVersion: nop.crossplane.io/v1alpha1
+kind: NopResource
+metadata:
+  name: pkg-provider-handoff
+spec:
+ forProvider:
+   conditionAfter:
+   - conditionType: Ready
+     conditionStatus: "False"
+     conditionReason: "Creating"
+     time: 0s
+   - conditionType: Ready
+     conditionStatus: "True"
+     conditionReason: "Available"
+     time: 1s

--- a/test/e2e/manifests/pkg/provider-handoff/provider-initial.yaml
+++ b/test/e2e/manifests/pkg/provider-handoff/provider-initial.yaml
@@ -1,0 +1,14 @@
+apiVersion: pkg.crossplane.io/v1
+kind: Provider
+metadata:
+  name: provider-nop-pkg-handoff
+spec:
+  # This should not be updated by renovate as we need this to be not on the
+  # latest version, ignored explicitly in renovate's configuration
+  package: xpkg.upbound.io/crossplane-contrib/provider-nop:v0.2.0
+  ignoreCrossplaneConstraints: true
+  # The test pauses the outgoing revision, which also stops it removing itself
+  # from the Lock. Two revisions of the same package in the Lock fail dependency
+  # resolution with "node ... already exists", which would mask the hand-off this
+  # test is about. provider-nop has no dependencies, so skip resolution.
+  skipDependencyResolution: true

--- a/test/e2e/manifests/pkg/provider-handoff/provider-upgrade.yaml
+++ b/test/e2e/manifests/pkg/provider-handoff/provider-upgrade.yaml
@@ -1,0 +1,9 @@
+apiVersion: pkg.crossplane.io/v1
+kind: Provider
+metadata:
+  name: provider-nop-pkg-handoff
+spec:
+  package: xpkg.upbound.io/crossplane-contrib/provider-nop:v0.3.0
+  ignoreCrossplaneConstraints: true
+  # See provider-initial.yaml.
+  skipDependencyResolution: true

--- a/test/e2e/pkg_test.go
+++ b/test/e2e/pkg_test.go
@@ -248,6 +248,11 @@ func TestProviderUpgradeInactiveRevisionHoldsControl(t *testing.T) {
 				funcs.ResourcesCreatedWithin(1*time.Minute, manifests, "mr.yaml"),
 				funcs.ResourcesHaveConditionWithin(2*time.Minute, manifests, "mr.yaml", xpv2.Available()),
 			)).
+			// Log revision conditions for the rest of the feature, so a failure
+			// below shows why the incoming revision is unhealthy. A setup step
+			// runs on the feature-level test, so the logging outlives any one
+			// assessment.
+			WithSetup("LogProviderRevisions", funcs.InBackground(funcs.LogResources(&pkgv1.ProviderRevisionList{}, revisionsOfProvider))).
 			// Record the objects the outgoing revision controls, rather than
 			// naming them here. Which kinds the establisher controls depends on
 			// whether managed resource CRDs were converted to MRDs.
@@ -312,9 +317,6 @@ func TestProviderUpgradeInactiveRevisionHoldsControl(t *testing.T) {
 					xpv2.ReconcilePaused(),
 				)(ctx, t, c)
 			}).
-			// Log revision conditions while the upgrade runs, so a failure of the
-			// assessment below shows why the incoming revision is unhealthy.
-			Assess("LogProviderRevisions", funcs.InBackground(funcs.LogResources(&pkgv1.ProviderRevisionList{}, revisionsOfProvider))).
 			Assess("UpgradeProvider", funcs.ApplyResources(FieldManager, manifests, "provider-upgrade.yaml")).
 			// This is the assessment that fails when the establisher can't take
 			// control from the revision it replaced. The provider stays unhealthy

--- a/test/e2e/pkg_test.go
+++ b/test/e2e/pkg_test.go
@@ -25,13 +25,20 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	k8sapiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/e2e-framework/klient/k8s"
+	"sigs.k8s.io/e2e-framework/klient/k8s/resources"
 	"sigs.k8s.io/e2e-framework/pkg/envconf"
 	"sigs.k8s.io/e2e-framework/pkg/features"
 	"sigs.k8s.io/e2e-framework/third_party/helm"
 
+	xpmeta "github.com/crossplane/crossplane-runtime/v2/pkg/meta"
+
 	apiextensionsv1 "github.com/crossplane/crossplane/apis/v2/apiextensions/v1"
+	apiextensionsv1alpha1 "github.com/crossplane/crossplane/apis/v2/apiextensions/v1alpha1"
 	xpv2 "github.com/crossplane/crossplane/apis/v2/core/v2"
 	pkgv1 "github.com/crossplane/crossplane/apis/v2/pkg/v1"
 	"github.com/crossplane/crossplane/apis/v2/pkg/v1beta1"
@@ -193,6 +200,237 @@ func TestProviderUpgrade(t *testing.T) {
 			WithTeardown("DeletePrerequisites", funcs.AllOf(
 				funcs.DeleteResourcesWithPropagationPolicy(manifests, "provider-upgrade.yaml", metav1.DeletePropagationForeground),
 				funcs.ResourcesDeletedWithin(1*time.Minute, manifests, "provider-upgrade.yaml"),
+			)).
+			Feature(),
+	)
+}
+
+// TestProviderUpgradeInactiveRevisionHoldsControl tests that the revision
+// activated by a provider upgrade takes control of the objects it installs even
+// when the revision it replaced still holds a controlling owner reference on
+// them.
+//
+// Regression test for https://github.com/crossplane/crossplane/issues/7656.
+//
+// The outgoing revision is paused before the upgrade, so it never relinquishes
+// control of its objects. That makes the hand-off deterministic: the incoming
+// revision has to take control away from a revision that still claims it,
+// rather than racing the outgoing revision's deactivation. It reproduces the
+// same establisher code path as the reported v1 to v2 upgrade failure, where the
+// outgoing revision is instead replaced before it can relinquish control.
+func TestProviderUpgradeInactiveRevisionHoldsControl(t *testing.T) {
+	manifests := "test/e2e/manifests/pkg/provider-handoff"
+
+	const providerName = "provider-nop-pkg-handoff"
+
+	revisionsOfProvider := resources.WithLabelSelector(pkgv1.LabelParentPackage + "=" + providerName)
+
+	// Recorded by the assessments below.
+	var (
+		outgoingName string
+		objectRefs   []xpv2.TypedReference
+	)
+
+	environment.Test(t,
+		features.NewWithDescription(t.Name(), "Tests that the revision activated by a provider upgrade takes control of its objects even when the revision it replaced still controls them.").
+			WithLabel(LabelArea, LabelAreaPkg).
+			WithLabel(LabelSize, LabelSizeSmall).
+			WithLabel(config.LabelTestSuite, config.TestSuiteDefault).
+			WithSetup("ApplyInitialProvider", funcs.AllOf(
+				funcs.ApplyResources(FieldManager, manifests, "provider-initial.yaml"),
+				funcs.ResourcesCreatedWithin(1*time.Minute, manifests, "provider-initial.yaml"),
+				funcs.ResourcesHaveConditionWithin(3*time.Minute, manifests, "provider-initial.yaml", pkgv1.Healthy(), pkgv1.Active()),
+			)).
+			// Create a managed resource, so the CRD the revisions are handing
+			// over holds live data, as it does in the reported failures.
+			WithSetup("InitialManagedResourceIsReady", funcs.AllOf(
+				funcs.ApplyResources(FieldManager, manifests, "mr.yaml"),
+				funcs.ResourcesCreatedWithin(1*time.Minute, manifests, "mr.yaml"),
+				funcs.ResourcesHaveConditionWithin(2*time.Minute, manifests, "mr.yaml", xpv2.Available()),
+			)).
+			// Record the objects the outgoing revision controls, rather than
+			// naming them here. Which kinds the establisher controls depends on
+			// whether managed resource CRDs were converted to MRDs.
+			Assess("RecordOutgoingRevision", func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+				t.Helper()
+
+				l := &pkgv1.ProviderRevisionList{}
+				if err := c.Client().Resources().List(ctx, l, revisionsOfProvider); err != nil {
+					t.Errorf("cannot list revisions of provider %s: %v", providerName, err)
+					return ctx
+				}
+
+				if len(l.Items) != 1 {
+					t.Errorf("want 1 revision of provider %s, got %d", providerName, len(l.Items))
+					return ctx
+				}
+
+				outgoing := l.Items[0]
+				if len(outgoing.Status.ObjectRefs) == 0 {
+					t.Errorf("revision %s controls no objects", outgoing.GetName())
+					return ctx
+				}
+
+				outgoingName = outgoing.GetName()
+				objectRefs = outgoing.Status.ObjectRefs
+
+				t.Logf("outgoing revision %s (UID %s) controls %d object(s)", outgoingName, outgoing.GetUID(), len(objectRefs))
+
+				return ctx
+			}).
+			// Pausing the outgoing revision stops its reconciler before it can
+			// deactivate, so it keeps its controlling owner reference on every
+			// object above for the rest of the test.
+			Assess("PauseOutgoingRevision", func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+				t.Helper()
+
+				if outgoingName == "" {
+					return ctx
+				}
+
+				// The revision's own controller writes to it while we do, so
+				// retry rather than failing the test for a conflict that has
+				// nothing to do with the hand-off.
+				if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+					pr := &pkgv1.ProviderRevision{}
+					if err := c.Client().Resources().Get(ctx, outgoingName, "", pr); err != nil {
+						return err
+					}
+
+					xpmeta.AddAnnotations(pr, map[string]string{xpmeta.AnnotationKeyReconciliationPaused: "true"})
+
+					return c.Client().Resources().Update(ctx, pr)
+				}); err != nil {
+					t.Errorf("cannot pause revision %s: %v", outgoingName, err)
+					return ctx
+				}
+
+				// Wait for the pause to take effect, so the revision can't
+				// relinquish control once the upgrade deactivates it.
+				return funcs.ResourceHasConditionWithin(1*time.Minute,
+					&pkgv1.ProviderRevision{ObjectMeta: metav1.ObjectMeta{Name: outgoingName}},
+					xpv2.ReconcilePaused(),
+				)(ctx, t, c)
+			}).
+			// Log revision conditions while the upgrade runs, so a failure of the
+			// assessment below shows why the incoming revision is unhealthy.
+			Assess("LogProviderRevisions", funcs.InBackground(funcs.LogResources(&pkgv1.ProviderRevisionList{}, revisionsOfProvider))).
+			Assess("UpgradeProvider", funcs.ApplyResources(FieldManager, manifests, "provider-upgrade.yaml")).
+			// This is the assessment that fails when the establisher can't take
+			// control from the revision it replaced. The provider stays unhealthy
+			// with "cannot establish control of object: <name> is already
+			// controlled by ProviderRevision <outgoing> (UID <uid>)".
+			Assess("ProviderBecomesHealthyAgain",
+				funcs.ResourcesHaveConditionWithin(3*time.Minute, manifests, "provider-upgrade.yaml", pkgv1.Healthy(), pkgv1.Active())).
+			Assess("IncomingRevisionControlsAllObjects", func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+				t.Helper()
+
+				if outgoingName == "" {
+					return ctx
+				}
+
+				l := &pkgv1.ProviderRevisionList{}
+				if err := c.Client().Resources().List(ctx, l, revisionsOfProvider); err != nil {
+					t.Errorf("cannot list revisions of provider %s: %v", providerName, err)
+					return ctx
+				}
+
+				var incoming *pkgv1.ProviderRevision
+
+				for i := range l.Items {
+					if l.Items[i].GetName() != outgoingName {
+						incoming = &l.Items[i]
+						break
+					}
+				}
+
+				if incoming == nil {
+					t.Errorf("no revision of provider %s other than %s", providerName, outgoingName)
+					return ctx
+				}
+
+				t.Logf("incoming revision %s (UID %s)", incoming.GetName(), incoming.GetUID())
+
+				checks := make([]features.Func, 0, 3*len(objectRefs)+1)
+
+				for _, ref := range objectRefs {
+					u := &unstructured.Unstructured{}
+					u.SetAPIVersion(ref.APIVersion)
+					u.SetKind(ref.Kind)
+					u.SetName(ref.Name)
+
+					checks = append(checks,
+						// Every object the outgoing revision controlled must
+						// now be controlled by the incoming one.
+						funcs.ResourceHasFieldValueWithin(1*time.Minute, u, "metadata.ownerReferences", funcs.ControlledBy(incoming.GetName())),
+						// The outgoing revision must survive as a plain owner,
+						// so that taking control doesn't change when the object
+						// is garbage collected.
+						funcs.ResourceHasFieldValueWithin(1*time.Minute, u, "metadata.ownerReferences", funcs.OwnedButNotControlledBy(outgoingName)),
+					)
+
+					// The CRD derived from an MRD is handed over too, by the
+					// MRD reconciler rather than the establisher. Its old
+					// controller entry is pruned by a later apply rather than
+					// kept, so only assert on the incoming controller.
+					if ref.Kind == apiextensionsv1alpha1.ManagedResourceDefinitionKind {
+						crd := &unstructured.Unstructured{}
+						crd.SetAPIVersion(k8sapiextensionsv1.SchemeGroupVersion.String())
+						crd.SetKind("CustomResourceDefinition")
+						crd.SetName(ref.Name)
+
+						checks = append(checks,
+							funcs.ResourceHasFieldValueWithin(1*time.Minute, crd, "metadata.ownerReferences", funcs.ControlledBy(incoming.GetName())),
+						)
+					}
+				}
+
+				// The runtime is only created once the revision is healthy, so
+				// this is the user visible symptom of a failed hand-off: the
+				// provider's pod is never created.
+				checks = append(checks, funcs.DeploymentBecomesAvailableWithin(2*time.Minute, namespace, incoming.GetName()))
+
+				return funcs.AllOf(checks...)(ctx, t, c)
+			}).
+			// The managed resource whose CRD was handed over must still work.
+			Assess("ManagedResourceIsStillAvailable",
+				funcs.ResourcesHaveConditionWithin(2*time.Minute, manifests, "mr.yaml", xpv2.Available())).
+			// Unpause the outgoing revision before deleting anything: pausing
+			// stops its reconciler handling deletion too, so a paused revision
+			// holding a finalizer would block teardown.
+			WithTeardown("UnpauseOutgoingRevision", func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+				t.Helper()
+
+				if outgoingName == "" {
+					return ctx
+				}
+
+				// Retry on conflict as above. Leaving the revision paused here
+				// would block the deletions below, since a paused reconciler
+				// never removes its finalizer.
+				err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+					pr := &pkgv1.ProviderRevision{}
+					if err := c.Client().Resources().Get(ctx, outgoingName, "", pr); err != nil {
+						return err
+					}
+
+					xpmeta.RemoveAnnotations(pr, xpmeta.AnnotationKeyReconciliationPaused)
+
+					return c.Client().Resources().Update(ctx, pr)
+				})
+				if err != nil && !kerrors.IsNotFound(err) {
+					t.Errorf("cannot unpause revision %s: %v", outgoingName, err)
+				}
+
+				return ctx
+			}).
+			WithTeardown("DeleteManagedResource", funcs.AllOf(
+				funcs.DeleteResources(manifests, "mr.yaml"),
+				funcs.ResourcesDeletedWithin(1*time.Minute, manifests, "mr.yaml"),
+			)).
+			WithTeardown("DeletePrerequisites", funcs.AllOf(
+				funcs.DeleteResourcesWithPropagationPolicy(manifests, "provider-upgrade.yaml", metav1.DeletePropagationForeground),
+				funcs.ResourcesDeletedWithin(2*time.Minute, manifests, "provider-upgrade.yaml"),
 			)).
 			Feature(),
 	)


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane! Please read the contribution docs
(linked below) if this is your first Crossplane pull request.
-->

### Description of your changes

Manual backport of #7733 to `release-2.3`. The automated backport failed to cherry-pick.

Two conflicts, both in the e2e test commit:

- `test/e2e/funcs/feature.go`: `SolelyOwnedBy` doesn't exist on this branch — it arrived with #7714, which was only backported to `release-2.4` — so this keeps just the two new checkers and rewords the comments that contrasted them with it.
- `test/e2e/pkg_test.go`: added the `apiextensions/v1alpha1` import, which `main` already had.

The fix itself applied unchanged: `demoteOldController`, `controlledByReplacedRevision` and `handOverControl` are identical to `main`.

Note that the three `pkg` e2e suites are already red on `release-2.3` independently of this change — the last run on the branch (https://github.com/crossplane/crossplane/actions/runs/33871739199) fails the same three.

<!--
Briefly describe what this pull request does, and how it is covered by tests.
Be proactive - direct your reviewers' attention to anything that needs special
consideration.

We love pull requests that fix an open issue. If yours does, use the below line
to indicate which issue it fixes, for example "Fixes #500".
-->

Fixes #

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `./nix.sh flake check` to ensure this PR is ready for review.
- [x] Added or updated unit tests.
- [x] Added or updated e2e tests.
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~ Bug fix, no documented behaviour changes.
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~ This is the backport.
- [ ] ~Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~ No API changes.

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md
