### PR TITLE
docs(security): add non-goal that Composition authors are trusted

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -43,6 +43,11 @@ directly to confirm receipt of the issue.
 
 ### Report Content
 
+Crossplane's [security non-goals](./security/self-assessment.md#non-goals)
+describe what Crossplane does not intend to protect against. Behavior covered by
+them will not be treated as a vulnerability. Please review them before
+submitting a report.
+
 Make sure to include all the details that might help maintainers better
 understand and prioritize it, for example here is a list of details that might be
 worth adding:

--- a/security/self-assessment.md
+++ b/security/self-assessment.md
@@ -179,12 +179,23 @@ cluster scoped and Crossplane does not have built-in mechanisms or experiences
 to further restrict their access. This can be configured outside of Crossplane
 via manual RBAC or policy configurations.
 
+`Compositions` and `CompositeResourceDefinitions` are cluster scoped resources
+authored by trusted members of the platform team, so Crossplane does not treat
+the logic of a `Composition` as a security boundary. Crossplane executes the
+function pipeline they define and applies the resulting composed resources using
+its own service account. A `Composition` that passes end user input through to
+the kind, scope, or other identity-related fields of a composed resource
+therefore grants that user whatever the `Composition` specifies. Preventing that
+is the platform team's responsibility, for example by controlling who can create
+`Compositions` and `CompositeResourceDefinitions`, by applying admission policy
+to the resources they compose, or by simply not writing `Compositions` that
+grant application developers more access than intended.
+
 Crossplane does not intend to exhaustively restrict the controller workloads
 that are run as extensions in the control plane. Users have the ability to
 configure the `Deployment` that manages the extension's pod (and therefore
 internal controllers), but the specific execution and runtime of the extension
 is not restricted further by Crossplane.
-
 
 ## Self-assessment Use
 


### PR DESCRIPTION
### Description of your changes

We've received numerous security vulnerability reports that are actually inline with the project's security design and policy.

The most common incorrect assumption is that the content of a Composition is a security boundary. Crossplane considers Composition authors trusted members of the platform team, but that position wasn't documented anywhere in the project.

This commit adds a non-goal to the security self-assessment making that more clear, and points reporters at the non-goals from SECURITY.md before they submit a report.

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Read and followed Crossplane's [AI policy] and confirmed a human stands behind this PR.
- [x] Run `./nix.sh flake check` to ensure this PR is ready for review.
- [ ] ~Added or updated unit tests.~
- [ ] ~Added or updated e2e tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~
- [ ] ~Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[AI policy]: https://github.com/crossplane/crossplane/blob/main/AI_POLICY.md
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md
