### PR TITLE
feat: report managed resource activation policy establishment

### DIFF
--- a/internal/controller/apiextensions/activationpolicy/reconciler.go
+++ b/internal/controller/apiextensions/activationpolicy/reconciler.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"time"
 
+	corev1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -118,10 +119,16 @@ func (r *Reconciler) Reconcile(ogctx context.Context, req reconcile.Request) (re
 	mrap.Status.ClearActivated()
 
 	// For each, see if it is activated by the activation policy.
-	var errs []error
+	var (
+		errs           []error
+		hasActivated   bool
+		allEstablished = true
+	)
 	for _, mrd := range mrds.Items {
 		if mrap.Activates(mrd.GetName()) {
+			hasActivated = true
 			if mrd.Spec.State != v1alpha1.ManagedResourceDefinitionActive {
+				allEstablished = false
 				orig := mrd.DeepCopy()
 				mrd.Spec.State = v1alpha1.ManagedResourceDefinitionActive
 				// Patch to ignore any other updates. Just focused on the spec.state value.
@@ -134,6 +141,9 @@ func (r *Reconciler) Reconcile(ogctx context.Context, req reconcile.Request) (re
 				r.record.Event(mrap, event.Normal(reasonActivatedMRD, reconcileActivateSuccessMsg))
 			}
 			mrap.Status.AppendActivated(mrd.GetName())
+			if mrd.GetCondition(v1alpha1.TypeEstablished).Status != corev1.ConditionTrue {
+				allEstablished = false
+			}
 		}
 	}
 	if errs != nil {
@@ -141,6 +151,11 @@ func (r *Reconciler) Reconcile(ogctx context.Context, req reconcile.Request) (re
 			fmt.Sprintf("failed to activate %d of %d ManagedResourceDefinitions", len(errs), len(mrap.Status.Activated))))
 	} else {
 		status.MarkConditions(v1alpha1.Healthy())
+	}
+	if hasActivated && allEstablished {
+		status.MarkConditions(v1alpha1.EstablishedManaged())
+	} else {
+		status.MarkConditions(v1alpha1.PendingManaged())
 	}
 
 	// TODO: we should really do a diff of the status to see if we should update or not.

--- a/internal/controller/apiextensions/activationpolicy/reconciler_test.go
+++ b/internal/controller/apiextensions/activationpolicy/reconciler_test.go
@@ -107,6 +107,12 @@ func WithMRDState(state v1alpha1.ManagedResourceDefinitionState) MRDModifier {
 	}
 }
 
+func WithMRDEstablished() MRDModifier {
+	return func(mrd *v1alpha1.ManagedResourceDefinition) {
+		mrd.SetConditions(v1alpha1.EstablishedManaged())
+	}
+}
+
 // A get function that supplies the input resource.
 func WithMRAP(t *testing.T, mrap *v1alpha1.ManagedResourceActivationPolicy) func(context.Context, client.ObjectKey, client.Object) error {
 	t.Helper()
@@ -292,7 +298,7 @@ func TestReconcile(t *testing.T) {
 					MockStatusUpdate: WantMRAP(t, NewMRAP(func(mrap *v1alpha1.ManagedResourceActivationPolicy) {
 						mrap.Spec.Activations = []v1alpha1.ActivationPolicy{"*.aws.crossplane.io"}
 						mrap.Status.Activated = nil
-						mrap.SetConditions(v1alpha1.Healthy())
+						mrap.SetConditions(v1alpha1.Healthy(), v1alpha1.PendingManaged())
 					})),
 				},
 			},
@@ -315,7 +321,7 @@ func TestReconcile(t *testing.T) {
 					MockStatusUpdate: WantMRAP(t, NewMRAP(func(mrap *v1alpha1.ManagedResourceActivationPolicy) {
 						mrap.Spec.Activations = []v1alpha1.ActivationPolicy{"*.aws.crossplane.io"}
 						mrap.Status.Activated = []string{"bucket.aws.crossplane.io"}
-						mrap.SetConditions(v1alpha1.Healthy())
+						mrap.SetConditions(v1alpha1.Healthy(), v1alpha1.PendingManaged())
 					})),
 				},
 			},
@@ -340,7 +346,7 @@ func TestReconcile(t *testing.T) {
 					MockStatusUpdate: WantMRAP(t, NewMRAP(func(mrap *v1alpha1.ManagedResourceActivationPolicy) {
 						mrap.Spec.Activations = []v1alpha1.ActivationPolicy{"*.aws.crossplane.io"}
 						mrap.Status.Activated = []string{"bucket.aws.crossplane.io", "instance.aws.crossplane.io"}
-						mrap.SetConditions(v1alpha1.Healthy())
+						mrap.SetConditions(v1alpha1.Healthy(), v1alpha1.PendingManaged())
 					})),
 				},
 			},
@@ -363,7 +369,7 @@ func TestReconcile(t *testing.T) {
 					MockStatusUpdate: WantMRAP(t, NewMRAP(func(mrap *v1alpha1.ManagedResourceActivationPolicy) {
 						mrap.Spec.Activations = []v1alpha1.ActivationPolicy{"*.aws.crossplane.io"}
 						mrap.Status.Activated = []string{"bucket.aws.crossplane.io", "instance.aws.crossplane.io"}
-						mrap.SetConditions(v1alpha1.Healthy())
+						mrap.SetConditions(v1alpha1.Healthy(), v1alpha1.PendingManaged())
 					})),
 				},
 			},
@@ -391,7 +397,7 @@ func TestReconcile(t *testing.T) {
 					MockStatusUpdate: WantMRAP(t, NewMRAP(func(mrap *v1alpha1.ManagedResourceActivationPolicy) {
 						mrap.Spec.Activations = []v1alpha1.ActivationPolicy{"*.aws.crossplane.io"}
 						mrap.Status.Activated = []string{"instance.aws.crossplane.io"}
-						mrap.SetConditions(v1alpha1.Unhealthy().WithMessage("failed to activate 1 of 1 ManagedResourceDefinitions"))
+						mrap.SetConditions(v1alpha1.Unhealthy().WithMessage("failed to activate 1 of 1 ManagedResourceDefinitions"), v1alpha1.PendingManaged())
 					})),
 				},
 			},
@@ -416,7 +422,7 @@ func TestReconcile(t *testing.T) {
 					MockStatusUpdate: WantMRAP(t, NewMRAP(func(mrap *v1alpha1.ManagedResourceActivationPolicy) {
 						mrap.Spec.Activations = []v1alpha1.ActivationPolicy{"*.aws.crossplane.io", "*.gcp.crossplane.io"}
 						mrap.Status.Activated = []string{"bucket.aws.crossplane.io", "storage.gcp.crossplane.io"}
-						mrap.SetConditions(v1alpha1.Healthy())
+						mrap.SetConditions(v1alpha1.Healthy(), v1alpha1.PendingManaged())
 					})),
 				},
 			},
@@ -435,7 +441,47 @@ func TestReconcile(t *testing.T) {
 					MockStatusUpdate: WantMRAP(t, NewMRAP(func(mrap *v1alpha1.ManagedResourceActivationPolicy) {
 						mrap.Spec.Activations = []v1alpha1.ActivationPolicy{}
 						mrap.Status.Activated = nil
-						mrap.SetConditions(v1alpha1.Healthy())
+						mrap.SetConditions(v1alpha1.Healthy(), v1alpha1.PendingManaged())
+					})),
+				},
+			},
+			want: want{
+				r: reconcile.Result{},
+			},
+		},
+		"AllActivatedMRDsEstablished": {
+			reason: "We should report the policy as established when every activated MRD is established.",
+			args: args{
+				c: &test.MockClient{
+					MockGet: WithMRAP(t, NewMRAP(WithMRAPActivations("*.aws.crossplane.io"))),
+					MockList: WithMRDList(t,
+						NewMRD("bucket.aws.crossplane.io", WithMRDState(v1alpha1.ManagedResourceDefinitionActive), WithMRDEstablished()),
+						NewMRD("instance.aws.crossplane.io", WithMRDState(v1alpha1.ManagedResourceDefinitionActive), WithMRDEstablished()),
+					),
+					MockStatusUpdate: WantMRAP(t, NewMRAP(func(mrap *v1alpha1.ManagedResourceActivationPolicy) {
+						mrap.Spec.Activations = []v1alpha1.ActivationPolicy{"*.aws.crossplane.io"}
+						mrap.Status.Activated = []string{"bucket.aws.crossplane.io", "instance.aws.crossplane.io"}
+						mrap.SetConditions(v1alpha1.Healthy(), v1alpha1.EstablishedManaged())
+					})),
+				},
+			},
+			want: want{
+				r: reconcile.Result{},
+			},
+		},
+		"WaitForAllActivatedMRDs": {
+			reason: "We should wait until every activated MRD is established.",
+			args: args{
+				c: &test.MockClient{
+					MockGet: WithMRAP(t, NewMRAP(WithMRAPActivations("*.aws.crossplane.io"))),
+					MockList: WithMRDList(t,
+						NewMRD("bucket.aws.crossplane.io", WithMRDState(v1alpha1.ManagedResourceDefinitionActive), WithMRDEstablished()),
+						NewMRD("instance.aws.crossplane.io", WithMRDState(v1alpha1.ManagedResourceDefinitionActive)),
+					),
+					MockStatusUpdate: WantMRAP(t, NewMRAP(func(mrap *v1alpha1.ManagedResourceActivationPolicy) {
+						mrap.Spec.Activations = []v1alpha1.ActivationPolicy{"*.aws.crossplane.io"}
+						mrap.Status.Activated = []string{"bucket.aws.crossplane.io", "instance.aws.crossplane.io"}
+						mrap.SetConditions(v1alpha1.Healthy(), v1alpha1.PendingManaged())
 					})),
 				},
 			},

--- a/test/e2e/apiextensions_activation_policy_test.go
+++ b/test/e2e/apiextensions_activation_policy_test.go
@@ -87,6 +87,12 @@ func TestMRAPActivatesSingleMRD(t *testing.T) {
 					v1alpha1.EstablishedManaged()),
 			)).
 
+			// Verify MRAP becomes established after its activated MRD
+			Assess("MRAPBecomesEstablished",
+				funcs.ResourcesHaveConditionWithin(1*time.Minute, manifests, "mrap.yaml",
+					v1alpha1.EstablishedManaged()),
+			).
+
 			// Verify CRD is created
 			Assess("CRDIsCreated", funcs.AllOf(
 				funcs.ResourcesCreatedWithin(1*time.Minute, manifests, "expected-crd.yaml"),


### PR DESCRIPTION
### Description of your changes

Adds an `Established` condition to `ManagedResourceActivationPolicy`. The condition remains `Unknown` until every matching `ManagedResourceDefinition` has established its CRD, so consumers can wait for an activated kind to be served before creating resources of that kind. The existing MRD watch re-reconciles the policy when that state changes.

Validation:

- `./nix.sh flake check`
- `DOCKER_HOST=unix:///var/run/docker.sock ./nix.sh run .#e2e -- -test.v -test-suite=mrap -test.run '^TestMRAPActivatesSingleMRD$'` — created a kind cluster, activated an MRD, and observed the policy reach `Established=True` after the MRD did.

Fixes #7822

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Read and followed Crossplane's [AI policy] and confirmed a human stands behind this PR.
- [x] Run `./nix.sh flake check` to ensure this PR is ready for review.
- [x] Added or updated unit tests.
- [x] Added or updated e2e tests.
- [x] Linked a [docs tracking issue](https://github.com/crossplane/docs/issues/1153) to [document this change].
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR (this is an enhancement, so backport labels are not applicable).~
- [ ] ~Followed the [API promotion workflow] (this does not introduce, remove, or promote an API).~

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[AI policy]: https://github.com/crossplane/crossplane/blob/main/AI_POLICY.md
[document this change]: https://docs.crossplane.io/contribute/contribute
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md

