### PR TITLE
CronOperation: fix infinite AlreadyExists loop from clock skew

### DIFF
--- a/internal/controller/ops/cronoperation/reconciler.go
+++ b/internal/controller/ops/cronoperation/reconciler.go
@@ -23,6 +23,7 @@ import (
 	"slices"
 	"time"
 
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -111,9 +112,15 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 		return reconcile.Result{}, err
 	}
 
-	// Derive our last scheduled time from the last time we created an
-	// Operation.
-	if t := lifecycle.LatestCreateTime(ol.Items...); !t.IsZero() {
+	// Derive our last scheduled time from the scheduled time encoded in the
+	// name of the last Operation we created. We use the name - not the
+	// Operation's creationTimestamp - because creationTimestamp is set by
+	// the API server's clock, which can differ from the controller's clock
+	// by a second or more. That skew could otherwise make Next() below
+	// recompute the same scheduled slot forever, since the Operation we'd
+	// try to create already exists (see
+	// https://github.com/crossplane/crossplane/issues/7524).
+	if t := lifecycle.LatestScheduledTime(co.GetName(), ol.Items...); !t.IsZero() {
 		co.Status.LastScheduleTime = &metav1.Time{Time: t}
 	}
 
@@ -211,7 +218,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 	}
 
 	op := NewOperation(co, next)
-	if err := r.client.Create(ctx, op); err != nil {
+	if err := createOperationIfNotExists(ctx, r.client, op); err != nil {
 		log.Debug("Cannot create scheduled Operation", "error", err, "operation", op.GetName())
 		err = errors.Wrapf(err, "cannot create scheduled Operation %q", op.GetName())
 		r.record.Event(co, event.Warning(reasonCreateOperation, err))
@@ -220,11 +227,26 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 		return reconcile.Result{}, err
 	}
 
-	// We rely on our watch to add the new Operation to status at the top of
-	// the Reconcile.
+	// We rely on our watch to add the new (or pre-existing) Operation to
+	// status at the top of the Reconcile.
 
 	status.MarkConditions(xpv2.ReconcileSuccess())
 	return reconcile.Result{RequeueAfter: future.Sub(now)}, errors.Wrap(r.client.Status().Update(ctx, co), "cannot update CronOperation status")
+}
+
+// createOperationIfNotExists creates op, unless an Operation with the same
+// name already exists. An Operation already existing under the exact name
+// we just computed isn't an error: it means an Operation for this schedule
+// slot already exists, whether because we're retrying a partially failed
+// reconcile, or because our cache hasn't yet observed an Operation that an
+// earlier reconcile created. Either way the state we wanted already exists.
+func createOperationIfNotExists(ctx context.Context, c client.Client, op *v1alpha1.Operation) error {
+	err := c.Create(ctx, op)
+	if kerrors.IsAlreadyExists(err) {
+		return nil
+	}
+
+	return err
 }
 
 // NewOperation creates a new operation given the CronOperation's template.

--- a/internal/controller/ops/cronoperation/reconciler_test.go
+++ b/internal/controller/ops/cronoperation/reconciler_test.go
@@ -18,6 +18,7 @@ package cronoperation
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -573,6 +574,178 @@ func TestReconcile(t *testing.T) {
 				t.Errorf("\n%s\nr.Reconcile(...): -want result, +got result:\n%s", tc.reason, diff)
 			}
 		})
+	}
+}
+
+// TestReconcileClockSkewCollision reproduces
+// https://github.com/crossplane/crossplane/issues/7524.
+//
+// It simulates an Operation that was created for a scheduled slot, but
+// whose K8s creationTimestamp was stamped by the API server ~1s before that
+// slot's boundary (clock skew between the controller and the API server).
+//
+// Before the fix, LastScheduleTime is derived from the skewed
+// creationTimestamp, so Next(schedule, creationTimestamp) recomputes the
+// *same* scheduled slot on every subsequent reconcile, and the controller
+// tries - forever - to re-create an Operation that already exists.
+//
+// After the fix, LastScheduleTime is derived from the scheduled time
+// encoded in the Operation's own name, which is not affected by clock
+// skew, so the controller correctly advances to the next slot instead of
+// colliding with the existing Operation.
+func TestReconcileClockSkewCollision(t *testing.T) {
+	now := time.Now().UTC()
+
+	// A real "*/5 * * * *" tick, comfortably in the past so it's due.
+	boundary := now.Truncate(5 * time.Minute)
+	scheduled := boundary.Add(-10 * time.Minute)
+
+	// The API server stamped creationTimestamp 1s *before* the scheduled
+	// boundary - the clock skew described in the issue.
+	skewedCreation := scheduled.Add(-1 * time.Second)
+
+	// The CronOperation itself is much older, so its own creation
+	// timestamp is never the deciding factor here.
+	coCreation := scheduled.Add(-24 * time.Hour)
+
+	existingOpName := fmt.Sprintf("test-cron-%d", scheduled.Unix())
+
+	c := &test.MockClient{
+		MockGet: test.NewMockGetFn(nil, func(obj client.Object) error {
+			co := &v1alpha1.CronOperation{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "test-cron",
+					CreationTimestamp: metav1.Time{Time: coCreation},
+				},
+				Spec: v1alpha1.CronOperationSpec{
+					Schedule: "*/5 * * * *",
+					OperationTemplate: v1alpha1.OperationTemplate{
+						Spec: v1alpha1.OperationSpec{
+							Mode: v1alpha1.OperationModePipeline,
+							Pipeline: []v1alpha1.PipelineStep{
+								{
+									Step:        "test-step",
+									FunctionRef: v1alpha1.FunctionReference{Name: "test-function"},
+								},
+							},
+						},
+					},
+				},
+			}
+			co.DeepCopyInto(obj.(*v1alpha1.CronOperation))
+			return nil
+		}),
+		MockList: test.NewMockListFn(nil, func(obj client.ObjectList) error {
+			list := obj.(*v1alpha1.OperationList)
+			list.Items = []v1alpha1.Operation{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              existingOpName,
+						CreationTimestamp: metav1.Time{Time: skewedCreation},
+					},
+					Status: v1alpha1.OperationStatus{
+						ConditionedStatus: xpv2.ConditionedStatus{
+							Conditions: []xpv2.Condition{
+								{
+									Type:   v1alpha1.TypeSucceeded,
+									Status: "True",
+									Reason: v1alpha1.ReasonPipelineSuccess,
+								},
+							},
+						},
+					},
+				},
+			}
+			return nil
+		}),
+		MockCreate: test.NewMockCreateFn(nil, func(obj client.Object) error {
+			op := obj.(*v1alpha1.Operation)
+			if op.GetName() == existingOpName {
+				// The exact race from the issue: the controller tries to
+				// recreate the Operation that already occupies this slot.
+				return kerrors.NewAlreadyExists(schema.GroupResource{Resource: "operations"}, op.GetName())
+			}
+			return nil
+		}),
+		MockStatusUpdate: test.NewMockSubResourceUpdateFn(nil),
+	}
+
+	// Deliberately use the real cron scheduler (the Reconciler's default),
+	// not a mocked one, so we exercise the actual Next() computation the
+	// issue describes.
+	r := NewReconciler(c)
+
+	got, err := r.Reconcile(context.Background(), reconcile.Request{
+		NamespacedName: types.NamespacedName{Name: "test-cron"},
+	})
+	if err != nil {
+		t.Errorf("r.Reconcile(...): unexpected error - this is the infinite AlreadyExists loop from issue #7524: %v", err)
+	}
+
+	if got.RequeueAfter <= 0 {
+		t.Errorf("r.Reconcile(...): got RequeueAfter = %v, want a positive requeue interval for the next tick", got.RequeueAfter)
+	}
+}
+
+// TestReconcileCreateAlreadyExistsIsTreatedAsSuccess exercises the
+// defensive half of the fix for issue #7524: even independent of the
+// clock-skew root cause, if Create() reports AlreadyExists for the exact
+// Operation name we just computed, that's not a real error - an Operation
+// for this schedule slot already exists (e.g. because our informer cache
+// hasn't yet observed an Operation created by an earlier reconcile). The
+// controller should treat that as success rather than erroring out and
+// requeuing forever.
+func TestReconcileCreateAlreadyExistsIsTreatedAsSuccess(t *testing.T) {
+	now := time.Now()
+	past := now.Add(-time.Hour)
+	future := now.Add(time.Hour)
+	due := now.Add(-time.Minute)
+
+	calls := 0
+	c := &test.MockClient{
+		MockGet: test.NewMockGetFn(nil, func(obj client.Object) error {
+			co := &v1alpha1.CronOperation{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "test-cron",
+					CreationTimestamp: metav1.Time{Time: past},
+				},
+				Spec: v1alpha1.CronOperationSpec{
+					Schedule: "0 * * * *",
+				},
+			}
+			co.DeepCopyInto(obj.(*v1alpha1.CronOperation))
+			return nil
+		}),
+		// The Operation that already occupies this slot isn't visible in
+		// our list yet (e.g. informer cache lag after a partial previous
+		// reconcile).
+		MockList: test.NewMockListFn(nil),
+		MockCreate: test.NewMockCreateFn(nil, func(obj client.Object) error {
+			return kerrors.NewAlreadyExists(schema.GroupResource{Resource: "operations"}, obj.(*v1alpha1.Operation).GetName())
+		}),
+		MockStatusUpdate: test.NewMockSubResourceUpdateFn(nil),
+	}
+
+	r := NewReconciler(c, WithScheduler(SchedulerFn(func(_ string, _ time.Time) (time.Time, error) {
+		calls++
+		if calls == 1 {
+			// First call determines "next" - due now.
+			return due, nil
+		}
+		// Second call determines "future".
+		return future, nil
+	})))
+
+	got, err := r.Reconcile(context.Background(), reconcile.Request{
+		NamespacedName: types.NamespacedName{Name: "test-cron"},
+	})
+	if err != nil {
+		t.Errorf("r.Reconcile(...): unexpected error treating Create's AlreadyExists as success: %v", err)
+	}
+
+	want := reconcile.Result{RequeueAfter: future.Sub(now)}
+	if diff := cmp.Diff(want, got, EquateApproxDuration(time.Second)); diff != "" {
+		t.Errorf("r.Reconcile(...): -want, +got:\n%s", diff)
 	}
 }
 

--- a/internal/ops/lifecycle/operations.go
+++ b/internal/ops/lifecycle/operations.go
@@ -19,6 +19,8 @@ package lifecycle
 
 import (
 	"slices"
+	"strconv"
+	"strings"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -35,6 +37,44 @@ func LatestCreateTime(ops ...v1alpha1.Operation) time.Time {
 	for _, op := range ops {
 		if t := op.GetCreationTimestamp(); t.After(latest) {
 			latest = t.Time
+		}
+	}
+
+	return latest
+}
+
+// LatestScheduledTime returns the latest schedule time encoded in the names
+// of the supplied Operations, for the CronOperation with the supplied name.
+//
+// CronOperation names the Operations it creates "<cronName>-<unix>", where
+// unix is the Unix timestamp of the schedule slot the Operation was created
+// for (see cronoperation.NewOperation). Deriving the latest schedule time
+// from this name - rather than from the Operations' Kubernetes
+// creationTimestamp - avoids clock skew between the controller and the API
+// server: creationTimestamp is stamped by the API server's clock and can
+// land a second or more before or after the schedule boundary the
+// controller computed, which would otherwise cause the controller to
+// recompute the same scheduled slot forever.
+//
+// Operations that don't match the expected name format (e.g. because they
+// weren't created by this CronOperation) are ignored.
+func LatestScheduledTime(cronName string, ops ...v1alpha1.Operation) time.Time {
+	prefix := cronName + "-"
+	latest := time.Time{}
+
+	for _, op := range ops {
+		suffix, ok := strings.CutPrefix(op.GetName(), prefix)
+		if !ok {
+			continue
+		}
+
+		unix, err := strconv.ParseInt(suffix, 10, 64)
+		if err != nil {
+			continue
+		}
+
+		if t := time.Unix(unix, 0); t.After(latest) {
+			latest = t
 		}
 	}
 

--- a/internal/ops/lifecycle/operations_test.go
+++ b/internal/ops/lifecycle/operations_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package lifecycle
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -102,6 +103,99 @@ func TestLatestCreateTime(t *testing.T) {
 			got := LatestCreateTime(tc.args.ops...)
 			if diff := cmp.Diff(tc.want.latest, got); diff != "" {
 				t.Errorf("\n%s\nLatestCreateTime(...): -want, +got:\n%s", tc.reason, diff)
+			}
+		})
+	}
+}
+
+func TestLatestScheduledTime(t *testing.T) {
+	scheduled := time.Unix(1609459200, 0) // 2021-01-01 00:00:00 UTC
+	earlier := scheduled.Add(-time.Hour)
+	later := scheduled.Add(time.Hour)
+
+	// Simulates the exact clock skew from
+	// https://github.com/crossplane/crossplane/issues/7524: the
+	// creationTimestamp lands 1s before the scheduled boundary encoded in
+	// the name. LatestScheduledTime must ignore creationTimestamp and use
+	// the name instead.
+	skewedCreation := scheduled.Add(-1 * time.Second)
+
+	type args struct {
+		cronName string
+		ops      []v1alpha1.Operation
+	}
+	type want struct {
+		latest time.Time
+	}
+
+	cases := map[string]struct {
+		reason string
+		args   args
+		want   want
+	}{
+		"EmptySlice": {
+			reason: "Should return zero time for empty slice",
+			args: args{
+				cronName: "test-cron",
+				ops:      []v1alpha1.Operation{},
+			},
+			want: want{
+				latest: time.Time{},
+			},
+		},
+		"IgnoresCreationTimestampSkew": {
+			reason: "Should derive the scheduled time from the Operation's name, ignoring a skewed creationTimestamp",
+			args: args{
+				cronName: "test-cron",
+				ops: []v1alpha1.Operation{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:              fmt.Sprintf("test-cron-%d", scheduled.Unix()),
+							CreationTimestamp: metav1.Time{Time: skewedCreation},
+						},
+					},
+				},
+			},
+			want: want{
+				latest: scheduled,
+			},
+		},
+		"MultipleOperations": {
+			reason: "Should return the latest scheduled time from multiple operations",
+			args: args{
+				cronName: "test-cron",
+				ops: []v1alpha1.Operation{
+					{ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("test-cron-%d", earlier.Unix())}},
+					{ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("test-cron-%d", later.Unix())}},
+					{ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("test-cron-%d", scheduled.Unix())}},
+				},
+			},
+			want: want{
+				latest: later,
+			},
+		},
+		"IgnoresNonMatchingNames": {
+			reason: "Should ignore Operations whose name doesn't match <cronName>-<unix>",
+			args: args{
+				cronName: "test-cron",
+				ops: []v1alpha1.Operation{
+					{ObjectMeta: metav1.ObjectMeta{Name: "some-other-name"}},
+					{ObjectMeta: metav1.ObjectMeta{Name: "other-cron-" + fmt.Sprint(later.Unix())}},
+					{ObjectMeta: metav1.ObjectMeta{Name: "test-cron-not-a-number"}},
+					{ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("test-cron-%d", scheduled.Unix())}},
+				},
+			},
+			want: want{
+				latest: scheduled,
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got := LatestScheduledTime(tc.args.cronName, tc.args.ops...)
+			if diff := cmp.Diff(tc.want.latest, got); diff != "" {
+				t.Errorf("\n%s\nLatestScheduledTime(...): -want, +got:\n%s", tc.reason, diff)
 			}
 		})
 	}


### PR DESCRIPTION
### Description of changes

Fixes #7524.

The issue's own root-cause analysis is correct: `CronOperation` names each
`Operation` it creates from the *scheduled* time (`scheduled.Unix()`), but
derives `LastScheduleTime` from that `Operation`'s Kubernetes
`creationTimestamp` (via `lifecycle.LatestCreateTime`). Those two clocks can
disagree by a second or more between the controller and the API server. When
`creationTimestamp` lands just before a schedule boundary,
`Next(schedule, creationTimestamp)` recomputes the exact same scheduled slot
forever, so the controller keeps trying to recreate an `Operation` that
already exists. `Create`'s error was never checked for `AlreadyExists`, so
this became a permanent `Synced: False` loop that never schedules another
`Operation`.

I confirmed this by reproducing it with the real `robfig/cron` scheduler in a
reconciler-level test (`TestReconcileClockSkewCollision`): an existing
`Operation` named for a scheduled slot, with `creationTimestamp` 1s before
that slot's boundary, causes the current code to recompute the same slot and
fail with `AlreadyExists`.

I went with two changes rather than only the minimal one, because I found
that just swallowing `AlreadyExists` on its own isn't quite enough here:

1. **Root cause** — derive `LastScheduleTime` from the scheduled time
   encoded in the `Operation`'s name (new `lifecycle.LatestScheduledTime`)
   instead of `creationTimestamp`. The name is assigned by the controller
   itself and isn't subject to API server clock skew, so this removes the
   collision entirely for the scenario in the issue. Without this, merely
   tolerating `AlreadyExists` would stop the error spam but leave
   `LastScheduleTime` permanently pinned to the skewed slot — `Next()` would
   keep returning that same past slot on every reconcile, so the
   `CronOperation` would silently stop scheduling *any* new `Operation`
   forever, which seemed like a worse outcome than the current bug.

2. **Defensive handling** — treat `Create` returning `AlreadyExists` for the
   exact name we just computed as success, not an error. Even with (1)
   fixed, an informer cache that hasn't yet observed an `Operation` created
   by a previous reconcile (or a retry after a partially-failed reconcile)
   can still hit this. This follows the same `IsAlreadyExists`-on-`Create`
   idiom already used in this codebase, e.g.
   `internal/controller/pkg/resolver/reconciler.go`.

Both changes are small and I think the combination is the more correct fix,
but if maintainers would rather ship just (2) as the minimal safety net
and defer (1), I'm glad to split it that way instead.

### Testing

- Added `TestReconcileClockSkewCollision` and
  `TestReconcileCreateAlreadyExistsIsTreatedAsSuccess` to
  `internal/controller/ops/cronoperation/reconciler_test.go`. I verified
  both fail against the pre-fix code (reproducing the issue) and pass with
  the fix applied.
- Added `TestLatestScheduledTime` to `internal/ops/lifecycle/operations_test.go`
  for the new helper, including a case that specifically exercises a skewed
  `creationTimestamp` next to a correct name-derived time.
- `go test ./internal/controller/ops/cronoperation/... ./internal/ops/lifecycle/... -v`: all pass.
- `go test ./internal/...`: all pass.
- `go build ./...`: succeeds.
- `golangci-lint run ./internal/ops/lifecycle/... ./internal/controller/ops/cronoperation/...`: 0 issues.
- I don't have Docker available in my environment to run `./nix.sh flake check`, so I wasn't able to run the e2e suite locally.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Read and followed Crossplane's [AI policy] and confirmed a human stands behind this PR.
- [ ] ~Run `./nix.sh flake check` to ensure this PR is ready for review.~ (no Docker available in my environment; ran `go build`, `go vet`, `go test ./internal/...`, and `golangci-lint` directly instead)
- [x] Added or updated unit tests.
- [ ] ~Added or updated e2e tests.~ (existing reconciler-level unit tests cover this; happy to add an e2e test if maintainers want one)
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~ (bugfix, no user-facing doc change)
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~ (leaving to maintainers to decide which release lines this applies to)
- [ ] ~Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~ (no API changes)

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[AI policy]: https://github.com/crossplane/crossplane/blob/main/AI_POLICY.md
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md
